### PR TITLE
Use the suffix -dev for development builds.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -19,7 +19,7 @@ QT += network opengl uitools multimedia
 # (it is NOT a Qt built-in variable) for a release build or, if you are
 # distributing modified code, it would be useful if you could put something to
 # distinguish the version:
-BUILD = -rc2_chris7_mudletdev
+BUILD = -rc2-dev
 
 # Changing the above pair of values affects: ctelnet.cpp, main.cpp, mudlet.cpp
 # dlgAboutDialog.cpp and TLuaInterpreter.cpp.  It does NOT cause those files to


### PR DESCRIPTION
Users can change this locally if they wish.
