### PR TITLE
Remove Qt 4.6 checks.

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -452,9 +452,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     mpBufferSearchBox->setSizePolicy( sizePolicy5 );
     mpBufferSearchBox->setFont(mpHost->mCommandLineFont);
     mpBufferSearchBox->setFocusPolicy( Qt::ClickFocus );
-#if QT_VERSION >= 0x040700
     mpBufferSearchBox->setPlaceholderText("Search ...");
-#endif
     QPalette __pal;
     __pal.setColor(QPalette::Text, mpHost->mCommandLineFgColor );//QColor(0,0,192));
     __pal.setColor(QPalette::Highlight,QColor(0,0,192));

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -533,9 +533,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
     connect(delete_profile_lineedit, SIGNAL(textChanged(const QString)), this, SLOT(slot_deleteprofile_check(const QString)));
     connect(delete_profile_dialog, SIGNAL(accepted()), this, SLOT(slot_reallyDeleteProfile()));
 
-    #if QT_VERSION >= 0x040700
     delete_profile_lineedit->setPlaceholderText(profile);
-    #endif
     cancel_button->setFocus();
     delete_button->setDisabled(true);
     delete_profile_dialog->setWindowTitle("Deleting '"+profile+"'");


### PR DESCRIPTION
Considering that room_exits.ui doesn't compile with Qt 4.6,
remove the #if guards for more recent functionality.
