### PR TITLE
Add .clang-format for automated formatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,95 @@
+############################################################################
+#    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
+#                                                                          #
+#    This program is free software; you can redistribute it and/or modify  #
+#    it under the terms of the GNU General Public License version 2 as     #
+#    published by the Free Software Foundation.                            #
+#                                                                          #
+#    This program is distributed in the hope that it will be useful,       #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         #
+#    GNU General Public License for more details.                          #
+#                                                                          #
+#    You should have received a copy of the GNU General Public License     #
+#    along with this program; if not, write to the                         #
+#    Free Software Foundation, Inc.,                                       #
+#    59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
+############################################################################
+
+# For more information on clang-format:
+# http://clang.llvm.org/docs/ClangFormat.html
+
+BasedOnStyle: LLVM
+
+# language
+Language:        Cpp
+Standard:        Cpp03
+DisableFormat: false
+
+# line length
+ColumnLimit: 200
+
+# indentation
+IndentWidth: 4
+UseTab: Never
+TabWidth: 8
+AccessModifierOffset: -4
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+IndentWrappedFunctionNames: false
+NamespaceIndentation: None
+
+# line breaks
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBinaryOperators: true
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+
+# spaces
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: true
+
+# parameters
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackParameters: false
+
+# pointers
+DerivePointerAlignment: false
+PointerAlignment: true
+
+# braces
+Cpp11BracedListStyle: false
+
+# single line statements
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+# alignment
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+
+# penalties
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+
+# comments
+# CommentPragmas:


### PR DESCRIPTION
These settings seem to reflect the most consistent formatting across the
codebase, though some things could be a little off. The penalties and the
line length will probably need more adjustment at some point.
