### PR TITLE
Cleanup clang-format settings.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,8 +22,8 @@
 BasedOnStyle: LLVM
 
 # language
-Language:        Cpp
-Standard:        Cpp03
+Language: Cpp
+Standard: Cpp03
 DisableFormat: false
 
 # line length
@@ -68,7 +68,7 @@ BinPackParameters: false
 
 # pointers
 DerivePointerAlignment: false
-PointerAlignment: true
+PointerAlignment: Left
 
 # braces
 Cpp11BracedListStyle: false
@@ -90,6 +90,9 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
+
+# macros
+ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH ]
 
 # comments
 # CommentPragmas:


### PR DESCRIPTION
This doesn't change the settings, just fixing some issues that weren't
noticed before.
