### PR TITLE
Fixup: unsquash cust.line. form "cancel" button + swap pressed() to clic...

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2538,7 +2538,7 @@ void T2DMap::slot_customLineProperties()
             file.close();
             if( ! d )
             {
-                qWarning("T2DMap::slot_customLineProperties() ERRROR: failed to create the dialog!");
+                qWarning("T2DMap::slot_customLineProperties() ERROR: failed to create the dialog!");
                 return;
             }
             d->setWindowIcon( QIcon( QStringLiteral( ":/icons/mudlet_custom_exit_properties.png" ) ) );
@@ -2626,7 +2626,7 @@ void T2DMap::slot_customLineProperties()
 
             QString _styleSheet = QString("background-color:"+ mCurrentLineColor.name() );
             mpCurrentLineColor->setStyleSheet( _styleSheet );
-            connect( mpCurrentLineColor, SIGNAL(pressed()), this, SLOT(slot_customLineColor()));
+            connect( mpCurrentLineColor, SIGNAL(clicked()), this, SLOT(slot_customLineColor()));
 
             if( d->exec() == QDialog::Accepted )
             {
@@ -3660,13 +3660,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("NW")||pR->customLines.contains("nw") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("n");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"n\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"n\" exit line button!");
         return;
     }
     else if( pR->getNorth() <= 0 )
@@ -3678,13 +3678,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("N")||pR->customLines.contains("n") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("ne");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"ne\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"ne\" exit line button!");
         return;
     }
     else if( pR->getNortheast() <= 0 )
@@ -3696,13 +3696,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("NE")||pR->customLines.contains("ne") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("up");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"up\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"up\" exit line button!");
         return;
     }
     else if( pR->getUp() <= 0 )
@@ -3714,13 +3714,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("UP")||pR->customLines.contains("up") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("w");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"w\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"w\" exit line button!");
         return;
     }
     else if( pR->getWest() <= 0 )
@@ -3732,13 +3732,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("W")||pR->customLines.contains("w") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("e");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"e\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"e\" exit line button!");
         return;
     }
     else if( pR->getEast() <= 0 )
@@ -3750,13 +3750,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("E")||pR->customLines.contains("e") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("down");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"down\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"down\" exit line button!");
         return;
     }
     else if( pR->getDown() <= 0 )
@@ -3768,13 +3768,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("DOWN")||pR->customLines.contains("down") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("sw");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"sw\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"sw\" exit line button!");
         return;
     }
     else if( pR->getSouthwest() <= 0 )
@@ -3786,13 +3786,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("SW")||pR->customLines.contains("sw") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("s");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"s\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"s\" exit line button!");
         return;
     }
     else if( pR->getSouth() <= 0 )
@@ -3804,13 +3804,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("S")||pR->customLines.contains("s") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("se");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"se\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"se\" exit line button!");
         return;
     }
     else if( pR->getSoutheast() <= 0 )
@@ -3822,13 +3822,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("SE")||pR->customLines.contains("se") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("in");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"in\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"in\" exit line button!");
         return;
     }
     else if( pR->getIn() <= 0 )
@@ -3840,13 +3840,13 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("IN")||pR->customLines.contains("in") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     b_ = d->findChild<QPushButton*>("out");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"out\" exit line button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"out\" exit line button!");
         return;
     }
     else if( pR->getOut() <= 0 )
@@ -3858,7 +3858,7 @@ void T2DMap::slot_setCustomLine()
     {
         b_->setCheckable(true);
         b_->setChecked( pR->customLines.contains("OUT")||pR->customLines.contains("out") );
-        connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+        connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     }
 
     QMapIterator<int, QString> it(pR->getOtherMap());
@@ -3885,10 +3885,10 @@ void T2DMap::slot_setCustomLine()
     b_ = d->findChild<QPushButton*>("button_cancel");
     if( !b_ )
     {
-        qWarning("T2DMap::slot_setCustomLine() ERRROR: failed to find \"cancel\" button!");
+        qWarning("T2DMap::slot_setCustomLine() ERROR: failed to find \"cancel\" button!");
         return;
     }
-    connect(b_, SIGNAL(pressed()), this, SLOT(slot_setCustomLine2()));
+    connect(b_, SIGNAL(clicked()), this, SLOT(slot_setCustomLine2()));
     // Arrange that even a cancel request gets handled by the slot_setCustomLine2() method
 
     QStringList _lineStyles;
@@ -3898,7 +3898,7 @@ void T2DMap::slot_setCustomLine()
     mpCurrentLineArrow->setChecked(mCurrentLineArrow);
     mpCurrentLineColor->setStyleSheet("background-color:" + mCurrentLineColor.name());
     connect(specialExits, SIGNAL(itemClicked(QTreeWidgetItem *,int)), this, SLOT(slot_setCustomLine2B(QTreeWidgetItem*, int)));
-    connect(mpCurrentLineColor, SIGNAL(pressed()), this, SLOT(slot_customLineColor()));
+    connect(mpCurrentLineColor, SIGNAL(clicked()), this, SLOT(slot_customLineColor()));
     d->show();
     d->raise();
 }

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1647,14 +1647,14 @@ void dlgRoomExits::init( int id ) {
 // We now do not connect up all these things until AFTER we have initialised
 // things as some controls will issue unwanted signals upon setting values into
 // them as we have above...
-    connect( button_save,          SIGNAL(pressed()),                            this, SLOT(slot_endEditSpecialExits()));
-    connect( button_save,          SIGNAL(pressed()),                            this, SLOT(slot_checkModified()));
-    connect( button_save,          SIGNAL(pressed()),                            this, SLOT(save()));
-    connect( button_addSpecialExit,SIGNAL(pressed()),                            this, SLOT(slot_addSpecialExit()));
+    connect( button_save,          SIGNAL(clicked()),                            this, SLOT(slot_endEditSpecialExits()));
+    connect( button_save,          SIGNAL(clicked()),                            this, SLOT(slot_checkModified()));
+    connect( button_save,          SIGNAL(clicked()),                            this, SLOT(save()));
+    connect( button_addSpecialExit,SIGNAL(clicked()),                            this, SLOT(slot_addSpecialExit()));
     connect( specialExits,         SIGNAL(itemClicked( QTreeWidgetItem *, int)), this, SLOT(slot_editSpecialExit(QTreeWidgetItem *, int)));
     connect( specialExits,         SIGNAL(itemClicked( QTreeWidgetItem *, int)), this, SLOT(slot_checkModified()));
-    connect( button_endEditing,    SIGNAL(pressed()),                            this, SLOT(slot_endEditSpecialExits()));
-    connect( button_endEditing,    SIGNAL(pressed()),                            this, SLOT(slot_checkModified()));
+    connect( button_endEditing,    SIGNAL(clicked()),                            this, SLOT(slot_endEditSpecialExits()));
+    connect( button_endEditing,    SIGNAL(clicked()),                            this, SLOT(slot_checkModified()));
     connect( nw,                   SIGNAL(textEdited(const QString &)),          this, SLOT(slot_nw_textEdited(const QString &)));
     connect( n,                    SIGNAL(textEdited(const QString &)),          this, SLOT(slot_n_textEdited(const QString &)));
     connect( ne,                   SIGNAL(textEdited(const QString &)),          this, SLOT(slot_ne_textEdited(const QString &)));

--- a/src/ui/custom_lines.ui
+++ b/src/ui/custom_lines.ui
@@ -533,19 +533,20 @@ Custom Line?</string>
       <item row="4" column="0">
        <widget class="QPushButton" name="button_cancel">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
-          <width>50</width>
-          <height>20</height>
+          <width>85</width>
+          <height>27</height>
          </size>
         </property>
         <property name="toolTip">
-         <string>To remove a custom line, select it and right-click to obtain a &quot;delete&quot; option.</string>
+         <string>To remove a custom line, cancel this dialog,
+select the line and right-click to obtain a &quot;delete&quot; option.</string>
         </property>
         <property name="layoutDirection">
          <enum>Qt::RightToLeft</enum>

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1965,21 +1965,33 @@
      <property name="enabled">
       <bool>false</bool>
      </property>
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string>Use this button to save any changes, will also remove any invalid Special exits.</string>
      </property>
      <property name="text">
-      <string>Save</string>
+      <string>&amp;Save</string>
      </property>
     </widget>
    </item>
    <item row="2" column="4">
     <widget class="QPushButton" name="button_cancel">
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string>Use this button to close the dialogue without changing anything.</string>
      </property>
      <property name="text">
-      <string>Cancel</string>
+      <string>&amp;Cancel</string>
      </property>
     </widget>
    </item>
@@ -2106,6 +2118,12 @@ or LUA script</string>
    </item>
    <item row="2" column="0">
     <widget class="QPushButton" name="button_addSpecialExit">
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string>Add an empty item to Special exits to be edited as required</string>
      </property>
@@ -2118,6 +2136,12 @@ or LUA script</string>
     <widget class="QPushButton" name="button_endEditing">
      <property name="enabled">
       <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
      </property>
      <property name="toolTip">
       <string>Press this button to deactivate the selection of a Special exit</string>
@@ -2180,17 +2204,17 @@ or LUA script</string>
   </property>
  </designerdata>
  <buttongroups>
+  <buttongroup name="doortype_nw"/>
   <buttongroup name="doortype_n"/>
   <buttongroup name="doortype_ne"/>
-  <buttongroup name="doortype_nw"/>
-  <buttongroup name="doortype_se"/>
-  <buttongroup name="doortype_out"/>
+  <buttongroup name="doortype_up"/>
+  <buttongroup name="doortype_w"/>
+  <buttongroup name="doortype_e"/>
+  <buttongroup name="doortype_down"/>
   <buttongroup name="doortype_sw"/>
   <buttongroup name="doortype_s"/>
+  <buttongroup name="doortype_se"/>
   <buttongroup name="doortype_in"/>
-  <buttongroup name="doortype_up"/>
-  <buttongroup name="doortype_down"/>
-  <buttongroup name="doortype_e"/>
-  <buttongroup name="doortype_w"/>
+  <buttongroup name="doortype_out"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
...ked()

Removed the fixed constraint on the cancel button on the custom_lines.ui
form - as on some systems it was too narrow - it now fills the available
width of the dialog.  I clarified the tool-tip for this button slightly
to make the information more closely match reality

Following comments from Vadim, changed code associated with all buttons on
this form to use the clicked() signal rather than the previous pressed()
one.

Also correct a spelling mistake in several error messages.

Noting the same usage on the room_exits.ui form, performed the SAME change
from pressed() to clicked() signals there.

Also to avoid any squishing of the four buttons on the bottom of THAT
dialog set uniform minimum sizes for them.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
