### PR TITLE
Add a 'check' target for better testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 script:
   - qmake && make -j2
   - cd ../build
-  - if [ -z "${TRAVIS_OS_NAME}" ] || [ "${TRAVIS_OS_NAME}" = "linux" ]; then cmake .. && make -j2 && make test; fi
+  - if [ -z "${TRAVIS_OS_NAME}" ] || [ "${TRAVIS_OS_NAME}" = "linux" ]; then cmake .. && make -j2 && make check; fi
 notifications:
   webhooks:
     urls:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ ELSE()
   CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
 ENDIF()
 
+IF(CMAKE_CONFIGURATION_TYPES)
+  ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    --force-new-ctest-process --output-on-failure
+                    --build-config "$<CONFIGURATION>")
+ELSE()
+  ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    --force-new-ctest-process --output-on-failure)
+ENDIF()
+
 ENABLE_TESTING()
 
 IF(POLICY CMP0020)


### PR DESCRIPTION
This makes CTest output the results of failed tests, by default.
