### PR TITLE
Separate creating the mudlet instance from accessing it.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -420,6 +420,7 @@ int main(int argc, char *argv[])
         splash.showMessage(startupMessage.join("\n"), Qt::AlignHCenter|Qt::AlignBottom);
         app->processEvents();
 
+        mudlet::start();
         splash.finish( mudlet::self() );
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -80,14 +80,15 @@ QPointer<TConsole> mudlet::mpDebugConsole = 0;
 QScopedPointer<QMainWindow> mudlet::mpDebugArea;
 bool mudlet::debugMode = false;
 
-mudlet * mudlet::_self = 0;
+QPointer<mudlet> mudlet::_self;
+
+void mudlet::start()
+{
+    _self = new mudlet;
+}
 
 mudlet * mudlet::self()
 {
-    if( ! _self )
-    {
-        _self = new mudlet;
-    }
     return _self;
 }
 
@@ -2272,6 +2273,7 @@ void mudlet::slot_stopAllTriggers()
 
 mudlet::~mudlet()
 {
+    mudlet::_self = 0;
 }
 
 void mudlet::toggleFullScreenView()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -63,6 +63,8 @@ public:
                                  mudlet();
                                 ~mudlet();
    static                        mudlet * self();
+   // This method allows better debugging when mudlet::self() is called inappropriately.
+   static                        void start();
    void                          addSubWindow(TConsole* p);
    int                           getColumnNumber( Host * pHost, QString & name );
    int                           getLineNumber( Host * pHost, QString & name );
@@ -235,7 +237,7 @@ private:
    QQueue<QString>               tempLoginQueue;
    QQueue<QString>               tempPassQueue;
    QQueue<Host *>                tempHostQueue;
-   static                        mudlet * _self;
+   static                        QPointer<mudlet> _self;
    QMap<QString, QDockWidget *>  dockWindowMap;
    //QMap<QString, TConsole *>     dockWindowConsoleMap;
    //QMap<QString, TLabel *>>       mLabelMap;


### PR DESCRIPTION
In situations where something tries to access mudlet (the class), after it
is destructed, make it easier to tell what is going on.
