### PR TITLE
Tidyup: moved some replay globals out of header, renaming some others

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1566,8 +1566,8 @@ void cTelnet::_loadReplay()
                offset / 1000.0,
                offset / (1000.0 * mudlet::self()->mReplaySpeed));
         loadBuffer[loadedBytes] = '\0'; // Previous use of loadedBytes + 1 caused a spurious character at end of string display by a qDebug of the loadBuffer contents
-        QTimer::singleShot( offset/mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
         mudlet::self()->mReplayTime = mudlet::self()->mReplayTime.addMSecs(offset);
+        QTimer::singleShot(offset / mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
     }
     else
     {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2317,6 +2317,11 @@ void mudlet::replayStart()
     txt.append("X</b></font>");
     replaySpeedDisplay->setText(txt);
 
+    replayTimer = new QTimer(this);
+    replayTimer->setInterval(1000);
+    replayTimer->setSingleShot(false);
+    connect(replayTimer, SIGNAL(timeout()), this, SLOT(slot_replayTimeChanged()));
+
     QString txt2 = "<font size=25><b>Time:";
     txt2.append( mReplayTime.toString( timeFormat ) );
     txt2.append("</b></font>");
@@ -2326,10 +2331,6 @@ void mudlet::replayStart()
     replayTime->show();
     insertToolBar( mpMainToolBar, replayToolBar );
     replayToolBar->show();
-    replayTimer = new QTimer( this );
-    replayTimer->setInterval(1000);
-    replayTimer->setSingleShot( false );
-    connect( replayTimer, SIGNAL( timeout() ), this, SLOT(slot_replayTimeChanged()));
     replayTimer->start();
 }
 


### PR DESCRIPTION
Global items renamed (and moved from middle of .cpp file to top, only used
within class file):
QAction \* actionSpeedDisplay    ==> pActionSpeedDisplay
QAction \* actionReplayTime      ==> pActionReplayTime
QLabel \* replaySpeedDisplay     ==> pReplaySpeedDisplay
QLabel \* replayTime             ==> pReplayTime
QTimer \* replayTimer            ==> pReplayTimer
QToolBar \* replayToolBar        ==> pReplayToolBar

Global items moved out of class header (as not used outside of class files):
QAction \* actionReplaySpeedUp   ==> pActionReplaySpeedUp
QAction \* actionReplaySpeedDown ==> pActionReplaySpeedDown

Signed-off-by: Stephen Lyons slysven@virginmedia.com
