### PR TITLE
Fix warnings.

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -812,7 +812,7 @@ bool TMap::findPath( int from, int to )
                        predecessor_map(&p[0]).distance_map(&d[0]).
                        visitor(astar_goal_visitor<vertex>(goal)) );
      }
-     catch( found_goal fg )
+     catch( found_goal )
      {
          qDebug()<<"time elapsed in astar:"<<t.elapsed();
          t.restart();

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -290,10 +290,7 @@ bool TTrigger::match_perl( char * subject, QString & toMatch, int regexNumber, i
 
     if( rc < 0 )
     {
-        switch(rc)
-        {
-             return false;
-        }
+        return false;
     }
     if( rc > 0 )
     {


### PR DESCRIPTION
One instance of a unnecessary switch statement.
One instance of an unreferenced parameter.
