### PR TITLE
Make HostManager a member of mudlet (the class).

### DIFF
--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -23,6 +23,7 @@
 
 
 #include "Host.h"
+#include "mudlet.h"
 
 #include "pre_guard.h"
 #include <QDir>
@@ -32,21 +33,9 @@
 #include <ostream>
 
 
-QScopedPointer<HostManager> HostManager::_self;
-
 HostManager * HostManager::self()
 {
-    if( ! _self )
-    {
-        _self.reset( new HostManager );
-        _self->init();
-    }
-    return _self.data();
-}
-
-void HostManager::init()
-{
-    mpActiveHost = 0;
+    return mudlet::self()->getHostManager();
 }
 
 Host * HostManager::getHost( QString hostname )

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -39,6 +39,7 @@ class HostManager
 {
 public:
 
+                       HostManager() : mpActiveHost() {}
     static             HostManager * self();
     Host *             getHost( QString hostname );
     Host *             getHost( std::string hostname );
@@ -53,13 +54,7 @@ public:
 
 private:
 
-                        HostManager(){;}
-    void                init();
-
-
-    static QScopedPointer<HostManager> _self;
     HostPool            mHostPool;
-    QMutex              mLock;
     Host *              mpActiveHost;
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -425,7 +425,6 @@ int main(int argc, char *argv[])
     }
 
     mudlet::debugMode = false;
-    HostManager::self();
     FontManager fm;
     fm.addFonts();
     QString home = QDir::homePath()+"/.config/mudlet";

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -272,8 +272,8 @@ mudlet::mudlet()
     disableToolbarButtons();
 
     mpDebugArea.reset( new QMainWindow(0) );
-    HostManager::self()->addHost("default_host", "", "","" );
-    mpDefaultHost = HostManager::self()->getHost(QString("default_host"));
+    mHostManager.addHost("default_host", "", "","" );
+    mpDefaultHost = mHostManager.getHost(QString("default_host"));
     mpDebugConsole = new TConsole( mpDefaultHost, true );
     mpDebugConsole->setSizePolicy( sizePolicy );
     mpDebugConsole->setWrapAt(100);
@@ -410,6 +410,11 @@ mudlet::mudlet()
     mpMusicBox3 = new QMediaPlayer;
     mpMusicBox4 = new QMediaPlayer;
 
+}
+
+HostManager * mudlet::getHostManager()
+{
+    return &mHostManager;
 }
 
 bool mudlet::moduleTableVisible()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -65,6 +65,7 @@ public:
    static                        mudlet * self();
    // This method allows better debugging when mudlet::self() is called inappropriately.
    static                        void start();
+   HostManager *                 getHostManager();
    void                          addSubWindow(TConsole* p);
    int                           getColumnNumber( Host * pHost, QString & name );
    int                           getLineNumber( Host * pHost, QString & name );
@@ -262,6 +263,7 @@ private:
    QPushButton *                 moduleInstallButton;
    QPushButton *                 moduleHelpButton;
 
+   HostManager                   mHostManager;
 };
 
 class TConsoleMonitor : public QObject


### PR DESCRIPTION
This approach, rather than using a global singleton, makes it so that its
lifetime is better understood. Also fixes the crashes that have been occurring.
