### PR TITLE
Fix sendMSDP to actually work 

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4953,6 +4953,15 @@ int TLuaInterpreter::sendGMCP( lua_State *L )
     return 0;
 }
 
+#define    MSDP_VAR              1
+#define    MSDP_VAL              2
+#define    MSDP_TABLE_OPEN      3
+#define    MSDP_TABLE_CLOSE      4
+#define    MSDP_ARRAY_OPEN      5
+#define    MSDP_ARRAY_CLOSE      6
+#define    IAC 255
+#define    SB 250
+#define    SE 240
 int TLuaInterpreter::sendMSDP( lua_State *L )
 {
     string msg;
@@ -4975,11 +4984,12 @@ int TLuaInterpreter::sendMSDP( lua_State *L )
     string _h;
     _h += TN_IAC;
     _h += TN_SB;
-    _h += 69; //MSDP
+    _h += MSDP;
+    _h += MSDP_VAR;
     _h += msg;
     if( what != "" )
     {
-        _h += " ";
+        _h += MSDP_VAL;
         _h += what;
     }
     _h += TN_IAC;
@@ -10174,15 +10184,6 @@ void TLuaInterpreter::parseJSON( QString & key, QString & string_data, QString p
     lua_pop( L, lua_gettop( L ) );
 }
 
-#define    MSDP_VAR              1
-#define    MSDP_VAL              2
-#define    MSDP_TABLE_OPEN      3
-#define    MSDP_TABLE_CLOSE      4
-#define    MSDP_ARRAY_OPEN      5
-#define    MSDP_ARRAY_CLOSE      6
-#define    IAC 255
-#define    SB 250
-#define    SE 240
 #define BUFFER_SIZE 20000
 void TLuaInterpreter::msdp2Lua(char *src, int srclen)
 {

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -69,6 +69,7 @@ const char TN_EOR = 239;
 
 const char GMCP = 201; /* GMCP */
 const char MXP = 91; // MXP
+const char MSDP = 69; // MSDP, documented at http://tintin.sourceforge.net/msdp/
 
 const char OPT_ECHO = 1;
 const char OPT_SUPPRESS_GA = 3;


### PR DESCRIPTION
It wasn't following the specification per http://tintin.sourceforge.net/msdp/ perviously. Since we introduced MSDP in 3.0, we should release a functional version...
