### PR TITLE
BugFix: Prevent crash when starting with -q(uiet) command line argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,6 +480,8 @@ int main(int argc, char *argv[])
         mudlet::start();
         splash.finish( mudlet::self() );
     }
+    else
+        mudlet::start();
 
     mudlet::debugMode = false;
     FontManager fm;


### PR DESCRIPTION
Recent change failed to spot alternate program flow when splash-screen
suppressed with -q / --quiet command line argument.  mudlet singleton was
not being instantiated in this case causing crash.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
