### PR TITLE
BugFix: Fix underlines AND italics in HTML copy.

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3095,7 +3095,7 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
     // - so use as initialization values
     QString fontWeight;
     QString fontStyle;
-    QString fontDecoration;
+    QString textDecoration;
     bool needChange = true;
     for( ; x<P2.x(); x++ )
     {
@@ -3127,13 +3127,13 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
             else
                 fontWeight = "normal";
             if( italics )
-                fontStyle = "italics";
+                fontStyle = "italic";
             else
                 fontStyle = "normal";
             if( underline )
-                fontDecoration = "underline";
+                textDecoration = "underline";
             else
-                fontDecoration = "normal";
+                textDecoration = "normal";
             s += "</span><span style=\"";
             s += "color: rgb(" + QString::number(fgR) + ","
                                + QString::number(fgG) + ","
@@ -3143,7 +3143,7 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
                                      + QString::number(bgB) + ");";
             s += " font-weight: " + fontWeight +
                  "; font-style: " + fontStyle +
-                 "; font-decoration: " + fontDecoration + "\">";
+                 "; text-decoration: " + textDecoration + "\">";
         }
         if( lineBuffer[y][x] == '<' )
             s.append("&lt;");

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1202,7 +1202,7 @@ QString TConsole::assemble_html_font_specs()
     }
     s += " font-weight: " + m_LoggerfontSpecs.getFontWeight() +
         "; font-style: " + m_LoggerfontSpecs.getFontStyle() +
-        "; font-decoration: " + m_LoggerfontSpecs.getFontDecoration() +
+        "; text-decoration: " + m_LoggerfontSpecs.getTextDecoration() +
         "\">";
     return s;
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -53,16 +53,9 @@ class TFontSpecsLogger
 {
 public:
     TFontSpecsLogger(){ reset(); }
-    QString getFontWeight()
-    {
-        if(bold)
-        {
-            return QString("bold");
-        }
-        else return QString("normal");
-    }
-    QString getFontStyle(){ return (italics) ? QString("italics") : QString("normal");}
-    QString getFontDecoration(){ return (underline) ? QString("underline") : QString("normal");}
+    QString getFontWeight(){ return (bold) ? QString("bold") : QString("normal");}
+    QString getFontStyle(){ return (italics) ? QString("italic") : QString("normal");}
+    QString getTextDecoration(){ return (underline) ? QString("underline") : QString("normal");}
     void reset()
     {
         bold = false;


### PR DESCRIPTION
The CSS declaration for underline (and overline and strike-through) is
introduce by the words "text-decoration" NOT "font-decoration", this commit
fixes that error. https://bugs.launchpad.net/mudlet/+bug/1130450 raised
this issue and is solved by it.

Also the CSS declaration for a font-style of sloping text derived from a
font that is constructed for that sloping text is "italic" singular NOT
"italics" plural.  N.B. The other alternative to "normal" is "oblique"
which specifies sloping text derived from a font that is upright but
converted to sloping by algorithm rather than definition...!  Correcting
this solves: https://bugs.launchpad.net/mudlet/+bug/1102360

This is a bare-bones commit that addresses these issues only. Further work
is planned to produce Html that is both actually valid and more compact,
there are still other issues to be addressed.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
