### PR TITLE
Fix: Revise HTML producing code to produce VALID html

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -89,7 +89,7 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
 , mpNotePad( 0 )
 , mPort(port)
 , mPrintCommand( true )
-, mRawStreamDump( false )
+, mIsCurrentLogFileInHtmlFormat( false )
 , mResetProfile( false )
 , mRetries( 5 )
 , mSaveProfileOnExit( false )

--- a/src/Host.h
+++ b/src/Host.h
@@ -205,7 +205,21 @@ public:
     int                mPort;
     bool               mPrintCommand;
     QString            mPrompt;
-    bool               mRawStreamDump;
+                       // The following was incorrectly called mRawStreamDump
+                       // and caused the log file to be in HTML format rather
+                       // then plain text.  To cover the corner case of the user
+                       // changing the mode whilst a log is being written it has
+                       // been split into:
+    bool               mIsNextLogFileInHtmlFormat;
+                       // What the user has set as their preference
+    bool               mIsCurrentLogFileInHtmlFormat;
+                       // What the current file will use, set from the previous
+                       // member at the point that logging starts.
+                       // Ideally this ought to become a number so that we can
+                       // support more than two logging format modes - phpBB
+                       // format would be useful for those wanting to post to
+                       // MUD forums...!  Problem will be reading and write the
+                       // game save file in a compatible way.
     QString            mReplacementCommand;
     QString            mRest;
     bool               mResetProfile;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -489,11 +489,9 @@ NORMAL_ANSI_COLOR_TAG:
         break;
     case 27:
         break; //FIXME inverse off
-    case 28:
-        mStrikeOut = false;
-        break; 
     case 29:
-        break; //FIXME
+        mStrikeOut = false;
+        break;
     case 30:
         fgColorR = mBlackR;
         fgColorG = mBlackG;
@@ -1820,40 +1818,42 @@ void TBuffer::append(const QString & text,
                       bool strikeout,
                       int linkID )
 {
-    if( static_cast<int>(buffer.size()) > mLinesLimit )
-    {
+    const QString lineBreaks = QStringLiteral( ",.- " );
+
+    if( static_cast<int>(buffer.size()) > mLinesLimit ) {
         shrinkBuffer();
     }
     int last = buffer.size()-1;
-    if( last < 0 )
-    {
+    if( last < 0 ) {
         std::deque<TChar> newLine;
         TChar c(fgColorR,fgColorG,fgColorB,bgColorR,bgColorG,bgColorB,bold,italics,underline,strikeout);
-        if( mEchoText )
+        if( mEchoText ) {
             c.flags |= TCHAR_ECHO;
+        }
         newLine.push_back( c );
         buffer.push_back( newLine );
         lineBuffer.push_back(QString());
-        timeBuffer << (QTime::currentTime()).toString("hh:mm:ss.zzz") + "   ";
+        timeBuffer << QTime::currentTime().toString(QStringLiteral("hh:mm:ss.zzz   "));
         promptBuffer << false;
         dirty << true;
         last = 0;
     }
     bool firstChar = (lineBuffer.back().size() == 0);
     int length = text.size();
-    if( length < 1 ) return;
-    if( sub_end >= length ) sub_end = text.size()-1;
+    if( length < 1 ) {
+        return;
+    }
+    if( sub_end >= length ) {
+        sub_end = text.size()-1;
+    }
 
-    for( int i=sub_start; i<length; i++ )//FIXME <=substart+sub_end muss nachsehen, ob wirklich noch teilbereiche gebraucht werden
-    {
-        if( text.at(i) == '\n' )
-        {
+    for( int i=sub_start; i<length; i++ ) {//FIXME <=substart+sub_end muss nachsehen, ob wirklich noch teilbereiche gebraucht werden
+        if( text.at(i) == '\n' ) {
             log(size()-1, size()-1);
             std::deque<TChar> newLine;
             buffer.push_back( newLine );
             lineBuffer.push_back( QString() );
-            QString time = "-----";
-            timeBuffer << time;
+            timeBuffer << QStringLiteral( "-----" );
             promptBuffer << false;
             dirty << true;
             mLastLine++;
@@ -1861,24 +1861,17 @@ void TBuffer::append(const QString & text,
             firstChar = true;
             continue;
         }
-        if( lineBuffer.back().size() >= mWrapAt )
-        {
-            const QString lineBreaks = ",.- ";
-            const QString nothing = "";
-            for( int i=lineBuffer.back().size()-1; i>=0; i-- )
-            {
-                if( lineBreaks.indexOf( lineBuffer.back().at(i) ) > -1 )
-                {
+        if( lineBuffer.back().size() >= mWrapAt ) {
+            for( int i=lineBuffer.back().size()-1; i>=0; i-- ) {
+                if( lineBreaks.indexOf( lineBuffer.back().at(i) ) > -1 ) {
                     QString tmp = lineBuffer.back().mid(0,i+1);
                     QString lineRest = lineBuffer.back().mid(i+1);
                     lineBuffer.back() = tmp;
                     std::deque<TChar> newLine;
 
                     int k = lineRest.size();
-                    if( k > 0 )
-                    {
-                        while( k > 0 )
-                        {
+                    if( k > 0 ) {
+                        while( k > 0 ) {
                             newLine.push_front(buffer.back().back());
                             buffer.back().pop_back();
                             k--;
@@ -1886,28 +1879,33 @@ void TBuffer::append(const QString & text,
                     }
 
                     buffer.push_back( newLine );
-                    if( lineRest.size() > 0 )
+                    if( lineRest.size() > 0 ) {
                         lineBuffer.append( lineRest );
-                    else
-                        lineBuffer.append( nothing );
-                    QString time = "-----";
-                    timeBuffer << time;
+                    }
+                    else {
+                        lineBuffer.append( QString() );
+                    }
+                    timeBuffer << QStringLiteral( "-----" );
                     promptBuffer << false;
                     dirty << true;
                     mLastLine++;
                     newLines++;
+                    log(size()-2, size()-2);
+                    // Was absent causing loss of all but last line of wrapped
+                    // long lines of user input and some other console displayed
+                    // test from log file.
                     break;
                 }
             }
         }
         lineBuffer.back().append( text.at( i ) );
         TChar c(fgColorR,fgColorG,fgColorB,bgColorR,bgColorG,bgColorB,bold,italics,underline,strikeout,linkID);
-        if( mEchoText )
+        if( mEchoText ) {
             c.flags |= TCHAR_ECHO;
+        }
         buffer.back().push_back( c );
-        if( firstChar )
-        {
-            timeBuffer.back() = (QTime::currentTime()).toString("hh:mm:ss.zzz") + "   ";
+        if( firstChar ) {
+            timeBuffer.back() = QTime::currentTime().toString( QStringLiteral( "hh:mm:ss.zzz   " ) );
         }
     }
 }
@@ -3134,24 +3132,25 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
     int y = P1.y();
     int x = P1.x();
     QString s;
-    if( y < 0 || y >= static_cast<int>(buffer.size()) )
+    if( y < 0 || y >= static_cast<int>(buffer.size()) ) {
         return s;
+    }
 
     if( ( x < 0 )
         || ( x >= static_cast<int>(buffer[y].size()) )
-        || ( P2.x() >= static_cast<int>(buffer[y].size()) ) )
-    {
+        || ( P2.x() >= static_cast<int>(buffer[y].size()) ) ) {
         x=0;
     }
-    if( P2.x() < 0 )
-    {
+    if( P2.x() < 0 ) {
         P2.setX(buffer[y].size());
     }
 
     bool bold = false;
     bool italics = false;
     bool underline = false;
+    bool overline = false;
     bool strikeout = false;
+    bool inverse = false;
     int fgR=0;
     int fgG=0;
     int fgB=0;
@@ -3163,12 +3162,12 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
     QString fontWeight;
     QString fontStyle;
     QString textDecoration;
-    bool needChange = true;
-    for( ; x<P2.x(); x++ )
-    {
-        if( x >= static_cast<int>(buffer[y].size()) )
+    bool firstSpan = true;
+    for( ; x<P2.x(); x++ ) {
+        if( x >= static_cast<int>(buffer[y].size()) ) {
             break;
-        if( needChange
+        }
+        if( firstSpan
             || buffer[y][x].fgR != fgR
             || buffer[y][x].fgG != fgG
             || buffer[y][x].fgB != fgB
@@ -3177,13 +3176,17 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
             || buffer[y][x].bgB != bgB
             || bool( buffer[y][x].flags & TCHAR_BOLD ) != bold
             || bool( buffer[y][x].flags & TCHAR_UNDERLINE ) != underline
-            || bool( buffer[y][x].flags & TCHAR_ITALICS ) != italics 
-            || bool( buffer[y][x].flags & TCHAR_STRIKEOUT ) != strikeout ) 
-        {
-            if( needChange )
-                needChange = false; // The first span won't need to close the previous one
-            else
+            || bool( buffer[y][x].flags & TCHAR_ITALICS ) != italics
+            || bool( buffer[y][x].flags & TCHAR_STRIKEOUT ) != strikeout
+//            || bool( buffer[y][x].flags & TCHAR_OVERLINE ) != overline
+//            || bool( buffer[y][x].flags & TCHAR_INVERSE ) != inverse
+            ) { // Can leave this on a separate line until line above uncommented.
+            if( firstSpan ) {
+                firstSpan = false; // The first span won't need to close the previous one
+            }
+            else {
                 s += "</span>";
+            }
             fgR = buffer[y][x].fgR;
             fgG = buffer[y][x].fgG;
             fgB = buffer[y][x].fgB;
@@ -3194,46 +3197,63 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
             italics = buffer[y][x].flags & TCHAR_ITALICS;
             underline = buffer[y][x].flags & TCHAR_UNDERLINE;
             strikeout = buffer[y][x].flags & TCHAR_STRIKEOUT;
-            if( bold )
+//            overline = buffer[y][x].flags & TCHAR_OVERLINE;
+//            inverse = buffer[y][x].flags & TCHAR_INVERSE;
+            if( bold ) {
                 fontWeight = "bold";
-            else
+            }
+            else {
                 fontWeight = "normal";
-            if( italics )
+            }
+            if( italics ) {
                 fontStyle = "italic";
-            else
+            }
+            else {
                 fontStyle = "normal";
-            //In CSS the underline and line-through are mutually exclusive.
-            //Workarounds exist but are clumsy and will be avoided. We will
-            //give underline priority.
-            if( underline )
-                textDecoration = "underline";
-            else if ( strikeout )
-                textDecoration = "line-through";
-            else
+            }
+            if( ! (underline || strikeout || overline) ) {
                 textDecoration = "normal";
+            }
+            else {
+                textDecoration = "";
+                if( underline ) {
+                    textDecoration += "underline ";
+                }
+                if( strikeout ) {
+                    textDecoration += "line-through ";
+                }
+                if( overline ) {
+                    textDecoration += "overline ";
+                }
+                textDecoration = textDecoration.trimmed();
+            }
             s += "<span style=\"";
-            s += "color: rgb(" + QString::number(fgR) + ","
-                               + QString::number(fgG) + ","
-                               + QString::number(fgB) + ");";
-            s += " background: rgb(" + QString::number(bgR) + ","
-                                     + QString::number(bgG) + ","
-                                     + QString::number(bgB) + ");";
+            s += "color: rgb(" + QString::number(inverse ? bgR : fgR) + ","
+                               + QString::number(inverse ? bgG : fgG) + ","
+                               + QString::number(inverse ? bgB : fgB) + ");";
+            s += " background: rgb(" + QString::number(inverse ? fgR : bgR) + ","
+                                     + QString::number(inverse ? fgG : bgG) + ","
+                                     + QString::number(inverse ? fgB : bgB) + ");";
             s += " font-weight: " + fontWeight +
                  "; font-style: " + fontStyle +
                  "; text-decoration: " + textDecoration + "\">";
         }
-        if( lineBuffer[y][x] == '<' )
+        if( lineBuffer[y][x] == '<' ) {
             s.append("&lt;");
-        else if( lineBuffer[y][x] == '>' )
+        }
+        else if( lineBuffer[y][x] == '>' ) {
             s.append("&gt;");
-        else
+        }
+        else {
             s.append(lineBuffer[y][x]);
+        }
     }
-    if( s.size() > 0 )
+    if( s.size() > 0 ) {
         s.append("</span>");
         // Needed to balance the very first open <span>, but only if we have
         // included anything. the previously appearing <br /> is an XML tag, NOT
         // a (strict) HTML 4 one
+    }
 
     s.append( QStringLiteral( "<br>\n" ) );
     // Needed to reproduce empty lines in capture, as this method is called for
@@ -3245,7 +3265,7 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
     // formatting. To get the line feeds at the end of displayed HTML lines the
     // <br> is used.  This slightly weird way of doing things is so that some
     // on-line tools preserve the formatting when the HTML-lised selection is
-    // pasted to them and AND retain the ability to paste the HTML from the
+    // pasted to them AND retain the ability to paste the HTML from the
     // clipboard into a plain text editor and not have everything on one line in
     // that editor!
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2384,7 +2384,7 @@ void TBuffer::log( int from, int to )
             {
 
                 QString toLog;
-                if( mpHost->mRawStreamDump )
+                if( mpHost->mIsCurrentLogFileInHtmlFormat )
                 {
                     QPoint P1 = QPoint(0,i);
                     QPoint P2 = QPoint( buffer[i].size(), i);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -94,7 +94,6 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
 , mWindowIsHidden( false )
 , mWrapAt( 100 )
 , networkLatency( new QLineEdit )
-, mLastBufferLogLine( 0 )
 , mUserAgreedToCloseConsole( false )
 , mpBufferSearchBox( new QLineEdit )
 , mpBufferSearchUp( new QToolButton )
@@ -396,7 +395,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     logButton->setCheckable( true );
     logButton->setSizePolicy( sizePolicy5 );
     logButton->setFocusPolicy( Qt::NoFocus );
-    logButton->setToolTip( tr("start logging MUD output to log file") );
+    logButton->setToolTip( tr("<html><head/><body><p>Start logging MUD output to log file.</p></body></html>") );
     logButton->setIcon( QIcon( QStringLiteral( ":/icons/folder-downloads.png" ) ) );
     connect( logButton, SIGNAL(pressed()), this, SLOT(slot_toggleLogging()));
 
@@ -857,47 +856,49 @@ int TConsole::getButtonState()
 
 void TConsole::slot_toggleLogging()
 {
-    if( mIsDebugConsole || mIsSubConsole )
+    if( mIsDebugConsole || mIsSubConsole ) {
         return;
         // We don't support logging anything other than main console (at present?)
+    }
 
-    mLogToLogFile = ! mLogToLogFile;
-    //mpHost->mLogStatus = mLogToLogFile;
-    if( mLogToLogFile )
-    {
+    if( ! mLogToLogFile ) {
         QFile file( QDir::homePath()+"/.config/mudlet/autolog" );
         file.open( QIODevice::WriteOnly | QIODevice::Text );
         QTextStream out(&file);
         file.close();
-    }
-    else
-    {
-       QFile file( QDir::homePath()+"/.config/mudlet/autolog" );
-       file.remove();
-    }
-    if( mLogToLogFile )
-    {
-        mLastBufferLogLine = buffer.size();
+
         QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
         mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("yyyy-MM-dd#hh-mm-ss");
         // Revised file name derived from time so that alphabetical filename and
         // date sort order are the same...
         QDir dirLogFile;
-        if( ! dirLogFile.exists( directoryLogFile ) )
+        if( ! dirLogFile.exists( directoryLogFile ) ) {
             dirLogFile.mkpath( directoryLogFile );
+        }
 
-        if( mpHost->mRawStreamDump )
+        if( mpHost->mRawStreamDump ) {
             mLogFileName.append(".html");
-        else
+        }
+        else {
             mLogFileName.append(".txt");
-
+        }
         mLogFile.setFileName( mLogFileName );
         mLogFile.open( QIODevice::WriteOnly );
         mLogStream.setDevice( &mLogFile );
         QString message = QString("Logging has started. Log file is ") + mLogFile.fileName() + "\n";
         printSystemMessage( message );
-        if( mpHost->mRawStreamDump )
-        {
+        // This puts text onto console that WOULD IMMEDIATELY BE POSTED into log
+        // file so must be done BEFORE logging starts - or actually mLogToLogFile gets set!
+        mLogToLogFile = true;
+    }
+    else {
+        QFile file( QDir::homePath()+"/.config/mudlet/autolog" );
+        file.remove();
+        mLogToLogFile = false;
+    }
+
+    if( mLogToLogFile ) {
+        if( mpHost->mRawStreamDump ) {
             QStringList fontsList; // List of fonts to become the font-family entry for
                                    // the master css in the header
             fontsList << this->fontInfo().family(); // Seems to be the best way to get the
@@ -932,12 +933,10 @@ void TConsole::slot_toggleLogging()
             // strict HTML 4 as we do not use <p></p>s or anything else
             mLogFile.flush();
         }
-        logButton->setToolTip( tr("stop logging MUD output to log file") );
+        logButton->setToolTip( tr("<html><head/><body><p>Stop logging MUD output to log file.</p></body></html>") );
     }
-    else
-    {
-        if( mpHost->mRawStreamDump )
-        {
+    else {
+        if( mpHost->mRawStreamDump ) {
             mLogStream << "</div></body>\n";
             mLogStream << "</html>\n";
         }
@@ -945,7 +944,7 @@ void TConsole::slot_toggleLogging()
         mLogFile.close();
         QString message = QString("Logging has been stopped. Log file is ") + mLogFile.fileName() + "\n";
         printSystemMessage( message );
-        logButton->setToolTip( tr("start logging MUD output to log file") );
+        logButton->setToolTip( tr("<html><head/><body><p>Start logging MUD output to log file.</p></body></html>") );
     }
 }
 
@@ -1150,44 +1149,7 @@ void TConsole::printOnDisplay( std::string & incomingSocketData )
     mTriggerEngineMode = true;
     buffer.translateToPlainText( incomingSocketData );
     mTriggerEngineMode = false;
-//    if( mLogToLogFile )
-//    {
-//        if( ! mIsDebugConsole )
-//        {
-//            if( buffer.size() < mLastBufferLogLine )
-//            {
-//                mLastBufferLogLine -= buffer.mBatchDeleteSize;
-//                qDebug()<<"---> RESETTING mLastBufferLogLine";
-//                if( mLastBufferLogLine < 0 )
-//                {
-//                    mLastBufferLogLine = 0;
-//                }
-//            }
-//            if( buffer.size() > mLastBufferLogLine + 1 )
-//            {
-//                for( int i=mLastBufferLogLine+1; i<buffer.size(); i++ )
-//                {
-//                    QString toLog;
-//                    if( mpHost->mRawStreamDump )
-//                    {
-//                        QPoint P1 = QPoint(0,i);
-//                        QPoint P2 = QPoint( buffer.buffer[i].size(), i);
-//                        toLog = buffer.bufferToHtml(P1, P2);
-//                    }
-//                    else
-//                    {
-//                        toLog = buffer.lineBuffer[i];
-//                        toLog.append("\n");
-//                    }
-//                    mLogStream << toLog;
-//                    qDebug()<<"LOG:"<<i<<" lastLogLine="<<mLastBufferLogLine<<" size="<<buffer.size()<<" toLog<"<<toLog<<">";
-//                    mLastBufferLogLine++;
-//                }
-//                mLastBufferLogLine--;
-//            }
-//            mLogStream.flush();
-//        }
-//    }
+
     double processT = mProcessingTime.elapsed();
     if( mpHost->mTelnet.mGA_Driver )
     {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -396,7 +396,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     logButton->setCheckable( true );
     logButton->setSizePolicy( sizePolicy5 );
     logButton->setFocusPolicy( Qt::NoFocus );
-    logButton->setToolTip("start logging MUD output to log file");
+    logButton->setToolTip( tr("start logging MUD output to log file") );
     logButton->setIcon( QIcon( QStringLiteral( ":/icons/folder-downloads.png" ) ) );
     connect( logButton, SIGNAL(pressed()), this, SLOT(slot_toggleLogging()));
 
@@ -857,7 +857,10 @@ int TConsole::getButtonState()
 
 void TConsole::slot_toggleLogging()
 {
-    if( mIsDebugConsole ) return;
+    if( mIsDebugConsole || mIsSubConsole )
+        return;
+        // We don't support logging anything other than main console (at present?)
+
     mLogToLogFile = ! mLogToLogFile;
     //mpHost->mLogStatus = mLogToLogFile;
     if( mLogToLogFile )
@@ -876,32 +879,73 @@ void TConsole::slot_toggleLogging()
     {
         mLastBufferLogLine = buffer.size();
         QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-        QString mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
+        mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("yyyy-MM-dd#hh-mm-ss");
+        // Revised file name derived from time so that alphabetical filename and
+        // date sort order are the same...
+        QDir dirLogFile;
+        if( ! dirLogFile.exists( directoryLogFile ) )
+            dirLogFile.mkpath( directoryLogFile );
+
         if( mpHost->mRawStreamDump )
-        {
             mLogFileName.append(".html");
-        }
         else
             mLogFileName.append(".txt");
 
-        QDir dirLogFile;
-        if( ! dirLogFile.exists( directoryLogFile ) )
-        {
-            dirLogFile.mkpath( directoryLogFile );
-        }
         mLogFile.setFileName( mLogFileName );
         mLogFile.open( QIODevice::WriteOnly );
         mLogStream.setDevice( &mLogFile );
-        if( mpHost->mRawStreamDump ) mLogStream << "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'><html><head><style><!-- *{ font-family: 'Courier New', 'Monospace', 'Courier';} *{ white-space: pre-wrap; } *{color:rgb(255,255,255);} *{background-color:rgb("<<mpHost->mBgColor.red()<<","<<mpHost->mBgColor.green()<<","<<mpHost->mBgColor.blue()<<");} --></style><meta http-equiv='content-type' content='text/html; charset=utf-8'></head><body>";
         QString message = QString("Logging has started. Log file is ") + mLogFile.fileName() + "\n";
         printSystemMessage( message );
+        if( mpHost->mRawStreamDump )
+        {
+            QStringList fontsList; // List of fonts to become the font-family entry for
+                                   // the master css in the header
+            fontsList << this->fontInfo().family(); // Seems to be the best way to get the
+                                                // font in use, as different TConsole
+                                                // instances within the same profile
+                                                // might have different fonts in future,
+                                                // and although the font is settable for
+                                                // the main profile window, it is not yet
+                                                // for user miniConsoles, or the Debug one
+            fontsList << QStringLiteral( "Courier New" );
+            fontsList << QStringLiteral( "Monospace" );
+            fontsList << QStringLiteral( "Courier" );
+            fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
+
+            mLogStream << "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
+            mLogStream << "<html>\n";
+            mLogStream << " <head>\n";
+            mLogStream << "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>";
+            // put the charset as early as possible as the parser MUST restart when it
+            // switches away from the ASCII default
+            mLogStream << "  <meta name='generator' content='Mudlet MUD Client version: " << APP_VERSION << APP_BUILD << "'>\n";
+            // Nice to identify what made the file!
+            mLogStream << "  <title>" << tr( "Mudlet, log from %1 profile" ).arg(profile_name) << "</title>\n" ;
+             // Web-page title
+            mLogStream << "  <style type='text/css'>\n";
+            mLogStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(255,255,255); background-color:rgb("<<mpHost->mBgColor.red()<<","<<mpHost->mBgColor.green()<<","<<mpHost->mBgColor.blue()<<");}\n";
+            mLogStream << "        span { white-space: pre; } -->\n";
+            mLogStream << "  </style>\n";
+            mLogStream << "  </head>\n";
+            mLogStream << "  <body><div>";
+            // <div></div> tags required around outside of the body <span></spans> for
+            // strict HTML 4 as we do not use <p></p>s or anything else
+            mLogFile.flush();
+        }
+        logButton->setToolTip( tr("stop logging MUD output to log file") );
     }
     else
     {
-        if( mpHost->mRawStreamDump ) mLogStream << "</pre></body></html>";
+        if( mpHost->mRawStreamDump )
+        {
+            mLogStream << "</div></body>\n";
+            mLogStream << "</html>\n";
+        }
+        mLogFile.flush();
         mLogFile.close();
         QString message = QString("Logging has been stopped. Log file is ") + mLogFile.fileName() + "\n";
         printSystemMessage( message );
+        logButton->setToolTip( tr("start logging MUD output to log file") );
     }
 }
 
@@ -1345,7 +1389,7 @@ QString TConsole::logger_translate( QString & s )
       23 italics off
       24 underline off
       27 inverse off
-      28 strikethrough off
+      29 strikethrough off
       30 fg black
       31 fg red
       32 fg green

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -876,7 +876,8 @@ void TConsole::slot_toggleLogging()
             dirLogFile.mkpath( directoryLogFile );
         }
 
-        if( mpHost->mRawStreamDump ) {
+        mpHost->mIsCurrentLogFileInHtmlFormat = mpHost->mIsNextLogFileInHtmlFormat;
+        if( mpHost->mIsCurrentLogFileInHtmlFormat ) {
             mLogFileName.append(".html");
         }
         else {
@@ -898,7 +899,7 @@ void TConsole::slot_toggleLogging()
     }
 
     if( mLogToLogFile ) {
-        if( mpHost->mRawStreamDump ) {
+        if( mpHost->mIsCurrentLogFileInHtmlFormat ) {
             QStringList fontsList; // List of fonts to become the font-family entry for
                                    // the master css in the header
             fontsList << this->fontInfo().family(); // Seems to be the best way to get the
@@ -936,7 +937,7 @@ void TConsole::slot_toggleLogging()
         logButton->setToolTip( tr("<html><head/><body><p>Stop logging MUD output to log file.</p></body></html>") );
     }
     else {
-        if( mpHost->mRawStreamDump ) {
+        if( mpHost->mIsCurrentLogFileInHtmlFormat ) {
             mLogStream << "</div></body>\n";
             mLogStream << "</html>\n";
         }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -269,7 +269,6 @@ public:
       QPoint            P_end;
       QString           profile_name;
       TSplitter *       splitter;
-      int               mLastBufferLogLine;
       bool              mIsPromptLine;
       QToolButton *     logButton;
       bool              mUserAgreedToCloseConsole;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1370,31 +1370,104 @@ void TTextEdit::copySelectionToClipboardHTML()
     {
         swap( mPA, mPB );
     }
-    QString text = "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'><html><head><style><!-- *{ font-family: 'Courier New', 'Monospace', 'Courier';} *{ white-space: pre-wrap; } *{color:rgb(255,255,255);} *{background-color:rgb(";
+
+    QString title;
+    if( this->mIsDebugConsole ) {
+        title = tr( "Mudlet, debug console extract" );
+    }
+    else if( this->mIsMiniConsole ) {
+        if( ! this->mpHost->mpConsole->mSubConsoleMap.empty() ) {
+            for( auto it = this->mpHost->mpConsole->mSubConsoleMap.cbegin(); it != this->mpHost->mpConsole->mSubConsoleMap.cend(); ++it ) {
+                if( (*it).second == this->mpConsole ) {
+                    title = tr( "Mudlet, %1 mini-console extract from %2 profile" ).arg( (*it).first.data() ).arg( this->mpHost->getName() );
+                    break;
+                }
+            }
+        }
+    }
+    else {
+        title = tr( "Mudlet, %1 console extract from %2 profile" ).arg( this->mpConsole->mConsoleName ).arg(  this->mpHost->getName() );
+    }
+
+    QStringList fontsList; // List of fonts to become the font-family entry for
+                           // the master css in the header
+    fontsList << this->fontInfo().family(); // Seems to be the best way to get the
+                                        // font in use, as different TConsole
+                                        // instances within the same profile
+                                        // might have different fonts in future,
+                                        // and although the font is settable for
+                                        // the main profile window, it is not yet
+                                        // for user miniConsoles, or the Debug one
+    fontsList << QStringLiteral( "Courier New" );
+    fontsList << QStringLiteral( "Monospace" );
+    fontsList << QStringLiteral( "Courier" );
+    fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
+
+    QString text =   "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n";
+    text.append("<html>\n");
+    text.append(" <head>\n");
+    text.append("  <meta http-equiv='content-type' content='text/html; charset=utf-8'>");
+    // put the charset as early as possible as the parser MUST restart when it
+    // switches away from the ASCII default
+    text.append("  <meta name='generator' content='Mudlet MUD Client version: ");
+    text.append(APP_VERSION);
+    text.append(APP_BUILD);
+    text.append("'>\n");
+    // Nice to identify what made the file!
+    text.append("  <title>");
+    text.append(title);
+    text.append("</title>\n");
+     // Web-page title
+    text.append("  <style type='text/css'>\n");
+    text.append("   <!-- body { font-family: '");
+    text.append(fontsList.join("', '"));
+    text.append("'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(255,255,255); background-color:rgb(");
+    // Line height, I think, should be equal to 18 point for a 16 point default
+    // font size by default but this seems to work even when the size is not 16
+    // Use a "%age" for a IE compatible font size, 16 point is the default for
+    // web-pages, but 14 seems to produce a more reasonable size but that could
+    // just be the browsers I tested it on! - Slysven
     text.append(QString::number(mpHost->mBgColor.red()));
     text.append(",");
     text.append(QString::number(mpHost->mBgColor.green()));
     text.append(",");
     text.append(QString::number(mpHost->mBgColor.blue()));
-    text.append(");} --></style><meta http-equiv='content-type' content='text/html; charset=utf-8'></head><body>");
+    text.append(");}\n");
+    text.append("        span { white-space: pre; } -->\n");
+    text.append("  </style>\n");
+    text.append("  </head>\n");
+    text.append("  <body><div>");
+    // <div></div> tags required around outside of the body <span></spans> for
+    // strict HTML 4 as we do not use <p></p>s or anything else
 
     for( int y=mPA.y(); y<=mPB.y(); y++ )
     {
         if( y >= static_cast<int>(mpBuffer->buffer.size()) ) return;
         int x = 0;
-        if( y == mPA.y() )
+        if( y == mPA.y() ) // First line of selection
         {
             x = mPA.x();
+            if( x )
+            {
+                text.append( "<span>" );
+                text.append( QString( x, QLatin1Char(' ') ) );
+                text.append( "</span>" );
+                // Pad out with spaces to the right so a partial first line lines up
+            }
+
             text.append(mpBuffer->bufferToHtml( QPoint(x,y), QPoint(-1,y)));
         }
-        else if ( y == mPB.y() )
+        else if ( y == mPB.y() ) // Last line of selection
         {
             x = mPB.x();
             text.append(mpBuffer->bufferToHtml( QPoint(0,y), QPoint(x,y)));
         }
-        else
+        else // inside lines of selection
             text.append(mpBuffer->bufferToHtml( QPoint(0,y), QPoint(-1,y)));
     }
+    text.append( QStringLiteral( " </div></body>\n"
+                                 "</html>" ) );
+    // The last two of these tags were missing and meant the HTML was not terminated properly
     QClipboard * clipboard = QApplication::clipboard();
     clipboard->setText( text );
     mSelectedRegion = QRegion( 0, 0, 0, 0 );

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1362,12 +1362,10 @@ void TTextEdit::copySelectionToClipboard()
 
 void TTextEdit::copySelectionToClipboardHTML()
 {
-    if( ( mPA.y() == mPB.y() ) && ( mPA.x() > mPB.x() ) )
-    {
+    if( ( mPA.y() == mPB.y() ) && ( mPA.x() > mPB.x() ) ) {
         swap( mPA, mPB );
     }
-    if( mPA.y() > mPB.y() )
-    {
+    if( mPA.y() > mPB.y() ) {
         swap( mPA, mPB );
     }
 
@@ -1440,15 +1438,14 @@ void TTextEdit::copySelectionToClipboardHTML()
     // <div></div> tags required around outside of the body <span></spans> for
     // strict HTML 4 as we do not use <p></p>s or anything else
 
-    for( int y=mPA.y(); y<=mPB.y(); y++ )
-    {
-        if( y >= static_cast<int>(mpBuffer->buffer.size()) ) return;
+    for( int y=mPA.y(); y<=mPB.y(); y++ ) {
+        if( y >= static_cast<int>(mpBuffer->buffer.size()) ) {
+            return;
+        }
         int x = 0;
-        if( y == mPA.y() ) // First line of selection
-        {
+        if( y == mPA.y() ) {// First line of selection
             x = mPA.x();
-            if( x )
-            {
+            if( x ) {
                 text.append( "<span>" );
                 text.append( QString( x, QLatin1Char(' ') ) );
                 text.append( "</span>" );
@@ -1457,13 +1454,13 @@ void TTextEdit::copySelectionToClipboardHTML()
 
             text.append(mpBuffer->bufferToHtml( QPoint(x,y), QPoint(-1,y)));
         }
-        else if ( y == mPB.y() ) // Last line of selection
-        {
+        else if ( y == mPB.y() ) {// Last line of selection
             x = mPB.x();
             text.append(mpBuffer->bufferToHtml( QPoint(0,y), QPoint(x,y)));
         }
-        else // inside lines of selection
+        else { // inside lines of selection
             text.append(mpBuffer->bufferToHtml( QPoint(0,y), QPoint(-1,y)));
+        }
     }
     text.append( QStringLiteral( " </div></body>\n"
                                  "</html>" ) );

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -237,7 +237,10 @@ bool XMLexport::writeHost( Host * pT )
     writeAttribute( "mUSE_FORCE_LF_AFTER_PROMPT", pT->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no" );
     writeAttribute( "mUSE_UNIX_EOL", pT->mUSE_UNIX_EOL ? "yes" : "no" );
     writeAttribute( "mNoAntiAlias", pT->mNoAntiAlias ? "yes" : "no" );
-    writeAttribute( "mRawStreamDump", pT->mRawStreamDump ? "yes" : "no" );
+    // FIXME: Change to a string or integer property when possible to support more
+    // than false (perhaps 0 or "PlainText") or true (perhaps 1 or "HTML") in the
+    // future - phpBB code might be useful if it can be done.
+    writeAttribute( "mRawStreamDump", pT->mIsNextLogFileInHtmlFormat ? "yes" : "no" );
     writeAttribute( "mAlertOnNewData", pT->mAlertOnNewData ? "yes" : "no" );
     writeAttribute( "mFORCE_NO_COMPRESSION", pT->mFORCE_NO_COMPRESSION ? "yes" : "no" );
     writeAttribute( "mFORCE_GA_OFF", pT->mFORCE_GA_OFF ? "yes" : "no" );

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -854,7 +854,7 @@ void XMLimport::readHostPackage( Host * pT )
     pT->mUSE_FORCE_LF_AFTER_PROMPT = ( attributes().value("mUSE_FORCE_LF_AFTER_PROMPT") == "yes" );
     pT->mUSE_UNIX_EOL = ( attributes().value("mUSE_UNIX_EOL") == "yes" );
     pT->mNoAntiAlias = ( attributes().value("mNoAntiAlias") == "yes" );
-    pT->mRawStreamDump = ( attributes().value("mRawStreamDump") == "yes" );
+    pT->mIsNextLogFileInHtmlFormat = ( attributes().value("mRawStreamDump") == "yes" );
     pT->mAlertOnNewData = ( attributes().value("mAlertOnNewData") == "yes" );
     pT->mFORCE_NO_COMPRESSION = ( attributes().value("mFORCE_NO_COMPRESSION") == "yes" );
     pT->mFORCE_GA_OFF = ( attributes().value("mFORCE_GA_OFF") == "yes" );

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -213,7 +213,7 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
             showToolbar->setChecked( true );
         else
             showToolbar->setChecked( mudlet::self()->mShowToolbar );
-        mRawStreamDump->setChecked( pHost->mRawStreamDump );
+        mIsToLogInHtml->setChecked( pHost->mIsNextLogFileInHtmlFormat );
         commandLineMinimumHeight->setValue( pHost->commandLineMinimumHeight );
         mNoAntiAlias->setChecked( ! pHost->mNoAntiAlias );
         mFORCE_MCCP_OFF->setChecked( pHost->mFORCE_NO_COMPRESSION );
@@ -920,7 +920,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         mudlet::self()->mpMainToolBar->show();
     else
         mudlet::self()->mpMainToolBar->hide();
-    pHost->mRawStreamDump = mRawStreamDump->isChecked();
+    pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
     pHost->mNoAntiAlias = !mNoAntiAlias->isChecked();
     pHost->mAlertOnNewData = mAlertOnNewData->isChecked();
     if( mudlet::self()->mConsoleMap.contains( pHost ) )

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -154,9 +154,9 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="mRawStreamDump">
+           <widget class="QCheckBox" name="mIsToLogInHtml">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked will cause the date-stamp named log file to be HTML (file extention '.html') which can convey color, font and other formatting information rather than a plain text (file extension '.txt') format.  It is not recommended to change this setting whilst logging is active!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked will cause the date-stamp named log file to be HTML (file extention '.html') which can convey color, font and other formatting information rather than a plain text (file extension '.txt') format.  If changed whilst logging is already in progress it is necessary to stop and restart logging for this setting to take effect in a new log file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Save log files in HTML format instead of plain text</string>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -156,10 +156,10 @@
           <item>
            <widget class="QCheckBox" name="mRawStreamDump">
             <property name="toolTip">
-             <string>Switch log file format from HTML to raw stream dump in logfiles as sent by server. The logfile can then be can be loaded by Mudlet to test your trigger systems offline.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked will cause the date-stamp named log file to be HTML (file extention '.html') which can convey color, font and other formatting information rather than a plain text (file extension '.txt') format.  It is not recommended to change this setting whilst logging is active!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
-             <string>Save log files in html format instead of text only</string>
+             <string>Save log files in HTML format instead of plain text</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
HTLM Issues addressed:
* a stray, unopened \</span\> was being placed at start of body of HTML.
* use of XHTML \<br /\> instead of correct HTML \<br\> to force new lines
  in produced HTML text.
* empty lines were not being reproduced when copying from clipboard to
  HTML.
* previously produced HTML was being place all on one line, no line-feeds
  in HTML source - by changing the CSS "white-space" arguments they are now
  put into the produced HTML making it possible to edit it in a normal text
  editor but it should still render correctly.
* the data "type='text/css'" was missing from HTML \<style\> tags - this is a
  mandatory attribute for that type of tag under HTML 4.01 strict (although
  not for later HTML 5).
* the \<title\>\</title\> tag-pair was missing from the \<head\> part of HTML
  documents produced - The \<title\> element is mandatory for HTML 4.01
  strict.  It is now created with data about the source of the HTML.
* the charset \<meta\> information was not as far as possible towards the
  start of the HTML \<head\> as it could have been - it is best practice to
  do this as a parser must restart parsing a document when it encounters
  this type of information that changes the encoding away from the default
  ISO-8859 form.
* the list of mono-spaced fonts in the header CSS data did not include, as
  the first entry, the font that was actually used for the source of the
  HTML data.
* no default font size or line spacing was set which makes different
  browsers behave differently, especially if zooming is used, the
  parameters used now should produce HTML that is as similar as possible
  when showing the same output on most modern GUI-type browsers.
* there was no indication as to Mudlet, being the source of the HTML, as
  the generator of the HTML - this now happens and includes the application
  version data.
* the "copy To HTML on the clipboard" code ( in
  TTextEdit::copySelectionToClipboardHTML() ) did not append the \</body\> &
  \</html\> tags to close the end of the document produced.
* the selection of only part of the first line of text onto the clip-board
  did not previously take account of the offset necessary for that line
  to line up with the following lines.
* the use of \<span\>\</span\> tags requires them to be used inside another
  block element inside the \<body\>\</body\> part of the HTML document but
  this was not being done. A \<div\>\</div\> pair now meets that requirement.

Also:

When logging console output to a file the filename was being saved in a
local variable in TConsole::slot_toggleLogging() and not the class member
with the SAME name "mLogFileName" that was defined for the purpose.

The date-time format used for log file names has been changed
from: dd-MM-yyyy#hh-mm-ss
  to: yyyy-MM-dd#hh-mm-ss
so that an alphabetic sort of file-names will agree with a sort on the
file creation/last modified metadata.  This should make it easier to pick
out a wanted log file from a directory listing.

The tool-tip for the "record to log file" TConsole control button is now
dynamically modified to reflect the current recording/not recording state.

With these changes the HTML that is produced should pass validation by
the W3C on-line or other HTML validators.

Note: to concatenate multiple log files they may be joined by cutting and
pasting at the \<div\> and \</div\> boundaries - possibly with an \<hr\> to
delimit the join so that they are arranged:
\<!doc..\>\<html(1)\>\<head(1)\>\</head(1)\>\<body(1)\>
           \<div(1)\>...\</div(1)\>\<hr\>
           \<div(2)\>...\</div(2)\>\<hr\>
                   ...         \<hr\>
           \<div(n)\>...\</div(n)\>\</body(n)\>\</html(n)\>

Signed-off-by: Stephen Lyons \<slysven@virginmedia.com\>