### PR TITLE
BugFix: Fix wrong coloured Lua debug message

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9835,7 +9835,7 @@ bool TLuaInterpreter::compile(const QString & code, QString & errorMsg )
     }
     else
     {
-        if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"\nLUA: code compiled without errors. OK\n" >> 0;}
+        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"\nLUA: code compiled without errors. OK\n" >> 0;}
     }
     lua_pop( L, lua_gettop( L ) );
 


### PR DESCRIPTION
In (bool)TLuaInterpreter::compile(const QString & code, QString & errorMsg)
an OK response was being coloured red rather than the dark green that other
messages in similar methods were using.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
