### PR TITLE
Enhance: lua searchRoom() search, allow non-ASCII room names

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3956,9 +3956,7 @@ int TLuaInterpreter::searchRoom( lua_State *L )
 
             }
         }
-        // Return a SORTED list...!
         if( ! roomIdsFound.isEmpty() ) {
-            std::sort(roomIdsFound.begin(), roomIdsFound.end());
             for( int i=0; i<roomIdsFound.size();i++ ) {
                 TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomIdsFound.at(i) );
                 QString name = pR->name;


### PR DESCRIPTION
Update getRoomName(), setRoomName() and searchRoom() to handle non-ASCII
room name data.  The strings passed to and from the lua subsystem now use
Utf-8 which is a super-set of (backwards compatible with) ASCII.

Also, the original lua command when invoked as searchRoom("string") did a
case insensitive room name search and used the supplied string for a
partial search of all room names in the map.  One or two optional Boolean
arguments can now supplement the supplied search string for the
room-name: the first, if true, makes the search case sensitive and the
second, requires the string to be a complete match rather than a sub-string
of the room name to be found.  Both of these arguments can make it easier
to find a specific room.

In the same manner as another recent commit addressing map room user data
the error messages from these three lua commands have been made capable of
being translated by the Qt internationalisation system, and the resultant
texts can be passed as utf-8 data to the lua system and on to the user with
non-ASCII characters.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
