### PR TITLE
Rebased4 fix replay

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,6 +4,32 @@ Installing on Windows
 Installing on Linux
 -------------------
 
+The replay files (recording of input received during a session from a MUD
+server) have gained some magic(5) and now have a .mreplay extension.  To permit
+some useful data to be extracted from them on the command line by file(1) you
+will wish to have this chunk (inside the "=====" delimiters, contains and NEEDS
+the TAB characters therein as separators) added to your system /etc/magic file:
+
+=====
+0	string	MudletReplayFile\0
+>17	byte	>1	Mudlet replay file, version %i
+>>18	beqdate	x	\b, started: %s (UTC)
+>>26	beshort	>0	\bi, %i:
+>>>28	byte	x	\b%02i:
+>>>29	byte	x	\b%02i.
+>>>30	beshort	x	\b%03i(h:m:s) long
+>>>32	pstring/L	x	\b, profile: "%s"
+>>26	beshort	0	
+>>>28	byte	>0	\b, %02i:
+>>>>29	byte	x	\b%02i.
+>>>>30	beshort	x	\b%03i(m:s) long
+>>>>32	pstring/L	x	\b, profile: "%s"
+>>>28	byte	0	
+>>>>29	byte	x	\b, %02i.
+>>>>30	beshort	x	\b%03i(s) long
+>>>>32	pstring/L	x	\b, profile: "%s"
+=====
+
 Installing on OSX
 -----------------
 

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -166,3 +166,21 @@ Host * HostManager::getFirstHost()
     QMutexLocker locker(& mPoolLock);
     return mHostPool.begin().value().data();
 }
+
+Host * HostManager::getNextHost( QString lastHost )
+{
+    QMutexLocker locker(& mPoolLock);
+
+    QList<QSharedPointer<Host> > hostList = mHostPool.values();
+    uint hostCount = mHostPool.count();
+    for( int i=0; i<hostCount; i++ ) {
+        if( hostList[i]->getName() == lastHost ) {
+            if( i < ( hostCount - 1 ) )
+                return hostList.at(i+1).data();
+            else
+                return 0;
+
+        }
+    }
+    return 0;
+}

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -42,6 +42,7 @@ public:
     QStringList        getHostList();
     QList<QString>     getHostNameList();
     Host *             getFirstHost();
+    Host *             getNextHost( QString LastHost ); //get next host key by providing a LastHost
     bool               addHost( QString name, QString port, QString login, QString pass );
     bool               deleteHost( QString );
     bool               renameHost( QString );

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1086,15 +1086,6 @@ void TConsole::setConsoleFgColor( int r, int g, int b )
     return time;
 } */
 
-
-
-void TConsole::loadRawFile( std::string n )
-{
-    QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-    QString fileName = directoryLogFile + "/"+QString(n.c_str());
-    mpHost->mTelnet.loadReplay( fileName );
-}
-
 void TConsole::printOnDisplay( std::string & incomingSocketData )
 {
     //buffer.messen();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -85,8 +85,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
 , mpMainDisplay( new QWidget( mpMainFrame ) )
 , mpMapper( 0 )
 , mpScrollBar( new QScrollBar )
-
-, mRecordReplay( false )
+, mIsRecording( false )
 , mSystemMessageBgColor( mBgColor )
 , mSystemMessageFgColor( QColor( 255,0,0 ) )
 , mTriggerEngineMode( false )
@@ -101,6 +100,9 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
 , mpBufferSearchDown( new QToolButton )
 , mCurrentSearchResult( 0 )
 , mSearchQuery("")
+, mReplayMagic( "MudletReplayFile" )   // Do not change, will be used to validate replay file in the future.
+, mReplayVersion( 2 )    // Just in case we ever change the format, treat unversioned "old" replays as version 1 .
+, mReplayDurationOffset( 0 )
 {
     QShortcut * ps = new QShortcut(this);
     ps->setKey(Qt::CTRL + Qt::Key_W);
@@ -781,7 +783,7 @@ void TConsole::closeEvent( QCloseEvent *event )
         {
             // Must abort any replay in progress for this profile!
             if( mpHost->mTelnet.isReplaying() )
-                mpHost->mTelnet.abortReplay();
+                mpHost->mTelnet.abortReplaying();
 
             QString directory_xml = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/current";
             QString filename_xml = directory_xml + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss")+".xml";
@@ -832,7 +834,7 @@ void TConsole::closeEvent( QCloseEvent *event )
         {
             // Must abort any replay in progress for this profile!
             if( mpHost->mTelnet.isReplaying() )
-                mpHost->mTelnet.abortReplay();
+                mpHost->mTelnet.abortReplaying();
 
             event->accept();
             return;
@@ -861,6 +863,8 @@ int TConsole::getButtonState()
     return mButtonState;
 }
 
+// TODO: HTML output needs updating, to include the now mandatory
+// tag <title...></title> at least...
 void TConsole::slot_toggleLogging()
 {
     if( mIsDebugConsole ) return;
@@ -882,7 +886,7 @@ void TConsole::slot_toggleLogging()
     {
         mLastBufferLogLine = buffer.size();
         QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-        QString mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
+        mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
         if( mpHost->mRawStreamDump )
         {
             mLogFileName.append(".html");
@@ -913,31 +917,137 @@ void TConsole::slot_toggleLogging()
 
 void TConsole::slot_toggleReplayRecording()
 {
-    if( mIsDebugConsole ) return;
-    mRecordReplay = ! mRecordReplay;
-    if( mRecordReplay )
-    {
-        QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-        QString mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
-        mLogFileName.append(".dat");
-        QDir dirLogFile;
-        if( ! dirLogFile.exists( directoryLogFile ) )
-        {
-            dirLogFile.mkpath( directoryLogFile );
+    if( mIsDebugConsole )
+        return;
+
+    mIsRecording = ! mIsRecording;
+    if( mIsRecording ) {
+        QString recordingPath = QStringLiteral( "%1/.config/mudlet/profiles/%2/log" )
+                                .arg( QDir::homePath() )
+                                .arg( profile_name );
+        mRecordStartTime = QDateTime::currentDateTimeUtc();
+        // Use UTC internally as this will avoid issues with DST changes.
+        QString recordingPathFile = QStringLiteral( "%1/%2.mreplay" )
+                               .arg( recordingPath )
+                               .arg( mRecordStartTime.toLocalTime().toString("yyyy-MM-dd#hh-mm-ss") );
+        // Previous date format might have looked nice but doesn't sort well,
+        // this way (common in Far East) makes an alphanumberic sort return the
+        // same as an actual datetime sort and if the files involved have been
+        // copied or archived they do not always retain their original datetime
+        // values, which can be a pain if one ends up with a group of files all
+        // with the same datetime metadata...!
+
+        QDir dirRecordingFile;
+        if( ! dirRecordingFile.exists( recordingPath ) )
+            dirRecordingFile.mkpath( recordingPath );
+
+        mRecordFile.setFileName( recordingPathFile );
+        if( ! mRecordFile.open( QIODevice::ReadWrite ) ) {
+            QString message = tr( "[ ERROR ] - Replay recording has NOT started. Cannot open for read and writing file:\n"
+                                               "\"%1\".\n" ).arg(mRecordFile.fileName());
+            mpHost->mTelnet.postMessage( message );
         }
-        mReplayFile.setFileName( mLogFileName );
-        mReplayFile.open( QIODevice::WriteOnly );
-        mReplayStream.setDevice( &mReplayFile );
-        mpHost->mTelnet.recordReplay();
-        QString message = QString("Replay recording has started. File: ") + mReplayFile.fileName() + "\n";
-        printSystemMessage( message );
+        mRecordStream.setDevice( &mRecordFile );
+        mRecordStream.setVersion( QDataStream::Qt_4_6 );
+        // Ensure that we use a consistant datastream version over time
+
+        // Additional stuff to provide some "magic", also allows some useful
+        // external inspection by *nix file(1) command:
+        mRecordStream.writeRawData( mReplayMagic.constData(), mReplayMagic.size() + 1 );
+        mRecordStream << mReplayVersion; // A single byte
+        mpHost->mTelnet.mRecordLastDateTimeOffset = mRecordStartTime;
+        // Unlike previously used QTime this is good for more than 24 Hours or
+        // if system time changes when DST goes on/off, both rare but not
+        // impossible occurrances!
+        qint64 secondsFromEpoch = mRecordStartTime.toMSecsSinceEpoch() / 1000;
+        mRecordStream << secondsFromEpoch;
+        // A qint64, 8-byte (long long) signed number of seconds since
+        // 1970-01-01T00:00:00.000
+        mRecordFile.flush();
+        mReplayDurationOffset = mRecordFile.pos();
+        // Store this position so we can seek back to overwrite the following
+        // pieces of information; have found that it is tricky to divide up a
+        // single number of milliseconds in the magic(5) configuration file used
+        // in the file(1) utility on *nix systems so will save the numbers
+        // separately:
+        mRecordStream << static_cast<quint16>( 0 ); // hours (0-65536 ?)
+        mRecordStream << static_cast<quint8>( 0 ); // mins (0-59)
+        mRecordStream << static_cast<quint8>( 0 ); // Secs (0-59)
+        mRecordStream << static_cast<quint16>( 0 ); // milliSecs (0-999)
+        // The above zero values will be overwritten by the duration of the
+        // replay when we close the file - if all goes well...
+        mRecordStream.writeBytes( profile_name.toUtf8().constData(), profile_name.toUtf8().length() );
+        // And note the name of the profile from which it was recorded, using a
+        // format that can be externally parsed (a so-called "pascal" string,
+        // with a leading quint32 number {4 bytes} of bytes followed by the
+        // NON-null terminated string {in a Utf-8 encoding}).
+
+        QString message = tr( "[ INFO ]  - Replay recording has started. File: %1\n" ).arg(mRecordFile.fileName());
+        mpHost->mTelnet.postMessage( message );
     }
+    else {
+        mRecordFile.flush();
+        mRecordFile.seek(mReplayDurationOffset);
+        qint64 duration = mRecordStartTime.msecsTo( mpHost->mTelnet.mRecordLastDateTimeOffset );
+        qint16 duration_mSec = duration % 1000;
+        duration /= 1000;
+        qint8 duration_sec = duration % 60;
+        duration /= 60;
+        qint8 duration_min = duration % 60;
+        qint16 duration_hour = duration / 60;
+        mRecordStream << duration_hour;
+        mRecordStream << duration_min;
+        mRecordStream << duration_sec;
+        mRecordStream << duration_mSec;
+        mRecordFile.close();
+        QString message = tr( "[  OK  ]  - Replay recording has been stopped. File: %1\n").arg(mRecordFile.fileName());
+        mpHost->mTelnet.postMessage( message );
+    }
+}
+
+void TConsole::abortRecording()
+{
+    mIsRecording = false;
+    mRecordFile.flush();
+    if( mRecordStream.status() == QDataStream::WriteFailed )
+        mRecordStream.resetStatus(); // Recover the file datastream if possible
+
+    qint64 duration = mRecordStartTime.msecsTo( mpHost->mTelnet.mRecordLastDateTimeOffset );
+    // as mRecordLastDateTimeOffset was not updated by the last failed write
+    // that brought us here, it will only report the duration up to the end of
+    // the previous replay chunk that WAS written out correctly, so if we can
+    // regain write capabilites to the already written portion of the file we
+    // can at least report the duration up to that point, if not the duration
+    // will be zeroed in the start of the file, which can be detected as
+    // indicative of a defective recording.
+    qint16 duration_mSec = duration % 1000;
+    duration /= 1000;
+    qint8 duration_sec = duration % 60;
+    duration /= 60;
+    qint8 duration_min = duration % 60;
+    qint16 duration_hour = duration / 60;
+    if( mRecordFile.seek(mReplayDurationOffset) && mRecordStream.status() == QDataStream::Ok ) {
+        mRecordStream << duration_hour;
+        mRecordStream << duration_min;
+        mRecordStream << duration_sec;
+        mRecordStream << duration_mSec;
+    }
+    QString message;
+    if( mRecordStream.status() == QDataStream::WriteFailed )
+        message = tr( "[ ERROR ] - Replay recording has been terminated unexpectedly.\n"
+                                  "Mudlet has not even been able to cleanly handle what has\n"
+                                  "already been recorded so playback of this recording may\n"
+                                  "be problematic.  Is there still space on the relevant\n"
+                                  "filesystem device?\n" );
     else
-    {
-        mReplayFile.close();
-        QString message = QString("Replay recording has been stopped. File: ") + mLogFile.fileName() + "\n";
-        printSystemMessage( message );
-    }
+        message = tr( "[ WARN ]  - Replay recording has been terminated unexpectedly.\n"
+                                  "However the initial %1%2 {hh:mm:ss} should still be replayable."
+                                  "Is there still space on the relevant filesystem device?\n" )
+                  .arg( duration_hour > 23 ? tr( "(+%1 days)" ).arg(duration_hour / 24 ) : "" )
+                  .arg( QTime( duration_hour % 24, duration_min, duration_sec, duration_mSec ).toString( "hh:mm:ss.zzz" ) );
+
+    mpHost->mTelnet.postMessage( message );
+    mRecordFile.close();
 }
 
 void TConsole::changeColors()

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -779,6 +779,10 @@ void TConsole::closeEvent( QCloseEvent *event )
         }
         if( choice == QMessageBox::Yes )
         {
+            // Must abort any replay in progress for this profile!
+            if( mpHost->mTelnet.isReplaying() )
+                mpHost->mTelnet.abortReplay();
+
             QString directory_xml = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/current";
             QString filename_xml = directory_xml + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss")+".xml";
             QDir dir_xml;
@@ -826,6 +830,10 @@ void TConsole::closeEvent( QCloseEvent *event )
         }
         else if( choice == QMessageBox::No )
         {
+            // Must abort any replay in progress for this profile!
+            if( mpHost->mTelnet.isReplaying() )
+                mpHost->mTelnet.abortReplay();
+
             event->accept();
             return;
         }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -118,7 +118,6 @@ public:
 
       int               getColumnNumber();
       void              createMapper( int, int, int, int );
-      void              loadRawFile( std::string );
       void              setWrapAt( int pos ){ mWrapAt = pos; buffer.setWrapAt( pos ); }
       void              setIndentCount( int count ){ mIndentCount = count; buffer.setWrapIndent( count ); }
       void              echo(const QString & );

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -25,6 +25,7 @@
 #include "TBuffer.h"
 
 #include "pre_guard.h"
+#include <QByteArray>
 #include <QFile>
 #include <QTextStream>
 #include <QDataStream>
@@ -89,14 +90,13 @@ public:
       void              resetMainConsole();
       void              echoUserWindow(const QString & );
       Host *            getHost();
-      TCommandLine *    mpCommandLine;
-      void              replace(const QString& );
-      void              insertHTML(const QString& );
-      void              insertText(const QString& );
-      void              insertText(const QString&, QPoint );
-      void              insertLink(const QString&, QStringList &, QStringList &, QPoint, bool customFormat=false );
-      void              insertLink(const QString&, QStringList &, QStringList &, bool customFormat=false );
-      void              echoLink(const QString & text, QStringList & func, QStringList & hint, bool customFormat=false );
+      void              replace(const QString &);
+      void              insertHTML(const QString &);
+      void              insertText(const QString &);
+      void              insertText(const QString &, QPoint );
+      void              insertLink(const QString &, QStringList &, QStringList &, QPoint, bool customFormat=false );
+      void              insertLink(const QString &, QStringList &, QStringList &, bool customFormat=false );
+      void              echoLink(const QString &, QStringList &, QStringList &, bool customFormat=false );
       void              setLabelStyleSheet( std::string & buf, std::string & sh );
       void              copy();
       void              cut();
@@ -115,7 +115,6 @@ public:
       std::list<int>    getFgColor( std::string & buf );
       std::list<int>    getBgColor( std::string & buf );
       void              luaWrapLine( std::string & buf, int line );
-
       int               getColumnNumber();
       void              createMapper( int, int, int, int );
       void              setWrapAt( int pos ){ mWrapAt = pos; buffer.setWrapAt( pos ); }
@@ -177,7 +176,10 @@ public:
       void              logger_set_text_properties(const QString& );
       QString           assemble_html_font_specs();
       QSize             getMainWindowSize() const;  // Returns the size of the main buffer area (excluding the command line and toolbars).
+      void              abortRecording();
 
+
+      TCommandLine *    mpCommandLine;
       QPointer<Host>    mpHost;
 
       TBuffer           buffer;
@@ -247,9 +249,9 @@ public:
 
 
       QTime             mProcessingTime;
-      bool              mRecordReplay;
-      QFile             mReplayFile;
-      QDataStream       mReplayStream;
+      bool              mIsRecording;
+      QFile             mRecordFile;
+      QDataStream       mRecordStream;
       TChar             mStandardFormat;
       QList<TConsole *> mSubConsoleList;
       std::map<std::string, TConsole *> mSubConsoleMap;
@@ -277,6 +279,9 @@ public:
       int               mCurrentSearchResult;
       QList<int>        mSearchResults;
       QString           mSearchQuery;
+      const QByteArray  mReplayMagic;
+      const quint8      mReplayVersion;
+
 
 signals:
 
@@ -289,6 +294,11 @@ public slots:
       void              slot_stop_all_triggers( bool );
       void              slot_toggleLogging();
 
+private:
+      QDateTime         mRecordStartTime;
+      qint64            mReplayDurationOffset;
+                        // The offset in the replay file to the duration item
+                        // (which has to be overwritten at the end of recording).
 };
 
 #endif // MUDLET_TCONSOLE_H

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -790,7 +790,7 @@ int TLuaInterpreter::loadRawFile( lua_State * L )
     if( ! ok )
         retCode = -1;
     switch( retCode ) {
-        case 0: // OK, remainder is canonical pathFile of replay file
+        case 0: // OK, remainder includes canonical pathFile of replay file
             lua_pushboolean( L, true );
             lua_pushstring( L, result.mid(1).toUtf8().constData() );
             lua_pushnumber( L, result.left(1).toInt() );
@@ -799,6 +799,8 @@ int TLuaInterpreter::loadRawFile( lua_State * L )
         case 2: // Replay active in other profile
         case 3: // File does not exist
         case 4: // File is not readable
+        case 5: // Replay file version is too high, newer than we understand...
+        case 6: // Replay file might be version 1 (original) but the name does not fit the pattern
             lua_pushnil( L );
             lua_pushstring( L, result.mid(1).toUtf8().constData() );
             lua_pushnumber( L, result.left(1).toInt() );
@@ -809,6 +811,174 @@ int TLuaInterpreter::loadRawFile( lua_State * L )
             lua_pushnumber( L, result.left(1).toInt() );
     }
     return 3;
+}
+
+int TLuaInterpreter::abortReplay( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( pHost->mTelnet.isReplaying() ){
+        pHost->mTelnet.abortReplaying();
+        lua_pushboolean( L , true );
+        lua_pushstring( L, tr( "abortReplay: replay aborted." ).toUtf8().constData());
+    }
+    else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "abortReplay: no replay currently playing, in this profile, to abort!" ).toUtf8().constData());
+    }
+
+    return 2;
+}
+
+int TLuaInterpreter::setReplaySpeed( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( pHost->mTelnet.isReplaying() ){
+        if( ! lua_isnumber( L, 1 ) ) {
+            lua_pushstring( L, tr( "setReplaySpeed: bad argument #1 (replay speed, float expected, got %1)" )
+                               .arg( luaL_typename(L, 1) ).toUtf8() );
+            lua_error( L );
+            return 1;
+        }
+        else {
+            float value = lua_tonumber( L, 1 );
+            int newSpeed = 0;
+            if( qFuzzyCompare ( static_cast<float>(1.0), static_cast<float>(value) ) )
+                newSpeed = 1; // Use floats rather than doubles as they should have a wider margin for fuzziness
+            else if( qFuzzyCompare ( static_cast<float>(129.0), static_cast<float>(1.0 + value) ) )
+                newSpeed = 128;
+            else if( qFuzzyCompare ( static_cast<float>(65.0), static_cast<float>(1.0 + value ) ) )
+                newSpeed = 64;
+            else if( qFuzzyCompare ( static_cast<float>(33.0), static_cast<float>(1.0 + value ) ) )
+                newSpeed = 32;
+            else if( qFuzzyCompare ( static_cast<float>(17.0), static_cast<float>(1.0 + value ) ) )
+                newSpeed = 16;
+            else if( qFuzzyCompare ( static_cast<float>(9.0), static_cast<float>(1.0 + value ) ) )
+                newSpeed = 8;
+            else if( qFuzzyCompare ( static_cast<float>(5.0), static_cast<float>(1.0 + value ) ) )
+                newSpeed = 4;
+            else if( qFuzzyCompare ( static_cast<float>(3.0), static_cast<float>(1.0 + value ) ) )
+                newSpeed = 2;
+            else if( qFuzzyCompare ( static_cast<float>(1.5), static_cast<float>(1.0 + value ) ) )
+                newSpeed = -2;
+            else if( qFuzzyCompare ( static_cast<float>(1.25), static_cast<float>(1.0 + value ) ) )
+                newSpeed = -4;
+            else if( qFuzzyCompare ( static_cast<float>(1.125), static_cast<float>(1.0 + value ) ) )
+                newSpeed = -8;
+            else {
+                lua_pushstring( L, tr( "setReplaySpeed: bad value #1 (replay speed, value got %1,\n"
+                                       "value expected, one of: 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125)" )
+                                   .arg( QString::number(value) ).toUtf8().constData() );
+                lua_error( L );
+                return 1;
+            }
+            mudlet::self()->mReplaySpeed = newSpeed;
+            mudlet::self()->updateReplaySpeedDisplay();
+        }
+        lua_pushboolean( L , true );
+        lua_pushstring( L, tr( "setReplaySpeed: replay speed will be set to x%1 real time from next chunk." )
+                           .arg( QString::number( mudlet::self()->mReplaySpeed ) ).toUtf8().constData() );
+    }
+    else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setReplaySpeed: no replay currently playing, in this profile, to change the speed of!" ).toUtf8().data() );
+    }
+
+    return 2;
+}
+
+int TLuaInterpreter::getReplayStatus( lua_State * L )
+{
+
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( pHost->mTelnet.isReplaying() ) {
+        uint replayVersion = pHost->mTelnet.mReplayFileVersion;
+
+        lua_newtable( L );
+
+        lua_pushstring( L, "currentSpeed" );
+        // The speed that is CURRENTLY being used, can't be changed
+        int currentReplaySpeed = mudlet::self()->mPreviousReplaySpeed;
+        double currentReportedSpeed;
+        if( currentReplaySpeed > 0 )
+            currentReportedSpeed = currentReplaySpeed;
+        else
+            currentReportedSpeed = -1.0/currentReplaySpeed;
+
+        lua_pushnumber( L, currentReportedSpeed );
+        lua_settable( L, -3 );
+
+        lua_pushstring( L, "newSpeed" );
+        // The speed that will be used from the start of the NEXT replay chunk,
+        // what is set by setReplaySpeed()
+        int nextReplaySpeed = mudlet::self()->mReplaySpeed;
+        double nextReportedSpeed;
+        if( nextReplaySpeed > 0 )
+            nextReportedSpeed = nextReplaySpeed;
+        else
+            nextReportedSpeed = -1.0/nextReplaySpeed;
+
+        lua_pushnumber( L, nextReportedSpeed );
+        lua_settable( L, -3 );
+
+        lua_pushstring( L, "displayedTime" );
+        // The value on the toolbar display
+        QString replayDisplayedElapsedTime = mudlet::self()->mReplayTime.addMSecs( mudlet::self()->mReplayTimeOffset - mudlet::self()->mReplayChunkTime ).toString();
+        lua_pushstring( L, replayDisplayedElapsedTime.toLatin1().constData() );
+        lua_settable(L, -3);
+
+        uint replayHours = pHost->mTelnet.mReplayHours;
+        uint replayMinutes = pHost->mTelnet.mReplayMins;
+        uint replaySeconds = pHost->mTelnet.mReplaySecs;
+        uint replayMilliSeconds = pHost->mTelnet.mReplayMSecs;
+        uint replayDays = replayHours/24;
+        uint replayHoursInDay = replayHours%24;
+
+        lua_pushstring( L, "duration" );
+        // A string representation of the length of the replay, can handle a
+        // replay of more than a day in length!  However is nil for original
+        // replay file format.
+        if( replayVersion == 1 )
+            lua_pushnil( L );
+        else {
+            QString replayDuration;
+            if( replayDays )
+                replayDuration = tr( "(+%1 days) %2", "An extremely long duration replay that is >=24 hours!", replayDays )
+                                 .arg( replayDays )
+                                 .arg( QTime( replayHoursInDay, replayMinutes, replaySeconds, replayMilliSeconds ).toString("hh:mm:ss.zzz") );
+            else
+                replayDuration = QTime( replayHoursInDay, replayMinutes, replaySeconds, replayMilliSeconds ).toString("hh:mm:ss.zzz");
+
+            lua_pushstring( L, replayDuration.toUtf8().constData() );
+        }
+        lua_settable( L, -3 );
+
+        lua_pushstring( L, "file" );
+        // The full, absolute pathfile name of the replay file
+        QString replayFile = pHost->mTelnet.mReplayFile.fileName();
+        lua_pushstring( L, replayFile.toUtf8().constData() );
+        lua_settable( L, -3 );
+
+        lua_pushstring( L, "recorded" );
+        // The date and time of the recording, for original replay format it is
+        // derived from the file name and will be in the local system time, for
+        // later format it should be in Utc though this may not be correct on
+        // Windows OS/platform if the system time configuration is not set right
+        // in eihter case the date is in a standard (parseable) string format.
+        QString replayRecordingStart = pHost->mTelnet.mReplayStartDateTime.toString( Qt::ISODate );
+        lua_pushstring( L, replayRecordingStart.toLatin1().constData() );
+        lua_settable( L, -3 );
+
+        lua_pushstring( L, "version" );
+        // The replay file format, can be used to determine the characteristics
+        // of the other items (and whether THEY have useful information)
+        lua_pushinteger( L, replayVersion );
+        lua_settable( L, -3 );
+
+    }
+    else
+        lua_pushnil(L);
+
+    return 1;
 }
 
 int TLuaInterpreter::getCurrentLine( lua_State * L )
@@ -10848,6 +11018,9 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "showToolBar", TLuaInterpreter::showToolBar );
     lua_register( pGlobalLua, "hideToolBar", TLuaInterpreter::hideToolBar );
     lua_register( pGlobalLua, "loadRawFile", TLuaInterpreter::loadRawFile );
+    lua_register( pGlobalLua, "abortReplay", TLuaInterpreter::abortReplay );
+    lua_register( pGlobalLua, "setReplaySpeed", TLuaInterpreter::setReplaySpeed );
+    lua_register( pGlobalLua, "getReplayStatus", TLuaInterpreter::getReplayStatus );
     lua_register( pGlobalLua, "setBold", TLuaInterpreter::setBold );
     lua_register( pGlobalLua, "setItalics", TLuaInterpreter::setItalics );
     lua_register( pGlobalLua, "setUnderline", TLuaInterpreter::setUnderline );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -784,31 +784,23 @@ int TLuaInterpreter::loadRawFile( lua_State * L )
     else
         pathFileName = checkFileInfo.filePath(); // Probably file doesn't exist!
 
-    QString result = pHost->mTelnet.loadReplay( pathFileName, false );
-    bool ok = false;
-    int retCode = result.left(1).toUInt( & ok );
-    if( ! ok )
-        retCode = -1;
-    switch( retCode ) {
-        case 0: // OK, remainder includes canonical pathFile of replay file
-            lua_pushboolean( L, true );
-            lua_pushstring( L, result.mid(1).toUtf8().constData() );
-            lua_pushnumber( L, result.left(1).toInt() );
-            break;
-        case 1: // Replay active in this profile
-        case 2: // Replay active in other profile
-        case 3: // File does not exist
-        case 4: // File is not readable
-        case 5: // Replay file version is too high, newer than we understand...
-        case 6: // Replay file might be version 1 (original) but the name does not fit the pattern
-            lua_pushnil( L );
-            lua_pushstring( L, result.mid(1).toUtf8().constData() );
-            lua_pushnumber( L, result.left(1).toInt() );
-            break;
-        default:
-            lua_pushnil( L );
-            lua_pushstring( L, tr( "loadRawFile: unexpected internal error code: \"%1\"!" ).arg( result.left(1) ).toUtf8().constData() );
-            lua_pushnumber( L, result.left(1).toInt() );
+    QPair<int, QString> result = pHost->mTelnet.loadReplay( pathFileName, false );
+    if( result.first ) {
+        // 1 = Replay active in this profile
+        // 2 = Replay active in other profile
+        // 3 = File does not exist
+        // 4 = File is not readable
+        // 5 = Replay file version is too high, newer than we understand...
+        // 6 = Replay file might be version 1 (original) but the name does not fit the pattern
+        lua_pushnil( L );
+        lua_pushstring( L, result.second.toUtf8().constData() );
+        lua_pushnumber( L, result.first );
+    }
+    else {
+        // 0 = OK, message includes canonical pathFile of replay file
+        lua_pushboolean( L, true );
+        lua_pushstring( L, result.second.toUtf8().constData() );
+        lua_pushnumber( L, result.first );
     }
     return 3;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -316,6 +316,9 @@ public:
     static int showToolBar( lua_State * );
     static int hideToolBar( lua_State * );
     static int loadRawFile( lua_State * );
+    static int abortReplay( lua_State * );
+    static int setReplaySpeed( lua_State * );
+    static int getReplayStatus( lua_State * );
     static int setBold( lua_State * );
     static int setItalics( lua_State * );
     static int setUnderline( lua_State * );

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1551,22 +1551,89 @@ void cTelnet::recordReplay()
     timeOffset.start();
 }
 
-void cTelnet::loadReplay( QString & name )
+// This is where replay code program flow converges when initiated from main
+// toolbar and user lua request, to enable the method to determine which called
+// it the former should set the second argument to true.
+// For the latter QString status messages beginning with a digit are used and
+// made available to the user's lua scripts, the values are:
+// 0 = Replay file loaded and replay has started, includes the canonical path
+//     and filename in the message.
+// 1 = THIS profile is already running a replay so cannot run another now.
+// 2 = ANOTHER profile is running a replay so this one cannot run one now.
+// 3 = The replay file does not seem to exist. Includes the canonical path
+//     and filename in the message to enable user to check for themselves.
+// 4 = The replay file can not be read - user may have to check permissions.
+//     Includes the canonical path and filename in the message to enable user to
+//     check for themselves.
+// TODO: once a "New" replay format has been designed with magic and version data:
+//    5 = The file doesn't have the right "magic" so does not appear to be a Mudlet replay file.
+//    6 = The file is from a newer (unsupported) version of Mudlet.
+// For the former usage a message in a format suitable with this class's
+// postMessage() method is returned with the same sort of information.
+QString cTelnet::loadReplay( QString & name, bool isStatusToBeReportedInConsole )
 {
-    mReplayFile.setFileName( name );
-    QString msg = "loading replay " + name;
-    postMessage( msg );
-    mReplayFile.open( QIODevice::ReadOnly );
-    mReplayStream.setDevice( &mReplayFile );
-    mIsReplaying = true;
-    mudlet::self()->replayStart();
-    _loadReplay();
+    QString msg;
+    if( mIsReplaying ) {
+        // Prevent trying to start a SECOND replay in THIS profile
+        if( isStatusToBeReportedInConsole )
+            msg = tr( "[ ALERT ] - A replay is already in progress for this profile!" );
+        else
+            msg = tr( "1error: a replay is already in progress in this profile.", "Do not change the inital digit '1' it is used to return status information to the caller." );
+
+    }
+    else if( mudlet::self()->isReplayInProgress() ) {
+        // Prevent trying to start a SECOND replay (in ANY profile as it happens) if one is in progress
+        if( isStatusToBeReportedInConsole )
+            msg = tr( "[ ALERT ] - A replay is already in progress in another profile, please let that one finish before trying to load another!" );
+        else
+            msg = tr( "2error: a replay is already in progress in another profile.", "Do not change the inital digit '2' it is used to return status information to the caller." );
+
+    }
+    else {
+        QFileInfo replayFileInfo( name );
+        mReplayFile.setFileName( replayFileInfo.canonicalFilePath() );
+        if( ! replayFileInfo.exists() ) {
+            if( isStatusToBeReportedInConsole )
+                msg = tr( "[ ALERT ] - Replay file does not exist: %1 .", "Do not translate [ ALERT ] it is used to key the color coding of the message" )
+                              .arg( QDir::toNativeSeparators( replayFileInfo.absoluteFilePath() ) );
+            else
+                msg = tr( "3error: the file \"%1\" does not exist.", "Do not change the initial digit '3' it is used to return status information to the caller." )
+                      .arg( QDir::toNativeSeparators( replayFileInfo.absoluteFilePath() ) );
+
+        }
+        else {
+            if( ! mReplayFile.open( QIODevice::ReadOnly ) ) {
+                if( isStatusToBeReportedInConsole )
+                    msg = tr( "[ ALERT ] - Unable to read replay file: %1 .", "Do not translate [ ALERT ] it is used to key the color coding of the message" )
+                          .arg( QDir::toNativeSeparators( replayFileInfo.absoluteFilePath() ) );
+                else
+                    msg = tr( "4error: unable to read existing file \"%1\".", "Do not change the initial digit '4' it is used to return status information to the caller." )
+                          .arg( QDir::toNativeSeparators( replayFileInfo.absoluteFilePath() ) );
+
+            }
+            else {
+                if( isStatusToBeReportedInConsole ) {
+                    mIsReportingReplayStatus = true;
+                    msg = tr( "[ INFO ]  - Loading replay file: %1 .", "Do not translate [ INFO ] it is used to key the color coding of the message" )
+                          .arg( QDir::toNativeSeparators( mReplayFile.fileName() ) );
+                }
+                else
+                    msg = tr( "0Replay file \"%1\" loaded.", "Do not change the initial digit '0' it is used to return status information to the caller." )
+                          .arg( QDir::toNativeSeparators( mReplayFile.fileName() ) );
+
+                mReplayStream.setDevice( &mReplayFile );
+                mIsReplaying = true;
+                mudlet::self()->replayStart();
+                _loadReplay();
+            }
+        }
+    }
+    return msg;
 }
 
 void cTelnet::_loadReplay()
 {
-    if( ! mReplayStream.atEnd() )
-    {
+    if( ! mReplayStream.atEnd() ) {
         mudlet::self()->mpReplayTimer->stop();
         int offset;
         int amount;
@@ -1574,13 +1641,14 @@ void cTelnet::_loadReplay()
         mReplayStream >> amount;
 
         char * pB = &mLoadBuffer[0];
-        mLoadedBytes = mReplayStream.readRawData ( pB, amount );
+        mLoadedBytes = mReplayStream.readRawData ( pB, amount ); // loadedBytes will be -1 on error!
+        mLoadBuffer[mLoadedBytes] = '\0'; // Previous use of loadedBytes + 1 caused a spurious character at end of string display by a qDebug of the loadBuffer contents
+
         if( mudlet::self()->mReplaySpeed < 1 )
             qDebug( "_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f Seconds. )", mLoadedBytes, amount, offset/1000.0 , - mudlet::self()->mReplaySpeed * offset/1000.0 );
         else
             qDebug( "_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f Seconds. )", mLoadedBytes, amount, offset/1000.0 , offset/(1000.0 * mudlet::self()->mReplaySpeed) );
 
-        mLoadBuffer[mLoadedBytes] = '\0'; // Previous use of loadedBytes + 1 caused a spurious character at end of string display by a qDebug of the loadBuffer contents
 
         mudlet::self()->mReplayChunkTime = offset;
         mudlet::self()->mReplayTimeOffset = 0;
@@ -1594,12 +1662,14 @@ void cTelnet::_loadReplay()
             QTimer::singleShot( offset / mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
         }
     }
-    else
-    {
+    else {
         mIsReplaying = false;
         mReplayFile.close();
-        QString msg = "The replay has ended.\n";
-        postMessage( msg );
+        if( mIsReportingReplayStatus ) {
+            QString msg = tr( "[  OK  ]  - The replay has ended.\n", "Do not translate [  OK  ] it is used to color code the message." );
+            postMessage( msg );
+            mIsReportingReplayStatus = false;
+        }
         mudlet::self()->replayOver();
     }
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1567,6 +1567,7 @@ void cTelnet::_loadReplay()
 {
     if( ! mReplayStream.atEnd() )
     {
+        mudlet::self()->mpReplayTimer->stop();
         int offset;
         int amount;
         mReplayStream >> offset;
@@ -1574,13 +1575,13 @@ void cTelnet::_loadReplay()
 
         char * pB = &mLoadBuffer[0];
         mLoadedBytes = mReplayStream.readRawData ( pB, amount );
-        qDebug("_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f seconds.)",
-               mLoadedBytes,
-               amount,
-               offset / 1000.0,
-               offset / (1000.0 * mudlet::self()->mReplaySpeed));
+        qDebug("_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f seconds.)", mLoadedBytes, amount, offset / 1000.0, offset / (1000.0 * mudlet::self()->mReplaySpeed));
         mLoadBuffer[mLoadedBytes] = '\0'; // Previous use of loadedBytes + 1 caused a spurious character at end of string display by a qDebug of the loadBuffer contents
+
+        mudlet::self()->mReplayChunkTime = offset;
+        mudlet::self()->mReplayTimeOffset = 0;
         mudlet::self()->mReplayTime = mudlet::self()->mReplayTime.addMSecs(offset);
+        mudlet::self()->mpReplayTimer->start( 100 / mudlet::self()->mReplaySpeed );
         QTimer::singleShot(offset / mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
     }
     else

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1575,14 +1575,24 @@ void cTelnet::_loadReplay()
 
         char * pB = &mLoadBuffer[0];
         mLoadedBytes = mReplayStream.readRawData ( pB, amount );
-        qDebug("_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f seconds.)", mLoadedBytes, amount, offset / 1000.0, offset / (1000.0 * mudlet::self()->mReplaySpeed));
+        if( mudlet::self()->mReplaySpeed < 1 )
+            qDebug( "_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f Seconds. )", mLoadedBytes, amount, offset/1000.0 , - mudlet::self()->mReplaySpeed * offset/1000.0 );
+        else
+            qDebug( "_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f Seconds. )", mLoadedBytes, amount, offset/1000.0 , offset/(1000.0 * mudlet::self()->mReplaySpeed) );
+
         mLoadBuffer[mLoadedBytes] = '\0'; // Previous use of loadedBytes + 1 caused a spurious character at end of string display by a qDebug of the loadBuffer contents
 
         mudlet::self()->mReplayChunkTime = offset;
         mudlet::self()->mReplayTimeOffset = 0;
         mudlet::self()->mReplayTime = mudlet::self()->mReplayTime.addMSecs(offset);
-        mudlet::self()->mpReplayTimer->start( 100 / mudlet::self()->mReplaySpeed );
-        QTimer::singleShot(offset / mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
+        if( mudlet::self()->mReplaySpeed < 1 ) {
+            mudlet::self()->mpReplayTimer->start( -100 * mudlet::self()->mReplaySpeed );
+            QTimer::singleShot( - offset * mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
+        }
+        else {
+            mudlet::self()->mpReplayTimer->start( 100 / mudlet::self()->mReplaySpeed );
+            QTimer::singleShot( offset / mudlet::self()->mReplaySpeed, this, SLOT(readPipe()));
+        }
     }
     else
     {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1631,6 +1631,19 @@ QString cTelnet::loadReplay( QString & name, bool isStatusToBeReportedInConsole 
     return msg;
 }
 
+void cTelnet::abortReplay()
+{
+    mudlet::self()->mpReplayTimer->stop();
+    mReplayFile.close();
+    if( mIsReportingReplayStatus ) {
+        QString msg = tr( "[  OK  ]  - The replay has been aborted.\n", "Do not translate [  OK  ] it is used to color code the message." );
+        postMessage( msg );
+        mIsReportingReplayStatus = false;
+    }
+    mudlet::self()->replayOver(mpHost, false);
+    mIsReplaying = false;
+}
+
 void cTelnet::_loadReplay()
 {
     if( ! mReplayStream.atEnd() ) {
@@ -1699,7 +1712,7 @@ void cTelnet::_loadReplay()
             postMessage( msg );
             mIsReportingReplayStatus = false;
         }
-        mudlet::self()->replayOver(mpHost);
+        mudlet::self()->replayOver(mpHost, true);
     }
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -52,18 +52,12 @@
 #include <stdio.h>
 #include <time.h>
 
-
-#ifdef DEBUG
-    #undef DEBUG
-#endif
-
-//#ifdef QT_DEBUG
-//    #define DEBUG
-//#endif
-
-
-
-#define DEBUG
+// Uncomment this for various qDebug() entries - some are quite spammy.
+// #define DEBUG_TELNET 0x7
+// To control what is enabled change the power of 2 values (bitfield):
+// 0x1  - show Telnet option negotiation
+// 0x2  - show Replay chunk data and timer details for next chunk
+// 0x4  - show Data
 
 using namespace std;
 
@@ -417,7 +411,7 @@ void cTelnet::setDisplayDimensions()
 
 void cTelnet::sendTelnetOption( char type, char option )
 {
-#ifdef DEBUG_TELNET
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
     QString _type;
     switch ((quint8)type)
     {
@@ -469,7 +463,7 @@ void cTelnet::setDownloadProgress( qint64 got, qint64 tot )
 void cTelnet::processTelnetCommand( const string & command )
 {
   char ch = command[1];
-#ifdef DEBUG_TELNET
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
   QString _type;
   switch ((quint8)ch)
   {
@@ -684,9 +678,9 @@ void cTelnet::processTelnetCommand( const string & command )
       {
 
           //server refuses to enable some option...
-          #ifdef DEBUG
-              qDebug() << "cTelnet::processTelnetCommand() TN_WONT command="<<(quint8)command[2];
-          #endif
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
+          qDebug() << "cTelnet::processTelnetCommand() TN_WONT command="<<(quint8)command[2];
+#endif
           option = command[2];
           int idxOption = static_cast<int>(option);
           if( triedToEnable[idxOption] )
@@ -697,9 +691,9 @@ void cTelnet::processTelnetCommand( const string & command )
           }
           else
           {
-              #ifdef DEBUG
-                  qDebug() << "cTelnet::processTelnetCommand() we dont accept his option because we didnt want it to be enabled";
-              #endif
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
+              qDebug() << "cTelnet::processTelnetCommand() we dont accept his option because we didnt want it to be enabled";
+#endif
               //send DONT if needed (see RFC 854 for details)
               if( hisOptionState[idxOption] || ( heAnnouncedState[idxOption] ) )
               {
@@ -726,8 +720,8 @@ void cTelnet::processTelnetCommand( const string & command )
 
       case TN_DO:
       {
-#ifdef DEBUG
-      qDebug() << "telnet: server wants us to enable option:"<< (quint8)command[2];
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
+          qDebug() << "telnet: server wants us to enable option:"<< (quint8)command[2];
 #endif
           //server wants us to enable some option
           option = command[2];
@@ -766,7 +760,7 @@ void cTelnet::processTelnetCommand( const string & command )
             sendTelnetOption( TN_WILL, 102 );
             break;
           }
-#ifdef DEBUG
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
           qDebug() << "server wants us to enable telnet option " << (quint8)option << "(TN_DO + "<< (quint8)option<<")";
 #endif
           if(option == OPT_TIMING_MARK)
@@ -809,7 +803,7 @@ void cTelnet::processTelnetCommand( const string & command )
       case TN_DONT:
       {
           //only respond if value changed or if this option has not been announced yet
-#ifdef DEBUG
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
               qDebug() << "cTelnet::processTelnetCommand() TN_DONT command="<<(quint8)command[2];
 #endif
           option = command[2];
@@ -1853,11 +1847,12 @@ void cTelnet::_loadReplay(quint8 version=0)
 
         // If the next four lines are commented out, please leave for debugging
         // future replay development - Slysven
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x2 )
         if( mudlet::self()->mReplaySpeed < 1 )
             qDebug( "_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f Seconds. )", mLoadedBytes, amount, offset/1000.0 , - mudlet::self()->mReplaySpeed * offset/1000.0 );
         else
             qDebug( "_loadReplay(): loaded: %i/%i bytes, wait for %1.3f seconds. (Single shot duration is: %1.3f Seconds. )", mLoadedBytes, amount, offset/1000.0 , offset/(1000.0 * mudlet::self()->mReplaySpeed) );
-
+#endif
 
         mudlet::self()->mReplayChunkTime = offset;
         mudlet::self()->mReplayTimeOffset = 0;
@@ -1935,15 +1930,17 @@ void cTelnet::slot_readPipe()
     recvdGA = false;
     // If the next line is commented out please leave for future replay
     // development/debugging work - Slysven
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x2 )
     qDebug("Replay data: \"%s\"", mLoadBuffer.constData());
+#endif
     for( int i = 0; i < datalen; i++ )
     {
         char ch = mLoadBuffer.at(i);
         if( iac || iac2 || insb || (ch == TN_IAC) )
         {
-            #ifdef DEBUG
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
                 qDebug() <<" SERVER sends telnet command "<<(quint8)ch;
-            #endif
+#endif
             if (! (iac || iac2 || insb) && ( ch == TN_IAC ) )
             {
                 iac = true;
@@ -2083,9 +2080,9 @@ void cTelnet::handle_socket_signal_readyRead()
         buffer = out_buffer;
     }
     buffer[datalen] = '\0';
-    #ifdef DEBUG
-        //qDebug()<<"got<"<<pBuffer<<">";
-    #endif
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x4 )
+    qDebug()<<"got<"<<pBuffer<<">";
+#endif
     if( mpHost->mpConsole->mIsRecording ) {
         qint64 interval = mRecordLastDateTimeOffset.msecsTo( QDateTime::currentDateTimeUtc() );
         // now use a qint64 for same reason given as for amount above
@@ -2115,9 +2112,9 @@ void cTelnet::handle_socket_signal_readyRead()
 
         if( iac || iac2 || insb || (ch == TN_IAC) )
         {
-            #ifdef DEBUG
-                //qDebug() <<" SERVER SENDS telnet command "<<(unsigned int)ch;
-            #endif
+#if defined( DEBUG_TELNET ) && ( DEBUG_TELNET & 0x1 )
+            qDebug() <<" SERVER SENDS telnet command "<<(unsigned int)ch;
+#endif
             if( ! (iac || iac2 || insb) && ( ch == TN_IAC ) )
             {
                 iac = true;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -109,7 +109,7 @@ public:
     void              set_USE_IRE_DRIVER_BUGFIX( bool b ){ mUSE_IRE_DRIVER_BUGFIX=b; }
     void              set_LF_ON_GA( bool b ){ mLF_ON_GA=b; }
     void              recordReplay();
-    void              loadReplay( QString & );
+    QString           loadReplay( QString &, bool );
     void              _loadReplay();
     bool              isReplaying() { return mIsReplaying; }
     void              setChannel102Variables(const QString & );
@@ -213,6 +213,7 @@ private:
     bool              enableChannel102;
     QStringList       messageStack;
     bool              mIsReplaying;
+    bool              mIsReportingReplayStatus;
     char              mLoadBuffer[100001];
     int               mLoadedBytes;
     QDataStream       mReplayStream;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -109,7 +109,7 @@ public:
     void              set_USE_IRE_DRIVER_BUGFIX( bool b ){ mUSE_IRE_DRIVER_BUGFIX=b; }
     void              set_LF_ON_GA( bool b ){ mLF_ON_GA=b; }
     void              recordReplay();
-    QString           loadReplay( QString &, bool );
+    QPair<int, QString> loadReplay( QString &, bool );
     void              _loadReplay( quint8 );
     bool              isReplaying() { return mIsReplaying; }
     void              abortReplaying();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -24,13 +24,14 @@
 
 
 #include "pre_guard.h"
+#include <QFile>
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QPointer>
+#include <QStringList>
 #include <QTcpSocket>
 #include <QTime>
 #include "post_guard.h"
-#include <QStringList>
 
 #include <zlib.h>
 
@@ -110,7 +111,7 @@ public:
     void              recordReplay();
     void              loadReplay( QString & );
     void              _loadReplay();
-    bool              isReplaying() { return loadingReplay; }
+    bool              isReplaying() { return mIsReplaying; }
     void              setChannel102Variables(const QString & );
 
 
@@ -211,7 +212,11 @@ private:
     bool              enableGMCP;
     bool              enableChannel102;
     QStringList       messageStack;
-    bool              loadingReplay;
+    bool              mIsReplaying;
+    char              mLoadBuffer[100001];
+    int               mLoadedBytes;
+    QDataStream       mReplayStream;
+    QFile             mReplayFile;
 };
 
 #endif // MUDLET_CTELNET_H

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -110,11 +110,12 @@ public:
     void              set_LF_ON_GA( bool b ){ mLF_ON_GA=b; }
     void              recordReplay();
     QString           loadReplay( QString &, bool );
-    void              _loadReplay();
+    void              _loadReplay( quint8 );
     bool              isReplaying() { return mIsReplaying; }
-    void              abortReplay();
+    void              abortReplaying();
     void              setChannel102Variables(const QString & );
     bool              socketOutRaw(std::string & data);
+    void              postMessage(const QString);
 
 
     QMap<int, bool>   supportedTelnetOptions;
@@ -128,12 +129,22 @@ public:
     QNetworkAccessManager * mpDownloader;
     QProgressDialog * mpProgressDialog;
     QString           mServerPackage;
-    void              postMessage( QString msg );
+    QDateTime           mRecordLastDateTimeOffset;
+    QFile               mReplayFile;
+    quint8              mReplayFileVersion;
+    QDateTime           mReplayStartDateTime;
+    QDateTime           mReplayPlaybackStartDateTime;
+    quint16             mReplayHours;
+    quint8              mReplayMins;
+    quint8              mReplaySecs;
+    quint16             mReplayMSecs;
+    QString             mReplayProfileName;
+
 
 public slots:
     void              setDownloadProgress( qint64, qint64 );
     void              replyFinished( QNetworkReply * );
-    void              readPipe();
+    void              slot_readPipe();
     void              handle_socket_signal_hostFound(QHostInfo);
     void              handle_socket_signal_connected();
     void              handle_socket_signal_disconnected();
@@ -147,7 +158,7 @@ public slots:
 private:
                       cTelnet(){}
     void              initStreamDecompressor();
-    int               decompressBuffer( char *& in_buffer, int& length, char* out_buffer );
+    int               decompressBuffer( char *& in_buffer, qint64 & length, char * out_buffer );
     void              reset();
     void              connectionFailed();
 
@@ -203,19 +214,16 @@ private:
     bool              mIsTimerPosting;
     QTimer *          mTimerLogin;
     QTimer *          mTimerPass;
-    QTime             timeOffset;
     QTime             mConnectionTime;
-    int               lastTimeOffset;
     bool              enableATCP;
     bool              enableGMCP;
     bool              enableChannel102;
     QStringList       messageStack;
     bool              mIsReplaying;
     bool              mIsReportingReplayStatus;
-    char              mLoadBuffer[100001];
+    QByteArray        mLoadBuffer;
     int               mLoadedBytes;
     QDataStream       mReplayStream;
-    QFile             mReplayFile;
 };
 
 #endif // MUDLET_CTELNET_H

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -112,12 +112,10 @@ public:
     QString           loadReplay( QString &, bool );
     void              _loadReplay();
     bool              isReplaying() { return mIsReplaying; }
+    void              abortReplay();
     void              setChannel102Variables(const QString & );
-
-
-
-
     bool              socketOutRaw(std::string & data);
+
 
     QMap<int, bool>   supportedTelnetOptions;
     bool              mResponseProcessed;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2279,7 +2279,7 @@ void mudlet::slot_replayTimeChanged()
     mpReplayTimeDisplay->show();
 }
 
-void mudlet::replayOver(Host * pHost)
+void mudlet::replayOver(Host * pHost, bool isEndOfReplay)
 {
     if( ! mpMainToolBar )
         return;
@@ -2310,7 +2310,10 @@ void mudlet::replayOver(Host * pHost)
     otherReplayOverEvent.mArgumentList.append( QStringLiteral( "sysReplayEvent" ) );
     myReplayOverEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     otherReplayOverEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    myReplayOverEvent.mArgumentList.append( QStringLiteral( "myReplayOver" ) );
+    if( isEndOfReplay )
+        myReplayOverEvent.mArgumentList.append( QStringLiteral( "myReplayOver" ) );
+    else
+        myReplayOverEvent.mArgumentList.append( QStringLiteral( "myReplayAborted" ) );
     otherReplayOverEvent.mArgumentList.append( QStringLiteral( "otherReplayOver" ) );
     myReplayOverEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     otherReplayOverEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1989,8 +1989,8 @@ void mudlet::slot_replay()
     // This call to cTelnet class is where the replay code becomes common with
     // the lua loadRawFile() ...
     // Second argument is to enable display of messages in console
-    QString msg = pHost->mTelnet.loadReplay( replayFileName, true );
-    pHost->mTelnet.postMessage( msg );
+    QPair<int, QString> result = pHost->mTelnet.loadReplay( replayFileName, true );
+    pHost->mTelnet.postMessage( result.second );
 }
 
 void mudlet::printSystemMessage( Host * pH, const QString & s )

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1695,6 +1695,10 @@ void mudlet::setIcoSize( int s )
         mpMainToolBar->setToolButtonStyle( Qt::ToolButtonTextUnderIcon );
     else
         mpMainToolBar->setToolButtonStyle( Qt::ToolButtonIconOnly );
+    if( mpReplayToolBar ) {
+        mpReplayToolBar->setIconSize( mpMainToolBar->iconSize() );
+        mpReplayToolBar->setToolButtonStyle( mpMainToolBar->toolButtonStyle() );
+    }
     if( mShowMenuBar )
         menuBar()->show();
     else
@@ -2208,6 +2212,8 @@ void mudlet::replayStart()
     mpReplaySpeedDisplay = new QLabel( this );
     mpActionSpeedDisplay = mpReplayToolBar->addWidget( mpReplaySpeedDisplay );
 
+    mpReplayToolBar->setIconSize( mpMainToolBar->iconSize() );
+    mpReplayToolBar->setToolButtonStyle( mpMainToolBar->toolButtonStyle() );
     connect(mpActionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
     connect(mpActionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
 
@@ -2215,6 +2221,13 @@ void mudlet::replayStart()
     txt.append( QString::number( mReplaySpeed ) );
     txt.append("X</b></font>");
     mpReplaySpeedDisplay->setText(txt);
+
+    mReplayTime = QTime( 0, 0, 0, 1);
+    // Use the smallest possible valid time as a starting value. Since Qt5 a
+    // NULL(zero) QTime is NOT valid and adding anything to an invalid time is
+    // STILL invalid afterwards!
+    // It does not run in real time, instead it is updated every time a chunk
+    // from the replay file (with an offset value) is consumed.
 
     mpReplayTimer = new QTimer(this);
     mpReplayTimer->setInterval(1000);
@@ -2239,6 +2252,7 @@ void mudlet::slot_replayTimeChanged()
     txt2.append( mReplayTime.toString( timeFormat ) );
     txt2.append("</b></font>");
     mpReplayTimeDisplay->setText( txt2 );
+    mpReplayTimeDisplay->show();
 }
 
 void mudlet::replayOver()
@@ -2273,6 +2287,7 @@ void mudlet::slot_replaySpeedUp()
     txt.append("X</b></font>");
     mpReplaySpeedDisplay->setText(txt);
     mpReplaySpeedDisplay->show();
+    mpReplayToolBar->update(); // If the speed values gains a character it won't fit unless the toolbar is redrawn
 }
 
 void mudlet::slot_replaySpeedDown()
@@ -2284,6 +2299,7 @@ void mudlet::slot_replaySpeedDown()
     txt.append("X</b></font>");
     mpReplaySpeedDisplay->setText(txt);
     mpReplaySpeedDisplay->show();
+    mpReplayToolBar->update(); // If the speed values gains a character it won't fit unless the toolbar is redrawn
 }
 
 void mudlet::stopSounds()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2216,9 +2216,9 @@ void mudlet::replayStart()
     connect(mpActionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
     connect(mpActionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
 
-    QString txt = "<font size=25><b>speed:";
-    txt.append( QString::number( mReplaySpeed ) );
-    txt.append("X</b></font>");
+    QString txt = tr( "<font size=25><b> Speed: %1%2</b></font>", "Don't try to translate the HTML tags!")
+                  .arg( QChar(215) ) // N.B. The first argument is U+00D7 "multiplication sign"
+                  .arg( QString::number( mReplaySpeed ) );
     mpReplaySpeedDisplay->setText(txt);
 
     mReplayTime = QTime( 0, 0, 0, 1);
@@ -2234,9 +2234,8 @@ void mudlet::replayStart()
     mpReplayTimer->setSingleShot(false);
     connect(mpReplayTimer, SIGNAL(timeout()), this, SLOT(slot_replayTimeChanged()));
 
-    QString txt2 = "<font size=25><b>Time:";
-    txt2.append( mReplayTime.toString() );
-    txt2.append("</b></font>");
+    QString txt2 = tr( "<font size=25><b>Time: %1 </b></font>", "Don't try to translate the HTML tags!")
+                   .arg( mReplayTime.toString() );
     mpReplayTimeDisplay->setText( txt2 );
 
     mpReplaySpeedDisplay->show();
@@ -2248,9 +2247,9 @@ void mudlet::replayStart()
 
 void mudlet::slot_replayTimeChanged()
 {
-    QString txt2 = "<font size=25><b>Time:";
-    txt2.append( mReplayTime.addMSecs( mReplayTimeOffset - mReplayChunkTime ).toString() );
-    txt2.append("</b></font>");
+    QString txt2 = tr( "<font size=25><b>Time: %1 </b></font>", "Don't try to translate the HTML tags!")
+              .arg( mReplayTime.addMSecs( mReplayTimeOffset - mReplayChunkTime ).toString() );
+
     mReplayTimeOffset += 100;
     mpReplayTimeDisplay->setText( txt2 );
     mpReplayTimeDisplay->show();
@@ -2285,10 +2284,34 @@ void mudlet::replayOver()
 
 void mudlet::slot_replaySpeedUp()
 {
-    mReplaySpeed = mReplaySpeed * 2;
-    QString txt = "<font size=25><b>speed:";
-    txt.append( QString::number( mReplaySpeed ) );
-    txt.append("X</b></font>");
+    switch( mReplaySpeed )
+    {
+        case -2:
+            mReplaySpeed = 1;
+            break;
+        case -4:
+            mReplaySpeed = -2;
+            break;
+        case -8:
+            mReplaySpeed = -4;
+            break;
+        case 128:
+            mReplaySpeed = 128;
+            break;
+        default:
+            mReplaySpeed *= 2;
+    }
+
+    QString txt;
+    if( mReplaySpeed < 1 )
+        txt = tr( "<font size=25><b> Speed: %1<sup>1</sup>/<sub>%2<sub></b></font>", "Don't try to translate the HTML tags!")
+              .arg( QChar(215) )
+              .arg( QString::number( -mReplaySpeed ) );
+    else
+        txt = tr( "<font size=25><b> Speed: %1%2</b></font>", "Don't try to translate the HTML tags!")
+              .arg( QChar(215) )
+              .arg( QString::number( mReplaySpeed ) );
+
     mpReplaySpeedDisplay->setText(txt);
     mpReplaySpeedDisplay->show();
     mpReplayToolBar->update(); // If the speed values gains a character it won't fit unless the toolbar is redrawn
@@ -2296,11 +2319,33 @@ void mudlet::slot_replaySpeedUp()
 
 void mudlet::slot_replaySpeedDown()
 {
-    mReplaySpeed = mReplaySpeed / 2;
-    if( mReplaySpeed < 1 ) mReplaySpeed = 1;
-    QString txt = "<font size=25><b>speed:";
-    txt.append( QString::number( mReplaySpeed ) );
-    txt.append("X</b></font>");
+    switch( mReplaySpeed )
+    {
+        case 1:
+            mReplaySpeed = -2;
+            break;
+        case -2:
+            mReplaySpeed = -4;
+            break;
+        case -4:
+            mReplaySpeed = -8;
+            break;
+        case -8:
+            mReplaySpeed = -8;
+            break;
+        default:
+            mReplaySpeed /= 2;
+    }
+
+    QString txt;
+    if( mReplaySpeed < 1 )
+        txt = tr( "<font size=25><b> Speed: %1<sup>1</sup>/<sub>%2<sub></b></font>", "Don't try to translate the HTML tags!")
+              .arg( QChar(215) )
+              .arg( QString::number( -mReplaySpeed ) );
+    else
+        txt = tr( "<font size=25><b> Speed: %1%2</b></font>", "Don't try to translate the HTML tags!")
+              .arg( QChar(215) )
+              .arg( QString::number( mReplaySpeed ) );
     mpReplaySpeedDisplay->setText(txt);
     mpReplaySpeedDisplay->show();
     mpReplayToolBar->update(); // If the speed values gains a character it won't fit unless the toolbar is redrawn

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -104,14 +104,14 @@ mudlet::mudlet()
 , version( QString("Mudlet ") + QString(APP_VERSION) + QString(APP_BUILD) )
 , mpCurrentActiveHost( 0 )
 , mIsGoingDown( false )
-, actionReplaySpeedDown( 0 )
-, actionReplaySpeedUp( 0 )
-, actionSpeedDisplay( 0 )
-, actionReplayTime( 0 )
-, replaySpeedDisplay( 0 )
-, replayTime( 0 )
-, replayTimer( 0 )
-, replayToolBar( 0 )
+, mpActionReplaySpeedDown( 0 )
+, mpActionReplaySpeedUp( 0 )
+, mpActionSpeedDisplay( 0 )
+, mpActionReplayTime( 0 )
+, mpReplaySpeedDisplay( 0 )
+, mpReplayTimeDisplay( 0 )
+, mpReplayTimer( 0 )
+, mpReplayToolBar( 0 )
 {
     setupUi(this);
     setUnifiedTitleAndToolBarOnMac( true );
@@ -2190,45 +2190,47 @@ void mudlet::toggleFullScreenView()
 
 void mudlet::replayStart()
 {
-    if( ! mpMainToolBar ) return;
-    replayToolBar = new QToolBar( this );
+    if( ! mpMainToolBar )
+        return;
+
+    mpReplayToolBar = new QToolBar( this );
     mReplaySpeed = 1;
-    replayTime = new QLabel( this );
-    actionReplayTime = replayToolBar->addWidget( replayTime );
+    mpReplayTimeDisplay = new QLabel( this );
+    mpActionReplayTime = mpReplayToolBar->addWidget( mpReplayTimeDisplay );
 
-    actionReplaySpeedUp = new QAction( QIcon( QStringLiteral( ":/icons/export.png" ) ), tr("Faster"), this);
-    actionReplaySpeedUp->setStatusTip(tr("Replay Speed Up"));
-    replayToolBar->addAction( actionReplaySpeedUp );
+    mpActionReplaySpeedUp = new QAction( QIcon( QStringLiteral( ":/icons/export.png" ) ), tr("Faster"), this);
+    mpActionReplaySpeedUp->setStatusTip(tr("Replay Speed Up"));
+    mpReplayToolBar->addAction( mpActionReplaySpeedUp );
 
-    actionReplaySpeedDown = new QAction( QIcon( QStringLiteral( ":/icons/import.png" ) ), tr("Slower"), this);
-    actionReplaySpeedDown->setStatusTip(tr("Replay Speed Down"));
-    replayToolBar->addAction( actionReplaySpeedDown );
-    replaySpeedDisplay = new QLabel( this );
-    actionSpeedDisplay = replayToolBar->addWidget( replaySpeedDisplay );
+    mpActionReplaySpeedDown = new QAction( QIcon( QStringLiteral( ":/icons/import.png" ) ), tr("Slower"), this);
+    mpActionReplaySpeedDown->setStatusTip(tr("Replay Speed Down"));
+    mpReplayToolBar->addAction( mpActionReplaySpeedDown );
+    mpReplaySpeedDisplay = new QLabel( this );
+    mpActionSpeedDisplay = mpReplayToolBar->addWidget( mpReplaySpeedDisplay );
 
-    connect(actionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
-    connect(actionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
+    connect(mpActionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
+    connect(mpActionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
 
     QString txt = "<font size=25><b>speed:";
     txt.append( QString::number( mReplaySpeed ) );
     txt.append("X</b></font>");
-    replaySpeedDisplay->setText(txt);
+    mpReplaySpeedDisplay->setText(txt);
 
-    replayTimer = new QTimer(this);
-    replayTimer->setInterval(1000);
-    replayTimer->setSingleShot(false);
-    connect(replayTimer, SIGNAL(timeout()), this, SLOT(slot_replayTimeChanged()));
+    mpReplayTimer = new QTimer(this);
+    mpReplayTimer->setInterval(1000);
+    mpReplayTimer->setSingleShot(false);
+    connect(mpReplayTimer, SIGNAL(timeout()), this, SLOT(slot_replayTimeChanged()));
 
     QString txt2 = "<font size=25><b>Time:";
     txt2.append( mReplayTime.toString( timeFormat ) );
     txt2.append("</b></font>");
-    replayTime->setText( txt2 );
+    mpReplayTimeDisplay->setText( txt2 );
 
-    replaySpeedDisplay->show();
-    replayTime->show();
-    insertToolBar( mpMainToolBar, replayToolBar );
-    replayToolBar->show();
-    replayTimer->start();
+    mpReplaySpeedDisplay->show();
+    mpReplayTimeDisplay->show();
+    insertToolBar( mpMainToolBar, mpReplayToolBar );
+    mpReplayToolBar->show();
+    mpReplayTimer->start();
 }
 
 void mudlet::slot_replayTimeChanged()
@@ -2236,27 +2238,30 @@ void mudlet::slot_replayTimeChanged()
     QString txt2 = "<font size=25><b>Time:";
     txt2.append( mReplayTime.toString( timeFormat ) );
     txt2.append("</b></font>");
-    replayTime->setText( txt2 );
+    mpReplayTimeDisplay->setText( txt2 );
 }
 
 void mudlet::replayOver()
 {
-    if( ! mpMainToolBar ) return;
-    if( ! replayToolBar ) return;
+    if( ! mpMainToolBar )
+        return;
+    if( ! mpReplayToolBar )
+        return;
 
-    if( actionReplaySpeedUp )
+    if( mpActionReplaySpeedUp )
     {
-        disconnect(actionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
-        disconnect(actionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
-        replayToolBar->removeAction( actionReplaySpeedUp );
-        replayToolBar->removeAction( actionReplaySpeedDown );
-        replayToolBar->removeAction( actionSpeedDisplay );
-        removeToolBar( replayToolBar );
-        actionReplaySpeedUp = 0;
-        actionReplaySpeedDown = 0;
-        actionSpeedDisplay = 0;
-        actionReplayTime = 0;
-        replayToolBar = 0;
+        disconnect(mpActionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
+        disconnect(mpActionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
+        mpReplayToolBar->removeAction( mpActionReplaySpeedUp );
+        mpReplayToolBar->removeAction( mpActionReplaySpeedDown );
+        mpReplayToolBar->removeAction( mpActionSpeedDisplay );
+
+        removeToolBar( mpReplayToolBar );
+        mpActionReplaySpeedUp = 0;
+        mpActionReplaySpeedDown = 0;
+        mpActionSpeedDisplay = 0;
+        mpActionReplayTime = 0;
+        mpReplayToolBar = 0;
     }
 }
 
@@ -2266,8 +2271,8 @@ void mudlet::slot_replaySpeedUp()
     QString txt = "<font size=25><b>speed:";
     txt.append( QString::number( mReplaySpeed ) );
     txt.append("X</b></font>");
-    replaySpeedDisplay->setText(txt);
-    replaySpeedDisplay->show();
+    mpReplaySpeedDisplay->setText(txt);
+    mpReplaySpeedDisplay->show();
 }
 
 void mudlet::slot_replaySpeedDown()
@@ -2277,8 +2282,8 @@ void mudlet::slot_replaySpeedDown()
     QString txt = "<font size=25><b>speed:";
     txt.append( QString::number( mReplaySpeed ) );
     txt.append("X</b></font>");
-    replaySpeedDisplay->setText(txt);
-    replaySpeedDisplay->show();
+    mpReplaySpeedDisplay->setText(txt);
+    mpReplaySpeedDisplay->show();
 }
 
 void mudlet::stopSounds()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2291,18 +2291,32 @@ void mudlet::replayOver(Host * pHost, bool isEndOfReplay)
         mpReplayTimer->stop();
         disconnect(mpActionReplaySpeedUp, SIGNAL(triggered()), this, SLOT(slot_replaySpeedUp()));
         disconnect(mpActionReplaySpeedDown, SIGNAL(triggered()), this, SLOT(slot_replaySpeedDown()));
-        mpReplayToolBar->removeAction( mpActionReplaySpeedUp );
-        mpReplayToolBar->removeAction( mpActionReplaySpeedDown );
-        mpReplayToolBar->removeAction( mpActionSpeedDisplay );
         disconnect(mpReplayTimer, SIGNAL(timeout()), this, SLOT(slot_replayTimeChanged()));
-        delete( mpReplayTimer );
-        mpReplayTimer = 0;
+        delete mpReplayTimer.data();
+
         removeToolBar( mpReplayToolBar );
-        mpActionReplaySpeedUp = 0;
-        mpActionReplaySpeedDown = 0;
-        mpActionSpeedDisplay = 0;
-        mpActionReplayTime = 0;
-        mpReplayToolBar = 0;
+        mpReplayToolBar->clear();
+        // It is a little unclear whether the items that were on the tool bar
+        // get deleted when QToolBar::clear() is used...
+        delete mpReplayToolBar.data();
+
+        if( mpActionReplaySpeedUp )
+            delete mpActionReplaySpeedUp.data();
+
+        if( mpActionReplaySpeedDown )
+            delete mpActionReplaySpeedDown.data();
+
+        if( mpActionSpeedDisplay )
+            delete mpActionSpeedDisplay.data();
+
+        if( mpActionReplayTime )
+            delete mpActionReplayTime.data();
+
+        if( mpReplaySpeedDisplay )
+            delete mpReplaySpeedDisplay;
+
+        if( mpReplayTimeDisplay )
+            delete mpReplayTimeDisplay;
     }
 
     TEvent myReplayOverEvent, otherReplayOverEvent;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -240,7 +240,7 @@ mudlet::mudlet()
 
 
     QAction * actionReplay = new QAction( QIcon( QStringLiteral( ":/icons/media-optical.png" ) ), tr("Replay"), this);
-    actionReplay->setToolTip(tr("Load a Mudlet replay"));
+    actionReplay->setToolTip(tr("Once a profile is loaded - allows you to load a Mudlet replay"));
     mpMainToolBar->addAction( actionReplay );
 
     actionReconnect = new QAction( QIcon( QStringLiteral( ":/icons/system-restart.png" ) ), tr("Reconnect"), this);
@@ -904,6 +904,7 @@ void mudlet::disableToolbarButtons()
     mpMainToolBar->actions()[12]->setEnabled( false );
     mpMainToolBar->actions()[13]->setEnabled( false );
     mpMainToolBar->actions()[14]->setEnabled( false );
+    mpMainToolBar->actions()[15]->setEnabled( false ); // Replay
 }
 
 void mudlet::enableToolbarButtons()
@@ -921,6 +922,8 @@ void mudlet::enableToolbarButtons()
     mpMainToolBar->actions()[12]->setEnabled( true );
     mpMainToolBar->actions()[13]->setEnabled( true );
     mpMainToolBar->actions()[14]->setEnabled( true );
+    mpMainToolBar->actions()[15]->setEnabled( true ); // Replay
+    mpMainToolBar->actions()[15]->setToolTip(tr("Allows you to load a Mudlet replay"));
 }
 
 bool mudlet::openWindow( Host * pHost, const QString & name )
@@ -1966,27 +1969,24 @@ void mudlet::slot_disconnect()
 void mudlet::slot_replay()
 {
     Host * pHost = getActiveHost();
-    if( ! pHost ) return;
-    QString home = QDir::homePath() + "/.config/mudlet/profiles/";
-    home.append( pHost->getName() );
-    home.append( "/log/" );
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
-                                                    home,
-                                                    tr("*.dat"));
-    if( fileName.isEmpty() ) return;
-
-    QFile file(fileName);
-    if( ! file.open(QFile::ReadOnly | QFile::Text) )
-    {
-        QMessageBox::warning(this, tr("Select Replay"),
-                             tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
+    if( ! pHost )
         return;
-    }
-    //QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-    //QString fileName = directoryLogFile + "/"+QString(n.c_str());
-    pHost->mTelnet.loadReplay( fileName );
+
+    QString replayHomePath = QStringLiteral( "%1/.config/mudlet/profiles/%2/log/" )
+                             .arg( QDir::homePath() )
+                             .arg( pHost->getName() );
+
+    QString replayFileName = QFileDialog::getOpenFileName(this, tr("Select Replay"),
+                                                    replayHomePath,
+                                                    tr("*.dat"));
+    if( replayFileName.isEmpty() )
+        return; // will be empty if cancel is used in above dialog
+
+    // This call to cTelnet class is where the replay code becomes common with
+    // the lua loadRawFile() ...
+    // Second argument is to enable display of messages in console
+    QString msg = pHost->mTelnet.loadReplay( replayFileName, true );
+    pHost->mTelnet.postMessage( msg );
 }
 
 void mudlet::printSystemMessage( Host * pH, const QString & s )
@@ -2196,6 +2196,9 @@ void mudlet::replayStart()
     if( ! mpMainToolBar )
         return;
 
+    mpMainToolBar->actions()[15]->setEnabled( false ); // Disable Replay button;
+    mpMainToolBar->actions()[15]->setToolTip( tr( "Unable to load a Mudlet replay as one is already being played for a loaded profile!"));
+
     mpReplayToolBar = new QToolBar( this );
     mReplaySpeed = 1;
     mpReplayTimeDisplay = new QLabel( this );
@@ -2280,6 +2283,9 @@ void mudlet::replayOver()
         mpActionReplayTime = 0;
         mpReplayToolBar = 0;
     }
+
+    mpMainToolBar->actions()[15]->setEnabled( true ); // Enable Replay button;
+    mpMainToolBar->actions()[15]->setToolTip(tr("Allows you to load a Mudlet replay"));
 }
 
 void mudlet::slot_replaySpeedUp()
@@ -2382,4 +2388,20 @@ void mudlet::playSound( QString s )
         mpMusicBox4->setMedia( QUrl::fromLocalFile( s ) );
         mpMusicBox4->play();
     }
+}
+
+// Survey all the profiles loaded and check whether any are already replaying a
+// stored log - the current mechanism is not reentrant so must prevent more
+// than one replay at a time!
+bool mudlet::isReplayInProgress()
+{
+    Host * pHost = mHostManager.getFirstHost();
+    while( pHost ) {
+        if( pHost->mTelnet.isReplaying() )
+            return true;
+
+        pHost = mHostManager.getNextHost( pHost->getName() );
+    }
+
+    return false;
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -137,9 +137,9 @@ public:
    int                           mMainIconSize;
    int                           mTEFolderIconSize;
    void                          setIcoSize( int s );
-   void                          replayStart();
+   void                          replayStart( Host * );
    bool                          setConsoleBufferSize( Host * pHost, const QString & name, int x1, int y1 );
-   void                          replayOver();
+   void                          replayOver( Host * );
    void                          showEvent( QShowEvent * event ) override;
    void                          hideEvent( QHideEvent * event ) override;
    bool                          resetFormat( Host *, QString & name );
@@ -155,6 +155,7 @@ public:
    int                           mReplayTimeOffset; // How many milliSeconds into this chunk of replay are we?
    int                           mReplayChunkTime; // How long does this piece of replay file take in real milliseconds
    int                           mReplaySpeed; // Now uses a NEGATIVE value to represent a FRACTIONAL value
+   int                           mPreviousReplaySpeed;
    QToolBar *                    mpMainToolBar;
    QMap<QTimer *, TTimer *>      mTimerMap;
    dlgIRC *                      mpIRC;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -245,14 +245,14 @@ private:
    QMenu *                       restoreBar;
    bool                          mIsGoingDown;
 
-   QAction *                     actionReplaySpeedDown;
-   QAction *                     actionReplaySpeedUp;
-   QAction *                     actionSpeedDisplay;
-   QAction *                     actionReplayTime;
-   QLabel *                      replaySpeedDisplay;
-   QLabel *                      replayTime;
-   QTimer *                      replayTimer;
-   QToolBar *                    replayToolBar;
+   QAction *                     mpActionReplaySpeedDown;
+   QAction *                     mpActionReplaySpeedUp;
+   QAction *                     mpActionSpeedDisplay;
+   QAction *                     mpActionReplayTime;
+   QLabel *                      mpReplaySpeedDisplay;
+   QLabel *                      mpReplayTimeDisplay;
+   QTimer *                      mpReplayTimer;
+   QToolBar *                    mpReplayToolBar;
 
    QAction *                     actionReconnect;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -138,8 +138,8 @@ public:
    int                           mTEFolderIconSize;
    void                          setIcoSize( int s );
    void                          replayStart( Host * );
+   void                          replayOver( Host *, bool );
    bool                          setConsoleBufferSize( Host * pHost, const QString & name, int x1, int y1 );
-   void                          replayOver( Host * );
    void                          showEvent( QShowEvent * event ) override;
    void                          hideEvent( QHideEvent * event ) override;
    bool                          resetFormat( Host *, QString & name );

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -150,8 +150,12 @@ public:
    void                          stopSounds();
    void                          playSound( QString s );
    bool                          isReplayInProgress();
+   void                          updateReplaySpeedDisplay();
+
+
    QTime                         mReplayTime;
-   QPointer<QTimer>              mpReplayTimer;
+   QPointer<QTimer>              mpReplayDisplayTimer;
+   QPointer<QTimer>              mpReplayChunkTimer;
    int                           mReplayTimeOffset; // How many milliSeconds into this chunk of replay are we?
    int                           mReplayChunkTime; // How long does this piece of replay file take in real milliseconds
    int                           mReplaySpeed; // Now uses a NEGATIVE value to represent a FRACTIONAL value

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -149,6 +149,7 @@ public:
    void                          deselect( Host * pHost, const QString & name );
    void                          stopSounds();
    void                          playSound( QString s );
+   bool                          isReplayInProgress();
    QTime                         mReplayTime;
    QTimer *                      mpReplayTimer;
    int                           mReplayTimeOffset; // How many milliSeconds into this chunk of replay are we?

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -153,7 +153,7 @@ public:
    QTimer *                      mpReplayTimer;
    int                           mReplayTimeOffset; // How many milliSeconds into this chunk of replay are we?
    int                           mReplayChunkTime; // How long does this piece of replay file take in real milliseconds
-   int                           mReplaySpeed;
+   int                           mReplaySpeed; // Now uses a NEGATIVE value to represent a FRACTIONAL value
    QToolBar *                    mpMainToolBar;
    QMap<QTimer *, TTimer *>      mTimerMap;
    dlgIRC *                      mpIRC;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -151,7 +151,7 @@ public:
    void                          playSound( QString s );
    bool                          isReplayInProgress();
    QTime                         mReplayTime;
-   QTimer *                      mpReplayTimer;
+   QPointer<QTimer>              mpReplayTimer;
    int                           mReplayTimeOffset; // How many milliSeconds into this chunk of replay are we?
    int                           mReplayChunkTime; // How long does this piece of replay file take in real milliseconds
    int                           mReplaySpeed; // Now uses a NEGATIVE value to represent a FRACTIONAL value
@@ -250,13 +250,13 @@ private:
    QMenu *                       restoreBar;
    bool                          mIsGoingDown;
 
-   QAction *                     mpActionReplaySpeedDown;
-   QAction *                     mpActionReplaySpeedUp;
-   QAction *                     mpActionSpeedDisplay;
-   QAction *                     mpActionReplayTime;
-   QLabel *                      mpReplaySpeedDisplay;
-   QLabel *                      mpReplayTimeDisplay;
-   QToolBar *                    mpReplayToolBar;
+   QPointer<QAction>             mpActionReplaySpeedDown;
+   QPointer<QAction>             mpActionReplaySpeedUp;
+   QPointer<QAction>             mpActionSpeedDisplay;
+   QPointer<QAction>             mpActionReplayTime;
+   QPointer<QLabel>              mpReplaySpeedDisplay;
+   QPointer<QLabel>              mpReplayTimeDisplay;
+   QPointer<QToolBar>            mpReplayToolBar;
 
    QAction *                     actionReconnect;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -150,6 +150,9 @@ public:
    void                          stopSounds();
    void                          playSound( QString s );
    QTime                         mReplayTime;
+   QTimer *                      mpReplayTimer;
+   int                           mReplayTimeOffset; // How many milliSeconds into this chunk of replay are we?
+   int                           mReplayChunkTime; // How long does this piece of replay file take in real milliseconds
    int                           mReplaySpeed;
    QToolBar *                    mpMainToolBar;
    QMap<QTimer *, TTimer *>      mTimerMap;
@@ -251,7 +254,6 @@ private:
    QAction *                     mpActionReplayTime;
    QLabel *                      mpReplaySpeedDisplay;
    QLabel *                      mpReplayTimeDisplay;
-   QTimer *                      mpReplayTimer;
    QToolBar *                    mpReplayToolBar;
 
    QAction *                     actionReconnect;


### PR DESCRIPTION
Right, hopefully I've taken on-board all the points raised about #200 others have made with the exception of:
- Not not renaming some variables/members: _I felt that the names I changed were justified despite the fact that it might make it harder to trace the other changes.  In one case the convention of prefixing class members with an 'm' (and pointers with 'p') pointed out to me where a method's local variable (which erroneously had an 'm' prefix) was masking a class member with the same name which would cause issue when the member was used when it had not been set to the wanted value._

~~\* For a method that returned messages about the action it did or the error that prevented it from doing so that required two different style of message depending on the caller, _returning both types and allowing the caller to choose which to use_ was not the optimum solution because it also had to configure whether another method would send a further message or not when _that_ had finished. In other circumstances it might have been worth considering but not this time!~~
