### PR TITLE
BugFix: close button on map custom exit dialog not cancelling line drawi...

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -108,7 +108,7 @@ public:
     bool     mShiftMode;
     bool     mShowInfo;
     QComboBox * arealist_combobox;
-    QDialog * mpCustomLinesDialog;
+    QPointer<QDialog> mpCustomLinesDialog;
     int  mCustomLinesRoomFrom;
     int  mCustomLinesRoomTo;
     QString mCustomLinesRoomExit;
@@ -177,6 +177,10 @@ public slots:
     void slot_customLineProperties();
     void slot_customLineAddPoint();
     void slot_customLineRemovePoint();
+    void slot_cancelCustomLineDialog();
+
+private:
+    bool    mDialogLock;
 };
 
 #endif // MUDLET_T2DMAP_H


### PR DESCRIPTION
As per http://bugs.launchpad.net/mudlet/+bug/1369041 the built-in dialog
button that some OS/Window systems provide did close the dialog but did not
cancel the custom line drawing process.  This fixes the matter by
connecting the reject() signal that the button produces to code to clean
up.

During debugging this, it became clear that: if the custom line dialog was
being displayed but before the user had selected the exit to draw the line
for, it was possible to click on the map and add points to create a line;
this would be for a custom line with an Empty exit name which should not be
permitted.  To prevent this a private flag "mDialogLock" was added to the
class to prevent the mouse events that would draw or modify a custom line
from proceeding until the custom line dialog had been used or cancelled.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
