### PR TITLE
BugFix: Fix original coding errors creating data in TArea::exits member

### DIFF
--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,11 +23,11 @@
 #include "TArea.h"
 
 
-#include "TMap.h"
 #include "TRoom.h"
 #include "TRoomDB.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QDebug>
 #include <QTime>
 #include "post_guard.h"
@@ -51,6 +52,7 @@ TArea::TArea(TMap * map , TRoomDB * pRDB )
 , isZone( false )
 , zoneAreaRef( 0 )
 , mpRoomDB( pRDB )
+, mIsDirty( false )
 {
 }
 
@@ -160,102 +162,89 @@ QList<int> TArea::getCollisionNodes()
     return problems;
 }
 
-void TArea::fast_ausgaengeBestimmen( int id )
+void TArea::determineAreaExitsOfRoom( int id )
 {
-    if( ! mpRoomDB )
+    if( ! mpRoomDB ) {
         return;
+    }
 
     TRoom * pR = mpRoomDB->getRoom(id);
-    if( ! pR )
+    if( ! pR ) {
         return;
+    }
 
     exits.remove(id);
     int exitId = pR->getNorth();
     // The second term in the ifs below looks for exit room id in TArea
     // instance's own list of rooms which will fail (with a -1 if it is NOT in
     // the list and hence the area.
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
         exits.insertMulti( id, p );
     }
     exitId = pR->getNortheast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
         exits.insertMulti( id, p );
     }
     exitId = pR->getEast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
         exits.insertMulti( id, p );
     }
     exitId = pR->getSoutheast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
         exits.insertMulti( id, p );
     }
     exitId = pR->getSouth();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
         exits.insertMulti( id, p );
     }
     exitId = pR->getSouthwest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
         exits.insertMulti( id, p );
     }
     exitId = pR->getWest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
         exits.insertMulti( id, p );
     }
     exitId = pR->getNorthwest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
         exits.insertMulti( id, p );
     }
     exitId = pR->getUp();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
         exits.insertMulti( id, p );
     }
     exitId = pR->getDown();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
         exits.insertMulti( id, p );
     }
     exitId = pR->getIn();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
         exits.insertMulti( id, p );
     }
     exitId = pR->getOut();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-    {
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
         QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
         exits.insertMulti( id, p );
     }
     const QMap<int, QString> otherMap = pR->getOtherMap();
     QMapIterator<int,QString> it( otherMap );
-    while( it.hasNext() )
-    {
+    while( it.hasNext() ) {
         it.next();
         int _exit = it.key();
         TRoom * pO = mpRoomDB->getRoom(_exit);
-        if( pO )
-        {
-            if( pO->getArea() != getAreaID() )
-            {
+        if( pO ) {
+            if( pO->getArea() != getAreaID() ) {
                 QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
                 exits.insertMulti( id, p );
             }
@@ -263,99 +252,84 @@ void TArea::fast_ausgaengeBestimmen( int id )
     }
 }
 
-void TArea::ausgaengeBestimmen()
+void TArea::determineAreaExits()
 {
     exits.clear();
-    for( int i=0; i<rooms.size(); i++ )
-    {
+    for( int i=0; i<rooms.size(); i++ ) {
         TRoom * pR = mpRoomDB->getRoom(rooms[i]);
-        if( ! pR )
+        if( ! pR ) {
             continue;
+        }
 
         int id = pR->getId();
         int exitId = pR->getNorth();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
             exits.insertMulti( id, p );
         }
         exitId = pR->getNortheast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
             exits.insertMulti( id, p );
         }
         exitId = pR->getEast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
             exits.insertMulti( id, p );
         }
         exitId = pR->getSoutheast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
             exits.insertMulti( id, p );
         }
         exitId = pR->getSouth();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
             exits.insertMulti( id, p );
         }
         exitId = pR->getSouthwest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
             exits.insertMulti( id, p );
         }
         exitId = pR->getWest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
             exits.insertMulti( id, p );
         }
         exitId = pR->getNorthwest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
             exits.insertMulti( id, p );
         }
         exitId = pR->getUp();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
             exits.insertMulti( id, p );
         }
         exitId = pR->getDown();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
             exits.insertMulti( id, p );
         }
         exitId = pR->getIn();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
             exits.insertMulti( id, p );
         }
         exitId = pR->getOut();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
-        {
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
             QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
             exits.insertMulti( id, p );
         }
         const QMap<int, QString> otherMap = pR->getOtherMap();
         QMapIterator<int,QString> it( otherMap );
-        while( it.hasNext() )
-        {
+        while( it.hasNext() ) {
             it.next();
             int _exit = it.key();
             TRoom * pO = mpRoomDB->getRoom(_exit);
-            if( pO )
-            {
-                if( pO->getArea() != getAreaID() )
-                {
+            if( pO ) {
+                if( pO->getArea() != getAreaID() ) {
                     QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
                     exits.insertMulti( id, p );
                 }
@@ -569,4 +543,72 @@ void TArea::removeRoom( int room )
 //    if( xmin == x || xmax == x || ymax == y ||
 //        ymin == y || zmin == z || zmax == z)
 //        calcSpan();
+}
+
+// Reconstruct the area exit data in a format that actually makes sense - only
+// needed until the TRoom & TArea classes can be restructured to store exits
+// using the exit direction as a key and the to room as a value instead of vice-versa
+const QMultiMap<int, QPair<QString, int> > TArea::getAreaExitRoomData() const
+{
+    QMultiMap<int, QPair<QString, int> > results;
+    QSet<int> roomsWithOtherAreaSpecialExits;
+
+    QMapIterator<int, QPair<int, int> > itAreaExit = exits;
+    // First parse the normal exits and also find the rooms where there is at
+    // least one special area exit
+    while( itAreaExit.hasNext() ) {
+        itAreaExit.next();
+        QPair<QString, int> exitData;
+        exitData.second = itAreaExit.value().first;
+        switch( itAreaExit.value().second ) {
+            case DIR_NORTH:     exitData.first = QString("north");         break;
+            case DIR_NORTHEAST: exitData.first = QString("northeast");     break;
+            case DIR_NORTHWEST: exitData.first = QString("northwest");     break;
+            case DIR_SOUTH:     exitData.first = QString("south");         break;
+            case DIR_WEST:      exitData.first = QString("west");          break;
+            case DIR_EAST:      exitData.first = QString("east");          break;
+            case DIR_SOUTHEAST: exitData.first = QString("southeast");     break;
+            case DIR_SOUTHWEST: exitData.first = QString("southwest");     break;
+            case DIR_UP:        exitData.first = QString("up");            break;
+            case DIR_DOWN:      exitData.first = QString("down");          break;
+            case DIR_IN:        exitData.first = QString("in");            break;
+            case DIR_OUT:       exitData.first = QString("out");           break;
+            case DIR_OTHER:     roomsWithOtherAreaSpecialExits.insert(itAreaExit.key());   break;
+            default:
+                qWarning("TArea::getAreaExitRoomData() Warning: unrecognised exit code %1 found for exit from room %2 to room %3.",
+                         itAreaExit.value().second, itAreaExit.key(), itAreaExit.value().first );
+        }
+        if( ! exitData.first.isEmpty() ) {
+            results.insert( itAreaExit.key(), exitData );
+        }
+    }
+    // Now have to find the special area exits in the rooms where we know there
+    // IS one
+    QSetIterator<int> itRoomWithOtherAreaSpecialExit = roomsWithOtherAreaSpecialExits;
+    while( itRoomWithOtherAreaSpecialExit.hasNext() ) {
+        int fromRoomId = itRoomWithOtherAreaSpecialExit.next();
+        TRoom * pFromRoom = mpRoomDB->getRoom( fromRoomId );
+        if( pFromRoom ) {
+            QMapIterator<int, QString> itOtherExit = pFromRoom->getOtherMap();
+            while( itOtherExit.hasNext() ) {
+                itOtherExit.next();
+                QPair<QString, int> exitData;
+                exitData.second = itOtherExit.key();
+                TRoom * pToRoom = mpRoomDB->getRoom( exitData.second );
+                if( pToRoom && mpRoomDB->getArea( pToRoom->getArea() ) != this ) {
+                    // Note that pToRoom->getArea() is misnamed, should be getAreaId() !
+                    if( itOtherExit.value().mid(0,1) == QStringLiteral("0") || itOtherExit.value().mid(0,1) == QStringLiteral("1") ) {
+                        exitData.first = itOtherExit.value().mid(1);
+                    }
+                    else {
+                        exitData.first = itOtherExit.value();
+                    }
+                    if( ! exitData.first.isEmpty() ) {
+                        results.insert( fromRoomId, exitData );
+                    }
+                }
+            }
+        }
+    }
+    return results;
 }

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -31,20 +31,14 @@
 #include <QTime>
 #include "post_guard.h"
 
-
-#define NORTH 12
-#define NORTHEAST 1
-#define EAST 3
-#define SOUTHEAST 4
-#define SOUTH 6
-#define SOUTHWEST 7
-#define WEST 9
-#define NORTHWEST 10
-#define UP 13
-#define DOWN 14
-#define IN 15
-#define OUT 16
-#define OTHER 17
+// Previous direction #defines here did not match the DIR_ defines in TRoom.h,
+// but as they are stored in the map file they ought not to be redefined without
+// a map file change - however the data that was stored - though wrong was not
+// actually used internally so we will just fix it and carry on!  We will use
+// the (supplimented by the addition of a code for OTHER) DIR_**** values set
+// in the top of TRoom.h.
+// FIXME: Modify mapper "painter" code to use "exits" rather than deriving the
+// same information each time it is run ???
 
 TArea::TArea(TMap * map , TRoomDB * pRDB )
 : min_x(0)
@@ -168,67 +162,87 @@ QList<int> TArea::getCollisionNodes()
 
 void TArea::fast_ausgaengeBestimmen( int id )
 {
+    if( ! mpRoomDB )
+        return;
+
     TRoom * pR = mpRoomDB->getRoom(id);
-    if( ! pR ) return;
+    if( ! pR )
+        return;
+
     exits.remove(id);
-    if( pR->getNorth() > 0 && rooms.indexOf( pR->getNorth() ) < 0 )
+    int exitId = pR->getNorth();
+    // The second term in the ifs below looks for exit room id in TArea
+    // instance's own list of rooms which will fail (with a -1 if it is NOT in
+    // the list and hence the area.
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, NORTH);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
         exits.insertMulti( id, p );
     }
-    if( pR->getNortheast() > 0 && rooms.indexOf( pR->getNortheast() )  < 0 )
+    exitId = pR->getNortheast();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, NORTHEAST);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
         exits.insertMulti( id, p );
     }
-    if( pR->getEast() > 0 && rooms.indexOf( pR->getEast() ) < 0 )
+    exitId = pR->getEast();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, EAST);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
         exits.insertMulti( id, p );
     }
-    if( pR->getSoutheast() > 0 && rooms.indexOf( pR->getSoutheast() ) < 0 )
+    exitId = pR->getSoutheast();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, SOUTHEAST);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
         exits.insertMulti( id, p );
     }
-    if( pR->getSouth() > 0 && rooms.indexOf( pR->getSouth() ) < 0 )
+    exitId = pR->getSouth();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, SOUTH);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
         exits.insertMulti( id, p );
     }
-    if( pR->getSouthwest() > 0 && rooms.indexOf( pR->getSouthwest() ) < 0 )
+    exitId = pR->getSouthwest();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, SOUTHWEST);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
         exits.insertMulti( id, p );
     }
-    if( pR->getWest() > 0 && rooms.indexOf( pR->getWest() ) < 0 )
+    exitId = pR->getWest();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, WEST);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
         exits.insertMulti( id, p );
     }
-    if( pR->getNorthwest() > 0 && rooms.indexOf( pR->getNorthwest() ) < 0 )
+    exitId = pR->getNorthwest();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, NORTHWEST);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
         exits.insertMulti( id, p );
     }
-    if( pR->getUp() > 0 && rooms.indexOf( pR->getUp() ) < 0 )
+    exitId = pR->getUp();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, UP);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
         exits.insertMulti( id, p );
     }
-    if( pR->getDown() > 0 && rooms.indexOf( pR->getDown() ) < 0 )
+    exitId = pR->getDown();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, DOWN);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
         exits.insertMulti( id, p );
     }
-    if( pR->getIn() > 0 && rooms.indexOf( pR->getIn() ) < 0 )
+    exitId = pR->getIn();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, IN);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
         exits.insertMulti( id, p );
     }
-    if( pR->getOut() > 0 && rooms.indexOf( pR->getOut() ) < 0 )
+    exitId = pR->getOut();
+    if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
     {
-        QPair<int, int> p = QPair<int,int>(id, OUT);
+        QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
         exits.insertMulti( id, p );
     }
     const QMap<int, QString> otherMap = pR->getOtherMap();
@@ -242,8 +256,8 @@ void TArea::fast_ausgaengeBestimmen( int id )
         {
             if( pO->getArea() != getAreaID() )
             {
-                QPair<int, int> p = QPair<int,int>(pO->getId(), OTHER);
-                exits.insertMulti( pO->getId(), p );
+                QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
+                exits.insertMulti( id, p );
             }
         }
     }
@@ -255,66 +269,80 @@ void TArea::ausgaengeBestimmen()
     for( int i=0; i<rooms.size(); i++ )
     {
         TRoom * pR = mpRoomDB->getRoom(rooms[i]);
-        if( ! pR ) continue;
+        if( ! pR )
+            continue;
+
         int id = pR->getId();
-        if( pR->getNorth() > 0 && rooms.indexOf( pR->getNorth() ) < 0 )
+        int exitId = pR->getNorth();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, NORTH);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
             exits.insertMulti( id, p );
         }
-        if( pR->getNortheast() > 0 && rooms.indexOf( pR->getNortheast() )  < 0 )
+        exitId = pR->getNortheast();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, NORTHEAST);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
             exits.insertMulti( id, p );
         }
-        if( pR->getEast() > 0 && rooms.indexOf( pR->getEast() ) < 0 )
+        exitId = pR->getEast();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, EAST);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
             exits.insertMulti( id, p );
         }
-        if( pR->getSoutheast() > 0 && rooms.indexOf( pR->getSoutheast() ) < 0 )
+        exitId = pR->getSoutheast();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, SOUTHEAST);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
             exits.insertMulti( id, p );
         }
-        if( pR->getSouth() > 0 && rooms.indexOf( pR->getSouth() ) < 0 )
+        exitId = pR->getSouth();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, SOUTH);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
             exits.insertMulti( id, p );
         }
-        if( pR->getSouthwest() > 0 && rooms.indexOf( pR->getSouthwest() ) < 0 )
+        exitId = pR->getSouthwest();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, SOUTHWEST);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
             exits.insertMulti( id, p );
         }
-        if( pR->getWest() > 0 && rooms.indexOf( pR->getWest() ) < 0 )
+        exitId = pR->getWest();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, WEST);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
             exits.insertMulti( id, p );
         }
-        if( pR->getNorthwest() > 0 && rooms.indexOf( pR->getNorthwest() ) < 0 )
+        exitId = pR->getNorthwest();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, NORTHWEST);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
             exits.insertMulti( id, p );
         }
-        if( pR->getUp() > 0 && rooms.indexOf( pR->getUp() ) < 0 )
+        exitId = pR->getUp();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, UP);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
             exits.insertMulti( id, p );
         }
-        if( pR->getDown() > 0 && rooms.indexOf( pR->getDown() ) < 0 )
+        exitId = pR->getDown();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, DOWN);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
             exits.insertMulti( id, p );
         }
-        if( pR->getIn() > 0 && rooms.indexOf( pR->getIn() ) < 0 )
+        exitId = pR->getIn();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, IN);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
             exits.insertMulti( id, p );
         }
-        if( pR->getOut() > 0 && rooms.indexOf( pR->getOut() ) < 0 )
+        exitId = pR->getOut();
+        if( exitId > 0 && rooms.indexOf( exitId ) < 0 )
         {
-            QPair<int, int> p = QPair<int,int>(id, OUT);
+            QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
             exits.insertMulti( id, p );
         }
         const QMap<int, QString> otherMap = pR->getOtherMap();
@@ -328,8 +356,8 @@ void TArea::ausgaengeBestimmen()
             {
                 if( pO->getArea() != getAreaID() )
                 {
-                    QPair<int, int> p = QPair<int,int>(pO->getId(), OTHER);
-                    exits.insertMulti( pO->getId(), p );
+                    QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
+                    exits.insertMulti( id, p );
                 }
             }
         }

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +23,8 @@
  ***************************************************************************/
 
 
+#include "TMap.h"
+
 #include "pre_guard.h"
 #include <QList>
 #include <QMap>
@@ -29,28 +32,33 @@
 #include <QVector3D>
 #include "post_guard.h"
 
-class TMap;
 class TRoomDB;
 
 
 class TArea
 {
+    friend bool TMap::serialize( QDataStream & );
+    friend bool TMap::restore( QString );
+
 public:
     TArea(TMap*, TRoomDB*);
     ~TArea();
     int getAreaID();
     void addRoom(int id);
     const QList<int>& getAreaRooms() const { return rooms; }
-    const QList<int> getAreaExits() const { return exits.uniqueKeys(); }
+    const QList<int> getAreaExitRoomIds() const { return exits.uniqueKeys(); }
+    const QMultiMap<int, QPair<QString, int> > getAreaExitRoomData() const ;
     void calcSpan();
     void fast_calcSpan(int);
-    void fast_ausgaengeBestimmen(int);
+    void determineAreaExits();
+    void determineAreaExitsOfRoom(int);
     void removeRoom(int);
     QList<int> getCollisionNodes();
     QList<int> getRoomsByPosition(int x, int y, int z);
     QMap<int, QMap<int, QMultiMap<int, int> > > koordinatenSystem();
-    void ausgaengeBestimmen();
-    QMultiMap<int, QPair<int, int> > exits; // rooms that border on this area: key=in_area room id, pair.first=out_of_area room id pair.second=direction
+    bool mIsDirty;
+
+
     QList<int> rooms;                       // rooms of this area
     QVector3D pos;                          // pos auf der map und 0 punkt des area internen koordinatensystems
     QVector3D span;
@@ -75,6 +83,12 @@ public:
 private:
     TArea() { qFatal("FATAL: illegal default constructor use of TArea()"); };
     // QMap<int, TMapLabel> labelMap;
+
+
+    QMultiMap<int, QPair<int, int> > exits;
+    // rooms that border on this area:
+    // key=in_area room id, pair.first=out_of_area room id pair.second=direction
+    // Made private as we may change implimentation detail
 };
 
 // - gezeichnet werden erstmal die areas

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4177,8 +4177,8 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     lua_newtable(L);
     for( int i=0; i<areaExits.size(); i++ )
     {
-        lua_pushnumber( L, i );
-        lua_pushnumber( L, areaExits[i] );
+        lua_pushnumber( L, i+1 ); // Lua lists/arrays begin at 1 not 0!
+        lua_pushnumber( L, areaExits.at(i) );
         lua_settable(L, -3);
     }
     return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -4148,38 +4148,72 @@ int TLuaInterpreter::getRooms( lua_State *L )
     return 1;
 }
 
+// Revised to take an optional second argument of a boolean to indicate whether
+// to return just the list of rooms in the area which have exits out of the area
+// (false) or nested tables of details (true). The latter case uses the "from"
+// room numbers as keys for the outer table, the value is an inner table with
+// the exit direction as key in the form of a text entry of either the text of
+// the special exit or (translatable) standard names for normal exits, the value
+// is the "to" room number.  In the event of an isolated area an empty table is
+// returned.
 int TLuaInterpreter::getAreaExits( lua_State *L )
 {
-    qDebug()<<"getAreaExits() enter";
     int area;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushstring( L, "getAreaExits: wrong argument type" );
+    int n = lua_gettop( L );
+    bool isFullDataRequired = false;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr("getAreaExits: Bad argument #1 (area ID, as number expected, got %1).").arg( luaL_typename(L, 1)).toUtf8().constData());
         lua_error( L );
-        return 1;
     }
-    else
-    {
+    else {
         area = lua_tonumber( L, 1 );
     }
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
 
+    if( n > 1 ) {
+        if( ! lua_isboolean( L, 2 ) ) {
+            lua_pushstring( L, tr("getAreaExits: Bad argument #2 (full data wanted, as boolean, optional, got %1).").arg( luaL_typename(L, 2)).toUtf8().constData());
+            lua_error( L );
+            return 1;
+        }
+        else {
+            isFullDataRequired = lua_toboolean( L, 2 );
+        }
+    }
+
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( area );
-    qDebug()<<"pA="<<pA;
-    if( !pA )
-    {
-        qDebug()<<"no area found";
+    if( !pA ) {
         lua_pushnil(L);
         return 1;
     }
-    QList<int> areaExits = pA->getAreaExits();
-    qDebug()<<"areaExits="<<areaExits;
+
     lua_newtable(L);
-    for( int i=0; i<areaExits.size(); i++ )
-    {
-        lua_pushnumber( L, i+1 ); // Lua lists/arrays begin at 1 not 0!
-        lua_pushnumber( L, areaExits.at(i) );
-        lua_settable(L, -3);
+    if( n < 2 || (n > 1 && ! isFullDataRequired ) ) {
+        // Replicate original implimentation
+        QList<int> areaExits = pA->getAreaExitRoomIds();
+        if( areaExits.size() > 1 ) {
+            std::sort(areaExits.begin(),areaExits.end());
+        }
+        for( int i=0; i<areaExits.size(); i++ ) {
+            lua_pushnumber( L, i+1 ); // Lua lists/arrays begin at 1 not 0!
+            lua_pushnumber( L, areaExits.at(i) );
+            lua_settable(L, -3);
+        }
+    }
+    else {
+        QMultiMap<int, QPair<QString, int> > areaExits = pA->getAreaExitRoomData();
+        QList<int> fromRooms = areaExits.uniqueKeys();
+        for( int i=0; i<fromRooms.size(); i++ ) {
+            lua_pushnumber( L, fromRooms.at(i) );
+            lua_newtable(L);
+            QList<QPair<QString, int> > toRoomsData = areaExits.values(fromRooms.at(i));
+            for( int j=0; j<toRoomsData.size(); j++ ) {
+                lua_pushstring( L, toRoomsData.at(j).first.toUtf8().constData() );
+                lua_pushnumber( L, toRoomsData.at(j).second );
+                lua_settable(L, -3);
+            }
+            lua_settable(L, -3);
+        }
     }
     return 1;
 }
@@ -6822,23 +6856,22 @@ int TLuaInterpreter::roomExists( lua_State * L )
 int TLuaInterpreter::addRoom( lua_State * L )
 {
     int id;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushstring( L, "getRoomArea: wrong argument type" );
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "addRoom: bad argument #1 type (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-    {
+    else {
         id = lua_tointeger( L, 1 );
     }
 
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     bool added = pHost->mpMap->addRoom( id );
     lua_pushboolean( L, added );
-    if ( added )
-        pHost->mpMap->setRoomArea( id, -1 );
-    pHost->mpMap->mMapGraphNeedsUpdate = true;
+    if( added ) {
+        pHost->mpMap->setRoomArea( id, -1, false );
+        pHost->mpMap->mMapGraphNeedsUpdate = true;
+    }
 
     return 1;
 }
@@ -8386,53 +8419,53 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 int TLuaInterpreter::setRoomArea( lua_State * L )
 {
     int id, area;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushstring( L, "setRoomArea: wrong argument type" );
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "setRoomArea: bad argument #1 type (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-    {
+    else {
         id = lua_tointeger( L, 1 );
     }
-    if( ! lua_isnumber( L, 2 ) )
-    {
-        lua_pushstring( L, "setRoomArea: wrong argument type" );
+
+    if( ! lua_isnumber( L, 2 ) ) {
+        lua_pushstring( L, tr( "setRoomArea: bad argument #2 type (area Id, as number expected, got %1)." ).arg( luaL_typename( L, 2 ) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-    {
+    else {
         area = lua_tointeger( L, 2 );
     }
+
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if ( area <= 0 )
-    {
-        lua_pushstring( L, "setRoomArea: Area ID must be > 0. To remove a room's area, use resetRoomArea(roomID)" );
+    if ( area <= 0 ) {
+        lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must be > 0.  To remove a room's area, use resetRoomArea(roomID) )." ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    pHost->mpMap->setRoomArea( id, area );
-    return 0;
+
+    lua_pushboolean( L, pHost->mpMap->setRoomArea( id, area, false ) );
+    return 1;
 }
 
 int TLuaInterpreter::resetRoomArea( lua_State * L )
 {
     //will reset the room area to our void area
     int id;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushstring( L, "resetRoomArea: wrong argument type" );
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "resetRoomArea: bad argument #1 (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
+    else {
         id = lua_tointeger( L, 1 );
+    }
 
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if ( pHost )
-        pHost->mpMap->setRoomArea( id, -1 );
+    if( pHost ) {
+        lua_pushboolean( L, pHost->mpMap->setRoomArea( id, -1, false ) );
+        return 1;
+    }
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4184,7 +4184,8 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( area );
     if( !pA ) {
         lua_pushnil(L);
-        return 1;
+        lua_pushstring( L, tr("getAreaExits: Bad value #1 (number %1 is not a valid area ID).").arg(area).toUtf8().constData());
+        return 2;
     }
 
     lua_newtable(L);
@@ -8438,14 +8439,35 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
     }
 
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if ( area <= 0 ) {
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomArea: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomArea: No map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( area <= 0 ) {
+        lua_pushnil( L );
         lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must be > 0.  To remove a room's area, use resetRoomArea(roomID) )." ).toUtf8().constData() );
-        lua_error( L );
+        return 2;
+    }
+    else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomArea: bad argument #1 value (room Id must exist.)" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( area ) ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must exist.)" ).toUtf8().constData() );
+        return 2;
+    }
+    else {
+        lua_pushboolean( L, pHost->mpMap->setRoomArea( id, area, false ) );
         return 1;
     }
-
-    lua_pushboolean( L, pHost->mpMap->setRoomArea( id, area, false ) );
-    return 1;
 }
 
 int TLuaInterpreter::resetRoomArea( lua_State * L )
@@ -8462,11 +8484,25 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     }
 
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if( pHost ) {
-        lua_pushboolean( L, pHost->mpMap->setRoomArea( id, -1, false ) );
-        return 1;
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "resetRoomArea: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
     }
-    return 0;
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "resetRoomArea: No map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "resetRoomArea: bad argumnet #1 value (room Id must exist)." ).toUtf8().constData() );
+        return 2;
+    }
+    else if ( pHost ) {
+       lua_pushboolean( L, pHost->mpMap->setRoomArea( id, -1, false ) );
+       return 1;
+    }
 }
 
 int TLuaInterpreter::setRoomChar( lua_State * L )

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4162,7 +4162,7 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     int n = lua_gettop( L );
     bool isFullDataRequired = false;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr("getAreaExits: Bad argument #1 (area ID, as number expected, got %1).").arg( luaL_typename(L, 1)).toUtf8().constData());
+        lua_pushstring( L, tr("getAreaExits: bad argument #1 type (area Id, as number expected, got %1).").arg( luaL_typename(L, 1)).toUtf8().constData());
         lua_error( L );
     }
     else {
@@ -4171,7 +4171,7 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
 
     if( n > 1 ) {
         if( ! lua_isboolean( L, 2 ) ) {
-            lua_pushstring( L, tr("getAreaExits: Bad argument #2 (full data wanted, as boolean, optional, got %1).").arg( luaL_typename(L, 2)).toUtf8().constData());
+            lua_pushstring( L, tr("getAreaExits: bad argument #2 type (full data wanted, as boolean, optional, got %1).").arg( luaL_typename(L, 2)).toUtf8().constData());
             lua_error( L );
             return 1;
         }
@@ -4184,7 +4184,7 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( area );
     if( !pA ) {
         lua_pushnil(L);
-        lua_pushstring( L, tr("getAreaExits: Bad value #1 (number %1 is not a valid area ID).").arg(area).toUtf8().constData());
+        lua_pushstring( L, tr("getAreaExits: bad argument #1 value (number %1 is not a valid area Id).").arg(area).toUtf8().constData());
         return 2;
     }
 
@@ -8446,12 +8446,12 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: No map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring( L, tr( "setRoomArea: no map present or loaded!" ).toUtf8().constData() );
         return 2;
     }
     else if( area <= 0 ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must be > 0.  To remove a room's area, use resetRoomArea(roomID) )." ).toUtf8().constData() );
+        lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must be > 0.  To remove a room's area, use resetRoomArea(roomId) )." ).toUtf8().constData() );
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
@@ -8475,7 +8475,7 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     //will reset the room area to our void area
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "resetRoomArea: bad argument #1 (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "resetRoomArea: bad argument #1 type (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
@@ -8491,12 +8491,12 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "resetRoomArea: No map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring( L, tr( "resetRoomArea: no map present or loaded!" ).toUtf8().constData() );
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "resetRoomArea: bad argumnet #1 value (room Id must exist)." ).toUtf8().constData() );
+        lua_pushstring( L, tr( "resetRoomArea: bad argument #1 value (room Id must exist)." ).toUtf8().constData() );
         return 2;
     }
     else if ( pHost ) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -131,21 +132,21 @@ void TMap::importMapFromDatabase()
     mpHost->mLuaInterpreter.compileAndExecuteScript( script );
 }
 
-void TMap::setRoomArea( int id, int area )
+bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculations )
 {
     TRoom * pR = mpRoomDB->getRoom( id );
 
-    if( !pR )
-    {
-        QString msg = QString("roomID=%1 does not exist, can't set area=%2 of nonexisting room").arg(id).arg(area);
+    if( !pR ) {
+        QString msg = qApp->translate( "TMap", "RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!" ).arg(id).arg(area);
         logError(msg);
-        return;
+        return false;
     }
 
-    pR->setArea( area );
-
-
-    mMapGraphNeedsUpdate = true;
+    bool result = pR->setArea( area, isToDeferAreaRelatedRecalculations );
+    if( result ) {
+        mMapGraphNeedsUpdate = true;
+    }
+    return result;
 }
 
 bool TMap::addRoom( int id )
@@ -260,15 +261,20 @@ bool TMap::setExit( int from, int to, int dir )
     TRoom * pR = mpRoomDB->getRoom( from );
     TRoom * pR_to = mpRoomDB->getRoom( to );
 
-    if( !pR ) return false;
-    if( !pR_to && to > 0 ) return false;
-    if( to < 1 ) to = -1;
+    if( !pR ) {
+        return false;
+    }
+    if( !pR_to && to > 0 ) {
+        return false;
+    }
+    if( to < 1 ) {
+        to = -1;
+    }
 
     mPlausaOptOut = 0;
     bool ret = true;
 
-    switch( dir )
-    {
+    switch( dir ) {
         case DIR_NORTH:
             pR->setNorth(to);
             break;
@@ -311,57 +317,73 @@ bool TMap::setExit( int from, int to, int dir )
     pR->setExitStub(dir, false);
     mMapGraphNeedsUpdate = true;
     TArea * pA = mpRoomDB->getArea( pR->getArea() );
-    if ( ! pA )
+    if( ! pA ) {
         return false;
-    pA->fast_ausgaengeBestimmen(pR->getId());
+    }
+    pA->determineAreaExitsOfRoom(pR->getId());
     return ret;
 }
 
 void TMap::init( Host * pH )
 {
     // init areas
-    QTime _time; _time.start();
-    if( version < 14 )
-    {
+    QTime _time;
+    _time.start();
+
+    if( version < 14 ) {
         mpRoomDB->initAreasForOldMaps();
     }
-    qDebug()<<" TMap::init() initialize area rooms: run time:"<<_time.elapsed();
+    else if( version < 17 ) {
+        // The second half of mpRoomDB->initAreasForOldMaps() - needed to fixup
+        // all the (TArea *)->areaExits() that were built wrongly previously,
+        // calcSpan() may not be required to be done here and now but it is in my
+        // sights as a target for revision in the future. Slysven
+        QMapIterator<int, TArea *> itArea( mpRoomDB->getAreaMap() );
+        while( itArea.hasNext() ) {
+            itArea.next();
+            itArea.value()->determineAreaExits();
+            itArea.value()->calcSpan();
+        }
+    }
     mpRoomDB->auditRooms();
-    // convert old style labels
-    QMapIterator<int, TArea *> it( mpRoomDB->getAreaMap() );
-    while( it.hasNext() )
-    {
-        it.next();
-        int areaID = it.key();
-        if( mapLabels.contains(areaID) )
-        {
-            QList<int> labelIDList = mapLabels[areaID].keys();
-            for( int i=0; i<labelIDList.size(); i++ )
-            {
-                TMapLabel l = mapLabels[areaID][labelIDList[i]];
-                if( l.pix.isNull() )
-                {
-                    int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50 );
-                    if( newID > -1 )
-                    {
-                        cout << "CONVERTING: old style label areaID:"<<areaID<<" labelID:"<< labelIDList[i]<<endl;
-                        mapLabels[areaID][labelIDList[i]] = mapLabels[areaID][newID];
-                        deleteMapLabel( areaID, newID );
+
+    if( version <16 ) {
+        // convert old style labels, wasn't made version conditional in past but
+        // not likely to be an issue in recent map file format versions (say 16+)
+        QMapIterator<int, TArea *> itArea( mpRoomDB->getAreaMap() );
+        while( itArea.hasNext() ) {
+            itArea.next();
+            int areaID = itArea.key();
+            if( mapLabels.contains(areaID) ) {
+                QList<int> labelIDList = mapLabels.value(areaID).keys();
+                for( int i=0; i<labelIDList.size(); i++ ) {
+                    TMapLabel l = mapLabels.value(areaID).value(labelIDList.at(i));
+                    if( l.pix.isNull() ) {
+                        int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50 );
+                        if( newID > -1 ) {
+                            QString msg = qApp->translate("TMap","[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
+                            mpHost->mTelnet.postMessage(msg);
+                            mapLabels[areaID][labelIDList.at(i)] = mapLabels[areaID][newID];
+                            deleteMapLabel( areaID, newID );
+                        }
+                        else {
+                            QString msg = qApp->translate("TMap","[ WARN ] - CONVERTING: cannot convert old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
+                            mpHost->mTelnet.postMessage(msg);
+                        }
                     }
-                    else
-                        cout << "ERROR: cannot convert old style label areaID:"<<areaID<<" labelID:"<< labelIDList[i]<<endl;
-                }
-                if ( ( l.size.width() > std::numeric_limits<qreal>::max() ) || ( l.size.width() < -std::numeric_limits<qreal>::max() ) )
-                {
-                    mapLabels[areaID][labelIDList[i]].size.setWidth(l.pix.width());
-                }
-                if ( ( l.size.height() > std::numeric_limits<qreal>::max() ) || ( l.size.height() < -std::numeric_limits<qreal>::max() ) )
-                {
-                    mapLabels[areaID][labelIDList[i]].size.setHeight(l.pix.height());
+                    if (    ( l.size.width() >  std::numeric_limits<qreal>::max() )
+                         || ( l.size.width() < -std::numeric_limits<qreal>::max() ) ) {
+                        mapLabels[areaID][labelIDList[i]].size.setWidth(l.pix.width());
+                    }
+                    if (    ( l.size.height() >  std::numeric_limits<qreal>::max() )
+                         || ( l.size.height() < -std::numeric_limits<qreal>::max() ) ) {
+                        mapLabels[areaID][labelIDList[i]].size.setHeight(l.pix.height());
+                    }
                 }
             }
         }
     }
+    qDebug("TMap::init() Initialize run time:%i milli-seconds.", _time.elapsed() );
 }
 
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -74,7 +75,7 @@ public:
     int createMapLabel(int area, QString text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop=true, bool noScaling=true, qreal zoom=15.0, int fontSize=15 );
     void deleteMapLabel( int area, int labelID );
     bool addRoom( int id=0 );
-    void setRoomArea( int id, int area );
+    bool setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculations = false );
     // void deleteRoom( int id );
     void deleteArea( int id );
     int createNewRoomID();

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,6 +27,7 @@
 #include "TRoomDB.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QDataStream>
 #include <QDebug>
 #include <QStringBuilder>
@@ -178,34 +180,65 @@ void TRoom::setId( int _id )
     id = _id;
 }
 
-void TRoom::setArea( int _areaID )
+// The second optional argument delays area related recaluclations when true
+// until called with false (the default) - it records the "dirty" areas so that
+// the affected areas can be identified.
+// The caller, should set the argument true for all but the last when working
+// through a list of rooms.
+// There IS a theoretical risk that if the last called room "doesn't exist" then
+// the area related recalculations won't get done - so had better provide an
+// alternative means to do them as a fault recovery
+bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
 {
-    TArea * pA = mpRoomDB->getArea( _areaID );
-    if( !pA )
-    {
-        mpRoomDB->addArea( _areaID );
-        pA = mpRoomDB->getArea( _areaID );
-        if( !pA )
-        {
-            QString error = QString( "TRoom::setArea(): No area created!  Requested area ID=%1. Note: Area IDs must be > 0" ).arg( _areaID );
+    static QSet<TArea *> dirtyAreas;
+    TArea * pA = mpRoomDB->getArea( areaID );
+    if( ! pA ) { // There is no TArea instance with that _areaID
+        mpRoomDB->addArea( areaID ); // So try and make it
+        pA = mpRoomDB->getArea( areaID );
+        if( ! pA ) { // Oh, dear THAT didn't work
+            QString error = qApp->translate( "TRoom", "No area created!  Requested area ID=%1. Note: Area IDs must be > 0" ).arg( areaID );
             mpRoomDB->mpMap->logError(error);
-            return;
+            return false;
         }
     }
 
     //remove from the old area
     TArea * pA2 = mpRoomDB->getArea( area );
-    if ( pA2 )
+    if( pA2 ) {
         pA2->removeRoom( id );
-    else
-    {
-        QString error = QString( "TRoom::setArea(): Warning: Room (Id: %1) had no current area!").arg( id );
-        mpRoomDB->mpMap->logError(error);
+        // Ah, all rooms in the OLD area that led to the room now become area
+        // exits for that OLD area {so must run determineAreaExits() for the
+        // old area after the room has moved to the new area see other
+        // "if( pA2 )" below} - other exits that led to the room from other
+        // areas are still "out of area exits" UNLESS the room moves to the SAME
+        // area that the other exits are in.
+        dirtyAreas.insert( pA2 ); // Add to local store of dirty areas
+        pA2->mIsDirty = true; // Flag the area itself in case soemthing goes
+                              // wrong on last room in a series
     }
-    area = _areaID;
+    else {
+        QString error = qApp->translate( "TRoom", "Warning: When setting the Area for Room (Id: %1) it did not have a current area!").arg( id );
+        mpRoomDB->mpMap->logError( error );
+    }
+
+    area = areaID;
     pA->addRoom( id );
-    pA->fast_ausgaengeBestimmen(id);
-    pA->fast_calcSpan(id);
+
+    dirtyAreas.insert( pA );
+    pA->mIsDirty;
+
+    if( ! isToDeferAreaRelatedRecalculations ) {
+        QSetIterator<TArea *> itpArea = dirtyAreas;
+        while( itpArea.hasNext() ) {
+            TArea * pArea = itpArea.next();
+            pArea->calcSpan();
+            pArea->determineAreaExits();
+            pArea->mIsDirty = false;
+        }
+        dirtyAreas.clear();
+    }
+
+    return true;
 }
 
 bool TRoom::setExit( int to, int direction )
@@ -513,7 +546,7 @@ void TRoom::setSpecialExit( int to, const QString& cmd )
     TArea * pA = mpRoomDB->getArea( area );
     if( pA )
     {
-        pA->fast_ausgaengeBestimmen( id );
+        pA->determineAreaExitsOfRoom( id );
         // This updates the (TArea *)->exits map even for exit REMOVALS
     }
 
@@ -534,7 +567,7 @@ void TRoom::removeAllSpecialExitsToRoom( int _id )
     TArea * pA = mpRoomDB->getArea( area );
     if( pA )
     {
-        pA->fast_ausgaengeBestimmen( id );
+        pA->determineAreaExitsOfRoom( id );
     }
 }
 

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -44,6 +44,7 @@
 #define DIR_DOWN 10
 #define DIR_IN 11
 #define DIR_OUT 12
+#define DIR_OTHER 13
 
 class XMLimport;
 class XMLexport;

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -78,7 +79,7 @@ public:
     bool hasExitStub( int direction );
     void setExitStub( int direction, bool status );
     void calcRoomDimensions();
-    void setArea( int _areaID );
+    bool setArea( int , bool isToDeferAreaRelatedRecalculations = false );
     int getExitWeight(const QString& cmd );
 
     int getWeight() { return weight; }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -243,12 +244,10 @@ QList<int> TRoomDB::getRoomIDList()
 TArea * TRoomDB::getArea( int id )
 {
     //area id of -1 is a room in the "void", 0 is a failure
-    if( areas.contains( id ) && ( id > 0 || id == -1 ) )
-    {
-        return areas[id];
+    if( id > 0 || id == -1 ) {
+        return areas.value( id, 0 );
     }
-    else
-    {
+    else {
         return 0;
     }
 }
@@ -361,7 +360,7 @@ void TRoomDB::initAreasForOldMaps()
     {
         it2.next();
         TArea * pA = it2.value();
-        pA->ausgaengeBestimmen();
+        pA->determineAreaExits();
         pA->calcSpan();
     }
 }

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -537,7 +537,7 @@ void dlgRoomExits::save()
 
     TArea * pA = mpHost->mpMap->mpRoomDB->getArea( pR->getArea() );
     if( pA )
-        pA->fast_ausgaengeBestimmen( pR->getId() );
+        pA->determineAreaExitsOfRoom( pR->getId() );
 
     close();
 }


### PR DESCRIPTION
The specification for this member is:
```
QMultiMap\<int, QPair\<int, int> > exits
```
and it is a record of the rooms that are on border on the TArea instance.
The outer QMultiMap key is the room id of the in_area room, and the value
pair is:
```
first=out_of_area room id
second=direction code
```
The original direction codes were defined at the start of the TArea.cpp
class file but there did not appear to be any logic to the values used:
N=12, NE=1, E=3, SE=4, S=6, SW=7, W=9, NW=10, UP=13, DOWN=14, IN=15,
OUT=16, OTHER=17.  Other than a lua function getAreaExits(areaId) which was
supposed to return just a list of unique keys via a TArea::getAreaExits()
method - i.e. a list of rooms in the given area which were exits to another
area, no other use was made of this data.  I propose to replace this list
of values with the better known list stored in the TRoom class header file
but as that does not currently have a value for "other" {a.k.a. Special}
exits I had added a new define: #DEFINE DIR_OTHER with the value 13.

The data IS stored in the map file but is not changed except by calls to:
```
* (void)TArea::ausgaengeBestimmen() called from:
    (void)TRoomDB::initAreasForOldMaps()
* (void)TArea::fast_ausgaengeBestimmen(int id) called from:
    (bool)TMap::setExit(int from, int to, int dir)
    (void)TRoom::setArea(int _areaID)
    (void)TRoom::setSpecialExit(int to, const QString & cmd)
    (void)TRoom::removeAllSpecialExitsToRoom(int _id)
    (void)dlgRoomExits::save()
* (void)TArea::removeRoom(int room) called from:
    (void)TRoom::setArea(int _areaID)
    (bool)TRoomDB::__removeRoom(int id)
```
The bugs are that the code in both "ausgaengeBestimmen" methods (with
and without the "fast_" prefix) used the FROM room Id as the first member
of the value pair rather than the TO (a.k.a. exit) room Id for Normal
exits and use the room ID of the TO (a.k.a. exit) room Id as the key for
Special exits (i.e. stores a room that is NOT in the relevant area as a
room IN the area that is an exit from THAT area!)  Additionally, even if
the code was correct the existing flawed data would not be corrected when
the map is loaded by running TArea::ausgaengeBestimmen() again because that
is only called at the end of TRoomDB::initAreasForOldMaps() which was
called only for old pre-version 15 map file formats (and we are currently
on 16 - though I have plans in pipeline for something that would require an
increment on that).  To further stir the faulty data up previous faulty
code that introduced problems when moving a room from one area to another
may also have contributed to errors with the TArea::exits data.

However:

tl;dr;

running the lua command "auditAreas()" runs TRoomDB::initAreasForOldMaps()
which will fix-up existing maps after this commit has been committed...!

This fixes ["getAreaExits is broken (bug 1380822)"](http://bugs.launchpad.net/mudlet/+bug/1380822) 8-)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>