### PR TITLE
Update package.cpath for OSX

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11155,8 +11155,7 @@ void TLuaInterpreter::initLuaGlobals()
     QString n;
     int error;
 
-    // if using LuaJIT, adjust the cpath to look in /usr/lib as well - it doesn't by default
-    luaL_dostring (pGlobalLua, "if jit then package.cpath = package.cpath .. ';/usr/lib/lua/5.1/?.so;/usr/lib/x86_64-linux-gnu/lua/5.1/?.so' end");
+    luaL_dostring (pGlobalLua, "package.cpath = package.cpath . ';?.dylib'");
 
     error = luaL_dostring( pGlobalLua, "require \"rex_pcre\"" );
     if( error != 0 )


### PR DESCRIPTION
Update package.cpath os it can find locally-shipped dylibs, and remove the LuaJIT cpath code as we don't use it.

This is actually currently in production for 3.0, I forgot to commit it after I made the fix.
