### PR TITLE
Add support for strikeout/strikethrough/linethrough text

### DIFF
--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -40,6 +40,7 @@
 #define TCHAR_UNDERLINE 4
 #define TCHAR_INVERSE 8
 #define TCHAR_ECHO 16
+#define TCHAR_STRIKEOUT 32
 
 class Host;
 
@@ -48,7 +49,7 @@ class TChar
 {
 public:
            TChar();
-           TChar( int, int, int, int, int, int, bool, bool, bool, int _link = 0 );
+           TChar( int, int, int, int, int, int, bool, bool, bool, bool, int _link = 0 );
            TChar( Host * );
            TChar( const TChar & copy );
     bool   operator==( const TChar & c );
@@ -81,7 +82,7 @@ class TBuffer
 public:
 
     TBuffer( Host * pH );
-    QPoint insert( QPoint &, const QString& text, int,int,int, int, int, int, bool bold, bool italics, bool underline );
+    QPoint insert( QPoint &, const QString& text, int,int,int, int, int, int, bool bold, bool italics, bool underline, bool strikeout );
     bool insertInLine( QPoint & cursor, const QString & what, TChar & format );
     void expandLine( int y, int count, TChar & );
     int wrapLine( int startLine, int screenWidth, int indentSize, TChar & format );
@@ -104,6 +105,7 @@ public:
     bool applyBold( QPoint & P_begin, QPoint & P_end, bool bold );
     bool applyLink( QPoint & P_begin, QPoint & P_end, const QString& linkText, QStringList &, QStringList & );
     bool applyItalics( QPoint & P_begin, QPoint & P_end, bool bold );
+    bool applyStrikeOut( QPoint & P_begin, QPoint & P_end, bool strikeout );
     bool applyFgColor( QPoint &, QPoint &, int, int, int );
     bool applyBgColor( QPoint &, QPoint &, int, int, int );
     void appendBuffer( TBuffer chunk );
@@ -115,8 +117,8 @@ public:
     void resetFontSpecs();
     QPoint getEndPos();
     void translateToPlainText( std::string & s );
-    void append(const QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, int linkID=0 );
-    void appendLine(const QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, int linkID=0 );
+    void append(const QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID=0 );
+    void appendLine(const QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID=0 );
     int lookupColor(const QString & s, int pos );
     void set_text_properties(int tag);
     void setWrapAt( int i ){ mWrapAt = i; }
@@ -270,6 +272,7 @@ private:
     bool              mBold;
     bool              mItalics;
     bool              mUnderline;
+    bool              mStrikeOut;
     bool              mFgColorCode;
     bool              mBgColorCode;
     int               mFgColorR;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -122,6 +122,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
         mStandardFormat.flags &= ~(TCHAR_BOLD);
         mStandardFormat.flags &= ~(TCHAR_ITALICS);
         mStandardFormat.flags &= ~(TCHAR_UNDERLINE);
+        mStandardFormat.flags &= ~(TCHAR_STRIKEOUT);
     }
     else
     {
@@ -154,6 +155,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
         mStandardFormat.flags &= ~(TCHAR_BOLD);
         mStandardFormat.flags &= ~(TCHAR_ITALICS);
         mStandardFormat.flags &= ~(TCHAR_UNDERLINE);
+        mStandardFormat.flags &= ~(TCHAR_STRIKEOUT);
     }
     setContentsMargins(0,0,0,0);
     if( mpHost )
@@ -1482,6 +1484,7 @@ void TConsole::reset()
     mFormatCurrent.flags &= ~(TCHAR_BOLD);
     mFormatCurrent.flags &= ~(TCHAR_ITALICS);
     mFormatCurrent.flags &= ~(TCHAR_UNDERLINE);
+    mFormatCurrent.flags &= ~(TCHAR_STRIKEOUT);
 }
 
 void TConsole::insertLink(const QString& text, QStringList & func, QStringList & hint, QPoint P, bool customFormat )
@@ -1518,7 +1521,7 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                 buffer.insertInLine( P, text, mFormatCurrent );
             else
             {
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true );
+                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
                 buffer.insertInLine( P, text, _f );
             }
             buffer.applyLink( P, P2, text, func, hint );
@@ -1530,7 +1533,7 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                 buffer.insertInLine( P, text, mFormatCurrent );
             else
             {
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true );
+                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
                 buffer.insertInLine( P, text, _f );
             }
             buffer.applyLink( P, P2, text, func, hint );
@@ -1545,7 +1548,7 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                 buffer.addLink( mTriggerEngineMode, text, func, hint, mFormatCurrent );
             else
             {
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true );
+                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
                 buffer.addLink( mTriggerEngineMode, text, func, hint, _f );
             }
 
@@ -1573,7 +1576,7 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                                      mFormatCurrent );
             else
             {
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true );
+                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
                 buffer.insertInLine( mUserCursor,
                                      text,
                                      _f );
@@ -1654,7 +1657,8 @@ void TConsole::insertText(const QString& text, QPoint P )
                            mFormatCurrent.bgB,
                            mFormatCurrent.flags & TCHAR_BOLD,
                            mFormatCurrent.flags & TCHAR_ITALICS,
-                           mFormatCurrent.flags & TCHAR_UNDERLINE );
+                           mFormatCurrent.flags & TCHAR_UNDERLINE,
+                           mFormatCurrent.flags & TCHAR_STRIKEOUT );
             console->showNewLines();
             console2->showNewLines();
         }
@@ -2140,6 +2144,15 @@ void TConsole::setUnderline( bool b )
     buffer.applyUnderline( P_begin, P_end, b );
 }
 
+void TConsole::setStrikeOut( bool b )
+{
+    if( b )
+        mFormatCurrent.flags |= TCHAR_STRIKEOUT;
+    else
+        mFormatCurrent.flags &= ~(TCHAR_STRIKEOUT);
+    buffer.applyStrikeOut( P_begin, P_end, b );
+}
+
 void TConsole::setFgColor( int r, int g, int b )
 {
     mFormatCurrent.fgR = r;
@@ -2178,6 +2191,7 @@ void TConsole::printCommand( QString & msg )
                            mCommandBgColor.red(),
                            mCommandBgColor.green(),
                            mCommandBgColor.blue(),
+                           false,
                            false,
                            false,
                            false );
@@ -2227,12 +2241,12 @@ void TConsole::echoLink(const QString & text, QStringList & func, QStringList & 
     {
         if( ! mIsSubConsole && ! mIsDebugConsole )
         {
-            TChar f = TChar(0, 0, 255, mpHost->mBgColor.red(), mpHost->mBgColor.green(), mpHost->mBgColor.blue(), false, false, true);
+            TChar f = TChar(0, 0, 255, mpHost->mBgColor.red(), mpHost->mBgColor.green(), mpHost->mBgColor.blue(), false, false, true, false);
             buffer.addLink( mTriggerEngineMode, text, func, hint, f );
         }
         else
         {
-            TChar f = TChar(0, 0, 255, mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true);
+            TChar f = TChar(0, 0, 255, mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false);
             buffer.addLink( mTriggerEngineMode, text, func, hint, f );
         }
     }
@@ -2253,7 +2267,8 @@ void TConsole::echo(const QString & msg )
                            mFormatCurrent.bgB,
                            mFormatCurrent.flags & TCHAR_BOLD,
                            mFormatCurrent.flags & TCHAR_ITALICS,
-                           mFormatCurrent.flags & TCHAR_UNDERLINE );
+                           mFormatCurrent.flags & TCHAR_UNDERLINE,
+                           mFormatCurrent.flags & TCHAR_STRIKEOUT ); 
     }
     else
     {
@@ -2275,7 +2290,8 @@ void TConsole::print( const char * txt )
                    mFormatCurrent.bgB,
                    mFormatCurrent.flags & TCHAR_BOLD,
                    mFormatCurrent.flags & TCHAR_ITALICS,
-                   mFormatCurrent.flags & TCHAR_UNDERLINE );
+                   mFormatCurrent.flags & TCHAR_UNDERLINE, 
+                   mFormatCurrent.flags & TCHAR_STRIKEOUT ); 
     console->showNewLines();
     console2->showNewLines();
 }
@@ -2291,6 +2307,7 @@ void TConsole::printDebug( QColor & c, QColor & d, const QString & msg )
                    d.red(),
                    d.green(),
                    d.blue(),
+                   false,
                    false,
                    false,
                    false );
@@ -2548,7 +2565,8 @@ void TConsole::print(const QString & msg )
                     mFormatCurrent.bgB,
                     mFormatCurrent.flags & TCHAR_BOLD,
                     mFormatCurrent.flags & TCHAR_ITALICS,
-                    mFormatCurrent.flags & TCHAR_UNDERLINE );
+                    mFormatCurrent.flags & TCHAR_UNDERLINE,
+                    mFormatCurrent.flags & TCHAR_STRIKEOUT );
     console->showNewLines();
     console2->showNewLines();
 }
@@ -2564,6 +2582,7 @@ void TConsole::print(const QString & msg, int fgColorR, int fgColorG, int fgColo
                     bgColorR,
                     bgColorG,
                     bgColorB,
+                    false,
                     false,
                     false,
                     false );
@@ -2600,6 +2619,7 @@ void TConsole::printSystemMessage(const QString & msg )
                     mSystemMessageBgColor.red(),
                     mSystemMessageBgColor.green(),
                     mSystemMessageBgColor.blue(),
+                    false,
                     false,
                     false,
                     false );

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -159,6 +159,7 @@ public:
       void              setLink(const QString & linkText, QStringList & linkFunction, QStringList & linkHint );
       void              setItalics( bool );
       void              setUnderline( bool );
+      void              setStrikeOut( bool );
       void              finalize();
       void              runTriggers( int );
       void              showStatistics();

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -320,6 +320,7 @@ public:
     static int setBold( lua_State * );
     static int setItalics( lua_State * );
     static int setUnderline( lua_State * );
+    static int setStrikeOut( lua_State * );
     static int disconnect( lua_State * );
     static int reconnect( lua_State * );
     static int getMudletHomeDir( lua_State * );

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -444,15 +444,17 @@ inline void TTextEdit::drawCharacters( QPainter & painter,
                                 bool isBold,
                                 bool isUnderline,
                                 bool isItalics,
+                                bool isStrikeOut,
                                 QColor & fgColor,
                                 QColor & bgColor )
 {
-    if( ( painter.font().bold() != isBold ) || ( painter.font().underline() != isUnderline ) || (painter.font().italic() != isItalics) )
+    if( ( painter.font().bold() != isBold ) || ( painter.font().underline() != isUnderline ) || (painter.font().italic() != isItalics) || (painter.font().strikeOut() != isStrikeOut))
     {
         QFont font = painter.font();
         font.setBold( isBold );
         font.setUnderline( isUnderline );
         font.setItalic( isItalics );
+        font.setStrikeOut( isStrikeOut );
 #if defined(Q_OS_MAC) || (defined(Q_OS_LINUX) && QT_VERSION >= 0x040800)
         font.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
 #endif
@@ -516,6 +518,7 @@ void TTextEdit::drawFrame( QPainter & p, const QRect & rect )
                 bool isBold = false;
                 bool isUnderline = false;
                 bool isItalics = false;
+                bool isStrikeOut = false;
                 QRect textRect = QRect( mFontWidth * i2,
                                         mFontHeight * i,
                                         mFontWidth * timeOffset,
@@ -523,7 +526,7 @@ void TTextEdit::drawFrame( QPainter & p, const QRect & rect )
                 QColor bgTime = QColor(22,22,22);
                 QColor fgTime = QColor(200,150,0);
                 drawBackground( p, textRect, bgTime );
-                drawCharacters( p, textRect, text, isBold, isUnderline, isItalics, fgTime, bgTime );
+                drawCharacters( p, textRect, text, isBold, isUnderline, isItalics, isStrikeOut, fgTime, bgTime );
                 i2+=timeOffset;
             }
             else
@@ -561,12 +564,13 @@ void TTextEdit::drawFrame( QPainter & p, const QRect & rect )
                     else
                         drawBackground( p, textRect, bgColor );
                 }
-                if( ( p.font().bold() != bool(f.flags & TCHAR_BOLD) ) || ( p.font().underline() != bool(f.flags & TCHAR_UNDERLINE) ) || (p.font().italic() != bool(f.flags & TCHAR_ITALICS)) )
+                if( ( p.font().bold() != bool(f.flags & TCHAR_BOLD) ) || ( p.font().underline() != bool(f.flags & TCHAR_UNDERLINE) ) || (p.font().italic() != bool(f.flags & TCHAR_ITALICS)) || (p.font().strikeOut() != bool(f.flags & TCHAR_STRIKEOUT)))
                 {
                     QFont font = p.font();
                     font.setBold( f.flags & TCHAR_BOLD );
                     font.setUnderline( f.flags & TCHAR_UNDERLINE );
                     font.setItalic( f.flags & TCHAR_ITALICS );
+                    font.setStrikeOut( f.flags & TCHAR_STRIKEOUT );
                     font.setLetterSpacing( QFont::AbsoluteSpacing, mLetterSpacing );
                     p.setFont( font );
                 }
@@ -721,6 +725,7 @@ void TTextEdit::drawForeground( QPainter & painter, const QRect & r )
                 bool isBold = false;
                 bool isUnderline = false;
                 bool isItalics = false;
+                bool isStrikeOut = false;
                 QRect textRect = QRect( mFontWidth * i2,
                                         mFontHeight * i,
                                         mFontWidth * timeOffset,
@@ -728,7 +733,7 @@ void TTextEdit::drawForeground( QPainter & painter, const QRect & r )
                 QColor bgTime = QColor(22,22,22);
                 QColor fgTime = QColor(200,150,0);
                 drawBackground( p, textRect, bgTime );
-                drawCharacters( p, textRect, text, isBold, isUnderline, isItalics, fgTime, bgTime );
+                drawCharacters( p, textRect, text, isBold, isUnderline, isItalics, isStrikeOut, fgTime, bgTime );
                 i2+=timeOffset;
             }
             else
@@ -774,7 +779,7 @@ void TTextEdit::drawForeground( QPainter & painter, const QRect & r )
                 {
                     drawBackground( p, textRect, bgColor );
                 }
-                drawCharacters( p, textRect, text, f.flags & TCHAR_BOLD, f.flags & TCHAR_UNDERLINE, f.flags & TCHAR_ITALICS, fgColor, bgColor );
+                drawCharacters( p, textRect, text, f.flags & TCHAR_BOLD, f.flags & TCHAR_UNDERLINE, f.flags & TCHAR_ITALICS, f.flags & TCHAR_STRIKEOUT, fgColor, bgColor );
                 i2+=delta;
             }
         }

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -64,6 +64,7 @@ public:
                                       bool isBold,
                                       bool isUnderline,
                                       bool isItalics,
+                                      bool isStrikeOut,
                                       QColor & fgColor,
                                       QColor & bgColor );
     std::string       getCurrentTime();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1052,7 +1052,7 @@ bool mudlet::setBackgroundImage( Host * pHost, const QString & name, QString & p
         return false;
 }
 
-bool mudlet::setTextFormat( Host * pHost, const QString & name, int r1, int g1, int b1, int r2, int g2, int b2, bool bold, bool underline, bool italics )
+bool mudlet::setTextFormat( Host * pHost, const QString & name, int r1, int g1, int b1, int r2, int g2, int b2, bool bold, bool underline, bool italics, bool strikeout )
 {
     QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
     if( dockWindowConsoleMap.contains( name ) )
@@ -1076,6 +1076,10 @@ bool mudlet::setTextFormat( Host * pHost, const QString & name, int r1, int g1, 
             pC->mFormatCurrent.flags |= TCHAR_ITALICS;
         else
             pC->mFormatCurrent.flags &= ~(TCHAR_ITALICS);
+        if( strikeout )
+            pC->mFormatCurrent.flags |= TCHAR_STRIKEOUT;
+        else
+            pC->mFormatCurrent.flags &= ~(TCHAR_STRIKEOUT);
         return true;
     }
     else
@@ -1421,6 +1425,16 @@ void mudlet::setUnderline( Host * pHost, const QString & name, bool b )
     {
         TConsole * pC = dockWindowConsoleMap[name];
         pC->setUnderline( b );
+    }
+}
+
+void mudlet::setStrikeOut( Host * pHost, const QString & name, bool b )
+{
+    QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
+    if( dockWindowConsoleMap.contains( name ) )
+    {
+        TConsole * pC = dockWindowConsoleMap[name];
+        pC->setStrikeOut( b );
     }
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -95,7 +95,7 @@ public:
    bool                          pasteWindow( Host * pHost, const QString & name );
    bool                          setBackgroundColor( Host *, const QString & name, int r, int g, int b, int alpha );
    bool                          setBackgroundImage( Host *, const QString & name, QString & path );
-   bool                          setTextFormat( Host *, const QString & name, int, int, int, int, int, int, bool, bool, bool );
+   bool                          setTextFormat( Host *, const QString & name, int, int, int, int, int, int, bool, bool, bool, bool );
    bool                          setLabelClickCallback( Host *, const QString &, const QString &, const TEvent & );
    bool                          setLabelOnEnter( Host *, const QString &, const QString &, const TEvent & );
    bool                          setLabelOnLeave( Host *, const QString &, const QString &, const TEvent & );
@@ -109,6 +109,7 @@ public:
    void                          setLink( Host * pHost, const QString & name, const QString & linkText, QStringList & linkFunction, QStringList & );
    void                          setItalics( Host *, const QString & name, bool );
    void                          setUnderline( Host *, const QString & name, bool );
+   void                          setStrikeOut( Host *, const QString & name, bool );
    void                          setFgColor( Host *, const QString & name, int, int, int );
    void                          setBgColor( Host *, const QString & name, int, int, int );
    bool                          userWindowLineWrap( Host * pHost, const QString & name, bool on );


### PR DESCRIPTION
Adds support for text with a line through it throughout the stack. 

In Qt this format is called StrikeOut so I kept that naming convention throughout.

Added an optional 11th parameter to the lua function setTextFormat to control whether strikeout is used.
Created new lua function setStrikeOut that exposes strikeout functionality. Usage is just like setBold.

Will add cecho tag support in a subsequent commit.
