### PR TITLE
Script loss bug fix

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -521,6 +521,7 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     connect( treeWidget_keys, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_key_selected( QTreeWidgetItem *) ) );
     connect( treeWidget_timers, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_timer_selected( QTreeWidgetItem *) ) );
     connect( treeWidget_scripts, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_scripts_selected( QTreeWidgetItem *) ) );
+    connect( treeWidget_scripts, SIGNAL( itemSelectionChanged()), this, SLOT( slot_scripts_selection_changed()) );
     connect( treeWidget_alias, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_alias_selected( QTreeWidgetItem *) ) );
     connect( treeWidget_actions, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_action_selected( QTreeWidgetItem *) ) );
     connect( treeWidget_vars, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_var_selected( QTreeWidgetItem *) ) );
@@ -4800,6 +4801,13 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem *pItem)
         }
         if( ! pT->state() ) showError( pT->getError() );
     }
+}
+
+void dlgTriggerEditor::slot_scripts_selection_changed()
+{
+    QList<QTreeWidgetItem *> items = treeWidget_scripts->selectedItems();
+    if (items.length())
+        slot_scripts_selected(items.first());
 }
 
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -151,6 +151,7 @@ public slots:
     void                        slot_trigger_selected( QTreeWidgetItem *pItem );
     void                        slot_timer_selected( QTreeWidgetItem *pItem );
     void                        slot_scripts_selected( QTreeWidgetItem *pItem );
+    void                        slot_scripts_selection_changed();
     void                        slot_alias_selected( QTreeWidgetItem *pItem );
     void                        slot_action_selected( QTreeWidgetItem * pItem );
     void                        slot_key_selected( QTreeWidgetItem *pItem );


### PR DESCRIPTION
This adds a listener for the itemSelectionChanged signal to update what item is currently selected in the script editor. It's a proposed solution to address this bug:

https://bugs.launchpad.net/mudlet/+bug/1377401

And if valid, will be applied to other treewidget items since that bug extends to those as well.
