### PR TITLE
BugFix: Treat and prevent further duplicate or empty map area names (Alternative)

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4069,16 +4069,25 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
 int TLuaInterpreter::getAreaTable( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaTable: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaTable: no map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
 
     QMapIterator<int, QString> it( pHost->mpMap->mpRoomDB->getAreaNamesMap() );
     lua_newtable(L);
-    while( it.hasNext() )
-    {
+    while( it.hasNext() ) {
         it.next();
-        int roomID = it.key();
+        int areaId = it.key();
         QString name = it.value();
-        lua_pushstring( L, name.toLatin1().data() );
-        lua_pushnumber( L, roomID );
+        lua_pushstring( L, name.toUtf8().constData() );
+        lua_pushnumber( L, areaId );
         lua_settable(L, -3);
     }
     return 1;
@@ -4087,15 +4096,25 @@ int TLuaInterpreter::getAreaTable( lua_State *L )
 int TLuaInterpreter::getAreaTableSwap( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaTableSwap: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaTableSwap: no map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
+
     QMapIterator<int, QString> it( pHost->mpMap->mpRoomDB->getAreaNamesMap() );
     lua_newtable(L);
-    while( it.hasNext() )
-    {
+    while( it.hasNext() ) {
         it.next();
-        int roomID = it.key();
+        int areaId = it.key();
         QString name = it.value();
-        lua_pushnumber( L, roomID );
-        lua_pushstring( L, name.toLatin1().data() );
+        lua_pushnumber( L, areaId );
+        lua_pushstring( L, name.toUtf8().constData() );
         lua_settable(L, -3);
     }
     return 1;
@@ -6539,37 +6558,116 @@ int TLuaInterpreter::setCustomEnvColor( lua_State *L )
     return 0;
 }
 
-
 int TLuaInterpreter::setAreaName( lua_State *L )
 {
     int id;
-    string name;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushstring( L, "setAreaName: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        id = lua_tointeger( L, 1 );
-    }
-
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "setAreaName: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        name = lua_tostring( L, 2 );
-    }
-
+    QString existingName;
+    QString newName;
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString _name = name.c_str();
-    pHost->mpMap->mpRoomDB->setAreaName( id, _name );
-    return 0;
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setAreaName: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setAreaName: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    if( lua_isnumber( L, 1 ) ) {
+        id = lua_tonumber( L, 1 );
+        if( id < 1 ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area Id expected > 0, got %1)." )
+                            .arg( id ).toUtf8().constData() );
+            return 2;
+        }
+        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area Id=%1 does not exist)." )
+                            .arg( id ).toUtf8().constData() );
+            return 2;
+        }
+    }
+    else if( lua_isstring( L, 1 ) ) {
+        existingName = QString::fromUtf8( lua_tostring( L, 1 ) );
+        id = pHost->mpMap->mpRoomDB->getAreaNamesMap().key( existingName, 0 );
+        if( existingName.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area name cannot be empty)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+        else if( ! pHost->mpMap->mpRoomDB->getAreaNamesMap().values().contains( existingName ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area name \"%1\" does not exist)." )
+                            .arg( existingName ).toUtf8().constData() );
+            return 2;
+        }
+    }
+    else {
+        lua_pushstring( L, tr( "setAreaName: bad argument #1 type (area Id as number or area name as string expected, got %1)." )
+                        .arg( luaL_typename( L, 1) ).toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setAreaName: bad argument #2 type (area name, as string expected, got %1)." )
+                        .arg( luaL_typename( L, 2) ).toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        newName = QString( lua_tostring( L, 2 ) );
+    }
+
+    if( newName.isEmpty() ) {
+        // Empty name not allowed (any more)
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setAreaName: bad argument #2 value (area names may not be empty strings)." ).toUtf8().constData() );
+        return 2;
+    }
+    else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().values().count( newName ) > 0 ) {
+        // That name is already IN the areaNamesMap, and since we now enforce
+        // uniqueness there can be only one of it - so we can check if this is a
+        // problem or just pointless quite easily...!
+        if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) != newName ) {
+            lua_pushnil( L );
+            // And it isn't the trivial case, where the given areaID already IS that name
+            lua_pushstring( L, tr( "setAreaName: bad argument #2 value (area names may not be duplicated and area Id=%1 already has the name \"%2\")." )
+                            .arg( pHost->mpMap->mpRoomDB->getAreaNamesMap().key( newName ) )
+                            .arg( newName ).toUtf8().constData() );
+            return 2;
+        }
+        else {
+            // Renaming an area to the same name is pointlessly successful!
+            lua_pushboolean( L, true );
+            return 1;
+        }
+    }
+
+    bool isCurrentAreaRenamed = false;
+    if( pHost->mpMap->mpMapper ) {
+        if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) == pHost->mpMap->mpMapper->showArea->currentText() ) {
+            isCurrentAreaRenamed = true;
+        }
+    }
+    bool result = pHost->mpMap->mpRoomDB->setAreaName( id, newName );
+    if( result ) {
+        // Update mapper Area names widget, using method designed for it...!
+        if( pHost->mpMap->mpMapper ) {
+            pHost->mpMap->mpMapper->updateAreaComboBox();
+            if( isCurrentAreaRenamed ) {
+                pHost->mpMap->mpMapper->showArea->setCurrentText( newName );
+            }
+        }
+    }
+    lua_pushboolean( L, result );
+    return 1;
 }
 
 int TLuaInterpreter::getRoomAreaName( lua_State *L )
@@ -6624,89 +6722,131 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
     }
 }
 
+// Note that adding an area name implicitly creates an underlying TArea instance
 int TLuaInterpreter::addAreaName( lua_State *L )
 {
-// N/U:     int id;
-    string name;
+    QString name;
 
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "addAreaName: wrong argument type" );
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "addAreaName: bad argument #1 type (area name, as string expected, got %1)." )
+                        .arg( luaL_typename( L, 1) ).toUtf8().constData() ) ;
         lua_error( L );
         return 1;
     }
-    else
-    {
-        name = lua_tostring( L, 1 );
+    else {
+        name = QString::fromUtf8( lua_tostring( L, 1 ) );
     }
 
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString _name = name.c_str();
-
-    int newAreaID = pHost->mpMap->mpRoomDB->addArea( _name );
-    if ( ! newAreaID )
-    {
-        lua_pushstring( L, "addAreaName: Failed to create new area. It may already exist" );
-        lua_error( L );
-        return 1;
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "addAreaName: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
     }
-    lua_pushnumber( L, newAreaID );
-    if( pHost->mpMap->mpMapper )
-    {
-        pHost->mpMap->mpMapper->showArea->clear();
-        QMapIterator<int, QString> it( pHost->mpMap->mpRoomDB->getAreaNamesMap() );
-        //sort them alphabetically (case sensitive)
-        QMap <QString, QString> areaNames;
-        while( it.hasNext() )
-        {
-            it.next();
-            QString name = it.value();
-            areaNames.insert(name.toLower(), name);
-        }
-
-        QMapIterator<QString, QString> areaIt( areaNames );
-        while( areaIt.hasNext() )
-        {
-            areaIt.next();
-            pHost->mpMap->mpMapper->showArea->addItem( areaIt.value() );
-        }
+    else if( ( ! pHost->mpMap ) || ( ! pHost->mpMap->mpRoomDB ) ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "addAreaName: error, no map seems to be loaded!" )
+                        .toUtf8().constData() );
+        return 2;
     }
+    else if( name.isEmpty() ) {
+        // Empty names now not allowed
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "addAreaName: bad argument #1 value (area names may not be empty strings)." )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().values().count( name ) > 0 ) {
+        // That name is already IN the areaNamesMap
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "addAreaName: bad argument #2 value (area names may not be duplicated and area Id=%1 already has the name \"%2\")." )
+                        .arg( pHost->mpMap->mpRoomDB->getAreaNamesMap().key( name ) )
+                        .arg( name ).toUtf8().constData() );
+        return 2;
+    }
+
+    // Update mapper Area names widget, using method designed for it...!
+    if( pHost->mpMap->mpMapper ) {
+        pHost->mpMap->mpMapper->updateAreaComboBox();
+    }
+
+    lua_pushnumber( L, pHost->mpMap->mpRoomDB->addArea( name ) );
     return 1;
-
-
 }
 
 int TLuaInterpreter::deleteArea( lua_State *L )
 {
     int id = 0;
-    string name;
+    QString name;
 
-    if( lua_isnumber( L, 1 ) )
-    {
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "deleteArea: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "deleteArea: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    if( lua_isnumber( L, 1 ) ) {
         id = lua_tonumber( L, 1 );
+        if( id < 1 ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (area Id expected > 0, got %1)." )
+                            .arg( id ).toUtf8().constData() );
+            return 2;
+        }
+        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (area Id=%1 does not exist)." )
+                            .arg( id ).toUtf8().constData() );
+            return 2;
+        }
     }
-    else if( lua_isstring( L, 1 ) )
-    {
-        name = lua_tostring( L, 1 );
+    else if( lua_isstring( L, 1 ) ) {
+        name = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( name.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (area name cannot be empty)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+        else if( ! pHost->mpMap->mpRoomDB->getAreaNamesMap().values().contains( name ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (area name \"%1\" does not exist)." )
+                            .arg( name ).toUtf8().constData() );
+            return 2;
+        }
     }
-    else
-    {
-        lua_pushstring( L, "deleteArea: wrong argument type" );
+    else {
+        lua_pushstring( L, tr( "deleteArea: bad argument #1 type (area Id as number or area name as string expected, got %1)." )
+                        .arg( luaL_typename( L, 1) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if( ! id )
-    {
-        QString _name = name.c_str();
-        lua_pushboolean( L, pHost->mpMap->mpRoomDB->removeArea( _name ) );
+    bool result = false;
+    if( ! id ) {
+        result = pHost->mpMap->mpRoomDB->removeArea( name );
     }
-    else
-    {
-        lua_pushboolean( L, pHost->mpMap->mpRoomDB->removeArea( id ) );
+    else {
+        result = pHost->mpMap->mpRoomDB->removeArea( id );
     }
 
+    if( result ) {
+        // Update mapper Area names widget, using method designed for it...!
+        if( pHost->mpMap->mpMapper ) {
+            pHost->mpMap->mpMapper->updateAreaComboBox();
+        }
+        pHost->mpMap->mMapGraphNeedsUpdate = true;
+    }
+    lua_pushboolean( L, result );
     return 1;
 }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -135,9 +135,15 @@ void TMap::importMapFromDatabase()
 bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculations )
 {
     TRoom * pR = mpRoomDB->getRoom( id );
-
     if( !pR ) {
         QString msg = qApp->translate( "TMap", "RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!" ).arg(id).arg(area);
+        logError(msg);
+        return false;
+    }
+
+    TArea * pA = mpRoomDB->getArea( area );
+    if( ! pA ) {
+        QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
         logError(msg);
         return false;
     }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -25,8 +25,10 @@
 #include "TArea.h"
 #include "TMap.h"
 #include "TRoom.h"
+#include "Host.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QDebug>
 #include <QTime>
 #include "post_guard.h"
@@ -34,6 +36,7 @@
 
 TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
+, mUnnamedAreaName( qApp->translate( "TRoomDB", "Unnamed Area" ) )
 {
 }
 
@@ -148,8 +151,13 @@ bool TRoomDB::__removeRoom( int id )
 
 bool TRoomDB::removeRoom( int id )
 {
-    if( rooms.contains(id ) && id > 0 )
-    {
+    if( rooms.contains( id ) && id > 0 ) {
+        if( mpMap->mRoomId == id ) {
+            mpMap->mRoomId = 0;
+        }
+        if( mpMap->mTargetID == id ) {
+            mpMap->mTargetID = 0;
+        }
         TRoom * pR = getRoom( id );
         delete pR;
         return true;
@@ -159,19 +167,16 @@ bool TRoomDB::removeRoom( int id )
 
 bool TRoomDB::removeArea( int id )
 {
-    areaNamesMap.remove( id );
-    if( areas.contains( id ) )
-    {
-        TArea * pA = areas[id];
+    if( areas.contains( id ) ) {
+        TArea * pA = areas.value(id);
         QList<int> rl;
-        for( int i=0; i< pA->rooms.size(); i++ )
-        {
-            rl.push_back( pA->rooms[i] );
+        for( int i=0; i< pA->rooms.size(); i++ ) {
+            rl.push_back( pA->rooms.at(i) );
         }
-        for( int i=0; i<rl.size(); i++ )
-        {
-            removeRoom( rl[i] );
+        for( int i=rl.size()-1; i >= 0; i-- ) {
+            removeRoom( rl.at(i) );
         }
+        areaNamesMap.remove( id );
         areas.remove( id );
 
         mpMap->mMapGraphNeedsUpdate = true;
@@ -252,21 +257,51 @@ TArea * TRoomDB::getArea( int id )
     }
 }
 
-void TRoomDB::setAreaName( int areaID, QString name )
+bool TRoomDB::setAreaName( int areaID, QString name )
 {
+    if( areaID < 1 ) {
+        qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Suspect areaID: %n supplied.", areaID );
+        return false;
+    }
+    if( name.isEmpty() ) {
+        qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Empty name supplied." );
+        return false;
+    }
+    else if( areaNamesMap.values().count(name) > 0 ) {
+        // That name is already IN the areaNamesMap
+        if( areaNamesMap.value( areaID ) == name ) {
+            // The trivial case, the given areaID already IS that name
+            return true;
+        }
+        else {
+            qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Duplicate name supplied \"%s\"- that is not a good idea!", name.toUtf8().constData() );
+            return false;
+        }
+    }
     areaNamesMap[areaID] = name;
+    return true;
 }
 
 bool TRoomDB::addArea( int id )
 {
-    if( !areas.contains( id ) )
-    {
+    if( ! areas.contains( id ) ) {
         areas[id] = new TArea( mpMap, this );
+        if( ! areaNamesMap.contains( id ) ) {
+            // Must provide a name for this new area
+            QString newAreaName = mUnnamedAreaName;
+            if( areaNamesMap.values().contains( newAreaName ) ) {
+                // We already have an "unnamed area"
+                uint deduplicateSuffix = 0;
+                do {
+                    newAreaName = QStringLiteral( "%1_%2" ).arg( mUnnamedAreaName ).arg( ++deduplicateSuffix, 3, 10, QLatin1Char('0') );
+                } while ( areaNamesMap.values().contains( newAreaName ) );
+            }
+            areaNamesMap.insert( id, newAreaName );
+        }
         return true;
     }
-    else
-    {
-        QString error = QString("Area with ID=%1 already exists!").arg(id);
+    else {
+        QString error = qApp->translate( "TRoomDB", "Area with ID=%1 already exists!" ).arg(id);
         mpMap->logError(error);
         return false;
     }
@@ -274,47 +309,60 @@ bool TRoomDB::addArea( int id )
 
 int TRoomDB::createNewAreaID()
 {
-    int _id = 1;
-    for( ; ; _id++ )
-    {
-        if( !areas.contains(_id) )
-        {
-            return _id;
-        }
+    int id = 1;
+    while( areas.contains( id ) ) {
+        id++;
     }
-    return 0;
+    return id;
 }
 
 int TRoomDB::addArea( QString name )
 {
-    // area name already exists
-    if( areaNamesMap.values().contains( name ) ) return 0;
+    // reject it if area name already exists or is empty
+    if( name.isEmpty() ) {
+        QString error = qApp->translate( "TRoomDB", "An Unnamed Area is (no longer) permitted!" );
+        mpMap->logError(error);
+        return 0;
+    }
+    else if( areaNamesMap.values().contains( name ) ) {
+        QString error = qApp->translate( "TRoomDB", "An area called %1 already exists!" ).arg(name);
+        mpMap->logError(error);
+        return 0;
+    }
 
     int areaID = createNewAreaID();
-    if( addArea( areaID ) )
-    {
+    if( addArea( areaID ) ) {
         areaNamesMap[areaID] = name;
+        // This will overwrite the "Unnamed Area_###" that addArea( areaID )
+        // will generate - but that is fine.
         return areaID;
     }
-    else
+    else {
         return 0; //fail
+    }
 }
 
 // this func is called by the xml map importer
 // NOTE: we no longer accept duplicate IDs or duplicate area names
 //       duplicate definitions are ignored
+//       Unless the area name is empty, in which case we provide one!
 bool TRoomDB::addArea( int id, QString name )
 {
-    if( areaNamesMap.values().contains(name) ) return false;
-    if( areaNamesMap.keys().contains(id) ) return false;
-    bool ret = addArea( id );
-    if( ret ) // Wrong check for error (==0 was being made)
-    {
-        areaNamesMap[id] = name;
+    if(   ( ( ! name.isEmpty() ) && areaNamesMap.values().contains( name ) )
+       || areaNamesMap.keys().contains( id ) ) {
+        return false;
+    }
+    else if( addArea( id ) ) {
+        // This will generate an "Unnamed Area_###" area name which we should
+        // overwrite only if we have a name!
+        if( ! name.isEmpty() ) {
+            areaNamesMap[id] = name;
+        }
         return true;
     }
-    return false;
-
+    else {
+        return false;
+    }
 }
 
 const QList<TArea *> TRoomDB::getAreaPtrList()
@@ -387,10 +435,148 @@ void TRoomDB::clearMapDB()
 
 }
 
-
 void TRoomDB::restoreAreaMap( QDataStream & ifs )
 {
-    ifs >> areaNamesMap;
+    QMap<int, QString> areaNamesMapWithPossibleEmptyOrDuplicateItems;
+    ifs >> areaNamesMapWithPossibleEmptyOrDuplicateItems;
+
+    // Validate names: name nameless areas and rename duplicates
+    QMultiMap<QString, QString> renamedMap; // For warning message, holds renamed area map
+    QMapIterator<int, QString> itArea = areaNamesMapWithPossibleEmptyOrDuplicateItems;
+    bool isMatchingSuffixAlreadyPresent = false;
+    bool isEmptyAreaNamePresent = false;
+    while( itArea.hasNext() ) {
+        itArea.next();
+        QString nonEmptyAreaName;
+        if( itArea.value().isEmpty() ) {
+            isEmptyAreaNamePresent = true;
+            nonEmptyAreaName = mUnnamedAreaName;
+            // Will trip following if more than one
+        }
+        else {
+            nonEmptyAreaName = itArea.value();
+        }
+        if( areaNamesMap.values().contains( nonEmptyAreaName ) ) {
+            // Oh dear, we have a duplicate
+            if( nonEmptyAreaName.contains( QRegExp( "_\d\d\d$" ) ) ) {
+                // the areaName already is of form "something_###" where # is a
+                // digit, have to strip that off and remember so warning message
+                // can include advice on this change
+                isMatchingSuffixAlreadyPresent = true;
+                nonEmptyAreaName.chop(4); // Take off existing suffix
+            }
+            uint deduplicateSuffix = 0;
+            QString replacementName;
+            do {
+                replacementName = QStringLiteral( "%1_%2" ).arg(nonEmptyAreaName).arg(++deduplicateSuffix, 3, 10, QLatin1Char('0') );
+            } while ( areaNamesMap.values().contains( replacementName ) );
+            if( ( ! itArea.value().isEmpty() ) && ( ! renamedMap.contains( itArea.value() ) ) ) {
+                // if the renamedMap does not contain the first, unaltered value
+                // that a subsequent match has been found for, then include it
+                // in the data so the user can see the UNCHANGED one as well
+                // Only have to do this once for each duplicate area name, hence
+                // the test conditions above
+                renamedMap.insert( itArea.value(), itArea.value() );
+            }
+            renamedMap.insert( itArea.value(), replacementName );
+            areaNamesMap.insert( itArea.key(), replacementName );
+        }
+        else {
+            if( itArea.value().isEmpty() ) {
+                renamedMap.insert( itArea.value(), nonEmptyAreaName );
+            }
+            areaNamesMap.insert( itArea.key(), nonEmptyAreaName );
+        }
+    }
+    if( renamedMap.size() || isEmptyAreaNamePresent ) {
+        QString alertText;
+        QString informativeText;
+        QString extraTextForMatchingSuffixAlreadyUsed;
+        QString detailText;
+        if( isMatchingSuffixAlreadyPresent ) {
+            extraTextForMatchingSuffixAlreadyUsed = qApp->translate( "TRoomDB", "It has been detected that \"_###\" form suffixes have already been used, for "
+                                                                                "simplicity in the renaming algorithm these will have been removed and possibly "
+                                                                                "changed as Mudlet sorts this matter out, if a number assigned in this way "
+                                                                                "<b>is</b> important to you, you can change it back, provided you rename the area "
+                                                                                "that has been allocated the suffix that was wanted first...!</p>" );
+        }
+        if( renamedMap.size() ) {
+            detailText = qApp->translate( "TRoomDB", "[  OK  ]  - The changes made are:\n"
+                                                                 "(ID) \"old name\" ==> \"new name\"\n" );
+            QMapIterator<QString, QString> itRemappedNames = renamedMap;
+            itRemappedNames.toBack();
+            // Seems to look better if we iterate through backwards!
+            while( itRemappedNames.hasPrevious() ) {
+                itRemappedNames.previous();
+                detailText.append( QStringLiteral( "(%1) \"%2\" ==> \"%3\"\n" )
+                                   .arg( areaNamesMap.key( itRemappedNames.value() ) )
+                                   .arg( itRemappedNames.key().isEmpty() ? qApp->translate( "TRoomDB", "<nothing>" ) : itRemappedNames.key() )
+                                   .arg( itRemappedNames.value() ) );
+            }
+            detailText.chop(1); // Trim last "\n" off
+        }
+        if( renamedMap.size() && isEmptyAreaNamePresent ) {
+            // At least one unnamed area and at least one duplicate area name
+            // - may be the same items
+            alertText = qApp->translate( "TRoomDB", "[ ALERT ] - Empty and duplicate area names detected in Map file!" );
+            informativeText = qApp->translate( "TRoomDB", "[ INFO ]  - Due to some situations not being checked in the past,  Mudlet had\n"
+                                                                      "allowed the map to have more than one area with the same or no name.\n"
+                                                                      "These make some things confusing and are now disallowed.\n"
+                                                                      "  To resolve these cases, an area without a name here (or created in\n"
+                                                                      "the future) will automatically be assigned the name \"%1\".\n"
+                                                                      "  Duplicated area names will cause all but the first encountered one\n"
+                                                                      "to gain a \"_###\" style suffix where each \"###\" is an increasing\n"
+                                                                      "number; you may wish to change these, perhaps by replacing them with\n"
+                                                                      "a \"(sub-area name)\" but it is entirely up to you how you do this,\n"
+                                                                      "other then you will not be able to set one area's name to that of\n"
+                                                                      "another that exists at the time.\n"
+                                                                      "  If there were more than one area without a name then all but the\n"
+                                                                      "first will also gain a suffix in this manner.\n"
+                                                                      "%2")
+                              .arg( mUnnamedAreaName )
+                              .arg( extraTextForMatchingSuffixAlreadyUsed );
+        }
+        else if( renamedMap.size() ) {
+            // Duplicates but no unnnamed area
+            alertText = qApp->translate( "TRoomDB", "[ ALERT ] - Duplicate area names detected in the Map file!" );
+            informativeText = qApp->translate( "TRoomDB", "[ INFO ]  - Due to some situations not being checked in the past, Mudlet had\n"
+                                                                      "allowed the user to have more than one area with the same name.\n"
+                                                                      "These make some things confusing and are now disallowed.\n"
+                                                                      "  Duplicated area names will cause all but the first encountered one\n"
+                                                                      "to gain a \"_###\" style suffix where each \"###\" is an increasing\n"
+                                                                      "number; you may wish to change these, perhaps by replacing them with\n"
+                                                                      "a \"(sub-area name)\" but it is entirely up to you how you do this,\n"
+                                                                      "other then you will not be able to set one area's name to that of\n"
+                                                                      "another that exists at the time.\n"
+                                                                      "  If there were more than one area without a name then all but the\n"
+                                                                      "first will also gain a suffix in this manner.\n"
+                                                                      "%1)")
+                              .arg( extraTextForMatchingSuffixAlreadyUsed );
+        }
+        else {
+            // A single unnamed area found
+            alertText = qApp->translate( "TRoomDB", "[ ALERT ] - An empty area name was detected in the Map file!" );
+            // Use OK for this one because it is the last part and indicates the
+            // sucessful end of something, whereas INFO is an intermediate step
+            informativeText = qApp->translate( "TRoomDB", "[  OK  ]  - Due to some situations not being checked in the past, Mudlet had\n"
+                                                                      "allowed the map to have an area with no name. This can make some\n"
+                                                                      "things confusing and is now disallowed.\n"
+                                                                      "  To resolve this case, the area without a name here (or one created\n"
+                                                                      "in the future) will automatically be assigned the name \"%1\".\n"
+                                                                      "  If this happens more then once the duplication of area names will\n"
+                                                                      "cause all but the first encountered one to gain a \"_###\" style\n"
+                                                                      "suffix where each \"###\" is an increasing number; you may wish to\n"
+                                                                      "change these, perhaps by adding more meaningful area names but it is\n"
+                                                                      "entirely up to you what is used, other then you will not be able to\n"
+                                                                      "set one area's name to that of another that exists at the time.")
+                              .arg( mUnnamedAreaName );
+        }
+        mpMap->mpHost->mTelnet.postMessage( alertText );
+        mpMap->mpHost->mTelnet.postMessage( informativeText );
+        if( ! detailText.isEmpty() ) {
+            mpMap->mpHost->mTelnet.postMessage( detailText );
+        }
+    }
 }
 
 void TRoomDB::restoreSingleArea(QDataStream & ifs, int areaID, TArea * pA )

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -51,7 +52,7 @@ public:
     bool addArea(int id);
     int addArea( QString name );
     bool addArea( int id, QString name );
-    void setAreaName( int areaID, QString name );
+    bool setAreaName( int areaID, QString name );
     const QList<TRoom *> getRoomPtrList();
     const QList<TArea *> getAreaPtrList();
     const QHash<int, TRoom *> & getRoomMap() const { return rooms; }
@@ -84,6 +85,7 @@ private:
     QMap<int, TArea *> areas;
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;
+    QString mUnnamedAreaName;
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -141,22 +142,26 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
 void dlgMapper::updateAreaComboBox()
 {
-    QMapIterator<int, QString> it( mpMap->mpRoomDB->getAreaNamesMap() );
-    //sort them alphabetically (case sensitive)
-    QMap <QString, QString> areaNames;
-    while( it.hasNext() )
-    {
-        it.next();
-        QString name = it.value();
-        areaNames.insert(name.toLower(), name);
+    QMapIterator<int, QString> itAreaNamesA( mpMap->mpRoomDB->getAreaNamesMap() );
+    //insert sort them alphabetically (case INsensitive)
+    QMap <QString, QString> _areaNames;
+    while( itAreaNamesA.hasNext() ) {
+        itAreaNamesA.next();
+        uint deduplicate = 0;
+        QString _name;
+        do {
+            _name = QStringLiteral( "%1+%2" ).arg( itAreaNamesA.value().toLower() ).arg( ++deduplicate );
+            // Use a different suffix separator to one that area names
+            // deduplication uses ('_') - makes debugging easier?
+        } while( _areaNames.contains( _name ) );
+        _areaNames.insert( _name, itAreaNamesA.value() );
     }
-    //areaNames.sort();
-    QMapIterator<QString, QString> areaIt( areaNames );
+
     showArea->clear();
-    while( areaIt.hasNext() )
-    {
-        areaIt.next();
-        showArea->addItem( areaIt.value() );
+    QMapIterator<QString, QString> itAreaNamesB( _areaNames );
+    while( itAreaNamesB.hasNext() ) {
+        itAreaNamesB.next();
+        showArea->addItem( itAreaNamesB.value() );
     }
 }
 


### PR DESCRIPTION
Some steps had previously been taken to enforce no duplicate area names
when importing an XML map or when adding a new name but other mechanisms
were left unchecked, specifically this was when renaming an existing area.

This commit adds a number of validation steps to many of the lua functions
that manipulate areas and their names.  This includes taking steps when
creating a new TArea instance to ensure a suitable area name is created and
added to the areaNamesMap which may be overwritten if a valid (non-empty,
non-duplicate) name is provided at the time or later.  This avoids problems
with the Area selection widget on the 2 or 3D Map Display and the lua
getAreaTable() function, neither of which will handle duplicate area names
and for the former, does not handle nameless areas well either.  The
deleteArea() function could take either an area Id or a name as the target
of its action so the area that is to be deleted is now not subject to any
ambiguity if supplied as a name!

Should a map file be loaded where empty or duplicated area names are found
these will be "fixed" and warning messages inserted onto the main profile
to explain what has happened.  The user will only get this once per map
file as there should now be no way to modified the map file to have either
of these issues.

The code that builds the area selection widget is revised to handle the
corner cases of two areas that have the same letters in their name but the
cases vary (the widget is sorted by name in a case insensitive manner)
which previously was not handled (same as duplicate names were not).

As a side effect of revising the TLuaInterpreter Class, area names
containing non-ASCII characters can now be handled - they will be passed
through the lua subsystem using the UTF-8 encoding.

*** This commit is a reworking of one that produced a QMessageBox to alert
and advised the user what was happening - that was deemed to be too
intrusive so this version instead displays the information in the console,
as such the detail of the renaming has to be shown now whereas the dialog
solution had the option of providing it as "Show Details..." to display it
only if requested at the time. ***

Additionally, the lua setAreaName(areaId, newAreaName) has been extended to
allow the existing area to be specified as a name (string) as well as an Id
as we can now uniquely identify it by that means.  This now matches the
behaviour of deleteArea which already acts in that manner.  It also means
a user script can use "setAreaNAme(oldName, newName)" to rename an area
without concern about determining the area Id.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>