### PR TITLE
Fix: Empty TRoomDB::areaNamesMap before (re)loading it from file

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -439,6 +439,8 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
 {
     QMap<int, QString> areaNamesMapWithPossibleEmptyOrDuplicateItems;
     ifs >> areaNamesMapWithPossibleEmptyOrDuplicateItems;
+    areaNamesMap.clear(); // Following code assumes areaNamesMap is empty but
+                          // under some situations this has not been the case...
 
     // Validate names: name nameless areas and rename duplicates
     QMultiMap<QString, QString> renamedMap; // For warning message, holds renamed area map


### PR DESCRIPTION
Found in practice that some situations cause the map file to be loaded
twice - whilst that is not ideal from a performance point of view it was
inducing problems with a recent Pull Request (#237) into the development
branch where every area was being detected as a duplicate.  It turns out
that that change assumed the areaNamesMap was empty when restoring a map
from a file, which was not the case.  This change fixes that - but the
fact that the map file is loaded twice still needs looking at.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>