### PR TITLE
(release 30)fix crashes on room deletion

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,6 +37,8 @@
 #include "pre_guard.h"
 #include <QtUiTools>
 #include <QDir>
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QMessageBox>
 #include "post_guard.h"
 
@@ -154,6 +157,10 @@ Host::Host( int port, QString hostname, QString login, QString pass, int id )
 , mCommandLineBgColor( QColor(  0,  0,  0) )
 , mFORCE_MXP_NEGOTIATION_OFF( false )
 , mHaveMapperScript( false )
+/* DEBUGCONTROLS 3P - Per profile debug variable default values
+ * controls in dlgProfilePreferences here. Existing host instance.
+ */
+, mDebug_IsMapFormatToBeDownVersioned( false )
 {
    // mLogStatus = mudlet::self()->mAutolog;
     mLuaInterface = new LuaInterface(this);
@@ -175,6 +182,8 @@ Host::Host( int port, QString hostname, QString login, QString pass, int id )
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');
     mDoubleClickIgnore.insert('\'');
+    // Assigned value will be false for a "production" or "release" build:
+    mDebug_IsMapFormatToBeDownVersioned = ! ( QByteArray( APP_BUILD ).isEmpty() );
 }
 
 Host::~Host()
@@ -1241,4 +1250,12 @@ void Host::readPackageConfig( QString luaConfig, QString & packageName )
         lua_pop(L, -1);
         lua_close(L);
     }
+}
+
+/* DEBUGCONTROLS 4P - Per profile debug control adjustment slots
+ *
+ */
+void Host::slot_setMapFormatToBeDownVersioned(bool isEnabled)
+{
+    mDebug_IsMapFormatToBeDownVersioned = isEnabled;
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -40,6 +41,8 @@
 
 class QDialog;
 class QPushButton;
+class QHBoxLayout;
+class QLabel;
 class QListWidget;
 
 class dlgTriggerEditor;
@@ -55,14 +58,13 @@ class TMap;
 
 class Host  : public QObject
 {
+    Q_OBJECT
     friend class XMLexport;
     friend class XMLimport;
 
 public:
-
                        Host( int port, QString mHostName, QString login, QString pass, int host_id );
-
-                       ~Host();
+                      ~Host();
 
     QString            getName()                        { QMutexLocker locker(& mLock); return mHostName; }
     void               setName( QString s )             { QMutexLocker locker(& mLock); mHostName = s; }
@@ -306,6 +308,22 @@ public:
     bool               mFORCE_MXP_NEGOTIATION_OFF;
     bool               mHaveMapperScript;
     QSet<QChar>         mDoubleClickIgnore;
+
+/* DEBUGCONTROLS 1P - Per profile debug variables declarations
+ * development/debug feature controls.
+ * Please use a "mDebug_" prefix - so others can search for where they are used
+ * 8-)!
+ */
+    bool                mDebug_IsMapFormatToBeDownVersioned;
+
+
+public slots:
+/* DEBUGCONTROLS 2P - Per profile debug variable control slots declarations
+ * connect SIGNALS from dlgProfilePreferences.cpp to these SLOTS.
+ */
+    void                slot_setMapFormatToBeDownVersioned(bool isEnabled);
+
+
 };
 
 #endif // MUDLET_HOST_H

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2988,11 +2988,9 @@ void T2DMap::slot_setImage()
 
 void T2DMap::slot_deleteRoom()
 {
+    mpMap->mpRoomDB->removeRooms( mMultiSelectionList );
+    mMultiSelectionList.clear();
     mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
-    {
-        mpMap->mpRoomDB->removeRoom( mMultiSelectionList[j] );
-    }
     mMultiSelectionListWidget.clear();
     mMultiSelectionListWidget.hide();
     repaint();

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -174,80 +174,19 @@ void TArea::determineAreaExitsOfRoom( int id )
     }
 
     exits.remove(id);
-    int exitId = pR->getNorth();
-    // The second term in the ifs below looks for exit room id in TArea
-    // instance's own list of rooms which will fail (with a -1 if it is NOT in
-    // the list and hence the area.
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
-        exits.insertMulti( id, p );
+    QSetIterator<QPair<quint8, quint64> > itNormalExitSet = pR->getNormalExits();
+    while( itNormalExitSet.hasNext() ) {
+        QPair<quint8, quint64> _exit = itNormalExitSet.next();
+        if( rooms.indexOf( _exit.second ) < 0 ) {
+            exits.insertMulti( id, qMakePair( _exit.second, _exit.first ) );
+        }
     }
-    exitId = pR->getNortheast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getEast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getSoutheast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getSouth();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getSouthwest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getWest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getNorthwest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getUp();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getDown();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getIn();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getOut();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
-        exits.insertMulti( id, p );
-    }
-    const QMap<int, QString> otherMap = pR->getOtherMap();
-    QMapIterator<int,QString> it( otherMap );
-    while( it.hasNext() ) {
-        it.next();
-        int _exit = it.key();
-        TRoom * pO = mpRoomDB->getRoom(_exit);
-        if( pO ) {
-            if( pO->getArea() != getAreaID() ) {
-                QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
-                exits.insertMulti( id, p );
-            }
+
+    QSetIterator<QPair<QString, quint64> > itSpecialExitSet = pR->getSpecialExits();
+    while( itSpecialExitSet.hasNext() ) {
+        QPair<QString, quint64> _exit = itSpecialExitSet.next();
+        if( rooms.indexOf( _exit.second ) < 0 ) {
+            exits.insertMulti( id, qMakePair( _exit.second, DIR_OTHER ) );
         }
     }
 }
@@ -256,87 +195,27 @@ void TArea::determineAreaExits()
 {
     exits.clear();
     for( int i=0; i<rooms.size(); i++ ) {
-        TRoom * pR = mpRoomDB->getRoom(rooms[i]);
+        TRoom * pR = mpRoomDB->getRoom(rooms.at(i));
         if( ! pR ) {
             continue;
         }
 
-        int id = pR->getId();
-        int exitId = pR->getNorth();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
-            exits.insertMulti( id, p );
+        QSetIterator<QPair<quint8, quint64> > itNormalExitSet = pR->getNormalExits();
+        while( itNormalExitSet.hasNext() ) {
+            QPair<quint8, quint64> _exit = itNormalExitSet.next();
+            if( rooms.indexOf( _exit.second ) < 0 ) {
+                exits.insertMulti( rooms.at(i), qMakePair( _exit.second, _exit.first ) );
+            }
         }
-        exitId = pR->getNortheast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getEast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getSoutheast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getSouth();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getSouthwest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getWest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getNorthwest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getUp();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getDown();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getIn();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getOut();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
-            exits.insertMulti( id, p );
-        }
-        const QMap<int, QString> otherMap = pR->getOtherMap();
-        QMapIterator<int,QString> it( otherMap );
-        while( it.hasNext() ) {
-            it.next();
-            int _exit = it.key();
-            TRoom * pO = mpRoomDB->getRoom(_exit);
-            if( pO ) {
-                if( pO->getArea() != getAreaID() ) {
-                    QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
-                    exits.insertMulti( id, p );
-                }
+
+        QSetIterator<QPair<QString, quint64> > itSpecialExitSet = pR->getSpecialExits();
+        while( itSpecialExitSet.hasNext() ) {
+            QPair<QString, quint64> _exit = itSpecialExitSet.next();
+            if( rooms.indexOf( _exit.second ) < 0 ) {
+                exits.insertMulti( rooms.at(i), qMakePair( _exit.second, DIR_OTHER ) );
             }
         }
     }
-    //qDebug()<<"exits:"<<exits.size();
 }
 
 void TArea::fast_calcSpan( int id )
@@ -522,7 +401,9 @@ void TArea::removeRoom( int room )
 //    TRoom * pR = mpRoomDB->getRoom( room );
     rooms.removeOne( room );
     exits.remove( room );
-    qDebug()<<"Area removal took"<<time.elapsed();
+//    qDebug()<<"Area removal took"<<time.elapsed(); // Is room not Area!
+//// FIXME: The following recalculations are probably required despite being
+//// commented out by another coder! - SlySven
 //    int x = pR->x;
 //    int y = pR->y*-1;
 //    int z = pR->z;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -39,6 +39,14 @@
 #include <QMessageBox>
 #include "post_guard.h"
 
+// Moved up from depths of file - a version dependent change (16=>17) will speed
+// up a file loading operation (switches from manual regeneration of room
+// entrance data on loading to storing it in the map file) at the cost of older
+// Mudlet versions not supporting file format - once switch has been adopted
+// the conditional aspect of the write of the data in TMap::serialize(...) can
+// be removed to make it always run - recommend this is done for actual release
+// version (not greek suffixed previews). SlySven
+const int CURRENT_MAP_VERSION = 16;
 
 TMap::TMap( Host * pH )
 : mpRoomDB( new TRoomDB( this ) )
@@ -257,69 +265,26 @@ int TMap::createNewRoomID()
 
 bool TMap::setExit( int from, int to, int dir )
 {
-    TRoom * pR = mpRoomDB->getRoom( from );
+    TRoom * pR_from = mpRoomDB->getRoom( from );
     TRoom * pR_to = mpRoomDB->getRoom( to );
 
-    if( !pR ) {
+    if( ! pR_from ) {
         return false;
     }
-    if( !pR_to && to > 0 ) {
+
+    if( to > 0 && ! pR_to ) {
         return false;
     }
-    if( to < 1 ) {
+    else if( to < 1 ) {
         to = -1;
     }
 
-    mPlausaOptOut = 0;
-    bool ret = true;
+    bool ret = pR_from->setExit(to, dir);
+    // This will handle revising entrance information and updating TArea data
 
-    switch( dir ) {
-        case DIR_NORTH:
-            pR->setNorth(to);
-            break;
-        case DIR_NORTHEAST:
-            pR->setNortheast(to);
-            break;
-        case DIR_NORTHWEST:
-            pR->setNorthwest(to);
-            break;
-        case DIR_EAST:
-            pR->setEast(to);
-            break;
-        case DIR_WEST:
-            pR->setWest(to);
-            break;
-        case DIR_SOUTH:
-            pR->setSouth(to);
-            break;
-        case DIR_SOUTHEAST:
-            pR->setSoutheast(to);
-            break;
-        case DIR_SOUTHWEST:
-            pR->setSouthwest(to);
-            break;
-        case DIR_UP:
-            pR->setUp(to);
-            break;
-        case DIR_DOWN:
-            pR->setDown(to);
-            break;
-        case DIR_IN:
-            pR->setIn(to);
-            break;
-        case DIR_OUT:
-            pR->setOut(to);
-            break;
-        default:
-            ret = false;
-    }
-    pR->setExitStub(dir, false);
+    pR_from->setExitStub(dir, false);
+
     mMapGraphNeedsUpdate = true;
-    TArea * pA = mpRoomDB->getArea( pR->getArea() );
-    if( ! pA ) {
-        return false;
-    }
-    pA->determineAreaExitsOfRoom(pR->getId());
     return ret;
 }
 
@@ -382,10 +347,8 @@ void TMap::init( Host * pH )
             }
         }
     }
-    qDebug("TMap::init() Initialize run time:%i milli-seconds.", _time.elapsed() );
+    qDebug( "TMap::init() Initialize run time: %i milli-Seconds.", _time.elapsed() );
 }
-
-
 
 void TMap::setView(float x, float y, float z, float zoom )
 {
@@ -953,8 +916,6 @@ bool TMap::findPath( int from, int to )
      return false;
 }
 
-const int CURRENT_MAP_VERSION = 16;
-
 bool TMap::serialize( QDataStream & ofs )
 {
     version = CURRENT_MAP_VERSION;
@@ -967,8 +928,7 @@ bool TMap::serialize( QDataStream & ofs )
     ofs << mpRoomDB->getAreaMap().size();
     // serialize area table
     QMapIterator<int, TArea *> itAreaList(mpRoomDB->getAreaMap());
-    while( itAreaList.hasNext() )
-    {
+    while( itAreaList.hasNext() ) {
         itAreaList.next();
         int areaID = itAreaList.key();
         TArea * pA = itAreaList.value();
@@ -995,23 +955,22 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pA->zoneAreaRef;
     }
 
-    if (mRoomId)
+    if (mRoomId) {
         ofs << mRoomId;
-    else{
+    }
+    else {
         mRoomId = 0;
         ofs << mRoomId;
     }
     ofs << mapLabels.size(); //anzahl der areas
     QMapIterator<int, QMap<int, TMapLabel> > itL1(mapLabels);
-    while( itL1.hasNext() )
-    {
+    while( itL1.hasNext() ) {
         itL1.next();
         int i = itL1.key();
         ofs << itL1.value().size();//anzahl der labels pro area
         ofs << itL1.key(); //area id
         QMapIterator<int, TMapLabel> itL2(mapLabels[i]);
-        while( itL2.hasNext() )
-        {
+        while( itL2.hasNext() ) {
             itL2.next();
 // N/U:             int ii = itL2.key();
             ofs << itL2.key();//label ID
@@ -1028,8 +987,7 @@ bool TMap::serialize( QDataStream & ofs )
         }
     }
     QHashIterator<int, TRoom *> it( mpRoomDB->getRoomMap() );
-    while( it.hasNext() )
-    {
+    while( it.hasNext() ) {
 
         it.next();
 // N/U:         int i = it.key();
@@ -1070,6 +1028,13 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pR->exitStubs;
         ofs << pR->getExitWeights();
         ofs << pR->doors;
+        if( version >= 17 ) {
+            // TODO: At the time of writing this is NOT true, but will make
+            // future versions faster - once the version IS incremented then
+            // take out this conditional so code always runs
+            ofs << pR->getNormalEntrances();
+            ofs << pR->getSpecialEntrances();
+        }
     }
 
     return true;
@@ -1217,13 +1182,10 @@ bool TMap::restore(QString location)
                 areaLabelCount++;
             }
         }
-        while( ! ifs.atEnd() )
-        {
-            int i;
-            ifs >> i;
+        while( ! ifs.atEnd() ) {
             TRoom * pT = new TRoom(mpRoomDB);
-            mpRoomDB->restoreSingleRoom( ifs, i, pT );
-            pT->restore( ifs, i, version );
+            pT->restore( ifs, version );
+            mpRoomDB->restoreSingleRoom( ifs, pT );
 
 
         }
@@ -1243,7 +1205,8 @@ bool TMap::restore(QString location)
         customEnvColors[270] = mpHost->mLightCyan_2;
         customEnvColors[271] = mpHost->mLightWhite_2;
         customEnvColors[272] = mpHost->mLightBlack_2;
-        qDebug()<<"LOADED rooms:"<<mpRoomDB->size()<<" loading time:"<<_time.elapsed();
+        qDebug( "TMap::restore(\"%s\") LOADED %i rooms - loading time: %i milli-Seconds.",
+                file.fileName().toUtf8().constData(), mpRoomDB->size(), _time.elapsed());
         if( canRestore )
         {
             return true;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -46,11 +46,13 @@
 // Moved up from depths of file - a version dependent change (16=>17) will speed
 // up a file loading operation (switches from manual regeneration of room
 // entrance data on loading to storing it in the map file) at the cost of older
-// Mudlet versions not supporting file format - once switch has been adopted
-// the conditional aspect of the write of the data in TMap::serialize(...) can
-// be removed to make it always run - recommend this is done for actual release
-// version (not greek suffixed previews). SlySven
-const int CURRENT_MAP_VERSION = 16;
+// Mudlet versions not supporting file format - this has been ovecome by a check
+// box option on the last page of the profile preferences dialog to forceably
+// downgrade when saving.  Recommend that the value is incremented at the point
+// an incompatible (e.g. not readable by prior code) change is made to the SAVE
+// /SERIALIZE code - and make what is written by that code sensitive to the
+// now (localVersion) variable therein. SlySven
+const int CURRENT_MAP_VERSION = 17;
 
 TMap::TMap( Host * pH )
 : mpRoomDB( new TRoomDB( this ) )
@@ -932,8 +934,11 @@ bool TMap::findPath( int from, int to )
 
 bool TMap::serialize( QDataStream & ofs )
 {
-    version = CURRENT_MAP_VERSION;
-    ofs << version;
+    int usedVersion = CURRENT_MAP_VERSION;
+    if( mpHost->mDebug_IsMapFormatToBeDownVersioned ) {
+        usedVersion--;
+    }
+    ofs << usedVersion;
     ofs << envColors;
     ofs << mpRoomDB->getAreaNamesMap();
     ofs << customEnvColors;
@@ -969,13 +974,7 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pA->zoneAreaRef;
     }
 
-    if (mRoomId) {
-        ofs << mRoomId;
-    }
-    else {
-        mRoomId = 0;
-        ofs << mRoomId;
-    }
+    ofs << mRoomId;
     ofs << mapLabels.size(); //anzahl der areas
     QMapIterator<int, QMap<int, TMapLabel> > itL1(mapLabels);
     while( itL1.hasNext() ) {
@@ -1006,7 +1005,7 @@ bool TMap::serialize( QDataStream & ofs )
         it.next();
 // N/U:         int i = it.key();
         TRoom * pR = it.value();
-        ofs <<  pR->getId();
+        ofs << pR->getId();
         ofs << pR->getArea();
         ofs << pR->x;
         ofs << pR->y;
@@ -1042,10 +1041,7 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pR->exitStubs;
         ofs << pR->getExitWeights();
         ofs << pR->doors;
-        if( version >= 17 ) {
-            // TODO: At the time of writing this is NOT true, but will make
-            // future versions faster - once the version IS incremented then
-            // take out this conditional so code always runs
+        if( usedVersion > 16 ) {
             ofs << pR->getNormalEntrances();
             ofs << pR->getSpecialEntrances();
         }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -32,8 +32,12 @@
 #include "TRoomDB.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QDebug>
 #include <QDir>
+#if defined(DEBUG_TIMING)
+#include <QElapsedTimer>
+#endif
 #include <QFileDialog>
 #include <QMainWindow>
 #include <QMessageBox>
@@ -291,8 +295,10 @@ bool TMap::setExit( int from, int to, int dir )
 void TMap::init( Host * pH )
 {
     // init areas
-    QTime _time;
+#if defined(DEBUG_TIMING)
+    QElapsedTimer _time;
     _time.start();
+#endif
 
     if( version < 14 ) {
         mpRoomDB->initAreasForOldMaps();
@@ -309,7 +315,13 @@ void TMap::init( Host * pH )
             itArea.value()->calcSpan();
         }
     }
+#if defined(DEBUG_TIMING)
+    qDebug( "TMap::init() Initialize (part one) run time: %i milli-Seconds.", _time.elapsed() );
+#endif
     mpRoomDB->auditRooms();
+#if defined(DEBUG_TIMING)
+    _time.restart();
+#endif
 
     if( version <16 ) {
         // convert old style labels, wasn't made version conditional in past but
@@ -347,7 +359,9 @@ void TMap::init( Host * pH )
             }
         }
     }
-    qDebug( "TMap::init() Initialize run time: %i milli-Seconds.", _time.elapsed() );
+#if defined(DEBUG_TIMING)
+    qDebug( "TMap::init() Initialize (part two) run time: %i milli-Seconds.", _time.elapsed() );
+#endif
 }
 
 void TMap::setView(float x, float y, float z, float zoom )

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -129,8 +129,6 @@ public:
     QList<int> conList;
     QMap<int, int> roomidToIndex;
     QMap<int, int> indexToRoomid;
-    int mPlausaOptOut;
-
     QMap<QString, int> pixNameTable;
     QMap<int, QPixmap> pixTable;
     typedef adjacency_list<listS, vecS, directedS, no_property, property<edge_weight_t, cost> > mygraph_t;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -20,10 +20,10 @@
  ***************************************************************************/
 
 
-// Define for testing deletion of rooms - NOT RECOMMENDED as the time to display
-// the individual room timing must slow the process down - enable and use the
-// averaging code in T2DMap::slot_deleteRoom() and TRoomDB::removeArea() instead!
-// #define DEBUG_TIMING
+// Define for testing deletion of rooms - NOT RECOMMENDED HERE as the time to
+// display the individual room timing must slow the process down - enable and
+// use the averaging code in other classes instead!
+#undef DEBUG_TIMING
 
 #include "TRoom.h"
 
@@ -78,15 +78,12 @@ TRoom::TRoom(TRoomDB * pRDB)
 TRoom::~TRoom()
 {
 #if defined(DEBUG_TIMING)
-    static bool isToShowTime= false; // Set to true within debugger to control the display of this - may slow down code anyhow
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 #endif
     mpRoomDB->__removeRoom( id );
 #if defined(DEBUG_TIMING)
-    if( isToShowTime ) {
-        qDebug( "TRoom::~TRoom() - Room (%i) destruction took: %i milli-seconds.", id, timer.elapsed() );
-    }
+    qDebug( "TRoom::~TRoom() - Room (%i) destruction took: %i milli-seconds.", id, timer.elapsed() );
 #endif
 }
 

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -20,6 +20,11 @@
  ***************************************************************************/
 
 
+// Define for testing deletion of rooms - NOT RECOMMENDED as the time to display
+// the individual room timing must slow the process down - enable and use the
+// averaging code in T2DMap::slot_deleteRoom() and TRoomDB::removeArea() instead!
+// #define DEBUG_TIMING
+
 #include "TRoom.h"
 
 
@@ -30,10 +35,12 @@
 #include <QApplication>
 #include <QDataStream>
 #include <QDebug>
+#if defined(DEBUG_TIMING)
+#include <QElapsedTimer>
+#endif
+#include <QPair>
 #include <QStringBuilder>
-#include <QTime>
 #include "post_guard.h"
-
 
 TRoom::TRoom(TRoomDB * pRDB)
 : x( 0 )
@@ -70,10 +77,17 @@ TRoom::TRoom(TRoomDB * pRDB)
 
 TRoom::~TRoom()
 {
+#if defined(DEBUG_TIMING)
+    static bool isToShowTime= false; // Set to true within debugger to control the display of this - may slow down code anyhow
     QTime timer;
     timer.start();
+#endif
     mpRoomDB->__removeRoom( id );
-    qDebug()<<"room destructor took"<<timer.elapsed();
+#if defined(DEBUG_TIMING)
+    if( isToShowTime ) {
+        qDebug( "TRoom::~TRoom() - Room (%i) destruction took: %i milli-seconds.", id, timer.elapsed() );
+    }
+#endif
 }
 
 bool TRoom::hasExitStub(int direction)
@@ -244,21 +258,79 @@ bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
 
 bool TRoom::setExit( int to, int direction )
 {
+    int * pExit;
     switch(direction){
-    case DIR_NORTH:     north     = to; return true; break;
-    case DIR_NORTHEAST: northeast = to; return true; break;
-    case DIR_NORTHWEST: northwest = to; return true; break;
-    case DIR_EAST:      east      = to; return true; break;
-    case DIR_WEST:      west      = to; return true; break;
-    case DIR_SOUTH:     south     = to; return true; break;
-    case DIR_SOUTHEAST: southeast = to; return true; break;
-    case DIR_SOUTHWEST: southwest = to; return true; break;
-    case DIR_UP:        up        = to; return true; break;
-    case DIR_DOWN:      down      = to; return true; break;
-    case DIR_IN:        in        = to; return true; break;
-    case DIR_OUT:       out       = to; return true;
+        case DIR_NORTH:     pExit = &north;     break;
+        case DIR_NORTHEAST: pExit = &northeast; break;
+        case DIR_NORTHWEST: pExit = &northwest; break;
+        case DIR_EAST:      pExit = &east;      break;
+        case DIR_WEST:      pExit = &west;      break;
+        case DIR_SOUTH:     pExit = &south;     break;
+        case DIR_SOUTHEAST: pExit = &southeast; break;
+        case DIR_SOUTHWEST: pExit = &southwest; break;
+        case DIR_UP:        pExit = &up;        break;
+        case DIR_DOWN:      pExit = &down;      break;
+        case DIR_IN:        pExit = &in;        break;
+        case DIR_OUT:       pExit = &out;       break;
+        default:
+            qWarning( "TRoom::setExit(%i, %i) - Warning: invalid argument(s) for Normal exit supplied!", to, direction );
+            Q_UNREACHABLE(); // Unhandled DIR_**** code value encounter!
+            return false;
     }
-    return false;
+    if( *pExit == to ) { // Bypass if no change
+        return true;
+    }
+
+    TArea * pA = mpRoomDB->getArea( area );
+    TRoom * pR_oldTo = mpRoomDB->getRoom( *pExit );
+    TArea * pA_oldTo;
+    TArea * pA_newTo;
+    if( pR_oldTo ) {
+        pA_oldTo = mpRoomDB->getArea( pR_oldTo->getArea() );
+        pR_oldTo->resetEntrance(id, direction);
+    }
+    else {
+        pA_oldTo = 0;
+    }
+
+    *pExit = to;
+
+    TRoom * pR_newTo = mpRoomDB->getRoom( to );
+    if( pR_newTo ) {
+        pA_newTo = mpRoomDB->getArea( pR_newTo->getArea() );
+        pR_newTo->setEntrance(id, direction);
+    }
+    else {
+        pA_newTo = 0;
+    }
+
+    if( pA_oldTo ) {
+        if( pA_oldTo == pA_newTo ) { // The exit used to point to a valid area and it still points to THAT area
+            if( pA && pA != pA_oldTo ) { // The room is in a valid area and the exit is (still) pointing to a DIFFERENT one
+                pA->determineAreaExitsOfRoom( id ); // So update the exit in the Area's Exits list
+            }
+        }
+        else if( pA_newTo ) {  // The exit used to point to a valid area and it now points to a DIFFERENT VALID area
+            if( pA && pA != pA_oldTo ) { // The room is in a valid area and the exit is (still) pointing to a DIFFERENT one
+                pA->determineAreaExitsOfRoom( id ); // So update the exit in the Area's Exits list
+            }
+        }
+        else if( pA ) {  // The exit used to point to a valid area and it now DOESN'T
+            pA->determineAreaExitsOfRoom( id ); // So remove the exit from the Area's Exits list
+        }
+    }
+    else if( pA_newTo ) {  // The exit DON'T used to point to a valid area and but it DOES NOW
+        if( pA && pA != pA_newTo ) {  // The exit DON'T used to point to a valid area and but it DOES NOW and that ISN'T the same as the room's
+            pA->determineAreaExitsOfRoom( id ); // So add this exit to the Area's Exits list
+        }
+    }
+    else if( pA ) {  // The exit DON'T used to point to a valid area and it still DOESN'T
+        ; // No-op
+    }
+    else { // Um, pA is NULL so this room IS NOT in a valid area SO HOW COME WE ARE SETTING EXITS TO IT?
+        qWarning( "TRoom::setExit(...) Warning: attempting to set an exit in a room(Id=%i) that is NOT within a TArea instance - area(Id=%i)!", id, area );
+    }
+    return true;
 }
 
 // Original code unused - checked all the normal exits to see if there is one to
@@ -295,6 +367,70 @@ bool TRoom::setExit( int to, int direction )
  *        return false;
  *}
  */
+
+void TRoom::setEntrance( int from, quint8 from_dir )
+{
+    if( from > 0 && from_dir >= DIR_NORTH && from_dir <= DIR_OUT ) {
+        mNormalEntrances.insert( qMakePair( from_dir, from ) );
+    }
+    else {
+        qWarning( "TRoom::setEntrance((int)%i, (quint8)%i) - Warning: invalid argument(s) for Normal entrance supplied!", from, from_dir );
+    }
+}
+
+void TRoom::setEntrance( QPair<quint8, quint64> from )
+{
+    if( from.first >=DIR_NORTH && from.first <=DIR_OUT ) {
+        mNormalEntrances.insert( from );
+    }
+    else {
+        qWarning( "TRoom::setEntrance(QPair<(quint8)%i, (quint64)%s>) - Warning: invalid argument(s) for Normal entrance supplied!", from.first, from.second );
+    }
+}
+
+void TRoom::resetEntrance( int from, quint8 from_dir )
+{
+    if( from > 0 && from_dir >= DIR_NORTH && from_dir <= DIR_OUT ) {
+        mNormalEntrances.remove( qMakePair( from_dir, from ) );
+    }
+    else {
+        qWarning( "TRoom::resetEntrance((int)%i, (quint8)%i) - Warning: invalid argument(s) for Normal entrance supplied!", from, from_dir );
+    }
+}
+
+// Note: from_dir DOES NOT include a '0'/'1' prefix to indicate lock status
+void TRoom::setEntrance( int from, QString from_dir )
+{
+    if( from > 0 && ! from_dir.isEmpty() ) {
+        mSpecialEntrances.insert( qMakePair( from_dir, from ) );
+    }
+    else {
+        qWarning( "TRoom::setEntrance((int)%i, (QString)\"%s\") - Warning: invalid argument(s) for Special entrance supplied!", from, from_dir.toUtf8().constData() );
+    }
+}
+
+// Note: from.first DOES NOT include a '0'/'1' prefix to indicate lock status
+void TRoom::setEntrance( QPair<QString, quint64> from )
+{
+    if( ! from.first.isEmpty() ) {
+        mSpecialEntrances.insert( from );
+    }
+    else {
+        qWarning( "TRoom::setEntrance(QPair<(QString)\"%s\", (quint8)%i>) - Warning: invalid argument(s) for Special entrance supplied!", from.first.toUtf8().constData(), from.second );
+    }
+}
+
+// Note: from_dir DOES NOT include a '0'/'1' prefix to indicate lock status
+void TRoom::resetEntrance( int from, QString from_dir )
+{
+    if( from > 0 && ! from_dir.isEmpty() ) {
+        mSpecialEntrances.remove( qMakePair( from_dir, from ) );
+    }
+    else {
+        qWarning( "TRoom::resetEntrance(%i, \"%s\") - Warning: invalid argument(s) for Special entrance supplied!", from, from_dir.toUtf8().constData() );
+    }
+}
+
 bool TRoom::hasExit( int direction )
 {
     switch(direction){
@@ -333,40 +469,70 @@ int TRoom::getExit( int direction )
     return -1;
 }
 
-QHash<int, int> TRoom::getExits()
+QSet<QPair<quint8, quint64> > TRoom::getNormalExits()
 {
-    // key is room id we exit to, value is type of exit. 0 is normal, 1 is special
-    QHash<int, int> exitList;
-    if (north != -1)
-        exitList[north] = 0;
-    if (northeast != -1)
-        exitList[northeast] = 0;
-    if (east != -1)
-        exitList[east] = 0;
-    if (southeast != -1)
-        exitList[southeast] = 0;
-    if (south != -1)
-        exitList[south] = 0;
-    if (southwest != -1)
-        exitList[southwest] = 0;
-    if (west != -1)
-        exitList[west] = 0;
-    if (northwest != -1)
-        exitList[northwest] = 0;
-    if (up != -1)
-        exitList[up] = 0;
-    if (down != -1)
-        exitList[down] = 0;
-    if (in != -1)
-        exitList[in] = 0;
-    if (out != -1)
-        exitList[out] = 0;
-    QMapIterator<int, QString> it(other);
-    while (it.hasNext()) {
-        it.next();
-        exitList[it.key()] = 1;
+    // first is direction code, second is room id we exit to
+    QSet<QPair<quint8, quint64> > exitSet;
+    if( north >= 0 ) {
+        exitSet.insert( qMakePair( DIR_NORTH,       static_cast<quint64>(north) ) );
     }
-    return exitList;
+    if( northeast >= 0 ) {
+        exitSet.insert( qMakePair( DIR_NORTHEAST,   static_cast<quint64>(northeast) ) );
+    }
+    if( east >= 0 ) {
+        exitSet.insert( qMakePair( DIR_EAST,        static_cast<quint64>(east) ) );
+    }
+    if( southeast >= 0 ) {
+        exitSet.insert( qMakePair( DIR_SOUTHEAST,   static_cast<quint64>(southeast) ) );
+    }
+    if( south >= 0 ) {
+        exitSet.insert( qMakePair( DIR_SOUTH,       static_cast<quint64>(south) ) );
+    }
+    if( southwest >= 0 ) {
+        exitSet.insert( qMakePair( DIR_SOUTHWEST,   static_cast<quint64>(southwest) ) );
+    }
+    if( west >= 0 ) {
+        exitSet.insert( qMakePair( DIR_WEST,        static_cast<quint64>(west) ) );
+    }
+    if( northwest >= 0 ) {
+        exitSet.insert( qMakePair( DIR_NORTHWEST,   static_cast<quint64>(northwest) ) );
+    }
+    if( up >= 0 ) {
+        exitSet.insert( qMakePair( DIR_UP,          static_cast<quint64>(up) ) );
+    }
+    if( down >= 0 ) {
+        exitSet.insert( qMakePair( DIR_DOWN,        static_cast<quint64>(down) ) );
+    }
+    if( in >= 0 ) {
+        exitSet.insert( qMakePair( DIR_IN,          static_cast<quint64>(in) ) );
+    }
+    if( out >= 0 ) {
+        exitSet.insert( qMakePair( DIR_OUT,         static_cast<quint64>(out) ) );
+    }
+    return exitSet;
+}
+
+// Note: .first DOES NOT include a '0'/'1' prefix to indicate lock status
+QSet<QPair<QString, quint64> > TRoom::getSpecialExits()
+{
+    QSet<QPair<QString, quint64> > exitSet;
+
+    // first is room id we exit to, second is command (eventually might be "name"...?)
+    QMapIterator<int, QString> it(other);
+    while( it.hasNext() ) {
+        it.next();
+        if( it.key() >=0 ) {
+            if(      it.value().length() > 1
+                && (    it.value().left(1) == QStringLiteral("0")
+                     || it.value().left(1) == QStringLiteral("1") ) ) {
+                exitSet.insert( qMakePair( it.value().mid(1), static_cast<quint64>(it.key()) ) );
+            }
+            else if( ! it.value().isEmpty() ) {
+                exitSet.insert( qMakePair( it.value(), static_cast<quint64>(it.key()) ) );
+            }
+        }
+    }
+    return exitSet;
 }
 
 void TRoom::setExitLock( int exit, bool state )
@@ -500,57 +666,85 @@ bool TRoom::hasSpecialExitLock( int to, QString cmd )
 // a poorer choice than the "command" which is currently the value item...
 // FIXME: swap key/value items in (TRoom *)->other<int, QString> map?
 // Changing to setSpecialExit(), "to" values less than 1 remove exit...
-void TRoom::setSpecialExit( int to, QString cmd )
+// This code is considerably more complex because of the initial character of
+// the command being '0' or '1' to indicate that this special exit is "locked"
+// the coding complexity would be seriously simpler if we just had a
+// QSet<QString>TRoom::specialExitLocks member
+bool TRoom::setSpecialExit( int to, QString cmd )
 {
     QString _strippedCmd;
-    QString _prefix= "";
+    QString _newPrefix;
+    QString _oldPrefix;
+    TRoom * pR_oldTo;
+    TRoom * pR_newTo;
+    TArea * pA_oldTo;
+    TArea * pA_newTo;
 
-    if( cmd.startsWith('0') || cmd.startsWith('1') )
-    {
+    if( cmd.startsWith(QLatin1Char('0')) || cmd.startsWith(QLatin1Char('1')) ) {
         _strippedCmd = cmd.mid(1);
-        _prefix = cmd.mid(0,1);
+        _newPrefix = cmd.mid(0,1);
     }
-    else
-    {
+    else {
         _strippedCmd = cmd;
     }
 
-    if( _strippedCmd.isEmpty() )
-        return; // Refuse to create an unnamed special exit!!!
-    // replace if this special exit exists, otherwise add
+    if( _strippedCmd.isEmpty() ) {
+        qWarning("TRoom::setSpecialExit( %i, \"\" ) Warning: attempt to create a special exit from room (Id=%i) with no name!", to, id);
+        return false; // Refuse to create an unnamed special exit!!!
+    }
     QMutableMapIterator<int, QString> it( other );
-    while(it.hasNext() )
-    {
+    while(it.hasNext() ) {
         it.next();
-        if( ! it.value().size() )
+        if( ! it.value().size() ) {
             continue;
+        }
 
-        if( Q_LIKELY( it.value().startsWith('0') || it.value().startsWith('1') ) )
-        {
-            if( it.value().mid(1) != _strippedCmd )
+        if( Q_LIKELY( it.value().startsWith(QLatin1Char('0')) || it.value().startsWith(QLatin1Char('1')) ) ) {
+            if( it.value().mid(1) != _strippedCmd ) {
                 continue;
-            else
-            { // Found the matching command, preserve the existing lock state
+            }
+            else {
+              // Found the matching command, preserve the existing lock state
               // unless overriden in command and also the old destination to
               // note which areas are affected
-                if( _prefix.isEmpty() )
-                {
-                    _prefix = it.value().mid(0,1);
+                _oldPrefix = it.value().mid(0,1);
+                if( _newPrefix.isEmpty() ) {
+                    _newPrefix = it.value().mid(0,1);
                 }
+                pR_oldTo = mpRoomDB->getRoom( it.key() );
+                if( pR_oldTo ) {
+                    pR_oldTo->resetEntrance(id, _strippedCmd);
+                }
+                else {
+                    qWarning( "TRoom::setSpecialExit( %i, \"%s\" ) - Warning: invalid argument(s) for Special exit supplied!", to, cmd.toUtf8().constData() );
+                }
+                if( to == it.key() && _oldPrefix == _newPrefix ) {
+                    // The above tests might be a bit too tight but should work to detect "No change" situations
+                    return true;
+                }
+
                 it.remove(); // Despite this being a "Mutable" iterator it does
                              // NOT allow us to change the KEY - we only can
                              // remove the entry to add-in a new one later.
                 break;
             }
         }
-        else
-        {
-            if( it.value() != _strippedCmd )
+        else {
+            if( it.value() != _strippedCmd ) {
                 continue;
-            else
-            { // Found the matching command, but this is an old one with no lock state prefix
-                if( _prefix.isEmpty() )
-                    _prefix = '0'; // Assume default unlock case if not set
+            }
+            else {
+                // Found the matching command, but this is an old one with no lock state prefix
+                if( _newPrefix.isEmpty() ) {
+                    _newPrefix = QLatin1Char('0'); // Assume default unlock case if not set
+                }
+                pR_oldTo = mpRoomDB->getRoom( it.key() );
+                if( pR_oldTo ) {
+                    pR_oldTo->resetEntrance(id, _strippedCmd);
+                }
+                else {
+                    qWarning( "TRoom::setSpecialExit( %i, \"%s\" ) - Warning: invalid argument(s) for Special exit supplied!", to, cmd.toUtf8().constData() );
+                }
                 it.remove();
                 break;
             }
@@ -560,16 +754,15 @@ void TRoom::setSpecialExit( int to, QString cmd )
     // Have definately removed the existing case of this command
     // Now add it to map if wanted
 
-    if( to > 1 )
-    {
-        if( _prefix.isEmpty() )
-            _prefix = '0';
-
-        QString finalCmd = _prefix % _strippedCmd;
+    if( to > 0 ) {
+        QString finalCmd = _newPrefix % _strippedCmd;
         other.insertMulti(to, finalCmd);
+        pR_newTo = mpRoomDB->getRoom( to );
+        if( pR_newTo ) {
+            pR_newTo->setEntrance(id, _strippedCmd);
+        }
     }
-    else
-    { // Clean up related data:
+    else { // Clean up related data:
         customLinesArrow.remove( _strippedCmd );
         customLinesColor.remove( _strippedCmd );
         customLinesStyle.remove( _strippedCmd );
@@ -579,31 +772,47 @@ void TRoom::setSpecialExit( int to, QString cmd )
     }
 
     TArea * pA = mpRoomDB->getArea( area );
-    if( pA )
-    {
-        pA->determineAreaExitsOfRoom( id );
-        // This updates the (TArea *)->exits map even for exit REMOVALS
+    if( pR_oldTo ) {
+        pA_oldTo = mpRoomDB->getArea( pR_oldTo->getArea() );
+    }
+    else {
+        pA_oldTo = 0;
     }
 
-}
+    if( pR_newTo ) {
+        pA_newTo = mpRoomDB->getArea( pR_newTo->getArea() );
+    }
+    else {
+        pA_newTo = 0;
+    }
 
-void TRoom::removeAllSpecialExitsToRoom( int _id )
-{
-    QList<int> keyList = other.keys();
-    QList<QString> valList = other.values();
-    for( int i=0; i<keyList.size(); i++ )
-    {
-        if( keyList[i] == _id )
-        {
-            // guaranteed to be in synch according to Qt docs
-            other.remove(keyList[i], valList[i]);
+    if( pA_oldTo ) {
+        if( pA_oldTo == pA_newTo ) { // The exit used to point to a valid area and it still points to THAT area
+            if( pA && pA != pA_oldTo ) { // The room is in a valid area and the exit is (still) pointing to a DIFFERENT one
+                pA->determineAreaExitsOfRoom( id ); // So update the exit in the Area's Exits list
+            }
+        }
+        else if( pA_newTo ) {  // The exit used to point to a valid area and it now points to a DIFFERENT VALID area
+            if( pA && pA != pA_oldTo ) { // The room is in a valid area and the exit is (still) pointing to a DIFFERENT one
+                pA->determineAreaExitsOfRoom( id ); // So update the exit in the Area's Exits list
+            }
+        }
+        else if( pA ) {  // The exit used to point to a valid area and it now DOESN'T
+                pA->determineAreaExitsOfRoom( id ); // So remove the exit from the Area's Exits list
         }
     }
-    TArea * pA = mpRoomDB->getArea( area );
-    if( pA )
-    {
-        pA->determineAreaExitsOfRoom( id );
+    else if( pA_newTo ) {  // The exit DON'T used to point to a valid area and but it DOES NOW
+        if( pA && pA != pA_newTo ) {  // The exit DON'T used to point to a valid area and but it DOES NOW and that ISN'T the same as the room's
+            pA->determineAreaExitsOfRoom( id ); // So add this exit to the Area's Exits list
+        }
     }
+    else if( pA ) {  // The exit DON'T used to point to a valid area and it still DOESN'T
+        ; // No-op
+    }
+    else { // Um, pA is NULL so this room IS NOT in a valid area SO HOW COME WE ARE SETTING EXITS TO IT?
+        qWarning( "TRoom::setSpecialExit(...) Warning: attempting to set an exit in a room(Id=%i) that is NOT within a TArea instance - area(Id=%i)!", id, area );
+    }
+    return true;
 }
 
 void TRoom::calcRoomDimensions()
@@ -646,10 +855,10 @@ void TRoom::calcRoomDimensions()
 }
 
 /* bool - N/U: no return value created or used */
-void TRoom::restore( QDataStream & ifs, int roomID, int version )
+void TRoom::restore( QDataStream & ifs, int version )
 {
 
-    id = roomID;
+    ifs >> id;
     ifs >> area;
     ifs >> x;
     ifs >> y;
@@ -670,13 +879,11 @@ void TRoom::restore( QDataStream & ifs, int roomID, int version )
     ifs >> weight;
 
     // force room weight >= 1 otherwise pathfinding choses random pathes.
-    if( weight < 1 )
-    {
+    if( weight < 1 ) {
         weight = 1;
     }
 
-    if( version < 8 )
-    {
+    if( version < 8 ) {
         float f1,f2,f3,f4;
         ifs >> f1;//rooms[i]->xRot;
         ifs >> f2;//rooms[i]->yRot;
@@ -685,123 +892,165 @@ void TRoom::restore( QDataStream & ifs, int roomID, int version )
     }
     ifs >> name;
     ifs >> isLocked;
-    if( version >= 6 )
-    {
+    if( version >= 6 ) {
         ifs >> other;
     }
-    if( version >= 9 )
-    {
+    if( version >= 9 ) {
         ifs >> c;
     }
-    if( version >= 10 )
-    {
+    if( version >= 10 ) {
         ifs >> userData;
     }
-    if( version >= 11 )
-    {
+    if( version >= 11 ) {
         ifs >> customLines;
         ifs >> customLinesArrow;
         ifs >> customLinesColor;
         ifs >> customLinesStyle;
         ifs >> exitLocks;
     }
-    if( version >= 13 )
-    {
+    if( version >= 13 ) {
         ifs >> exitStubs;
     }
-    if( version >= 16 )
-    {
+    if( version >= 16 ) {
         ifs >> exitWeights;
         ifs >> doors;
+    }
+    if( version >= 17 ) {
+        // At the time of writing this is NOT true, but will make future
+        // versions faster...
+        ifs >> mNormalEntrances;
+        ifs >> mSpecialEntrances;
     }
     calcRoomDimensions();
 }
 
 void TRoom::auditExits()
 {
-    if( north != -1 && ! mpRoomDB->getRoom(north) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"north\"", id);
-        north = -1;
+    if( north != -1 ) {
+        if( ! mpRoomDB->getRoom(north) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"north\"", id);
+            north = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            // Will only be true, and needed for pre-version 17 format map files
+            mpRoomDB->mpTempAllNormalEntrances->insert( north, qMakePair(DIR_NORTH, id ) );
+        }
     }
-    if( south != -1 && ! mpRoomDB->getRoom(south) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"south\"", id);
-        south = -1;
+    if( northeast != -1 ) {
+        if( ! mpRoomDB->getRoom(northeast) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"northeast\"", id);
+            northeast = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( northeast, qMakePair(DIR_NORTHEAST, id ) );
+        }
     }
-    if( northwest != -1 && ! mpRoomDB->getRoom(northwest) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"northwest\"", id);
-        northwest = -1;
+    if( east != -1 ) {
+        if( ! mpRoomDB->getRoom(east) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"east\"", id);
+            east = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( east, qMakePair(DIR_EAST, id ) );
+        }
     }
-    if( northeast != -1 && ! mpRoomDB->getRoom(northeast) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"northeast\"", id);
-        northeast = -1;
+    if( southeast != -1 ) {
+        if( ! mpRoomDB->getRoom(southeast) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"southeast\"", id);
+            southeast = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( southeast, qMakePair(DIR_SOUTHEAST, id ) );
+        }
     }
-    if( southwest != -1 && ! mpRoomDB->getRoom(southwest) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"southwest\"", id);
-        southwest = -1;
+    if( south != -1 ) {
+        if( ! mpRoomDB->getRoom(south) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"south\"", id);
+            south = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( south, qMakePair(DIR_SOUTH, id ) );
+        }
     }
-    if( southeast != -1 && ! mpRoomDB->getRoom(southeast) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"southeast\"", id);
-        southeast = -1;
+    if( southwest != -1 ) {
+        if( ! mpRoomDB->getRoom(southwest) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"southwest\"", id);
+            southwest = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( southwest, qMakePair(DIR_SOUTHWEST, id ) );
+        }
     }
-    if( west != -1 && ! mpRoomDB->getRoom(west) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"west\"", id);
-        west = -1;
+    if( west != -1 ) {
+        if( ! mpRoomDB->getRoom(west) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"west\"", id);
+            west = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( west, qMakePair(DIR_WEST, id ) );
+        }
     }
-    if( east != -1 && ! mpRoomDB->getRoom(east) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"east\"", id);
-        east = -1;
+    if( northwest != -1 ) {
+        if( ! mpRoomDB->getRoom(northwest) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"northwest\"", id);
+            northwest = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( northwest, qMakePair(DIR_NORTHWEST, id ) );
+        }
     }
-    if( in != -1 && ! mpRoomDB->getRoom(in) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"in\"", id);
-        in = -1;
+    if( up != -1 ) {
+        if( ! mpRoomDB->getRoom(up) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"up\"", id);
+            up = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( up, qMakePair(DIR_UP, id ) );
+        }
     }
-    if( out != -1 && ! mpRoomDB->getRoom(out) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"out\"", id);
-        out = -1;
+    if( down != -1 ) {
+        if( ! mpRoomDB->getRoom(down) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"down\"", id);
+            down = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( down, qMakePair(DIR_DOWN, id ) );
+        }
     }
-    if( up != -1 && ! mpRoomDB->getRoom(up) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"up\"", id);
-        up = -1;
+    if( in != -1 ) {
+        if( ! mpRoomDB->getRoom(in) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"in\"", id);
+            in = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( in, qMakePair(DIR_IN, id ) );
+        }
     }
-    if( down != -1 && ! mpRoomDB->getRoom(down) )
-    {
-        qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"down\"", id);
-        down = -1;
+    if( out != -1 ) {
+        if( ! mpRoomDB->getRoom(out) ) {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (general) exit: \"out\"", id);
+            out = -1;
+        }
+        else if( mpRoomDB->mpTempAllNormalEntrances ) {
+            mpRoomDB->mpTempAllNormalEntrances->insert( out, qMakePair(DIR_OUT, id ) );
+        }
     }
-    // These last two were missing!
 
-//    AUDIT_SPECIAL_EXITS: QMapIterator<int, QString> it( other );
-// If we use the Mutable iterator we don't have to restart after a deletion
     QMutableMapIterator<int, QString> it( other );
-    while( it.hasNext() )
-    {
+    while( it.hasNext() ) {
         it.next();
         QString _cmd = it.value();
-        if( _cmd.size() <= 0 )
-        {
+        if(      _cmd.size() == 0
+            || ( _cmd.size() == 1 && ( _cmd.startsWith(QLatin1Char('1')) || _cmd.startsWith(QLatin1Char('0')) ) ) ) {
             qWarning("TRoom::auditExits() WARNING: roomID:%6i REMOVING invalid (special) exit to %i.", id, it.key());
-            // If size is less than or equal to 0 then there is nothing to print!!!
-//            qDebug()<<"AUDIT_SPECIAL_EXITS: roomID:"<<id<<" REMOVING invalid special exit:"<<_cmd;
-//            goto AUDIT_SPECIAL_EXITS;
+            // If size is equal to 0, or 1 and is holds the lock codes '0' or '1' then there is not a valid exit
             other.remove( it.key(), it.value() );
         }
-        else if( ! ( _cmd.startsWith('1') || _cmd.startsWith('0') ) )
-        {
+        else if( _cmd.size() > 1 && ! ( _cmd.startsWith(QLatin1Char('1')) || _cmd.startsWith(QLatin1Char('0')) ) ) {
+            // Old, prepatched special exit, without lock code
             QString _nc = it.value();
             int _nk = it.key();
             _nc.prepend('0');
-            // Old, prepatched special exit could not have a lock
             other.remove( it.key(), it.value() );
             other.insertMulti( _nk, _nc );
             qWarning("TRoom::auditExits() WARNING: roomID:%6i PATCHING invalid (special) exit to %i, was:%s now:%s.",
@@ -809,8 +1058,23 @@ void TRoom::auditExits()
                      _nk,
                      qPrintable(_cmd),
                      qPrintable(_nc));
-//            qDebug()<<"AUDIT_SPECIAL_EXITS: roomID:"<<id<<" PATCHING invalid special exit:"<<_cmd << " new:"<<_nc;
-//            goto AUDIT_SPECIAL_EXITS;
+            if( mpRoomDB->mpTempAllSpecialEntrances ) {
+                // Will only be true, and needed for pre-version 17 format map files
+                mpRoomDB->mpTempAllSpecialEntrances->insert( _nk, qMakePair(_cmd, id ) );
+            }
+        }
+        else if( _cmd.size() >= 2 ) {
+            // Correctly formed special exit
+            if( mpRoomDB->mpTempAllSpecialEntrances ) {
+                mpRoomDB->mpTempAllSpecialEntrances->insert( it.key(), qMakePair(_cmd.mid(1), id ) );
+            }
+        }
+        else {
+            qWarning("TRoom::auditExits() WARNING: roomID:%6i UNEXPECTED {invalid?} (special) exit to %i, called:%s.",
+                     id,
+                     it.key(),
+                     qPrintable(it.value()));
+            Q_UNREACHABLE();
         }
     }
 }

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -59,7 +59,12 @@ public:
     void setId( int );
     bool setExit( int to, int direction );
     int getExit( int direction );
-    QHash<int, int> getExits();
+    QSet<QPair<quint8, quint64> > getNormalExits();
+    QSet<QPair<QString, quint64> > getSpecialExits();
+    QSet<QPair<quint8, quint64> > getNormalEntrances() const { return mNormalEntrances; }
+    QSet<QPair<QString, quint64> > getSpecialEntrances() const { return mSpecialEntrances; }
+    void setEntrance( QPair<quint8, quint64> );
+    void setEntrance( QPair<QString, quint64> );
     bool hasExit( int direction );
     void setWeight( int );
     void setExitLock( int, bool );
@@ -67,8 +72,7 @@ public:
     bool setSpecialExitLock( QString cmd, bool doLock );
     bool hasExitLock( int to );
     bool hasSpecialExitLock( int, QString );
-    void removeAllSpecialExitsToRoom(int _id );
-    void setSpecialExit( int to, QString cmd );
+    bool setSpecialExit( int to, QString cmd );
     void clearSpecialExits() { other.clear(); }
     const QMultiMap<int, QString> & getOtherMap() const { return other; }
     const QMap<QString, int> & getExitWeights() const { return exitWeights; }
@@ -81,41 +85,29 @@ public:
     void calcRoomDimensions();
     int getExitWeight( QString cmd );
     bool setArea( int , bool isToDeferAreaRelatedRecalculations = false );
-
     int getWeight() { return weight; }
     int getNorth() { return north; }
-    void setNorth( int id ) { north=id; }
     int getNorthwest() { return northwest; }
-    void setNorthwest( int id ) { northwest=id; }
     int getNortheast() { return northeast; }
-    void setNortheast( int id ) { northeast=id; }
     int getSouth() { return south; }
-    void setSouth( int id ) { south=id; }
     int getSouthwest() { return southwest; }
-    void setSouthwest( int id ) { southwest=id; }
     int getSoutheast() { return southeast; }
-    void setSoutheast( int id ) { southeast=id; }
     int getWest() { return west; }
-    void setWest( int id ) { west=id; }
     int getEast() { return east; }
-    void setEast( int id ) { east=id; }
     int getUp() { return up; }
-    void setUp( int id ) { up=id; }
     int getDown() { return down; }
-    void setDown( int id ) { down=id; }
     int getIn() { return in; }
-    void setIn( int id ) { in=id; }
     int getOut() { return out; }
-    void setOut( int id ) { out=id; }
     int getId() { return id; }
     int getArea() { return area; }
     void auditExits();
-    /*bool*/ void restore( QDataStream & ifs, int roomID, int version );
+    /*bool*/ void restore( QDataStream & ifs, int version );
+
+
     int x;
     int y;
     int z;
     int environment;
-
     bool isLocked;
     qreal min_x;
     qreal min_y;
@@ -123,7 +115,7 @@ public:
     qreal max_y;
     qint8 c;
     QString name;
-    QVector3D v;
+//    QVector3D v;
     QList<int> exitStubs; //contains a list of: exittype (according to defined values above)
     QMap<QString, QString> userData;
     QList<int> exitLocks;
@@ -140,6 +132,11 @@ public:
 
 
 private:
+    void setEntrance( int, quint8 );
+    void setEntrance( int, QString );
+    void resetEntrance( int, quint8 );
+    void resetEntrance( int, QString );
+
     int id;
     int area;
     int weight;
@@ -156,6 +153,25 @@ private:
     int down;
     int in;
     int out;
+// To add in the next map file format increment so we don't have to regenerate
+// them on loading:
+    QSet<QPair<quint8, quint64> > mNormalEntrances;
+// Normal exits that have THIS room as a destination
+// first is direction code from the OTHER room, but NOT DIR_OTHER, second is fromRoomId.
+    QSet<QPair<QString, quint64> > mSpecialEntrances;
+// Special exits that have THIS room as a destination
+// first is exit text from the OTHER room, second is fromRoomId.
+// Reason for separation for special from normal entrances:
+// using text for normal exits is language dependent would make code for normal
+// exits more complex (slower) than needs be - this is based on the assumption
+// that a MUD has many more normal than special exits.
+//
+// Actually the same concept could be done for:
+//    QHash<quint8, quint64> normalExits;
+//    QHash<QString, quint64> SpecialExits;
+// Where second is the toRoomId in both cases and the first is the normal exit
+// code or special exit name...
+
 
     // FIXME: This should be a map of String->room id because there can be multiple special exits to the same room
     QMultiMap<int, QString> other; // es knnen mehrere exits zum gleichen raum verlaufen

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -20,6 +20,9 @@
  ***************************************************************************/
 
 
+// Define for testing TRoomDB::deleteArea(...) and TRoomDB::deleteRooms(...)!
+#define DEBUG_TIMING
+
 #include "TRoomDB.h"
 
 #include "TArea.h"
@@ -27,13 +30,14 @@
 #include "TRoom.h"
 
 #include "pre_guard.h"
-#include <QDebug>
-#include <QTime>
+#include <QApplication>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 
 TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
+, mpDeletionRooms( 0 )
 {
 }
 
@@ -49,24 +53,27 @@ TRoom * TRoomDB::getRoom( int id )
 
 bool TRoomDB::addRoom( int id )
 {
-    qDebug()<<"addRoom("<<id<<")";
-    if( !rooms.contains( id ) && id > 0 )
-    {
-        rooms[id] = new TRoom( this );
-        rooms[id]->setId(id);
-        QHash<int, int> exits = rooms[id]->getExits();
-        QList<int> toExits = exits.keys();
-        for (int i = 0; i < toExits.size(); i++)
-            reverseExitMap.insert(id, toExits[i]);
+    qDebug( "TRoomDB::addRoom(%i) called.", id );
+    if( id > 0 && ! rooms.contains( id ) ) {
+        TRoom * pR = new TRoom( this );
+        if( ! pR ) {
+            QString error = qApp->translate( "TRoomDB", "Unable to create room id (%1) - out of memory?").arg(id);
+            mpMap->logError(error);
+            return false;
+        }
+        rooms[id] = pR;
+        pR->setId(id);
         return true;
     }
-    else
-    {
-        if( id <= 0 )
-        {
-            QString error = QString("illegal room id=%1. roomID must be > 0").arg(id);
-            mpMap->logError(error);
+    else {
+        QString error;
+        if( id <= 0 ) {
+            error = qApp->translate( "TRoomDB", "Illegal room id (%1) - it must be greater than zero!").arg(id);
         }
+        else {
+            error = qApp->translate( "TRoomDB", "Duplicate room id (%1) - there is already a room with that number!").arg(id);
+        }
+        mpMap->logError(error);
         return false;
     }
 }
@@ -88,40 +95,74 @@ bool TRoomDB::addRoom( int id, TRoom * pR )
 // this is call by TRoom destructor only
 bool TRoomDB::__removeRoom( int id )
 {
-    TRoom* pR = getRoom(id);
-    if (pR) {
+    TRoom * pR = getRoom(id);
+    if( pR ) {
         // FIXME: make a proper exit controller so we don't need to do all these if statements
-        QMultiHash<int, int>::iterator i = reverseExitMap.find(id);
-        while (i != reverseExitMap.end() && i.key() == id) {
-            TRoom* r = getRoom(i.value());
-            if (r) {
-                if (r->getNorth() == id)
-                    r->setNorth(-1);
-                if (r->getNortheast() == id)
-                    r->setNortheast(-1);
-                if (r->getNorthwest() == id)
-                    r->setNorthwest(-1);
-                if (r->getEast() == id)
-                    r->setEast(-1);
-                if (r->getWest() == id)
-                    r->setWest(-1);
-                if (r->getSouth() == id)
-                    r->setSouth(-1);
-                if (r->getSoutheast() == id)
-                    r->setSoutheast(-1);
-                if (r->getSouthwest() == id)
-                    r->setSouthwest(-1);
-                if (r->getUp() == id)
-                    r->setUp(-1);
-                if (r->getDown() == id)
-                    r->setDown(-1);
-                if (r->getIn() == id)
-                    r->setIn(-1);
-                if (r->getOut() == id)
-                    r->setOut(-1);
-                r->removeAllSpecialExitsToRoom(id);
+
+        // Delete the Exits that lead TO THIS room, use the stored entrance data
+        // so we can identify the rooms that have exits leading here - this is
+        // the primary reason for maintaining Entrance data otherwise we'd have
+        // to check EVERY exit for EVERY room! 8-) SlySven
+        QSet<QPair<quint8, quint64> > _normalEntrances(pR->getNormalEntrances());
+        _normalEntrances.detach();
+        QSetIterator<QPair<quint8, quint64> > itNormalEntrances = _normalEntrances;
+        while( itNormalEntrances.hasNext() ) {
+            QPair<quint8, quint64> entranceFrom = itNormalEntrances.next();
+            if(      entranceFrom.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( entranceFrom.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
             }
-            ++i;
+            TRoom * pR_from = getRoom( entranceFrom.second );
+            if( pR_from ) {
+                pR_from->setExit( -1, entranceFrom.first );
+                // This call WILL modify pR->getNormalEntrances() that we might
+                // otherwise iterate over directly - this is a no-no for many Qt
+                // iterators, even the mutable ones (they expect to be making
+                // the changes!) - hence the explicit deep copying above caused
+                // by making a copy and then using "detach()"
+            }
+        }
+        QSet<QPair<QString,quint64> > _specialEntrances( pR->getSpecialEntrances() );
+        _specialEntrances.detach();
+        QSetIterator<QPair<QString,quint64> > itSpecialEntrances = _specialEntrances;
+        while( itSpecialEntrances.hasNext() ) {
+            QPair<QString, quint64> entranceFrom = itSpecialEntrances.next();
+            if(      entranceFrom.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( entranceFrom.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
+            }
+            TRoom * pR_from = getRoom( entranceFrom.second );
+            if( pR_from ) {
+                pR_from->setSpecialExit( -1, entranceFrom.first );
+            }
+        }
+        // And EXITS from THIS room are entrances in other rooms so clear THIS
+        // room's exits to erase those ENTRANCE details from OTHER rooms:
+        QSet<QPair<quint8, quint64> > _normalExits(pR->getNormalExits());
+        _normalEntrances.detach();
+        QSetIterator<QPair<quint8, quint64> > itNormalExits = _normalExits;
+        while( itNormalExits.hasNext() ) {
+            QPair<quint8, quint64> exitTo = itNormalExits.next();
+            if(       exitTo.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( exitTo.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
+            }
+            pR->setExit( -1, exitTo.first );
+        }
+        QSet<QPair<QString, quint64> > _specialExits(pR->getSpecialExits());
+        _specialExits.detach();
+        QSetIterator<QPair<QString, quint64> > itSpecialExits = _specialExits;
+        while( itSpecialExits.hasNext() ) {
+            QPair<QString, quint64> exitTo = itSpecialExits.next();
+            if(       exitTo.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( exitTo.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
+            }
+            pR->setSpecialExit( -1, exitTo.first );
         }
         rooms.remove(id);
         // FIXME: make hashTable a bimap
@@ -134,9 +175,9 @@ bool TRoomDB::__removeRoom( int id )
         }
         int areaID = pR->getArea();
         TArea * pA = getArea( areaID );
-        if (pA)
+        if(pA) {
             pA->removeRoom(id);
-        reverseExitMap.remove(id);
+        }
         // Because we clear the graph in initGraph which will be called
         // if mMapGraphNeedsUpdate is true -- we don't need to
         // remove the vertex using clear_vertex and remove_vertex here
@@ -148,8 +189,7 @@ bool TRoomDB::__removeRoom( int id )
 
 bool TRoomDB::removeRoom( int id )
 {
-    if( rooms.contains(id ) && id > 0 )
-    {
+    if( id > 0 && rooms.contains(id) ) {
         TRoom * pR = getRoom( id );
         delete pR;
         return true;
@@ -157,26 +197,80 @@ bool TRoomDB::removeRoom( int id )
     return false;
 }
 
+void TRoomDB::removeRooms( QList<int> & ids )
+{
+#if defined(DEBUG_TIMING)
+    static bool isToShowTime = true; // Set to true within debugger to control the display of this
+    QElapsedTimer timer;
+    timer.start();
+#endif
+    mpDeletionRooms = new QSet<int>( ids.toSet() );
+#if defined(DEBUG_TIMING)
+    quint64 roomCount = mpDeletionRooms->size();
+#endif
+    QSetIterator<int> itRoom = *mpDeletionRooms;
+    while( itRoom.hasNext() ) {
+        removeRoom( itRoom.next() ); // This will update other area's rooms about exit changes
+    }
+    delete mpDeletionRooms;
+    mpDeletionRooms = 0;
+#if defined(DEBUG_TIMING)
+    if( isToShowTime ) {
+        qint64 elapsed = timer.elapsed();
+        double elaspedTime = elapsed / 1000.0;
+        double unitTime = 0.0;
+        if(roomCount) {
+            unitTime = elapsed / (double)(roomCount);
+        }
+        // Can't get the printf format string character right to present
+        // meaningful data - so let's let Qt sort it out
+        qDebug()<<"TRoomDB::removeRooms(...) - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+    }
+#endif
+}
+
 bool TRoomDB::removeArea( int id )
 {
+#if defined(DEBUG_TIMING)
+    static bool isToShowTime = true; // Set to true within debugger to control the display of this
+    QElapsedTimer timer;
+    timer.start();
+#endif
     areaNamesMap.remove( id );
-    if( areas.contains( id ) )
-    {
+    if( areas.contains( id ) ) {
         TArea * pA = areas[id];
-        QList<int> rl;
-        for( int i=0; i< pA->rooms.size(); i++ )
-        {
-            rl.push_back( pA->rooms[i] );
+        mpDeletionRooms = new QSet<int>( pA->rooms.toSet() );
+#if defined(DEBUG_TIMING)
+        quint64 roomCount = mpDeletionRooms->size();
+#endif
+        QSetIterator<int> itRoom = *mpDeletionRooms;
+        while( itRoom.hasNext() ) {
+            removeRoom( itRoom.next() ); // This will update other area's rooms about exit changes
         }
-        for( int i=0; i<rl.size(); i++ )
-        {
-            removeRoom( rl[i] );
-        }
+        delete mpDeletionRooms;
+        mpDeletionRooms = 0;
         areas.remove( id );
-
         mpMap->mMapGraphNeedsUpdate = true;
+#if defined(DEBUG_TIMING)
+        if( isToShowTime ) {
+            qint64 elapsed = timer.elapsed();
+            double elaspedTime = elapsed / 1000.0;
+            double unitTime = 0.0;
+            if(roomCount) {
+                unitTime = elapsed / (double)(roomCount);
+            }
+            // Can't get the printf format string character right to present
+            // meaningful data - so let's let Qt sort it out
+            qDebug()<<"TRoomDB::removeArea(" << id << ") - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+        }
+#endif
         return true;
     }
+#if defined(DEBUG_TIMING)
+        if( isToShowTime ) {
+            qDebug( "TRoomDB::removeArea(%i) - No area found to destroy.", id );
+        }
+#endif
     return false;
 }
 
@@ -201,7 +295,8 @@ int TRoomDB::getAreaID( TArea * pA )
 
 void TRoomDB::buildAreas()
 {
-    QTime _time; _time.start();
+    QElapsedTimer _time;
+    _time.start();
     QHashIterator<int, TRoom *> it( rooms );
     while( it.hasNext() )
     {
@@ -227,7 +322,7 @@ void TRoomDB::buildAreas()
            areas[id] = new TArea( mpMap, this );
        }
     }
-    qDebug()<<"BUILD AREAS run time:"<<_time.elapsed();
+    qDebug( "TRoomDB::buildAreas(): run time: %i milli-Seconds.", _time.elapsed());
 }
 
 
@@ -341,17 +436,46 @@ QList<int> TRoomDB::getAreaIDList()
 
 void TRoomDB::auditRooms()
 {
-    QTime t; t.start();
+    QElapsedTimer t;
+    t.start();
+    bool ok = true;
+    mpTempAllNormalEntrances = new QMultiHash<quint64, QPair<quint8, quint64> >;  // key is toRoomdId, value.first is direction code, value.second is fromRoomId
+    mpTempAllSpecialEntrances = new QMultiHash<quint64, QPair<QString, quint64> >;// key is toRoomId, value.first is exit name, value.second is fromRoomId
+    if( ( ! mpTempAllNormalEntrances ) || ( ! mpTempAllSpecialEntrances ) ) {
+        qCritical( "TRoomDB::auditRooms() Critical error: unable to create temporary structures to validate map route data." );
+        ok = false;
+    }
+
     // rooms konsolidieren
-    QHashIterator<int, TRoom* > itRooms( rooms );
-    while( itRooms.hasNext() )
-    {
+    QHashIterator<int, TRoom * > itRooms( rooms );
+    while( itRooms.hasNext() ) {
         itRooms.next();
         TRoom * pR = itRooms.value();
         pR->auditExits();
-
     }
-    qDebug()<<"audit map: runtime:"<<t.elapsed();
+
+    if( ok && mpMap->version < 17 ) {
+        // Right now build entrance data
+        itRooms.toFront();
+        while( itRooms.hasNext() ) {
+            itRooms.next();
+            TRoom * pR = itRooms.value();
+            QList<QPair<quint8, quint64> > normalRoomEntrancesList = mpTempAllNormalEntrances->values( pR->getId() );
+            for( uint i = 0; i < normalRoomEntrancesList.size(); i++ ) {
+                pR->setEntrance( normalRoomEntrancesList.at(i) );
+            }
+            QList<QPair<QString, quint64> > specialRoomEntrancesList = mpTempAllSpecialEntrances->values( pR->getId() );
+            for( uint i = 0; i < specialRoomEntrancesList.size(); i++ ) {
+                pR->setEntrance( specialRoomEntrancesList.at(i) );
+            }
+        }
+    }
+
+    if( ok ) {
+        delete mpTempAllNormalEntrances;
+        delete mpTempAllSpecialEntrances;
+    }
+    qDebug( "TRoomDB::auditRooms() audit Rooms took: %i milli-Seconds.", t.elapsed() );
 }
 
 void TRoomDB::initAreasForOldMaps()
@@ -410,7 +534,12 @@ void TRoomDB::restoreSingleArea(QDataStream & ifs, int areaID, TArea * pA )
     areas[areaID] = pA;
 }
 
-void TRoomDB::restoreSingleRoom(QDataStream & ifs, int i, TRoom *pT)
+void TRoomDB::restoreSingleRoom(QDataStream & ifs, TRoom * pR )
 {
-    rooms[i] = pT;
+    Q_UNUSED(ifs);
+
+    if( ! pR ) {
+        return;
+    }
+    rooms[ pR->getId() ] = pR;
 }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -20,9 +20,6 @@
  ***************************************************************************/
 
 
-// Define for testing TRoomDB::deleteArea(...) and TRoomDB::deleteRooms(...)!
-#define DEBUG_TIMING
-
 #include "TRoomDB.h"
 
 #include "TArea.h"
@@ -31,7 +28,10 @@
 
 #include "pre_guard.h"
 #include <QApplication>
+#include <QDebug>
+#if defined(DEBUG_TIMING)
 #include <QElapsedTimer>
+#endif
 #include "post_guard.h"
 
 
@@ -200,7 +200,6 @@ bool TRoomDB::removeRoom( int id )
 void TRoomDB::removeRooms( QList<int> & ids )
 {
 #if defined(DEBUG_TIMING)
-    static bool isToShowTime = true; // Set to true within debugger to control the display of this
     QElapsedTimer timer;
     timer.start();
 #endif
@@ -215,24 +214,21 @@ void TRoomDB::removeRooms( QList<int> & ids )
     delete mpDeletionRooms;
     mpDeletionRooms = 0;
 #if defined(DEBUG_TIMING)
-    if( isToShowTime ) {
-        qint64 elapsed = timer.elapsed();
-        double elaspedTime = elapsed / 1000.0;
-        double unitTime = 0.0;
-        if(roomCount) {
-            unitTime = elapsed / (double)(roomCount);
-        }
-        // Can't get the printf format string character right to present
-        // meaningful data - so let's let Qt sort it out
-        qDebug()<<"TRoomDB::removeRooms(...) - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+    qint64 elapsed = timer.elapsed();
+    double elaspedTime = elapsed / 1000.0;
+    double unitTime = 0.0;
+    if(roomCount) {
+        unitTime = elapsed / (double)(roomCount);
     }
+    // Can't get the printf format string character right to present
+    // meaningful data - so let's let Qt sort it out
+    qDebug()<<"TRoomDB::removeRooms(...) - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
 #endif
 }
 
 bool TRoomDB::removeArea( int id )
 {
 #if defined(DEBUG_TIMING)
-    static bool isToShowTime = true; // Set to true within debugger to control the display of this
     QElapsedTimer timer;
     timer.start();
 #endif
@@ -252,24 +248,20 @@ bool TRoomDB::removeArea( int id )
         areas.remove( id );
         mpMap->mMapGraphNeedsUpdate = true;
 #if defined(DEBUG_TIMING)
-        if( isToShowTime ) {
-            qint64 elapsed = timer.elapsed();
-            double elaspedTime = elapsed / 1000.0;
-            double unitTime = 0.0;
-            if(roomCount) {
-                unitTime = elapsed / (double)(roomCount);
-            }
-            // Can't get the printf format string character right to present
-            // meaningful data - so let's let Qt sort it out
-            qDebug()<<"TRoomDB::removeArea(" << id << ") - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+        qint64 elapsed = timer.elapsed();
+        double elaspedTime = elapsed / 1000.0;
+        double unitTime = 0.0;
+        if(roomCount) {
+            unitTime = elapsed / (double)(roomCount);
         }
+        // Can't get the printf format string character right to present
+        // meaningful data - so let's let Qt sort it out
+        qDebug()<<"TRoomDB::removeArea(" << id << ") - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
 #endif
         return true;
     }
 #if defined(DEBUG_TIMING)
-        if( isToShowTime ) {
-            qDebug( "TRoomDB::removeArea(%i) - No area found to destroy.", id );
-        }
+    qDebug( "TRoomDB::removeArea(%i) - No area found to destroy.", id );
 #endif
     return false;
 }
@@ -295,8 +287,10 @@ int TRoomDB::getAreaID( TArea * pA )
 
 void TRoomDB::buildAreas()
 {
+#if defined(DEBUG_TIMING)
     QElapsedTimer _time;
     _time.start();
+#endif
     QHashIterator<int, TRoom *> it( rooms );
     while( it.hasNext() )
     {
@@ -322,7 +316,9 @@ void TRoomDB::buildAreas()
            areas[id] = new TArea( mpMap, this );
        }
     }
+#if defined(DEBUG_TIMING)
     qDebug( "TRoomDB::buildAreas(): run time: %i milli-Seconds.", _time.elapsed());
+#endif
 }
 
 
@@ -436,8 +432,10 @@ QList<int> TRoomDB::getAreaIDList()
 
 void TRoomDB::auditRooms()
 {
+#if defined(DEBUG_TIMING)
     QElapsedTimer t;
     t.start();
+#endif
     bool ok = true;
     mpTempAllNormalEntrances = new QMultiHash<quint64, QPair<quint8, quint64> >;  // key is toRoomdId, value.first is direction code, value.second is fromRoomId
     mpTempAllSpecialEntrances = new QMultiHash<quint64, QPair<QString, quint64> >;// key is toRoomId, value.first is exit name, value.second is fromRoomId
@@ -475,7 +473,9 @@ void TRoomDB::auditRooms()
         delete mpTempAllNormalEntrances;
         delete mpTempAllSpecialEntrances;
     }
+#if defined(DEBUG_TIMING)
     qDebug( "TRoomDB::auditRooms() audit Rooms took: %i milli-Seconds.", t.elapsed() );
+#endif
 }
 
 void TRoomDB::initAreasForOldMaps()

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -371,6 +372,48 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
     need_reconnect_for_specialoption->hide();
     connect(mFORCE_MCCP_OFF, SIGNAL(clicked()), need_reconnect_for_specialoption, SLOT(show()));
     connect(mFORCE_GA_OFF, SIGNAL(clicked()), need_reconnect_for_specialoption, SLOT(show()));
+
+/* DEBUGCONTROLS 0 - Insert debug variable controls
+ * they go into groupbox_debug and are initalised from variables in THost.cpp
+ * (per profile) or mudlet.cpp (application wide).  The controls are to be
+ * connected to corresponding slots to adjust those variables via "slot_"'s
+ * in the appropriate one of those files.
+ *
+ * Use a QHBoxLayout for each control or group of controls and add that layout
+ * into "verticalLayout_debug" - which is on the last tab of the
+ * profile_preference dialog.
+ */
+    QHBoxLayout * horizontalLayout_mapFormatToBeDownVersioned = new QHBoxLayout( 0 );
+    QCheckBox * checkBox_mapFormatToBeDownVersioned = new QCheckBox( 0 );
+    checkBox_mapFormatToBeDownVersioned->setText( tr("Save Map File in previous format for use with older Mudlet version.") );
+    checkBox_mapFormatToBeDownVersioned->setToolTip( tr("<html><head/><body>"
+                                                        "<p>When set, forces the map file format to be downgraded so that maps can be loaded "
+                                                        "into the previous Mudlet version - this is to prevent the issue that when the file "
+                                                        "format is changed to improve performance and/or fix a problem the previous version "
+                                                        "will not be able to read the new type of file.</p>"
+                                                        "<p>If you are sharing your Map files with others or testing out a <i>non-release</i> version "
+                                                        "using a Map file that you will want to reused with your current version you will "
+                                                        "want to leave this control set so that a compatible file is produced on "
+                                                        "saving, however loading is likely to take longer in this or later version as the "
+                                                        "data is reconverted back into a form now used internally.  Alternatively if this "
+                                                        "is the earliest copy of Mudlet you use and you are not going to share the map "
+                                                        "saved you will get best results (a faster Map loading time) by <b>not</b> having "
+                                                        "the control activated.</p>"
+                                                        "<p>This control defaults to being set on <i>preview</i> and <i>development</i> "
+                                                        "versions but is cleared on a <i>release</i> one (it is determined from "
+                                                        "whether there is anything after the x.y.z part of the version string, which is "
+                                                        "visible on the Splash Screen or the <i>About Mudlet</i> dialog.)  The setting is "
+                                                        "<b>not</b> saved at the end of a session or affect other profiles you may have "
+                                                        "running alongside this one.</p>"
+                                                        "<p><u>Do not worry though, whichever setting you choose here, a version of the "
+                                                        "Mudlet aplication will always be able to read the Map files it saves itself!</u></body></html>" ) );
+    checkBox_mapFormatToBeDownVersioned->setChecked( mpHost->mDebug_IsMapFormatToBeDownVersioned );
+    connect(checkBox_mapFormatToBeDownVersioned, SIGNAL(clicked(bool)), mpHost, SLOT( slot_setMapFormatToBeDownVersioned(bool) ));
+    horizontalLayout_mapFormatToBeDownVersioned->addWidget(checkBox_mapFormatToBeDownVersioned);
+    verticalLayout_debug->addLayout(horizontalLayout_mapFormatToBeDownVersioned);
+    verticalLayout_debug->setAlignment( Qt::AlignTop );
+
+    groupBox_Debug->setLayout(verticalLayout_debug);
 
     Host * pHost = mpHost;
     if( pHost )

--- a/src/src.pro
+++ b/src/src.pro
@@ -37,6 +37,11 @@ msvc:QMAKE_CXXFLAGS += -MP
 # Mac specific flags.
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.5
 
+# Enable some timing reporting code - undef for release version, must touch:
+# TArea.cpp, TMap.cpp, TRoomDB.cpp (in, but unused in TRoom.cpp) when this is
+# added or removed from DEFINES - this is not in the CMake project file!
+DEFINES += DEBUG_TIMING
+
 QT += network opengl uitools multimedia
 
 # Leave the value of the following empty, line should be "BUILD =" without quotes

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>744</width>
-    <height>592</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,7 +25,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QTabWidget" name="tabWidgeta">
+    <widget class="QTabWidget" name="tabWidget_main">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -44,7 +44,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="General">
+     <widget class="QWidget" name="tab_General">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -113,7 +113,7 @@
           <item row="2" column="0">
            <widget class="QCheckBox" name="showMenuBar">
             <property name="toolTip">
-             <string>Enables the typical menu bar with drop-down menus in the main window. Requires restart to take effect</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the typical menu bar with drop-down menus in the main window. Requires restart to take effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Show menu bar</string>
@@ -123,7 +123,7 @@
           <item row="3" column="0">
            <widget class="QCheckBox" name="showToolbar">
             <property name="toolTip">
-             <string>Enables the default button bar in the main window. Requires restart to take effect</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the default button bar in the main window. Requires restart to take effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Show main toolbar</string>
@@ -156,7 +156,7 @@
           <item>
            <widget class="QCheckBox" name="mRawStreamDump">
             <property name="toolTip">
-             <string>Switch log file format from HTML to raw stream dump in logfiles as sent by server. The logfile can then be can be loaded by Mudlet to test your trigger systems offline.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Switch log file format from HTML (contaning colored text) to raw stream dump (containing ANSI Color Esc codes) in logfiles as sent by server.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Save log files in html format instead of text only</string>
@@ -227,7 +227,7 @@
         </widget>
        </item>
        <item row="6" column="0">
-        <spacer name="verticalSpacer_8">
+        <spacer name="verticalSpacer_General">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -262,7 +262,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="input_line_tab">
+     <widget class="QWidget" name="tab_InputLine">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -291,7 +291,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Strict UNIX line endings</string>
@@ -304,7 +304,7 @@
              <bool>true</bool>
             </property>
             <property name="toolTip">
-             <string>Echo the text you send in the display box</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Echo the text you send in the display box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Show the text you sent</string>
@@ -394,7 +394,7 @@
         </widget>
        </item>
        <item row="2" column="0">
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer_InputLine">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -408,7 +408,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab_MainDisplay">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -729,9 +729,7 @@
           <item>
            <widget class="QCheckBox" name="checkBox_USE_IRE_DRIVER_BUGFIX">
             <property name="toolTip">
-             <string>Some MUDs (notably all IRE ones) suffer from a bug where they don't properly
-communicate with the client on where a newline should be. Enable this to fix text
-from getting appended to the previous prompt line</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some MUDs (notably all IRE ones) suffer from a bug where they do not properly communicate with the client on where a newline should be. Enable this to fix text from getting appended to the previous prompt line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Fix unnecessary linebreaks on GA servers</string>
@@ -741,8 +739,7 @@ from getting appended to the previous prompt line</string>
           <item>
            <widget class="QCheckBox" name="checkBox_USE_SMALL_SCREEN">
             <property name="toolTip">
-             <string>Select this option for better compatability if you are using a netbook, 
-or some other computer model that has a small screen.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select this option for better compatability if you are using a netbook, or some other computer model that has a small screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Use Mudlet on a netbook with a small screen</string>
@@ -753,7 +750,7 @@ or some other computer model that has a small screen.</string>
         </widget>
        </item>
        <item row="5" column="0">
-        <spacer name="verticalSpacer">
+        <spacer name="verticalSpacer_MainDisplay">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -813,7 +810,7 @@ or some other computer model that has a small screen.</string>
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="mNoAntiAlias">
             <property name="toolTip">
-             <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
             </property>
             <property name="text">
              <string>Enable anti-aliasing</string>
@@ -839,7 +836,7 @@ or some other computer model that has a small screen.</string>
           <item>
            <widget class="QLineEdit" name="doubleclick_ignore_lineedit">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the characters you'd like double-clicking to stop selecting text on here. If you don't enter any, double-clicking on a word will only stop at a space, and will include characters like a double or a single quote. For example, double-clicking on the word &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; in the following will select &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;quot;&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you set the characters in the field to &lt;span style=&quot; font-weight:600;&quot;&gt;'&amp;quot;! &lt;/span&gt;which will mean it should stop selecting on ' &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; &amp;quot; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; ! then double-clicking on &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; will just select &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &amp;quot;&lt;span style=&quot; font-weight:600;&quot;&gt;Hello&lt;/span&gt;!&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the characters you would like double-clicking to stop selecting text on here. If you do not enter any, double-clicking on a word will only stop at a space, and will include characters like a double or a single quote. For example, double-clicking on the word &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; in the following will select &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;quot;&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you set the characters in the field to &lt;span style=&quot; font-weight:600;&quot;&gt;'&amp;quot;! &lt;/span&gt;which will mean it should stop selecting on ' &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; &amp;quot; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; ! then double-clicking on &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; will just select &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &amp;quot;&lt;span style=&quot; font-weight:600;&quot;&gt;Hello&lt;/span&gt;!&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>'&quot;</string>
@@ -854,7 +851,7 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="color_view_tab">
+     <widget class="QWidget" name="tab_ColorView">
       <attribute name="title">
        <string>Color view</string>
       </attribute>
@@ -1245,7 +1242,7 @@ or some other computer model that has a small screen.</string>
            </layout>
           </item>
           <item row="6" column="0" colspan="4">
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_ColorView">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -1285,7 +1282,7 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="mapper_tab">
+     <widget class="QWidget" name="tab_Mapper">
       <attribute name="title">
        <string>Mapper</string>
       </attribute>
@@ -1364,9 +1361,6 @@ or some other computer model that has a small screen.</string>
          <layout class="QGridLayout" name="gridLayout_23">
           <item row="0" column="0">
            <widget class="QLabel" name="label_11">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On MUDs that provide maps for download (currently IRE games only), you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
             <property name="text">
              <string>Download latest map provided by your MUD:</string>
             </property>
@@ -1375,7 +1369,7 @@ or some other computer model that has a small screen.</string>
           <item row="0" column="1">
            <widget class="QPushButton" name="buttonDownloadMap">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On MUDs that provide maps for download (currently IRE games only), you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On MUDs that provide maps for download (currently IRE games only), you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Download</string>
@@ -1438,7 +1432,7 @@ or some other computer model that has a small screen.</string>
         </widget>
        </item>
        <item row="4" column="0">
-        <spacer name="mapper_tab_bottom_spacer">
+        <spacer name="verticalSpace_Mapper">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -1452,7 +1446,7 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_4">
+     <widget class="QWidget" name="tab_MapperColors">
       <attribute name="title">
        <string>Mapper colors</string>
       </attribute>
@@ -1489,7 +1483,7 @@ or some other computer model that has a small screen.</string>
           <item row="0" column="0">
            <widget class="QLabel" name="label_39">
             <property name="text">
-             <string>Link color</string>
+             <string>Link color:</string>
             </property>
            </widget>
           </item>
@@ -1805,30 +1799,17 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_3">
+     <widget class="QWidget" name="tab_SpecialOptions">
       <attribute name="title">
        <string>Special Options</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_7">
-       <item row="1" column="0">
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
+      <layout class="QGridLayout" name="gridLayout_SpecialOptions">
        <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_7">
+        <widget class="QGroupBox" name="groupBox_SpecialOptions">
          <property name="title">
           <string>Special options needed for some older MUD drivers (needs client restart to take effect)</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <layout class="QVBoxLayout" name="verticalLayout_SpecialOptions">
           <item>
            <widget class="QCheckBox" name="mFORCE_MCCP_OFF">
             <property name="text">
@@ -1846,8 +1827,8 @@ or some other computer model that has a small screen.</string>
           <item>
            <widget class="QCheckBox" name="checkBox_mUSE_FORCE_LF_AFTER_PROMPT">
             <property name="toolTip">
-             <string>This option adds a line line break &lt;LF&gt; or &quot;
-&quot; to your command input on empty commands. This option will rarely be necessary.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option adds a line line break &lt;LF&gt; or &quot;
+&quot; to your command input on empty commands. This option will rarely be necessary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Force new line on empty commands</string>
@@ -1888,12 +1869,51 @@ or some other computer model that has a small screen.</string>
          </layout>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="groupBox_Debug">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Debug options, for run-time control of test/development features.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_debug"/>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer_SpecialOptions">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget_BottomButtons" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>


### PR DESCRIPTION
Is fix for bug [1413435 {Ghost exits left in the Exits dialog when a room is deleted}](https://bugs.launchpad.net/mudlet/+bug/1413435) - done in a different way to what Chris originally started out doing as it now stores the room entrance information (in a pair of QSets) in the TRoom instance itself rather than a central table in the TRoomDB class.  All uses of (TRoom \*)->setExit( roomId, direction ) now update the room on the other end of the exit as appropriate.  Loses all the inline (TRoom \*)->set{North|NorthEast|...|Out}( roomId ) but the getters remain.  Room Deletion uses information to update rooms on other ends of a route - both exits and entrances.  Bulk deletion by deletion of Area or selection in Mapper optimised by skipping the unnecessary route updates on rooms that are to be deleted anyhow.  *In empirical testing with the room_deletion_bug_map.dat file (which I can't find where I got it from :blush:) which has 69K rooms with 40K odd of them in area 255 the "Wilderness" area it took 150 seconds to delete all the rooms on my system in that area without that optimisation compared to, at most ten seconds.*

**Due to the need to regenerate the entrance data on current format files each time they are loaded means the time to load can be *significant* and when combined with the recent fix for area exits also needing to be rebuilt on loading has forced a need to update the Map File Format to save the entrance data in the rooms so it does NOT need to be built each time - only once - but we may get complaints about this :cry: .**

To warn the user that at least something is happening the busy cursor will switch in if processing a section takes more than a fraction of a second so the user doe get a hint of something happening - this is part of the second commit.

**To cover our bases though with the problem of a new file format not being readable by old (current) code, the third of the three commits provides a run-time workaround for the problem by enabling Mudlet to save in the previous version format.  For safety this is automatically set to be disabled on release builds but enable on, say, this preview branch - which by default on the latter means they will save in the older, slower to load/process file format to be compatible with being able to share the file with others or use with another installed system version - but it can be toggled by a tool-tipped option on the last tab of the profile preferences dialog.**

There is a fourth commit I have on ice that gives the user or their scripts access to the room entrance data ```getAllRoomEntrances( roomId )``` for all entrances (both special and normal in one command) and a matching ```getAllRoomExits( roomId )``` for all exits, as, surprisingly, there is not a _single_ command to do that.  However it isn't appropriate for this branch but the following Pull Request #247 being the corresponding changes for the development branch DOES have this additional commit.