### PR TITLE
Fix crashes on room deletion

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,6 +37,8 @@
 #include "pre_guard.h"
 #include <QtUiTools>
 #include <QDir>
+#include <QHBoxLayout>
+#include <QLabel>
 #include <QMessageBox>
 #include "post_guard.h"
 
@@ -154,6 +157,10 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
 , mCommandLineBgColor(Qt::black)
 , mFORCE_MXP_NEGOTIATION_OFF( false )
 , mHaveMapperScript( false )
+/* DEBUGCONTROLS 3P - Per profile debug variable default values
+ * controls in dlgProfilePreferences here. Existing host instance.
+ */
+, mDebug_IsMapFormatToBeDownVersioned( false )
 {
    // mLogStatus = mudlet::self()->mAutolog;
     mLuaInterface.reset(new LuaInterface(this));
@@ -175,6 +182,8 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');
     mDoubleClickIgnore.insert('\'');
+    // Assigned value will be false for a "production" or "release" build:
+    mDebug_IsMapFormatToBeDownVersioned = ! ( QByteArray( APP_BUILD ).isEmpty() );
 }
 
 Host::~Host()
@@ -1236,4 +1245,12 @@ void Host::readPackageConfig(const QString& luaConfig, QString & packageName )
         lua_pop(L, -1);
         lua_close(L);
     }
+}
+
+/* DEBUGCONTROLS 4P - Per profile debug control adjustment slots
+ *
+ */
+void Host::slot_setMapFormatToBeDownVersioned(bool isEnabled)
+{
+    mDebug_IsMapFormatToBeDownVersioned = isEnabled;
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -41,6 +42,8 @@
 
 class QDialog;
 class QPushButton;
+class QHBoxLayout;
+class QLabel;
 class QListWidget;
 
 class dlgTriggerEditor;
@@ -56,14 +59,13 @@ class TMap;
 
 class Host  : public QObject
 {
+    Q_OBJECT
     friend class XMLexport;
     friend class XMLimport;
 
 public:
-
                        Host( int port, const QString& mHostName, const QString& login, const QString& pass, int host_id );
-
-                       ~Host();
+                      ~Host();
 
     QString            getName()                        { QMutexLocker locker(& mLock); return mHostName; }
     void               setName(const QString& s )       { QMutexLocker locker(& mLock); mHostName = s; }
@@ -306,6 +308,22 @@ public:
     bool               mFORCE_MXP_NEGOTIATION_OFF;
     bool               mHaveMapperScript;
     QSet<QChar>         mDoubleClickIgnore;
+
+/* DEBUGCONTROLS 1P - Per profile debug variables declarations
+ * development/debug feature controls.
+ * Please use a "mDebug_" prefix - so others can search for where they are used
+ * 8-)!
+ */
+    bool                mDebug_IsMapFormatToBeDownVersioned;
+
+
+public slots:
+/* DEBUGCONTROLS 2P - Per profile debug variable control slots declarations
+ * connect SIGNALS from dlgProfilePreferences.cpp to these SLOTS.
+ */
+    void                slot_setMapFormatToBeDownVersioned(bool isEnabled);
+
+
 };
 
 #endif // MUDLET_HOST_H

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2998,11 +2998,9 @@ void T2DMap::slot_setImage()
 
 void T2DMap::slot_deleteRoom()
 {
+    mpMap->mpRoomDB->removeRooms( mMultiSelectionList );
+    mMultiSelectionList.clear();
     mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
-    {
-        mpMap->mpRoomDB->removeRoom( mMultiSelectionList[j] );
-    }
     mMultiSelectionListWidget.clear();
     mMultiSelectionListWidget.hide();
     repaint();

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -174,80 +174,19 @@ void TArea::determineAreaExitsOfRoom( int id )
     }
 
     exits.remove(id);
-    int exitId = pR->getNorth();
-    // The second term in the ifs below looks for exit room id in TArea
-    // instance's own list of rooms which will fail (with a -1 if it is NOT in
-    // the list and hence the area.
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
-        exits.insertMulti( id, p );
+    QSetIterator<QPair<quint8, quint64> > itNormalExitSet = pR->getNormalExits();
+    while( itNormalExitSet.hasNext() ) {
+        QPair<quint8, quint64> _exit = itNormalExitSet.next();
+        if( rooms.indexOf( _exit.second ) < 0 ) {
+            exits.insertMulti( id, qMakePair( _exit.second, _exit.first ) );
+        }
     }
-    exitId = pR->getNortheast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getEast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getSoutheast();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getSouth();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getSouthwest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getWest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getNorthwest();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getUp();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getDown();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getIn();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
-        exits.insertMulti( id, p );
-    }
-    exitId = pR->getOut();
-    if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-        QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
-        exits.insertMulti( id, p );
-    }
-    const QMap<int, QString> otherMap = pR->getOtherMap();
-    QMapIterator<int,QString> it( otherMap );
-    while( it.hasNext() ) {
-        it.next();
-        int _exit = it.key();
-        TRoom * pO = mpRoomDB->getRoom(_exit);
-        if( pO ) {
-            if( pO->getArea() != getAreaID() ) {
-                QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
-                exits.insertMulti( id, p );
-            }
+
+    QSetIterator<QPair<QString, quint64> > itSpecialExitSet = pR->getSpecialExits();
+    while( itSpecialExitSet.hasNext() ) {
+        QPair<QString, quint64> _exit = itSpecialExitSet.next();
+        if( rooms.indexOf( _exit.second ) < 0 ) {
+            exits.insertMulti( id, qMakePair( _exit.second, DIR_OTHER ) );
         }
     }
 }
@@ -256,87 +195,27 @@ void TArea::determineAreaExits()
 {
     exits.clear();
     for( int i=0; i<rooms.size(); i++ ) {
-        TRoom * pR = mpRoomDB->getRoom(rooms[i]);
+        TRoom * pR = mpRoomDB->getRoom(rooms.at(i));
         if( ! pR ) {
             continue;
         }
 
-        int id = pR->getId();
-        int exitId = pR->getNorth();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTH);
-            exits.insertMulti( id, p );
+        QSetIterator<QPair<quint8, quint64> > itNormalExitSet = pR->getNormalExits();
+        while( itNormalExitSet.hasNext() ) {
+            QPair<quint8, quint64> _exit = itNormalExitSet.next();
+            if( rooms.indexOf( _exit.second ) < 0 ) {
+                exits.insertMulti( rooms.at(i), qMakePair( _exit.second, _exit.first ) );
+            }
         }
-        exitId = pR->getNortheast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHEAST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getEast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_EAST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getSoutheast();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHEAST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getSouth();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTH);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getSouthwest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_SOUTHWEST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getWest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_WEST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getNorthwest();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_NORTHWEST);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getUp();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_UP);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getDown();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_DOWN);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getIn();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_IN);
-            exits.insertMulti( id, p );
-        }
-        exitId = pR->getOut();
-        if( exitId > 0 && rooms.indexOf( exitId ) < 0 ) {
-            QPair<int, int> p = QPair<int,int>(exitId, DIR_OUT);
-            exits.insertMulti( id, p );
-        }
-        const QMap<int, QString> otherMap = pR->getOtherMap();
-        QMapIterator<int,QString> it( otherMap );
-        while( it.hasNext() ) {
-            it.next();
-            int _exit = it.key();
-            TRoom * pO = mpRoomDB->getRoom(_exit);
-            if( pO ) {
-                if( pO->getArea() != getAreaID() ) {
-                    QPair<int, int> p = QPair<int,int>(pO->getId(), DIR_OTHER);
-                    exits.insertMulti( id, p );
-                }
+
+        QSetIterator<QPair<QString, quint64> > itSpecialExitSet = pR->getSpecialExits();
+        while( itSpecialExitSet.hasNext() ) {
+            QPair<QString, quint64> _exit = itSpecialExitSet.next();
+            if( rooms.indexOf( _exit.second ) < 0 ) {
+                exits.insertMulti( rooms.at(i), qMakePair( _exit.second, DIR_OTHER ) );
             }
         }
     }
-    //qDebug()<<"exits:"<<exits.size();
 }
 
 void TArea::fast_calcSpan( int id )
@@ -522,7 +401,9 @@ void TArea::removeRoom( int room )
 //    TRoom * pR = mpRoomDB->getRoom( room );
     rooms.removeOne( room );
     exits.remove( room );
-    qDebug()<<"Area removal took"<<time.elapsed();
+//    qDebug()<<"Area removal took"<<time.elapsed(); // Is room not Area!
+//// FIXME: The following recalculations are probably required despite being
+//// commented out by another coder! - SlySven
 //    int x = pR->x;
 //    int y = pR->y*-1;
 //    int z = pR->z;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -109,7 +109,7 @@ public:
     void clearCaptureGroups();
     bool callEventHandler(const QString & function, const TEvent & pE );
     static QString dirToString( lua_State *, int );
-    static int dirToNumber( lua_State *, int );
+    static int dirToNumber( lua_State *, int, QString );
 
 
     int startTempTimer( double, const QString & );
@@ -385,6 +385,8 @@ public:
     static int openWebPage( lua_State * L );
     static int getRoomUserDataKeys( lua_State * L );
     static int getAllRoomUserData( lua_State * L );
+    static int getAllRoomExits( lua_State * );
+    static int getAllRoomEntrances( lua_State * );
 
 
     std::list<std::string> mCaptureGroupList;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -32,8 +32,12 @@
 #include "TRoomDB.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QDebug>
 #include <QDir>
+#if defined(DEBUG_TIMING)
+#include <QElapsedTimer>
+#endif
 #include <QFileDialog>
 #include <QMainWindow>
 #include <QMessageBox>
@@ -298,8 +302,10 @@ bool TMap::setExit( int from, int to, int dir )
 void TMap::init( Host * pH )
 {
     // init areas
-    QTime _time;
+#if defined(DEBUG_TIMING)
+    QElapsedTimer _time;
     _time.start();
+#endif
 
     if( version < 14 ) {
         mpRoomDB->initAreasForOldMaps();
@@ -316,7 +322,13 @@ void TMap::init( Host * pH )
             itArea.value()->calcSpan();
         }
     }
+#if defined(DEBUG_TIMING)
+    qDebug( "TMap::init() Initialize (part one) run time: %i milli-Seconds.", _time.elapsed() );
+#endif
     mpRoomDB->auditRooms();
+#if defined(DEBUG_TIMING)
+    _time.restart();
+#endif
 
     if( version <16 ) {
         // convert old style labels, wasn't made version conditional in past but
@@ -354,7 +366,9 @@ void TMap::init( Host * pH )
             }
         }
     }
-    qDebug( "TMap::init() Initialize run time: %i milli-Seconds.", _time.elapsed() );
+#if defined(DEBUG_TIMING)
+    qDebug( "TMap::init() Initialize (part two) run time: %i milli-Seconds.", _time.elapsed() );
+#endif
 }
 
 void TMap::setView(float x, float y, float z, float zoom )

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -131,8 +131,6 @@ public:
     QList<int> conList;
     QMap<int, int> roomidToIndex;
     QMap<int, int> indexToRoomid;
-    int mPlausaOptOut;
-
     QMap<QString, int> pixNameTable;
     QMap<int, QPixmap> pixTable;
     typedef adjacency_list<listS, vecS, directedS, no_property, property<edge_weight_t, cost> > mygraph_t;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -20,10 +20,10 @@
  ***************************************************************************/
 
 
-// Define for testing deletion of rooms - NOT RECOMMENDED as the time to display
-// the individual room timing must slow the process down - enable and use the
-// averaging code in T2DMap::slot_deleteRoom() and TRoomDB::removeArea() instead!
-// #define DEBUG_TIMING
+// Define for testing deletion of rooms - NOT RECOMMENDED HERE as the time to
+// display the individual room timing must slow the process down - enable and
+// use the averaging code in other classes instead!
+#undef DEBUG_TIMING
 
 #include "TRoom.h"
 
@@ -78,15 +78,12 @@ TRoom::TRoom(TRoomDB * pRDB)
 TRoom::~TRoom()
 {
 #if defined(DEBUG_TIMING)
-    static bool isToShowTime= false; // Set to true within debugger to control the display of this - may slow down code anyhow
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 #endif
     mpRoomDB->__removeRoom( id );
 #if defined(DEBUG_TIMING)
-    if( isToShowTime ) {
-        qDebug( "TRoom::~TRoom() - Room (%i) destruction took: %i milli-seconds.", id, timer.elapsed() );
-    }
+    qDebug( "TRoom::~TRoom() - Room (%i) destruction took: %i milli-seconds.", id, timer.elapsed() );
 #endif
 }
 

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -87,6 +87,26 @@ TRoom::~TRoom()
 #endif
 }
 
+QString TRoom::dirToString( int direction )
+{
+    switch( direction ) {
+        case DIR_NORTH:     return qApp->translate( "TRoom", "north" );       break;
+        case DIR_NORTHEAST: return qApp->translate( "TRoom", "northeast" );   break;
+        case DIR_NORTHWEST: return qApp->translate( "TRoom", "northwest" );   break;
+        case DIR_EAST:      return qApp->translate( "TRoom", "east" );        break;
+        case DIR_WEST:      return qApp->translate( "TRoom", "west" );        break;
+        case DIR_SOUTH:     return qApp->translate( "TRoom", "south" );       break;
+        case DIR_SOUTHEAST: return qApp->translate( "TRoom", "southeast" );   break;
+        case DIR_SOUTHWEST: return qApp->translate( "TRoom", "southwest" );   break;
+        case DIR_UP:        return qApp->translate( "TRoom", "up" );          break;
+        case DIR_DOWN:      return qApp->translate( "TRoom", "down" );        break;
+        case DIR_IN:        return qApp->translate( "TRoom", "in" );          break;
+        case DIR_OUT:       return qApp->translate( "TRoom", "out" );         break;
+        case DIR_OTHER:     return qApp->translate( "TRoom", "other");        break;
+        default:            return qApp->translate( "TRoom", "invalid(%1)" ).arg(direction);
+    }
+}
+
 bool TRoom::hasExitStub(int direction)
 {
     if (exitStubs.contains(direction))

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -59,7 +59,12 @@ public:
     void setId( int );
     bool setExit( int to, int direction );
     int getExit( int direction );
-    QHash<int, int> getExits();
+    QSet<QPair<quint8, quint64> > getNormalExits();
+    QSet<QPair<QString, quint64> > getSpecialExits();
+    QSet<QPair<quint8, quint64> > getNormalEntrances() const { return mNormalEntrances; }
+    QSet<QPair<QString, quint64> > getSpecialEntrances() const { return mSpecialEntrances; }
+    void setEntrance( QPair<quint8, quint64> );
+    void setEntrance( QPair<QString, quint64> );
     bool hasExit( int direction );
     void setWeight( int );
     void setExitLock( int, bool );
@@ -67,8 +72,7 @@ public:
     bool setSpecialExitLock(const QString& cmd, bool doLock );
     bool hasExitLock( int to );
     bool hasSpecialExitLock( int, const QString& );
-    void removeAllSpecialExitsToRoom(int _id );
-    void setSpecialExit( int to, const QString& cmd );
+    bool setSpecialExit( int, const QString& );
     void clearSpecialExits() { other.clear(); }
     const QMultiMap<int, QString> & getOtherMap() const { return other; }
     const QMap<QString, int> & getExitWeights() const { return exitWeights; }
@@ -81,41 +85,29 @@ public:
     void calcRoomDimensions();
     bool setArea( int , bool isToDeferAreaRelatedRecalculations = false );
     int getExitWeight(const QString& cmd );
-
     int getWeight() { return weight; }
     int getNorth() { return north; }
-    void setNorth( int id ) { north=id; }
     int getNorthwest() { return northwest; }
-    void setNorthwest( int id ) { northwest=id; }
     int getNortheast() { return northeast; }
-    void setNortheast( int id ) { northeast=id; }
     int getSouth() { return south; }
-    void setSouth( int id ) { south=id; }
     int getSouthwest() { return southwest; }
-    void setSouthwest( int id ) { southwest=id; }
     int getSoutheast() { return southeast; }
-    void setSoutheast( int id ) { southeast=id; }
     int getWest() { return west; }
-    void setWest( int id ) { west=id; }
     int getEast() { return east; }
-    void setEast( int id ) { east=id; }
     int getUp() { return up; }
-    void setUp( int id ) { up=id; }
     int getDown() { return down; }
-    void setDown( int id ) { down=id; }
     int getIn() { return in; }
-    void setIn( int id ) { in=id; }
     int getOut() { return out; }
-    void setOut( int id ) { out=id; }
     int getId() { return id; }
     int getArea() { return area; }
     void auditExits();
-    /*bool*/ void restore( QDataStream & ifs, int roomID, int version );
+    /*bool*/ void restore( QDataStream & ifs, int version );
+
+
     int x;
     int y;
     int z;
     int environment;
-
     bool isLocked;
     qreal min_x;
     qreal min_y;
@@ -123,7 +115,7 @@ public:
     qreal max_y;
     qint8 c;
     QString name;
-    QVector3D v;
+//    QVector3D v;
     QList<int> exitStubs; //contains a list of: exittype (according to defined values above)
     QMap<QString, QString> userData;
     QList<int> exitLocks;
@@ -140,6 +132,11 @@ public:
 
 
 private:
+    void setEntrance( int, quint8 );
+    void setEntrance( int, QString );
+    void resetEntrance( int, quint8 );
+    void resetEntrance( int, QString );
+
     int id;
     int area;
     int weight;
@@ -156,6 +153,25 @@ private:
     int down;
     int in;
     int out;
+// To add in the next map file format increment so we don't have to regenerate
+// them on loading:
+    QSet<QPair<quint8, quint64> > mNormalEntrances;
+// Normal exits that have THIS room as a destination
+// first is direction code from the OTHER room, but NOT DIR_OTHER, second is fromRoomId.
+    QSet<QPair<QString, quint64> > mSpecialEntrances;
+// Special exits that have THIS room as a destination
+// first is exit text from the OTHER room, second is fromRoomId.
+// Reason for separation for special from normal entrances:
+// using text for normal exits is language dependent would make code for normal
+// exits more complex (slower) than needs be - this is based on the assumption
+// that a MUD has many more normal than special exits.
+//
+// Actually the same concept could be done for:
+//    QHash<quint8, quint64> normalExits;
+//    QHash<QString, quint64> SpecialExits;
+// Where second is the toRoomId in both cases and the first is the normal exit
+// code or special exit name...
+
 
     // FIXME: This should be a map of String->room id because there can be multiple special exits to the same room
     QMultiMap<int, QString> other; // es knnen mehrere exits zum gleichen raum verlaufen

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -102,6 +102,8 @@ public:
     int getArea() { return area; }
     void auditExits();
     /*bool*/ void restore( QDataStream & ifs, int version );
+    QString dirToString( int );
+
 
 
     int x;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -20,6 +20,9 @@
  ***************************************************************************/
 
 
+// Define for testing TRoomDB::deleteArea(...) and TRoomDB::deleteRooms(...)!
+#define DEBUG_TIMING
+
 #include "TRoomDB.h"
 
 #include "TArea.h"
@@ -30,13 +33,14 @@
 #include "pre_guard.h"
 #include <QApplication>
 #include <QDebug>
-#include <QTime>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 
 TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
 , mUnnamedAreaName( qApp->translate( "TRoomDB", "Unnamed Area" ) )
+, mpDeletionRooms( 0 )
 {
 }
 
@@ -52,24 +56,27 @@ TRoom * TRoomDB::getRoom( int id )
 
 bool TRoomDB::addRoom( int id )
 {
-    qDebug()<<"addRoom("<<id<<")";
-    if( !rooms.contains( id ) && id > 0 )
-    {
-        rooms[id] = new TRoom( this );
-        rooms[id]->setId(id);
-        QHash<int, int> exits = rooms[id]->getExits();
-        QList<int> toExits = exits.keys();
-        for (int i = 0; i < toExits.size(); i++)
-            reverseExitMap.insert(id, toExits[i]);
+    qDebug( "TRoomDB::addRoom(%i) called.", id );
+    if( id > 0 && ! rooms.contains( id ) ) {
+        TRoom * pR = new TRoom( this );
+        if( ! pR ) {
+            QString error = qApp->translate( "TRoomDB", "Unable to create room id (%1) - out of memory?").arg(id);
+            mpMap->logError(error);
+            return false;
+        }
+        rooms[id] = pR;
+        pR->setId(id);
         return true;
     }
-    else
-    {
-        if( id <= 0 )
-        {
-            QString error = QString("illegal room id=%1. roomID must be > 0").arg(id);
-            mpMap->logError(error);
+    else {
+        QString error;
+        if( id <= 0 ) {
+            error = qApp->translate( "TRoomDB", "Illegal room id (%1) - it must be greater than zero!").arg(id);
         }
+        else {
+            error = qApp->translate( "TRoomDB", "Duplicate room id (%1) - there is already a room with that number!").arg(id);
+        }
+        mpMap->logError(error);
         return false;
     }
 }
@@ -91,40 +98,74 @@ bool TRoomDB::addRoom( int id, TRoom * pR )
 // this is call by TRoom destructor only
 bool TRoomDB::__removeRoom( int id )
 {
-    TRoom* pR = getRoom(id);
-    if (pR) {
+    TRoom * pR = getRoom(id);
+    if( pR ) {
         // FIXME: make a proper exit controller so we don't need to do all these if statements
-        QMultiHash<int, int>::iterator i = reverseExitMap.find(id);
-        while (i != reverseExitMap.end() && i.key() == id) {
-            TRoom* r = getRoom(i.value());
-            if (r) {
-                if (r->getNorth() == id)
-                    r->setNorth(-1);
-                if (r->getNortheast() == id)
-                    r->setNortheast(-1);
-                if (r->getNorthwest() == id)
-                    r->setNorthwest(-1);
-                if (r->getEast() == id)
-                    r->setEast(-1);
-                if (r->getWest() == id)
-                    r->setWest(-1);
-                if (r->getSouth() == id)
-                    r->setSouth(-1);
-                if (r->getSoutheast() == id)
-                    r->setSoutheast(-1);
-                if (r->getSouthwest() == id)
-                    r->setSouthwest(-1);
-                if (r->getUp() == id)
-                    r->setUp(-1);
-                if (r->getDown() == id)
-                    r->setDown(-1);
-                if (r->getIn() == id)
-                    r->setIn(-1);
-                if (r->getOut() == id)
-                    r->setOut(-1);
-                r->removeAllSpecialExitsToRoom(id);
+
+        // Delete the Exits that lead TO THIS room, use the stored entrance data
+        // so we can identify the rooms that have exits leading here - this is
+        // the primary reason for maintaining Entrance data otherwise we'd have
+        // to check EVERY exit for EVERY room! 8-) SlySven
+        QSet<QPair<quint8, quint64> > _normalEntrances(pR->getNormalEntrances());
+        _normalEntrances.detach();
+        QSetIterator<QPair<quint8, quint64> > itNormalEntrances = _normalEntrances;
+        while( itNormalEntrances.hasNext() ) {
+            QPair<quint8, quint64> entranceFrom = itNormalEntrances.next();
+            if(      entranceFrom.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( entranceFrom.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
             }
-            ++i;
+            TRoom * pR_from = getRoom( entranceFrom.second );
+            if( pR_from ) {
+                pR_from->setExit( -1, entranceFrom.first );
+                // This call WILL modify pR->getNormalEntrances() that we might
+                // otherwise iterate over directly - this is a no-no for many Qt
+                // iterators, even the mutable ones (they expect to be making
+                // the changes!) - hence the explicit deep copying above caused
+                // by making a copy and then using "detach()"
+            }
+        }
+        QSet<QPair<QString,quint64> > _specialEntrances( pR->getSpecialEntrances() );
+        _specialEntrances.detach();
+        QSetIterator<QPair<QString,quint64> > itSpecialEntrances = _specialEntrances;
+        while( itSpecialEntrances.hasNext() ) {
+            QPair<QString, quint64> entranceFrom = itSpecialEntrances.next();
+            if(      entranceFrom.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( entranceFrom.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
+            }
+            TRoom * pR_from = getRoom( entranceFrom.second );
+            if( pR_from ) {
+                pR_from->setSpecialExit( -1, entranceFrom.first );
+            }
+        }
+        // And EXITS from THIS room are entrances in other rooms so clear THIS
+        // room's exits to erase those ENTRANCE details from OTHER rooms:
+        QSet<QPair<quint8, quint64> > _normalExits(pR->getNormalExits());
+        _normalEntrances.detach();
+        QSetIterator<QPair<quint8, quint64> > itNormalExits = _normalExits;
+        while( itNormalExits.hasNext() ) {
+            QPair<quint8, quint64> exitTo = itNormalExits.next();
+            if(       exitTo.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( exitTo.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
+            }
+            pR->setExit( -1, exitTo.first );
+        }
+        QSet<QPair<QString, quint64> > _specialExits(pR->getSpecialExits());
+        _specialExits.detach();
+        QSetIterator<QPair<QString, quint64> > itSpecialExits = _specialExits;
+        while( itSpecialExits.hasNext() ) {
+            QPair<QString, quint64> exitTo = itSpecialExits.next();
+            if(       exitTo.second == id
+                || ( mpDeletionRooms && mpDeletionRooms->contains( exitTo.second ) ) ) {
+                continue; // Ignore circular entrances/exits in THIS room
+                          // or other rooms being deleted!!!
+            }
+            pR->setSpecialExit( -1, exitTo.first );
         }
         rooms.remove(id);
         // FIXME: make hashTable a bimap
@@ -137,9 +178,9 @@ bool TRoomDB::__removeRoom( int id )
         }
         int areaID = pR->getArea();
         TArea * pA = getArea( areaID );
-        if (pA)
+        if(pA) {
             pA->removeRoom(id);
-        reverseExitMap.remove(id);
+        }
         // Because we clear the graph in initGraph which will be called
         // if mMapGraphNeedsUpdate is true -- we don't need to
         // remove the vertex using clear_vertex and remove_vertex here
@@ -151,7 +192,7 @@ bool TRoomDB::__removeRoom( int id )
 
 bool TRoomDB::removeRoom( int id )
 {
-    if( rooms.contains( id ) && id > 0 ) {
+    if( id >= 0 && rooms.contains( id ) ) { // Allow id to be 0 have seen such a room id in the wild and would be undeleteable otheriwse
         if( mpMap->mRoomId == id ) {
             mpMap->mRoomId = 0;
         }
@@ -165,23 +206,80 @@ bool TRoomDB::removeRoom( int id )
     return false;
 }
 
+void TRoomDB::removeRooms( QList<int> & ids )
+{
+#if defined(DEBUG_TIMING)
+    static bool isToShowTime = true; // Set to true within debugger to control the display of this
+    QElapsedTimer timer;
+    timer.start();
+#endif
+    mpDeletionRooms = new QSet<int>( ids.toSet() );
+#if defined(DEBUG_TIMING)
+    quint64 roomCount = mpDeletionRooms->size();
+#endif
+    QSetIterator<int> itRoom = *mpDeletionRooms;
+    while( itRoom.hasNext() ) {
+        removeRoom( itRoom.next() ); // This will update other area's rooms about exit changes
+    }
+    delete mpDeletionRooms;
+    mpDeletionRooms = 0;
+#if defined(DEBUG_TIMING)
+    if( isToShowTime ) {
+        qint64 elapsed = timer.elapsed();
+        double elaspedTime = elapsed / 1000.0;
+        double unitTime = 0.0;
+        if(roomCount) {
+            unitTime = elapsed / (double)(roomCount);
+        }
+        // Can't get the printf format string character right to present
+        // meaningful data - so let's let Qt sort it out
+        qDebug()<<"TRoomDB::removeRooms(...) - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+    }
+#endif
+}
+
 bool TRoomDB::removeArea( int id )
 {
+#if defined(DEBUG_TIMING)
+    static bool isToShowTime = true; // Set to true within debugger to control the display of this
+    QElapsedTimer timer;
+    timer.start();
+#endif
     if( areas.contains( id ) ) {
-        TArea * pA = areas.value(id);
-        QList<int> rl;
-        for( int i=0; i< pA->rooms.size(); i++ ) {
-            rl.push_back( pA->rooms.at(i) );
+        TArea * pA = areas[id];
+        mpDeletionRooms = new QSet<int>( pA->rooms.toSet() );
+#if defined(DEBUG_TIMING)
+        quint64 roomCount = mpDeletionRooms->size();
+#endif
+        QSetIterator<int> itRoom = *mpDeletionRooms;
+        while( itRoom.hasNext() ) {
+            removeRoom( itRoom.next() ); // This will update other area's rooms about exit changes
         }
-        for( int i=rl.size()-1; i >= 0; i-- ) {
-            removeRoom( rl.at(i) );
-        }
+        delete mpDeletionRooms;
+        mpDeletionRooms = 0;
         areaNamesMap.remove( id );
         areas.remove( id );
-
         mpMap->mMapGraphNeedsUpdate = true;
+#if defined(DEBUG_TIMING)
+        if( isToShowTime ) {
+            qint64 elapsed = timer.elapsed();
+            double elaspedTime = elapsed / 1000.0;
+            double unitTime = 0.0;
+            if(roomCount) {
+                unitTime = elapsed / (double)(roomCount);
+            }
+            // Can't get the printf format string character right to present
+            // meaningful data - so let's let Qt sort it out
+            qDebug()<<"TRoomDB::removeArea(" << id << ") - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+        }
+#endif
         return true;
     }
+#if defined(DEBUG_TIMING)
+        if( isToShowTime ) {
+            qDebug( "TRoomDB::removeArea(%i) - No area found to destroy.", id );
+        }
+#endif
     return false;
 }
 
@@ -206,7 +304,8 @@ int TRoomDB::getAreaID( TArea * pA )
 
 void TRoomDB::buildAreas()
 {
-    QTime _time; _time.start();
+    QElapsedTimer _time;
+    _time.start();
     QHashIterator<int, TRoom *> it( rooms );
     while( it.hasNext() )
     {
@@ -232,7 +331,7 @@ void TRoomDB::buildAreas()
            areas[id] = new TArea( mpMap, this );
        }
     }
-    qDebug()<<"BUILD AREAS run time:"<<_time.elapsed();
+    qDebug( "TRoomDB::buildAreas(): run time: %i milli-Seconds.", _time.elapsed());
 }
 
 
@@ -377,17 +476,46 @@ QList<int> TRoomDB::getAreaIDList()
 
 void TRoomDB::auditRooms()
 {
-    QTime t; t.start();
+    QElapsedTimer t;
+    t.start();
+    bool ok = true;
+    mpTempAllNormalEntrances = new QMultiHash<quint64, QPair<quint8, quint64> >;  // key is toRoomdId, value.first is direction code, value.second is fromRoomId
+    mpTempAllSpecialEntrances = new QMultiHash<quint64, QPair<QString, quint64> >;// key is toRoomId, value.first is exit name, value.second is fromRoomId
+    if( ( ! mpTempAllNormalEntrances ) || ( ! mpTempAllSpecialEntrances ) ) {
+        qCritical( "TRoomDB::auditRooms() Critical error: unable to create temporary structures to validate map route data." );
+        ok = false;
+    }
+
     // rooms konsolidieren
-    QHashIterator<int, TRoom* > itRooms( rooms );
-    while( itRooms.hasNext() )
-    {
+    QHashIterator<int, TRoom * > itRooms( rooms );
+    while( itRooms.hasNext() ) {
         itRooms.next();
         TRoom * pR = itRooms.value();
         pR->auditExits();
-
     }
-    qDebug()<<"audit map: runtime:"<<t.elapsed();
+
+    if( ok && mpMap->version < 17 ) {
+        // Right now build entrance data
+        itRooms.toFront();
+        while( itRooms.hasNext() ) {
+            itRooms.next();
+            TRoom * pR = itRooms.value();
+            QList<QPair<quint8, quint64> > normalRoomEntrancesList = mpTempAllNormalEntrances->values( pR->getId() );
+            for( uint i = 0; i < normalRoomEntrancesList.size(); i++ ) {
+                pR->setEntrance( normalRoomEntrancesList.at(i) );
+            }
+            QList<QPair<QString, quint64> > specialRoomEntrancesList = mpTempAllSpecialEntrances->values( pR->getId() );
+            for( uint i = 0; i < specialRoomEntrancesList.size(); i++ ) {
+                pR->setEntrance( specialRoomEntrancesList.at(i) );
+            }
+        }
+    }
+
+    if( ok ) {
+        delete mpTempAllNormalEntrances;
+        delete mpTempAllSpecialEntrances;
+    }
+    qDebug( "TRoomDB::auditRooms() audit Rooms took: %i milli-Seconds.", t.elapsed() );
 }
 
 void TRoomDB::initAreasForOldMaps()
@@ -584,7 +712,12 @@ void TRoomDB::restoreSingleArea(QDataStream & ifs, int areaID, TArea * pA )
     areas[areaID] = pA;
 }
 
-void TRoomDB::restoreSingleRoom(QDataStream & ifs, int i, TRoom *pT)
+void TRoomDB::restoreSingleRoom(QDataStream & ifs, TRoom * pR )
 {
-    rooms[i] = pT;
+    Q_UNUSED(ifs);
+
+    if( ! pR ) {
+        return;
+    }
+    rooms[ pR->getId() ] = pR;
 }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -20,9 +20,6 @@
  ***************************************************************************/
 
 
-// Define for testing TRoomDB::deleteArea(...) and TRoomDB::deleteRooms(...)!
-#define DEBUG_TIMING
-
 #include "TRoomDB.h"
 
 #include "TArea.h"
@@ -33,7 +30,9 @@
 #include "pre_guard.h"
 #include <QApplication>
 #include <QDebug>
+#if defined(DEBUG_TIMING)
 #include <QElapsedTimer>
+#endif
 #include "post_guard.h"
 
 
@@ -209,7 +208,6 @@ bool TRoomDB::removeRoom( int id )
 void TRoomDB::removeRooms( QList<int> & ids )
 {
 #if defined(DEBUG_TIMING)
-    static bool isToShowTime = true; // Set to true within debugger to control the display of this
     QElapsedTimer timer;
     timer.start();
 #endif
@@ -224,24 +222,21 @@ void TRoomDB::removeRooms( QList<int> & ids )
     delete mpDeletionRooms;
     mpDeletionRooms = 0;
 #if defined(DEBUG_TIMING)
-    if( isToShowTime ) {
-        qint64 elapsed = timer.elapsed();
-        double elaspedTime = elapsed / 1000.0;
-        double unitTime = 0.0;
-        if(roomCount) {
-            unitTime = elapsed / (double)(roomCount);
-        }
-        // Can't get the printf format string character right to present
-        // meaningful data - so let's let Qt sort it out
-        qDebug()<<"TRoomDB::removeRooms(...) - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+    qint64 elapsed = timer.elapsed();
+    double elaspedTime = elapsed / 1000.0;
+    double unitTime = 0.0;
+    if(roomCount) {
+        unitTime = elapsed / (double)(roomCount);
     }
+    // Can't get the printf format string character right to present
+    // meaningful data - so let's let Qt sort it out
+    qDebug()<<"TRoomDB::removeRooms(...) - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
 #endif
 }
 
 bool TRoomDB::removeArea( int id )
 {
 #if defined(DEBUG_TIMING)
-    static bool isToShowTime = true; // Set to true within debugger to control the display of this
     QElapsedTimer timer;
     timer.start();
 #endif
@@ -261,24 +256,20 @@ bool TRoomDB::removeArea( int id )
         areas.remove( id );
         mpMap->mMapGraphNeedsUpdate = true;
 #if defined(DEBUG_TIMING)
-        if( isToShowTime ) {
-            qint64 elapsed = timer.elapsed();
-            double elaspedTime = elapsed / 1000.0;
-            double unitTime = 0.0;
-            if(roomCount) {
-                unitTime = elapsed / (double)(roomCount);
-            }
-            // Can't get the printf format string character right to present
-            // meaningful data - so let's let Qt sort it out
-            qDebug()<<"TRoomDB::removeArea(" << id << ") - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
+        qint64 elapsed = timer.elapsed();
+        double elaspedTime = elapsed / 1000.0;
+        double unitTime = 0.0;
+        if(roomCount) {
+            unitTime = elapsed / (double)(roomCount);
         }
+        // Can't get the printf format string character right to present
+        // meaningful data - so let's let Qt sort it out
+        qDebug()<<"TRoomDB::removeArea(" << id << ") - (" << roomCount << ") Rooms destruction took" << elaspedTime << "seconds in total. This averages to" << unitTime << "milli-seconds per room.";
 #endif
         return true;
     }
 #if defined(DEBUG_TIMING)
-        if( isToShowTime ) {
-            qDebug( "TRoomDB::removeArea(%i) - No area found to destroy.", id );
-        }
+    qDebug( "TRoomDB::removeArea(%i) - No area found to destroy.", id );
 #endif
     return false;
 }
@@ -304,8 +295,10 @@ int TRoomDB::getAreaID( TArea * pA )
 
 void TRoomDB::buildAreas()
 {
+#if defined(DEBUG_TIMING)
     QElapsedTimer _time;
     _time.start();
+#endif
     QHashIterator<int, TRoom *> it( rooms );
     while( it.hasNext() )
     {
@@ -331,7 +324,9 @@ void TRoomDB::buildAreas()
            areas[id] = new TArea( mpMap, this );
        }
     }
+#if defined(DEBUG_TIMING)
     qDebug( "TRoomDB::buildAreas(): run time: %i milli-Seconds.", _time.elapsed());
+#endif
 }
 
 
@@ -476,8 +471,10 @@ QList<int> TRoomDB::getAreaIDList()
 
 void TRoomDB::auditRooms()
 {
+#if defined(DEBUG_TIMING)
     QElapsedTimer t;
     t.start();
+#endif
     bool ok = true;
     mpTempAllNormalEntrances = new QMultiHash<quint64, QPair<quint8, quint64> >;  // key is toRoomdId, value.first is direction code, value.second is fromRoomId
     mpTempAllSpecialEntrances = new QMultiHash<quint64, QPair<QString, quint64> >;// key is toRoomId, value.first is exit name, value.second is fromRoomId
@@ -515,7 +512,9 @@ void TRoomDB::auditRooms()
         delete mpTempAllNormalEntrances;
         delete mpTempAllSpecialEntrances;
     }
+#if defined(DEBUG_TIMING)
     qDebug( "TRoomDB::auditRooms() audit Rooms took: %i milli-Seconds.", t.elapsed() );
+#endif
 }
 
 void TRoomDB::initAreasForOldMaps()

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -27,6 +27,7 @@
 #include <QHash>
 #include <QMultiHash>
 #include <QMap>
+#include <QPair>
 #include <QString>
 #include "post_guard.h"
 
@@ -60,8 +61,6 @@ public:
     QList<int> getRoomIDList();
     QList<int> getAreaIDList();
     const QMap<int, QString> & getAreaNamesMap() const { return areaNamesMap; }
-
-
     void buildAreas();
     void clearMapDB();
     void initAreasForOldMaps();
@@ -70,9 +69,17 @@ public:
     int getAreaID(TArea * pA);
     void restoreAreaMap( QDataStream & );
     void restoreSingleArea( QDataStream &, int, TArea * );
-    void restoreSingleRoom( QDataStream &, int, TRoom * );
-    QMap<QString,int> hashTable;
+    void restoreSingleRoom( QDataStream &, TRoom * );
+    void removeRooms( QList<int> & );
 
+
+    QMap<QString,int> hashTable;
+    // These public pointers are only intended to be used during map file
+    // loading of older file formats so the data can be built as the file is
+    // read and then discarded (the data is held within the individual rooms and
+    // saved with them from file version 17 onwards)
+    QMultiHash<quint64, QPair<quint8, quint64> > * mpTempAllNormalEntrances;    // key is toRoomdId, value.first is direction code, value.second is fromRoomId
+    QMultiHash<quint64, QPair<QString, quint64> > * mpTempAllSpecialEntrances;  // key is toRoomId, value.first is exit name, value.second is fromRoomId
 
 
 private:
@@ -81,11 +88,13 @@ private:
     bool __removeRoom( int id );
 
     QHash<int, TRoom *> rooms;
-    QMultiHash<int, int> reverseExitMap;
     QMap<int, TArea *> areas;
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;
     QString mUnnamedAreaName;
+    // Temporarily used to hold a list of room Ids that are being bulk deleted
+    // so that we can skip some operations on them for speedup purposes:
+    QSet<int> * mpDeletionRooms;
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -169,6 +170,48 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
     need_reconnect_for_specialoption->hide();
     connect(mFORCE_MCCP_OFF, SIGNAL(clicked()), need_reconnect_for_specialoption, SLOT(show()));
     connect(mFORCE_GA_OFF, SIGNAL(clicked()), need_reconnect_for_specialoption, SLOT(show()));
+
+/* DEBUGCONTROLS 0 - Insert debug variable controls
+ * they go into groupbox_debug and are initalised from variables in THost.cpp
+ * (per profile) or mudlet.cpp (application wide).  The controls are to be
+ * connected to corresponding slots to adjust those variables via "slot_"'s
+ * in the appropriate one of those files.
+ *
+ * Use a QHBoxLayout for each control or group of controls and add that layout
+ * into "verticalLayout_debug" - which is on the last tab of the
+ * profile_preference dialog.
+ */
+    QHBoxLayout * horizontalLayout_mapFormatToBeDownVersioned = new QHBoxLayout( 0 );
+    QCheckBox * checkBox_mapFormatToBeDownVersioned = new QCheckBox( 0 );
+    checkBox_mapFormatToBeDownVersioned->setText( tr("Save Map File in previous format for use with older Mudlet version.") );
+    checkBox_mapFormatToBeDownVersioned->setToolTip( tr("<html><head/><body>"
+                                                        "<p>When set, forces the map file format to be downgraded so that maps can be loaded "
+                                                        "into the previous Mudlet version - this is to prevent the issue that when the file "
+                                                        "format is changed to improve performance and/or fix a problem the previous version "
+                                                        "will not be able to read the new type of file.</p>"
+                                                        "<p>If you are sharing your Map files with others or testing out a <i>non-release</i> version "
+                                                        "using a Map file that you will want to reused with your current version you will "
+                                                        "want to leave this control set so that a compatible file is produced on "
+                                                        "saving, however loading is likely to take longer in this or later version as the "
+                                                        "data is reconverted back into a form now used internally.  Alternatively if this "
+                                                        "is the earliest copy of Mudlet you use and you are not going to share the map "
+                                                        "saved you will get best results (a faster Map loading time) by <b>not</b> having "
+                                                        "the control activated.</p>"
+                                                        "<p>This control defaults to being set on <i>preview</i> and <i>development</i> "
+                                                        "versions but is cleared on a <i>release</i> one (it is determined from "
+                                                        "whether there is anything after the x.y.z part of the version string, which is "
+                                                        "visible on the Splash Screen or the <i>About Mudlet</i> dialog.)  The setting is "
+                                                        "<b>not</b> saved at the end of a session or affect other profiles you may have "
+                                                        "running alongside this one.</p>"
+                                                        "<p><u>Do not worry though, whichever setting you choose here, a version of the "
+                                                        "Mudlet aplication will always be able to read the Map files it saves itself!</u></body></html>" ) );
+    checkBox_mapFormatToBeDownVersioned->setChecked( mpHost->mDebug_IsMapFormatToBeDownVersioned );
+    connect(checkBox_mapFormatToBeDownVersioned, SIGNAL(clicked(bool)), mpHost, SLOT( slot_setMapFormatToBeDownVersioned(bool) ));
+    horizontalLayout_mapFormatToBeDownVersioned->addWidget(checkBox_mapFormatToBeDownVersioned);
+    verticalLayout_debug->addLayout(horizontalLayout_mapFormatToBeDownVersioned);
+    verticalLayout_debug->setAlignment( Qt::AlignTop );
+
+    groupBox_Debug->setLayout(verticalLayout_debug);
 
     Host * pHost = mpHost;
     if( pHost )

--- a/src/src.pro
+++ b/src/src.pro
@@ -40,6 +40,11 @@ msvc:QMAKE_CXXFLAGS += -MP
 # Mac specific flags.
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
 
+# Enable some timing reporting code - undef for release version, must touch:
+# TArea.cpp, TMap.cpp, TRoomDB.cpp (in, but unused in TRoom.cpp) when this is
+# added or removed from DEFINES - this is not in the CMake project file!
+DEFINES += DEBUG_TIMING
+
 QT += network opengl uitools multimedia
 
 # Leave the value of the following empty, line should be "BUILD =" without quotes

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>744</width>
-    <height>596</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,7 +25,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QTabWidget" name="tabWidgeta">
+    <widget class="QTabWidget" name="tabWidget_main">
      <property name="enabled">
       <bool>true</bool>
      </property>
@@ -44,7 +44,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="General">
+     <widget class="QWidget" name="tab_General">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -113,7 +113,7 @@
           <item row="2" column="0">
            <widget class="QCheckBox" name="showMenuBar">
             <property name="toolTip">
-             <string>Enables the typical menu bar with drop-down menus in the main window. Requires restart to take effect</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the typical menu bar with drop-down menus in the main window. Requires restart to take effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Show menu bar</string>
@@ -123,7 +123,7 @@
           <item row="3" column="0">
            <widget class="QCheckBox" name="showToolbar">
             <property name="toolTip">
-             <string>Enables the default button bar in the main window. Requires restart to take effect</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enables the default button bar in the main window. Requires restart to take effect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Show main toolbar</string>
@@ -156,7 +156,7 @@
           <item>
            <widget class="QCheckBox" name="mRawStreamDump">
             <property name="toolTip">
-             <string>Switch log file format from HTML to raw stream dump in logfiles as sent by server. The logfile can then be can be loaded by Mudlet to test your trigger systems offline.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Switch log file format from HTML (contaning colored text) to raw stream dump (containing ANSI Color Esc codes) in logfiles as sent by server.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Save log files in html format instead of text only</string>
@@ -227,7 +227,7 @@
         </widget>
        </item>
        <item row="6" column="0">
-        <spacer name="verticalSpacer_8">
+        <spacer name="verticalSpacer_General">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -262,7 +262,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="input_line_tab">
+     <widget class="QWidget" name="tab_InputLine">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -291,7 +291,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Strict UNIX line endings</string>
@@ -304,7 +304,7 @@
              <bool>true</bool>
             </property>
             <property name="toolTip">
-             <string>Echo the text you send in the display box</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Echo the text you send in the display box.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Show the text you sent</string>
@@ -394,7 +394,7 @@
         </widget>
        </item>
        <item row="2" column="0">
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer_InputLine">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -408,7 +408,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="tab_MainDisplay">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
@@ -729,9 +729,7 @@
           <item>
            <widget class="QCheckBox" name="checkBox_USE_IRE_DRIVER_BUGFIX">
             <property name="toolTip">
-             <string>Some MUDs (notably all IRE ones) suffer from a bug where they don't properly
-communicate with the client on where a newline should be. Enable this to fix text
-from getting appended to the previous prompt line</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some MUDs (notably all IRE ones) suffer from a bug where they do not properly communicate with the client on where a newline should be. Enable this to fix text from getting appended to the previous prompt line.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Fix unnecessary linebreaks on GA servers</string>
@@ -741,8 +739,7 @@ from getting appended to the previous prompt line</string>
           <item>
            <widget class="QCheckBox" name="checkBox_USE_SMALL_SCREEN">
             <property name="toolTip">
-             <string>Select this option for better compatability if you are using a netbook, 
-or some other computer model that has a small screen.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select this option for better compatability if you are using a netbook, or some other computer model that has a small screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Use Mudlet on a netbook with a small screen</string>
@@ -753,7 +750,7 @@ or some other computer model that has a small screen.</string>
         </widget>
        </item>
        <item row="5" column="0">
-        <spacer name="verticalSpacer">
+        <spacer name="verticalSpacer_MainDisplay">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -813,7 +810,7 @@ or some other computer model that has a small screen.</string>
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="mNoAntiAlias">
             <property name="toolTip">
-             <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
             </property>
             <property name="text">
              <string>Enable anti-aliasing</string>
@@ -839,7 +836,7 @@ or some other computer model that has a small screen.</string>
           <item>
            <widget class="QLineEdit" name="doubleclick_ignore_lineedit">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the characters you'd like double-clicking to stop selecting text on here. If you don't enter any, double-clicking on a word will only stop at a space, and will include characters like a double or a single quote. For example, double-clicking on the word &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; in the following will select &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;quot;&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you set the characters in the field to &lt;span style=&quot; font-weight:600;&quot;&gt;'&amp;quot;! &lt;/span&gt;which will mean it should stop selecting on ' &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; &amp;quot; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; ! then double-clicking on &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; will just select &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &amp;quot;&lt;span style=&quot; font-weight:600;&quot;&gt;Hello&lt;/span&gt;!&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter the characters you would like double-clicking to stop selecting text on here. If you do not enter any, double-clicking on a word will only stop at a space, and will include characters like a double or a single quote. For example, double-clicking on the word &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; in the following will select &lt;span style=&quot; font-style:italic;&quot;&gt;&amp;quot;&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;quot;Hello!&amp;quot;&lt;/span&gt;&lt;/p&gt;&lt;p&gt;If you set the characters in the field to &lt;span style=&quot; font-weight:600;&quot;&gt;'&amp;quot;! &lt;/span&gt;which will mean it should stop selecting on ' &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; &amp;quot; &lt;span style=&quot; font-style:italic;&quot;&gt;or&lt;/span&gt; ! then double-clicking on &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt; will just select &lt;span style=&quot; font-style:italic;&quot;&gt;Hello&lt;/span&gt;&lt;/p&gt;&lt;p&gt;You say, &amp;quot;&lt;span style=&quot; font-weight:600;&quot;&gt;Hello&lt;/span&gt;!&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>'&quot;</string>
@@ -854,7 +851,7 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="color_view_tab">
+     <widget class="QWidget" name="tab_ColorView">
       <attribute name="title">
        <string>Color view</string>
       </attribute>
@@ -1245,7 +1242,7 @@ or some other computer model that has a small screen.</string>
            </layout>
           </item>
           <item row="6" column="0" colspan="4">
-           <spacer name="verticalSpacer_3">
+           <spacer name="verticalSpacer_ColorView">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -1285,7 +1282,7 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="mapper_tab">
+     <widget class="QWidget" name="tab_Mapper">
       <attribute name="title">
        <string>Mapper</string>
       </attribute>
@@ -1364,9 +1361,6 @@ or some other computer model that has a small screen.</string>
          <layout class="QGridLayout" name="gridLayout_23">
           <item row="0" column="0">
            <widget class="QLabel" name="label_11">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On MUDs that provide maps for download (currently IRE games only), you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
             <property name="text">
              <string>Download latest map provided by your MUD:</string>
             </property>
@@ -1375,7 +1369,7 @@ or some other computer model that has a small screen.</string>
           <item row="0" column="1">
            <widget class="QPushButton" name="buttonDownloadMap">
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On MUDs that provide maps for download (currently IRE games only), you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;On MUDs that provide maps for download (currently IRE games only), you can press this button to get the latest map. Note that this will &lt;span style=&quot; font-weight:600;&quot;&gt;overwrite&lt;/span&gt; any changes you've done to your map, and will use the new map only.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Download</string>
@@ -1438,7 +1432,7 @@ or some other computer model that has a small screen.</string>
         </widget>
        </item>
        <item row="4" column="0">
-        <spacer name="mapper_tab_bottom_spacer">
+        <spacer name="verticalSpace_Mapper">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -1452,7 +1446,7 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_4">
+     <widget class="QWidget" name="tab_MapperColors">
       <attribute name="title">
        <string>Mapper colors</string>
       </attribute>
@@ -1489,7 +1483,7 @@ or some other computer model that has a small screen.</string>
           <item row="0" column="0">
            <widget class="QLabel" name="label_39">
             <property name="text">
-             <string>Link color</string>
+             <string>Link color:</string>
             </property>
            </widget>
           </item>
@@ -1805,30 +1799,17 @@ or some other computer model that has a small screen.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_3">
+     <widget class="QWidget" name="tab_SpecialOptions">
       <attribute name="title">
        <string>Special Options</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_7">
-       <item row="1" column="0">
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
+      <layout class="QGridLayout" name="gridLayout_SpecialOptions">
        <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_7">
+        <widget class="QGroupBox" name="groupBox_SpecialOptions">
          <property name="title">
           <string>Special options needed for some older MUD drivers (needs client restart to take effect)</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <layout class="QVBoxLayout" name="verticalLayout_SpecialOptions">
           <item>
            <widget class="QCheckBox" name="mFORCE_MCCP_OFF">
             <property name="text">
@@ -1846,8 +1827,8 @@ or some other computer model that has a small screen.</string>
           <item>
            <widget class="QCheckBox" name="checkBox_mUSE_FORCE_LF_AFTER_PROMPT">
             <property name="toolTip">
-             <string>This option adds a line line break &lt;LF&gt; or &quot;
-&quot; to your command input on empty commands. This option will rarely be necessary.</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option adds a line line break &lt;LF&gt; or &quot;
+&quot; to your command input on empty commands. This option will rarely be necessary.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
              <string>Force new line on empty commands</string>
@@ -1888,12 +1869,51 @@ or some other computer model that has a small screen.</string>
          </layout>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="groupBox_Debug">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Debug options, for run-time control of test/development features.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_debug"/>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer_SpecialOptions">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget" native="true">
+    <widget class="QWidget" name="widget_BottomButtons" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>


### PR DESCRIPTION
Is fix for bug [1413435 {Ghost exits left in the Exits dialog when a room is deleted}](https://bugs.launchpad.net/mudlet/+bug/1413435) - done in a different way to what Chris originally started out doing as it now stores the room entrance information (in a pair of QSets) in the TRoom instance itself rather than a central table in the TRoomDB class.  All uses of (TRoom \*)->setExit( roomId, direction ) now update the room on the other end of the exit as appropriate.  Loses all the inline (TRoom \*)->set{North|NorthEast|...|Out}( roomId ) but the getters remain.  Room Deletion uses information to update rooms on other ends of a route - both exits and entrances.  Bulk deletion by deletion of Area or selection in Mapper optimised by skipping the unnecessary route updates on rooms that are to be deleted anyhow.  *In empirical testing with the room_deletion_bug_map.dat file (which I can't find where I got it from :blush:) which has 69K rooms with 40K odd of them in area 255 the "Wilderness" area it took 150 seconds to delete all the rooms on my system in that area without that optimisation compared to, at most ten seconds.*

**Due to the need to regenerate the entrance data on current format files each time they are loaded means the time to load can be *significant* and when combined with the recent fix for area exits also needing to be rebuilt on loading has forced a need to update the Map File Format to save the entrance data in the rooms so it does NOT need to be built each time - only once - but we may get complaints about this :cry: .**

To warn the user that at least something is happening the busy cursor will switch in if processing a section takes more than a fraction of a second so the user doe get a hint of something happening - this is part of the second commit.

**To cover our bases though with the problem of a new file format not being readable by old (current) code, the third of the three commits provides a run-time workaround for the problem by enabling Mudlet to save in the previous version format.  For safety this is automatically set to be disabled on release builds but enable on, say, this preview branch - which by default on the latter means they will save in the older, slower to load/process file format to be compatible with being able to share the file with others or use with another installed system version - but it can be toggled by a tool-tipped option on the last tab of the profile preferences dialog.**

The fourth commit gives the user or their scripts access to the room entrance data ```getAllRoomEntrances( roomId )``` for all entrances (both special and normal in one command) and a matching ```getAllRoomExits( roomId )``` for all exits, as, surprisingly, there is not a _single_ command to do that.  This fourth commit is the functional difference between this Pull Request and #246.