### PR TITLE
Remove some Mudlet 1.0 cruft.

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -682,7 +682,7 @@ void dlgTriggerEditor::closeEvent(QCloseEvent *event)
 
 void dlgTriggerEditor::readSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "mudlet");
     QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize( size );
@@ -691,7 +691,7 @@ void dlgTriggerEditor::readSettings()
 
 void dlgTriggerEditor::writeSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "mudlet");
     settings.setValue("script_editor_pos", pos());
     settings.setValue("script_editor_size", size());
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1668,7 +1668,7 @@ void mudlet::closeEvent(QCloseEvent *event)
 
 void mudlet::readSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "mudlet");
     QPoint pos = settings.value("pos", QPoint(0, 0)).toPoint();
     QSize size = settings.value("size", QSize(750, 550)).toSize();
     mMainIconSize = settings.value("mainiconsize",QVariant(3)).toInt();
@@ -1717,7 +1717,7 @@ void mudlet::setIcoSize( int s )
 
 void mudlet::writeSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "mudlet");
     settings.setValue("pos", pos());
     settings.setValue("size", size());
     settings.setValue("mainiconsize", mMainIconSize);


### PR DESCRIPTION
Under Linux (possibly OSX too) ~/.config/mudlet/ and ~/.config/Mudlet/ are created. The ~/.config/Mudlet/ seems unneeded as it only contains "Mudlet 1.0.conf". This moves ~/.config/Mudlet/Mudlet 1.0.conf to ~/.config/mudlet/mudlet.conf