### PR TITLE
Fix for exit map being out of sync

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2988,11 +2988,10 @@ void T2DMap::slot_setImage()
 
 void T2DMap::slot_deleteRoom()
 {
+    mpMap->mpRoomDB->removeRoom( mMultiSelectionList );
+    // mMultiSelectionList gets cleared as rooms are removed by
+    // TRoomDB::removeRoom() so no need to clear it here!
     mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
-    {
-        mpMap->mpRoomDB->removeRoom( mMultiSelectionList[j] );
-    }
     mMultiSelectionListWidget.clear();
     mMultiSelectionListWidget.hide();
     repaint();

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -29,7 +29,7 @@
 #include "pre_guard.h"
 #include <QApplication>
 #include <QDebug>
-#include <QTime>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 // Previous direction #defines here did not match the DIR_ defines in TRoom.h,
@@ -254,6 +254,9 @@ void TArea::determineAreaExitsOfRoom( int id )
 
 void TArea::determineAreaExits()
 {
+    QElapsedTimer timer;
+    timer.start();
+
     exits.clear();
     for( int i=0; i<rooms.size(); i++ ) {
         TRoom * pR = mpRoomDB->getRoom(rooms[i]);
@@ -337,6 +340,7 @@ void TArea::determineAreaExits()
         }
     }
     //qDebug()<<"exits:"<<exits.size();
+    qDebug() << "TArea::determineAreaExits() area"<< mpRoomDB->getAreaID(this) << "took:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 void TArea::fast_calcSpan( int id )
@@ -517,12 +521,18 @@ void TArea::calcSpan()
 
 void TArea::removeRoom( int room )
 {
-    QTime time;
-    time.start();
+    static double cumulativeMean = 0.0;
+    static quint64 runCount = 0 ;
+    QElapsedTimer timer;
+    timer.start();
 //    TRoom * pR = mpRoomDB->getRoom( room );
     rooms.removeOne( room );
     exits.remove( room );
-    qDebug()<<"Area removal took"<<time.elapsed();
+    quint64 thisTime = timer.nsecsElapsed();
+    cumulativeMean += ( ( (thisTime * 1.0e-9) - cumulativeMean) / ++runCount );
+    if( runCount % 1000 == 0 ) {
+        qDebug()<<"TArea::removeRoom(" << room << ") from Area took" << thisTime * 1.0e-9 << "sec. this time and after" << runCount << "times the average is" << cumulativeMean << "sec.";
+    }
 //    int x = pR->x;
 //    int y = pR->y*-1;
 //    int z = pR->z;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7930,7 +7930,6 @@ int TLuaInterpreter::addSpecialExit( lua_State * L )
     {
         pR_from->setSpecialExit( id_to, _dir );
         pR_from->setSpecialExitLock( id_to, _dir, false );
-        pHost->mpMap->mMapGraphNeedsUpdate = true;
     }
     return 0;
 }
@@ -7965,7 +7964,6 @@ int TLuaInterpreter::removeSpecialExit( lua_State * L )
     if( pR )
     {
         pR->setSpecialExit( -1, _dir );
-        pHost->mpMap->mMapGraphNeedsUpdate = true;
     }
     return 0;
 }
@@ -8010,7 +8008,6 @@ int TLuaInterpreter::clearSpecialExits( lua_State * L )
     if( pR )
     {
         pR->clearSpecialExits();
-        pHost->mpMap->mMapGraphNeedsUpdate = true;
     }
     return 0;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3948,6 +3948,54 @@ int TLuaInterpreter::getRoomExits( lua_State *L )
         return 0;
 }
 
+// Give a room Id number returns a lua list (monotonically increasing keys
+// starting at 1) with (sorted) values being room Id numbers that have exit(s)
+// that enter the given room (even one way routes).
+// TODO: Provide exit details:
+int TLuaInterpreter::getAllRoomEntrances( lua_State *L )
+{
+    int roomId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "getAllRoomEntrances: bad argument #1 type (room Id, as number expected, got %1)." ).arg( luaL_typename(L, 1)).toUtf8().constData());
+        lua_error( L );
+    }
+    else {
+       roomId = lua_tonumber( L, 1 );
+    }
+
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllRoomEntrances: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllRoomEntrances: no map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
+    else {
+        TRoom * pR = pHost->mpMap->mpRoomDB->getRoom(roomId);
+        if( ! pR ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "getAllRoomEntrances: bad argument #1 value (number %1 is not a valid room Id)." ).arg(roomId).toUtf8().constData() );
+            return 2;
+        }
+        lua_newtable(L);
+        QList<int> entrances = pHost->mpMap->mpRoomDB->getEntranceHash().values( roomId );
+        // Could use a .toSet().toList() to remove duplicates values
+        if( entrances.count() > 1 ) {
+            std::sort( entrances.begin(), entrances.end() );
+        }
+        for( uint i = 0; i < entrances.size(); i++ ) {
+            lua_pushnumber( L, i+1 );
+            lua_pushnumber( L, entrances.at( i ) );
+            lua_settable(L, -3);
+        }
+        return 1;
+    }
+}
+
 int TLuaInterpreter::searchRoom( lua_State *L )
 {
     int room_id = 0;
@@ -11080,6 +11128,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "getCustomLines", TLuaInterpreter::getCustomLines );
     lua_register( pGlobalLua, "getMudletVersion", TLuaInterpreter::getMudletVersion );
     lua_register( pGlobalLua, "openWebPage", TLuaInterpreter::openWebPage);
+    lua_register( pGlobalLua, "getAllRoomEntrances", TLuaInterpreter::getAllRoomEntrances );
 
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -379,6 +379,7 @@ public:
     static int getMapMenus(lua_State * L);
     static int getMudletVersion( lua_State * L );
     static int openWebPage( lua_State * L );
+    static int getAllRoomEntrances( lua_State * L );
 
     std::list<std::string> mCaptureGroupList;
     std::list<int> mCaptureGroupPosList;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -34,6 +34,7 @@
 #include "pre_guard.h"
 #include <QDebug>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFileDialog>
 #include <QMainWindow>
 #include <QMessageBox>
@@ -328,7 +329,7 @@ bool TMap::setExit( int from, int to, int dir )
 void TMap::init( Host * pH )
 {
     // init areas
-    QTime _time;
+    QElapsedTimer _time;
     _time.start();
 
     if( version < 14 ) {
@@ -384,7 +385,7 @@ void TMap::init( Host * pH )
             }
         }
     }
-    qDebug("TMap::init() Initialize run time:%i milli-seconds.", _time.elapsed() );
+    qDebug() << "TMap::init() Initialize run time:" << _time.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 
@@ -1079,7 +1080,8 @@ bool TMap::serialize( QDataStream & ofs )
 bool TMap::restore(QString location)
 {
     qDebug()<<"restoring map of profile:"<<mpHost->getName()<<" url:"<<mpHost->getUrl();
-    QTime _time; _time.start();
+    QElapsedTimer _time;
+    _time.start();
     QString folder;
     QStringList entries;
     qDebug()<<"RESTORING MAP";
@@ -1242,7 +1244,7 @@ bool TMap::restore(QString location)
         customEnvColors[270] = mpHost->mLightCyan_2;
         customEnvColors[271] = mpHost->mLightWhite_2;
         customEnvColors[272] = mpHost->mLightBlack_2;
-        qDebug()<<"LOADED rooms:"<<mpRoomDB->size()<<" loading time:"<<_time.elapsed();
+        qDebug() << "TMap::restore() Loaded" << mpRoomDB->size() << "rooms in:" << _time.nsecsElapsed()* 1.0e-9 << "sec.";
         if( canRestore )
         {
             return true;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -257,6 +257,7 @@ int TMap::createNewRoomID()
 
 bool TMap::setExit( int from, int to, int dir )
 {
+    // FIXME: This along with TRoom->setExit need to be unified to a controller.
     TRoom * pR = mpRoomDB->getRoom( from );
     TRoom * pR_to = mpRoomDB->getRoom( to );
 
@@ -320,6 +321,7 @@ bool TMap::setExit( int from, int to, int dir )
         return false;
     }
     pA->determineAreaExitsOfRoom(pR->getId());
+    mpRoomDB->updateEntranceMap(pR);
     return ret;
 }
 
@@ -1071,7 +1073,6 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pR->getExitWeights();
         ofs << pR->doors;
     }
-
     return true;
 }
 
@@ -1222,10 +1223,8 @@ bool TMap::restore(QString location)
             int i;
             ifs >> i;
             TRoom * pT = new TRoom(mpRoomDB);
-            mpRoomDB->restoreSingleRoom( ifs, i, pT );
             pT->restore( ifs, i, version );
-
-
+            mpRoomDB->restoreSingleRoom( ifs, i, pT );
         }
         customEnvColors[257] = mpHost->mRed_2;
         customEnvColors[258] = mpHost->mGreen_2;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -244,21 +244,24 @@ bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
 
 bool TRoom::setExit( int to, int direction )
 {
+    // FIXME: This along with TRoom->setExit need to be unified to a controller.
     switch(direction){
-    case DIR_NORTH:     north     = to; return true; break;
-    case DIR_NORTHEAST: northeast = to; return true; break;
-    case DIR_NORTHWEST: northwest = to; return true; break;
-    case DIR_EAST:      east      = to; return true; break;
-    case DIR_WEST:      west      = to; return true; break;
-    case DIR_SOUTH:     south     = to; return true; break;
-    case DIR_SOUTHEAST: southeast = to; return true; break;
-    case DIR_SOUTHWEST: southwest = to; return true; break;
-    case DIR_UP:        up        = to; return true; break;
-    case DIR_DOWN:      down      = to; return true; break;
-    case DIR_IN:        in        = to; return true; break;
-    case DIR_OUT:       out       = to; return true;
+    case DIR_NORTH:     north     = to; break;
+    case DIR_NORTHEAST: northeast = to; break;
+    case DIR_NORTHWEST: northwest = to; break;
+    case DIR_EAST:      east      = to; break;
+    case DIR_WEST:      west      = to; break;
+    case DIR_SOUTH:     south     = to; break;
+    case DIR_SOUTHEAST: southeast = to; break;
+    case DIR_SOUTHWEST: southwest = to; break;
+    case DIR_UP:        up        = to; break;
+    case DIR_DOWN:      down      = to; break;
+    case DIR_IN:        in        = to; break;
+    case DIR_OUT:       out       = to; break;
+    default: return false;
     }
-    return false;
+    mpRoomDB->updateEntranceMap(this);
+    return true;
 }
 
 // Original code unused - checked all the normal exits to see if there is one to
@@ -584,7 +587,14 @@ void TRoom::setSpecialExit( int to, QString cmd )
         pA->determineAreaExitsOfRoom( id );
         // This updates the (TArea *)->exits map even for exit REMOVALS
     }
+    mpRoomDB->updateEntranceMap(this);
+    mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
+}
 
+void TRoom::clearSpecialExits(){
+    other.clear();
+    mpRoomDB->updateEntranceMap(this);
+    mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
 }
 
 void TRoom::removeAllSpecialExitsToRoom( int _id )
@@ -604,6 +614,8 @@ void TRoom::removeAllSpecialExitsToRoom( int _id )
     {
         pA->determineAreaExitsOfRoom( id );
     }
+    mpRoomDB->updateEntranceMap(this);
+    mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
 }
 
 void TRoom::calcRoomDimensions()

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -31,7 +31,7 @@
 #include <QDataStream>
 #include <QDebug>
 #include <QStringBuilder>
-#include <QTime>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 
@@ -70,10 +70,16 @@ TRoom::TRoom(TRoomDB * pRDB)
 
 TRoom::~TRoom()
 {
-    QTime timer;
+    static double cumulativeMean = 0.0;
+    static quint64 runCount = 0 ;
+    QElapsedTimer timer;
     timer.start();
     mpRoomDB->__removeRoom( id );
-    qDebug()<<"room destructor took"<<timer.elapsed();
+    quint64 thisTime = timer.nsecsElapsed();
+    cumulativeMean += ( ( (thisTime * 1.0e-9) - cumulativeMean) / ++runCount );
+    if( runCount % 1000 == 0 ) {
+        qDebug()<<"TRoom::~TRoom() took" << thisTime * 1.0e-9 << "Sec this time and after" << runCount <<"times the average is" << cumulativeMean << "Sec.";
+    }
 }
 
 bool TRoom::hasExitStub(int direction)

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -69,7 +69,7 @@ public:
     bool hasSpecialExitLock( int, QString );
     void removeAllSpecialExitsToRoom(int _id );
     void setSpecialExit( int to, QString cmd );
-    void clearSpecialExits() { other.clear(); }
+    void clearSpecialExits();
     const QMultiMap<int, QString> & getOtherMap() const { return other; }
     const QMap<QString, int> & getExitWeights() const { return exitWeights; }
     void setExitWeight( QString cmd, int w );

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -89,8 +89,10 @@ void TRoomDB::updateEntranceMap(int id){
 }
 
 void TRoomDB::updateEntranceMap(TRoom * pR){
-    // entranceMap maps the room to rooms it has a viable exit to
-    // so {room_a: room_b, room_a: room_c} and so on. This allows us to delete
+    // entranceMap maps the room to rooms it has a viable exit to. So if room b and c both have
+    // an exit to room a, upon deleting room a we want a map that allows us to find
+    // room b and c efficiently.
+    // So we create a mapping like: {room_a: room_b, room_a: room_c}. This allows us to delete
     // rooms and know which other rooms are impacted by this change in a single lookup.
     if(pR){
         int id = pR->getId();
@@ -98,7 +100,7 @@ void TRoomDB::updateEntranceMap(TRoom * pR){
         QList<int> toExits = exits.keys();
         entranceMap.remove(id);
         for (int i = 0; i < toExits.size(); i++)
-           entranceMap.insert(id, toExits[i]);
+           entranceMap.insert(toExits.at(i), id);
     }
 }
 
@@ -108,6 +110,7 @@ bool TRoomDB::__removeRoom( int id )
     TRoom* pR = getRoom(id);
     if (pR) {
         // FIXME: make a proper exit controller so we don't need to do all these if statements
+        // Remove the links from the rooms entering this room
         QMultiHash<int, int>::iterator i = entranceMap.find(id);
         while (i != entranceMap.end() && i.key() == id) {
             TRoom* r = getRoom(i.value());

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -98,7 +98,11 @@ void TRoomDB::updateEntranceMap(TRoom * pR){
         int id = pR->getId();
         QHash<int, int> exits = pR->getExits();
         QList<int> toExits = exits.keys();
-        entranceMap.remove(id);
+        // to update this we need to iterate the entire entranceMap and remove invalid
+        // connections. I'm not sure if this is efficient for every update, and given
+        // that we check for rooms existance when the map is used, we'll deal with
+        // possible spurious exits for now.
+        //entranceMap.remove(id);
         for (int i = 0; i < toExits.size(); i++)
            entranceMap.insert(toExits.at(i), id);
     }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -28,12 +28,13 @@
 
 #include "pre_guard.h"
 #include <QDebug>
-#include <QTime>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 
 TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
+, mpTempRoomDeletionList( 0 )
 {
 }
 
@@ -68,13 +69,13 @@ bool TRoomDB::addRoom( int id )
     }
 }
 
-bool TRoomDB::addRoom( int id, TRoom * pR )
+bool TRoomDB::addRoom( int id, TRoom * pR, bool isMapLoading )
 {
     if( !rooms.contains( id ) && id > 0 && pR )
     {
         rooms[id] = pR;
         pR->setId(id);
-        updateEntranceMap(pR);
+        updateEntranceMap(pR, isMapLoading);
         return true;
     }
     else
@@ -83,12 +84,51 @@ bool TRoomDB::addRoom( int id, TRoom * pR )
     }
 }
 
-void TRoomDB::updateEntranceMap(int id){
+void TRoomDB::deleteValuesFromEntranceMap( int value )
+{
+    QList<int> keyList = entranceMap.keys();
+    QList<int> valueList = entranceMap.values();
+    QList<uint> deleteEntries;
+    uint index = valueList.indexOf( value );
+    while ( index != -1 ) {
+        deleteEntries.append( index );
+        index = valueList.indexOf( value, index + 1 );
+    }
+    for (int i = deleteEntries.size() - 1; i >= 0; --i ) {
+        entranceMap.remove( keyList.at(deleteEntries.at(i)), valueList.at(deleteEntries.at(i)) );
+    }
+}
+
+void TRoomDB::deleteValuesFromEntranceMap( QSet<int> & valueSet )
+{
+    QElapsedTimer timer;
+    timer.start();
+    QList<int> keyList = entranceMap.keys();
+    QList<int> valueList = entranceMap.values();
+    QList<uint> deleteEntries;
+    foreach(int roomId, valueSet) {
+        int index = valueList.indexOf( roomId );
+        while (index >= 0 ) {
+            deleteEntries.append( index );
+            index = valueList.indexOf( roomId, index + 1 );
+        }
+    }
+    for (uint i = 0; i < deleteEntries.size(); ++i) {
+        entranceMap.remove( keyList.at(deleteEntries.at(i)), valueList.at(deleteEntries.at(i)) );
+    }
+    qDebug() << "TRoomDB::deleteValuesFromEntranceMap() with a list of:" << valueSet.size() << "items, run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
+}
+
+void TRoomDB::updateEntranceMap(int id)
+{
     TRoom * pR = getRoom(id);
     updateEntranceMap(pR);
 }
 
-void TRoomDB::updateEntranceMap(TRoom * pR){
+void TRoomDB::updateEntranceMap(TRoom * pR, bool isMapLoading)
+{
+    static bool showDebug = false; // Enable this at runtime (set a breakpoint on it) for debugging!
+
     // entranceMap maps the room to rooms it has a viable exit to. So if room b and c both have
     // an exit to room a, upon deleting room a we want a map that allows us to find
     // room b and c efficiently.
@@ -98,25 +138,79 @@ void TRoomDB::updateEntranceMap(TRoom * pR){
         int id = pR->getId();
         QHash<int, int> exits = pR->getExits();
         QList<int> toExits = exits.keys();
+        QString values;
         // to update this we need to iterate the entire entranceMap and remove invalid
         // connections. I'm not sure if this is efficient for every update, and given
         // that we check for rooms existance when the map is used, we'll deal with
         // possible spurious exits for now.
-        //entranceMap.remove(id);
-        for (int i = 0; i < toExits.size(); i++)
-           entranceMap.insert(toExits.at(i), id);
+        // entranceMap.remove(id); // <== not what is wanted
+        // We need to remove all values == id NOT keys == id, so try and do that
+        // now. SlySven
+
+        if( ! isMapLoading ) {
+            deleteValuesFromEntranceMap( id ); // When LOADING a map, will never need to do this
+        }
+        for (int i = 0; i < toExits.size(); i++) {
+            if( showDebug ) {
+                values.append( QStringLiteral("%1,").arg(toExits.at(i)) );
+            }
+            entranceMap.insert(toExits.at(i), id);
+        }
+        if( showDebug ) {
+            if( ! values.isEmpty() ) {
+                values.chop(1);
+            }
+            if( values.isEmpty() ) {
+                qDebug( "TRoomDB::updateEntranceMap(TRoom * pR) called for room with Id:%i, it is not an Entrance for any Rooms.", id );
+            }
+            else {
+                qDebug( "TRoomDB::updateEntranceMap(TRoom * pR) called for room with Id:%i, it is an Entrance for Room(s): %s.", id, values.toLatin1().constData() );
+            }
+        }
     }
 }
 
 // this is call by TRoom destructor only
 bool TRoomDB::__removeRoom( int id )
 {
-    TRoom* pR = getRoom(id);
+    static QMultiHash<int, int> _entranceMap; // Make it persistant - for multiple room deletions
+    static bool isBulkDelete = false;
+    // Gets set / reset by mpTempRoomDeletionList being non-null, used to setup
+    // _entranceMap the first time around for multi-room deletions
+
+    TRoom * pR = getRoom(id);
+    // This will FAIL during map deletion as TRoomDB::rooms has already been
+    // zapped, so can use to skip everything...
     if (pR) {
+        if( mpTempRoomDeletionList && mpTempRoomDeletionList->size() > 1 ) { // We are deleting multiple rooms
+            if( ! isBulkDelete ) {
+                _entranceMap = entranceMap;
+                _entranceMap.detach(); // MUST take a deep copy of the data
+                isBulkDelete = true; // But only do it the first time for a bulk delete
+            }
+        }
+        else { // We are deleting a single room
+            if( isBulkDelete ) { // Last time was a bulk delete but it isn't one now
+                isBulkDelete = false;
+            }
+            _entranceMap.clear();
+            _entranceMap = entranceMap; // Refresh our local copy
+            _entranceMap.detach(); // MUST take a deep copy of the data
+        }
+
         // FIXME: make a proper exit controller so we don't need to do all these if statements
         // Remove the links from the rooms entering this room
-        QMultiHash<int, int>::iterator i = entranceMap.find(id);
+        QMultiHash<int, int>::const_iterator i = _entranceMap.find(id);
+        // The removeAllSpecialExitsToRoom below modifies the entranceMap - and
+        // it is unsafe to modify (use copy operations on) something that an STL
+        // iterator is active on - see "Implicit sharing iterator problem" in
+        // "Container Class | Qt 5.x Core" - this is now avoid by taking a deep
+        // copy and iterating through that instead whilst modifying the original
         while (i != entranceMap.end() && i.key() == id) {
+            if( i.value() == id || mpTempRoomDeletionList && mpTempRoomDeletionList->size() > 1 && mpTempRoomDeletionList->contains( i.value() ) ) {
+                ++i;
+                continue; // Bypass rooms we know are also to be deleted
+            }
             TRoom* r = getRoom(i.value());
             if (r) {
                 if (r->getNorth() == id)
@@ -160,7 +254,10 @@ bool TRoomDB::__removeRoom( int id )
         TArea * pA = getArea( areaID );
         if (pA)
             pA->removeRoom(id);
-        entranceMap.remove(id);
+        if( ( ! mpTempRoomDeletionList ) || mpTempRoomDeletionList->size() == 1 ) { // if NOT deleting multiple rooms
+            entranceMap.remove(id); // Only removes matching keys
+            deleteValuesFromEntranceMap(id); // Needed to remove matching values
+        }
         // Because we clear the graph in initGraph which will be called
         // if mMapGraphNeedsUpdate is true -- we don't need to
         // remove the vertex using clear_vertex and remove_vertex here
@@ -181,22 +278,49 @@ bool TRoomDB::removeRoom( int id )
     return false;
 }
 
+void TRoomDB::removeRoom( QList<int> & ids )
+{
+    QElapsedTimer timer;
+    timer.start();
+    QSet<int> deletedRoomIds;
+    mpTempRoomDeletionList = &ids; // Will activate "bulk room deletion" code
+                                   // When used by TLuaInterpreter::deleteArea()
+                                   // via removeArea(int) the list of rooms to
+                                   // delete - as suppplied by the reference
+                                   // type argument IS NOT CONSTANT - it is
+                                   // ALTERED by TArea::removeRoom( int room )
+                                   // for each room that is removed
+    quint64 roomcount = mpTempRoomDeletionList->size();
+    while( ! mpTempRoomDeletionList->isEmpty() ) {
+        int deleteRoomId = mpTempRoomDeletionList->first();
+        TRoom * pR = getRoom( deleteRoomId );
+        if( pR ) {
+            deletedRoomIds.insert( deleteRoomId );
+            delete pR;
+        }
+    }
+    foreach(int deleteRoomId, deletedRoomIds ) {
+        entranceMap.remove( deleteRoomId ); // This has been deferred from __removeRoom()
+    }
+    deleteValuesFromEntranceMap( deletedRoomIds );
+    mpTempRoomDeletionList->clear();
+    mpTempRoomDeletionList=0;
+    qDebug() << "TRoomDB::removeRoom(QList<int>) run time for" << roomcount << "rooms:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
+}
+
 bool TRoomDB::removeArea( int id )
 {
-    areaNamesMap.remove( id );
-    if( areas.contains( id ) )
-    {
-        TArea * pA = areas[id];
-        QList<int> rl;
-        for( int i=0; i< pA->rooms.size(); i++ )
-        {
-            rl.push_back( pA->rooms[i] );
+    if( areas.contains( id ) ) {
+        TArea * pA = areas.value( id );
+        if( ! rooms.isEmpty() ) {
+            removeRoom( pA->rooms ); // During map deletion rooms will already
+                                     // have been cleared so this would not
+                                     // be wanted to be done in that case.
         }
-        for( int i=0; i<rl.size(); i++ )
-        {
-            removeRoom( rl[i] );
-        }
-        areas.remove( id );
+        areaNamesMap.remove( id ); // During map deletion areaNamesMap will
+                                   // already have been cleared !!!
+        areas.remove( id ); // This means areas.clear() is not needed during map
+                            // deletion
 
         mpMap->mMapGraphNeedsUpdate = true;
         return true;
@@ -206,16 +330,30 @@ bool TRoomDB::removeArea( int id )
 
 bool TRoomDB::removeArea( QString name )
 {
-    if( areaNamesMap.values().contains( name ) )
-    {
-        return removeArea( areaNamesMap.key( name ) );
+    if( areaNamesMap.values().contains( name ) ) {
+        return removeArea( areaNamesMap.key( name ) ); // i.e. call the removeArea(int) method
     }
-    return false;
+    else {
+        return false;
+    }
 }
 
 void TRoomDB::removeArea( TArea * pA )
 {
-    removeArea( getAreaID(pA) );
+    if( ! pA ) {
+        qWarning( "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area with a NULL TArea pointer!" );
+        return;
+    }
+
+    int areaId = areas.key(pA, 0);
+    if( areaId == areas.key(pA, -1) ) {
+        // By testing twice with different default keys to return if value NOT
+        // found, we can be certain we have an actual valid value
+        removeArea( areaId );
+    }
+    else {
+        qWarning( "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area NOT in TRoomDB::areas!" );
+    }
 }
 
 int TRoomDB::getAreaID( TArea * pA )
@@ -225,7 +363,8 @@ int TRoomDB::getAreaID( TArea * pA )
 
 void TRoomDB::buildAreas()
 {
-    QTime _time; _time.start();
+    QElapsedTimer timer;
+    timer.start();
     QHashIterator<int, TRoom *> it( rooms );
     while( it.hasNext() )
     {
@@ -251,7 +390,7 @@ void TRoomDB::buildAreas()
            areas[id] = new TArea( mpMap, this );
        }
     }
-    qDebug()<<"BUILD AREAS run time:"<<_time.elapsed();
+    qDebug() << "TRoomDB::buildAreas() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 
@@ -365,7 +504,8 @@ QList<int> TRoomDB::getAreaIDList()
 
 void TRoomDB::auditRooms()
 {
-    QTime t; t.start();
+    QElapsedTimer timer;
+    timer.start();
     // rooms konsolidieren
     QHashIterator<int, TRoom* > itRooms( rooms );
     while( itRooms.hasNext() )
@@ -375,7 +515,7 @@ void TRoomDB::auditRooms()
         pR->auditExits();
 
     }
-    qDebug()<<"audit map: runtime:"<<t.elapsed();
+    qDebug() << "TRoomDB::auditRooms() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 void TRoomDB::initAreasForOldMaps()
@@ -403,24 +543,27 @@ void TRoomDB::initAreasForOldMaps()
 
 void TRoomDB::clearMapDB()
 {
+    QElapsedTimer timer;
+    timer.start();
     QList<TRoom*> rPtrL = getRoomPtrList();
-    rooms.clear();
+    rooms.clear(); // Prevents any further use of TRoomDB::getRoom(int) !!!
+    entranceMap.clear();
     areaNamesMap.clear();
     hashTable.clear();
-    for(int i=0; i<rPtrL.size(); i++ )
+    for( uint i=0; i<rPtrL.size(); i++ )
     {
-        delete rPtrL[i];
+        delete rPtrL.at(i); // Uses the internally held value of the room Id
+                            // (TRoom::id) to call TRoomDB::__removeRoom(id)
     }
-    assert( rooms.size() == 0 );
+//    assert( rooms.size() == 0 ); // Pointless as rooms.clear() will have achieved the test condition
 
     QList<TArea*> areaList = getAreaPtrList();
-    for( int i=0; i<areaList.size(); i++ )
+    for( uint i=0; i<areaList.size(); i++ )
     {
-        delete areaList[i];
+        delete areaList.at(i);
     }
     assert( areas.size() == 0 );
-
-
+    qDebug() << "TRoomDB::clearMapDB() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 
@@ -436,5 +579,5 @@ void TRoomDB::restoreSingleArea(QDataStream & ifs, int areaID, TArea * pA )
 
 void TRoomDB::restoreSingleRoom(QDataStream & ifs, int i, TRoom *pT)
 {
-    addRoom(i, pT);
+    addRoom(i, pT, true);
 }

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -59,6 +59,8 @@ public:
     QList<int> getRoomIDList();
     QList<int> getAreaIDList();
     const QMap<int, QString> & getAreaNamesMap() const { return areaNamesMap; }
+    void updateEntranceMap(TRoom *);
+    void updateEntranceMap(int);
 
 
     void buildAreas();
@@ -80,7 +82,7 @@ private:
     bool __removeRoom( int id );
 
     QHash<int, TRoom *> rooms;
-    QMultiHash<int, int> reverseExitMap;
+    QMultiHash<int, int> entranceMap;
     QMap<int, TArea *> areas;
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -44,7 +44,8 @@ public:
 //     int getArea( TArea * pA ); use duplicate int getAreaID( TArea * pA ) instead
     bool addRoom( int id );
     int size() { return rooms.size(); }
-    bool removeRoom( int id );
+    bool removeRoom( int );
+    void removeRoom( QList<int> & );
     bool removeArea( int id );
     bool removeArea( QString name );
     void removeArea( TArea * );
@@ -59,15 +60,17 @@ public:
     QList<int> getRoomIDList();
     QList<int> getAreaIDList();
     const QMap<int, QString> & getAreaNamesMap() const { return areaNamesMap; }
-    void updateEntranceMap(TRoom *);
+    void updateEntranceMap(TRoom *, bool isMapLoading = false );
     void updateEntranceMap(int);
-
+    const QMultiHash<int, int> & getEntranceHash() const { return entranceMap; }
+    void deleteValuesFromEntranceMap( int );
+    void deleteValuesFromEntranceMap( QSet<int> & );
 
     void buildAreas();
     void clearMapDB();
     void initAreasForOldMaps();
     void auditRooms();
-    bool addRoom(int id, TRoom *pR);
+    bool addRoom(int id, TRoom *pR, bool isMapLoading = false);
     int getAreaID(TArea * pA);
     void restoreAreaMap( QDataStream & );
     void restoreSingleArea( QDataStream &, int, TArea * );
@@ -86,6 +89,7 @@ private:
     QMap<int, TArea *> areas;
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;
+    QList<int> * mpTempRoomDeletionList; // Used during bulk room deletion
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -254,7 +254,9 @@ void dlgRoomExits::save()
 
     if (nw->isEnabled() && nw->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != 0 ) {
         // There IS a valid exit on the dialogue in this direction
-        pR->setExit( nw->text().toInt(), DIR_NORTHWEST ); // So store it
+        if( originalExits.value( DIR_NORTHWEST )->destination != nw->text().toInt() ) {
+            pR->setExit( nw->text().toInt(), DIR_NORTHWEST ); // Destination is different - so store it
+        }
         if (pR->hasExitStub(DIR_NORTHWEST))   // And ensure that stub exit is cleared if set
             pR->setExitStub(DIR_NORTHWEST, false);
         if (weight_nw->value())  // And store any weighing specifed
@@ -262,7 +264,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "nw", 0);
     } else { // No valid exit on the dialogue
-        pR->setExit( -1, DIR_NORTHWEST ); // So ensure the value for no exit is stored
+        if( originalExits.value( DIR_NORTHWEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_NORTHWEST ); // Destination has been deleted So ensure the value for no exit is stored
+        }
         if (stub_nw->isChecked() != pR->hasExitStub(DIR_NORTHWEST))
             // Does the stub exit setting differ from what is stored
             pR->setExitStub(DIR_NORTHWEST, stub_nw->isChecked()); // So change stored idea to match
@@ -274,7 +278,9 @@ void dlgRoomExits::save()
     }
 
     if (n->isEnabled() && n->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != 0 ) {
-        pR->setExit( n->text().toInt(), DIR_NORTH );
+        if( originalExits.value( DIR_NORTH )->destination != n->text().toInt() ) {
+            pR->setExit( n->text().toInt(), DIR_NORTH );
+        }
         if (pR->hasExitStub(DIR_NORTH))
             pR->setExitStub(DIR_NORTH, false);
         if (weight_n->value())
@@ -282,7 +288,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "n", 0);
     } else {
-        pR->setExit( -1, DIR_NORTH );
+        if( originalExits.value( DIR_NORTH )->destination > 0 ) {
+            pR->setExit( -1, DIR_NORTH );
+        }
         if (stub_n->isChecked() != pR->hasExitStub(DIR_NORTH))
             pR->setExitStub(DIR_NORTH, stub_n->isChecked());
         pR->setExitWeight( "n", 0);
@@ -293,7 +301,9 @@ void dlgRoomExits::save()
     }
 
     if (ne->isEnabled() && ne->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != 0 ) {
-        pR->setExit( ne->text().toInt(), DIR_NORTHEAST );
+        if( originalExits.value( DIR_NORTHEAST )->destination != ne->text().toInt() ) {
+            pR->setExit( ne->text().toInt(), DIR_NORTHEAST );
+        }
         if (pR->hasExitStub(DIR_NORTHEAST))
             pR->setExitStub(DIR_NORTHEAST, false);
         if (weight_ne->value())
@@ -301,7 +311,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "ne", 0);
     } else {
-        pR->setExit( -1, DIR_NORTHEAST );
+        if( originalExits.value( DIR_NORTHEAST )->destination > 0 ) {
+            pR->setExit( -1, DIR_NORTHEAST );
+        }
         if (stub_ne->isChecked() != pR->hasExitStub(DIR_NORTHEAST))
             pR->setExitStub(DIR_NORTHEAST, stub_ne->isChecked());
         pR->setExitWeight( "ne", 0);
@@ -312,7 +324,9 @@ void dlgRoomExits::save()
     }
 
     if (up->isEnabled() && up->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != 0 ) {
-        pR->setExit( up->text().toInt(), DIR_UP );
+        if( originalExits.value( DIR_UP )->destination != up->text().toInt() ) {
+            pR->setExit( up->text().toInt(), DIR_UP );
+        }
         if (pR->hasExitStub(DIR_UP))
             pR->setExitStub(DIR_UP, false);
         if (weight_up->value())
@@ -320,7 +334,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "up", 0);
     } else {
-        pR->setExit( -1, DIR_UP );
+        if( originalExits.value( DIR_UP )->destination > 0 ) {
+            pR->setExit( -1, DIR_UP );
+        }
         if (stub_up->isChecked() != pR->hasExitStub(DIR_UP))
             pR->setExitStub(DIR_UP, stub_up->isChecked());
         pR->setExitWeight( "up", 0);
@@ -331,7 +347,9 @@ void dlgRoomExits::save()
     }
 
     if (w->isEnabled() && w->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != 0 ) {
-        pR->setExit( w->text().toInt(), DIR_WEST );
+        if( originalExits.value( DIR_WEST )->destination != w->text().toInt() ) {
+            pR->setExit( w->text().toInt(), DIR_WEST );
+        }
         if (pR->hasExitStub(DIR_WEST))
             pR->setExitStub(DIR_WEST, false);
         if (weight_w->value())
@@ -339,7 +357,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "w", 0);
     } else {
-        pR->setExit( -1, DIR_WEST );
+        if( originalExits.value( DIR_WEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_WEST );
+        }
         if (stub_w->isChecked() != pR->hasExitStub(DIR_WEST))
             pR->setExitStub(DIR_WEST, stub_w->isChecked());
         pR->setExitWeight( "w", 0);
@@ -350,7 +370,9 @@ void dlgRoomExits::save()
     }
 
     if (e->isEnabled() && e->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != 0 ) {
-        pR->setExit( e->text().toInt(), DIR_EAST );
+        if( originalExits.value( DIR_EAST )->destination != e->text().toInt() ) {
+            pR->setExit( e->text().toInt(), DIR_EAST );
+        }
         if (pR->hasExitStub(DIR_EAST))
             pR->setExitStub(DIR_EAST, false);
         if (weight_e->value())
@@ -358,7 +380,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "e", 0);
     } else {
-        pR->setExit( -1, DIR_EAST );
+        if( originalExits.value( DIR_EAST )->destination > 0 ) {
+            pR->setExit( -1, DIR_EAST );
+        }
         if (stub_e->isChecked() != pR->hasExitStub(DIR_EAST))
             pR->setExitStub(DIR_EAST, stub_e->isChecked());
         pR->setExitWeight( "e", 0);
@@ -369,7 +393,9 @@ void dlgRoomExits::save()
     }
 
     if (down->isEnabled() && down->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != 0 ) {
-        pR->setExit( down->text().toInt(), DIR_DOWN );
+        if( originalExits.value( DIR_DOWN )->destination != down->text().toInt() ) {
+            pR->setExit( down->text().toInt(), DIR_DOWN );
+        }
         if (pR->hasExitStub(DIR_DOWN))
             pR->setExitStub(DIR_DOWN, false);
         if (weight_down->value())
@@ -377,7 +403,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "down", 0);
     } else {
-        pR->setExit( -1, DIR_DOWN );
+        if( originalExits.value( DIR_DOWN )->destination > 0 ) {
+            pR->setExit( -1, DIR_DOWN );
+        }
         if (stub_down->isChecked() != pR->hasExitStub(DIR_DOWN))
             pR->setExitStub(DIR_DOWN, stub_down->isChecked());
         pR->setExitWeight( "down", 0);
@@ -388,7 +416,9 @@ void dlgRoomExits::save()
     }
 
     if (sw->isEnabled() && sw->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != 0 ) {
-        pR->setExit( sw->text().toInt(), DIR_SOUTHWEST );
+        if( originalExits.value( DIR_SOUTHWEST )->destination != sw->text().toInt() ) {
+            pR->setExit( sw->text().toInt(), DIR_SOUTHWEST );
+        }
         if (pR->hasExitStub(DIR_SOUTHWEST))
             pR->setExitStub(DIR_SOUTHWEST, false);
         if (weight_sw->value())
@@ -396,7 +426,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "sw", 0);
     } else {
-        pR->setExit( -1, DIR_SOUTHWEST );
+        if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_SOUTHWEST );
+        }
         if (stub_sw->isChecked() != pR->hasExitStub(DIR_SOUTHWEST))
             pR->setExitStub(DIR_SOUTHWEST, stub_sw->isChecked());
         pR->setExitWeight( "sw", 0);
@@ -407,7 +439,9 @@ void dlgRoomExits::save()
     }
 
     if (s->isEnabled() && s->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != 0 ) {
-        pR->setExit( s->text().toInt(), DIR_SOUTH );
+        if( originalExits.value( DIR_SOUTH )->destination != s->text().toInt() ) {
+            pR->setExit( s->text().toInt(), DIR_SOUTH );
+        }
         if (pR->hasExitStub(DIR_SOUTH))
             pR->setExitStub(DIR_SOUTH, false);
         if (weight_s->value())
@@ -415,7 +449,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "s", 0);
     } else {
-        pR->setExit( -1, DIR_SOUTH );
+        if( originalExits.value( DIR_SOUTH )->destination > 0 ) {
+            pR->setExit( -1, DIR_SOUTH );
+        }
         if (stub_s->isChecked() != pR->hasExitStub(DIR_SOUTH))
             pR->setExitStub(DIR_SOUTH, stub_s->isChecked());
         pR->setExitWeight( "s", 0);
@@ -426,7 +462,9 @@ void dlgRoomExits::save()
     }
 
     if (se->isEnabled() && se->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != 0 ) {
-        pR->setExit( se->text().toInt(), DIR_SOUTHEAST );
+        if( originalExits.value( DIR_SOUTHEAST )->destination != se->text().toInt() ) {
+            pR->setExit( se->text().toInt(), DIR_SOUTHEAST );
+        }
         if (pR->hasExitStub(DIR_SOUTHEAST))
             pR->setExitStub(DIR_SOUTHEAST, false);
         if (weight_se->value())
@@ -434,7 +472,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "se", 0);
     } else {
-        pR->setExit( -1, DIR_SOUTHEAST );
+        if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_SOUTHEAST );
+        }
         if (stub_se->isChecked() != pR->hasExitStub(DIR_SOUTHEAST))
             pR->setExitStub(DIR_SOUTHEAST, stub_se->isChecked());
         pR->setExitWeight( "se", 0);
@@ -445,7 +485,9 @@ void dlgRoomExits::save()
     }
 
     if (in->isEnabled() && in->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != 0 ) {
-        pR->setExit( in->text().toInt(), DIR_IN );
+        if( originalExits.value( DIR_IN )->destination != in->text().toInt() ) {
+            pR->setExit( in->text().toInt(), DIR_IN );
+        }
         if (pR->hasExitStub(DIR_IN))
             pR->setExitStub(DIR_IN, false);
         if (weight_in->value())
@@ -453,7 +495,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "in", 0);
     } else {
-        pR->setExit( -1, DIR_IN );
+        if( originalExits.value( DIR_IN )->destination > 0 ) {
+            pR->setExit( -1, DIR_IN );
+        }
         if (stub_in->isChecked() != pR->hasExitStub(DIR_IN))
             pR->setExitStub(DIR_IN, stub_in->isChecked());
         pR->setExitWeight( "in", 0);
@@ -464,7 +508,9 @@ void dlgRoomExits::save()
     }
 
     if (out->isEnabled() && out->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != 0 ) {
-        pR->setExit( out->text().toInt(), DIR_OUT );
+        if( originalExits.value( DIR_OUT )->destination != out->text().toInt() ) {
+            pR->setExit( out->text().toInt(), DIR_OUT );
+        }
         if (pR->hasExitStub(DIR_OUT))
             pR->setExitStub(DIR_OUT, false);
         if (weight_out->value())
@@ -472,7 +518,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( "out", 0);
     } else {
-        pR->setExit( -1, DIR_OUT );
+        if( originalExits.value( DIR_OUT )->destination > 0 ) {
+            pR->setExit( -1, DIR_OUT );
+        }
         if (stub_out->isChecked() != pR->hasExitStub(DIR_OUT))
             pR->setExitStub(DIR_OUT, stub_out->isChecked());
         pR->setExitWeight( "out", 0);
@@ -1462,6 +1510,14 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
     default:
         qWarning("dlgRoomExits::initExit roomId(%i) unexpected doors[\"%s\"] value:%i found for room!",
                  roomId, qPrintable( doorText ), pR->getDoor( doorText ) );
+    }
+
+    if ( exitId > 0 ) {
+        if( ! mpHost->mpMap->mpRoomDB->getRoom( exitId ) ) {
+            // Recover from a missing exit room - not doing this was causing seg. faults
+            qWarning("dlgRoomExits::initExit: Warning: missing exit to %i in direction %s, resetting exit.", exitId, weightText.toUtf8().constData() );
+            exitId = -1;
+        }
     }
 
     if ( exitId > 0 ) { //Does this exit point anywhere


### PR DESCRIPTION
This is my way to address https://bugs.launchpad.net/mudlet/+bug/1413435. It's an updated version of #249 .

It's a fix for keeping reverse area exit map in sync with exit creation/modification, room adding, and deletion. It also uses the nomenclature of entraceMap as suggested by @SlySven because I forgot what reverseExitMap meant as well :).