### PR TITLE
Add function getCmdLine()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9865,6 +9865,14 @@ int TLuaInterpreter::appendCmdLine( lua_State * L )
     return 0;
 }
 
+int TLuaInterpreter::getCmdLine( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    QString curText = pHost->mpConsole->mpCommandLine->toPlainText();
+    lua_pushstring( L, curText.toLatin1().data() );
+    return 1;
+}
+
 int TLuaInterpreter::installPackage( lua_State * L )
 {
     string event;
@@ -11346,6 +11354,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "clearRoomUserDataItem", TLuaInterpreter::clearRoomUserDataItem );
     lua_register( pGlobalLua, "downloadFile", TLuaInterpreter::downloadFile );
     lua_register( pGlobalLua, "appendCmdLine", TLuaInterpreter::appendCmdLine );
+    lua_register( pGlobalLua, "getCmdLine", TLuaInterpreter::getCmdLine );
     lua_register( pGlobalLua, "openUrl", TLuaInterpreter::openUrl );
     lua_register( pGlobalLua, "sendSocket", TLuaInterpreter::sendSocket );
     lua_register( pGlobalLua, "setRoomIDbyHash", TLuaInterpreter::setRoomIDbyHash );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9869,7 +9869,7 @@ int TLuaInterpreter::getCmdLine( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     QString curText = pHost->mpConsole->mpCommandLine->toPlainText();
-    lua_pushstring( L, curText.toLatin1().data() );
+    lua_pushstring( L, curText.toUtf8().constData() );
     return 1;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -191,6 +191,7 @@ public:
     static int getSpecialExits( lua_State * );
     static int getSpecialExitsSwap( lua_State * );
     static int appendCmdLine( lua_State * );
+    static int getCmdLine( lua_State * L );
     static int clearSpecialExits( lua_State * );
     static int solveRoomCollisions( lua_State * );
     static int setGridMode( lua_State * L );


### PR DESCRIPTION
Source: http://bc-dev.net/2013/02/23/mudlet-getcmdline-function/

This function was requested by an IRC user. While I usually don't jump at any request for new functions, the user mentioned this was a good way to increase accessability for disabled people, because they might need long for each keystroke. The user's usage example: 

> the way I do it is this c + keypad, cc + keypad, ccc +keypad, cccc +keypad the letter c stands for curing and the keypad num key determines what and the manner I cure,  prefer macros I type slower due to a disability