### PR TITLE
Added shortcut for keypad keys (comments)

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -105,6 +105,14 @@ bool TCommandLine::event( QEvent * event )
     if( event->type() == QEvent::KeyPress )
     {
         QKeyEvent *ke = static_cast<QKeyEvent *>( event );
+
+        // Shortcut for keypad keys
+        if(((int)ke->modifiers() & 0x20000000) && mpKeyUnit->processDataStream( ke->key(), (int)ke->modifiers() ) )
+        {
+            ke->accept();
+            return true;
+        }
+
         switch( ke->key() )
         {
             case Qt::Key_Space:

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -107,7 +107,7 @@ bool TCommandLine::event( QEvent * event )
         QKeyEvent *ke = static_cast<QKeyEvent *>( event );
 
         // Shortcut for keypad keys
-        if(((int)ke->modifiers() & 0x20000000) && mpKeyUnit->processDataStream( ke->key(), (int)ke->modifiers() ) )
+	if((ke->modifiers() & Qt::KeypadModifier) && mpKeyUnit->processDataStream( ke->key(), (int)ke->modifiers() ) )
         {
             ke->accept();
             return true;


### PR DESCRIPTION
On a full keyboard with a keypad, the special keys on the keypad are completely redundant.  Previously, much of the keypad couldn't be used because shift turns most of the buttons into these redundant special keys.  With this fix the buttons become available again.