### PR TITLE
(release_30)bugfix: typos in dlgColorTrigger messes up cyan and lWhite triggers

### DIFF
--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -335,7 +336,7 @@ void dlgColorTrigger::setColorCyan()
     {
         mpTrigger->mColorTriggerFg = true;
         mpTrigger->mColorTriggerFgAnsi = 14;
-        mpTrigger->mColorTriggerBgColor = mpTrigger->mpHost->mCyan;
+        mpTrigger->mColorTriggerFgColor = mpTrigger->mpHost->mCyan;
     }
     else
     {
@@ -427,7 +428,7 @@ void dlgColorTrigger::setColorLightWhite()
     {
         mpTrigger->mColorTriggerFg = true;
         mpTrigger->mColorTriggerFgAnsi = 15;
-        mpTrigger->mColorTriggerBgColor = mpTrigger->mpHost->mLightWhite;
+        mpTrigger->mColorTriggerFgColor = mpTrigger->mpHost->mLightWhite;
     }
     else
     {


### PR DESCRIPTION
Found these the hard way - in use - and it meant that one could not specify
a colour trigger to fire on cyan or light white (grey ?) - one of which was
just the colour I needed for a Mud that I had returned to after it had come
back after being off-line for more than six months - I'd always wondered
why I could never get my WoTMUD (now at game.wotmud.org:2224) room name
trigger to work...!

Using gitk blame it transpires that this bug dates to 03/11/2009 and
predates Mudlet version 1.0.1 !

Resolves bug [1103645](https://bugs.launchpad.net/mudlet/+bug/1103645), the patch I published there duplicates this PR. This PR duplicates https://github.com/Mudlet/Mudlet/pull/235 but it wasn't clear how to (or whether I even should) apply the same commit to multiple branches without creating separate Pull Requests for each branch.

Ideally would be back-ported to 2.1?

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>