### PR TITLE
(release_30)logicBombFix: remove useless and fatally recursive slot_ function

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -67,7 +67,6 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent) : QDialog(parent)
     connect( login_entry, SIGNAL(textEdited(const QString)), this, SLOT(slot_update_login(const QString)));
     connect( character_password_entry, SIGNAL(textEdited(const QString)), this, SLOT(slot_update_pass(const QString)));
     connect( mud_description_textedit, SIGNAL(textChanged()), this, SLOT(slot_update_description()));
-    connect( this, SIGNAL( update() ), this, SLOT( slot_update() ) );
     connect( profiles_tree_widget, SIGNAL( currentItemChanged( QListWidgetItem *, QListWidgetItem * ) ), this, SLOT( slot_item_clicked( QListWidgetItem * )));
     connect( profiles_tree_widget, SIGNAL( itemDoubleClicked( QListWidgetItem * ) ), this, SLOT ( accept() ) );
 
@@ -1293,11 +1292,6 @@ void dlgConnectionProfiles::slot_chose_history()
 
     emit signal_establish_connection( profile_name, -1 );
     QDialog::accept();
-}
-
-void dlgConnectionProfiles::slot_update()
-{
-    update();
 }
 
 bool dlgConnectionProfiles::validateConnect()

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -42,7 +42,6 @@ public:
 signals:
 
     void signal_establish_connection( QString profile_name, int historyVersion );
-    void update();
 
 public slots:
 
@@ -58,7 +57,6 @@ public slots:
     void slot_update_description();
 
     void slot_item_clicked( QListWidgetItem * );
-    void slot_update();
     void slot_addProfile();
     void slot_deleteProfile();
     void slot_reallyDeleteProfile();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -516,7 +516,6 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     mpSourceEditorArea->editor->setFont( mpHost->mDisplayFont );
 
     connect( comboBox_search_triggers, SIGNAL( activated( const QString )), this, SLOT(slot_search_triggers( const QString ) ) );
-    connect( this, SIGNAL( update() ), this, SLOT( slot_update() ) );
     connect( treeWidget, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_trigger_selected( QTreeWidgetItem *) ) );
     connect( treeWidget, SIGNAL( itemSelectionChanged()), this, SLOT( slot_tree_selection_changed()) );
     connect( treeWidget_keys, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_key_selected( QTreeWidgetItem *) ) );
@@ -6013,11 +6012,6 @@ void dlgTriggerEditor::expand_child_timers( TTimer * pTimerParent, QTreeWidgetIt
 
 void dlgTriggerEditor::slot_connection_dlg_finnished()
 {
-}
-
-void dlgTriggerEditor::slot_update()
-{
-    update();
 }
 
 void dlgTriggerEditor::slot_show_search_area()

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -110,8 +110,6 @@ public:
 signals:
 
     void                        signal_establish_connection( QString profile_name );
-    void                        accept();
-    void                        update();
 
 public slots:
     void                        slot_toggleHiddenVars();
@@ -154,7 +152,6 @@ public slots:
     void                        slot_alias_selected( QTreeWidgetItem *pItem );
     void                        slot_action_selected( QTreeWidgetItem * pItem );
     void                        slot_key_selected( QTreeWidgetItem *pItem );
-    void                        slot_update();
     void                        slot_connection_dlg_finnished();
     void                        slot_add_new();
     void                        slot_add_new_folder();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -107,9 +107,6 @@ public:
     void                        recurseVariablesDown( TVar *, QList< TVar * > &, int );
     void                        show_vars( );
 
-signals:
-
-    void                        signal_establish_connection( QString profile_name );
 
 public slots:
     void                        slot_toggleHiddenVars();


### PR DESCRIPTION
Connecting the (virtual, protected) update() signal to a slot that merely
calls the same thing makes any use of the update() method fatally
recursive.  This commit removes this misfeature from the two dialogs:
dlgConnectionProfile and dlgTriggerEditor that have it.

PR #257 does the same for the development branch

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>