### PR TITLE
BugFix: Treat and prevent further duplicate or empty map area names

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -135,9 +135,15 @@ void TMap::importMapFromDatabase()
 bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculations )
 {
     TRoom * pR = mpRoomDB->getRoom( id );
-
     if( !pR ) {
         QString msg = qApp->translate( "TMap", "RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!" ).arg(id).arg(area);
+        logError(msg);
+        return false;
+    }
+
+    TArea * pA = mpRoomDB->getArea( area );
+    if( ! pA ) {
+        QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
         logError(msg);
         return false;
     }

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -52,7 +53,7 @@ public:
     bool addArea(int id);
     int addArea( QString name );
     bool addArea( int id, QString name );
-    void setAreaName( int areaID, QString name );
+    bool setAreaName( int areaID, QString name );
     const QList<TRoom *> getRoomPtrList();
     const QList<TArea *> getAreaPtrList();
     const QHash<int, TRoom *> & getRoomMap() const { return rooms; }
@@ -90,6 +91,7 @@ private:
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;
     QList<int> * mpTempRoomDeletionList; // Used during bulk room deletion
+    QString mUnnamedAreaName;
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -141,22 +142,26 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
 void dlgMapper::updateAreaComboBox()
 {
-    QMapIterator<int, QString> it( mpMap->mpRoomDB->getAreaNamesMap() );
-    //sort them alphabetically (case sensitive)
-    QMap <QString, QString> areaNames;
-    while( it.hasNext() )
-    {
-        it.next();
-        QString name = it.value();
-        areaNames.insert(name.toLower(), name);
+    QMapIterator<int, QString> itAreaNamesA( mpMap->mpRoomDB->getAreaNamesMap() );
+    //insert sort them alphabetically (case INsensitive)
+    QMap <QString, QString> _areaNames;
+    while( itAreaNamesA.hasNext() ) {
+        itAreaNamesA.next();
+        uint deduplicate = 0;
+        QString _name;
+        do {
+            _name = QStringLiteral( "%1+%2" ).arg( itAreaNamesA.value().toLower() ).arg( ++deduplicate );
+            // Use a different suffix separator to one that area names
+            // deduplication uses ('_') - makes debugging easier?
+        } while( _areaNames.contains( _name ) );
+        _areaNames.insert( _name, itAreaNamesA.value() );
     }
-    //areaNames.sort();
-    QMapIterator<QString, QString> areaIt( areaNames );
+
     showArea->clear();
-    while( areaIt.hasNext() )
-    {
-        areaIt.next();
-        showArea->addItem( areaIt.value() );
+    QMapIterator<QString, QString> itAreaNamesB( _areaNames );
+    while( itAreaNamesB.hasNext() ) {
+        itAreaNamesB.next();
+        showArea->addItem( itAreaNamesB.value() );
     }
 }
 


### PR DESCRIPTION
Some steps had previously been taken to enforce no duplicate area names
when importing an XML map or when adding a new name but other mechanisms
were left unchecked, specifically this was when renaming an existing area.

This commit adds a number of validation steps to many of the lua functions
that manipulate areas and their names.  This includes taking steps when
creating a new TArea instance to ensure a suitable area name is created and
added to the areaNamesMap which may be overwritten if a valid (non-empty,
non-duplicate) name is provided at the time or later.  This avoids problems
with the Area selection widget on the 2 or 3D Map Display and the lua
getAreaTable() function, neither of which will handle duplicate area names
and for the former, does not handle nameless areas well either.  The
deleteArea() function could take either an area Id or a name as the target
of its action so the area that is to be deleted is now not subject to any
ambiguity if supplied as a name!

Should a map file be loaded where empty or duplicated area names are found
these will be "fixed" and warning messages inserted onto the main profile
to explain what has happened.  The user will only get this once per map
file as there should now be no way to modified the map file to have either
of these issues.

The code that builds the area selection widget is revised to handle the
corner cases of two areas that have the same letters in their name but the
cases vary (the widget is sorted by name in a case insensitive manner)
which previously was not handled (same as duplicate names were not).

As a side effect of revising the TLuaInterpreter Class, area names
containing non-ASCII characters can now be handled - they will be passed
through the lua subsystem using the UTF-8 encoding.

*** This commit is a reworking of one that produced a QMessageBox to alert
and advised the user what was happening - that was deemed to be too
intrusive so this version instead displays the information in the console
\- as such the detail of the renaming has to be shown now whereas the dialog
solution had the option of providing it as "Show Details..." to display it
only if requested at the time. ***

Additionally, the lua setAreaName(areaId, newAreaName) has been extended to
allow the existing area to be specified as a name (string) as well as an Id
as we can now uniquely identify it by that means.  This now matches the
behaviour of deleteArea which already acts in that manner.  It also means
a user script can use "setAreaNAme(oldName, newName)" to rename an area
without concern about determining the area Id.

This commit is based upon modifications made to the "development" branch
but corrects a bug that prevented setAreaName() from accepting a new
non-Ascii area name and includes the changes from a separate commit that
clears the area name table on loading a new map that was missed from the
original series of commits on the development branch.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>