### PR TITLE
(release_30)BugFix: Restore ability to create area name entry without a TArea instance

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8471,28 +8471,12 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
 }
 
-
+// Can now take area as a Name (non-Ascii characters in area names are now
+// permitted) instead of an Id number as the second argument.  Can set the room
+// to an area which does not have a TArea instance but does appear in the
+// TRoomDB::areaNamesMap...
 int TLuaInterpreter::setRoomArea( lua_State * L )
 {
-    int id, area;
-    if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setRoomArea: bad argument #1 type (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
-        lua_error( L );
-        return 1;
-    }
-    else {
-        id = lua_tointeger( L, 1 );
-    }
-
-    if( ! lua_isnumber( L, 2 ) ) {
-        lua_pushstring( L, tr( "setRoomArea: bad argument #2 type (area Id, as number expected, got %1)." ).arg( luaL_typename( L, 2 ) ).toUtf8().constData() );
-        lua_error( L );
-        return 1;
-    }
-    else {
-        area = lua_tointeger( L, 2 );
-    }
-
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
@@ -8504,25 +8488,77 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         lua_pushstring( L, tr( "setRoomArea: no map present or loaded!" ).toUtf8().constData() );
         return 2;
     }
-    else if( area <= 0 ) {
-        lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must be > 0.  To remove a room's area, use resetRoomArea(roomId) )." ).toUtf8().constData() );
-        return 2;
-    }
-    else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
-        lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: bad argument #1 value (room Id=%1 must exist.)" ).arg( id ).toUtf8().constData() );
-        return 2;
-    }
-    else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( area ) ) {
-        lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id=%1 must exist.)" ).arg( area ).toUtf8().constData() );
-        return 2;
-    }
-    else {
-        lua_pushboolean( L, pHost->mpMap->setRoomArea( id, area, false ) );
+
+    int id;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "setRoomArea: bad argument #1 type (room Id, as number expected, got %1)." ).arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+        lua_error( L );
         return 1;
     }
+    else {
+        id = lua_tointeger( L, 1 );
+        if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setRoomArea: bad argument #1 value (room Id=%1 must exist.)" ).arg( id ).toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    int areaId;
+    QString areaName;
+    if( lua_isnumber( L, 2 ) ) {
+        areaId = lua_tonumber( L, 2 );
+        if( areaId < 1 ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id must be > 0, got %1.  To remove a room's area, use resetRoomArea(roomId) )." )
+                            .arg( areaId ).toUtf8().constData() );
+            return 2;
+        }
+        else if( !pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( areaId ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area Id=%1 does not exist.)" )
+                            .arg( areaId ).toUtf8().constData() );
+            return 2;
+        }
+    }
+    else if( lua_isstring( L, 2 ) ) {
+        areaName = QString::fromUtf8( lua_tostring( L, 2 ) );
+        // areaId will be zero if not found!
+        if( areaName.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area name cannot be empty)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+        areaId = pHost->mpMap->mpRoomDB->getAreaNamesMap().key( areaName, 0 );
+        if( ! areaId ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area name \"%1\" does not exist)." )
+                            .arg( areaName ).toUtf8().constData() );
+            return 2;
+        }
+    }
+    else {
+        lua_pushstring( L, tr( "setRoomArea: bad argument #2 type (area Id as number or area name as string expected, got %1)." )
+                        .arg( luaL_typename( L, 2) ).toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+
+    bool result = pHost->mpMap->setRoomArea( id, areaId, false );
+    if( result ) {
+        // As a sucessfull result WILL change the area a room is in then the map
+        // should be updated.  The GUI code that modifies room(s) areas already
+        // includes such a call to update the mapper.
+        if( pHost->mpMap->mpMapper ) {
+            pHost->mpMap->mpMapper->mp2dMap->update();
+        }
+        if( pHost->mpMap->mpM ) {
+            pHost->mpMap->mpM->update();
+        }
+    }
+    lua_pushboolean( L, result );
+    return 1;
 }
 
 int TLuaInterpreter::resetRoomArea( lua_State * L )
@@ -8555,8 +8591,20 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
         return 2;
     }
     else {
-       lua_pushboolean( L, pHost->mpMap->setRoomArea( id, -1, false ) );
-       return 1;
+        bool result = pHost->mpMap->setRoomArea( id, -1, false );
+        if( result ) {
+            // As a sucessfull result WILL change the area a room is in then the map
+            // should be updated.  The GUI code that modifies room(s) areas already
+            // includes such a call to update the mapper.
+            if( pHost->mpMap->mpMapper ) {
+                pHost->mpMap->mpMapper->mp2dMap->update();
+            }
+            if( pHost->mpMap->mpM ) {
+                pHost->mpMap->mpM->update();
+            }
+        }
+        lua_pushboolean( L, result );
+        return 1;
     }
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6570,7 +6570,7 @@ int TLuaInterpreter::setCustomEnvColor( lua_State *L )
 
 int TLuaInterpreter::setAreaName( lua_State *L )
 {
-    int id;
+    int id = -1;
     QString existingName;
     QString newName;
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -6595,12 +6595,16 @@ int TLuaInterpreter::setAreaName( lua_State *L )
                             .arg( id ).toUtf8().constData() );
             return 2;
         }
-        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
-            lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area Id=%1 does not exist)." )
-                            .arg( id ).toUtf8().constData() );
-            return 2;
-        }
+// Strangely, previous code allowed this command to create a NEW area's name
+// with this ID, but without a TArea instance to accompany it (the latter was/is
+// instantiated as needed when a room is moved to the relevent area...) and we
+// need to continue to allow this - Slysven
+//        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
+//            lua_pushnil( L );
+//            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area Id=%1 does not exist)." )
+//                            .arg( id ).toUtf8().constData() );
+//            return 2;
+//        }
     }
     else if( lua_isstring( L, 1 ) ) {
         existingName = QString::fromUtf8( lua_tostring( L, 1 ) );
@@ -6664,10 +6668,11 @@ int TLuaInterpreter::setAreaName( lua_State *L )
 
     bool isCurrentAreaRenamed = false;
     if( pHost->mpMap->mpMapper ) {
-        if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) == pHost->mpMap->mpMapper->showArea->currentText() ) {
+        if( id > 0 && pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) == pHost->mpMap->mpMapper->showArea->currentText() ) {
             isCurrentAreaRenamed = true;
         }
     }
+
     bool result = pHost->mpMap->mpRoomDB->setAreaName( id, newName );
     if( result ) {
         // Update mapper Area names widget, using method designed for it...!
@@ -6820,7 +6825,8 @@ int TLuaInterpreter::deleteArea( lua_State *L )
                             .arg( id ).toUtf8().constData() );
             return 2;
         }
-        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
+        else if(    ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id )
+                 && ! pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( id ) ) {
             lua_pushnil( L );
             lua_pushstring( L, tr( "deleteArea: bad argument #1 value (area Id=%1 does not exist)." )
                             .arg( id ).toUtf8().constData() );

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -143,9 +143,19 @@ bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculation
 
     TArea * pA = mpRoomDB->getArea( area );
     if( ! pA ) {
-        QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
-        logError(msg);
-        return false;
+        // Uh oh, the area doesn't seem to exist as a TArea instance, lets check
+        // to see if it exists as a name only:
+        if( ! mpRoomDB->getAreaNamesMap().contains( area ) ) {
+            // Ah, no it doesn't so moan:
+            QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
+            logError(msg);
+            return false;
+        }
+        // If got to this point then there is NOT a TArea instance for the given
+        // area Id but there is a Name - and the pR->setArea(...) call WILL
+        // instantiate the required TArea structure - this seems a bit twisty
+        // and convoluted, but it was how previous code was wired up and we need
+        // to retain the API for the lua subsystem...
     }
 
     bool result = pR->setArea( area, isToDeferAreaRelatedRecalculations );

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -333,6 +333,11 @@ bool TRoomDB::removeArea( int id )
         mpMap->mMapGraphNeedsUpdate = true;
         return true;
     }
+    else if( areaNamesMap.contains( id ) ) {
+        // Handle corner case where the area name was created but not used
+        areaNamesMap.remove( id );
+        return true;
+    }
     return false;
 }
 
@@ -457,6 +462,10 @@ bool TRoomDB::setAreaName( int areaID, QString name )
         }
     }
     areaNamesMap[areaID] = name;
+    // This creates a NEW area name with given areaID if the ID was not
+    // previously used - but the TArea only gets created if the user manually
+    // creates it with TLuaInterpreter::addArea(areaId), OR moves a room to the
+    // area with either a Lua command or GUI action.
     return true;
 }
 


### PR DESCRIPTION
Before some recent changes it was possible to create a new area name entry with TLuaInterpreter::setAreaName(...) by supplying an unused area ID and a name so that it was stored in TRoomDB::areaNamesMap WITHOUT an actual TArea instance to pair it with.  This fix restores that mode of operation and the ability to DELETE such an orphan area name which had also been
removed by either the same series of commits or some other recent one that neglected to continue to provide the latter.