### PR TITLE
BugFix: Restore ability to create area name entry without a TArea instance

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6608,7 +6608,7 @@ int TLuaInterpreter::setCustomEnvColor( lua_State *L )
 
 int TLuaInterpreter::setAreaName( lua_State *L )
 {
-    int id;
+    int id = -1;
     QString existingName;
     QString newName;
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -6633,12 +6633,16 @@ int TLuaInterpreter::setAreaName( lua_State *L )
                             .arg( id ).toUtf8().constData() );
             return 2;
         }
-        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
-            lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area Id=%1 does not exist)." )
-                            .arg( id ).toUtf8().constData() );
-            return 2;
-        }
+// Strangely, previous code allowed this command to create a NEW area's name
+// with this ID, but without a TArea instance to accompany it (the latter was/is
+// instantiated as needed when a room is moved to the relevent area...) and we
+// need to continue to allow this - Slysven
+//        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
+//            lua_pushnil( L );
+//            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area Id=%1 does not exist)." )
+//                            .arg( id ).toUtf8().constData() );
+//            return 2;
+//        }
     }
     else if( lua_isstring( L, 1 ) ) {
         existingName = QString::fromUtf8( lua_tostring( L, 1 ) );
@@ -6702,10 +6706,11 @@ int TLuaInterpreter::setAreaName( lua_State *L )
 
     bool isCurrentAreaRenamed = false;
     if( pHost->mpMap->mpMapper ) {
-        if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) == pHost->mpMap->mpMapper->showArea->currentText() ) {
+        if( id > 0 && pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) == pHost->mpMap->mpMapper->showArea->currentText() ) {
             isCurrentAreaRenamed = true;
         }
     }
+
     bool result = pHost->mpMap->mpRoomDB->setAreaName( id, newName );
     if( result ) {
         // Update mapper Area names widget, using method designed for it...!
@@ -6858,7 +6863,8 @@ int TLuaInterpreter::deleteArea( lua_State *L )
                             .arg( id ).toUtf8().constData() );
             return 2;
         }
-        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
+        else if(    ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id )
+                 && ! pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( id ) ) {
             lua_pushnil( L );
             lua_pushstring( L, tr( "deleteArea: bad argument #1 value (area Id=%1 does not exist)." )
                             .arg( id ).toUtf8().constData() );

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -143,9 +143,19 @@ bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculation
 
     TArea * pA = mpRoomDB->getArea( area );
     if( ! pA ) {
-        QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
-        logError(msg);
-        return false;
+        // Uh oh, the area doesn't seem to exist as a TArea instance, lets check
+        // to see if it exists as a name only:
+        if( ! mpRoomDB->getAreaNamesMap().contains( area ) ) {
+            // Ah, no it doesn't so moan:
+            QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
+            logError(msg);
+            return false;
+        }
+        // If got to this point then there is NOT a TArea instance for the given
+        // area Id but there is a Name - and the pR->setArea(...) call WILL
+        // instantiate the required TArea structure - this seems a bit twisty
+        // and convoluted, but it was how previous code was wired up and we need
+        // to retain the API for the lua subsystem...
     }
 
     bool result = pR->setArea( area, isToDeferAreaRelatedRecalculations );

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -182,6 +182,11 @@ bool TRoomDB::removeArea( int id )
         mpMap->mMapGraphNeedsUpdate = true;
         return true;
     }
+    else if( areaNamesMap.contains( id ) ) {
+        // Handle corner case where the area name was created but not used
+        areaNamesMap.remove( id );
+        return true;
+    }
     return false;
 }
 
@@ -279,6 +284,10 @@ bool TRoomDB::setAreaName( int areaID, QString name )
         }
     }
     areaNamesMap[areaID] = name;
+    // This creates a NEW area name with given areaID if the ID was not
+    // previously used - but the TArea only gets created if the user manually
+    // creates it with TLuaInterpreter::addArea(areaId), OR moves a room to the
+    // area with either a Lua command or GUI action.
     return true;
 }
 


### PR DESCRIPTION
Before some recent changes it was possible to create a new area name entry
with TLuaInterpreter::setAreaName(...) by supplying an unused area ID and
a name so that it was stored in TRoomDB::areaNamesMap WITHOUT an actual
TArea instance to pair it with.  This fix restores that mode of operation
and the ability to DELETE such an orphan area name which had also been
removed by either the same series of commits or some other recent one that
neglected to continue to provide the latter.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>