### PR TITLE
BugFix: remove dlgTriggerEditor::accept() usage/properly escape a RegExp

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -469,7 +469,7 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
         }
         if( areaNamesMap.values().contains( nonEmptyAreaName ) ) {
             // Oh dear, we have a duplicate
-            if( nonEmptyAreaName.contains( QRegExp( "_\d\d\d$" ) ) ) {
+            if( nonEmptyAreaName.contains( QRegExp( "_\\d\\d\\d$" ) ) ) {
                 // the areaName already is of form "something_###" where # is a
                 // digit, have to strip that off and remember so warning message
                 // can include advice on this change

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -489,7 +490,6 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     connect( treeWidget_actions, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_action_selected( QTreeWidgetItem *) ) );
     connect( treeWidget_vars, SIGNAL( itemClicked( QTreeWidgetItem *, int ) ), this, SLOT( slot_var_selected( QTreeWidgetItem *) ) );
     connect( treeWidget_vars, SIGNAL( itemChanged(QTreeWidgetItem*,int) ), this, SLOT( slot_var_changed( QTreeWidgetItem *) ) );
-    connect( this, SIGNAL (accept()), this, SLOT (slot_connection_dlg_finnished()));
     connect( tree_widget_search_results_main, SIGNAL(itemClicked(QTreeWidgetItem*, int)), this, SLOT( slot_item_selected_search_list(QTreeWidgetItem*, int)));
     connect( mpScriptsMainArea->toolButton_add, SIGNAL(pressed()), this, SLOT(slot_script_main_area_add_handler()));
     connect( mpScriptsMainArea->toolButton_remove, SIGNAL(pressed()), this, SLOT( slot_script_main_area_delete_handler()));
@@ -5912,12 +5912,6 @@ void dlgTriggerEditor::expand_child_timers( TTimer * pTimerParent, QTreeWidgetIt
             showError( pT->getError() );
         }
     }
-}
-
-
-
-void dlgTriggerEditor::slot_connection_dlg_finnished()
-{
 }
 
 void dlgTriggerEditor::slot_show_search_area()

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -143,7 +144,6 @@ public slots:
     void                        slot_alias_selected( QTreeWidgetItem *pItem );
     void                        slot_action_selected( QTreeWidgetItem * pItem );
     void                        slot_key_selected( QTreeWidgetItem *pItem );
-    void                        slot_connection_dlg_finnished();
     void                        slot_add_new();
     void                        slot_add_new_folder();
     void                        slot_addTrigger();

--- a/src/src.pro
+++ b/src/src.pro
@@ -324,7 +324,9 @@ HEADERS += \
     TTreeWidgetItem.h \
     TTrigger.h \
     TVar.h \
-    VarUnit.h
+    VarUnit.h \
+    XMLexport.h \
+    XMLimport.h
 
 
 # This is for compiled UI files, not those used at runtime through the resource file.


### PR DESCRIPTION
Fixes a couple of one-liner errors that I recently introduced into the
Development branch (and also the release_30 but that uses different
commit references):

In commit 10fefa0a "revise: deletion of more redundant methods in header"
which removed definition of the above signal I forgot to remove the call
to connect(...) that used the signal.

In commit 94b492c1 "BugFix: Treat and prevent further duplicate or empty
map area names" I neglected to properly escape (using double '\') a regular
expression used to detect a de-duplicated Area Name.

Also: adds a couple of missing header files to qmake project file - their
absence means that they were NOT included in the group of files considered
when using the Qt IDE find/replace parts of the code editor - which can cause
problems when looking for usage of problematic functions/variables!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>