### PR TITLE
(release 30)bug fix correct strings used as room exit weight keys

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10230,7 +10230,7 @@ bool TLuaInterpreter::compile( QString & code, QString & errorMsg )
     }
     else
     {
-        if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"\nLUA: code compiled without errors. OK\n" >> 0;}
+        if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"\nLUA: code compiled without errors. OK\n" >> 0;}
     }
     lua_pop( L, lua_gettop( L ) );
 
@@ -10745,7 +10745,7 @@ bool TLuaInterpreter::call( QString & function, QString & mName )
             {
                 e += lua_tostring( L, i );
                 logError( e, mName, function );
-                if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::red))<<"LUA: ERROR running script "<< mName << " (" << function <<") ERROR:"<<e.c_str()>>0;}
+                if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::red))<<"LUA: ERROR running script "<< mName << " (" << function <<") ERROR:"<<e.c_str()<<"\n">>0;}
             }
         }
     }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -5,6 +5,7 @@
  *   Copyright (C) 2002-2005 by Tomas Mecir - kmuddy@kmuddy.com            *
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -169,7 +170,6 @@ private:
     QTextEncoder *    outgoingDataDecoder;
     QString           hostName;
     int               hostPort;
-    QDataStream       mOfs;
     double            networkLatencyMin;
     double            networkLatencyMax;
     bool              mWaitingForResponse;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -607,15 +607,25 @@ void dlgRoomExits::slot_nw_textEdited(const QString &text)
         doortype_open_nw->setEnabled(true);
         doortype_closed_nw->setEnabled(true);
         doortype_locked_nw->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            nw->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            nw->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to \"%1\"." )
+                                  .arg( exitToRoom->name ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to unnamed room is valid" ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0 ) {
         // Something is entered but it does not yield a valid exit roomID
         // Enable stub exit control
         nw->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        nw->setToolTip("Entered number is invalid, set the number of the room northwest of this one, will turn blue for a valid number.");
+        nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Entered number is invalid, set the number of the room northwest of this one, will turn blue for a valid number." ) ) );
         stub_nw->setEnabled(true);
         noroute_nw->setEnabled(false);
         weight_nw->setEnabled(false);
@@ -626,7 +636,8 @@ void dlgRoomExits::slot_nw_textEdited(const QString &text)
     } else {
         // Nothing is entered - so we can enable the stub exit control
         nw->setStyleSheet( QStringLiteral("") );
-        nw->setToolTip("Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.");
+        nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.") ) );
         stub_nw->setEnabled(true);
         noroute_nw->setEnabled(false);
         weight_nw->setEnabled(false);
@@ -652,13 +663,23 @@ void dlgRoomExits::slot_n_textEdited(const QString &text)
         doortype_open_n->setEnabled(true);
         doortype_closed_n->setEnabled(true);
         doortype_locked_n->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            n->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            n->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to \"%1\"." )
+                                 .arg( exitToRoom->name ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to unnamed room is valid" ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         n->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        n->setToolTip("Entered number is invalid, set the number of the room north of this one, will turn blue for a valid number.");
+        n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Entered number is invalid, set the number of the room north of this one, will turn blue for a valid number." ) ) );
         stub_n->setEnabled(true);
         noroute_n->setEnabled(false);
         weight_n->setEnabled(false);
@@ -668,7 +689,8 @@ void dlgRoomExits::slot_n_textEdited(const QString &text)
         doortype_locked_n->setEnabled(false);
     } else {
         n->setStyleSheet( QStringLiteral("") );
-        n->setToolTip("Set the number of the room north of this one, will be blue for a valid number or red for invalid.");
+        n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room north of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_n->setEnabled(true);
         noroute_n->setEnabled(false);
         weight_n->setEnabled(false);
@@ -694,13 +716,23 @@ void dlgRoomExits::slot_ne_textEdited(const QString &text)
         doortype_open_ne->setEnabled(true);
         doortype_closed_ne->setEnabled(true);
         doortype_locked_ne->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            ne->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            ne->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to \"%1\"." )
+                                  .arg( exitToRoom->name ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to unnamed room is valid" ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         ne->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        ne->setToolTip("Entered number is invalid, set the number of the room northeast of this one, will turn blue for a valid number.");
+        ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Entered number is invalid, set the number of the room northeast of this one, will turn blue for a valid number." ) ) );
         stub_ne->setEnabled(true);
         noroute_ne->setEnabled(false);
         weight_ne->setEnabled(false);
@@ -710,7 +742,8 @@ void dlgRoomExits::slot_ne_textEdited(const QString &text)
         doortype_locked_ne->setEnabled(false);
     } else {
         ne->setStyleSheet( QStringLiteral("") );
-        ne->setToolTip("Set the number of the room northeast of this one, will be blue for a valid number or red for invalid.");
+        ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room northeast of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_ne->setEnabled(true);
         noroute_ne->setEnabled(false);
         weight_ne->setEnabled(false);
@@ -736,13 +769,23 @@ void dlgRoomExits::slot_up_textEdited(const QString &text)
         doortype_open_up->setEnabled(true);
         doortype_closed_up->setEnabled(true);
         doortype_locked_up->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            up->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            up->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to \"%1\"." )
+                                 .arg( exitToRoom->name ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to unnamed room is valid" ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         up->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        up->setToolTip("Entered number is invalid, set the number of the room up from this one, will turn blue for a valid number.");
+        up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Entered number is invalid, set the number of the room up from this one, will turn blue for a valid number." ) ) );
         stub_up->setEnabled(true);
         noroute_up->setEnabled(false);
         weight_up->setEnabled(false);
@@ -752,7 +795,8 @@ void dlgRoomExits::slot_up_textEdited(const QString &text)
         doortype_locked_up->setEnabled(false);
     } else {
         up->setStyleSheet( QStringLiteral("") );
-        up->setToolTip("Set the number of the room up from this one, will be blue for a valid number or red for invalid.");
+        up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room up from this one, will be blue for a valid number or red for invalid." ) ) );
         stub_up->setEnabled(true);
         noroute_up->setEnabled(false);
         weight_up->setEnabled(false);
@@ -778,13 +822,23 @@ void dlgRoomExits::slot_w_textEdited(const QString &text)
         doortype_open_w->setEnabled(true);
         doortype_closed_w->setEnabled(true);
         doortype_locked_w->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            w->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            w->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to \"%1\"." )
+                                 .arg( exitToRoom->name ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to unnamed room is valid" ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         w->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        w->setToolTip("Entered number is invalid, set the number of the room west of this one, will turn blue for a valid number.");
+        w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Entered number is invalid, set the number of the room west of this one, will turn blue for a valid number." ) ) );
         stub_w->setEnabled(true);
         noroute_w->setEnabled(false);
         weight_w->setEnabled(false);
@@ -794,7 +848,8 @@ void dlgRoomExits::slot_w_textEdited(const QString &text)
         doortype_locked_w->setEnabled(false);
     } else {
         w->setStyleSheet( QStringLiteral("") );
-        w->setToolTip("Set the number of the room west of this one, will be blue for a valid number or red for invalid.");
+        w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room west of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_w->setEnabled(true);
         noroute_w->setEnabled(false);
         weight_w->setEnabled(false);
@@ -820,13 +875,23 @@ void dlgRoomExits::slot_e_textEdited(const QString &text)
         doortype_open_e->setEnabled(true);
         doortype_closed_e->setEnabled(true);
         doortype_locked_e->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            e->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            e->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to \"%1\"." )
+                                 .arg( exitToRoom->name ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to unnamed room is valid" ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         e->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        e->setToolTip("Entered number is invalid, set the number of the room east of this one, will turn blue for a valid number.");
+        e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Entered number is invalid, set the number of the room east of this one, will turn blue for a valid number." ) ) );
         stub_e->setEnabled(true);
         noroute_e->setEnabled(false);
         weight_e->setEnabled(false);
@@ -836,7 +901,8 @@ void dlgRoomExits::slot_e_textEdited(const QString &text)
         doortype_locked_e->setEnabled(false);
     } else {
         e->setStyleSheet( QStringLiteral("") );
-        e->setToolTip("Set the number of the room east of this one, will be blue for a valid number or red for invalid.");
+        e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room east of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_e->setEnabled(true);
         noroute_e->setEnabled(false);
         weight_e->setEnabled(false);
@@ -862,13 +928,23 @@ void dlgRoomExits::slot_down_textEdited(const QString &text)
         doortype_open_down->setEnabled(true);
         doortype_closed_down->setEnabled(true);
         doortype_locked_down->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            down->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            down->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                              .arg( tr( "Exit to \"%1\"." )
+                                    .arg( exitToRoom->name ) )
+                              .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                    .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                              .arg( tr( "Exit to unnamed room is valid" ) )
+                              .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                    .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         down->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        down->setToolTip("Entered number is invalid, set the number of the room down from this one, will turn blue for a valid number.");
+        down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                          .arg( tr( "Entered number is invalid, set the number of the room down from this one, will turn blue for a valid number." ) ) );
         stub_down->setEnabled(true);
         noroute_down->setEnabled(false);
         weight_down->setEnabled(false);
@@ -878,7 +954,8 @@ void dlgRoomExits::slot_down_textEdited(const QString &text)
         doortype_locked_down->setEnabled(false);
     } else {
         down->setStyleSheet( QStringLiteral("") );
-        down->setToolTip("Set the number of the room down from this one, will be blue for a valid number or red for invalid.");
+        down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                          .arg( tr( "Set the number of the room down from this one, will be blue for a valid number or red for invalid." ) ) );
         stub_down->setEnabled(true);
         noroute_down->setEnabled(false);
         weight_down->setEnabled(false);
@@ -904,13 +981,23 @@ void dlgRoomExits::slot_sw_textEdited(const QString &text)
         doortype_open_sw->setEnabled(true);
         doortype_closed_sw->setEnabled(true);
         doortype_locked_sw->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            sw->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            sw->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to \"%1\"." )
+                                  .arg( exitToRoom->name ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to unnamed room is valid" ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         sw->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        sw->setToolTip("Entered number is invalid, set the number of the room southwest of this one, will turn blue for a valid number.");
+        sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Entered number is invalid, set the number of the room southwest of this one, will turn blue for a valid number." ) ) );
         stub_sw->setEnabled(true);
         noroute_sw->setEnabled(false);
         weight_sw->setEnabled(false);
@@ -920,7 +1007,8 @@ void dlgRoomExits::slot_sw_textEdited(const QString &text)
         doortype_locked_sw->setEnabled(false);
     } else {
         sw->setStyleSheet( QStringLiteral("") );
-        sw->setToolTip("Set the number of the room southwest of this one, will be blue for a valid number or red for invalid.");
+        sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room southwest of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_sw->setEnabled(true);
         noroute_sw->setEnabled(false);
         weight_sw->setEnabled(false);
@@ -946,13 +1034,23 @@ void dlgRoomExits::slot_s_textEdited(const QString &text)
         doortype_open_s->setEnabled(true);
         doortype_closed_s->setEnabled(true);
         doortype_locked_s->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            s->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            s->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to \"%1\"." )
+                                 .arg( exitToRoom->name ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                           .arg( tr( "Exit to unnamed room is valid" ) )
+                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         s->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        s->setToolTip("Entered number is invalid, set the number of the room south of this one, will turn blue for a valid number.");
+        s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Entered number is invalid, set the number of the room south of this one, will turn blue for a valid number." ) ) );
         stub_s->setEnabled(true);
         noroute_s->setEnabled(false);
         weight_s->setEnabled(false);
@@ -962,7 +1060,8 @@ void dlgRoomExits::slot_s_textEdited(const QString &text)
         doortype_locked_s->setEnabled(false);
     } else {
         s->setStyleSheet( QStringLiteral("") );
-        s->setToolTip("Set the number of the room south of this one, will be blue for a valid number or red for invalid.");
+        s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room south of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_s->setEnabled(true);
         noroute_s->setEnabled(false);
         weight_s->setEnabled(false);
@@ -988,13 +1087,23 @@ void dlgRoomExits::slot_se_textEdited(const QString &text)
         doortype_open_se->setEnabled(true);
         doortype_closed_se->setEnabled(true);
         doortype_locked_se->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            se->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            se->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to \"%1\"." )
+                                  .arg( exitToRoom->name ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to unnamed room is valid" ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         se->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        se->setToolTip("Entered number is invalid, set the number of the room southeast of this one, will turn blue for a valid number.");
+        se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                         .arg( tr( "Entered number is invalid, set the number of the room southeast of this one, will turn blue for a valid number." ) ) );
         stub_se->setEnabled(true);
         noroute_se->setEnabled(false);
         weight_se->setEnabled(false);
@@ -1004,7 +1113,8 @@ void dlgRoomExits::slot_se_textEdited(const QString &text)
         doortype_locked_se->setEnabled(false);
     } else {
         se->setStyleSheet( QStringLiteral("") );
-        se->setToolTip("Set the number of the room southeast of this one, will be blue for a valid number or red for invalid.");
+        se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room southeast of this one, will be blue for a valid number or red for invalid." ) ) );
         stub_se->setEnabled(true);
         noroute_se->setEnabled(false);
         weight_se->setEnabled(false);
@@ -1030,13 +1140,23 @@ void dlgRoomExits::slot_in_textEdited(const QString &text)
         doortype_open_in->setEnabled(true);
         doortype_closed_in->setEnabled(true);
         doortype_locked_in->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            in->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            in->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to \"%1\"." )
+                                  .arg( exitToRoom->name ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                            .arg( tr( "Exit to unnamed room is valid" ) )
+                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         in->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        in->setToolTip("Entered number is invalid, set the number of the room in from this one, will turn blue for a valid number.");
+        in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Entered number is invalid, set the number of the room in from this one, will turn blue for a valid number." ) ) );
         stub_in->setEnabled(true);
         noroute_in->setEnabled(false);
         weight_in->setEnabled(false);
@@ -1046,7 +1166,8 @@ void dlgRoomExits::slot_in_textEdited(const QString &text)
         doortype_locked_in->setEnabled(false);
     } else {
         in->setStyleSheet( QStringLiteral("") );
-        in->setToolTip("Set the number of the room in from this one, will be blue for a valid number or red for invalid.");
+        in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room in from this one, will be blue for a valid number or red for invalid." ) ) );
         stub_in->setEnabled(true);
         noroute_in->setEnabled(false);
         weight_in->setEnabled(false);
@@ -1072,13 +1193,23 @@ void dlgRoomExits::slot_out_textEdited(const QString &text)
         doortype_open_out->setEnabled(true);
         doortype_closed_out->setEnabled(true);
         doortype_locked_out->setEnabled(true);
-        if( exitToRoom->name.trimmed().length() )
-            out->setToolTip(QString("Exit to \"" % exitToRoom->name % "\""));
-        else
-            out->setToolTip(QString("Exit to unnamed room is valid"));
+        if( exitToRoom->name.trimmed().length() ) {
+            out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                             .arg( tr( "Exit to \"%1\"." )
+                                   .arg( exitToRoom->name ) )
+                             .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                   .arg( exitToRoom->getWeight() ) ));
+        }
+        else {
+            out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                             .arg( tr( "Exit to unnamed room is valid" ) )
+                             .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                   .arg( exitToRoom->getWeight() ) ));
+        }
     } else if ( text.size() > 0) {
         out->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
-        out->setToolTip("Entered number is invalid, set the number of the room out from this one, will turn blue for a valid number.");
+        out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                         .arg( tr( "Entered number is invalid, set the number of the room out from this one, will turn blue for a valid number." ) ) );
         stub_out->setEnabled(true);
         noroute_out->setEnabled(false);
         weight_out->setEnabled(false);
@@ -1088,7 +1219,8 @@ void dlgRoomExits::slot_out_textEdited(const QString &text)
         doortype_locked_out->setEnabled(false);
     } else {
         out->setStyleSheet( QStringLiteral("") );
-        out->setToolTip("Set the number of the room out from this one, will be blue for a valid number or red for invalid.");
+        out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                         .arg( tr( "Set the number of the room out from this one, will be blue for a valid number or red for invalid." ) ) );
         stub_out->setEnabled(true);
         noroute_out->setEnabled(false);
         weight_out->setEnabled(false);
@@ -1511,22 +1643,32 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
         qWarning()<<"dlgRoomExits::initExit(...) in room Id("<<roomId<<") unexpected doors["<<doorAndWeightText<<"] value:"<<pR->getDoor( doorAndWeightText )<<"found for room!";
     }
 
+    TRoom * pExitR;
     if ( exitId > 0 ) {
-        if( ! mpHost->mpMap->mpRoomDB->getRoom( exitId ) ) {
+        pExitR = mpHost->mpMap->mpRoomDB->getRoom( exitId );
+        if( ! pExitR ) {
             // Recover from a missing exit room - not doing this was causing seg. faults
             qWarning()<<"dlgRoomExits::initExit(...): Warning: missing exit to"<<exitId<<"in direction "<<exitText<<", resetting exit.";
             exitId = -1;
         }
     }
 
-    if ( exitId > 0 ) { //Does this exit point anywhere
+    if ( exitId > 0 && pExitR ) { //Does this exit point anywhere
         exitLineEdit->setText(QString::number( exitId ));  //Put in the value
         exitLineEdit->setEnabled(true);     //Enable it for editing
         exitLineEdit->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        if( mpHost->mpMap->mpRoomDB->getRoom( exitId )->name.trimmed().length() )
-            exitLineEdit->setToolTip(QString("Exit to \"" % mpHost->mpMap->mpRoomDB->getRoom( exitId )->name % "\""));
-        else
-            exitLineEdit->setToolTip(QString("Exit to unnamed room is valid"));
+        if( pExitR->name.trimmed().length() ) {
+            exitLineEdit->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                                      .arg( tr( "Exit to \"%1\"." )
+                                            .arg( pExitR->name ) )
+                                      .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                            .arg( pExitR->getWeight() ) ));
+        } else {
+            exitLineEdit->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                                      .arg( tr( "Exit to unnamed room is valid" ) )
+                                      .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                            .arg( pExitR->getWeight() ) ));
+        }
         noRoute->setEnabled(true);    //Enable speedwalk lock control
         none->setEnabled(true);   //Enable door type controls...
         open->setEnabled(true);
@@ -1537,7 +1679,7 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
         stub->setChecked(false);  //Ensure stub exit isn't set
         noRoute->setChecked( pR->hasExitLock( direction ) );  //Set/reset "locK" control as appropriate
     } else {  //No exit is set on initialisation
-        exitLineEdit->setText("");    //Nothing to put in exitID box
+        exitLineEdit->setText( QStringLiteral("") );    //Nothing to put in exitID box
         exitLineEdit->setStyleSheet( QStringLiteral("") );
         noRoute->setEnabled(false);   //Disable lock control, can't lock a non-existant exit..
         noRoute->setChecked(false);   //.. and ensure there isn't one
@@ -1546,7 +1688,8 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
         stub->setEnabled(true);  //Enable stub exit control
         if ( pR->hasExitStub( direction ) ) {
             exitLineEdit->setEnabled(false); //There is a stub exit, so prevent exit number entry...
-            exitLineEdit->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+            exitLineEdit->setToolTip( QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                      .arg( tr("Clear the stub exit for this exit to enter an exit roomID." ) ) );
             stub->setChecked(true);
             none->setEnabled(true);   //Enable door type controls, can have a door on a stub exit..
             open->setEnabled(true);
@@ -1554,7 +1697,9 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
             locked->setEnabled(true);
         } else {
             exitLineEdit->setEnabled(true);
-            exitLineEdit->setToolTip("Set the number of the room " % doorAndWeightText % " of this one, will be blue for a valid number or red for invalid.");
+            exitLineEdit->setToolTip( QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                      .arg( tr("Set the number of the room %1 of this one, will be blue for a valid number or red for invalid.")
+                                            .arg( exitText ) ) );
             stub->setChecked(false);
             none->setEnabled(false);   //Disable door type controls, can't lock a non-existant exit..
             open->setEnabled(false);   //.. and ensure the "none" one is set if it ever gets enabled

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -75,10 +75,11 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem * pI, int column )
     if ( mpEditItem != 0 && ( pI != mpEditItem || mEditColumn != column ) ) {
         // Thing that was clicked on is not the same as last thing that was clicked on
         // ... so clean up the old column
+        TRoom * pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom( mpEditItem->text(0).toInt() );
         switch ( mEditColumn ) {
         case 0:
-            if( mpEditItem->text(0).toInt() < 1 || mpHost->mpMap->mpRoomDB->getRoom( mpEditItem->text(0).toInt() ) == 0 )
-                mpEditItem->setText(0, "<room ID>");
+            if( mpEditItem->text(0).toInt() < 1 )
+                mpEditItem->setText(0, tr("<room ID>", "This string is used in 2 places, ensure they match!") );
             specialExits->closePersistentEditor( mpEditItem, mEditColumn );
             break;
 
@@ -116,14 +117,36 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem * pI, int column )
             break;
 
         case 7:
-            if( ! mpEditItem->text(7).trimmed().length() )
-                mpEditItem->setText(7, "<command or Lua script>");
+            if( ! mpEditItem->text(7).trimmed().length() ) {
+                mpEditItem->setText(7, tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (1 of 5)" ) );
+            }
             specialExits->closePersistentEditor( mpEditItem, mEditColumn );
             //            qDebug()<<"Closed PE on item:"<<mpEditItem->text(7)<<"column:"<<mEditColumn;
             break;
         default:
             ; //noop for other column (1)
         }
+
+        if ( pExitToRoom ) {
+            mpEditItem->setForeground( 0, QColor(Qt::blue) );
+            if( ! pExitToRoom->name.isEmpty() ) {
+                mpEditItem->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                                        .arg( tr( "Exit to \"%1\"." )
+                                              .arg( pExitToRoom->name ) )
+                                        .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                              .arg( pExitToRoom->getWeight() ) ));
+            } else {
+                mpEditItem->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                                        .arg( tr( "Exit to unnamed room is valid" ) )
+                                        .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                              .arg( pExitToRoom->getWeight() ) ));
+            }
+        } else {
+            mpEditItem->setForeground( 0, QColor(Qt::red) );
+            mpEditItem->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                                    .arg( tr( "Entered number is invalid, set the number of the room that this special exit leads to, will turn blue for a valid number; if left like this, this exit will be deleted when &lt;i&gt;save&lt;/i&gt; is clicked." ) ) );
+        }
+
         mpEditItem = 0;   //This will cause a new PE to be opened, it will also be zeroed on the first time this funciton is called
         mEditColumn = -1;
     }
@@ -181,16 +204,31 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem * pI, int column )
 void dlgRoomExits::slot_addSpecialExit()
 {
     QTreeWidgetItem * pI = new QTreeWidgetItem(specialExits);
-    pI->setText(0, "<room ID>"); //Exit RoomID
+    pI->setText(0, tr("<room ID>", "This string is used in 2 places, ensure they match!") ); //Exit RoomID
+    pI->setForeground( 0, QColor(Qt::red) );
+    pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "Set the number of the room that this special exit leads to, will turn blue for a valid number; if left like this, this exit will be deleted when &lt;i&gt;save&lt;/i&gt; is clicked." ) ) );
     pI->setTextAlignment(0, Qt::AlignRight );
+    pI->setToolTip( 1, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "Prevent a route being created via this exit, equivalent to an infinite exit weight.") ) );
     pI->setCheckState(1, Qt::Unchecked); //Locked
-    pI->setText(2, "0");  //Exit Weight
+    pI->setText(2, QStringLiteral("0"));  //Exit Weight
     pI->setTextAlignment(2, Qt::AlignRight );
+    pI->setToolTip( 2, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.") ) );
     pI->setCheckState(3, Qt::Checked);   //Doortype: none
+    pI->setToolTip( 3, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "No door symbol is drawn on 2D Map for this exit (only functional choice currently).") ) );
     pI->setCheckState(4, Qt::Unchecked); //Doortype: open
+    pI->setToolTip( 4, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).") ) );
     pI->setCheckState(5, Qt::Unchecked); //Doortype: closed
+    pI->setToolTip( 5, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).") ) );
     pI->setCheckState(6, Qt::Unchecked); //Doortype: locked
-    pI->setText(7, "<command or Lua script>"); //Exit command
+    pI->setToolTip( 6, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                    .arg( tr( "Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).") ) );
+    pI->setText(7, tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (2 of 5)" ) ); //Exit command
     pI->setTextAlignment(7, Qt::AlignLeft );
     specialExits->addTopLevelItem(pI);
 }
@@ -227,7 +265,8 @@ void dlgRoomExits::save()
         else if ( pI->checkState(3) == Qt::Checked )
             door = 0;
         QString value = pI->text(7);
-        if ( value != "<command or Lua script>" && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) !=0 ) {
+        if (    value != tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (3 of 5)" )
+             && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) !=0 ) {
             originalExitCmds.remove( value );
             if ( pI->checkState(1) == Qt::Unchecked )
                 value = value.prepend( '0' );
@@ -1789,9 +1828,29 @@ void dlgRoomExits::init( int id ) {
 
         originalSpecialExits[dir] = new TExit();
         QTreeWidgetItem * pI = new QTreeWidgetItem(specialExits);
+        TRoom * pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom( id_to );
         //0 was locked, now exit roomID
         pI->setText( 0, QString::number(id_to) );
         pI->setTextAlignment( 0, Qt::AlignRight );
+        if ( pExitToRoom ) {
+            pI->setForeground( 0, QColor(Qt::blue) );
+            if( ! pExitToRoom->name.isEmpty() ) {
+                pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                                .arg( tr( "Exit to \"%1\"." )
+                                      .arg( pExitToRoom->name ) )
+                                .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                      .arg( pExitToRoom->getWeight() ) ));
+            } else {
+                pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
+                                .arg( tr( "Exit to unnamed room is valid" ) )
+                                .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                      .arg( pExitToRoom->getWeight() ) ));
+            }
+        } else {
+            pI->setForeground( 0, QColor(Qt::red) );
+            pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                            .arg( tr( "Room Id is invalid, set the number of the room that this special exit leads to, will turn blue for a valid number." ) ) );
+        }
         originalSpecialExits.value( dir )->destination = id_to;
         //1 was roomID, now locked (or more properly "No route") - setCheckedState
         //automagically makes it a CheckBox!!!
@@ -1802,6 +1861,8 @@ void dlgRoomExits::init( int id ) {
             pI->setCheckState( 1, Qt::Unchecked );
             originalSpecialExits.value( dir )->hasNoRoute = false;
         }
+        pI->setToolTip( 1, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Prevent a route being created via this exit, equivalent to an infinite exit weight.") ) );
 
         //2 was script, now exit weight - ideally want a spin box - but use a text edit for now
         if ( pR->hasExitWeight( dir ) )
@@ -1809,12 +1870,27 @@ void dlgRoomExits::init( int id ) {
         else
             pI->setText( 2, QString::number(0) );
         pI->setTextAlignment( 2, Qt::AlignRight );
+        pI->setToolTip( 2, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.") ) );
         originalSpecialExits.value( dir )->weight = pI->text(2).toInt();
+
 
         //3-6 are new, now holds a buttongroup of 4, ideally QRadioButtons, to select a door type
         pI->setCheckState( 3, Qt::Unchecked );
+        pI->setTextAlignment( 3, Qt::AlignCenter );
+        pI->setToolTip( 3, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "No door symbol is drawn on 2D Map for this exit (only functional choice currently).") ) );
         pI->setCheckState( 4, Qt::Unchecked );
+        pI->setTextAlignment( 4, Qt::AlignCenter );
+        pI->setToolTip( 4, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).") ) );
         pI->setCheckState( 5, Qt::Unchecked );
+        pI->setTextAlignment( 5, Qt::AlignCenter );
+        pI->setToolTip( 5, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).") ) );
+        pI->setTextAlignment( 6, Qt::AlignCenter );
+        pI->setToolTip( 6, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).") ) );
         pI->setCheckState( 6, Qt::Unchecked );
         {
             int specialDoor = pR->getDoor( dir );

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -598,7 +598,7 @@ void dlgRoomExits::slot_nw_textEdited(const QString &text)
 
     if ( exitToRoom != 0 ) {
         // Valid exit roomID in place
-        nw->setStyleSheet("color:blue");
+        nw->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_nw->setChecked(false);
         stub_nw->setEnabled(false);
         noroute_nw->setEnabled(true);
@@ -614,7 +614,7 @@ void dlgRoomExits::slot_nw_textEdited(const QString &text)
     } else if ( text.size() > 0 ) {
         // Something is entered but it does not yield a valid exit roomID
         // Enable stub exit control
-        nw->setStyleSheet("color:red");
+        nw->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         nw->setToolTip("Entered number is invalid, set the number of the room northwest of this one, will turn blue for a valid number.");
         stub_nw->setEnabled(true);
         noroute_nw->setEnabled(false);
@@ -625,7 +625,7 @@ void dlgRoomExits::slot_nw_textEdited(const QString &text)
         doortype_locked_nw->setEnabled(false);
     } else {
         // Nothing is entered - so we can enable the stub exit control
-        nw->setStyleSheet("");
+        nw->setStyleSheet( QStringLiteral("") );
         nw->setToolTip("Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.");
         stub_nw->setEnabled(true);
         noroute_nw->setEnabled(false);
@@ -643,7 +643,7 @@ void dlgRoomExits::slot_n_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        n->setStyleSheet("color:blue");;
+        n->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );;
         stub_n->setChecked(false);
         stub_n->setEnabled(false);
         noroute_n->setEnabled(true);
@@ -657,7 +657,7 @@ void dlgRoomExits::slot_n_textEdited(const QString &text)
         else
             n->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        n->setStyleSheet("color:red");
+        n->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         n->setToolTip("Entered number is invalid, set the number of the room north of this one, will turn blue for a valid number.");
         stub_n->setEnabled(true);
         noroute_n->setEnabled(false);
@@ -667,7 +667,7 @@ void dlgRoomExits::slot_n_textEdited(const QString &text)
         doortype_closed_n->setEnabled(false);
         doortype_locked_n->setEnabled(false);
     } else {
-        n->setStyleSheet("");
+        n->setStyleSheet( QStringLiteral("") );
         n->setToolTip("Set the number of the room north of this one, will be blue for a valid number or red for invalid.");
         stub_n->setEnabled(true);
         noroute_n->setEnabled(false);
@@ -685,7 +685,7 @@ void dlgRoomExits::slot_ne_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        ne->setStyleSheet("color:blue");
+        ne->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_ne->setChecked(false);
         stub_ne->setEnabled(false);
         noroute_ne->setEnabled(true);
@@ -699,7 +699,7 @@ void dlgRoomExits::slot_ne_textEdited(const QString &text)
         else
             ne->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        ne->setStyleSheet("color:red");
+        ne->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         ne->setToolTip("Entered number is invalid, set the number of the room northeast of this one, will turn blue for a valid number.");
         stub_ne->setEnabled(true);
         noroute_ne->setEnabled(false);
@@ -709,7 +709,7 @@ void dlgRoomExits::slot_ne_textEdited(const QString &text)
         doortype_closed_ne->setEnabled(false);
         doortype_locked_ne->setEnabled(false);
     } else {
-        ne->setStyleSheet("");
+        ne->setStyleSheet( QStringLiteral("") );
         ne->setToolTip("Set the number of the room northeast of this one, will be blue for a valid number or red for invalid.");
         stub_ne->setEnabled(true);
         noroute_ne->setEnabled(false);
@@ -727,7 +727,7 @@ void dlgRoomExits::slot_up_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        up->setStyleSheet("color:blue");
+        up->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_up->setChecked(false);
         stub_up->setEnabled(false);
         noroute_up->setEnabled(true);
@@ -741,7 +741,7 @@ void dlgRoomExits::slot_up_textEdited(const QString &text)
         else
             up->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        up->setStyleSheet("color:red");
+        up->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         up->setToolTip("Entered number is invalid, set the number of the room up from this one, will turn blue for a valid number.");
         stub_up->setEnabled(true);
         noroute_up->setEnabled(false);
@@ -751,7 +751,7 @@ void dlgRoomExits::slot_up_textEdited(const QString &text)
         doortype_closed_up->setEnabled(false);
         doortype_locked_up->setEnabled(false);
     } else {
-        up->setStyleSheet("");
+        up->setStyleSheet( QStringLiteral("") );
         up->setToolTip("Set the number of the room up from this one, will be blue for a valid number or red for invalid.");
         stub_up->setEnabled(true);
         noroute_up->setEnabled(false);
@@ -769,7 +769,7 @@ void dlgRoomExits::slot_w_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        w->setStyleSheet("color:blue");
+        w->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_w->setChecked(false);
         stub_w->setEnabled(false);
         noroute_w->setEnabled(true);
@@ -783,7 +783,7 @@ void dlgRoomExits::slot_w_textEdited(const QString &text)
         else
             w->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        w->setStyleSheet("color:red");
+        w->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         w->setToolTip("Entered number is invalid, set the number of the room west of this one, will turn blue for a valid number.");
         stub_w->setEnabled(true);
         noroute_w->setEnabled(false);
@@ -793,7 +793,7 @@ void dlgRoomExits::slot_w_textEdited(const QString &text)
         doortype_closed_w->setEnabled(false);
         doortype_locked_w->setEnabled(false);
     } else {
-        w->setStyleSheet("");
+        w->setStyleSheet( QStringLiteral("") );
         w->setToolTip("Set the number of the room west of this one, will be blue for a valid number or red for invalid.");
         stub_w->setEnabled(true);
         noroute_w->setEnabled(false);
@@ -811,7 +811,7 @@ void dlgRoomExits::slot_e_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        e->setStyleSheet("color:blue");
+        e->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_e->setChecked(false);
         stub_e->setEnabled(false);
         noroute_e->setEnabled(true);
@@ -825,7 +825,7 @@ void dlgRoomExits::slot_e_textEdited(const QString &text)
         else
             e->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        e->setStyleSheet("color:red");
+        e->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         e->setToolTip("Entered number is invalid, set the number of the room east of this one, will turn blue for a valid number.");
         stub_e->setEnabled(true);
         noroute_e->setEnabled(false);
@@ -835,7 +835,7 @@ void dlgRoomExits::slot_e_textEdited(const QString &text)
         doortype_closed_e->setEnabled(false);
         doortype_locked_e->setEnabled(false);
     } else {
-        e->setStyleSheet("");
+        e->setStyleSheet( QStringLiteral("") );
         e->setToolTip("Set the number of the room east of this one, will be blue for a valid number or red for invalid.");
         stub_e->setEnabled(true);
         noroute_e->setEnabled(false);
@@ -853,7 +853,7 @@ void dlgRoomExits::slot_down_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        down->setStyleSheet("color:blue");
+        down->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_down->setChecked(false);
         stub_down->setEnabled(false);
         noroute_down->setEnabled(true);
@@ -867,7 +867,7 @@ void dlgRoomExits::slot_down_textEdited(const QString &text)
         else
             down->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        down->setStyleSheet("color:red");
+        down->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         down->setToolTip("Entered number is invalid, set the number of the room down from this one, will turn blue for a valid number.");
         stub_down->setEnabled(true);
         noroute_down->setEnabled(false);
@@ -877,7 +877,7 @@ void dlgRoomExits::slot_down_textEdited(const QString &text)
         doortype_closed_down->setEnabled(false);
         doortype_locked_down->setEnabled(false);
     } else {
-        down->setStyleSheet("");
+        down->setStyleSheet( QStringLiteral("") );
         down->setToolTip("Set the number of the room down from this one, will be blue for a valid number or red for invalid.");
         stub_down->setEnabled(true);
         noroute_down->setEnabled(false);
@@ -895,7 +895,7 @@ void dlgRoomExits::slot_sw_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        sw->setStyleSheet("color:blue");
+        sw->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_sw->setChecked(false);
         stub_sw->setEnabled(false);
         noroute_sw->setEnabled(true);
@@ -909,7 +909,7 @@ void dlgRoomExits::slot_sw_textEdited(const QString &text)
         else
             sw->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        sw->setStyleSheet("color:red");
+        sw->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         sw->setToolTip("Entered number is invalid, set the number of the room southwest of this one, will turn blue for a valid number.");
         stub_sw->setEnabled(true);
         noroute_sw->setEnabled(false);
@@ -919,7 +919,7 @@ void dlgRoomExits::slot_sw_textEdited(const QString &text)
         doortype_closed_sw->setEnabled(false);
         doortype_locked_sw->setEnabled(false);
     } else {
-        sw->setStyleSheet("");
+        sw->setStyleSheet( QStringLiteral("") );
         sw->setToolTip("Set the number of the room southwest of this one, will be blue for a valid number or red for invalid.");
         stub_sw->setEnabled(true);
         noroute_sw->setEnabled(false);
@@ -937,7 +937,7 @@ void dlgRoomExits::slot_s_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        s->setStyleSheet("color:blue");
+        s->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_s->setChecked(false);
         stub_s->setEnabled(false);
         noroute_s->setEnabled(true);
@@ -951,7 +951,7 @@ void dlgRoomExits::slot_s_textEdited(const QString &text)
         else
             s->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        s->setStyleSheet("color:red");
+        s->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         s->setToolTip("Entered number is invalid, set the number of the room south of this one, will turn blue for a valid number.");
         stub_s->setEnabled(true);
         noroute_s->setEnabled(false);
@@ -961,7 +961,7 @@ void dlgRoomExits::slot_s_textEdited(const QString &text)
         doortype_closed_s->setEnabled(false);
         doortype_locked_s->setEnabled(false);
     } else {
-        s->setStyleSheet("");
+        s->setStyleSheet( QStringLiteral("") );
         s->setToolTip("Set the number of the room south of this one, will be blue for a valid number or red for invalid.");
         stub_s->setEnabled(true);
         noroute_s->setEnabled(false);
@@ -979,7 +979,7 @@ void dlgRoomExits::slot_se_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        se->setStyleSheet("color:blue");
+        se->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_se->setChecked(false);
         stub_se->setEnabled(false);
         noroute_se->setEnabled(true);
@@ -993,7 +993,7 @@ void dlgRoomExits::slot_se_textEdited(const QString &text)
         else
             se->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        se->setStyleSheet("color:red");
+        se->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         se->setToolTip("Entered number is invalid, set the number of the room southeast of this one, will turn blue for a valid number.");
         stub_se->setEnabled(true);
         noroute_se->setEnabled(false);
@@ -1003,7 +1003,7 @@ void dlgRoomExits::slot_se_textEdited(const QString &text)
         doortype_closed_se->setEnabled(false);
         doortype_locked_se->setEnabled(false);
     } else {
-        se->setStyleSheet("");
+        se->setStyleSheet( QStringLiteral("") );
         se->setToolTip("Set the number of the room southeast of this one, will be blue for a valid number or red for invalid.");
         stub_se->setEnabled(true);
         noroute_se->setEnabled(false);
@@ -1021,7 +1021,7 @@ void dlgRoomExits::slot_in_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        in->setStyleSheet("color:blue");
+        in->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_in->setChecked(false);
         stub_in->setEnabled(false);
         noroute_in->setEnabled(true);
@@ -1035,7 +1035,7 @@ void dlgRoomExits::slot_in_textEdited(const QString &text)
         else
             in->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        in->setStyleSheet("color:red");
+        in->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         in->setToolTip("Entered number is invalid, set the number of the room in from this one, will turn blue for a valid number.");
         stub_in->setEnabled(true);
         noroute_in->setEnabled(false);
@@ -1045,7 +1045,7 @@ void dlgRoomExits::slot_in_textEdited(const QString &text)
         doortype_closed_in->setEnabled(false);
         doortype_locked_in->setEnabled(false);
     } else {
-        in->setStyleSheet("");
+        in->setStyleSheet( QStringLiteral("") );
         in->setToolTip("Set the number of the room in from this one, will be blue for a valid number or red for invalid.");
         stub_in->setEnabled(true);
         noroute_in->setEnabled(false);
@@ -1063,7 +1063,7 @@ void dlgRoomExits::slot_out_textEdited(const QString &text)
     TRoom * exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
 
     if ( exitToRoom != 0 ) {
-        out->setStyleSheet("color:blue");
+        out->setStyleSheet( QStringLiteral(".QLineEdit { color:blue }") );
         stub_out->setChecked(false);
         stub_out->setEnabled(false);
         noroute_out->setEnabled(true);
@@ -1077,7 +1077,7 @@ void dlgRoomExits::slot_out_textEdited(const QString &text)
         else
             out->setToolTip(QString("Exit to unnamed room is valid"));
     } else if ( text.size() > 0) {
-        out->setStyleSheet("color:red");
+        out->setStyleSheet( QStringLiteral(".QLineEdit { color:red }") );
         out->setToolTip("Entered number is invalid, set the number of the room out from this one, will turn blue for a valid number.");
         stub_out->setEnabled(true);
         noroute_out->setEnabled(false);
@@ -1087,7 +1087,7 @@ void dlgRoomExits::slot_out_textEdited(const QString &text)
         doortype_closed_out->setEnabled(false);
         doortype_locked_out->setEnabled(false);
     } else {
-        out->setStyleSheet("");
+        out->setStyleSheet( QStringLiteral("") );
         out->setToolTip("Set the number of the room out from this one, will be blue for a valid number or red for invalid.");
         stub_out->setEnabled(true);
         noroute_out->setEnabled(false);
@@ -1106,7 +1106,7 @@ void dlgRoomExits::slot_stub_nw_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != 0 ) {
             nw->setText("");
-            nw->setStyleSheet("");
+            nw->setStyleSheet( QStringLiteral("") );
             weight_nw->setValue(0); // Can't have a weight for a stub exit
             noroute_nw->setChecked(false); // nor a "lock"
         }
@@ -1140,7 +1140,7 @@ void dlgRoomExits::slot_stub_n_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != 0 ) {
             n->setText("");
-            n->setStyleSheet("");
+            n->setStyleSheet( QStringLiteral("") );
             weight_n->setValue(0);
             noroute_n->setChecked(false);
         }
@@ -1171,7 +1171,7 @@ void dlgRoomExits::slot_stub_ne_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != 0 ) {
             ne->setText("");
-            ne->setStyleSheet("");
+            ne->setStyleSheet( QStringLiteral("") );
             weight_ne->setValue(0);
             noroute_ne->setChecked(false);
         }
@@ -1202,7 +1202,7 @@ void dlgRoomExits::slot_stub_up_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != 0 ) {
             up->setText("");
-            up->setStyleSheet("");
+            up->setStyleSheet( QStringLiteral("") );
             weight_up->setValue(0);
             noroute_up->setChecked(false);
         }
@@ -1233,7 +1233,7 @@ void dlgRoomExits::slot_stub_w_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != 0 ) {
             w->setText("");
-            w->setStyleSheet("");
+            w->setStyleSheet( QStringLiteral("") );
             weight_w->setValue(0);
             noroute_w->setChecked(false);
         }
@@ -1264,7 +1264,7 @@ void dlgRoomExits::slot_stub_e_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != 0 ) {
             e->setText("");
-            e->setStyleSheet("");
+            e->setStyleSheet( QStringLiteral("") );
             weight_e->setValue(0);
             noroute_e->setChecked(false);
         }
@@ -1295,7 +1295,7 @@ void dlgRoomExits::slot_stub_down_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != 0 ) {
             down->setText("");
-            down->setStyleSheet("");
+            down->setStyleSheet( QStringLiteral("") );
             weight_down->setValue(0);
             noroute_down->setChecked(false);
         }
@@ -1326,7 +1326,7 @@ void dlgRoomExits::slot_stub_sw_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != 0 ) {
             sw->setText("");
-            sw->setStyleSheet("");
+            sw->setStyleSheet( QStringLiteral("") );
             weight_sw->setValue(0);
             noroute_sw->setChecked(false);
         }
@@ -1357,7 +1357,7 @@ void dlgRoomExits::slot_stub_s_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != 0 ) {
             s->setText("");
-            s->setStyleSheet("");
+            s->setStyleSheet( QStringLiteral("") );
             weight_s->setValue(0);
             noroute_s->setChecked(false);
         }
@@ -1388,7 +1388,7 @@ void dlgRoomExits::slot_stub_se_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != 0 ) {
             se->setText("");
-            se->setStyleSheet("");
+            se->setStyleSheet( QStringLiteral("") );
             weight_se->setValue(0);
             noroute_se->setChecked(false);
         }
@@ -1419,7 +1419,7 @@ void dlgRoomExits::slot_stub_in_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != 0 ) {
             in->setText("");
-            in->setStyleSheet("");
+            in->setStyleSheet( QStringLiteral("") );
             weight_in->setValue(0);
             noroute_in->setChecked(false);
         }
@@ -1450,7 +1450,7 @@ void dlgRoomExits::slot_stub_out_stateChanged(int state)
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != 0 ) {
             out->setText("");
-            out->setStyleSheet("");
+            out->setStyleSheet( QStringLiteral("") );
             weight_out->setValue(0);
             noroute_out->setChecked(false);
         }
@@ -1522,7 +1522,7 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
     if ( exitId > 0 ) { //Does this exit point anywhere
         exitLineEdit->setText(QString::number( exitId ));  //Put in the value
         exitLineEdit->setEnabled(true);     //Enable it for editing
-        exitLineEdit->setStyleSheet("color:blue");
+        exitLineEdit->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
         if( mpHost->mpMap->mpRoomDB->getRoom( exitId )->name.trimmed().length() )
             exitLineEdit->setToolTip(QString("Exit to \"" % mpHost->mpMap->mpRoomDB->getRoom( exitId )->name % "\""));
         else
@@ -1538,7 +1538,7 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
         noRoute->setChecked( pR->hasExitLock( direction ) );  //Set/reset "locK" control as appropriate
     } else {  //No exit is set on initialisation
         exitLineEdit->setText("");    //Nothing to put in exitID box
-        exitLineEdit->setStyleSheet("");
+        exitLineEdit->setStyleSheet( QStringLiteral("") );
         noRoute->setEnabled(false);   //Disable lock control, can't lock a non-existant exit..
         noRoute->setChecked(false);   //.. and ensure there isn't one
         weight->setEnabled(false);   //Disable exit weight control...

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -1482,40 +1482,39 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
                              QRadioButton * closed, QRadioButton * locked,
                              QSpinBox * weight) {
 
-    QString doorText;   // lowercase, initials
-    QString weightText; // lowercase, full words, no space
+    QString doorAndWeightText;   // lowercase, initials for XY-plane, words for others
+    QString exitText; // lowercase, full words, no space
     switch( direction ) {
-        case DIR_NORTHWEST: doorText =   "nw"; weightText = "northwest"; break;
-        case DIR_NORTH    : doorText =    "n"; weightText =     "north"; break;
-        case DIR_NORTHEAST: doorText =   "ne"; weightText = "northeast"; break;
-        case DIR_UP       : doorText =   "up"; weightText =        "up"; break;
-        case DIR_WEST     : doorText =    "w"; weightText =      "west"; break;
-        case DIR_EAST     : doorText =    "e"; weightText =      "east"; break;
-        case DIR_DOWN     : doorText = "down"; weightText =      "down"; break;
-        case DIR_SOUTHWEST: doorText =   "sw"; weightText = "southwest"; break;
-        case DIR_SOUTH    : doorText =    "s"; weightText =     "south"; break;
-        case DIR_SOUTHEAST: doorText =   "se"; weightText = "southeast"; break;
-        case DIR_IN       : doorText =   "in"; weightText =        "in"; break;
-        case DIR_OUT      : doorText =  "out"; weightText =       "out"; break;
+        case DIR_NORTHWEST: doorAndWeightText = QStringLiteral("nw");   exitText = tr("northwest"); break;
+        case DIR_NORTH    : doorAndWeightText = QStringLiteral("n");    exitText = tr("north");     break;
+        case DIR_NORTHEAST: doorAndWeightText = QStringLiteral("ne");   exitText = tr("northeast"); break;
+        case DIR_UP       : doorAndWeightText = QStringLiteral("up");   exitText = tr("up");        break;
+        case DIR_WEST     : doorAndWeightText = QStringLiteral("w");    exitText = tr("west");      break;
+        case DIR_EAST     : doorAndWeightText = QStringLiteral("e");    exitText = tr("east");      break;
+        case DIR_DOWN     : doorAndWeightText = QStringLiteral("down"); exitText = tr("down");      break;
+        case DIR_SOUTHWEST: doorAndWeightText = QStringLiteral("sw");   exitText = tr("southwest"); break;
+        case DIR_SOUTH    : doorAndWeightText = QStringLiteral("s");    exitText = tr("south");     break;
+        case DIR_SOUTHEAST: doorAndWeightText = QStringLiteral("se");   exitText = tr("southeast"); break;
+        case DIR_IN       : doorAndWeightText = QStringLiteral("in");   exitText = tr("in");        break;
+        case DIR_OUT      : doorAndWeightText = QStringLiteral("out");  exitText = tr("out");       break;
         default: Q_UNREACHABLE();
     }
 
-    weight->setValue( pR->hasExitWeight( weightText ) ? pR->getExitWeight( weightText ) : 0 );
+    weight->setValue( pR->hasExitWeight( doorAndWeightText ) ? pR->getExitWeight( doorAndWeightText ) : 0 );
 
-    switch( pR->getDoor( doorText ) ) {
+    switch( pR->getDoor( doorAndWeightText ) ) {
     case 0:   none->setChecked(true); break;
     case 1:   open->setChecked(true); break;
     case 2: closed->setChecked(true); break;
     case 3: locked->setChecked(true); break;
     default:
-        qWarning("dlgRoomExits::initExit roomId(%i) unexpected doors[\"%s\"] value:%i found for room!",
-                 roomId, qPrintable( doorText ), pR->getDoor( doorText ) );
+        qWarning()<<"dlgRoomExits::initExit(...) in room Id("<<roomId<<") unexpected doors["<<doorAndWeightText<<"] value:"<<pR->getDoor( doorAndWeightText )<<"found for room!";
     }
 
     if ( exitId > 0 ) {
         if( ! mpHost->mpMap->mpRoomDB->getRoom( exitId ) ) {
             // Recover from a missing exit room - not doing this was causing seg. faults
-            qWarning("dlgRoomExits::initExit: Warning: missing exit to %i in direction %s, resetting exit.", exitId, weightText.toUtf8().constData() );
+            qWarning()<<"dlgRoomExits::initExit(...): Warning: missing exit to"<<exitId<<"in direction "<<exitText<<", resetting exit.";
             exitId = -1;
         }
     }
@@ -1555,7 +1554,7 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
             locked->setEnabled(true);
         } else {
             exitLineEdit->setEnabled(true);
-            exitLineEdit->setToolTip("Set the number of the room " % weightText % " of this one, will be blue for a valid number or red for invalid.");
+            exitLineEdit->setToolTip("Set the number of the room " % doorAndWeightText % " of this one, will be blue for a valid number or red for invalid.");
             stub->setChecked(false);
             none->setEnabled(false);   //Disable door type controls, can't lock a non-existant exit..
             open->setEnabled(false);   //.. and ensure the "none" one is set if it ever gets enabled
@@ -1688,7 +1687,7 @@ void dlgRoomExits::init( int id ) {
                 pI->setCheckState( 6, Qt::Checked );
                 break;
             default:
-                qDebug()<<"dlgRoomExits::init() unexpected (other exit) doors["<<dir<<"] value:"<<pR->doors[dir]<<" found for roomID["<<id<<"]!";
+                qDebug()<<"dlgRoomExits::init("<<id<<") unexpected (other exit) doors["<<dir<<"] value:"<<pR->doors[dir]<<" found!";
             }
             originalSpecialExits.value( dir )->door = specialDoor;
         }

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -19,21 +19,29 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+/*
+ * Eventually these should be defined for whole application to force explicit
+ * definition of all strings as:
+ * EITHER: QStringLiteral("<string>") for internal non-user visable use not
+ * subject to translation
+ * OR: tr("<string>") for GUI or other user visible strings that need to be
+ * handled by the translation system {or qApp->translate("<classname>",
+ * "<string>") for classes NOT derived from qobject...
+ */
+#define QT_NO_CAST_FROM_ASCII
+#define QT_NO_CAST_TO_ASCII
 
 #include "dlgRoomExits.h"
 
 
+#include "Host.h"
 #include "TArea.h"
 #include "TMap.h"
-#include "TRoom.h"
-#include "TRoomDB.h"
-#include "Host.h"
 #include "TRoom.h"
 #include "TRoomDB.h"
 
 #include "pre_guard.h"
 #include <QDebug>
-#include <QStringBuilder>
 #include "post_guard.h"
 
 dlgRoomExits::dlgRoomExits( Host * pH, QWidget * pW ): QDialog( pW ), mpHost( pH ), mpEditItem( 0 )
@@ -243,7 +251,8 @@ void dlgRoomExits::save()
     QMutableMapIterator<int, QString> exitIterator = oldSpecialExits;
     while (exitIterator.hasNext()) {
         exitIterator.next();
-        if ( exitIterator.value().length() > 1 && ( exitIterator.value().startsWith("0") || exitIterator.value().startsWith("1") ) )
+        if ( exitIterator.value().length() > 1 && (    exitIterator.value().startsWith( QStringLiteral("0") )
+                                                    || exitIterator.value().startsWith( QStringLiteral("1") ) ) )
             exitIterator.setValue( exitIterator.value().mid(1) );
     }
     QSet<QString> originalExitCmds = oldSpecialExits.values().toSet();
@@ -269,9 +278,9 @@ void dlgRoomExits::save()
              && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) !=0 ) {
             originalExitCmds.remove( value );
             if ( pI->checkState(1) == Qt::Unchecked )
-                value = value.prepend( '0' );
+                value = value.prepend( QStringLiteral( "0" ) );
             else
-                value = value.prepend( '1' );
+                value = value.prepend( QStringLiteral( "1" ) );
             pR->setSpecialExit( key, value ); // Now can overwrite an existing exit with a different destination
             if ( pR->hasExitWeight(value.mid(1))  || weight > 0 )
                 pR->setExitWeight(value.mid(1), weight);
@@ -299,9 +308,9 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_NORTHWEST))   // And ensure that stub exit is cleared if set
             pR->setExitStub(DIR_NORTHWEST, false);
         if (weight_nw->value())  // And store any weighing specifed
-            pR->setExitWeight( "nw", weight_nw->value());
+            pR->setExitWeight( QStringLiteral("nw"), weight_nw->value());
         else
-            pR->setExitWeight( "nw", 0);
+            pR->setExitWeight( QStringLiteral("nw"), 0);
     } else { // No valid exit on the dialogue
         if( originalExits.value( DIR_NORTHWEST )->destination > 0 ) {
             pR->setExit( -1, DIR_NORTHWEST ); // Destination has been deleted So ensure the value for no exit is stored
@@ -309,11 +318,11 @@ void dlgRoomExits::save()
         if (stub_nw->isChecked() != pR->hasExitStub(DIR_NORTHWEST))
             // Does the stub exit setting differ from what is stored
             pR->setExitStub(DIR_NORTHWEST, stub_nw->isChecked()); // So change stored idea to match
-        pR->setExitWeight( "nw", 0); // And clear any weighting that was stored
-        pR->customLinesArrow.remove( "NW" );
-        pR->customLinesColor.remove( "NW" );
-        pR->customLinesStyle.remove( "NW" );
-        pR->customLines.remove( "NW" ); // And remove any custom line stuff, which uses opposite case keys - *sigh*
+        pR->setExitWeight( QStringLiteral("nw"), 0); // And clear any weighting that was stored
+        pR->customLinesArrow.remove( QStringLiteral("NW") );
+        pR->customLinesColor.remove( QStringLiteral("NW") );
+        pR->customLinesStyle.remove( QStringLiteral("NW") );
+        pR->customLines.remove( QStringLiteral("NW") ); // And remove any custom line stuff, which uses opposite case keys - *sigh*
     }
 
     if (n->isEnabled() && n->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != 0 ) {
@@ -323,20 +332,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_NORTH))
             pR->setExitStub(DIR_NORTH, false);
         if (weight_n->value())
-            pR->setExitWeight( "n", weight_n->value());
+            pR->setExitWeight( QStringLiteral("n"), weight_n->value());
         else
-            pR->setExitWeight( "n", 0);
+            pR->setExitWeight( QStringLiteral("n"), 0);
     } else {
         if( originalExits.value( DIR_NORTH )->destination > 0 ) {
             pR->setExit( -1, DIR_NORTH );
         }
         if (stub_n->isChecked() != pR->hasExitStub(DIR_NORTH))
             pR->setExitStub(DIR_NORTH, stub_n->isChecked());
-        pR->setExitWeight( "n", 0);
-        pR->customLinesArrow.remove( "N" );
-        pR->customLinesColor.remove( "N" );
-        pR->customLinesStyle.remove( "N" );
-        pR->customLines.remove( "N" );
+        pR->setExitWeight( QStringLiteral("n"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("N") );
+        pR->customLinesColor.remove( QStringLiteral("N") );
+        pR->customLinesStyle.remove( QStringLiteral("N") );
+        pR->customLines.remove( QStringLiteral("N") );
     }
 
     if (ne->isEnabled() && ne->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != 0 ) {
@@ -346,20 +355,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_NORTHEAST))
             pR->setExitStub(DIR_NORTHEAST, false);
         if (weight_ne->value())
-            pR->setExitWeight( "ne", weight_ne->value());
+            pR->setExitWeight( QStringLiteral("ne"), weight_ne->value());
         else
-            pR->setExitWeight( "ne", 0);
+            pR->setExitWeight( QStringLiteral("ne"), 0);
     } else {
         if( originalExits.value( DIR_NORTHEAST )->destination > 0 ) {
             pR->setExit( -1, DIR_NORTHEAST );
         }
         if (stub_ne->isChecked() != pR->hasExitStub(DIR_NORTHEAST))
             pR->setExitStub(DIR_NORTHEAST, stub_ne->isChecked());
-        pR->setExitWeight( "ne", 0);
-        pR->customLinesArrow.remove( "NE" );
-        pR->customLinesColor.remove( "NE" );
-        pR->customLinesStyle.remove( "NE" );
-        pR->customLines.remove( "NE" );
+        pR->setExitWeight( QStringLiteral("ne"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("NE") );
+        pR->customLinesColor.remove( QStringLiteral("NE") );
+        pR->customLinesStyle.remove( QStringLiteral("NE") );
+        pR->customLines.remove( QStringLiteral("NE") );
     }
 
     if (up->isEnabled() && up->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != 0 ) {
@@ -369,20 +378,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_UP))
             pR->setExitStub(DIR_UP, false);
         if (weight_up->value())
-            pR->setExitWeight( "up", weight_up->value());
+            pR->setExitWeight( QStringLiteral("up"), weight_up->value());
         else
-            pR->setExitWeight( "up", 0);
+            pR->setExitWeight( QStringLiteral("up"), 0);
     } else {
         if( originalExits.value( DIR_UP )->destination > 0 ) {
             pR->setExit( -1, DIR_UP );
         }
         if (stub_up->isChecked() != pR->hasExitStub(DIR_UP))
             pR->setExitStub(DIR_UP, stub_up->isChecked());
-        pR->setExitWeight( "up", 0);
-        pR->customLinesArrow.remove( "UP" );
-        pR->customLinesColor.remove( "UP" );
-        pR->customLinesStyle.remove( "UP" );
-        pR->customLines.remove( "UP" );
+        pR->setExitWeight( QStringLiteral("up"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("UP") );
+        pR->customLinesColor.remove( QStringLiteral("UP") );
+        pR->customLinesStyle.remove( QStringLiteral("UP") );
+        pR->customLines.remove( QStringLiteral("UP") );
     }
 
     if (w->isEnabled() && w->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != 0 ) {
@@ -392,20 +401,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_WEST))
             pR->setExitStub(DIR_WEST, false);
         if (weight_w->value())
-            pR->setExitWeight( "w", weight_w->value());
+            pR->setExitWeight( QStringLiteral("w"), weight_w->value());
         else
-            pR->setExitWeight( "w", 0);
+            pR->setExitWeight( QStringLiteral("w"), 0);
     } else {
         if( originalExits.value( DIR_WEST )->destination > 0 ) {
             pR->setExit( -1, DIR_WEST );
         }
         if (stub_w->isChecked() != pR->hasExitStub(DIR_WEST))
             pR->setExitStub(DIR_WEST, stub_w->isChecked());
-        pR->setExitWeight( "w", 0);
-        pR->customLinesArrow.remove( "W" );
-        pR->customLinesColor.remove( "W" );
-        pR->customLinesStyle.remove( "W" );
-        pR->customLines.remove( "W" );
+        pR->setExitWeight( QStringLiteral("w"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("W") );
+        pR->customLinesColor.remove( QStringLiteral("W") );
+        pR->customLinesStyle.remove( QStringLiteral("W") );
+        pR->customLines.remove( QStringLiteral("W") );
     }
 
     if (e->isEnabled() && e->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != 0 ) {
@@ -415,20 +424,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_EAST))
             pR->setExitStub(DIR_EAST, false);
         if (weight_e->value())
-            pR->setExitWeight( "e", weight_e->value());
+            pR->setExitWeight( QStringLiteral("e"), weight_e->value());
         else
-            pR->setExitWeight( "e", 0);
+            pR->setExitWeight( QStringLiteral("e"), 0);
     } else {
         if( originalExits.value( DIR_EAST )->destination > 0 ) {
             pR->setExit( -1, DIR_EAST );
         }
         if (stub_e->isChecked() != pR->hasExitStub(DIR_EAST))
             pR->setExitStub(DIR_EAST, stub_e->isChecked());
-        pR->setExitWeight( "e", 0);
-        pR->customLinesArrow.remove( "E" );
-        pR->customLinesColor.remove( "E" );
-        pR->customLinesStyle.remove( "E" );
-        pR->customLines.remove( "E" );
+        pR->setExitWeight( QStringLiteral("e"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("E") );
+        pR->customLinesColor.remove( QStringLiteral("E") );
+        pR->customLinesStyle.remove( QStringLiteral("E") );
+        pR->customLines.remove( QStringLiteral("E") );
     }
 
     if (down->isEnabled() && down->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != 0 ) {
@@ -438,20 +447,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_DOWN))
             pR->setExitStub(DIR_DOWN, false);
         if (weight_down->value())
-            pR->setExitWeight( "down", weight_down->value());
+            pR->setExitWeight( QStringLiteral("down"), weight_down->value());
         else
-            pR->setExitWeight( "down", 0);
+            pR->setExitWeight( QStringLiteral("down"), 0);
     } else {
         if( originalExits.value( DIR_DOWN )->destination > 0 ) {
             pR->setExit( -1, DIR_DOWN );
         }
         if (stub_down->isChecked() != pR->hasExitStub(DIR_DOWN))
             pR->setExitStub(DIR_DOWN, stub_down->isChecked());
-        pR->setExitWeight( "down", 0);
-        pR->customLinesArrow.remove( "DOWN" );
-        pR->customLinesColor.remove( "DOWN" );
-        pR->customLinesStyle.remove( "DOWN" );
-        pR->customLines.remove( "DOWN" );
+        pR->setExitWeight( QStringLiteral("down"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("DOWN") );
+        pR->customLinesColor.remove( QStringLiteral("DOWN") );
+        pR->customLinesStyle.remove( QStringLiteral("DOWN") );
+        pR->customLines.remove( QStringLiteral("DOWN") );
     }
 
     if (sw->isEnabled() && sw->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != 0 ) {
@@ -461,20 +470,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_SOUTHWEST))
             pR->setExitStub(DIR_SOUTHWEST, false);
         if (weight_sw->value())
-            pR->setExitWeight( "sw", weight_sw->value());
+            pR->setExitWeight( QStringLiteral("sw"), weight_sw->value());
         else
-            pR->setExitWeight( "sw", 0);
+            pR->setExitWeight( QStringLiteral("sw"), 0);
     } else {
         if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
             pR->setExit( -1, DIR_SOUTHWEST );
         }
         if (stub_sw->isChecked() != pR->hasExitStub(DIR_SOUTHWEST))
             pR->setExitStub(DIR_SOUTHWEST, stub_sw->isChecked());
-        pR->setExitWeight( "sw", 0);
-        pR->customLinesArrow.remove( "SW" );
-        pR->customLinesColor.remove( "SW" );
-        pR->customLinesStyle.remove( "SW" );
-        pR->customLines.remove( "SW" );
+        pR->setExitWeight( QStringLiteral("sw"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("SW") );
+        pR->customLinesColor.remove( QStringLiteral("SW") );
+        pR->customLinesStyle.remove( QStringLiteral("SW") );
+        pR->customLines.remove( QStringLiteral("SW") );
     }
 
     if (s->isEnabled() && s->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != 0 ) {
@@ -484,20 +493,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_SOUTH))
             pR->setExitStub(DIR_SOUTH, false);
         if (weight_s->value())
-            pR->setExitWeight( "s", weight_s->value());
+            pR->setExitWeight( QStringLiteral("s"), weight_s->value());
         else
-            pR->setExitWeight( "s", 0);
+            pR->setExitWeight( QStringLiteral("s"), 0);
     } else {
         if( originalExits.value( DIR_SOUTH )->destination > 0 ) {
             pR->setExit( -1, DIR_SOUTH );
         }
         if (stub_s->isChecked() != pR->hasExitStub(DIR_SOUTH))
             pR->setExitStub(DIR_SOUTH, stub_s->isChecked());
-        pR->setExitWeight( "s", 0);
-        pR->customLinesArrow.remove( "S" );
-        pR->customLinesColor.remove( "S" );
-        pR->customLinesStyle.remove( "S" );
-        pR->customLines.remove( "S" );
+        pR->setExitWeight( QStringLiteral("s"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("S") );
+        pR->customLinesColor.remove( QStringLiteral("S") );
+        pR->customLinesStyle.remove( QStringLiteral("S") );
+        pR->customLines.remove( QStringLiteral("S") );
     }
 
     if (se->isEnabled() && se->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != 0 ) {
@@ -507,20 +516,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_SOUTHEAST))
             pR->setExitStub(DIR_SOUTHEAST, false);
         if (weight_se->value())
-            pR->setExitWeight( "se", weight_se->value());
+            pR->setExitWeight( QStringLiteral("se"), weight_se->value());
         else
-            pR->setExitWeight( "se", 0);
+            pR->setExitWeight( QStringLiteral("se"), 0);
     } else {
         if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
             pR->setExit( -1, DIR_SOUTHEAST );
         }
         if (stub_se->isChecked() != pR->hasExitStub(DIR_SOUTHEAST))
             pR->setExitStub(DIR_SOUTHEAST, stub_se->isChecked());
-        pR->setExitWeight( "se", 0);
-        pR->customLinesArrow.remove( "SE" );
-        pR->customLinesColor.remove( "SE" );
-        pR->customLinesStyle.remove( "SE" );
-        pR->customLines.remove( "SE" );
+        pR->setExitWeight( QStringLiteral("se"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("SE") );
+        pR->customLinesColor.remove( QStringLiteral("SE") );
+        pR->customLinesStyle.remove( QStringLiteral("SE") );
+        pR->customLines.remove( QStringLiteral("SE") );
     }
 
     if (in->isEnabled() && in->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != 0 ) {
@@ -530,20 +539,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_IN))
             pR->setExitStub(DIR_IN, false);
         if (weight_in->value())
-            pR->setExitWeight( "in", weight_in->value());
+            pR->setExitWeight( QStringLiteral("in"), weight_in->value());
         else
-            pR->setExitWeight( "in", 0);
+            pR->setExitWeight( QStringLiteral("in"), 0);
     } else {
         if( originalExits.value( DIR_IN )->destination > 0 ) {
             pR->setExit( -1, DIR_IN );
         }
         if (stub_in->isChecked() != pR->hasExitStub(DIR_IN))
             pR->setExitStub(DIR_IN, stub_in->isChecked());
-        pR->setExitWeight( "in", 0);
-        pR->customLinesArrow.remove( "IN" );
-        pR->customLinesColor.remove( "IN" );
-        pR->customLinesStyle.remove( "IN" );
-        pR->customLines.remove( "IN" );
+        pR->setExitWeight( QStringLiteral("in"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("IN") );
+        pR->customLinesColor.remove( QStringLiteral("IN") );
+        pR->customLinesStyle.remove( QStringLiteral("IN") );
+        pR->customLines.remove( QStringLiteral("IN") );
     }
 
     if (out->isEnabled() && out->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != 0 ) {
@@ -553,20 +562,20 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(DIR_OUT))
             pR->setExitStub(DIR_OUT, false);
         if (weight_out->value())
-            pR->setExitWeight( "out", weight_out->value());
+            pR->setExitWeight( QStringLiteral("out"), weight_out->value());
         else
-            pR->setExitWeight( "out", 0);
+            pR->setExitWeight( QStringLiteral("out"), 0);
     } else {
         if( originalExits.value( DIR_OUT )->destination > 0 ) {
             pR->setExit( -1, DIR_OUT );
         }
         if (stub_out->isChecked() != pR->hasExitStub(DIR_OUT))
             pR->setExitStub(DIR_OUT, stub_out->isChecked());
-        pR->setExitWeight( "out", 0);
-        pR->customLinesArrow.remove( "OUT" );
-        pR->customLinesColor.remove( "OUT" );
-        pR->customLinesStyle.remove( "OUT" );
-        pR->customLines.remove( "OUT" );
+        pR->setExitWeight( QStringLiteral("out"), 0);
+        pR->customLinesArrow.remove( QStringLiteral("OUT") );
+        pR->customLinesColor.remove( QStringLiteral("OUT") );
+        pR->customLinesStyle.remove( QStringLiteral("OUT") );
+        pR->customLines.remove( QStringLiteral("OUT") );
     }
 
     pR->setExitLock(DIR_NORTHWEST, noroute_nw->isChecked());
@@ -587,40 +596,40 @@ void dlgRoomExits::save()
     //   created without an explict Id, any attempt to set a different Id using
     //   setId() seems to fail for me :(
     if (doortype_nw->checkedId()<-1)
-        pR->setDoor( "nw", -2-doortype_nw->checkedId());
+        pR->setDoor( QStringLiteral("nw"), -2-doortype_nw->checkedId());
 
     if (doortype_n->checkedId()<-1)
-        pR->setDoor( "n", -2-doortype_n->checkedId());
+        pR->setDoor( QStringLiteral("n"), -2-doortype_n->checkedId());
 
     if (doortype_ne->checkedId()<-1)
-        pR->setDoor( "ne", -2-doortype_ne->checkedId());
+        pR->setDoor( QStringLiteral("ne"), -2-doortype_ne->checkedId());
 
     if (doortype_up->checkedId()<-1)
-        pR->setDoor( "up", -2-doortype_up->checkedId());
+        pR->setDoor( QStringLiteral("up"), -2-doortype_up->checkedId());
 
     if (doortype_w->checkedId()<-1)
-        pR->setDoor( "w", -2-doortype_w->checkedId());
+        pR->setDoor( QStringLiteral("w"), -2-doortype_w->checkedId());
 
     if (doortype_e->checkedId()<-1)
-        pR->setDoor( "e", -2-doortype_e->checkedId());
+        pR->setDoor( QStringLiteral("e"), -2-doortype_e->checkedId());
 
     if (doortype_down->checkedId()<-1)
-        pR->setDoor( "down", -2-doortype_down->checkedId());
+        pR->setDoor( QStringLiteral("down"), -2-doortype_down->checkedId());
 
     if (doortype_sw->checkedId()<-1)
-        pR->setDoor( "sw", -2-doortype_sw->checkedId());
+        pR->setDoor( QStringLiteral("sw"), -2-doortype_sw->checkedId());
 
     if (doortype_s->checkedId()<-1)
-        pR->setDoor( "s", -2-doortype_s->checkedId());
+        pR->setDoor( QStringLiteral("s"), -2-doortype_s->checkedId());
 
     if (doortype_se->checkedId()<-1)
-        pR->setDoor( "se", -2-doortype_se->checkedId());
+        pR->setDoor( QStringLiteral("se"), -2-doortype_se->checkedId());
 
     if (doortype_in->checkedId()<-1)
-        pR->setDoor( "in", -2-doortype_in->checkedId());
+        pR->setDoor( QStringLiteral("in"), -2-doortype_in->checkedId());
 
     if (doortype_out->checkedId()<-1)
-        pR->setDoor( "out", -2-doortype_out->checkedId());
+        pR->setDoor( QStringLiteral("out"), -2-doortype_out->checkedId());
 
     TArea * pA = mpHost->mpMap->mpRoomDB->getArea( pR->getArea() );
     if( pA )
@@ -1276,14 +1285,15 @@ void dlgRoomExits::slot_stub_nw_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != 0 ) {
-            nw->setText("");
+            nw->setText( QStringLiteral("") );
             nw->setStyleSheet( QStringLiteral("") );
             weight_nw->setValue(0); // Can't have a weight for a stub exit
             noroute_nw->setChecked(false); // nor a "lock"
         }
         noroute_nw->setEnabled(false); // Disable "lock" on this exit
         nw->setEnabled(false); // Prevent entry of an exit roomID
-        nw->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_nw->setEnabled(true);
         doortype_open_nw->setEnabled(true);
         doortype_closed_nw->setEnabled(true);
@@ -1291,7 +1301,8 @@ void dlgRoomExits::slot_stub_nw_stateChanged(int state)
         weight_nw->setEnabled(false); // Prevent a weight to be set/changed on a stub
     } else {
         nw->setEnabled(true);
-        nw->setToolTip("Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.");
+        nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room northwest of this one, will be blue for a valid number or red for invalid." ) ) );
         //  noroute_nw->setEnabled(true); although this branch will enable the exit entry
         //  there will not be a valid one there yet so don't enable the noroute(lock) control here!
         doortype_none_nw->setEnabled(false);
@@ -1310,14 +1321,15 @@ void dlgRoomExits::slot_stub_n_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != 0 ) {
-            n->setText("");
+            n->setText( QStringLiteral("") );
             n->setStyleSheet( QStringLiteral("") );
             weight_n->setValue(0);
             noroute_n->setChecked(false);
         }
         noroute_n->setEnabled(false);
         n->setEnabled(false);
-        n->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_n->setEnabled(true);
         doortype_open_n->setEnabled(true);
         doortype_closed_n->setEnabled(true);
@@ -1325,7 +1337,8 @@ void dlgRoomExits::slot_stub_n_stateChanged(int state)
         weight_n->setEnabled(false);
     } else {
         n->setEnabled(true);
-        n->setToolTip("Set the number of the room north of this one, will be blue for a valid number or red for invalid.");
+        n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room north of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_n->setEnabled(false);
         doortype_open_n->setEnabled(false);
         doortype_closed_n->setEnabled(false);
@@ -1341,14 +1354,15 @@ void dlgRoomExits::slot_stub_ne_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != 0 ) {
-            ne->setText("");
+            ne->setText( QStringLiteral("") );
             ne->setStyleSheet( QStringLiteral("") );
             weight_ne->setValue(0);
             noroute_ne->setChecked(false);
         }
         noroute_ne->setEnabled(false);
         ne->setEnabled(false);
-        ne->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_ne->setEnabled(true);
         doortype_open_ne->setEnabled(true);
         doortype_closed_ne->setEnabled(true);
@@ -1356,7 +1370,8 @@ void dlgRoomExits::slot_stub_ne_stateChanged(int state)
         weight_ne->setEnabled(false);
     } else {
         ne->setEnabled(true);
-        ne->setToolTip("Set the number of the room northeast of this one, will be blue for a valid number or red for invalid.");
+        ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room northeast of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_ne->setEnabled(false);
         doortype_open_ne->setEnabled(false);
         doortype_closed_ne->setEnabled(false);
@@ -1372,14 +1387,15 @@ void dlgRoomExits::slot_stub_up_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != 0 ) {
-            up->setText("");
+            up->setText( QStringLiteral("") );
             up->setStyleSheet( QStringLiteral("") );
             weight_up->setValue(0);
             noroute_up->setChecked(false);
         }
         noroute_up->setEnabled(false);
         up->setEnabled(false);
-        up->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_up->setEnabled(true);
         doortype_open_up->setEnabled(true);
         doortype_closed_up->setEnabled(true);
@@ -1387,7 +1403,8 @@ void dlgRoomExits::slot_stub_up_stateChanged(int state)
         weight_up->setEnabled(false);
     } else {
         up->setEnabled(true);
-        up->setToolTip("Set the number of the room up from this one, will be blue for a valid number or red for invalid.");
+        up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room up from this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_up->setEnabled(false);
         doortype_open_up->setEnabled(false);
         doortype_closed_up->setEnabled(false);
@@ -1403,14 +1420,15 @@ void dlgRoomExits::slot_stub_w_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != 0 ) {
-            w->setText("");
+            w->setText( QStringLiteral("") );
             w->setStyleSheet( QStringLiteral("") );
             weight_w->setValue(0);
             noroute_w->setChecked(false);
         }
         noroute_w->setEnabled(false);
         w->setEnabled(false);
-        w->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_w->setEnabled(true);
         doortype_open_w->setEnabled(true);
         doortype_closed_w->setEnabled(true);
@@ -1418,7 +1436,8 @@ void dlgRoomExits::slot_stub_w_stateChanged(int state)
         weight_w->setEnabled(false);
     } else {
         w->setEnabled(true);
-        w->setToolTip("Set the number of the room west of this one, will be blue for a valid number or red for invalid.");
+        w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room west of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_w->setEnabled(false);
         doortype_open_w->setEnabled(false);
         doortype_closed_w->setEnabled(false);
@@ -1434,14 +1453,15 @@ void dlgRoomExits::slot_stub_e_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != 0 ) {
-            e->setText("");
+            e->setText( QStringLiteral("") );
             e->setStyleSheet( QStringLiteral("") );
             weight_e->setValue(0);
             noroute_e->setChecked(false);
         }
         noroute_e->setEnabled(false);
         e->setEnabled(false);
-        e->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_e->setEnabled(true);
         doortype_open_e->setEnabled(true);
         doortype_closed_e->setEnabled(true);
@@ -1449,7 +1469,8 @@ void dlgRoomExits::slot_stub_e_stateChanged(int state)
         weight_e->setEnabled(false);
     } else {
         e->setEnabled(true);
-        e->setToolTip("Set the number of the room east of this one, will be blue for a valid number or red for invalid.");
+        e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room east of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_e->setEnabled(false);
         doortype_open_e->setEnabled(false);
         doortype_closed_e->setEnabled(false);
@@ -1465,14 +1486,15 @@ void dlgRoomExits::slot_stub_down_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != 0 ) {
-            down->setText("");
+            down->setText( QStringLiteral("") );
             down->setStyleSheet( QStringLiteral("") );
             weight_down->setValue(0);
             noroute_down->setChecked(false);
         }
         noroute_down->setEnabled(false);
         down->setEnabled(false);
-        down->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                          .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_down->setEnabled(true);
         doortype_open_down->setEnabled(true);
         doortype_closed_down->setEnabled(true);
@@ -1480,7 +1502,8 @@ void dlgRoomExits::slot_stub_down_stateChanged(int state)
         weight_down->setEnabled(false);
     } else {
         down->setEnabled(true);
-        down->setToolTip("Set the number of the room down from this one, will be blue for a valid number or red for invalid.");
+        down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                          .arg( tr( "Set the number of the room down from this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_down->setEnabled(false);
         doortype_open_down->setEnabled(false);
         doortype_closed_down->setEnabled(false);
@@ -1496,14 +1519,15 @@ void dlgRoomExits::slot_stub_sw_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != 0 ) {
-            sw->setText("");
+            sw->setText( QStringLiteral("") );
             sw->setStyleSheet( QStringLiteral("") );
             weight_sw->setValue(0);
             noroute_sw->setChecked(false);
         }
         noroute_sw->setEnabled(false);
         sw->setEnabled(false);
-        sw->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_sw->setEnabled(true);
         doortype_open_sw->setEnabled(true);
         doortype_closed_sw->setEnabled(true);
@@ -1511,7 +1535,8 @@ void dlgRoomExits::slot_stub_sw_stateChanged(int state)
         weight_sw->setEnabled(false);
     } else {
         sw->setEnabled(true);
-        sw->setToolTip("Set the number of the room southwest of this one, will be blue for a valid number or red for invalid.");
+        sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room southwest of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_sw->setEnabled(false);
         doortype_open_sw->setEnabled(false);
         doortype_closed_sw->setEnabled(false);
@@ -1527,14 +1552,15 @@ void dlgRoomExits::slot_stub_s_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != 0 ) {
-            s->setText("");
+            s->setText( QStringLiteral("") );
             s->setStyleSheet( QStringLiteral("") );
             weight_s->setValue(0);
             noroute_s->setChecked(false);
         }
         noroute_s->setEnabled(false);
         s->setEnabled(false);
-        s->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_s->setEnabled(true);
         doortype_open_s->setEnabled(true);
         doortype_closed_s->setEnabled(true);
@@ -1542,7 +1568,8 @@ void dlgRoomExits::slot_stub_s_stateChanged(int state)
         weight_s->setEnabled(false);
     } else {
         s->setEnabled(true);
-        s->setToolTip("Set the number of the room south of this one, will be blue for a valid number or red for invalid.");
+        s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                       .arg( tr( "Set the number of the room south of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_s->setEnabled(false);
         doortype_open_s->setEnabled(false);
         doortype_closed_s->setEnabled(false);
@@ -1558,14 +1585,15 @@ void dlgRoomExits::slot_stub_se_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != 0 ) {
-            se->setText("");
+            se->setText( QStringLiteral("") );
             se->setStyleSheet( QStringLiteral("") );
             weight_se->setValue(0);
             noroute_se->setChecked(false);
         }
         noroute_se->setEnabled(false);
         se->setEnabled(false);
-        se->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_se->setEnabled(true);
         doortype_open_se->setEnabled(true);
         doortype_closed_se->setEnabled(true);
@@ -1573,7 +1601,8 @@ void dlgRoomExits::slot_stub_se_stateChanged(int state)
         weight_se->setEnabled(false);
     } else {
         se->setEnabled(true);
-        se->setToolTip("Set the number of the room southeast of this one, will be blue for a valid number or red for invalid.");
+        se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room southeast of this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_se->setEnabled(false);
         doortype_open_se->setEnabled(false);
         doortype_closed_se->setEnabled(false);
@@ -1589,14 +1618,15 @@ void dlgRoomExits::slot_stub_in_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != 0 ) {
-            in->setText("");
+            in->setText( QStringLiteral("") );
             in->setStyleSheet( QStringLiteral("") );
             weight_in->setValue(0);
             noroute_in->setChecked(false);
         }
         noroute_in->setEnabled(false);
         in->setEnabled(false);
-        in->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Clear the stub exit for this exit to enter an exit roomID." ) ) );
         doortype_none_in->setEnabled(true);
         doortype_open_in->setEnabled(true);
         doortype_closed_in->setEnabled(true);
@@ -1604,7 +1634,8 @@ void dlgRoomExits::slot_stub_in_stateChanged(int state)
         weight_in->setEnabled(false);
     } else {
         in->setEnabled(true);
-        in->setToolTip("Set the number of the room in from this one, will be blue for a valid number or red for invalid.");
+        in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                        .arg( tr( "Set the number of the room in from this one, will be blue for a valid number or red for invalid." ) ) );
         doortype_none_in->setEnabled(false);
         doortype_open_in->setEnabled(false);
         doortype_closed_in->setEnabled(false);
@@ -1620,14 +1651,15 @@ void dlgRoomExits::slot_stub_out_stateChanged(int state)
 {
     if ( state==Qt::Checked ) {
         if ( mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != 0 ) {
-            out->setText("");
+            out->setText( QStringLiteral("") );
             out->setStyleSheet( QStringLiteral("") );
             weight_out->setValue(0);
             noroute_out->setChecked(false);
         }
         noroute_out->setEnabled(false);
         out->setEnabled(false);
-        out->setToolTip("Clear the stub exit for this exit to enter an exit roomID.");
+        out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                         .arg( tr("Clear the stub exit for this exit to enter an exit roomID.") ) );
         doortype_none_out->setEnabled(true);
         doortype_open_out->setEnabled(true);
         doortype_closed_out->setEnabled(true);
@@ -1635,7 +1667,8 @@ void dlgRoomExits::slot_stub_out_stateChanged(int state)
         weight_out->setEnabled(false);
     } else {
         out->setEnabled(true);
-        out->setToolTip("Set the number of the room out from this one, will be blue for a valid number or red for invalid.");
+        out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
+                         .arg( tr("Set the number of the room out from this one, will be blue for a valid number or red for invalid.") ) );
         doortype_none_out->setEnabled(false);
         doortype_open_out->setEnabled(false);
         doortype_closed_out->setEnabled(false);
@@ -1750,7 +1783,8 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
     originalExits[ direction ] = makeExitFromControls( direction );
 }
 
-void dlgRoomExits::init( int id ) {
+void dlgRoomExits::init( int id )
+{
     pR = mpHost->mpMap->mpRoomDB->getRoom( id );
     if ( !pR )
         return;
@@ -1759,9 +1793,9 @@ void dlgRoomExits::init( int id ) {
     roomWeight->setText(QString::number(pR->getWeight()));
     QString titleText;
     if( pR->name.trimmed().length() )
-        titleText = QString("Exits for room: \"%1\" [*]").arg(pR->name);
+        titleText = tr("Exits for room: \"%1\" [*]").arg(pR->name);
     else
-        titleText = QString("Exits for room Id: %1 [*]").arg(id);
+        titleText = tr("Exits for room Id: %1 [*]").arg(id);
 
     this->setWindowTitle(titleText);
 
@@ -1823,7 +1857,7 @@ void dlgRoomExits::init( int id ) {
         QString dir = it.value();
         if ( dir.size() < 1 )
             continue;
-        if ( dir.startsWith('0') || dir.startsWith('1') )
+        if ( dir.startsWith( QStringLiteral("0") ) || dir.startsWith( QStringLiteral("1") ) )
             dir = dir.mid(1);  // Not sure if this will be relevent here??
 
         originalSpecialExits[dir] = new TExit();
@@ -2208,7 +2242,7 @@ void dlgRoomExits::slot_checkModified()
  *                   pI->text(0).toInt(),
  *                   qPrintable(pI->text(7)));
  */
-            if( pI->text(7) == "<command or Lua script>"
+            if( pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (4 of 5)" )
                 || pI->text(0).toInt() <= 0 )
                 continue; // Ignore new or to be deleted entries
             currentCount++;
@@ -2229,7 +2263,7 @@ void dlgRoomExits::slot_checkModified()
  *                           pI->text(0).toInt(),
  *                           qPrintable(pI->text(7)));
  */
-                    if( pI->text(7) == "<command or Lua script>"
+                    if(    pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (5 of 5)" )
                         || pI->text(0).toInt() <= 0 )
                         continue; // Ignore new or to be deleted entries
                     QString currentCmd = pI->text(7);

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -67,7 +67,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -83,7 +83,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -93,7 +93,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="nw">
            <property name="toolTip">
-            <string>Set the number of the room northwest of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>NW exit...</string>
@@ -106,7 +106,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -119,7 +119,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -138,7 +138,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -154,7 +154,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -170,7 +170,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -207,7 +207,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -223,7 +223,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -233,7 +233,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="n">
            <property name="toolTip">
-            <string>Set the number of the room north of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room north of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>N exit...</string>
@@ -246,7 +246,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default..&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -259,7 +259,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -278,7 +278,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -294,7 +294,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -310,7 +310,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -347,7 +347,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -363,7 +363,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -373,7 +373,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="ne">
            <property name="toolTip">
-            <string>Set the number of the room northeast of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room northeast of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>NE exit...</string>
@@ -386,7 +386,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default..&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -399,7 +399,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -418,7 +418,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -434,7 +434,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -450,7 +450,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -487,7 +487,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -503,7 +503,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -513,7 +513,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="up">
            <property name="toolTip">
-            <string>Set the number of the room up from this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room up from this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>Up exit...</string>
@@ -526,7 +526,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default..&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -539,7 +539,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -558,7 +558,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -574,7 +574,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -590,7 +590,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -627,7 +627,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -643,7 +643,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -653,7 +653,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="w">
            <property name="toolTip">
-            <string>Set the number of the room west of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room west of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -669,7 +669,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -682,7 +682,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -701,7 +701,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -717,7 +717,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -733,7 +733,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -780,7 +780,7 @@
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>This is the Room ID Number for this room - it cannot be changed here!</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the Room ID Number for this room - it cannot be changed here!</string>
            </property>
            <property name="readOnly">
             <bool>true</bool>
@@ -803,7 +803,7 @@
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>This is the default weight for this room, which will be used for any exit which does not have its own value set - it cannot be changed here.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set - this value cannot be changed here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="readOnly">
             <bool>true</bool>
@@ -837,7 +837,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -853,7 +853,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -863,7 +863,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="e">
            <property name="toolTip">
-            <string>Set the number of the room east of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room east of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>E exit...</string>
@@ -875,6 +875,9 @@
            <property name="maximum">
             <number>9999</number>
            </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
           </widget>
          </item>
          <item row="1" column="2">
@@ -883,7 +886,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -902,7 +905,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -918,7 +921,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -934,7 +937,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -971,7 +974,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -987,7 +990,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -997,7 +1000,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="down">
            <property name="toolTip">
-            <string>Set the number of the room down from this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room down from this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>Down exit...</string>
@@ -1010,7 +1013,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -1023,7 +1026,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1042,7 +1045,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1058,7 +1061,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1074,7 +1077,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1117,7 +1120,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1139,7 +1142,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1149,7 +1152,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="sw">
            <property name="toolTip">
-            <string>Set the number of the room southwest of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room southwest of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>SW exit...</string>
@@ -1168,7 +1171,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -1181,7 +1184,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1200,7 +1203,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1216,7 +1219,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1232,7 +1235,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1269,7 +1272,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1285,7 +1288,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1295,7 +1298,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="s">
            <property name="toolTip">
-            <string>Set the number of the room south of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room south of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>S exit...</string>
@@ -1308,7 +1311,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -1321,7 +1324,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1340,7 +1343,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1356,7 +1359,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1372,7 +1375,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1409,7 +1412,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1425,7 +1428,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1435,7 +1438,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="se">
            <property name="toolTip">
-            <string>Set the number of the room southeast of this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room southeast of this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>SE exit...</string>
@@ -1448,7 +1451,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -1461,7 +1464,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1480,7 +1483,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1496,7 +1499,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1512,7 +1515,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol is drawn on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1549,7 +1552,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1565,7 +1568,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1575,7 +1578,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="in">
            <property name="toolTip">
-            <string>Set the number of the room in from this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room in from this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>In exit...</string>
@@ -1588,7 +1591,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -1601,7 +1604,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1620,7 +1623,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1636,7 +1639,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1652,7 +1655,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1689,7 +1692,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="toolTip">
-            <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1705,7 +1708,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create an exit in this direction with unknown destination, mutually exclusive with an actual exit roomID.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1715,7 +1718,7 @@
          <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="out">
            <property name="toolTip">
-            <string>Set the number of the room out from this one, will be blue for a valid number or red for invalid</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room out from this one, will be blue for a valid number or red for invalid.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>Out exit...</string>
@@ -1728,7 +1731,7 @@
             <cursorShape>SizeVerCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive value to overide the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="maximum">
             <number>9999</number>
@@ -1741,7 +1744,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>No door symbol is drawn on 2D Map for this exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1760,7 +1763,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1776,7 +1779,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1792,7 +1795,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1868,7 +1871,7 @@
             </font>
            </property>
            <property name="toolTip">
-            <string>Set the number of the room that's to the southwest here</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room that's to the southwest here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="placeholderText">
             <string>Exit RoomID number</string>
@@ -1972,7 +1975,7 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Use this button to save any changes, will also remove any invalid Special exits.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this button to save any changes, will also remove any invalid Special exits.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>&amp;Save</string>
@@ -1988,7 +1991,7 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Use this button to close the dialogue without changing anything.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this button to close the dialogue without changing anything.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>&amp;Cancel</string>
@@ -2007,7 +2010,7 @@
          <enum>Qt::StrongFocus</enum>
         </property>
         <property name="toolTip">
-         <string>Click on an item to edit/change it, to DELETE a Special Exit set its Exit Room ID to zero</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click on an item to edit/change it, to DELETE a Special Exit set its Exit Room ID to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="frameShadow">
          <enum>QFrame::Raised</enum>
@@ -2045,7 +2048,7 @@
 Room ID</string>
          </property>
          <property name="toolTip">
-          <string>Set the number of the room that this exit leads to, if set to zero the exit will be removed on saving the exits.</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set the number of the room that this exit leads to, if set to zero the exit will be removed on saving the exits.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2054,7 +2057,7 @@ Room ID</string>
 Route</string>
          </property>
          <property name="toolTip">
-          <string>Prevent a route being created via this exit, equivalent to an infinite exit weight</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prevent a route being created via this exit, equivalent to an infinite exit weight.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2063,7 +2066,7 @@ Route</string>
 Weight</string>
          </property>
          <property name="toolTip">
-          <string>Set to a positive integer value to overide the default (Room) Weight for using this Exit route, a zero value assigns the default.</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Set to a positive integer value to overide the default (Room) Weight for using this Exit route, a zero value assigns the default.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2072,7 +2075,7 @@ Weight</string>
 None</string>
          </property>
          <property name="toolTip">
-          <string>No door symbol is drawn on 2D Map for this exit (only functional choice currently).</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No door symbol is drawn on 2D Map for this exit (only functional choice currently).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2081,7 +2084,7 @@ None</string>
 Open</string>
          </property>
          <property name="toolTip">
-          <string>Green (Open) door symbol would be drawn on 2D Map (but not currently).</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2090,7 +2093,7 @@ Open</string>
 Closed</string>
          </property>
          <property name="toolTip">
-          <string>Orange (Closed) door symbol would be drawn on 2D Map (but not currently).</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2099,7 +2102,7 @@ Closed</string>
 Locked</string>
          </property>
          <property name="toolTip">
-          <string>Red (Locked) door symbol would be drawn on 2D Map (but not currently).</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
         <column>
@@ -2108,7 +2111,7 @@ Locked</string>
 or LUA script</string>
          </property>
          <property name="toolTip">
-          <string>(Lua scripts need to be prefixed with &quot;script:&quot;)</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(Lua scripts need to be prefixed with &quot;script:&quot;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </column>
        </widget>
@@ -2125,7 +2128,7 @@ or LUA script</string>
       </size>
      </property>
      <property name="toolTip">
-      <string>Add an empty item to Special exits to be edited as required</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add an empty item to Special exits to be edited as required.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>&amp;Add special exit</string>
@@ -2144,7 +2147,7 @@ or LUA script</string>
       </size>
      </property>
      <property name="toolTip">
-      <string>Press this button to deactivate the selection of a Special exit</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Press this button to deactivate the selection of a Special exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>&amp;End S. Exits editing</string>


### PR DESCRIPTION
The use of fixed strings as the keys for various QMaps associate with the exits is not optimal IMHO... this and https://github.com/Mudlet/Mudlet/pull/267 (for the development branch) are necessary to fix a long standing error I made with the dlgRoomExit class in that when it is initialising the form the wrong fixed strings were used to populate the exits' weights for the XY-plane normal exits. This has the result that they appear to be zero (meaning the weight of the destination room appears to be used) instead of reading the value that is actually stored in the map file/database. Any changes then made are written out with the correct key in the TRoom::exitWeight member for the edited room - but it can mess up any settings made using a lua script. This series of commits addresses the problem and also:
* improves the tooltips for each exit room Id to show the weight for the destination room (which is what setting an override for a particular exit will actually modify)
* implements https://github.com/Mudlet/Mudlet/pull/216 which was a noted bug where the coloration of the exit room numbers depending on whether they were valid or not was spreading to the tool-tips when it should not.  For some reason the fix made it into the development branch but not this one!
* adds the colour coding of valid/invalid room Id numbers to the special exits part of the dlgRoomExits class - and provides a tool-tip to the destination room id number 's with the name if available and weight as per the previous item.
* reformats the tool-tips across the entire dlgRoomExit class so that they are wrapped in HTML formatting - which optimises the on-screen rendering for the user's screen auto-magically.
* provides QStringLiteral() / tr() for all QStrings in the dlgRoomExit class ready for any future GUI translation work...
* fixes two cosmetic bug in the Lua subsystem - one a debug/error console message where a linefeed was missing and the other being a "OK" message that was drawn in red and not green as expected. 

The branches' code state after this and https://github.com/Mudlet/Mudlet/pull/267 are applied should be compatible.
