### PR TITLE
Backport: merge ten commits

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3002,11 +3002,10 @@ void T2DMap::slot_setImage()
 
 void T2DMap::slot_deleteRoom()
 {
+    mpMap->mpRoomDB->removeRoom( mMultiSelectionList );
+    // mMultiSelectionList gets cleared as rooms are removed by
+    // TRoomDB::removeRoom() so no need to clear it here!
     mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
-    {
-        mpMap->mpRoomDB->removeRoom( mMultiSelectionList[j] );
-    }
     mMultiSelectionListWidget.clear();
     mMultiSelectionListWidget.hide();
     repaint();
@@ -3300,8 +3299,8 @@ void T2DMap::slot_setArea()
 
     int newAreaId = arealist_combobox->itemData( arealist_combobox->currentIndex() ).toInt();
     mMultiRect = QRect(0,0,0,0);
-    uint maxRoomIndex = mMultiSelectionList.size() - 1;
-    for( int j = 0; j <= maxRoomIndex; j++ ) {
+    int maxRoomIndex = mMultiSelectionList.size() - 1;
+    for( unsigned int j = 0; j <= maxRoomIndex; j++ ) {
         if( j < maxRoomIndex ) {
             mpMap->setRoomArea( mMultiSelectionList.at(j), newAreaId, true );
         }

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -56,7 +56,6 @@ public:
     QList<int> getCollisionNodes();
     QList<int> getRoomsByPosition(int x, int y, int z);
     QMap<int, QMap<int, QMultiMap<int, int> > > koordinatenSystem();
-    bool mIsDirty;
 
 
     QList<int> rooms;                       // rooms of this area
@@ -78,7 +77,9 @@ public:
     bool gridMode;
     bool isZone;
     int zoneAreaRef;
-    TRoomDB* mpRoomDB;
+    TRoomDB * mpRoomDB;
+    bool mIsDirty;
+
 
 private:
     TArea() { qFatal("FATAL: illegal default constructor use of TArea()"); };

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -384,6 +384,7 @@ public:
     static int openWebPage( lua_State * L );
     static int getRoomUserDataKeys( lua_State * L );
     static int getAllRoomUserData( lua_State * L );
+    static int getAllRoomEntrances( lua_State * L );
 
 
     std::list<std::string> mCaptureGroupList;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -31,7 +31,7 @@
 #include <QDataStream>
 #include <QDebug>
 #include <QStringBuilder>
-#include <QTime>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 
@@ -70,10 +70,16 @@ TRoom::TRoom(TRoomDB * pRDB)
 
 TRoom::~TRoom()
 {
-    QTime timer;
+    static double cumulativeMean = 0.0;
+    static quint64 runCount = 0 ;
+    QElapsedTimer timer;
     timer.start();
     mpRoomDB->__removeRoom( id );
-    qDebug()<<"room destructor took"<<timer.elapsed();
+    quint64 thisTime = timer.nsecsElapsed();
+    cumulativeMean += ( ( (thisTime * 1.0e-9) - cumulativeMean) / ++runCount );
+    if( runCount % 1000 == 0 ) {
+        qDebug()<<"TRoom::~TRoom() took" << thisTime * 1.0e-9 << "Sec this time and after" << runCount <<"times the average is" << cumulativeMean << "Sec.";
+    }
 }
 
 bool TRoom::hasExitStub(int direction)
@@ -225,7 +231,7 @@ bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
     pA->addRoom( id );
 
     dirtyAreas.insert( pA );
-    pA->mIsDirty;
+    pA->mIsDirty = true;
 
     if( ! isToDeferAreaRelatedRecalculations ) {
         QSetIterator<TArea *> itpArea = dirtyAreas;
@@ -243,21 +249,24 @@ bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
 
 bool TRoom::setExit( int to, int direction )
 {
+    // FIXME: This along with TRoom->setExit need to be unified to a controller.
     switch(direction){
-    case DIR_NORTH:     north     = to; return true; break;
-    case DIR_NORTHEAST: northeast = to; return true; break;
-    case DIR_NORTHWEST: northwest = to; return true; break;
-    case DIR_EAST:      east      = to; return true; break;
-    case DIR_WEST:      west      = to; return true; break;
-    case DIR_SOUTH:     south     = to; return true; break;
-    case DIR_SOUTHEAST: southeast = to; return true; break;
-    case DIR_SOUTHWEST: southwest = to; return true; break;
-    case DIR_UP:        up        = to; return true; break;
-    case DIR_DOWN:      down      = to; return true; break;
-    case DIR_IN:        in        = to; return true; break;
-    case DIR_OUT:       out       = to; return true;
+    case DIR_NORTH:     north     = to; break;
+    case DIR_NORTHEAST: northeast = to; break;
+    case DIR_NORTHWEST: northwest = to; break;
+    case DIR_EAST:      east      = to; break;
+    case DIR_WEST:      west      = to; break;
+    case DIR_SOUTH:     south     = to; break;
+    case DIR_SOUTHEAST: southeast = to; break;
+    case DIR_SOUTHWEST: southwest = to; break;
+    case DIR_UP:        up        = to; break;
+    case DIR_DOWN:      down      = to; break;
+    case DIR_IN:        in        = to; break;
+    case DIR_OUT:       out       = to; break;
+    default: return false;
     }
-    return false;
+    mpRoomDB->updateEntranceMap(this);
+    return true;
 }
 
 bool TRoom::hasExit( int direction )
@@ -549,7 +558,15 @@ void TRoom::setSpecialExit( int to, const QString& cmd )
         pA->determineAreaExitsOfRoom( id );
         // This updates the (TArea *)->exits map even for exit REMOVALS
     }
+    mpRoomDB->updateEntranceMap(this);
+    mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
+}
 
+void TRoom::clearSpecialExits()
+{
+    other.clear();
+    mpRoomDB->updateEntranceMap(this);
+    mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
 }
 
 void TRoom::removeAllSpecialExitsToRoom( int _id )
@@ -569,6 +586,8 @@ void TRoom::removeAllSpecialExitsToRoom( int _id )
     {
         pA->determineAreaExitsOfRoom( id );
     }
+    mpRoomDB->updateEntranceMap(this);
+    mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
 }
 
 void TRoom::calcRoomDimensions()

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -69,7 +69,7 @@ public:
     bool hasSpecialExitLock( int, const QString& );
     void removeAllSpecialExitsToRoom(int _id );
     void setSpecialExit( int to, const QString& cmd );
-    void clearSpecialExits() { other.clear(); }
+    void clearSpecialExits();
     const QMultiMap<int, QString> & getOtherMap() const { return other; }
     const QMap<QString, int> & getExitWeights() const { return exitWeights; }
     void setExitWeight(const QString& cmd, int w );

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -30,13 +30,14 @@
 #include "pre_guard.h"
 #include <QApplication>
 #include <QDebug>
-#include <QTime>
+#include <QElapsedTimer>
 #include "post_guard.h"
 
 
 TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
 , mUnnamedAreaName( qApp->translate( "TRoomDB", "Unnamed Area" ) )
+, mpTempRoomDeletionList( 0 )
 {
 }
 
@@ -57,10 +58,7 @@ bool TRoomDB::addRoom( int id )
     {
         rooms[id] = new TRoom( this );
         rooms[id]->setId(id);
-        QHash<int, int> exits = rooms[id]->getExits();
-        QList<int> toExits = exits.keys();
-        for (int i = 0; i < toExits.size(); i++)
-            reverseExitMap.insert(id, toExits[i]);
+        // there is no point to update the entranceMap here, as the room has no exit information
         return true;
     }
     else
@@ -74,12 +72,13 @@ bool TRoomDB::addRoom( int id )
     }
 }
 
-bool TRoomDB::addRoom( int id, TRoom * pR )
+bool TRoomDB::addRoom( int id, TRoom * pR, bool isMapLoading )
 {
     if( !rooms.contains( id ) && id > 0 && pR )
     {
         rooms[id] = pR;
         pR->setId(id);
+        updateEntranceMap(pR, isMapLoading);
         return true;
     }
     else
@@ -88,14 +87,133 @@ bool TRoomDB::addRoom( int id, TRoom * pR )
     }
 }
 
+void TRoomDB::deleteValuesFromEntranceMap( int value )
+{
+    QList<int> keyList = entranceMap.keys();
+    QList<int> valueList = entranceMap.values();
+    QList<uint> deleteEntries;
+    uint index = valueList.indexOf( value );
+    while ( index != -1 ) {
+        deleteEntries.append( index );
+        index = valueList.indexOf( value, index + 1 );
+    }
+    for (int i = deleteEntries.size() - 1; i >= 0; --i ) {
+        entranceMap.remove( keyList.at(deleteEntries.at(i)), valueList.at(deleteEntries.at(i)) );
+    }
+}
+
+void TRoomDB::deleteValuesFromEntranceMap( QSet<int> & valueSet )
+{
+    QElapsedTimer timer;
+    timer.start();
+    QList<int> keyList = entranceMap.keys();
+    QList<int> valueList = entranceMap.values();
+    QList<uint> deleteEntries;
+    foreach(int roomId, valueSet) {
+        int index = valueList.indexOf( roomId );
+        while (index >= 0 ) {
+            deleteEntries.append( index );
+            index = valueList.indexOf( roomId, index + 1 );
+        }
+    }
+    for (uint i = 0; i < deleteEntries.size(); ++i) {
+        entranceMap.remove( keyList.at(deleteEntries.at(i)), valueList.at(deleteEntries.at(i)) );
+    }
+    qDebug() << "TRoomDB::deleteValuesFromEntranceMap() with a list of:" << valueSet.size() << "items, run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
+}
+
+void TRoomDB::updateEntranceMap(int id)
+{
+    TRoom * pR = getRoom(id);
+    updateEntranceMap(pR);
+}
+
+void TRoomDB::updateEntranceMap(TRoom * pR, bool isMapLoading)
+{
+    static bool showDebug = false; // Enable this at runtime (set a breakpoint on it) for debugging!
+
+    // entranceMap maps the room to rooms it has a viable exit to. So if room b and c both have
+    // an exit to room a, upon deleting room a we want a map that allows us to find
+    // room b and c efficiently.
+    // So we create a mapping like: {room_a: room_b, room_a: room_c}. This allows us to delete
+    // rooms and know which other rooms are impacted by this change in a single lookup.
+    if( pR ) {
+        int id = pR->getId();
+        QHash<int, int> exits = pR->getExits();
+        QList<int> toExits = exits.keys();
+        QString values;
+        // to update this we need to iterate the entire entranceMap and remove invalid
+        // connections. I'm not sure if this is efficient for every update, and given
+        // that we check for rooms existance when the map is used, we'll deal with
+        // possible spurious exits for now.
+        // entranceMap.remove(id); // <== not what is wanted
+        // We need to remove all values == id NOT keys == id, so try and do that
+        // now. SlySven
+
+        if( ! isMapLoading ) {
+            deleteValuesFromEntranceMap( id ); // When LOADING a map, will never need to do this
+        }
+        for(unsigned int i = 0; i < toExits.size(); i++) {
+            if( showDebug ) {
+                values.append( QStringLiteral("%1,").arg(toExits.at(i)) );
+            }
+            entranceMap.insert(toExits.at(i), id);
+        }
+        if( showDebug ) {
+            if( ! values.isEmpty() ) {
+                values.chop(1);
+            }
+            if( values.isEmpty() ) {
+                qDebug( "TRoomDB::updateEntranceMap(TRoom * pR) called for room with Id:%i, it is not an Entrance for any Rooms.", id );
+            }
+            else {
+                qDebug( "TRoomDB::updateEntranceMap(TRoom * pR) called for room with Id:%i, it is an Entrance for Room(s): %s.", id, values.toLatin1().constData() );
+            }
+        }
+    }
+}
+
 // this is call by TRoom destructor only
 bool TRoomDB::__removeRoom( int id )
 {
-    TRoom* pR = getRoom(id);
+    static QMultiHash<int, int> _entranceMap; // Make it persistant - for multiple room deletions
+    static bool isBulkDelete = false;
+    // Gets set / reset by mpTempRoomDeletionList being non-null, used to setup
+    // _entranceMap the first time around for multi-room deletions
+
+    TRoom * pR = getRoom(id);
+    // This will FAIL during map deletion as TRoomDB::rooms has already been
+    // zapped, so can use to skip everything...
     if (pR) {
+        if( mpTempRoomDeletionList && mpTempRoomDeletionList->size() > 1 ) { // We are deleting multiple rooms
+            if( ! isBulkDelete ) {
+                _entranceMap = entranceMap;
+                _entranceMap.detach(); // MUST take a deep copy of the data
+                isBulkDelete = true; // But only do it the first time for a bulk delete
+            }
+        }
+        else { // We are deleting a single room
+            if( isBulkDelete ) { // Last time was a bulk delete but it isn't one now
+                isBulkDelete = false;
+            }
+            _entranceMap.clear();
+            _entranceMap = entranceMap; // Refresh our local copy
+            _entranceMap.detach(); // MUST take a deep copy of the data
+        }
+
         // FIXME: make a proper exit controller so we don't need to do all these if statements
-        QMultiHash<int, int>::iterator i = reverseExitMap.find(id);
-        while (i != reverseExitMap.end() && i.key() == id) {
+        // Remove the links from the rooms entering this room
+        QMultiHash<int, int>::const_iterator i = _entranceMap.find(id);
+        // The removeAllSpecialExitsToRoom below modifies the entranceMap - and
+        // it is unsafe to modify (use copy operations on) something that an STL
+        // iterator is active on - see "Implicit sharing iterator problem" in
+        // "Container Class | Qt 5.x Core" - this is now avoid by taking a deep
+        // copy and iterating through that instead whilst modifying the original
+        while (i != entranceMap.end() && i.key() == id) {
+            if( i.value() == id || mpTempRoomDeletionList && mpTempRoomDeletionList->size() > 1 && mpTempRoomDeletionList->contains( i.value() ) ) {
+                ++i;
+                continue; // Bypass rooms we know are also to be deleted
+            }
             TRoom* r = getRoom(i.value());
             if (r) {
                 if (r->getNorth() == id)
@@ -139,7 +257,10 @@ bool TRoomDB::__removeRoom( int id )
         TArea * pA = getArea( areaID );
         if (pA)
             pA->removeRoom(id);
-        reverseExitMap.remove(id);
+        if( ( ! mpTempRoomDeletionList ) || mpTempRoomDeletionList->size() == 1 ) { // if NOT deleting multiple rooms
+            entranceMap.remove(id); // Only removes matching keys
+            deleteValuesFromEntranceMap(id); // Needed to remove matching values
+        }
         // Because we clear the graph in initGraph which will be called
         // if mMapGraphNeedsUpdate is true -- we don't need to
         // remove the vertex using clear_vertex and remove_vertex here
@@ -165,19 +286,49 @@ bool TRoomDB::removeRoom( int id )
     return false;
 }
 
+void TRoomDB::removeRoom( QList<int> & ids )
+{
+    QElapsedTimer timer;
+    timer.start();
+    QSet<int> deletedRoomIds;
+    mpTempRoomDeletionList = &ids; // Will activate "bulk room deletion" code
+                                   // When used by TLuaInterpreter::deleteArea()
+                                   // via removeArea(int) the list of rooms to
+                                   // delete - as suppplied by the reference
+                                   // type argument IS NOT CONSTANT - it is
+                                   // ALTERED by TArea::removeRoom( int room )
+                                   // for each room that is removed
+    quint64 roomcount = mpTempRoomDeletionList->size();
+    while( ! mpTempRoomDeletionList->isEmpty() ) {
+        int deleteRoomId = mpTempRoomDeletionList->first();
+        TRoom * pR = getRoom( deleteRoomId );
+        if( pR ) {
+            deletedRoomIds.insert( deleteRoomId );
+            delete pR;
+        }
+    }
+    foreach(int deleteRoomId, deletedRoomIds ) {
+        entranceMap.remove( deleteRoomId ); // This has been deferred from __removeRoom()
+    }
+    deleteValuesFromEntranceMap( deletedRoomIds );
+    mpTempRoomDeletionList->clear();
+    mpTempRoomDeletionList=0;
+    qDebug() << "TRoomDB::removeRoom(QList<int>) run time for" << roomcount << "rooms:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
+}
+
 bool TRoomDB::removeArea( int id )
 {
     if( areas.contains( id ) ) {
-        TArea * pA = areas.value(id);
-        QList<int> rl;
-        for( int i=0; i< pA->rooms.size(); i++ ) {
-            rl.push_back( pA->rooms.at(i) );
+        TArea * pA = areas.value( id );
+        if( ! rooms.isEmpty() ) {
+            removeRoom( pA->rooms ); // During map deletion rooms will already
+                                     // have been cleared so this would not
+                                     // be wanted to be done in that case.
         }
-        for( int i=rl.size()-1; i >= 0; i-- ) {
-            removeRoom( rl.at(i) );
-        }
-        areaNamesMap.remove( id );
-        areas.remove( id );
+        areaNamesMap.remove( id ); // During map deletion areaNamesMap will
+                                   // already have been cleared !!!
+        areas.remove( id ); // This means areas.clear() is not needed during map
+                            // deletion
 
         mpMap->mMapGraphNeedsUpdate = true;
         return true;
@@ -192,16 +343,30 @@ bool TRoomDB::removeArea( int id )
 
 bool TRoomDB::removeArea( QString name )
 {
-    if( areaNamesMap.values().contains( name ) )
-    {
-        return removeArea( areaNamesMap.key( name ) );
+    if( areaNamesMap.values().contains( name ) ) {
+        return removeArea( areaNamesMap.key( name ) ); // i.e. call the removeArea(int) method
     }
-    return false;
+    else {
+        return false;
+    }
 }
 
 void TRoomDB::removeArea( TArea * pA )
 {
-    removeArea( getAreaID(pA) );
+    if( ! pA ) {
+        qWarning( "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area with a NULL TArea pointer!" );
+        return;
+    }
+
+    int areaId = areas.key(pA, 0);
+    if( areaId == areas.key(pA, -1) ) {
+        // By testing twice with different default keys to return if value NOT
+        // found, we can be certain we have an actual valid value
+        removeArea( areaId );
+    }
+    else {
+        qWarning( "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area NOT in TRoomDB::areas!" );
+    }
 }
 
 int TRoomDB::getAreaID( TArea * pA )
@@ -211,7 +376,8 @@ int TRoomDB::getAreaID( TArea * pA )
 
 void TRoomDB::buildAreas()
 {
-    QTime _time; _time.start();
+    QElapsedTimer timer;
+    timer.start();
     QHashIterator<int, TRoom *> it( rooms );
     while( it.hasNext() )
     {
@@ -237,7 +403,7 @@ void TRoomDB::buildAreas()
            areas[id] = new TArea( mpMap, this );
        }
     }
-    qDebug()<<"BUILD AREAS run time:"<<_time.elapsed();
+    qDebug() << "TRoomDB::buildAreas() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 
@@ -386,7 +552,8 @@ QList<int> TRoomDB::getAreaIDList()
 
 void TRoomDB::auditRooms()
 {
-    QTime t; t.start();
+    QElapsedTimer timer;
+    timer.start();
     // rooms konsolidieren
     QHashIterator<int, TRoom* > itRooms( rooms );
     while( itRooms.hasNext() )
@@ -396,7 +563,7 @@ void TRoomDB::auditRooms()
         pR->auditExits();
 
     }
-    qDebug()<<"audit map: runtime:"<<t.elapsed();
+    qDebug() << "TRoomDB::auditRooms() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 void TRoomDB::initAreasForOldMaps()
@@ -424,24 +591,27 @@ void TRoomDB::initAreasForOldMaps()
 
 void TRoomDB::clearMapDB()
 {
+    QElapsedTimer timer;
+    timer.start();
     QList<TRoom*> rPtrL = getRoomPtrList();
-    rooms.clear();
+    rooms.clear(); // Prevents any further use of TRoomDB::getRoom(int) !!!
+    entranceMap.clear();
     areaNamesMap.clear();
     hashTable.clear();
-    for(int i=0; i<rPtrL.size(); i++ )
+    for( uint i=0; i<rPtrL.size(); i++ )
     {
-        delete rPtrL[i];
+        delete rPtrL.at(i); // Uses the internally held value of the room Id
+                            // (TRoom::id) to call TRoomDB::__removeRoom(id)
     }
-    assert( rooms.size() == 0 );
+//    assert( rooms.size() == 0 ); // Pointless as rooms.clear() will have achieved the test condition
 
     QList<TArea*> areaList = getAreaPtrList();
-    for( int i=0; i<areaList.size(); i++ )
+    for( uint i=0; i<areaList.size(); i++ )
     {
-        delete areaList[i];
+        delete areaList.at(i);
     }
     assert( areas.size() == 0 );
-
-
+    qDebug() << "TRoomDB::clearMapDB() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 void TRoomDB::restoreAreaMap( QDataStream & ifs )
@@ -597,5 +767,5 @@ void TRoomDB::restoreSingleArea(QDataStream & ifs, int areaID, TArea * pA )
 
 void TRoomDB::restoreSingleRoom(QDataStream & ifs, int i, TRoom *pT)
 {
-    rooms[i] = pT;
+    addRoom(i, pT, true);
 }

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -45,7 +45,8 @@ public:
 //     int getArea( TArea * pA ); use duplicate int getAreaID( TArea * pA ) instead
     bool addRoom( int id );
     int size() { return rooms.size(); }
-    bool removeRoom( int id );
+    bool removeRoom( int );
+    void removeRoom( QList<int> & );
     bool removeArea( int id );
     bool removeArea( QString name );
     void removeArea( TArea * );
@@ -60,13 +61,17 @@ public:
     QList<int> getRoomIDList();
     QList<int> getAreaIDList();
     const QMap<int, QString> & getAreaNamesMap() const { return areaNamesMap; }
-
+    void updateEntranceMap(TRoom *, bool isMapLoading = false );
+    void updateEntranceMap(int);
+    const QMultiHash<int, int> & getEntranceHash() const { return entranceMap; }
+    void deleteValuesFromEntranceMap( int );
+    void deleteValuesFromEntranceMap( QSet<int> & );
 
     void buildAreas();
     void clearMapDB();
     void initAreasForOldMaps();
     void auditRooms();
-    bool addRoom(int id, TRoom *pR);
+    bool addRoom(int id, TRoom *pR, bool isMapLoading = false);
     int getAreaID(TArea * pA);
     void restoreAreaMap( QDataStream & );
     void restoreSingleArea( QDataStream &, int, TArea * );
@@ -81,11 +86,12 @@ private:
     bool __removeRoom( int id );
 
     QHash<int, TRoom *> rooms;
-    QMultiHash<int, int> reverseExitMap;
+    QMultiHash<int, int> entranceMap;
     QMap<int, TArea *> areas;
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;
     QString mUnnamedAreaName;
+    QList<int> * mpTempRoomDeletionList; // Used during bulk room deletion
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -302,7 +302,9 @@ void dlgRoomExits::save()
 
     if (nw->isEnabled() && nw->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != 0 ) {
         // There IS a valid exit on the dialogue in this direction
-        pR->setExit( nw->text().toInt(), DIR_NORTHWEST ); // So store it
+        if( originalExits.value( DIR_NORTHWEST )->destination != nw->text().toInt() ) {
+            pR->setExit( nw->text().toInt(), DIR_NORTHWEST ); // Destination is different - so store it
+        }
         if (pR->hasExitStub(DIR_NORTHWEST))   // And ensure that stub exit is cleared if set
             pR->setExitStub(DIR_NORTHWEST, false);
         if (weight_nw->value())  // And store any weighing specifed
@@ -310,7 +312,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("nw"), 0);
     } else { // No valid exit on the dialogue
-        pR->setExit( -1, DIR_NORTHWEST ); // So ensure the value for no exit is stored
+        if( originalExits.value( DIR_NORTHWEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_NORTHWEST ); // Destination has been deleted So ensure the value for no exit is stored
+        }
         if (stub_nw->isChecked() != pR->hasExitStub(DIR_NORTHWEST))
             // Does the stub exit setting differ from what is stored
             pR->setExitStub(DIR_NORTHWEST, stub_nw->isChecked()); // So change stored idea to match
@@ -322,7 +326,9 @@ void dlgRoomExits::save()
     }
 
     if (n->isEnabled() && n->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != 0 ) {
-        pR->setExit( n->text().toInt(), DIR_NORTH );
+        if( originalExits.value( DIR_NORTH )->destination != n->text().toInt() ) {
+            pR->setExit( n->text().toInt(), DIR_NORTH );
+        }
         if (pR->hasExitStub(DIR_NORTH))
             pR->setExitStub(DIR_NORTH, false);
         if (weight_n->value())
@@ -330,7 +336,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("n"), 0);
     } else {
-        pR->setExit( -1, DIR_NORTH );
+        if( originalExits.value( DIR_NORTH )->destination > 0 ) {
+            pR->setExit( -1, DIR_NORTH );
+        }
         if (stub_n->isChecked() != pR->hasExitStub(DIR_NORTH))
             pR->setExitStub(DIR_NORTH, stub_n->isChecked());
         pR->setExitWeight( QStringLiteral("n"), 0);
@@ -341,7 +349,9 @@ void dlgRoomExits::save()
     }
 
     if (ne->isEnabled() && ne->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != 0 ) {
-        pR->setExit( ne->text().toInt(), DIR_NORTHEAST );
+        if( originalExits.value( DIR_NORTHEAST )->destination != ne->text().toInt() ) {
+            pR->setExit( ne->text().toInt(), DIR_NORTHEAST );
+        }
         if (pR->hasExitStub(DIR_NORTHEAST))
             pR->setExitStub(DIR_NORTHEAST, false);
         if (weight_ne->value())
@@ -349,7 +359,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("ne"), 0);
     } else {
-        pR->setExit( -1, DIR_NORTHEAST );
+        if( originalExits.value( DIR_NORTHEAST )->destination > 0 ) {
+            pR->setExit( -1, DIR_NORTHEAST );
+        }
         if (stub_ne->isChecked() != pR->hasExitStub(DIR_NORTHEAST))
             pR->setExitStub(DIR_NORTHEAST, stub_ne->isChecked());
         pR->setExitWeight( QStringLiteral("ne"), 0);
@@ -360,7 +372,9 @@ void dlgRoomExits::save()
     }
 
     if (up->isEnabled() && up->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != 0 ) {
-        pR->setExit( up->text().toInt(), DIR_UP );
+        if( originalExits.value( DIR_UP )->destination != up->text().toInt() ) {
+            pR->setExit( up->text().toInt(), DIR_UP );
+        }
         if (pR->hasExitStub(DIR_UP))
             pR->setExitStub(DIR_UP, false);
         if (weight_up->value())
@@ -368,7 +382,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("up"), 0);
     } else {
-        pR->setExit( -1, DIR_UP );
+        if( originalExits.value( DIR_UP )->destination > 0 ) {
+            pR->setExit( -1, DIR_UP );
+        }
         if (stub_up->isChecked() != pR->hasExitStub(DIR_UP))
             pR->setExitStub(DIR_UP, stub_up->isChecked());
         pR->setExitWeight( QStringLiteral("up"), 0);
@@ -379,7 +395,9 @@ void dlgRoomExits::save()
     }
 
     if (w->isEnabled() && w->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != 0 ) {
-        pR->setExit( w->text().toInt(), DIR_WEST );
+        if( originalExits.value( DIR_WEST )->destination != w->text().toInt() ) {
+            pR->setExit( w->text().toInt(), DIR_WEST );
+        }
         if (pR->hasExitStub(DIR_WEST))
             pR->setExitStub(DIR_WEST, false);
         if (weight_w->value())
@@ -387,7 +405,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("w"), 0);
     } else {
-        pR->setExit( -1, DIR_WEST );
+        if( originalExits.value( DIR_WEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_WEST );
+        }
         if (stub_w->isChecked() != pR->hasExitStub(DIR_WEST))
             pR->setExitStub(DIR_WEST, stub_w->isChecked());
         pR->setExitWeight( QStringLiteral("w"), 0);
@@ -398,7 +418,9 @@ void dlgRoomExits::save()
     }
 
     if (e->isEnabled() && e->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != 0 ) {
-        pR->setExit( e->text().toInt(), DIR_EAST );
+        if( originalExits.value( DIR_EAST )->destination != e->text().toInt() ) {
+            pR->setExit( e->text().toInt(), DIR_EAST );
+        }
         if (pR->hasExitStub(DIR_EAST))
             pR->setExitStub(DIR_EAST, false);
         if (weight_e->value())
@@ -406,7 +428,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("e"), 0);
     } else {
-        pR->setExit( -1, DIR_EAST );
+        if( originalExits.value( DIR_EAST )->destination > 0 ) {
+            pR->setExit( -1, DIR_EAST );
+        }
         if (stub_e->isChecked() != pR->hasExitStub(DIR_EAST))
             pR->setExitStub(DIR_EAST, stub_e->isChecked());
         pR->setExitWeight( QStringLiteral("e"), 0);
@@ -417,7 +441,9 @@ void dlgRoomExits::save()
     }
 
     if (down->isEnabled() && down->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != 0 ) {
-        pR->setExit( down->text().toInt(), DIR_DOWN );
+        if( originalExits.value( DIR_DOWN )->destination != down->text().toInt() ) {
+            pR->setExit( down->text().toInt(), DIR_DOWN );
+        }
         if (pR->hasExitStub(DIR_DOWN))
             pR->setExitStub(DIR_DOWN, false);
         if (weight_down->value())
@@ -425,7 +451,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("down"), 0);
     } else {
-        pR->setExit( -1, DIR_DOWN );
+        if( originalExits.value( DIR_DOWN )->destination > 0 ) {
+            pR->setExit( -1, DIR_DOWN );
+        }
         if (stub_down->isChecked() != pR->hasExitStub(DIR_DOWN))
             pR->setExitStub(DIR_DOWN, stub_down->isChecked());
         pR->setExitWeight( QStringLiteral("down"), 0);
@@ -436,7 +464,9 @@ void dlgRoomExits::save()
     }
 
     if (sw->isEnabled() && sw->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != 0 ) {
-        pR->setExit( sw->text().toInt(), DIR_SOUTHWEST );
+        if( originalExits.value( DIR_SOUTHWEST )->destination != sw->text().toInt() ) {
+            pR->setExit( sw->text().toInt(), DIR_SOUTHWEST );
+        }
         if (pR->hasExitStub(DIR_SOUTHWEST))
             pR->setExitStub(DIR_SOUTHWEST, false);
         if (weight_sw->value())
@@ -444,7 +474,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("sw"), 0);
     } else {
-        pR->setExit( -1, DIR_SOUTHWEST );
+        if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_SOUTHWEST );
+        }
         if (stub_sw->isChecked() != pR->hasExitStub(DIR_SOUTHWEST))
             pR->setExitStub(DIR_SOUTHWEST, stub_sw->isChecked());
         pR->setExitWeight( QStringLiteral("sw"), 0);
@@ -455,7 +487,9 @@ void dlgRoomExits::save()
     }
 
     if (s->isEnabled() && s->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != 0 ) {
-        pR->setExit( s->text().toInt(), DIR_SOUTH );
+        if( originalExits.value( DIR_SOUTH )->destination != s->text().toInt() ) {
+            pR->setExit( s->text().toInt(), DIR_SOUTH );
+        }
         if (pR->hasExitStub(DIR_SOUTH))
             pR->setExitStub(DIR_SOUTH, false);
         if (weight_s->value())
@@ -463,7 +497,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("s"), 0);
     } else {
-        pR->setExit( -1, DIR_SOUTH );
+        if( originalExits.value( DIR_SOUTH )->destination > 0 ) {
+            pR->setExit( -1, DIR_SOUTH );
+        }
         if (stub_s->isChecked() != pR->hasExitStub(DIR_SOUTH))
             pR->setExitStub(DIR_SOUTH, stub_s->isChecked());
         pR->setExitWeight( QStringLiteral("s"), 0);
@@ -474,7 +510,9 @@ void dlgRoomExits::save()
     }
 
     if (se->isEnabled() && se->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != 0 ) {
-        pR->setExit( se->text().toInt(), DIR_SOUTHEAST );
+        if( originalExits.value( DIR_SOUTHEAST )->destination != se->text().toInt() ) {
+            pR->setExit( se->text().toInt(), DIR_SOUTHEAST );
+        }
         if (pR->hasExitStub(DIR_SOUTHEAST))
             pR->setExitStub(DIR_SOUTHEAST, false);
         if (weight_se->value())
@@ -482,7 +520,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("se"), 0);
     } else {
-        pR->setExit( -1, DIR_SOUTHEAST );
+        if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
+            pR->setExit( -1, DIR_SOUTHEAST );
+        }
         if (stub_se->isChecked() != pR->hasExitStub(DIR_SOUTHEAST))
             pR->setExitStub(DIR_SOUTHEAST, stub_se->isChecked());
         pR->setExitWeight( QStringLiteral("se"), 0);
@@ -493,7 +533,9 @@ void dlgRoomExits::save()
     }
 
     if (in->isEnabled() && in->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != 0 ) {
-        pR->setExit( in->text().toInt(), DIR_IN );
+        if( originalExits.value( DIR_IN )->destination != in->text().toInt() ) {
+            pR->setExit( in->text().toInt(), DIR_IN );
+        }
         if (pR->hasExitStub(DIR_IN))
             pR->setExitStub(DIR_IN, false);
         if (weight_in->value())
@@ -501,7 +543,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("in"), 0);
     } else {
-        pR->setExit( -1, DIR_IN );
+        if( originalExits.value( DIR_IN )->destination > 0 ) {
+            pR->setExit( -1, DIR_IN );
+        }
         if (stub_in->isChecked() != pR->hasExitStub(DIR_IN))
             pR->setExitStub(DIR_IN, stub_in->isChecked());
         pR->setExitWeight( QStringLiteral("in"), 0);
@@ -512,7 +556,9 @@ void dlgRoomExits::save()
     }
 
     if (out->isEnabled() && out->text().size() > 0 && mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != 0 ) {
-        pR->setExit( out->text().toInt(), DIR_OUT );
+        if( originalExits.value( DIR_OUT )->destination != out->text().toInt() ) {
+            pR->setExit( out->text().toInt(), DIR_OUT );
+        }
         if (pR->hasExitStub(DIR_OUT))
             pR->setExitStub(DIR_OUT, false);
         if (weight_out->value())
@@ -520,7 +566,9 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("out"), 0);
     } else {
-        pR->setExit( -1, DIR_OUT );
+        if( originalExits.value( DIR_OUT )->destination > 0 ) {
+            pR->setExit( -1, DIR_OUT );
+        }
         if (stub_out->isChecked() != pR->hasExitStub(DIR_OUT))
             pR->setExitStub(DIR_OUT, stub_out->isChecked());
         pR->setExitWeight( QStringLiteral("out"), 0);


### PR DESCRIPTION
This is a condensed copy of recent changes relating to what is now TRoomDB::entranceMap and bulk room deletion code (_that improves things by doing the relatively slow updating of the former only once when many rooms are being removed; and in debug builds only reports on the timings for every 1000 rooms deleted instead of each one!_) that was made in "release_30" to backport them to the  "development" branch.  This should help to *reduce* the differences between those branches :pray:.

Commit 01 of 10 originally entitled:
"fix for keeping reverse area exit map in sync with exit creation, adding,
and deletion"
Conflicts resolved in:
	src/TRoom.h

Commit 02 of 10 originally entitled:
"bug fix for entranceMap having reversed key and value"
Conflicts resolved in:
	src/TRoomDB.cpp

Commit 03 of 10 originally entitled:
"removal of entranceMap cleanup"
Conflicts resolved in:
	src/TRoomDB.cpp

Commit 04 of 10 originally entitled:
"BugFix: prevent crash in dlgRoomExits::initExits() on missing exit"

Code deficiencies that remove rooms without properly updating connected
rooms were causing segmentation faults because this method - perhaps
foolishly - expected a room to exist when another room had an exit Id to
the room given.  This commit corrects any faulty normal exits now by
resetting them to the no exit -1 value.

Commit 05 of 10 originally entitled:
"Fixup: prevent unneeded TRoom::setExit() calls from dlgRoomExits class"

Each individual call to TRoom::setExit((int)exitRoomId,(int)directionCode)
from dlgRoomExit::save() creates additional entries in TRoom::entranceMap
even for non-exit directions.  To reduce (but unfortunately not eliminate)
the number of duplicates change the save() code to only use setExit()
when a difference between the current and saved exit room numbers is
found.

Commit 06 of 10 originally entitled:
"Fixup: clear TRoomDB::entranceMap on map clearance"

Obvious but was missing.

Commit 07 of 10 originally entitled:
"Fixup: add getAllRoomEntrances() to Lua command set"

Though suitable for release code this was added to help
with debugging.  This was what enabled me to spot the
problems that the previous pair of commits ameliorates.

This currently only reports the rooms that have exit(s)
that lead to the given room Id.  It is anticipated that
there will be a future revision to report the particular
direction(s) from the given room(s) are the one(s) that
lead to the room, using a second argument that will be
a boolean true to trigger that behavior (the absence of,
or a false, second argument would then cause the result
that this code produces.)
Conflicts resolved in:
	src/TLuaInterpreter.cpp
	src/TLuaInterpreter.h

Commit 08 of 10 originally entitled:
"Fixup: add debugging output to TRoomDB::updateEntranceMap(TRoom *)"

Set a break point in the method and change the static bool showDebug to
dis-/en-able output...

Conflicts resolved in:
	src/TRoomDB.cpp

Commit 09 of 10 originally entitled:
"FixEnhance: fix entranceMap maintenance, bulk room deletion & map loading"

Previously we were not removing entries from the entranceMap involving
the value (a room that the room Id that was a key had an entrance FROM)
when a route was changed.  There is a performance cost in ensuring the
data is kept correctly - there may be a modest gain by storing the
entrance data within each TRoom class instance rather than a central
database in TRoomDB...

Deletion of multiple rooms and map loading can be done more efficiently
if we skip some redundant steps.

Also added/revised some timing code to measure things.

Conflicts resolved in:
	src/TRoomDB.cpp
	src/TRoomDB.h

Commit 10 of 10 originally entitled:
"BugFix: Some previous coding errors"

* T2DMap::slot_setArea(): used a uint where I should have used an int as a
  method I called can return a -1 in some cases.

* TArea::getAreaExitRoomData(): a qWarning() in a debugging line I had
  used the wrong type (%1,%2,...) of format string argument characters when
  I should of used (%i or %s)...

* (bool)TArea::mIsDirty: was put in wrong block of lines in header

Conflicts resolved in:
	src/TArea.h

Further conflicts resolved which were brought about by later re-basing
before posting code out to world:
	src/dlgRoomExits.cpp

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>