### PR TITLE
(release_30)Enhance: provide missing functionality for Map Room User Data

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -182,6 +182,7 @@ public:
     static int getRoomUserData( lua_State * );
     static int searchRoomUserData( lua_State * );
     static int clearRoomUserData( lua_State * );
+    static int clearRoomUserDataItem( lua_State * );
     static int addSpecialExit( lua_State * );
     static int removeSpecialExit( lua_State * );
     static int getSpecialExits( lua_State * );
@@ -380,6 +381,8 @@ public:
     static int getMudletVersion( lua_State * L );
     static int openWebPage( lua_State * L );
     static int getAllRoomEntrances( lua_State * L );
+    static int getRoomUserDataKeys( lua_State * L );
+    static int getAllRoomUserData( lua_State * L );
 
     std::list<std::string> mCaptureGroupList;
     std::list<int> mCaptureGroupPosList;


### PR DESCRIPTION
This implements Pull Request #212 (commit-859c2b68) in the development
branch with revisions to more closely match our adopted coding style (open
'{' on same line as conditional, single line code blocks always wrapped
with '{'...'}') and Lua run-time (value) errors returned as nil plus an
error message rather than throwing a lua error as argument type errors
do.

Adds lua commands:
* ```getAllRoomUserData(roomID)```: given a roomId number returns a lua table
  of all the user data.
* ```getRoomUserDataKeys(roomID)```: given a roomId number returns a lua list
  of all the keys of the user data for that room.
* ```clearRoomUserDataItem(roomID,key)```: given a roomId number and a user
  data key removes that key/value pair from the user data for that room.
  Returns true if data was removed, false if not and nil if the room
  does not exist for that roomId number.

Enhance existing commands:
* ```searchRoomUserData(key, value)```: given a string "key" and "value"
  returns a list of the roomIDs which contain that value for that key,
  now returns a sorted list of room numbers.
  Additionally extended so, in the absence of a second argument:
* ```searchRoomUserData(key)```: given a string "key" returns an ascending
  sorted list (lua table with monotonically incrementing integer keys
  from unity) of the unique values stored against that key in all rooms.

Also:
  Correct (and reformat to revised Mudlet "standard") error messages for
  setRoomUserData() {they referred to getRoomUserData() instead which
  was confusing!} and reformat getRoomUserData() error messages as well.

ALL OF THESE FUNCTIONS:
A) Return messages that can be internationalised, and will return them
   as Utf-8 encoded strings to the Lua subsystem.
B) Accept and pass Utf-8 encoded strings to and from the Lua subsystem,
   so non-ASCII text can be used both as identifiers (keys) for room
   user data items and the data (values) stored under those keys.

The searchRoomUserData functions search in a linear manner so may not be
particularly fast for large maps - the user is encouraged to develop/use
their own index systems rather than directly utilise the map room user
data if they wish to optimise actions that requires access across all or
a sizeable part of a large map.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>