### PR TITLE
(release_30)Bugfix/Enhance:  Suppress debug output from short interval timers

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -321,6 +321,14 @@ public:
     bool               mFORCE_MXP_NEGOTIATION_OFF;
     bool               mHaveMapperScript;
     QSet<QChar>         mDoubleClickIgnore;
+    int                 mTimerDebugOutputSuppressionInterval;
+                        // Set from last page of profile preferences if the
+                        // timer interval is less than this in milliseconds then
+                        // the normal reoccuring debug output of the entire
+                        // command and script for any timer with a timeout LESS
+                        // than this is NOT shown - this is so the spammy output
+                        // from short timeout timers can be suppressed.  The
+                        // single execute OK line will still be shown.
 };
 
 #endif // MUDLET_HOST_H

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -237,22 +237,29 @@ bool TTimer::checkRestart()
 
 void TTimer::execute()
 {
-    if( ! isActive() || mIsFolder )
-    {
+    if( ! isActive() || mIsFolder ) {
         mpTimer->stop();
         return;
     }
 
-    if( mudlet::debugMode ) {TDebug(QColor(Qt::darkYellow),QColor(Qt::darkBlue)) << "\n[TIMER EXECUTES]: "<<mName<<" fired. Executing command="<<mCommand<<" and executing script:"<<mScript<<"\n" >> 0;}
+    if( mudlet::debugMode
+     && mpTimer->interval() > mpHost->mTimerDebugOutputSuppressionInterval ) {
+        // Second term is to suppress execution debug output from short interval timers
+        TDebug( QColor(Qt::darkYellow), QColor(Qt::darkBlue) ) << "\n[TIMER EXECUTES]: "
+                                                               << mName
+                                                               << " fired. Executing command="
+                                                               << mCommand
+                                                               << " and executing script:"
+                                                               << mScript
+                                                               << "\n"
+                                                               >> 0;
+    }
 
-    if( mIsTempTimer )
-    {
-        if( mScript == "" )
-        {
+    if( mIsTempTimer ) {
+        if( mScript.isEmpty() ) {
             mpHost->mLuaInterpreter.call_luafunction( this );
         }
-        else
-        {
+        else {
             mpHost->mLuaInterpreter.compileAndExecuteScript( mScript );
         }
         mpTimer->stop();
@@ -260,41 +267,37 @@ void TTimer::execute()
         return;
     }
 
-    if( ( ! isFolder() && hasChildren() ) || ( isOffsetTimer() ) )
-    {
+    if( ( ! isFolder() && hasChildren() )
+     || ( isOffsetTimer() ) ) {
+
         typedef list<TTimer *>::const_iterator I;
-        for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
-        {
+        for( I it = mpMyChildrenList->begin();
+             it != mpMyChildrenList->end();
+             ++it ) {
+
             TTimer * pChild = *it;
-            if( pChild->isOffsetTimer() )
-            {
+            if( pChild->isOffsetTimer() ) {
                 pChild->enableTimer( pChild->getID() );
             }
         }
-        if( isOffsetTimer() )
-        {
+        if( isOffsetTimer() ) {
             disableTimer( mID );
             deactivate();
         }
     }
 
-    if( mCommand.size() > 0 )
-    {
+    if( ! mCommand.isEmpty() ) {
         mpHost->send( mCommand );
     }
 
-    if( mScript.size() > 0 )
-    {
-        if( mNeedsToBeCompiled )
-        {
-            if( ! compileScript() )
-            {
+    if( ! mScript.isEmpty() ) {
+        if( mNeedsToBeCompiled ) {
+            if( ! compileScript() ) {
                 disableTimer();
                 return;
             }
         }
-        if( ! mpHost->mLuaInterpreter.call( mFuncName, mName ) )
-        {
+        if( ! mpHost->mLuaInterpreter.call( mFuncName, mName ) ) {
             mpTimer->stop();
         }
     }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -456,6 +456,10 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
             ignore = ignore.append(it.next());
         doubleclick_ignore_lineedit->setText( ignore );
 
+        timeEdit_timerDebugOutputMinimumInterval->setTime( QTime( 0, 0, 0, 1).addMSecs( pHost->mTimerDebugOutputSuppressionInterval - 1 ) );
+        // The above funky setting method is because a zero time is INVALID
+        // and since Qt 5.0-ish adding any value to an invalid time still leaves
+        // the time as "invalid".
     }
 }
 
@@ -1544,9 +1548,17 @@ void dlgProfilePreferences::slot_save_and_exit()
         mudlet::self()->mConsoleMap[pHost]->changeColors();
     }
     QString lIgnore = doubleclick_ignore_lineedit->text();
-    mpHost->mDoubleClickIgnore.clear();
+    pHost->mDoubleClickIgnore.clear();
     for(int i=0;i<lIgnore.size();i++){
-        mpHost->mDoubleClickIgnore.insert(lIgnore.at(i));
+        pHost->mDoubleClickIgnore.insert(lIgnore.at(i));
+    }
+    QTime _midnight( 0, 0, 0, 1 );
+    // zero time is NOT valid and QTime::msecsTo( const QTime & other ) returns
+    // 0 if EITHER time is invalid
+    pHost->mTimerDebugOutputSuppressionInterval = _midnight.msecsTo( timeEdit_timerDebugOutputMinimumInterval->time() ) - 1;
+    if( pHost->mTimerDebugOutputSuppressionInterval < 0 ) {
+        // Clean up if the control IS at zero, so the msecTo() fails and returns 0
+        pHost->mTimerDebugOutputSuppressionInterval = 0;
     }
 
     //pHost->mIRCNick = ircNick->text();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1810,19 +1810,6 @@ or some other computer model that has a small screen.</string>
        <string>Special Options</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_7">
-       <item row="1" column="0">
-        <spacer name="verticalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
        <item row="0" column="0">
         <widget class="QGroupBox" name="groupBox_7">
          <property name="title">
@@ -1882,6 +1869,66 @@ or some other computer model that has a small screen.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="verticalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="groupBox_Debug">
+         <property name="title">
+          <string>Other Special options</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_timerDebugOutputMinimumInterval">
+            <property name="text">
+             <string>Minimum interval for a Timer to show execution output in debug window:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QTimeEdit" name="timeEdit_timerDebugOutputMinimumInterval">
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::PlusMinus</enum>
+            </property>
+            <property name="specialValueText">
+             <string>show all</string>
+            </property>
+            <property name="accelerated">
+             <bool>true</bool>
+            </property>
+            <property name="showGroupSeparator" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="currentSection">
+             <enum>QDateTimeEdit::HourSection</enum>
+            </property>
+            <property name="displayFormat">
+             <string notr="true">h:mm:ss.zzz</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Adds a spinbox control to the last page of the profile preferences that
allows the user to set an interval for which any Timer less than this will
NOT dump it's command and script content to the debug console in dark
yellow on a blue background EVERY time it fires.  The Execute OK line will
still show up in green - so the timer can be seen to be firing but the
windows will not fill up with spammy text so much.

This fixes [bug 1511590](https://bugs.launchpad.net/mudlet/+bug/1511590) that I have raised in response to my encountering it
and remembering a user reporting it in the [forums](http://forums.mudlet.org/viewtopic.php?f=7&t=4745).

Also: I also spotted and corrected a couple of lines above my addition to
dlgProfilePreferences::slot_save_and_exit() where the unchecked global
pointer to the Host (mpHost) was being used instead of the local checked
pointer (pHost) which is a copy of it and used everywhere else in the
method.

See #275 for *development* branch version

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>