### PR TITLE
(release_30)BugFix: faulty message alignment, cTelnet::postMessage() in non-ERROR…

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -142,6 +142,8 @@ public:
     bool               uninstallPackage( QString, int module);
     bool               removeDir( const QString dirName, QString originalPath);
     void               readPackageConfig( QString, QString & );
+    void                postMessage( const QString message ) { mTelnet.postMessage(message); }
+
 
     cTelnet            mTelnet;
     TConsole *         mpConsole;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11822,12 +11822,12 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[ ERROR ] - Cannot find Lua module rex_pcre.\n"
                                   "Some functions may not be available.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module rex_pcre loaded.";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
     error = luaL_dostring( pGlobalLua, "require \"zip\"" );
@@ -11841,12 +11841,12 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = "[ ERROR ] - Cannot find Lua module zip.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module zip loaded.";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
     error = luaL_dostring( pGlobalLua, "require \"lfs\"" );
@@ -11861,12 +11861,12 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[ ERROR ] - Cannot find Lua module lfs (Lua File System).\n"
                                   "Probably will not be able to access Mudlet Lua code.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module lfs loaded";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
     error = luaL_dostring( pGlobalLua, "luasql = require \"luasql.sqlite3\"" );
@@ -11881,12 +11881,12 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[ ERROR ] - Cannot find Lua module luasql.sqlite3.\n"
                                   "Database support will not be available.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module sqlite3 loaded";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
 //    QString path = QDir::homePath()+"/.config/mudlet/mudlet-lua/lua/LuaGlobal.lua";
@@ -11963,15 +11963,15 @@ void TLuaInterpreter::loadGlobal()
                                 "Error from Lua: ";
                 e += lua_tostring( pGlobalLua, -1 );
             }
-            mpHost->mTelnet.postMessage( e.c_str() );
+            mpHost->postMessage( e.c_str() );
         }
         else {
-            mpHost->mTelnet.postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+            mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
         }
     }
     else
     {
-        mpHost->mTelnet.postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+        mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
     }
 
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -379,13 +379,13 @@ void TMap::init( Host * pH )
                         int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50 );
                         if( newID > -1 ) {
                             QString msg = qApp->translate("TMap","[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
-                            mpHost->mTelnet.postMessage(msg);
+                            mpHost->postMessage(msg);
                             mapLabels[areaID][labelIDList.at(i)] = mapLabels[areaID][newID];
                             deleteMapLabel( areaID, newID );
                         }
                         else {
                             QString msg = qApp->translate("TMap","[ WARN ] - CONVERTING: cannot convert old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
-                            mpHost->mTelnet.postMessage(msg);
+                            mpHost->postMessage(msg);
                         }
                     }
                     if (    ( l.size.width() >  std::numeric_limits<qreal>::max() )

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -764,10 +764,10 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
                                                                       "set one area's name to that of another that exists at the time.")
                               .arg( mUnnamedAreaName );
         }
-        mpMap->mpHost->mTelnet.postMessage( alertText );
-        mpMap->mpHost->mTelnet.postMessage( informativeText );
+        mpMap->mpHost->postMessage( alertText );
+        mpMap->mpHost->postMessage( informativeText );
         if( ! detailText.isEmpty() ) {
-            mpMap->mpHost->mTelnet.postMessage( detailText );
+            mpMap->mpHost->postMessage( detailText );
         }
     }
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1296,7 +1296,9 @@ void cTelnet::postMessage( QString msg )
                 mpHost->mpConsole->print( firstLineTail.append('\n'), 190, 150, 0, 0, 0, 0 ); //Foreground dark grey, background bright grey
                 for( quint8 _i = 0; _i < body.size(); _i++ )
                 {
-                    body[_i] = body.at(_i).rightJustified( body.at(0).length() + prefixLength );
+                    QString temp = body.at(_i);
+                    temp.replace('\t', "        ");
+                    body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if( body.size() )
                     mpHost->mpConsole->print( body.join('\n').append('\n'), 190, 150, 0, 0, 0, 0 );
@@ -1307,7 +1309,9 @@ void cTelnet::postMessage( QString msg )
                 mpHost->mpConsole->print( firstLineTail.append('\n'), 190, 190, 50, 0, 0, 0 ); // Yellow on Black
                 for( quint8 _i = 0; _i < body.size(); _i++ )
                 {
-                    body[_i] = body.at(_i).rightJustified( body.at(0).length() + prefixLength );
+                    QString temp = body.at(_i);
+                    temp.replace('\t', "        ");
+                    body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if( body.size() )
                     mpHost->mpConsole->print( body.join('\n').append('\n'), 190, 190, 50, 0, 0, 0 ); // Yellow on Black
@@ -1318,7 +1322,9 @@ void cTelnet::postMessage( QString msg )
                 mpHost->mpConsole->print( firstLineTail.append('\n'), 0, 160, 0, 0, 0, 0 );  // Light Green on Black
                 for( quint8 _i = 0; _i < body.size(); _i++ )
                 {
-                    body[_i] = body.at(_i).rightJustified( body.at(0).length() + prefixLength );
+                    QString temp = body.at(_i);
+                    temp.replace('\t', "        ");
+                    body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if( body.size() )
                     mpHost->mpConsole->print( body.join('\n').append('\n'), 0, 160, 0, 0, 0, 0 );  // Light Green on Black
@@ -1329,7 +1335,9 @@ void cTelnet::postMessage( QString msg )
                 mpHost->mpConsole->print( firstLineTail.append('\n'), 190, 100, 50, 0, 0, 0 ); // Orangish on black
                 for( quint8 _i = 0; _i < body.size(); _i++ )
                 {
-                    body[_i] = body.at(_i).rightJustified( body.at(0).length() + prefixLength );
+                    QString temp = body.at(_i);
+                    temp.replace('\t', "        ");
+                    body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if( body.size() )
                     mpHost->mpConsole->print( body.join('\n').append('\n'), 190, 100, 50, 0, 0, 0 ); // Orangish on black
@@ -1340,7 +1348,9 @@ void cTelnet::postMessage( QString msg )
                 mpHost->mpConsole->print( firstLineTail.append('\n'), 50, 50, 50, 190, 190, 190 ); //Foreground dark grey, background bright grey
                 for( quint8 _i = 0; _i < body.size(); _i++ )
                 {
-                    body[_i] = body.at(_i).rightJustified( body.at(0).length() + prefixLength );
+                    QString temp = body.at(_i);
+                    temp.replace('\t', "        ");
+                    body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if( body.size() )
                     mpHost->mpConsole->print( body.join('\n').append('\n'), 50, 50, 50, 190, 190, 190 ); //Foreground dark grey, background bright grey

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -23,7 +23,6 @@
 #include "mudlet.h"
 
 
-#include "ctelnet.h"
 #include "dlgAboutDialog.h"
 #include "dlgConnectionProfiles.h"
 #include "dlgIRC.h"


### PR DESCRIPTION
… cases

A version of this commit never got into the release_30 branch with the
effect that all the postMessage() type calls with messages OTHER than the
ones beginning with "[ ERROR ]" were not being aligned correctly.

Original commit e17d023b0c6e0a63fe146bd8972358343cf56bfc read:
 ===========================================================================
Code that was put in to fix messages with tag "[ ERROR ] - " was not copied
to the other tag types, so those messages were not lined up correctly as
per:
    
    "[<tag>] - <message line 1 ...>
               <message line 2 ...>
               ...
               <message line n ...>"

   
 ===========================================================================

Whilst fixing this I decided to give the Host class a wrapper around
mTelnet.postMessage() so that other classes could access this without
having to include the cTelnet header or access it via a Host pointer.
As a result other existing uses have been modified where it is advantagous
to do so.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>