### PR TITLE
Code match (release 30)bugfix faulty non error message alignment

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -142,6 +142,8 @@ public:
     bool               uninstallPackage(const QString&, int module);
     bool               removeDir( const QString& dirName, const QString& originalPath);
     void               readPackageConfig(const QString&, QString & );
+    void                postMessage( const QString message ) { mTelnet.postMessage( message ); }
+
 
     cTelnet            mTelnet;
     QPointer<TConsole> mpConsole;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11628,12 +11628,12 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[ ERROR ] - Cannot find Lua module rex_pcre.\n"
                                   "Some functions may not be available.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module rex_pcre loaded.";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
     error = luaL_dostring( pGlobalLua, "require \"zip\"" );
@@ -11647,12 +11647,12 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = "[ ERROR ] - Cannot find Lua module zip.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module zip loaded.";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
     error = luaL_dostring( pGlobalLua, "require \"lfs\"" );
@@ -11667,12 +11667,12 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[ ERROR ] - Cannot find Lua module lfs (Lua File System).\n"
                                   "Probably will not be able to access Mudlet Lua code.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module lfs loaded";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
     error = luaL_dostring( pGlobalLua, "luasql = require \"luasql.sqlite3\"" );
@@ -11687,12 +11687,12 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[ ERROR ] - Cannot find Lua module luasql.sqlite3.\n"
                                   "Database support will not be available.\n";
         msg.append( e.c_str() );
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
     else
     {
         QString msg = "[  OK  ]  - Lua module sqlite3 loaded";
-        mpHost->mTelnet.postMessage( msg );
+        mpHost->postMessage( msg );
     }
 
 //    QString path = QDir::homePath()+"/.config/mudlet/mudlet-lua/lua/LuaGlobal.lua";
@@ -11769,15 +11769,15 @@ void TLuaInterpreter::loadGlobal()
                                 "Error from Lua: ";
                 e += lua_tostring( pGlobalLua, -1 );
             }
-            mpHost->mTelnet.postMessage( e.c_str() );
+            mpHost->postMessage( e.c_str() );
         }
         else {
-            mpHost->mTelnet.postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+            mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
         }
     }
     else
     {
-        mpHost->mTelnet.postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+        mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
     }
 
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -380,13 +380,13 @@ void TMap::init( Host * pH )
                         int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50 );
                         if( newID > -1 ) {
                             QString msg = qApp->translate("TMap","[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
-                            mpHost->mTelnet.postMessage(msg);
+                            mpHost->postMessage(msg);
                             mapLabels[areaID][labelIDList.at(i)] = mapLabels[areaID][newID];
                             deleteMapLabel( areaID, newID );
                         }
                         else {
                             QString msg = qApp->translate("TMap","[ WARN ] - CONVERTING: cannot convert old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
-                            mpHost->mTelnet.postMessage(msg);
+                            mpHost->postMessage(msg);
                         }
                     }
                     if (    ( l.size.width() >  std::numeric_limits<qreal>::max() )

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -752,10 +752,10 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
                                                                       "set one area's name to that of another that exists at the time.")
                               .arg( mUnnamedAreaName );
         }
-        mpMap->mpHost->mTelnet.postMessage( alertText );
-        mpMap->mpHost->mTelnet.postMessage( informativeText );
+        mpMap->mpHost->postMessage( alertText );
+        mpMap->mpHost->postMessage( informativeText );
         if( ! detailText.isEmpty() ) {
-            mpMap->mpHost->mTelnet.postMessage( detailText );
+            mpMap->mpHost->postMessage( detailText );
         }
     }
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1310,7 +1310,6 @@ void cTelnet::postMessage( QString msg )
                 {
                     QString temp = body.at(_i);
                     temp.replace('\t', "        ");
-                    // Fix for lua using tabs for indentation which was messing up justification:
                     body[_i] = temp.rightJustified(temp.length() + prefixLength);
                 }
                 if( body.size() )

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -23,7 +23,6 @@
 #include "mudlet.h"
 
 
-#include "ctelnet.h"
 #include "dlgAboutDialog.h"
 #include "dlgConnectionProfiles.h"
 #include "dlgIRC.h"


### PR DESCRIPTION
Uh, this should have been a single commit but I forgot to squash them together * *sigh* *.

Read the message for the second commit for details but the bottom line is that it add a Host::postMessage(const QString) wrapper for cTelnet::postMessage(QString) so the latter class doesn't have to be __#include__ d or referred to directly by the using class.

This is to make the two code branches have the same code in the areas touched after #277 is Pulled...