### PR TITLE
Enhance add area and map user data structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@
 
 PROJECT(mudlet)
 
+# FIXME: We need a check (for Qt 5.2 or greater) it is needed (at least) because
+# of: using QComboBox::currentData() introduced in 5.2, in dlgProfilePreferences
+# class
+
+# Windows builds need 2.8.11, but for other platforms 2.8.9 should be enough
 IF(MSVC)
   CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 ELSE()

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -79,6 +79,7 @@ public:
     int zoneAreaRef;
     TRoomDB * mpRoomDB;
     bool mIsDirty;
+    QMap<QString, QString> mUserData;
 
 
 private:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4143,6 +4143,93 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
     return 1;
 }
 
+// Derived from searchRoomUserData(...)
+int TLuaInterpreter::searchAreaUserData( lua_State *L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "searchAreaUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "searchAreaUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+
+    QString key;
+    if( lua_isstring( L, 1 ) ) {
+        key = QString::fromUtf8( lua_tostring( L, 1 ) );
+    }
+    else {
+        lua_pushstring( L, tr( "searchAreaUserData: bad argument #1 type (\"key\" as string expected, got %1!)." )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+
+    QString value = QString(); //assigns null value which is detectable different from the empty value
+    if( lua_gettop( L ) > 1 ) {
+        if( lua_isstring( L, 2 ) ) {
+            value = QString::fromUtf8( lua_tostring( L, 2 ) );
+        }
+        else {
+            lua_pushstring( L, tr( "searchAreaUserData: bad argument #2  type (\"value\" as optional string value, got %1!)." )
+                            .arg( luaL_typename(L, 2) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+    }
+
+    lua_newtable(L);
+    QList<TArea *> areaList = pHost->mpMap->mpRoomDB->getAreaPtrList();
+    QSet<QString> valuesFound; // Use a set as it automatically eliminates duplicates
+    QList<int> areaIdsFound;
+
+    for( int i=0; i<areaList.size(); i++ ) {
+        TArea * pA = areaList.at(i);
+        if(pA->mUserData.contains( key )) {
+            QString keyValue = pA->mUserData.value(key, QString() );
+            // If the key is NOT present, will return second argument which is a
+            // null QString which is NOT the same as an empty QString.
+            if( value.isNull() ) {
+                if( ! keyValue.isNull() ) {
+                    valuesFound.insert(keyValue);
+                }
+            }
+            else {
+                if( (! keyValue.isNull() ) && (keyValue.compare(value) == 0) ) {
+                    areaIdsFound.append( pA->getAreaID() );
+                }
+            }
+        }
+    }
+    if( value.isNull() ) {
+        QList<QString> valuesList = valuesFound.toList();
+        std::sort(valuesList.begin(), valuesList.end());
+        for( int i=0; i<valuesList.size(); i++ ) {
+            lua_pushnumber( L, i+1 ); // List arrays begin at 1 not 0
+            lua_pushstring( L, valuesList.at(i).toUtf8().constData() );
+            lua_settable(L, -3);
+        }
+    }
+    else{
+        std::sort(areaIdsFound.begin(), areaIdsFound.end());
+        for( int i=0; i<areaIdsFound.size(); i++ ) {
+            lua_pushnumber( L, i+1 ); // List arrays begin at 1 not 0
+            lua_pushnumber( L, areaIdsFound.at(i) );
+            lua_settable(L, -3);
+        }
+    }
+    return 1;
+}
+
 int TLuaInterpreter::getAreaTable( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -8302,31 +8389,50 @@ int TLuaInterpreter::removeSpecialExit( lua_State * L )
 // found for given roomID
 int TLuaInterpreter::clearRoomUserData( lua_State * L )
 {
-    int id;
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+         lua_pushnil( L );
+        lua_pushstring( L, tr( "clearRoomUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearRoomUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
 
+    int roomId;
     if(! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearRoomUserData: bad argument #1 (number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "clearRoomUserData: bad argument #1 type (room Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-        id = lua_tointeger( L, 1 );
+    else {
+        roomId = lua_tointeger( L, 1 );
+    }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( id );
-    if( pR ) {
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( ! pR ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearRoomUserData: bad argument #1 value (room Id %1 is not a valid room Id)." )
+                        .arg(roomId)
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
         if( ! pR->userData.isEmpty() ) {
             pR->userData.clear();
             lua_pushboolean( L , true );
         }
-        else
+        else {
             lua_pushboolean( L, false );
-
+        }
+        return 1;
     }
-    else
-        lua_pushnil( L );
-
-    return 1;
 }
 
 // clearRoomUserDataItem( roomID, key )
@@ -8335,31 +8441,56 @@ int TLuaInterpreter::clearRoomUserData( lua_State * L )
 // present in the data. Returns nil if the room for the roomID not found.
 int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
 {
-    int id;
-    QString key = QString(); // This assign the null value which is different from an empty one
-
-    if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #1 (number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
-        lua_error( L );
-        return 1;
-    }
-    else
-        id = lua_tointeger( L, 1 );
-
-    if ( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #2 (string expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
-        lua_error( L );
-        return 1;
-    }
-    else
-        key = QString::fromUtf8( lua_tostring( L, 2 ) );
-
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( id );
-    if( pR ) {
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearRoomUserDataItem: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearRoomUserDataItem: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #1 type (room Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        roomId = lua_tointeger( L, 1 );
+    }
+
+    QString key = QString(); // This assigns the null value which is different from an empty one
+    if ( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( ! pR ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #1 value (room Id %1 is not a valid room)." )
+                        .arg(roomId)
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
 // Turns out that an empty key IS possible, but if this changes this should be uncommented
-//        if( key.isEmpty() )
-//        {  // If the user accidently supplied an white-space only or empty key
+//        if( key.isEmpty() ) {
+//           // If the user accidently supplied an white-space only or empty key
 //           // string we don't do anything, but we, sucessfully, fail to do it... 8-)
 //            lua_pushboolean( L, false );
 //        }
@@ -8367,14 +8498,192 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
             pR->userData.remove(key);
             lua_pushboolean( L , true );
         }
-        else
+        else {
             lua_pushboolean( L, false );
-
+        }
+        return 1;
     }
-    else
-        lua_pushnil( L );
+}
 
+// Derived from clearRoomUserData
+int TLuaInterpreter::clearAreaUserData( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearAreaUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearAreaUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int areaId;
+    if(! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "clearAreaUserData: bad argument #1 type (area Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        areaId = lua_tointeger( L, 1 );
+    }
+
+    TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
+    if( ! pA ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearAreaUserData: bad argument #1 value (area Id %1 is not a valid area Id)." )
+                        .arg(areaId)
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
+        if( ! pA->mUserData.isEmpty() ) {
+            pA->mUserData.clear();
+            lua_pushboolean( L , true );
+        }
+        else {
+            lua_pushboolean( L, false );
+        }
+        return 1;
+    }
+}
+
+// Derived from clearRoomUserDataItem
+int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearAreaUserDataItem: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearAreaUserDataItem: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int areaId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #1 type (area Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        areaId = lua_tointeger( L, 1 );
+    }
+
+    QString key = QString(); // This assigns the null value which is different from an empty one
+    if ( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
+    if( ! pA ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #1 value (area Id %1 is not a valid room)." )
+                        .arg( areaId )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
+        if( key.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #2 value (\"key\" can not be an empty string)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+        else {
+            lua_pushboolean( L, (pA->mUserData.remove(key) > 0) );
+        }
+        return 1;
+    }
+}
+
+// Derived from clearRoomUserData
+// But as there is only one instance it takes no arguments
+int TLuaInterpreter::clearMapUserData( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearMapUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearMapUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    if( ! pHost->mpMap->mUserData.isEmpty() ) {
+        pHost->mpMap->mUserData.clear();
+        lua_pushboolean( L , true );
+    }
+    else {
+        lua_pushboolean( L, false );
+    }
     return 1;
+}
+
+// Derived from clearRoomUserDataItem
+// But as there is only one instance it only takes one argument
+int TLuaInterpreter::clearMapUserDataItem( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearMapUserDataItem: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "clearMapUserDataItem: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    QString key = QString(); // This assigns the null value which is different from an empty one
+    if ( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "clearMapUserDataItem: bad argument #1 type (\"key\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( key.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "clearMapUserDataItem: bad argument #1 value (\"key\" can not be an empty string)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+        else {
+            lua_pushboolean( L, (pHost->mpMap->mUserData.remove(key) > 0) );
+            return 1;
+        }
+    }
 }
 
 int TLuaInterpreter::clearSpecialExits( lua_State * L )
@@ -8517,82 +8826,409 @@ int TLuaInterpreter::getRoomEnv( lua_State * L )
 
 int TLuaInterpreter::getRoomUserData( lua_State * L )
 {
-    int roomID;
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getRoomUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getRoomUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getRoomUserData: bad argument #1 (number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "getRoomUserData: bad argument #1 (room Id as number expected, got %1)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-        roomID = lua_tointeger( L, 1 );
+    else {
+        roomId = lua_tointeger( L, 1 );
+    }
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "getRoomUserData: bad argument #2 (string expected, got %1)" ).arg( luaL_typename(L, 2) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "getRoomUserData: bad argument #2 (\"key\" as string expected, got %1)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
+    else {
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomID );
-    if( pR ) {
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( ! pR ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getRoomUserData: bad argument #1 value (number %1 is not a valid room Id)." )
+                        .arg(roomId)
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
         if( pR->userData.contains( key ) ) {
             lua_pushstring( L, pR->userData.value( key ).toUtf8().constData() );
             return 1;
         }
         else {
-            lua_pushstring( L, "" );
-            return 1;
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "getRoomUserData: bad argument #2 value (no user data with Key:\"%1\" in room with Id:%2 )." )
+                            .arg( key )
+                            .arg(roomId)
+                            .toUtf8().constData() );
+            return 2;
         }
     }
-    else {
-        lua_pushstring( L, "" );
+}
+
+// Derived from getRoomUserData(...)
+int TLuaInterpreter::getAreaUserData( lua_State * L )
+{
+    int areaId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "getAreaUserData: bad argument #1 (area Id as number expected, got %1)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
         return 1;
+    }
+    else {
+        areaId = lua_tointeger( L, 1 );
+    }
+
+    QString key;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "getAreaUserData: bad argument #2 (\"key\" as string expected, got %1)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 2 ) );
+        if( key.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "getAreaUserData: bad argument #2 value (\"key\" is not allowed to be an empty string)." )
+                            .arg(areaId)
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
+    if( ! pA ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAreaUserData: bad argument #1 value (number %1 is not a valid area Id)." )
+                        .arg( areaId )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
+        if( pA->mUserData.contains( key ) ) {
+            lua_pushstring( L, pA->mUserData.value( key ).toUtf8().constData() );
+            return 1;
+        }
+        else {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "getAreaUserData: bad argument #2 value (no user data with Key:\"%1\" in area with Id:%2 )." )
+                            .arg( key )
+                            .arg( areaId )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+}
+
+// Derived from getRoomUserData(...) but as there is only one instance only one
+// argument is needed
+int TLuaInterpreter::getMapUserData( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getMapUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getMapUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    QString key;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "getMapUserData: bad argument #1 (\"key\" as string expected, got %1)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 1 ) );
+    }
+
+    if( pHost->mpMap->mUserData.contains( key ) ) {
+        lua_pushstring( L, pHost->mpMap->mUserData.value( key ).toUtf8().constData() );
+        return 1;
+    }
+    else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getMapUserData: bad argument #1 value (no user data with Key:\"%1\" in map)." )
+                        .arg( key )
+                        .toUtf8().constData() );
+        return 2;
     }
 }
 
 int TLuaInterpreter::setRoomUserData( lua_State * L )
 {
-    int roomID;
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #1 (number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "setRoomUserData: bad argument #1 type (room Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-        roomID = lua_tointeger( L, 1 );
+    else {
+        roomId = lua_tointeger( L, 1 );
+    }
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #2 (string expected, got %1)" ).arg( luaL_typename(L, 2) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "setRoomUserData: bad argument #2 type (\"key\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
+    else {
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
+        // Ideally should reject empty keys but this could break existing scripts so we can't
+    }
 
     QString value;
     if( ! lua_isstring( L, 3 ) ) {
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #3 (string expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "setRoomUserData: bad argument #3 type (\"value\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 3) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
+    else {
         value = QString::fromUtf8( lua_tostring( L, 3 ) );
+    }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomID );
-    if( pR ) {
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( ! pR ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setRoomUserData: bad argument #1 value (number %1 is not a valid room Id)." )
+                        .arg(roomId)
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
         pR->userData[key] = value;
         lua_pushboolean( L, true );
         return 1;
     }
-    else {
-        lua_pushboolean( L, false );
+}
+
+// Derived from setRoomUserData(...)
+int TLuaInterpreter::setAreaUserData( lua_State * L )
+{
+    int areaId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "setAreaUserData: bad argument #1 type (area Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
         return 1;
     }
+    else {
+        areaId = lua_tointeger( L, 1 );
+    }
+
+    QString key;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setAreaUserData: bad argument #2 type (\"key\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 2 ) );
+        if( key.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setAreaUserData: bad argument #2 value (\"key\" is not allowed to be an empty string)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString value;
+    if( ! lua_isstring( L, 3 ) ) {
+        lua_pushstring( L, tr( "setAreaUserData: bad argument #3 type (\"value\" as string expected, got %1!)" )
+                        .arg( luaL_typename(L, 3) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        value = QString::fromUtf8( lua_tostring( L, 3 ) );
+    }
+
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setAreaUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8()
+                        .constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setAreaUserData: no map present or loaded!" )
+                        .toUtf8()
+                        .constData() );
+        return 2;
+    }
+
+    // TODO: Remove this block of code once it is not needed (map file format updated to 17)
+    {
+        static bool isWarningIssued = false;
+        if( !isWarningIssued && pHost->mpMap->mDefaultVersion <= 16 && pHost->mpMap->mSaveVersion < 17 ) {
+            QString warnMsg = tr( "[ WARN ]  - Lua command setAreaUserData() used - it is currently flagged as experimental!" );
+            QString infoMsg = tr( "[ INFO ]  - To be fully functional the above command requests a revision to the map file format\n"
+                                              "and although that has been coded it is NOT enabled so this feature's effects\n"
+                                              "will NOT persist between sessions as the relevent data IS NOT SAVED.\n\n"
+                                              "To avoid filling the screen up with repeated messages, this is your only warning about\n"
+                                              "this command...!" );
+            pHost->postMessage( warnMsg );
+            pHost->postMessage( infoMsg );
+            isWarningIssued = true;
+        }
+    }
+
+    TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
+    if( ! pA ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setAreaUserData: bad argument #1 value (number %1 is not a valid area Id)." )
+                        .arg( areaId )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
+        pA->mUserData[key] = value;
+        lua_pushboolean( L, true );
+        return 1;
+    }
+}
+
+// Derived from setRoomUserData(...)
+// But as there is only one instance there is only two arguements, key and value
+int TLuaInterpreter::setMapUserData( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setMapUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setMapUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    QString key;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "setMapUserData: bad argument #1 type (\"key\" as string expected, got %1)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        key = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( key.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setMapUserData: bad argument #1 value (\"key\" is not allowed to be an empty string)." )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString value;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setMapUserData: bad argument #2 type (\"value\" as string expected, got %1)" )
+                        .arg( luaL_typename(L, 2) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        value = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    // TODO: Remove this block of code once it is not needed (map file format updated to 17)
+    {
+        static bool isWarningIssued = false;
+        if( !isWarningIssued && pHost->mpMap->mDefaultVersion <= 16 && pHost->mpMap->mSaveVersion < 17 ) {
+            QString warnMsg = tr( "[ WARN ]  - Lua command setMapUserData() used - it is currently flagged as experimental!" );
+            QString infoMsg = tr( "[ INFO ]  - To be fully functional the above command requests a revision to the map file format\n"
+                                              "and although that has been coded it is NOT enabled so this feature's effects\n"
+                                              "will NOT persist between sessions as the relevent data IS NOT SAVED.\n\n"
+                                              "To avoid filling the screen up with repeated messages, this is your only warning about\n"
+                                              "this command...!" );
+            pHost->postMessage( warnMsg );
+            pHost->postMessage( infoMsg );
+            isWarningIssued = true;
+        }
+    }
+
+    pHost->mpMap->mUserData[key] = value;
+    lua_pushboolean( L, true );
+    return 1;
 }
 
 // getRoomUserDataKeys( roomID )
@@ -8600,21 +9236,42 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
 // an empty table if no user data or nil if the room does not exist for the
 // given roomID. This will be useful if the user is not the creator of the data
 // and does not know what has been stored in the user data area!
+// In hindsight - is a little pointless when we can use getAllRoomUserData() directly
 int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
 {
-    int roomID;
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getRoomUserDataKeys: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getRoomUserDataKeys: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getRoomUserDataKeys: bad argument #1 (number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "getRoomUserDataKeys: bad argument #1 (room Id as number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
     else
-        roomID = lua_tointeger( L, 1 );
+        roomId = lua_tointeger( L, 1 );
 
     QStringList keys;
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomID );
-    if( pR ) {
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( ! pR ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getRoomUserDataKeys: bad argument #1 value (number %1 is not a valid room Id)." )
+                        .arg( roomId )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
         keys = pR->userData.keys();
         lua_newtable( L );
         for( int i=0; i<keys.size(); i++ ) {
@@ -8622,11 +9279,8 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
             lua_pushstring( L, keys.at(i).toUtf8().constData() );
             lua_settable(L, -3);
         }
+        return 1;
     }
-    else
-        lua_pushnil( L);
-
-    return 1;
 }
 
 // getAllRoomUserData( roomID )
@@ -8635,20 +9289,40 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
 // roomID.
 int TLuaInterpreter::getAllRoomUserData( lua_State * L )
 {
-    int roomID;
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllRoomUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllRoomUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getAllRoomUserData: bad argument #1 (number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
+        lua_pushstring( L, tr( "getAllRoomUserData: bad argument #1 (room Id as number expected, got %1)" ).arg( luaL_typename(L, 1) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
     else
-        roomID = lua_tointeger( L, 1 );
+        roomId = lua_tointeger( L, 1 );
 
     QStringList keys;
     QStringList values;
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomID );
-    if( pR ) {
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( ! pR ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllRoomUserData: bad argument #1 value (number %1 is not a valid room Id)." )
+                        .arg( roomId )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
         keys = pR->userData.keys();
         values = pR->userData.values();
         lua_newtable( L );
@@ -8657,10 +9331,90 @@ int TLuaInterpreter::getAllRoomUserData( lua_State * L )
             lua_pushstring( L, values.at(i).toUtf8().constData() );
             lua_settable(L, -3);
         }
+        return 1;
     }
-    else
-        lua_pushnil( L);
+}
 
+// Derived from getAllRoomUserData(...)
+int TLuaInterpreter::getAllAreaUserData( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllAreaUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllAreaUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int areaId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "getAllAreaUserData: bad argument #1 (area Id as number expected, got %1)." )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        areaId = lua_tointeger( L, 1 );
+    }
+
+    QStringList keys;
+    QStringList values;
+    TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
+    if( ! pA ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllAreaUserData: bad argument #1 value (number %1 is not a valid area Id)." )
+                        .arg( areaId )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else {
+        keys = pA->mUserData.keys();
+        values = pA->mUserData.values();
+        lua_newtable( L );
+        for( int i=0; i<keys.size(); i++ ) {
+            lua_pushstring( L, keys.at(i).toUtf8().constData() );
+            lua_pushstring( L, values.at(i).toUtf8().constData() );
+            lua_settable(L, -3);
+        }
+        return 1;
+    }
+}
+
+// Derived from getAllRoomUserData(...)
+// But as there is only one instance there are no arguments
+int TLuaInterpreter::getAllMapUserData( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllMapUserData: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getAllMapUserData: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    QStringList keys;
+    QStringList values;
+    keys = pHost->mpMap->mUserData.keys();
+    values = pHost->mpMap->mUserData.values();
+    lua_newtable( L );
+    for( int i=0; i<keys.size(); i++ ) {
+        lua_pushstring( L, keys.at(i).toUtf8().constData() );
+        lua_pushstring( L, values.at(i).toUtf8().constData() );
+        lua_settable(L, -3);
+    }
     return 1;
 }
 
@@ -11616,7 +12370,18 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "getRoomUserDataKeys", TLuaInterpreter::getRoomUserDataKeys );
     lua_register( pGlobalLua, "getAllRoomUserData", TLuaInterpreter::getAllRoomUserData );
     lua_register( pGlobalLua, "getAllRoomEntrances", TLuaInterpreter::getAllRoomEntrances );
-
+    lua_register( pGlobalLua, "searchAreaUserData", TLuaInterpreter::searchAreaUserData );
+    lua_register( pGlobalLua, "searchRoomUserData", TLuaInterpreter::searchRoomUserData );
+    lua_register( pGlobalLua, "getMapUserData", TLuaInterpreter::getMapUserData );
+    lua_register( pGlobalLua, "getAreaUserData", TLuaInterpreter::getAreaUserData );
+    lua_register( pGlobalLua, "setMapUserData", TLuaInterpreter::setMapUserData );
+    lua_register( pGlobalLua, "setAreaUserData", TLuaInterpreter::setAreaUserData );
+    lua_register( pGlobalLua, "getAllAreaUserData", TLuaInterpreter::getAllAreaUserData );
+    lua_register( pGlobalLua, "getAllMapUserData", TLuaInterpreter::getAllMapUserData );
+    lua_register( pGlobalLua, "clearAreaUserData", TLuaInterpreter::clearAreaUserData );
+    lua_register( pGlobalLua, "clearAreaUserDataItem", TLuaInterpreter::clearAreaUserDataItem );
+    lua_register( pGlobalLua, "clearMapUserData", TLuaInterpreter::clearMapUserData );
+    lua_register( pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem );
 
 
     luaopen_yajl(pGlobalLua);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -387,6 +387,17 @@ public:
     static int getRoomUserDataKeys( lua_State * L );
     static int getAllRoomUserData( lua_State * L );
     static int getAllRoomEntrances( lua_State * L );
+    static int searchAreaUserData( lua_State * );
+    static int getMapUserData( lua_State * );
+    static int getAreaUserData( lua_State * );
+    static int setMapUserData( lua_State * );
+    static int setAreaUserData( lua_State * );
+    static int getAllAreaUserData( lua_State * );
+    static int getAllMapUserData( lua_State * );
+    static int clearAreaUserData( lua_State * );
+    static int clearAreaUserDataItem( lua_State * );
+    static int clearMapUserData( lua_State * );
+    static int clearMapUserDataItem( lua_State * );
 
 
     std::list<std::string> mCaptureGroupList;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -55,8 +55,6 @@ TMap::TMap( Host * pH )
                             // TLuaInterpreter::setAreaUserData()
                             // TLuaInterpreter::setMapUserData() need 17
                             // (for persistant storage of data)
-, mVersion( mDefaultVersion ) // This is overwritten during a map restore and is
-                              // the loaded file version
 , mSaveVersion( mDefaultVersion ) // This needs to be set (for when writing new
                             // map files) as it triggers some version features
                             // that NEED a new map file format to be usable, it
@@ -65,6 +63,8 @@ TMap::TMap( Host * pH )
 , mMaxVersion( 17 )              // CHECKME: Allow 17 ( mDefaultVersion + 1 ) for testing
 , mMinVersion( mDefaultVersion ) // CHECKME: Allow 16 ( mDefaultVersion )
 {
+    mVersion = mDefaultVersion; // This is overwritten during a map restore and
+                                // is the loaded file version
     customEnvColors[257] = mpHost->mRed_2;
     customEnvColors[258] = mpHost->mGreen_2;
     customEnvColors[259] = mpHost->mYellow_2;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -48,7 +48,22 @@ TMap::TMap( Host * pH )
 , mpMapper( 0 )
 , mMapGraphNeedsUpdate( true )
 , mNewMove( true )
-, version( 0 )
+, mDefaultVersion( 16 )      // <== replaces CURRENT_MAP_VERSION
+                            // THIS, mMinVersion AND mMaxVersion SHOULD BE
+                            // REVISED WHEN WE SWITCH FROM A PREVIEW TO A RELEASE VERSION!
+                            // Currently:
+                            // TLuaInterpreter::setAreaUserData()
+                            // TLuaInterpreter::setMapUserData() need 17
+                            // (for persistant storage of data)
+, mVersion( mDefaultVersion ) // This is overwritten during a map restore and is
+                              // the loaded file version
+, mSaveVersion( mDefaultVersion ) // This needs to be set (for when writing new
+                            // map files) as it triggers some version features
+                            // that NEED a new map file format to be usable, it
+                            // can be changed by control in last tab of profile
+                            // preference dialog.
+, mMaxVersion( 17 )              // CHECKME: Allow 17 ( mDefaultVersion + 1 ) for testing
+, mMinVersion( mDefaultVersion ) // CHECKME: Allow 16 ( mDefaultVersion )
 {
     customEnvColors[257] = mpHost->mRed_2;
     customEnvColors[258] = mpHost->mGreen_2;
@@ -137,7 +152,9 @@ bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculation
 {
     TRoom * pR = mpRoomDB->getRoom( id );
     if( !pR ) {
-        QString msg = qApp->translate( "TMap", "RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!" ).arg(id).arg(area);
+        QString msg = tr( "RoomID=%1 does not exist, can not set AreaID=%2 for non-existing room!" )
+                      .arg(id)
+                      .arg(area);
         logError(msg);
         return false;
     }
@@ -148,7 +165,9 @@ bool TMap::setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculation
         // to see if it exists as a name only:
         if( ! mpRoomDB->getAreaNamesMap().contains( area ) ) {
             // Ah, no it doesn't so moan:
-            QString msg = qApp->translate( "TMap", "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" ).arg(id).arg(area);
+            QString msg = tr( "AreaID=%2 does not exist, can not set RoomID=%1 to non-existing area!" )
+                          .arg(id)
+                          .arg(area);
             logError(msg);
             return false;
         }
@@ -348,10 +367,10 @@ void TMap::init( Host * pH )
     QElapsedTimer _time;
     _time.start();
 
-    if( version < 14 ) {
+    if( mVersion < 14 ) {
         mpRoomDB->initAreasForOldMaps();
     }
-    else if( version < 17 ) {
+    else if( mVersion < 17 ) {
         // The second half of mpRoomDB->initAreasForOldMaps() - needed to fixup
         // all the (TArea *)->areaExits() that were built wrongly previously,
         // calcSpan() may not be required to be done here and now but it is in my
@@ -365,7 +384,7 @@ void TMap::init( Host * pH )
     }
     mpRoomDB->auditRooms();
 
-    if( version <16 ) {
+    if( mVersion <16 ) {
         // convert old style labels, wasn't made version conditional in past but
         // not likely to be an issue in recent map file format versions (say 16+)
         QMapIterator<int, TArea *> itArea( mpRoomDB->getAreaMap() );
@@ -379,13 +398,17 @@ void TMap::init( Host * pH )
                     if( l.pix.isNull() ) {
                         int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50 );
                         if( newID > -1 ) {
-                            QString msg = qApp->translate("TMap","[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
+                            QString msg = tr( "[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2." )
+                                          .arg(areaID)
+                                          .arg(labelIDList.at(i) );
                             mpHost->postMessage(msg);
                             mapLabels[areaID][labelIDList.at(i)] = mapLabels[areaID][newID];
                             deleteMapLabel( areaID, newID );
                         }
                         else {
-                            QString msg = qApp->translate("TMap","[ WARN ] - CONVERTING: cannot convert old style label, areaID:%1 labelID:%2.").arg(areaID).arg(labelIDList.at(i));
+                            QString msg = tr( "[ WARN ] - CONVERTING: cannot convert old style label, areaID:%1 labelID:%2." )
+                                          .arg(areaID)
+                                          .arg(labelIDList.at(i));
                             mpHost->postMessage(msg);
                         }
                     }
@@ -895,18 +918,18 @@ bool TMap::findPath( int from, int to )
             // happens - Slysven
             mWeightList.prepend( r.cost );
             switch( r.direction ) {  // TODO: Eventually this can instead drop in I18ned values set by country or user preference!
-            case DIR_NORTH:        mDirList.prepend( qApp->translate( "TMap", "n", "This translation converts the direction that DIR_NORTH codes for to a direction string that the MUD server will accept!" ) );      break;
-            case DIR_NORTHEAST:    mDirList.prepend( qApp->translate( "TMap", "ne", "This translation converts the direction that DIR_NORTHEAST codes for to a direction string that the MUD server will accept!" ) ); break;
-            case DIR_EAST:         mDirList.prepend( qApp->translate( "TMap", "e", "This translation converts the direction that DIR_EAST codes for to a direction string that the MUD server will accept!" ) );       break;
-            case DIR_SOUTHEAST:    mDirList.prepend( qApp->translate( "TMap", "se", "This translation converts the direction that DIR_SOUTHEAST codes for to a direction string that the MUD server will accept!" ) ); break;
-            case DIR_SOUTH:        mDirList.prepend( qApp->translate( "TMap", "s", "This translation converts the direction that DIR_SOUTH codes for to a direction string that the MUD server will accept!" ) );      break;
-            case DIR_SOUTHWEST:    mDirList.prepend( qApp->translate( "TMap", "sw", "This translation converts the direction that DIR_SOUTHWEST codes for to a direction string that the MUD server will accept!" ) ); break;
-            case DIR_WEST:         mDirList.prepend( qApp->translate( "TMap", "w", "This translation converts the direction that DIR_WEST codes for to a direction string that the MUD server will accept!" ) );       break;
-            case DIR_NORTHWEST:    mDirList.prepend( qApp->translate( "TMap", "nw", "This translation converts the direction that DIR_NORTHWEST codes for to a direction string that the MUD server will accept!" ) ); break;
-            case DIR_UP:           mDirList.prepend( qApp->translate( "TMap", "up", "This translation converts the direction that DIR_UP codes for to a direction string that the MUD server will accept!" ) );        break;
-            case DIR_DOWN:         mDirList.prepend( qApp->translate( "TMap", "down", "This translation converts the direction that DIR_DOWN codes for to a direction string that the MUD server will accept!" ) );    break;
-            case DIR_IN:           mDirList.prepend( qApp->translate( "TMap", "in", "This translation converts the direction that DIR_IN codes for to a direction string that the MUD server will accept!" ) );        break;
-            case DIR_OUT:          mDirList.prepend( qApp->translate( "TMap", "out", "This translation converts the direction that DIR_OUT codes for to a direction string that the MUD server will accept!" ) );      break;
+            case DIR_NORTH:        mDirList.prepend( tr( "n", "This translation converts the direction that DIR_NORTH codes for to a direction string that the MUD server will accept!" ) );      break;
+            case DIR_NORTHEAST:    mDirList.prepend( tr( "ne", "This translation converts the direction that DIR_NORTHEAST codes for to a direction string that the MUD server will accept!" ) ); break;
+            case DIR_EAST:         mDirList.prepend( tr( "e", "This translation converts the direction that DIR_EAST codes for to a direction string that the MUD server will accept!" ) );       break;
+            case DIR_SOUTHEAST:    mDirList.prepend( tr( "se", "This translation converts the direction that DIR_SOUTHEAST codes for to a direction string that the MUD server will accept!" ) ); break;
+            case DIR_SOUTH:        mDirList.prepend( tr( "s", "This translation converts the direction that DIR_SOUTH codes for to a direction string that the MUD server will accept!" ) );      break;
+            case DIR_SOUTHWEST:    mDirList.prepend( tr( "sw", "This translation converts the direction that DIR_SOUTHWEST codes for to a direction string that the MUD server will accept!" ) ); break;
+            case DIR_WEST:         mDirList.prepend( tr( "w", "This translation converts the direction that DIR_WEST codes for to a direction string that the MUD server will accept!" ) );       break;
+            case DIR_NORTHWEST:    mDirList.prepend( tr( "nw", "This translation converts the direction that DIR_NORTHWEST codes for to a direction string that the MUD server will accept!" ) ); break;
+            case DIR_UP:           mDirList.prepend( tr( "up", "This translation converts the direction that DIR_UP codes for to a direction string that the MUD server will accept!" ) );        break;
+            case DIR_DOWN:         mDirList.prepend( tr( "down", "This translation converts the direction that DIR_DOWN codes for to a direction string that the MUD server will accept!" ) );    break;
+            case DIR_IN:           mDirList.prepend( tr( "in", "This translation converts the direction that DIR_IN codes for to a direction string that the MUD server will accept!" ) );        break;
+            case DIR_OUT:          mDirList.prepend( tr( "out", "This translation converts the direction that DIR_OUT codes for to a direction string that the MUD server will accept!" ) );      break;
             case DIR_OTHER:        mDirList.prepend( r.specialExitName );  break;
             default:               qWarning() << "TMap::findPath(" << from << "," << to << ") WARN: found route between rooms (from Id:" << previousRoomId << ", to Id:" << currentRoomId << ") with an invalid DIR_xxxx code:" << r.direction << " - the path will not be valid!" ;
             }
@@ -922,16 +945,41 @@ bool TMap::findPath( int from, int to )
     return false;
 }
 
-const int CURRENT_MAP_VERSION = 16;
-
 bool TMap::serialize( QDataStream & ofs )
 {
-    version = CURRENT_MAP_VERSION;
-    ofs << version;
+
+    if( mSaveVersion != mVersion ) {
+        QString message = tr( "[ ALERT ]  - Saving map in a format {%1} that is different than the one it was\n"
+                                           "loaded as {%2}. This may be an issue if you want to share the resulting\n"
+                                           "map with others relying on the original format." )
+                          .arg( mSaveVersion )
+                          .arg( mVersion );
+        mpHost->mTelnet.postMessage( message );
+    }
+
+    if( mSaveVersion != mDefaultVersion ) {
+        QString message = tr( "[ WARN ]   - Saving map in a format {%1} that is different than the one\n"
+                                           "recommended {%2} baring in mind the build status of the source\n"
+                                           "code.  Development code versions may offer the chance to try\n"
+                                           "experimental features needing a revised format that could be\n"
+                                           "incompatible with existing release code versions.  Conversely\n"
+                                           "a release version may allow you to downgrade to save a map in\n"
+                                           "a format compatible with others using older versions of MUDLET\n"
+                                           "however some features may be crippled or non-operational for\n"
+                                           "this version of MUDLET." )
+                          .arg( mSaveVersion )
+                          .arg( mDefaultVersion );
+        mpHost->postMessage( message );
+    }
+
+    ofs << mSaveVersion;
     ofs << envColors;
     ofs << mpRoomDB->getAreaNamesMap();
     ofs << customEnvColors;
     ofs << mpRoomDB->hashTable;
+    if( mSaveVersion >= 17 ) {
+        ofs << mUserData;
+    }
 
     ofs << mpRoomDB->getAreaMap().size();
     // serialize area table
@@ -962,14 +1010,13 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pA->pos;
         ofs << pA->isZone;
         ofs << pA->zoneAreaRef;
+        if( mSaveVersion >= 17 ) {
+            ofs << pA->mUserData;
+        }
     }
 
-    if (mRoomId)
-        ofs << mRoomId;
-    else{
-        mRoomId = 0;
-        ofs << mRoomId;
-    }
+    ofs << mRoomId;
+
     ofs << mapLabels.size(); //anzahl der areas
     QMapIterator<int, QMap<int, TMapLabel> > itL1(mapLabels);
     while( itL1.hasNext() )
@@ -1039,69 +1086,145 @@ bool TMap::serialize( QDataStream & ofs )
 
 bool TMap::restore(QString location)
 {
-    qDebug()<<"restoring map of profile:"<<mpHost->getName()<<" url:"<<mpHost->getUrl();
+    qDebug() << "TMap::restore(" << location << ") INFO: restoring map of Profile:"
+             << mpHost->getName()
+             << " URL:"
+             << mpHost->getUrl();
+
     QElapsedTimer _time;
     _time.start();
     QString folder;
     QStringList entries;
-    qDebug()<<"RESTORING MAP";
 
-    if(location == "")
-    {
-        folder = QDir::homePath()+"/.config/mudlet/profiles/"+mpHost->getName()+"/map/";
+    if( location.isEmpty() ) {
+        folder = QStringLiteral( "%1/.config/mudlet/profiles/%2/map/" )
+                 .arg( QDir::homePath() )
+                 .arg( mpHost->getName() );
         QDir dir( folder );
-        dir.setSorting(QDir::Time);
+        dir.setSorting( QDir::Time );
         entries = dir.entryList( QDir::Files, QDir::Time );
     }
 
     bool canRestore = true;
-    if( entries.size() > 0 || location != "")
-    {
-        QFile file((location == "") ? folder+entries[0] : location);
-        if (!file.open( QFile::ReadOnly ))
+    if( entries.size() || ! location.isEmpty() ) {
+        QFile file(   location.isEmpty()
+                    ? QStringLiteral( "%1%2" ).arg( folder ).arg( entries.at(0) )
+                    : location );
+
+        if( ! file.open( QFile::ReadOnly ) ) {
+            QString errMsg = tr( "[ ERROR ] - Unable to open (for reading) map file: \"%1\"!" )
+                             .arg( file.fileName() );
+            mpHost->postMessage( errMsg );
             return false;
-        qDebug()<<"[LOADING MAP]:"<<file.fileName();
+        }
+
         QDataStream ifs( & file );
 
-        ifs >> version;
-        qDebug()<<"map version:"<<version;
-        if( version > CURRENT_MAP_VERSION )
-        {
-            qDebug()<<"ERROR: map version > CURRENT_MAP_VERSION. Please upgrade Mudlet";
-            file.close();
-            return false;
+        ifs >> mVersion;
+//        qDebug()<<"map version:"<<mVersion;
+        if( mVersion > mDefaultVersion ) {
+            if( QByteArray( APP_BUILD ).isEmpty() ) {
+                // This is a release version - should not support any map file versions higher that it was built for
+                QString errMsg = tr( "[ ERROR ] - Map file is too new, it's file format (%1) is higher than this version of\n"
+                                                 "Mudlet can handle (%2)!" )
+                                 .arg( mVersion )
+                                 .arg( mDefaultVersion );
+                mpHost->postMessage( errMsg );
+                QString infoMsg = tr( "[ INFO ]  - You will need to upgrade your Mudlet or find a Map file saved in a\n"
+                                                  "format that it CAN read.  As this Mudlet appears to be based on a\n"
+                                                  "release version of the source code it is possible that you, or the\n"
+                                                  "creator of the Map file, may have been experimenting with a development\n"
+                                                  "version that has additional features that need a revised format and,\n"
+                                                  "unfortunately the file that has been loaded was from that.  If the\n"
+                                                  "map was loaded automatically on profile start up, you be able to recover\n"
+                                                  "from this by going to the \"map\" sub-directory of this profile's home\n"
+                                                  "directory and selecting a file to load that is NOT the most recent one\n"
+                                                  "(which is the one that is selected normally) though it is probable that\n"
+                                                  "the stored location of the current map location will be wrong." );
+                mpHost->postMessage( infoMsg );
+                file.close();
+                return false;
+            }
+            else {
+                // Is a development version so check against mMaxVersion
+                if( mVersion > mMaxVersion ) {
+                    // Oh dear, can't handle THIS
+                    QString errMsg = tr( "[ ERROR ] - Map file is too new, it's file format (%1) is higher than this version of\n"
+                                                     "Mudlet can handle (%2)!" )
+                                     .arg( mVersion )
+                                     .arg( mMaxVersion );
+                    mpHost->postMessage( errMsg );
+                    QString infoMsg = tr( "[ INFO ]  - You will need to upgrade your Mudlet or find a Map file saved in a\n"
+                                                      "format that it CAN read.  Even though this Mudlet appears to be based on a\n"
+                                                      "development version of the source code it is possible that you, or the\n"
+                                                      "creator of the Map file, may have been experimenting with an even more\n"
+                                                      "advanced version that has additional features that need a revised format\n"
+                                                      "and, unfortunately the file that has been loaded was from that.  If the\n"
+                                                      "map was loaded automatically on profile start up, you be able to recover\n"
+                                                      "from this by going to the \"map\" sub-directory of this profile's home\n"
+                                                      "directory and selecting a file to load that is NOT the most recent one\n"
+                                                      "(which is the one that is selected normally) though it is probable that\n"
+                                                      "the stored location of the current map location will be wrong." );
+                    mpHost->postMessage( infoMsg );
+                    file.close();
+                    return false;
+                }
+                else {
+                    QString alertMsg = tr( "[ ALERT ] - Map file is using new features, it's file format (%1) is higher than\n"
+                                                       "the default for this version of Mudlet (%2)!" )
+                                     .arg( mVersion )
+                                     .arg( mDefaultVersion );
+                    mpHost->postMessage( alertMsg );
+                    QString infoMsg = tr( "[ INFO ]  - You are using a new, possibly experimental, map file format which this\n"
+                                                      "version of Mudlet CAN read.  This Mudlet appears to be based on a\n"
+                                                      "development version of the source code so it is possible that you, or the\n"
+                                                      "creator of the Map file, may have been experimenting with this more\n"
+                                                      "advanced version that has additional features that need a revised format;\n"
+                                                      "beware that this file may not be usable by the current release version\n"
+                                                      "of Mudlet that you or others with whom you might share it have!" );
+                    mpHost->postMessage( infoMsg );
+                }
+            }
         }
-        if( version >= 3 )
-        {
-            ifs >> envColors;
-        }
-        else
-        {
+        else if( mVersion < 4 ) {
+            QString alertMsg = tr( "[ ALERT ] - Map file is really old, it's file format (%1) is so ancient that\n"
+                                               "this version of Mudlet may not gain enough information from\n"
+                                               "it but it will try!" )
+                               .arg( mVersion );
+            mpHost->postMessage( alertMsg );
+            QString infoMsg = tr( "[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
+                                              "There is so much data that it DOES NOT have that you could be\n"
+                                              "be better off starting again..." );
+            mpHost->postMessage( infoMsg );
             canRestore = false;
         }
-        if( version >= 4 )
-        {
+        else {
+            QString infoMsg = tr( "[ INFO ]  - Reading map file: \"%1\", format version:%2, please wait..." )
+                              .arg( file.fileName() )
+                              .arg( mVersion );
+            mpHost->postMessage( infoMsg );
+        }
+
+        // As all but the room reading have version checks the fact that sub-4
+        // files will still be parsed despite canRestore being false is probably OK
+        if( mVersion >= 4 ) {
+            ifs >> envColors;
             mpRoomDB->restoreAreaMap(ifs);
         }
-        else
-        {
-            canRestore = false;
-        }
-        if( version >= 5 )
-        {
+        if( mVersion >= 5 ) {
             ifs >> customEnvColors;
         }
-        if( version > 6 )
-        {
+        if( mVersion >= 7 ) {
             ifs >> mpRoomDB->hashTable;
         }
-        if( version >= 14 )
-        {
+        if( mVersion >= 17 ) {
+            ifs >> mUserData;
+        }
+        if( mVersion >= 14 ) {
             int areaSize;
             ifs >> areaSize;
             // restore area table
-            for( int i=0; i<areaSize; i++ )
-            {
+            for( int i=0; i<areaSize; i++ ) {
                 TArea * pA = new TArea( this, mpRoomDB );
                 int areaID;
                 ifs >> areaID;
@@ -1135,38 +1258,36 @@ bool TMap::restore(QString location)
                 ifs >> pA->pos;
                 ifs >> pA->isZone;
                 ifs >> pA->zoneAreaRef;
+                if( mVersion >= 17 ) {
+                    ifs >> pA->mUserData;
+                }
                 mpRoomDB->restoreSingleArea( ifs, areaID, pA );
             }
         }
 
-        if( version >= 12 )
-        {
+        if( mVersion >= 12 ) {
             ifs >> mRoomId;
         }
-        if( version >= 11 )
-        {
+
+        if( mVersion >= 11 ) {
             int size;
             ifs >> size; //size of mapLabels
             int areaLabelCount = 0;
-            while( ! ifs.atEnd() && areaLabelCount < size )
-            {
+            while( ! ifs.atEnd() && areaLabelCount < size ) {
                 int areaID;
                 int size_labels;
                 ifs >> size_labels;
                 ifs >> areaID;
                 int labelCount = 0;
                 QMap<int, TMapLabel> _map;
-                while( ! ifs.atEnd() &&  labelCount < size_labels )
-                {
+                while( ! ifs.atEnd() &&  labelCount < size_labels ) {
                     int labelID;
                     ifs >> labelID;
                     TMapLabel label;
-                    if( version >= 12 )
-                    {
+                    if( mVersion >= 12 ) {
                         ifs >> label.pos;
                     }
-                    else
-                    {
+                    else {
                         QPointF __label_pos;
                         ifs >> __label_pos;
                         label.pos = QVector3D(__label_pos.x(), __label_pos.y(), 0);
@@ -1177,8 +1298,7 @@ bool TMap::restore(QString location)
                     ifs >> label.fgColor;
                     ifs >> label.bgColor;
                     ifs >> label.pix;
-                    if( version >= 15 )
-                    {
+                    if( mVersion >= 15 ) {
                         ifs >> label.noScaling;
                         ifs >> label.showOnTop;
                     }
@@ -1189,14 +1309,15 @@ bool TMap::restore(QString location)
                 areaLabelCount++;
             }
         }
-        while( ! ifs.atEnd() )
-        {
+
+        while( ! ifs.atEnd() ) {
             int i;
             ifs >> i;
             TRoom * pT = new TRoom(mpRoomDB);
-            pT->restore( ifs, i, version );
+            pT->restore( ifs, i, mVersion );
             mpRoomDB->restoreSingleRoom( ifs, i, pT );
         }
+
         customEnvColors[257] = mpHost->mRed_2;
         customEnvColors[258] = mpHost->mGreen_2;
         customEnvColors[259] = mpHost->mYellow_2;
@@ -1213,39 +1334,40 @@ bool TMap::restore(QString location)
         customEnvColors[270] = mpHost->mLightCyan_2;
         customEnvColors[271] = mpHost->mLightWhite_2;
         customEnvColors[272] = mpHost->mLightBlack_2;
-        qDebug() << "TMap::restore() Loaded" << mpRoomDB->size() << "rooms in:" << _time.nsecsElapsed()* 1.0e-9 << "sec.";
-        if( canRestore )
-        {
+
+        QString okMsg = tr( "[  OK  ]  - Sucessfully read map file, will now check some consistancy details." );
+        mpHost->postMessage( okMsg );
+        if( canRestore ) {
             return true;
         }
     }
-    if( ! canRestore || entries.size() == 0 )
-    {
+
+    if( ! canRestore || entries.size() == 0 ) {
         QMessageBox msgBox;
 
-        if( mpHost->mUrl.toLower().contains( "achaea.com" )
+        if(    mpHost->mUrl.toLower().contains( "achaea.com" )
             || mpHost->mUrl.toLower().contains( "aetolia.com" )
             || mpHost->mUrl.toLower().contains( "imperian.com" )
             || mpHost->mUrl.toLower().contains( "midkemiaonline.com" )
-            || mpHost->mUrl.toLower().contains( "lusternia.com" ) )
-        {
+            || mpHost->mUrl.toLower().contains( "lusternia.com" ) ) {
+
             msgBox.setText("No map found. Would you like to download the map or start your own?");
             QPushButton *yesButton = msgBox.addButton("Download the map", QMessageBox::ActionRole);
             QPushButton *noButton = msgBox.addButton("Start my own", QMessageBox::ActionRole);
             msgBox.exec();
             init( mpHost );
-            if (msgBox.clickedButton() == yesButton) {
+            if( msgBox.clickedButton() == yesButton ) {
                 mpMapper->downloadMap();
             }
-            else if(msgBox.clickedButton() == noButton) {
+            else if( msgBox.clickedButton() == noButton ) {
                 ; //No-op to avoid unused "noButton"
             }
         }
-        else
-        {
+        else {
             mpHost->mpMap->init( mpHost );
         }
     }
+
     return canRestore;//FIXME
 }
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -26,6 +26,7 @@
 #include "TAstar.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QColor>
 #include <QMap>
 #include <QPixmap>
@@ -66,6 +67,8 @@ public:
 
 class TMap
 {
+    Q_DECLARE_TR_FUNCTIONS(TMap) // Needed so we can use tr() even though TMap is NOT derived from QObject
+
 public:
     TMap( Host *);
     ~TMap();
@@ -103,6 +106,8 @@ public:
     void exportMapToDatabase();
     void importMapFromDatabase();
     void connectExitStub(int roomId, int dirType);
+
+
     TRoomDB * mpRoomDB;
     QMap<int, int> envColors;
     QVector3D span;
@@ -139,7 +144,22 @@ public:
     bool mNewMove;
     QMap<qint32, QMap<qint32, TMapLabel> > mapLabels;
 
-    int version; // map file format version
+    int mVersion; // loaded map file format version
+    const int mDefaultVersion; // replaces CURRENT_MAP_VERSION
+    const int mMaxVersion; // normally the same as mDefaultVersion but can be
+                           // higher for development builds and is the maximum
+                           // version the development build can parse.
+    const int mMinVersion; // normally the same as mDefaultVersion but can be
+                           // lower for release builds and is the minimum
+                           // version recommended for saving , which might
+                           // perhaps be one less than mDefault to permit sharing
+                           // of a map with users of an older version "in the field"!
+    int mSaveVersion; // what to use when saving the map, defaults to mDefaultVersion
+                      // but can be override by control in special options (last)
+                      // tab on profile preference dialog using the limits set
+                      // by mMinVersion and mMaxVersion.
+
+    QMap<QString, QString> mUserData;
 };
 
 #endif // MUDLET_TMAP_H

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -816,7 +816,11 @@ void dlgProfilePreferences::saveMap()
 
     // Temporarily use whatever version is currently set
     int oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
+#if QT_VERSION >= 0x050200
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
+#else
+    pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->itemData( comboBox_mapFileSaveFormatVersion->currentIndex() ).toInt();
+#endif
     if( pHost->mpConsole->saveMap(fileName) ) {
         map_file_action->setText( tr("Saved map to %1").arg( fileName ) );
     } else {
@@ -980,7 +984,11 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mTimerDebugOutputSuppressionInterval = 0;
     }
 
+#if QT_VERSION >= 0x050200
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
+#else
+    pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->itemData( comboBox_mapFileSaveFormatVersion->currentIndex() ).toInt();
+#endif
     //pHost->mIRCNick = ircNick->text();
     QString old_nick = mudlet::self()->mIrcNick;
     QString new_nick = ircNick->text();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -258,6 +258,36 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
         // The above funky setting method is because a zero time is INVALID
         // and since Qt 5.0-ish adding any value to an invalid time still leaves
         // the time as "invalid".
+        timeEdit_timerDebugOutputMinimumInterval->setCurrentSection( QDateTimeEdit::SecondSection );
+        // Added so that the control is initially set to edit seconds (was
+        // defaulting to first shown which was hours which is not the most
+        // likely that the user would want to use)!
+
+        // FIXME: Check this each time that it is appropriate for THIS build version
+        comboBox_mapFileSaveFormatVersion->clear();
+        // Add default version:
+        comboBox_mapFileSaveFormatVersion->addItem( tr( "%1 {Default, recommended}" ).arg( pHost->mpMap->mDefaultVersion ),
+                                                    QVariant( pHost->mpMap->mDefaultVersion ) );
+        comboBox_mapFileSaveFormatVersion->setEnabled( false );
+        label_mapFileSaveFormatVersion->setEnabled( false );
+        if(  pHost->mpMap->mMaxVersion > pHost->mpMap->mDefaultVersion
+          || pHost->mpMap->mMinVersion < pHost->mpMap->mDefaultVersion ) {
+            for( short int i = pHost->mpMap->mMinVersion; i <= pHost->mpMap->mMaxVersion; ++i ) {
+                if( i == pHost->mpMap->mDefaultVersion ) {
+                    continue;
+                }
+                comboBox_mapFileSaveFormatVersion->setEnabled( true );
+                label_mapFileSaveFormatVersion->setEnabled( true );
+                if( i > pHost->mpMap->mDefaultVersion ) {
+                    comboBox_mapFileSaveFormatVersion->addItem( tr( "%1 {Upgraded, experimental/testing, NOT recommended}" ).arg( i ),
+                                                                QVariant( i ) );
+                }
+                else {
+                    comboBox_mapFileSaveFormatVersion->addItem( tr( "%1 {Downgraded, for sharing with older version users, NOT recommended}" ).arg( i ),
+                                                                QVariant( i ) );
+                }
+            }
+        }
     }
 }
 
@@ -784,13 +814,18 @@ void dlgProfilePreferences::saveMap()
     map_file_action->show();
     map_file_action->setText("Saving map...");
 
-    if ( mpHost->mpConsole->saveMap(fileName) ) {
-        map_file_action->setText("Saved map to "+fileName);
-        QTimer::singleShot(10*1000, this, SLOT(hideActionLabel()));
+    // Temporarily use whatever version is currently set
+    int oldSaveVersionFormat = pHost->mpMap->mSaveVersion;
+    pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
+    if( pHost->mpConsole->saveMap(fileName) ) {
+        map_file_action->setText( tr("Saved map to %1").arg( fileName ) );
     } else {
-        map_file_action->setText("Couldn't save map to "+fileName);
-        QTimer::singleShot(10*1000, this, SLOT(hideActionLabel()));
+        map_file_action->setText( tr("Could not save map to %1").arg( fileName ) );
     }
+    // Then restore prior version
+    pHost->mpMap->mSaveVersion = oldSaveVersionFormat;
+
+    QTimer::singleShot(10*1000, this, SLOT(hideActionLabel()));
 }
 
 void dlgProfilePreferences::hideActionLabel()
@@ -945,6 +980,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mTimerDebugOutputSuppressionInterval = 0;
     }
 
+    pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
     //pHost->mIRCNick = ircNick->text();
     QString old_nick = mudlet::self()->mIrcNick;
     QString new_nick = ircNick->text();

--- a/src/src.pro
+++ b/src/src.pro
@@ -18,19 +18,9 @@
 #    59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ############################################################################
 
-greaterThan(QT_MAJOR_VERSION, 4) {
-  # 5 or MORE
-  isEqual(QT_MAJOR_VERSION, 5) {
-    # Exactly 5:
-    lessThan(QT_MINOR_VERSION, 2): error("requires Qt 5.2 or later")
-  }
-} else {
-# Less than OR equal to Qt 4.x
-  error("requires Qt 5.2 or later")
+lessThan(QT_MAJOR_VERSION, 5) {
+  error("requires Qt 5.0 or later")
 }
-
-# The above check (for 5.2 or greater) is needed (at least) because of:
-#   using QComboBox::currentData() introduced in 5.2, in dlgProfilePreferences class
 
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:

--- a/src/src.pro
+++ b/src/src.pro
@@ -18,7 +18,19 @@
 #    59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ############################################################################
 
-lessThan(QT_MAJOR_VERSION, 5): error("requires Qt 5")
+greaterThan(QT_MAJOR_VERSION, 4) {
+  # 5 or MORE
+  isEqual(QT_MAJOR_VERSION, 5) {
+    # Exactly 5:
+    lessThan(QT_MINOR_VERSION, 2): error("requires Qt 5.2 or later")
+  }
+} else {
+# Less than OR equal to Qt 4.x
+  error("requires Qt 5.2 or later")
+}
+
+# The above check (for 5.2 or greater) is needed (at least) because of:
+#   using QComboBox::currentData() introduced in 5.2, in dlgProfilePreferences class
 
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1893,7 +1893,10 @@ or some other computer model that has a small screen.</string>
          <property name="title">
           <string>Other Special options</string>
          </property>
-         <layout class="QFormLayout" name="formLayout">
+         <layout class="QFormLayout" name="formLayout_Debug">
+          <property name="labelAlignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="label_timerDebugOutputMinimumInterval">
             <property name="text">
@@ -1930,6 +1933,37 @@ or some other computer model that has a small screen.</string>
             <property name="displayFormat">
              <string notr="true">h:mm:ss.zzz</string>
             </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_mapFileSaveFormatVersion">
+            <property name="text">
+             <string>Override map file format version:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="comboBox_mapFileSaveFormatVersion">
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="editable">
+             <bool>false</bool>
+            </property>
+            <property name="currentText">
+             <string># {default version}</string>
+            </property>
+            <item>
+             <property name="text">
+              <string># {default version}</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
~~The first pair of commits are actually #278.~~ That first pair have evaporated from here as that PR has already been merged.

The ~~third~~ first is the purpose of this PR.  See it's comments for the details but its primary purpose is to provide data storage on a per area and a whole map basis in the same manner as the per room TRoom::userData member.  I have a use for this to hold extra attributes found during importation of Xml Map files but I realised that there is a more general usefulness to being able to store these types of data within the map; just a couple of random examples of the top of my head would be, for areas: the name of a piece of background music to play whilst in that area and for the map: a history of edits or - for a profile that is used for more than one character from within the same profile, saving of pertinent details for each of the characters {like, where they were when last saved}.  This is not to say there are not other ways to do the same things but it seems a logical extension to an existing (per room) system.