### PR TITLE
(release 30)fix enhance travis ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,17 @@ os:
   - linux
 compiler:
   - gcc
+  - clang
+env:
+  - Q_OR_C_MAKE=qmake
+  - Q_OR_C_MAKE=cmake
+matrix:
+# Something goes wrong internally in Qt (5.0.2) for CMake Clang builds on Linux
+    allow_failures:
+    - os: linux
+      compiler: clang
+      env: Q_OR_C_MAKE=cmake
+
 before_install: ./CI/travis.before_install.sh
 install: ./CI/travis.install.sh
 before_script:
@@ -11,9 +22,9 @@ before_script:
   - mkdir build
   - cd src
 script:
-  - qmake && make -j2
   - cd ../build
-  - if [ -z "${TRAVIS_OS_NAME}" ] || [ "${TRAVIS_OS_NAME}" = "linux" ]; then cmake .. && make -j2; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then export LDFLAGS=" -L/usr/local/opt/qt5/lib ${LDFLAGS}"; export CPPFLAGS=" -I/usr/local/opt/qt5/include ${CPPFLAGS}"; fi
+  - if [ "${Q_OR_C_MAKE}" = "qmake" ]; then qmake -v; qmake ../src/src.pro && make -j2; else cmake --version; cmake .. && make -j2; fi
 notifications:
   webhooks:
     urls:

--- a/CI/travis.install.sh
+++ b/CI/travis.install.sh
@@ -7,3 +7,7 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
   echo Install on OSX.
   ./CI/travis.osx.install.sh;
 fi
+if [ ! -z "${CXX}" ]; then
+  echo "Testing (possibly updated) compiler version:"
+  ${CXX} --version;
+fi

--- a/CI/travis.linux.before_install.sh
+++ b/CI/travis.linux.before_install.sh
@@ -2,6 +2,9 @@
 set -ev
 sudo apt-add-repository ppa:ubuntu-sdk-team/ppa -y
 sudo apt-add-repository ppa:kalakris/cmake -y
+# newer GCC version, 4.7
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo add-apt-repository ppa:boost-latest/ppa -y
 sudo apt-get update
 pushd $HOME
 git clone https://github.com/lloyd/yajl.git

--- a/CI/travis.linux.install.sh
+++ b/CI/travis.linux.install.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 set -ev
+sudo apt-get remove \
+  qt4-qmake libqt4-designer libqt4-dev libboost-dev
+sudo apt-get autoremove
+# libboost seems messed up in Precise 12.04 lts it mixes 1.46 and 1.48 so try
+# and force a uniform 1.55 installation
 sudo apt-get install \
   build-essential \
   qt5-default qtmultimedia5-dev qttools5-dev \
   libhunspell-dev \
   lua5.1 liblua5.1-0-dev \
   libpcre3-dev \
-  libboost-dev \
+  libboost1.55-dev \
   zlib1g-dbg zlib1g-dev \
   libzip-dev \
   libpulse-dev \
-  cmake
+  cmake \
+  gcc-4.7 \
+  g++-4.7
+sudo update-alternatives --remove gcc /usr/bin/gcc-4.6
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.7
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 40 --slave /usr/bin/g++ g++ /usr/bin/g++-4.6
 pushd $HOME/yajl
 ./configure
 sudo make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
+#    Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -38,7 +39,7 @@ ELSE()
 ENDIF()
 
 SET(APP_VERSION 3.0.0)
-SET(APP_BUILD "-beta")
+SET(APP_BUILD "-delta")
 # APP_BUILD should only be empty/null in official "release" builds,
 # developers may like to set it to their user and branch names to make it easier
 # to tell different builds apart!

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
+#    Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -255,24 +256,80 @@ IF(EXISTS "${PROJECT_SOURCE_DIR}/../include/lua.h")
   ENDIF()
 ENDIF()
 
-IF(EXISTS "${PROJECT_SOURCE_DIR}/../include/zlib.h")
-  SET(ZLIB_INCLUDE_DIR_TEMP "${PROJECT_SOURCE_DIR}/../include")
-  GET_FILENAME_COMPONENT(ZLIB_INCLUDE_DIR ${ZLIB_INCLUDE_DIR_TEMP} ABSOLUTE CACHE)
-  SET(ZLIB_ROOT "${PROJECT_SOURCE_DIR}/..")
-  IF(EXISTS "${PROJECT_SOURCE_DIR}/../lib/zlibstat.lib")
-    SET(ZLIB_LIBRARY_RELEASE_TEMP "${PROJECT_SOURCE_DIR}/../lib/zlibstat.lib")
-    GET_FILENAME_COMPONENT(ZLIB_LIBRARY_RELEASE ${ZLIB_LIBRARY_RELEASE_TEMP} ABSOLUTE CACHE)
+IF(WIN32)
+  IF(EXISTS "${PROJECT_SOURCE_DIR}/../include/zlib.h")
+    SET(ZLIB_INCLUDE_DIR_TEMP "${PROJECT_SOURCE_DIR}/../include")
+    GET_FILENAME_COMPONENT(ZLIB_INCLUDE_DIR ${ZLIB_INCLUDE_DIR_TEMP} ABSOLUTE CACHE)
+    SET(ZLIB_ROOT "${PROJECT_SOURCE_DIR}/..")
+    IF(EXISTS "${PROJECT_SOURCE_DIR}/../lib/zlibstat.lib")
+      SET(ZLIB_LIBRARY_RELEASE_TEMP "${PROJECT_SOURCE_DIR}/../lib/zlibstat.lib")
+      GET_FILENAME_COMPONENT(ZLIB_LIBRARY_RELEASE ${ZLIB_LIBRARY_RELEASE_TEMP} ABSOLUTE CACHE)
+    ENDIF()
+    IF(EXISTS "${PROJECT_SOURCE_DIR}/../lib/zlibstatd.lib")
+      SET(ZLIB_LIBRARY_DEBUG_TEMP "${PROJECT_SOURCE_DIR}/../lib/zlibstatd.lib")
+      GET_FILENAME_COMPONENT(ZLIB_LIBRARY_DEBUG ${ZLIB_LIBRARY_DEBUG_TEMP} ABSOLUTE CACHE)
+    ENDIF()
+    IF(ZLIB_LIBRARY_DEBUG AND ZLIB_LIBRARY_RELEASE)
+      SET(ZLIB_LIBRARY optimized ${ZLIB_LIBRARY_RELEASE} debug ${ZLIB_LIBRARY_DEBUG} )
+    ELSEIF(ZLIB_LIBRARY_RELEASE)
+      SET(ZLIB_LIBRARY ${ZLIB_LIBRARY_RELEASE} )
+    ELSEIF(ZLIB_LIBRARY_DEBUG)
+      SET(ZLIB_LIBRARY ${ZLIB_LIBRARY_DEBUG} )
+    ENDIF()
   ENDIF()
-  IF(EXISTS "${PROJECT_SOURCE_DIR}/../lib/zlibstatd.lib")
-    SET(ZLIB_LIBRARY_DEBUG_TEMP "${PROJECT_SOURCE_DIR}/../lib/zlibstatd.lib")
-    GET_FILENAME_COMPONENT(ZLIB_LIBRARY_DEBUG ${ZLIB_LIBRARY_DEBUG_TEMP} ABSOLUTE CACHE)
+ENDIF()
+
+# Break each step into a separate command so any status message is output straigh away
+IF(APPLE)
+  # The include directory setup for Zip is unusual in that as well as e.g. /usr/include/zip.h
+  # we need the path to an interal header zipconf.g that it calls for using '<''>'s
+  # i.e. SYSTEM #include delimiters which are typically located at e.g. /usr/lib/libzip/include/zipconf.h
+  # and using pkg-config is the recommended way to get the details.
+  # Spotted recommendation to use pkg-config here https://github.com/Homebrew/homebrew/issues/13390
+  FIND_PACKAGE(PkgConfig)
+  IF(NOT(PKG_CONFIG_FOUND))
+    MESSAGE(WARNING "Unable to use pkg_config - will possibly fail to find/use Zip library...")
   ENDIF()
-  IF(ZLIB_LIBRARY_DEBUG AND ZLIB_LIBRARY_RELEASE)
-    SET(ZLIB_LIBRARY optimized ${ZLIB_LIBRARY_RELEASE} debug ${ZLIB_LIBRARY_DEBUG} )
-  ELSEIF(ZLIB_LIBRARY_RELEASE)
-    SET(ZLIB_LIBRARY ${ZLIB_LIBRARY_RELEASE} )
-  ELSEIF(ZLIB_LIBRARY_DEBUG)
-    SET(ZLIB_LIBRARY ${ZLIB_LIBRARY_DEBUG} )
+ENDIF()
+
+IF((APPLE) AND (PKG_CONFIG_FOUND))
+  PKG_SEARCH_MODULE(PC_ZIP zip libzip)
+  # Use a PC_ prefix to distinguish between what pkg-config finds and a direct use of FIND_PACKAGE(ZIP)
+  # Package "zip" is called "libzip" at least on MY Linux box so look for BOTH
+  IF(PC_ZIP_FOUND)
+    IF(PC_ZIP_zip_FOUND)
+      MESSAGE(STATUS "Using pkg_config, found \"zip\" version: ${PC_ZIP_zip_VERSION} with:")
+    ELSEIF(PC_ZIP_libzip_FOUND)
+      MESSAGE(STATUS "Using pkg_config, found \"libzip\" version: ${PC_ZIP_libzip_VERSION} with:")
+    ELSE()
+      MESSAGE(STATUS "Using pkg_config, found Zip version: ${PC_ZIP_VERSION} with:")
+    ENDIF()
+    MESSAGE(STATUS "  include directory(ies), ZIP_INCLUDE_DIRS: ${PC_ZIP_INCLUDE_DIRS} .")
+    MESSAGE(STATUS "  library(ies): ZIP_LIBRARY_DIRS: ${PC_ZIP_LIBRARY_DIRS}; ZIP_LIBDIR: ${PC_ZIP_LIBDIR}. ")
+  ELSE()
+    MESSAGE(WARNING "Using pkg_config, failed to find any version of Zip library!")
+  ENDIF()
+ENDIF()
+
+IF((APPLE) AND (PKG_CONFIG_FOUND))
+  # Examining Homebrew (for MacOs) for libzzip:
+  # https://bintray.com/homebrew/bottles/libzzip found that they use pkg-config
+  # So use that to try and find what we want
+  PKG_SEARCH_MODULE(PC_ZZIPLIB zziplib libzzip zzip)
+  IF(PC_ZZIPLIB_FOUND)
+    IF(PC_ZZIPLIB_zziplib_FOUND)
+      MESSAGE(STATUS "Using pkg_config, found \"zziplib\" version: ${PC_ZZIPLIB_zziplib_VERSION} with:")
+    ELSEIF(PC_ZZIPLIB_libzzip_FOUND)
+      MESSAGE(STATUS "Using pkg_config, found \"libzzip\" version: ${PC_ZZIPLIB_libzzip_VERSION} with:")
+    ELSEIF(PC_ZZIPLIB_zzip_FOUND)
+      MESSAGE(STATUS "Using pkg_config, found \"zzip\" version: ${PC_ZZIPLIB_zzip_VERSION} with:")
+    ELSE()
+      MESSAGE(STATUS "Using pkg_config, found Zzip version: ${PC_ZZIPLIB_VERSION} with:")
+    ENDIF()
+    MESSAGE(STATUS "  include directory(ies), ZZIPLIB_INCLUDE_DIRS: ${PC_ZZIPLIB_INCLUDE_DIRS} .")
+    MESSAGE(STATUS "  library(ies): ZZIPLIB_LIBRARY_DIRS: ${PC_ZZIPLIB_LIBRARY_DIRS}; ZZIPLIB_LIBDIR: ${PC_ZZIPLIB_LIBDIR}. ")
+  ELSEIF()
+    MESSAGE(WARNING "Using pkg_config, failed to find any version of Zziplib library!")
   ENDIF()
 ENDIF()
 
@@ -283,13 +340,24 @@ FIND_PACKAGE(Qt5OpenGL REQUIRED)
 FIND_PACKAGE(Qt5UiTools REQUIRED)
 FIND_PACKAGE(Qt5Widgets REQUIRED)
 
+IF(NOT(PC_ZIP_FOUND))
+  FIND_PACKAGE(ZIP REQUIRED)
+ENDIF()
 FIND_PACKAGE(OpenGL REQUIRED)
 FIND_PACKAGE(Lua51 REQUIRED)
+# Needed (just) on MacOs as an #include in luazip.h:
+IF(APPLE)
+  IF(NOT(PC_ZZIPLIB_FOUND))
+    FIND_PACKAGE(ZZIPLIB)
+  ENDIF()
+  IF(NOT((ZZIPLIB_FOUND) OR (PC_ZZIPLIB_FOUND) OR (PC_ZZIPLIB_zziplib_FOUND) OR (PC_ZZIPLIB_libzzip_FOUND) OR (PC_ZZIPLIB_zzip_FOUND)))
+    MESSAGE(WARNING "Failed to find any trace of zziplib (or zzip or libzzip)\n- so will not be able to build the (internal version for Mac builds) of the lua zip module that Mudlet needs.")
+  ENDIF()
+ENDIF()
 FIND_PACKAGE(ZLIB REQUIRED)
 FIND_PACKAGE(PCRE REQUIRED)
 FIND_PACKAGE(YAJL REQUIRED)
 FIND_PACKAGE(HUNSPELL REQUIRED)
-FIND_PACKAGE(ZIP REQUIRED)
 
 SET(Boost_USE_STATIC_LIBS ON)
 FIND_PACKAGE(Boost 1.44 COMPONENTS graph)
@@ -321,9 +389,24 @@ INCLUDE_DIRECTORIES(
     ${LUA_INCLUDE_DIR}
     ${PCRE_INCLUDE_DIR}
     ${YAJL_INCLUDE_DIR}
-    ${ZIP_INCLUDE_DIR}
-    ${ZLIB_INCLUDE_DIR}
 )
+
+# Need to use the plural variables as there can be more than ONE directory to specify:
+IF(PC_ZIP_FOUND)
+    INCLUDE_DIRECTORIES( ${PC_ZIP_INCLUDE_DIRS} )
+ELSE()
+    INCLUDE_DIRECTORIES( ${ZIP_INCLUDE_DIRS} )
+ENDIF()
+
+IF(APPLE)
+  IF(PC_ZZIPLIB_FOUND)
+    INCLUDE_DIRECTORIES( ${PC_ZZIPLIB_INCLUDE_DIRS} )
+  ELSE()
+    INCLUDE_DIRECTORIES( ${ZZIPLIB_INCLUDE_DIRS} )
+  ENDIF()
+ENDIF()
+
+INCLUDE_DIRECTORIES( ${ZLIB_INCLUDE_DIR} )
 
 QT5_WRAP_UI(mudlet_UIS_H ${mudlet_UIS})
 QT5_WRAP_CPP(mudlet_MOC_SRCS ${mudlet_MOC_HDRS})
@@ -351,7 +434,20 @@ TARGET_LINK_LIBRARIES(mudlet
     ${OPENGL_LIBRARIES}
     ${PCRE_LIBRARIES}
     ${YAJL_LIBRARIES}
-    ${ZIP_LIBRARIES}
     ${ZLIB_LIBRARIES}
     irccqt
 )
+
+IF(PC_ZIP_FOUND)
+    TARGET_LINK_LIBRARIES(mudlet ${PC_ZIP_LIBRARIES})
+ELSE()
+    TARGET_LINK_LIBRARIES(mudlet ${ZIP_LIBRARIES})
+ENDIF()
+
+IF(APPLE)
+  IF(PC_ZZIPLIB_FOUND)
+    TARGET_LINK_LIBRARIES(mudlet ${PC_ZZIPLIB_LIBRARIES})
+  ELSE()
+    TARGET_LINK_LIBRARIES(mudlet ${ZZIPLIB_LIBRARIES})
+  ENDIF()
+ENDIF()

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -40,8 +40,7 @@
 #include <QMessageBox>
 #include "post_guard.h"
 
-#include "zip.h"
-#include "zipconf.h"
+#include <zip.h>
 
 #include <errno.h>
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -59,8 +59,14 @@
 #include <list>
 #include <string>
 
+// Provides the lua zip module for MacOs platform that does not have an easy way
+// to provide it as a prebuilt library module (unlike Windows/Linux) - was
+// called luazip.c and it is an amalgum of both such files that came from
+// http://www.keplerproject.org/luazip {dead link} the Kelper Project has
+// restuctured their site but the URL can be pulled from the Wayback machine:
+// https://web.archive.org/web/20150129015700/http://www.keplerproject.org/luazip
 #ifdef Q_OS_MAC
-#include "luazip.c"
+#include "luazip.h"
 #endif
 
 

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -210,7 +210,8 @@ bool TRoomDB::__removeRoom( int id )
         // "Container Class | Qt 5.x Core" - this is now avoid by taking a deep
         // copy and iterating through that instead whilst modifying the original
         while (i != entranceMap.end() && i.key() == id) {
-            if( i.value() == id || mpTempRoomDeletionList && mpTempRoomDeletionList->size() > 1 && mpTempRoomDeletionList->contains( i.value() ) ) {
+            if(    i.value() == id
+              || ( mpTempRoomDeletionList && mpTempRoomDeletionList->size() > 1 && mpTempRoomDeletionList->contains( i.value() ) ) ) {
                 ++i;
                 continue; // Bypass rooms we know are also to be deleted
             }
@@ -443,7 +444,7 @@ TArea * TRoomDB::getArea( int id )
 bool TRoomDB::setAreaName( int areaID, QString name )
 {
     if( areaID < 1 ) {
-        qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Suspect areaID: %n supplied.", areaID );
+        qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Suspect areaID: %d supplied.", areaID );
         return false;
     }
     if( name.isEmpty() ) {

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -38,8 +38,7 @@
 #include <QInputDialog>
 #include "post_guard.h"
 
-#include "zip.h"
-#include "zipconf.h"
+#include <zip.h>
 
 #include <errno.h>
 

--- a/src/luazip.h
+++ b/src/luazip.h
@@ -1,12 +1,34 @@
-/*
- LuaZip - Reading files inside zip files.
- http://www.keplerproject.org/luazip/
+/******************************************************************************
+ * LuaZip - Reading files inside zip files.                                   *
+ * http://www.keplerproject.org/luazip/                                       *
+ *                                                                            *
+ * Author: Danilo Tuler                                                       *
+ * Copyright (c) 2003-2007 Kepler Project                                     *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included in *
+ * all copies or substantial portions of the Software.                        *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL   *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************
 
- Author: Danilo Tuler
- Copyright (c) 2003-2007 Kepler Project
+ ******************************************************************************
+ *           Converted into a single file to include into Mudlet              *
+ ******************************************************************************/
 
- $Id: luazip.h,v 1.5 2007/06/18 18:47:05 carregal Exp $
-*/
+// Only included into the application (in TLuaInterpreter) in MacOs builds - Slysven!
 
 #ifndef luazip_h
 #define luazip_h
@@ -14,29 +36,17 @@
 #include "lua.h"
 
 #ifndef LUAZIP_API
-#define LUAZIP_API	LUA_API
+#define LUAZIP_API  LUA_API
 #endif
 
-#define LUA_ZIPLIBNAME	"zip"
+#define LUA_ZIPLIBNAME  "zip"
 LUAZIP_API int luaopen_zip (lua_State *L);
 
 #endif
 
-
-/*
- LuaZip - Reading files inside zip files.
- http://www.keplerproject.org/luazip/
-
- Author: Danilo Tuler
- Copyright (c) 2003-2007 Kepler Project
-
- $Id: luazip.c,v 1.11 2007/06/18 18:47:05 carregal Exp $
-*/
-
 #include <string.h>
 #include <stdlib.h>
 #include "zzip/zzip.h"
-//#include "luazip.h"
 #include "lauxlib.h"
 #if ! defined (LUA_VERSION_NUM) || LUA_VERSION_NUM < 501
 #include "compat-5.1.h"
@@ -320,21 +330,21 @@ static char* zzip_fgets(char *str, int size, ZZIP_FILE *stream)
 {
   int c, i;
 
-	for (i = 0; i < size-1; i++)
-	{
+  for (i = 0; i < size-1; i++)
+  {
     c = zzip_getc(stream);
-		if (EOF == c)
-			return NULL;
-		str[i]=c;
-		if (('\n' == c)/* || ('\r' == c)*/)
-		{
+    if (EOF == c)
+      return NULL;
+    str[i]=c;
+    if (('\n' == c)/* || ('\r' == c)*/)
+    {
       str[i++]='\n';
-			break;
-		}
-	}
-	str[i] = '\0';
+      break;
+    }
+  }
+  str[i] = '\0';
 
-	return str;
+  return str;
 }
 
 /* no support to read numbers
@@ -356,8 +366,8 @@ static int read_number (lua_State *L, ZZIP_FILE *f) {
 
 static int test_eof (lua_State *L, ZZIP_FILE *f) {
   /* TODO */
-	(void) L;
-	(void) f;
+  (void) L;
+  (void) f;
   return 1;
 }
 
@@ -529,15 +539,15 @@ static const luaL_reg fflib[] = {
 ** Assumes the table is on top of the stack.
 */
 static void set_info (lua_State *L) {
-	lua_pushliteral (L, "_COPYRIGHT");
-	lua_pushliteral (L, "Copyright (C) 2003-2007 Kepler Project");
-	lua_settable (L, -3);
-	lua_pushliteral (L, "_DESCRIPTION");
-	lua_pushliteral (L, "Reading files inside zip files");
-	lua_settable (L, -3);
-	lua_pushliteral (L, "_VERSION");
-	lua_pushliteral (L, "LuaZip 1.2.3");
-	lua_settable (L, -3);
+  lua_pushliteral (L, "_COPYRIGHT");
+  lua_pushliteral (L, "Copyright (C) 2003-2007 Kepler Project");
+  lua_settable (L, -3);
+  lua_pushliteral (L, "_DESCRIPTION");
+  lua_pushliteral (L, "Reading files inside zip files");
+  lua_settable (L, -3);
+  lua_pushliteral (L, "_VERSION");
+  lua_pushliteral (L, "LuaZip 1.2.3");
+  lua_settable (L, -3);
 }
 
 static void createmeta (lua_State *L) {

--- a/src/src.pro
+++ b/src/src.pro
@@ -28,14 +28,25 @@ VERSION = 3.0.0
 !msvc:CONFIG += warn_off
 # ignore unused parameters, because boost has a ton of them and that is not something we need to know.
 !msvc:QMAKE_CXXFLAGS += -Wall -Wno-deprecated -Wno-unused-local-typedefs -Wno-unused-parameter
+# Before we impose OUR idea about the optimisation levels to use, remove any
+# that Qt tries to put in automatically for us for release builds, only the
+# last, ours, is supposed to apply but it can be confusing to see multiple
+# alternatives during compilations.
+!msvc:QMAKE_CXXFLAGS_RELEASE ~= s/-O[0123s]//g
+# NOW we can put ours in:
 !msvc:QMAKE_CXXFLAGS_RELEASE += -O3
-!msvc:QMAKE_CXXFLAGS_DEBUG += -O0 -g
+# There is NO need to put in the -g option as it is done already for debug bugs
+# For gdb type debugging it helps if there is NO optimisations so use -O0.
+!msvc:QMAKE_CXXFLAGS_DEBUG += -O0
+
+# enable C++11 for builds.
+CONFIG += c++11
 
 # MSVC specific flags. Enable multiprocessor MSVC builds.
 msvc:QMAKE_CXXFLAGS += -MP
 
 # Mac specific flags.
-macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.5
+macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
 
 QT += network opengl uitools multimedia
 
@@ -322,6 +333,7 @@ HEADERS += \
     XMLexport.h \
     XMLimport.h
 
+macx:HEADERS += luazip.h
 
 # This is for compiled UI files, not those used at runtime through the resource file.
 FORMS += \
@@ -446,3 +458,19 @@ unix:!macx: {
         LUA \
         LUA_GEYSER
 }
+
+DISTFILES += \
+    ../.travis.yml \
+    CMakeLists.txt \
+    ../CMakeLists.txt \
+    irc/CMakeLists.txt \
+    ../CI/travis.before_install.sh \
+    ../CI/travis.install.sh \
+    ../CI/travis.linux.before_install.sh \
+    ../CI/travis.linux.install.sh \
+    ../CI/travis.osx.before_install.sh \
+    ../CI/travis.osx.install.sh \
+    ../cmake/FindHUNSPELL.cmake \
+    ../cmake/FindPCRE.cmake \
+    ../cmake/FindYAJL.cmake \
+    ../cmake/FindZIP.cmake


### PR DESCRIPTION
This revises the Travis C.I. setup to:
Build all combinations of:
* MaoOs vs. Linux
* CMake vs. QMake project files
* G++ vs Clang++ compiler
Doing this has found a couple of small bugs in TRoomDB which the second commit fixes.
In testing we can have 5 (five) sub-builds active at a time and currently it takes around 11 minutes to do a full build.

The Linux build is using the _older_ "non-container" build as it uses sudo to tweak somethings that the new "container" based one does not allow.  I did try to migrate to the new (faster, more resources 2 cores per VM & 4GB vs. 1.5 cores & 3GB) but I found it impossible to setup the package selection we want.

I have made both this and the release_30 version much more similar - I have ported the development one's use of boost 1.55 libraries to this one which had a confusing mix of 1.46 & 1.48 even after upgrading {it seems the default Ubuntu "Precise Pangolin" (12.04 LTS) distribution that is used has some oddities in that regard}.

Importantly the CMake project files now have a chance of working on both Linux and MacOs - which is nice because they were written from a mainly Windows perspective as far as I can tell.  This was causing issues with the lua-zip module which is not readily available in a compiled for the MaoOs platform - so we `#include` d it as originally `luazip.c` into TLuaInterpreter.cpp for just __that__ platform, but which meant we also have to track down and include the `zziplib` library as well.  Also problematic was the zip library as we had it down as a '"..."' type include rather than a '<...>' and included it's own internal zipconf.h header ourselves - which is NOT necessarily stored in the obvious place {INCLUDE directory) but rather a subdirectory of the LIBRARY directory.  Since it uses pkg-config though the recommended process is to use that - which CMake has support for - so that is what I have done on the "APPLE" platform __only__.

FWIW The Travis system uses only Qt 5.0.2 for the Linux platform - which in it's way is a good check for ensuring maximum compatibility with all Qt5 versions - the MacOs platform currently seems to be using at least 5.5 at the time of writing.  For some obscure reason though, the combination of Clang and CMake on the Linux builds objects to something in the Qt headers for that version and consistently errors out.  Fortunately I now understand enough of how to configure Travis so that we can "allow_failure" for just that combination.  I could have prevented that combo from running but until it becomes more clearer why, I thought it was best to leave it in place.

This and it's companion #282 should be OK to go in without messing with any other PR as far as I can tell.