### PR TITLE
Bugfix/Enhance: Load LuaGlobal.lua from LUA_DEFAULT_PATH

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -363,6 +363,18 @@ ADD_SUBDIRECTORY(irc)
 
 ADD_DEFINITIONS(-DAPP_VERSION="${APP_VERSION}" -DAPP_BUILD="${APP_BUILD}" -DAPP_TARGET="${APP_TARGET}")
 
+IF(UNIX)
+    SET(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/share" CACHE STRING "The platform-specific directory in which read-only data is generally installed")
+    SET(DATADIR "${DATAROOTDIR}/mudlet" CACHE STRING "Directory in which mudlet installs its read-only data")
+    SET(LUA_DEFAULT_DIR "${DATADIR}/lua" CACHE STRING "Directory in which mudlet installs its read-only lua scripts")
+ENDIF(UNIX)
+
+# Define a preprocessor symbol with the default fallback location from which
+# to load installed mudlet lua files. Set LUA_DEFAULT_DIR to a
+# platform-specific value. If LUA_DEFAULT_DIR is unset, the root directory
+# will be used.
+ADD_DEFINITIONS(-DLUA_DEFAULT_PATH="${LUA_DEFAULT_DIR}")
+
 # Enable leak detection for MSVC debug builds.
 if(MSVC)
   SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -FItestdbg.h")

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4661,7 +4661,7 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
 
 int TLuaInterpreter::getMudletLuaDefaultPath( lua_State * L )
 {
-    QString path = LUA_DEFAULT_PATH "/";
+    QString path = QStringLiteral( "%1/" ).arg( LUA_DEFAULT_PATH );
     QString nativePath = QDir::toNativeSeparators( path );
     lua_pushstring( L, nativePath.toUtf8().constData() );
     return 1;
@@ -11788,7 +11788,7 @@ void TLuaInterpreter::loadGlobal()
     }
 
     // Finally try loading from LUA_DEFAULT_PATH
-    path = LUA_DEFAULT_PATH "/LuaGlobal.lua";
+    path = QStringLiteral( "%1/LuaGlobal.lua" ).arg( LUA_DEFAULT_PATH );
     error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
     if( error != 0 )
     {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4659,6 +4659,14 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
     return 1;
 }
 
+int TLuaInterpreter::getMudletLuaDefaultPath( lua_State * L )
+{
+    QString path = LUA_DEFAULT_PATH "/";
+    QString nativePath = QDir::toNativeSeparators( path );
+    lua_pushstring( L, nativePath.toUtf8().constData() );
+    return 1;
+}
+
 int TLuaInterpreter::disconnect( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -11438,6 +11446,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "tempButton", TLuaInterpreter::tempButton );
     lua_register( pGlobalLua, "reconnect", TLuaInterpreter::reconnect );
     lua_register( pGlobalLua, "getMudletHomeDir", TLuaInterpreter::getMudletHomeDir );
+    lua_register( pGlobalLua, "getMudletLuaDefaultPath", TLuaInterpreter::getMudletLuaDefaultPath );
     lua_register( pGlobalLua, "setTriggerStayOpen", TLuaInterpreter::setTriggerStayOpen );
     lua_register( pGlobalLua, "wrapLine", TLuaInterpreter::wrapLine );
     lua_register( pGlobalLua, "getFgColor", TLuaInterpreter::getFgColor );
@@ -11767,25 +11776,36 @@ void TLuaInterpreter::loadGlobal()
         // we check again for the user case of a windows install.
         path = "mudlet-lua/lua/LuaGlobal.lua";
         error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
-        if( error != 0 ) {
-            string e = "no error message available from Lua";
-            if( lua_isstring( pGlobalLua, -1 ) )
-            {
-                e = "[ ERROR ] - LuaGlobal.lua compile error - please report!\n"
-                                "Error from Lua: ";
-                e += lua_tostring( pGlobalLua, -1 );
-            }
-            mpHost->postMessage( e.c_str() );
-        }
-        else {
+        if( error == 0 ) {
             mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+            return;
         }
     }
     else
     {
         mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+        return;
     }
 
+    // Finally try loading from LUA_DEFAULT_PATH
+    path = LUA_DEFAULT_PATH "/LuaGlobal.lua";
+    error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
+    if( error != 0 )
+    {
+        string e = "no error message available from Lua";
+        if( lua_isstring( pGlobalLua, -1 ) )
+        {
+            e = "[ ERROR ] - LuaGlobal.lua compile error - please report!\n"
+                "Error from Lua: ";
+            e += lua_tostring( pGlobalLua, -1 );
+        }
+        mpHost->postMessage( e.c_str() );
+    }
+    else
+    {
+        mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+        return;
+    }
 }
 
 void TLuaInterpreter::slotEchoMessage(int hostID, const QString& msg)

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -324,6 +324,7 @@ public:
     static int disconnect( lua_State * );
     static int reconnect( lua_State * );
     static int getMudletHomeDir( lua_State * );
+    static int getMudletLuaDefaultPath( lua_State * );
     static int setTriggerStayOpen( lua_State * );
     static int wrapLine( lua_State * );
     static int getFgColor( lua_State * );

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -128,7 +128,8 @@ local packages = {
 -- TODO: extend to support common Lua code being placed in system shared directory
 -- tree as ought to happen for *nix install builds.
 local prefixes = {"../src/mudlet-lua/lua/", "../Resources/mudlet-lua/lua/",
-    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua"}
+    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua",
+    getMudletLuaDefaultPath()}
 
 local prefix
 for i = 1, #prefixes do

--- a/src/src.pro
+++ b/src/src.pro
@@ -139,8 +139,6 @@ unix:!macx {
 # installation details for the unix case:
         LUA.path = $${LUA_DEFAULT_DIR}
         LUA_GEYSER.path = $${LUA.path}/geyser
-# and define a preprocessor symbol LUA_DEFAULT_PATH with the value:
-        DEFINES += LUA_DEFAULT_PATH=\\\"$${LUA_DEFAULT_DIR}\\\"
 # and say what will happen:
         message("Lua files will be installed to "$${LUA.path}"...")
         message("Geyser lua files will be installed to "$${LUA_GEYSER.path}"...")
@@ -160,6 +158,12 @@ macx {
 macx:LIBS += \
     -lz \
     -lzzip
+
+# Define a preprocessor symbol with the default fallback location from which
+# to load installed mudlet lua files. Set LUA_DEFAULT_DIR to a
+# platform-specific value. If LUA_DEFAULT_DIR is unset, the root directory
+# will be used.
+DEFINES += LUA_DEFAULT_PATH=\\\"$${LUA_DEFAULT_DIR}\\\"
 
 INCLUDEPATH += irc/include
 


### PR DESCRIPTION
Add comptile-time fallback to LuaGlobal.lua loading logic to attempt to load
from LUA_DEFAULT_PATH, defined in src/src.pro using the value from
LUA_DEFAULT_DIR.

For platforms that don't currently define LUA_DEFAULT_DIR in src/src.pro (e.g.
win32, macx), the loading logic will behave as though LUA_DEFAULT_DIR were
defined as "/", the root directory. This is accomplished by compile time
concatenation of LUA_DEFAULT_PATH and the string literal "/". If necessary,
LUA_DEFAULT_DIR can later be defined for additional platforms (win32, macx,
etc) in src/src.pro to provide a different compile-time fallback for that
platform.