### PR TITLE
(release_30)Add the new "sysNegotiationFinishedEvent"

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1991,10 +1991,10 @@ MAIN_LOOP_END: ;
 
 void cTelnet::raiseProtocolEvent( const QString & name, const QString & protocol )
 {
-    TEvent me;
-    me.mArgumentList.append( name );
-    me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    me.mArgumentList.append( protocol );
-    me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    TEvent * me = new TEvent;
+    me->mArgumentList.append( name );
+    me->mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    me->mArgumentList.append( protocol );
+    me->mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
     mpHost->raiseEvent( me );
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3,7 +3,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2013-2014 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014 by Florian Scheel - keneanung@googlemail.com       *
+ *   Copyright (C) 2015 by Florian Scheel - keneanung@googlemail.com       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -533,7 +533,7 @@ void cTelnet::processTelnetCommand( const string & command )
                   _h += TN_SE;
                   socketOutRaw( _h );
                   qDebug() << "TELNET IAC DO MSDP";
-                  raiseNegotiationFinishedEvent( "MSDP" );
+                  raiseProtocolEvent( "sysProtocolEnabled", "MSDP" );
                   break;
               }
           }
@@ -554,7 +554,7 @@ void cTelnet::processTelnetCommand( const string & command )
               _h += TN_IAC;
               _h += TN_SE;
               socketOutRaw( _h );
-              raiseNegotiationFinishedEvent( "ATCP" );
+              raiseProtocolEvent( "sysProtocolEnabled", "ATCP" );
               break;
           }
 
@@ -585,7 +585,7 @@ void cTelnet::processTelnetCommand( const string & command )
 
               socketOutRaw( _h );
 
-              raiseNegotiationFinishedEvent( "GMCP" );
+              raiseProtocolEvent( "sysProtocolEnabled", "GMCP" );
               break;
           }
 
@@ -596,7 +596,7 @@ void cTelnet::processTelnetCommand( const string & command )
                 sendTelnetOption( TN_DO, 91 );
                 //mpHost->mpConsole->print("\n<MXP enabled>\n");
 
-                raiseNegotiationFinishedEvent( "MXP" );
+                raiseProtocolEvent( "sysProtocolEnabled", "MXP" );
                 break;
               }
               //else
@@ -609,7 +609,7 @@ void cTelnet::processTelnetCommand( const string & command )
               qDebug() << "Aardwulf channel 102 support enabled";
               enableChannel102 = true;
               sendTelnetOption( TN_DO, 102 );
-              raiseNegotiationFinishedEvent( "channel102" );
+              raiseProtocolEvent( "sysProtocolEnabled", "channel102" );
               break;
           }
 
@@ -703,6 +703,26 @@ void cTelnet::processTelnetCommand( const string & command )
               #ifdef DEBUG
                   qDebug() << "cTelnet::processTelnetCommand() we dont accept his option because we didnt want it to be enabled";
               #endif
+              if( option == static_cast<char>(69) ) // MSDP got turned off
+              {
+                  raiseProtocolEvent( "sysProtocolDisabled", "MSDP" );
+              }
+              if( option == static_cast<char>(200) ) // ATCP got turned off
+              {
+                  raiseProtocolEvent( "sysProtocolDisabled", "ATCP" );
+              }
+              if( option == static_cast<char>(201) ) // GMCP got turned off
+              {
+                  raiseProtocolEvent( "sysProtocolDisabled", "GMCP" );
+              }
+              if( option == MXP ) // MXP got turned off
+              {
+                  raiseProtocolEvent( "sysProtocolDisabled", "MXP" );
+              }
+              if( option == static_cast<char>(102) ) // channel 102 support
+              {
+                  raiseProtocolEvent( "sysProtocolDisabled", "channel102" );
+              }
               //send DONT if needed (see RFC 854 for details)
               if( hisOptionState[idxOption] || ( heAnnouncedState[idxOption] ) )
               {
@@ -740,7 +760,7 @@ void cTelnet::processTelnetCommand( const string & command )
             qDebug() << "TELNET IAC DO MSDP";
             sendTelnetOption( TN_WILL, 69 );
 
-            raiseNegotiationFinishedEvent( "MSDP" );
+            raiseProtocolEvent( "sysProtocolEnabled", "MSDP" );
             break;
           }
           if( option == static_cast<char>(200) && !mpHost->mEnableGMCP ) // ATCP support, enable only if GMCP is off as GMCP is better
@@ -748,7 +768,7 @@ void cTelnet::processTelnetCommand( const string & command )
             qDebug() << "TELNET IAC DO ATCP";
             enableATCP = true;
             sendTelnetOption( TN_WILL, 200 );
-            raiseNegotiationFinishedEvent( "ATCP" );
+            raiseProtocolEvent( "sysProtocolEnabled", "ATCP" );
             break;
           }
           if( option == static_cast<char>(201) && mpHost->mEnableGMCP ) // GMCP support
@@ -756,14 +776,14 @@ void cTelnet::processTelnetCommand( const string & command )
             qDebug() << "TELNET IAC DO GMCP";
             enableGMCP = true;
             sendTelnetOption( TN_WILL, 201 );
-            raiseNegotiationFinishedEvent( "GMCP" );
+            raiseProtocolEvent( "sysProtocolEnabled", "GMCP" );
             break;
           }
           if( option == MXP ) // MXP support
           {
             sendTelnetOption( TN_WILL, 91 );
             mpHost->mpConsole->print("\n<MXP support enabled>\n");
-            raiseNegotiationFinishedEvent( "MXP" );
+            raiseProtocolEvent( "sysProtocolEnabled", "MXP" );
             break;
           }
           if( option == static_cast<char>(102) ) // channel 102 support
@@ -771,7 +791,7 @@ void cTelnet::processTelnetCommand( const string & command )
             qDebug() << "TELNET IAC DO CHANNEL 102";
             enableChannel102 = true;
             sendTelnetOption( TN_WILL, 102 );
-            raiseNegotiationFinishedEvent( "channel102" );
+            raiseProtocolEvent( "sysProtocolEnabled", "channel102" );
             break;
           }
 #ifdef DEBUG
@@ -821,6 +841,26 @@ void cTelnet::processTelnetCommand( const string & command )
               qDebug() << "cTelnet::processTelnetCommand() TN_DONT command="<<(quint8)command[2];
 #endif
           option = command[2];
+          if( option == static_cast<char>(69) ) // MSDP got turned off
+          {
+             raiseProtocolEvent( "sysProtocolDisabled", "MSDP" );
+          }
+          if( option == static_cast<char>(200) ) // ATCP got turned off
+          {
+             raiseProtocolEvent( "sysProtocolDisabled", "ATCP" );
+          }
+          if( option == static_cast<char>(201) ) // GMCP got turned off
+          {
+             raiseProtocolEvent( "sysProtocolDisabled", "GMCP" );
+          }
+          if( option == MXP ) // MXP got turned off
+          {
+             raiseProtocolEvent( "sysProtocolDisabled", "MXP" );
+          }
+          if( option == static_cast<char>(102) ) // channel 102 support
+          {
+             raiseProtocolEvent( "sysProtocolDisabled", "channel102" );
+          }
           int idxOption = static_cast<int>(option);
           if( myOptionState[idxOption] || ( !announcedState[idxOption] ) )
           {
@@ -1949,10 +1989,10 @@ MAIN_LOOP_END: ;
     lastTimeOffset = timeOffset.elapsed();
 }
 
-void cTelnet::raiseNegotiationFinishedEvent( const QString & protocol )
+void cTelnet::raiseProtocolEvent( const QString & name, const QString & protocol )
 {
     TEvent me;
-    me.mArgumentList.append( "sysNegotiationFinished" );
+    me.mArgumentList.append( name );
     me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
     me.mArgumentList.append( protocol );
     me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -159,7 +159,7 @@ private:
     void              gotRest( std::string & );
     void              gotPrompt( std::string & );
     void              postData();
-    void              raiseNegotiationFinishedEvent( const QString & protocol );
+    void              raiseProtocolEvent( const QString & name, const QString & protocol );
 
 
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
- *   Copyright (C) 2014 by Florian Scheel - keneanung@googlemail.com       *
+ *   Copyright (C) 2014-2015 by Florian Scheel - keneanung@googlemail.com  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -6,6 +6,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2014 by Florian Scheel - keneanung@googlemail.com       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -158,6 +159,7 @@ private:
     void              gotRest( std::string & );
     void              gotPrompt( std::string & );
     void              postData();
+    void              raiseNegotiationFinishedEvent( const QString & protocol );
 
 
 


### PR DESCRIPTION
The event is fired when one of the data protocols MSDP, MXP, ATCP, GMCP or
Channel 102 were successfully enabled. User scripts can now freely use the
protocol.

The event has a second argument that denominates the protocol that was enabled.

The commit also makes sure that GMCP is only enabled if the user chose to enable
GMCP if the server sends IAC DO GMCP.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mudlet/mudlet/285)
<!-- Reviewable:end -->
