### PR TITLE
Make changes to TEvent and TLuaInterpreter to allow passing boolean args to raiseEvent().

### DIFF
--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -29,6 +29,7 @@
 
 #define ARGUMENT_TYPE_NUMBER 0
 #define ARGUMENT_TYPE_STRING 1
+#define ARGUMENT_TYPE_BOOLEAN 2
 
 class TEvent
 {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -309,6 +309,11 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
             pE.mArgumentList.append( QString(lua_tostring( L, i )) );
             pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
         }
+        else if( lua_isboolean( L, i ) )
+        {
+            pE.mArgumentList.append( QString::number(lua_toboolean( L, i )) );
+            pE.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+        }
     }
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     pHost->raiseEvent( pE );
@@ -11906,6 +11911,10 @@ bool TLuaInterpreter::callEventHandler(const QString & function, const TEvent & 
         {
             lua_pushnumber( L, pE.mArgumentList[i].toDouble() );
         }
+		else if( pE.mArgumentTypeList[i] == ARGUMENT_TYPE_BOOLEAN )
+		{
+			lua_pushboolean( L, pE.mArgumentList[i].toInt() );
+		}
         else
         {
             lua_pushstring( L, pE.mArgumentList[i].toLatin1().data() );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11913,7 +11913,7 @@ bool TLuaInterpreter::callEventHandler(const QString & function, const TEvent & 
         }
         else if( pE.mArgumentTypeList[i] == ARGUMENT_TYPE_BOOLEAN )
         {
-	        lua_pushboolean( L, pE.mArgumentList[i].toInt() );
+            lua_pushboolean( L, pE.mArgumentList[i].toInt() );
         }
         else
         {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11911,10 +11911,10 @@ bool TLuaInterpreter::callEventHandler(const QString & function, const TEvent & 
         {
             lua_pushnumber( L, pE.mArgumentList[i].toDouble() );
         }
-		else if( pE.mArgumentTypeList[i] == ARGUMENT_TYPE_BOOLEAN )
-		{
-			lua_pushboolean( L, pE.mArgumentList[i].toInt() );
-		}
+        else if( pE.mArgumentTypeList[i] == ARGUMENT_TYPE_BOOLEAN )
+        {
+	        lua_pushboolean( L, pE.mArgumentList[i].toInt() );
+        }
         else
         {
             lua_pushstring( L, pE.mArgumentList[i].toLatin1().data() );


### PR DESCRIPTION
Currently, the raiseEvent function only accepts string and number arguments. Args of other types are simply ignored, and the argument list is shortened. This is just a small change to allow passing booleans, as well. The same functionality can be achieved by passing 0 or 1 (or "true"/"false", or whatever) and putting an explicit check in the event handler function, but it would be convenient to be able to pass booleans as is.