### PR TITLE
Allow passing boolean arguments to raiseEvent() and callEventHandler()

### DIFF
--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -22,6 +22,7 @@
 
 #define ARGUMENT_TYPE_NUMBER 0
 #define ARGUMENT_TYPE_STRING 1
+#define ARGUMENT_TYPE_BOOLEAN 2
 
 class TEvent
 {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -304,6 +304,11 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
             pE->mArgumentList.append( QString(lua_tostring( L, i )) );
             pE->mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
         }
+        else if( lua_isboolean( L, i ) )
+        {
+            pE->mArgumentList.append( QString::number(lua_toboolean( L, i )) );
+            pE->mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+        }
     }
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     pHost->raiseEvent( pE );
@@ -12058,6 +12063,10 @@ bool TLuaInterpreter::callEventHandler( QString & function, TEvent * pE )
         if( pE->mArgumentTypeList[i] == ARGUMENT_TYPE_NUMBER )
         {
             lua_pushnumber( L, pE->mArgumentList[i].toDouble() );
+        }
+        else if( pE->mArgumentTypeList[i] == ARGUMENT_TYPE_BOOLEAN )
+        {
+            lua_pushboolean( L, pE->mArgumentList[i].toInt() );
         }
         else
         {


### PR DESCRIPTION
Same changes as in my recent PR to development. Haven't done any additional testing beyond making sure it compiles, but I don't see any potential sources of different behavior.