### PR TITLE
Fix: Bug where save profile as <name>.xml would save as <name>.xml.xml

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -2,6 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016 by Owen Davison - odavison@cs.dal.ca               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -6764,7 +6765,11 @@ void dlgTriggerEditor::slot_export()
                                                     QDir::currentPath(),
                                                     tr("Mudlet packages (*.xml)"));
     if(fileName.isEmpty()) return;
-    fileName.append(".xml");
+
+    if ( !fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+    {
+        fileName.append(".xml");
+    }
 
 
     QFile file(fileName);
@@ -6994,7 +6999,11 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
                                                     tr("trigger files (*.trigger *.xml)"));
 
     if(fileName.isEmpty()) return;
-    fileName.append(".xml");
+
+    if ( !fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+    {
+        fileName.append(".xml");
+    }
 
     QFile file(fileName);
     if( ! file.open(QFile::WriteOnly | QFile::Text) )


### PR DESCRIPTION
The functions responsible for exporting profiles and triggers were
blindly appending ".xml" onto the end of the filename before writing.
This would result in exporting a file called <name>.xml.xml if the
user specified <name>.xml. This commit adds a case-insensitive check
to see if the filename already ends in ".xml" before appending it
to the end of the filename.