### PR TITLE
BugFix: Prevent crash if module loaded via Lua before module widget c…

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -111,6 +111,7 @@ mudlet::mudlet()
 , replayTime( 0 )
 , replayTimer( 0 )
 , replayToolBar( 0 )
+, moduleTable( 0 )
 {
     setupUi(this);
     setUnifiedTitleAndToolBarOnMac( true );


### PR DESCRIPTION
…reated

This is to fix [bug 1537906](https://bugs.launchpad.net/mudlet/+bug/1537906)
This is caused by (bool)mudlet::moduleTableVisible() using the uninitialised
pointer (QTableWidget *)mudlet::moduleTable before that set to point at a
member of the Module Manager Dialog.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>