### PR TITLE
(release_30)bugFix: Prevent crash if module loaded via Lua before module widget c…

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -103,6 +103,7 @@ mudlet::mudlet()
 , mIsGoingDown( false )
 , actionReplaySpeedDown( 0 )
 , actionReplaySpeedUp( 0 )
+, moduleTable( 0 )
 {
     setupUi(this);
     setUnifiedTitleAndToolBarOnMac( true );


### PR DESCRIPTION
…reated

This is to fix [bug 1537906](https://bugs.launchpad.net/mudlet/+bug/1537906)
This is caused by (bool)mudlet::moduleTableVisible() using the uninitialised
pointer (QTableWidget *)mudlet::moduleTable before that set to point at a
member of the Module Manager Dialog.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>