### PR TITLE
Bugfix: correct errors in Lua command error messages

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2771,7 +2771,7 @@ int TLuaInterpreter::setMainWindowSize( lua_State *L )
     int x1;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "setBackgroundColor: wrong argument type" );
+        lua_pushstring( L, "setMainWindowSize: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -2782,7 +2782,7 @@ int TLuaInterpreter::setMainWindowSize( lua_State *L )
     int y1;
     if( ! lua_isnumber( L, 2 ) )
     {
-        lua_pushstring( L, "setBackgroundColor: wrong argument type" );
+        lua_pushstring( L, "setMainWindowSize: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3099,7 +3099,7 @@ int TLuaInterpreter::setLabelOnLeave( lua_State *L )
     string luaSendText="";
     if( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "setLabelClickCallback: wrong argument type" );
+        lua_pushstring( L, "setLabelOnLeave: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3110,7 +3110,7 @@ int TLuaInterpreter::setLabelOnLeave( lua_State *L )
     string luaName="";
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "setLabelClickCallback: wrong argument type" );
+        lua_pushstring( L, "setLabelOnLeave: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3686,7 +3686,7 @@ int TLuaInterpreter::lockExit( lua_State *L )
 
     if( ! lua_isboolean( L, 3 ) )
     {
-        lua_pushstring( L, "lockRoom: wrong argument type" );
+        lua_pushstring( L, "lockExit: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3722,7 +3722,7 @@ int TLuaInterpreter::lockSpecialExit( lua_State *L )
 
     if( ! lua_isnumber( L, 2 ) )
     {
-        lua_pushstring( L, "lockExit: wrong argument type" );
+        lua_pushstring( L, "lockSpecialExit: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3769,7 +3769,7 @@ int TLuaInterpreter::hasSpecialExitLock( lua_State *L )
     std::string dir;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "lockExit: wrong argument type" );
+        lua_pushstring( L, "hasSpecialExitLock: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3781,7 +3781,7 @@ int TLuaInterpreter::hasSpecialExitLock( lua_State *L )
 
     if( ! lua_isnumber( L, 2 ) )
     {
-        lua_pushstring( L, "lockExit: wrong argument type" );
+        lua_pushstring( L, "hasSpecialExitLock: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3816,7 +3816,7 @@ int TLuaInterpreter::hasExitLock( lua_State *L )
     int dir;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "lockExit: wrong argument type" );
+        lua_pushstring( L, "hasExitLock: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -3828,7 +3828,7 @@ int TLuaInterpreter::hasExitLock( lua_State *L )
     dir = dirToNumber( L, 2 );
     if( ! dir )
     {
-        lua_pushstring( L, "lockExit: wrong argument type" );
+        lua_pushstring( L, "hasExitLock: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -5449,7 +5449,7 @@ int TLuaInterpreter::tempExactMatchTrigger( lua_State *L )
     string luaRegex;
     if( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "tempTrigger: wrong argument type" );
+        lua_pushstring( L, "tempExactMatchTrigger: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -5461,7 +5461,7 @@ int TLuaInterpreter::tempExactMatchTrigger( lua_State *L )
     string luaFunction;
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "tempTrigger: wrong argument type" );
+        lua_pushstring( L, "tempExactMatchTrigger: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -5484,7 +5484,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger( lua_State *L )
     string luaRegex;
     if( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "tempTrigger: wrong argument type" );
+        lua_pushstring( L, "tempBeginOfLineTrigger: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -5496,7 +5496,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger( lua_State *L )
     string luaFunction;
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "tempTrigger: wrong argument type" );
+        lua_pushstring( L, "tempBeginOfLineTrigger: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -5843,7 +5843,7 @@ int TLuaInterpreter::tempButton( lua_State *L){
     int orientation;
     if(!lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "tempButtonToolbar: wrong first arg" );
+        lua_pushstring( L, "tempButton: wrong first arg" );
         lua_error( L );
         return 1;
     }
@@ -5853,7 +5853,7 @@ int TLuaInterpreter::tempButton( lua_State *L){
     }
     if(!lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "tempButtonToolbar: wrong 2nd arg" );
+        lua_pushstring( L, "tempButton: wrong second arg" );
         lua_error( L );
         return 1;
     }
@@ -5863,7 +5863,7 @@ int TLuaInterpreter::tempButton( lua_State *L){
     }
     if(!lua_isnumber( L, 3 ) )
     {
-        lua_pushstring( L, "tempButtonToolbar: wrong first arg" );
+        lua_pushstring( L, "tempButton: wrong third arg" );
         lua_error( L );
         return 1;
     }
@@ -7284,7 +7284,7 @@ int TLuaInterpreter::unHighlightRoom( lua_State * L )
     int id;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "highlightRoom: wrong argument type" );
+        lua_pushstring( L, "unHighlightRoom: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7640,7 +7640,7 @@ int TLuaInterpreter::setMapZoom( lua_State * L )
     int zoom = 3;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "setMapZoom: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7667,7 +7667,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 // N/U:     int args = lua_gettop(L);
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7678,7 +7678,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7689,7 +7689,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isnumber( L, 3 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7700,7 +7700,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isnumber( L, 4 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7711,7 +7711,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isnumber( L, 5 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7722,7 +7722,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isnumber( L, 6 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7733,7 +7733,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isnumber( L, 7 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7744,7 +7744,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isnumber( L, 8 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7755,7 +7755,7 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
 
     if( ! lua_isboolean( L, 9 ) )
     {
-        lua_pushstring( L, "createMapLabel: wrong argument type" );
+        lua_pushstring( L, "createMapImageLabel: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -7801,7 +7801,7 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
     if( ! lua_isnumber( L, 3 ) )
     {
-        lua_pushstring( L, "roomID: wrong argument type" );
+        lua_pushstring( L, "setDoor: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -8189,7 +8189,7 @@ int TLuaInterpreter::getMapLabels( lua_State * L )
     int area;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "deleteMapLabel: wrong argument type" );
+        lua_pushstring( L, "getMapLabels: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -9618,7 +9618,7 @@ int TLuaInterpreter::setRoomChar( lua_State * L )
     string c;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "setRoomArea: wrong argument type" );
+        lua_pushstring( L, "setRoomChar: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -9628,7 +9628,7 @@ int TLuaInterpreter::setRoomChar( lua_State * L )
     }
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "setRoomArea: wrong argument type" );
+        lua_pushstring( L, "setRoomChar: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -9640,7 +9640,7 @@ int TLuaInterpreter::setRoomChar( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( id );
     if( !pR )
     {
-        lua_pushstring( L, "setRoomArea: room ID does not exist");
+        lua_pushstring( L, "setRoomChar: room ID does not exist");
         lua_error( L );
         return 1;
     }
@@ -9757,7 +9757,7 @@ int TLuaInterpreter::setGridMode( lua_State * L )
     bool gridMode = false;
     if( ! lua_isnumber( L, 1 ) )
     {
-        lua_pushstring( L, "setRoomArea: wrong argument type" );
+        lua_pushstring( L, "setGridMode: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -9767,7 +9767,7 @@ int TLuaInterpreter::setGridMode( lua_State * L )
     }
     if( ! lua_isboolean( L, 2 ) )
     {
-        lua_pushstring( L, "setRoomArea: wrong argument type" );
+        lua_pushstring( L, "setGridMode: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -10865,7 +10865,7 @@ int TLuaInterpreter::uninstallPackage( lua_State * L )
     string event;
     if( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "installPackage(): wrong argument type" );
+        lua_pushstring( L, "uninstallPackage(): wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -10923,7 +10923,7 @@ int TLuaInterpreter::reloadModule( lua_State * L)
     string modName;
     if ( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "installModule(): wrong first argument (should be a module name)");
+        lua_pushstring( L, "reloadModule(): wrong first argument (should be a module name)");
         lua_error( L );
         return 1;
     }
@@ -10941,7 +10941,7 @@ int TLuaInterpreter::registerAnonymousEventHandler( lua_State * L )
     string event;
     if( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "appendCmdLine(): wrong argument type" );
+        lua_pushstring( L, "registerAnonymousEventHandler(): wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -10952,7 +10952,7 @@ int TLuaInterpreter::registerAnonymousEventHandler( lua_State * L )
     string func;
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "appendCmdLine(): wrong argument type" );
+        lua_pushstring( L, "registerAnonymousEventHandler(): wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -11084,7 +11084,7 @@ int TLuaInterpreter::sendIrc( lua_State * L )
     string who;
     if( ! lua_isstring( L, 1 ) )
     {
-        lua_pushstring( L, "sendSocket: wrong argument type" );
+        lua_pushstring( L, "sendIrc: wrong argument type" );
         lua_error( L );
         return 1;
     }
@@ -11095,7 +11095,7 @@ int TLuaInterpreter::sendIrc( lua_State * L )
     string text;
     if( ! lua_isstring( L, 2 ) )
     {
-        lua_pushstring( L, "sendSocket: wrong argument type" );
+        lua_pushstring( L, "sendIrc: wrong argument type" );
         lua_error( L );
         return 1;
     }


### PR DESCRIPTION
There has been a fair amount of copy and paste in creating various Lua
commands - but the error messages have not always been revised when this
has happened.  With a bit of *nix shell-fu I have identified the cases
where this has happened and changed the function that is given as the
name where an error occurred.

Note that this does not attempt to improve the formatting to bring the
standard up to current guidelines - or that the amended functions actually
operate as intended - merely it fixes gross errors that will definitely be
confusing to anyone seeing those messages.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>