### PR TITLE
Enhancement: move TArea::rooms to QSet (updated)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -170,8 +170,12 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
     mErrorLogFile.setFileName( logFileName );
     mErrorLogFile.open( QIODevice::Append );
     mErrorLogStream.setDevice( &mErrorLogFile );
-    mpMap->restore("");
-    mpMap->init( this );
+    // Do not try to load a map for the default_host dummy profile:
+    if( mHostName.compare( QStringLiteral( "default_host" ) ) ) {
+        if( mpMap->restore( QString() ) ) {
+            mpMap->audit();
+        }
+    }
     mMapStrongHighlight = false;
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -169,15 +169,14 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
     }
     mErrorLogFile.setFileName( logFileName );
     mErrorLogFile.open( QIODevice::Append );
-    mErrorLogStream.setDevice( &mErrorLogFile );
-// Do not try to load ANY map here...
-// // Do not try to load a map for the default_host dummy profile:
-//    if( mHostName.compare( QStringLiteral( "default_host" ) ) ) {
-//        qDebug() << "Host::Host() - restore map case 1.";
-//        if( mpMap->restore( QString() ) ) {
-//            mpMap->audit();
-//        }
-//    }
+    mErrorLogStream.setDevice( &mErrorLogFile ); // This is NOW used (for map
+                                                 // file auditing and other issues)
+
+    // There was a map load attempt made here but it did not seem to be needed
+    // and it caused issues being doing in the constructor (some other classes
+    // were not fully initialised at this point) so it seemed sensible to remove
+    // it - Slysven
+
     mMapStrongHighlight = false;
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -170,12 +170,14 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
     mErrorLogFile.setFileName( logFileName );
     mErrorLogFile.open( QIODevice::Append );
     mErrorLogStream.setDevice( &mErrorLogFile );
-    // Do not try to load a map for the default_host dummy profile:
-    if( mHostName.compare( QStringLiteral( "default_host" ) ) ) {
-        if( mpMap->restore( QString() ) ) {
-            mpMap->audit();
-        }
-    }
+// Do not try to load ANY map here...
+// // Do not try to load a map for the default_host dummy profile:
+//    if( mHostName.compare( QStringLiteral( "default_host" ) ) ) {
+//        qDebug() << "Host::Host() - restore map case 1.";
+//        if( mpMap->restore( QString() ) ) {
+//            mpMap->audit();
+//        }
+//    }
     mMapStrongHighlight = false;
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -545,8 +545,6 @@ void T2DMap::paintEvent( QPaintEvent * e )
         p.setRenderHint(QPainter::NonCosmeticDefaultPen);
     p.setPen( pen );
 
-    //mpMap->auditRooms();
-
     if( mpMap->mapLabels.contains( mAID ) )
     {
         QMapIterator<int, TMapLabel> it(mpMap->mapLabels[mAID]);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -23,6 +23,7 @@
 #include "T2DMap.h"
 
 
+#include "dlgMapper.h"
 #include "dlgRoomExits.h"
 #include "Host.h"
 #include "TArea.h"
@@ -388,7 +389,7 @@ void T2DMap::slot_switchArea(QString name)
             mShiftMode = true;
             pA->calcSpan();
 
-            if( playerAreaId != -1 && areaID == playerAreaId ) {
+            if( areaID == playerAreaId ) {
                 // We are switching back to the area that has the player in it
                 // recenter view on that room!
                 mOx = pPlayerRoom->x;
@@ -2095,6 +2096,36 @@ void T2DMap::paintEvent( QPaintEvent * e )
         p.drawText( mMapInfoRect.left()+10, mMapInfoRect.top()+10, mMapInfoRect.width()-20, mMapInfoRect.height()-20, Qt::TextWordWrap|Qt::AlignLeft|Qt::AlignTop, infoText );
         p.restore(); //forget about font size changing and bolding/italicisation
     }
+
+    static bool isAreaWidgetValid = true; // Remember between uses
+    QFont _f =  mpMap->mpMapper->showArea->font();
+    if( isAreaWidgetValid ) {
+        if(     mAID == -1                                       // * the map being shown is the "default" area
+                && ! mpMap->mpMapper->getDefaultAreaShown() ) {  // * the area widget is not showing the "default" area
+
+            isAreaWidgetValid = false;                      // So the widget CANNOT indicate the correct area
+            // Set the area widget to indicate the area widget is NOT
+            // showing valid text - so make it italic and crossed out
+            _f.setItalic( true );
+            _f.setUnderline( true );
+            _f.setStrikeOut( true );
+            _f.setOverline( true );
+        }
+    }
+    else {
+        if( ! ( mAID == -1
+                && ! mpMap->mpMapper->getDefaultAreaShown() ) ) {
+
+            isAreaWidgetValid = true;                      // So the widget CAN now indicate the correct area
+            // Reset to normal
+            _f.setItalic( false );
+            _f.setUnderline( false );
+            _f.setStrikeOut( false );
+            _f.setOverline( false );
+        }
+    }
+
+    mpMap->mpMapper->showArea->setFont( _f );
 
     if( mHelpMsg.size() > 0 )
     {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -422,20 +422,29 @@ void T2DMap::switchArea(QString name)
 
 void T2DMap::paintEvent( QPaintEvent * e )
 {
-    if( !mpMap ) return;
+    if( !mpMap )
+    {
+        return;
+    }
     bool __Pick = mPick;
     QElapsedTimer __time;
     __time.start();
 
     QPainter p( this );
-    if( ! p.isActive() ) return;
+    if( ! p.isActive() )
+    {
+        return;
+    }
 
     mAreaExitList.clear();
 
     float _w = width();
     float _h = height();
 
-    if( _w < 10 || _h < 10 ) return;
+    if( _w < 10 || _h < 10 )
+    {
+        return;
+    }
 
     if( _w > _h )
     {
@@ -468,6 +477,9 @@ void T2DMap::paintEvent( QPaintEvent * e )
 
     int ox, oy; // N/U: oz;
     if( mRID != mpMap->mRoomId && mShiftMode ) mShiftMode = false;
+    {
+        mShiftMode = false;
+    }
     TArea * pAID;
     TRoom * pRID;
     if( (! __Pick && ! mShiftMode ) || mpMap->mNewMove )
@@ -476,7 +488,10 @@ void T2DMap::paintEvent( QPaintEvent * e )
         mShiftMode = true;
         mpMap->mNewMove = false; // das ist nur hier von Interesse, weil es nur hier einen map editor gibt -> map wird unter Umstaenden nicht geupdated, deshalb force ich mit mNewRoom ein map update bei centerview()
 
-        if( !mpMap->mpRoomDB->getArea( pPlayerRoom->getArea() ) ) return;
+        if( !mpMap->mpRoomDB->getArea( pPlayerRoom->getArea() ) )
+        {
+            return;
+        }
         mRID = mpMap->mRoomId;
         pRID = mpMap->mpRoomDB->getRoom( mRID );
         mAID = pRID->getArea();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -467,7 +467,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
     int px,py;
     QList<int> exitList;
     QList<int> oneWayExits;
-    TRoom * pPlayerRoom = mpMap->mpRoomDB->getRoom( mpMap->mRoomId );
+    TRoom * pPlayerRoom = mpMap->mpRoomDB->getRoom( mpMap->mRoomIdHash.value( mpHost->getName() ) );
     if( !pPlayerRoom )
     {
         p.drawText(_w/2,_h/2,"No map or no valid position.");
@@ -476,7 +476,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
     }
 
     int ox, oy; // N/U: oz;
-    if( mRID != mpMap->mRoomId && mShiftMode ) mShiftMode = false;
+    if( mRID != mpMap->mRoomIdHash.value( mpHost->getName() ) && mShiftMode )
     {
         mShiftMode = false;
     }
@@ -492,7 +492,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
         {
             return;
         }
-        mRID = mpMap->mRoomId;
+        mRID = mpMap->mRoomIdHash.value( mpHost->getName() );
         pRID = mpMap->mpRoomDB->getRoom( mRID );
         mAID = pRID->getArea();
         pAID = mpMap->mpRoomDB->getArea( mAID );
@@ -1423,9 +1423,9 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 if( mpMap->mpRoomDB->getRoom(mTarget) )
                 {
                     mpMap->mTargetID = mTarget;
-                    if( mpMap->findPath( mpMap->mRoomId, mpMap->mTargetID) )
+                    if( mpMap->findPath( mpMap->mRoomIdHash.value( mpHost->getName() ), mpMap->mTargetID) )
                     {
-                        mpMap->mpHost->startSpeedWalk();
+                        mpHost->startSpeedWalk();
                     }
                     else
                     {
@@ -1504,7 +1504,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 p.setPen(__pen);
             }
 
-            if( mShiftMode && currentAreaRoom == mpMap->mRoomId )
+            if( mShiftMode && currentAreaRoom == mpMap->mRoomIdHash.value( mpHost->getName() ) )
             {
                 float _radius = (1.2*tx)/2;
                 QPointF _center = QPointF(rx,ry);
@@ -1654,9 +1654,9 @@ void T2DMap::paintEvent( QPaintEvent * e )
                    if( mpMap->mpRoomDB->getRoom(mTarget) )
                    {
                        mpMap->mTargetID = mTarget;
-                       if( mpMap->findPath( mpMap->mRoomId, mpMap->mTargetID) )
+                       if( mpMap->findPath( mpMap->mRoomIdHash.value( mpHost->getName() ), mpMap->mTargetID) )
                        {
-                          mpMap->mpHost->startSpeedWalk();
+                            mpHost->startSpeedWalk();
                        }
                        else
                        {
@@ -1702,7 +1702,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                     if( mpMap->mpRoomDB->getRoom(mTarget) )
                     {
                         mpMap->mTargetID = mTarget;
-                        if( mpMap->findPath( mpMap->mRoomId, mpMap->mTargetID) )
+                        if( mpMap->findPath( mpMap->mRoomIdHash.value( mpHost->getName() ), mpMap->mTargetID) )
                         {
                            mpMap->mpHost->startSpeedWalk();
                         }
@@ -3023,7 +3023,7 @@ void T2DMap::slot_setPlayerLocation()
     int _newRoomId = *( mMultiSelectionSet.constBegin() );
     if( mpMap->mpRoomDB->getRoom( _newRoomId ) ) {
         // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
-        mpMap->mRoomId = _newRoomId;
+        mpMap->mRoomIdHash[ mpHost->getName() ] = _newRoomId;
         mpMap->mNewMove = true;
         TEvent manualSetEvent;
         manualSetEvent.mArgumentList.append( QStringLiteral( "sysManualLocationSetEvent" ) );

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -358,21 +358,47 @@ void T2DMap::shiftZdown()
 }
 
 
-void T2DMap::switchArea(QString name)
+void T2DMap::slot_switchArea(QString name)
 {
-    if( !mpMap ) return;
+    Host * pHost = mpHost;
+    if( !pHost || !mpMap )
+    {
+        return;
+    }
+
+    int playerRoomId = mpMap->mRoomIdHash.value( pHost->getName() );
+    TRoom * pPlayerRoom = mpMap->mpRoomDB->getRoom( playerRoomId );
+    int playerAreaId = -2; // Cannot be valid (but -1 can be)!
+    if( pPlayerRoom ) {
+        playerAreaId = pPlayerRoom->getArea();
+    }
+
     QMapIterator<int, QString> it( mpMap->mpRoomDB->getAreaNamesMap() );
     while( it.hasNext() )
     {
         it.next();
         int areaID = it.key();
+
         QString _n = it.value();
         TArea * pA = mpMap->mpRoomDB->getArea( areaID );
         if( name == _n && pA )
         {
+
             mAID = areaID;
             mShiftMode = true;
             pA->calcSpan();
+
+            if( playerAreaId != -1 && areaID == playerAreaId ) {
+                // We are switching back to the area that has the player in it
+                // recenter view on that room!
+                mOx = pPlayerRoom->x;
+                mOy = -pPlayerRoom->y;  // Map y coordinates are reversed on 2D map!
+                mOz = pPlayerRoom->z;
+                repaint();
+                mpMap->set3DViewCenter( mAID, mOx, -mOy, mOz ); // Pass the coordinates to the TMap instance to pass to the 3D mapper
+                return; // escape early
+            }
+
             bool isAValidRoomFound = false;
             if( ! pA->ebenen.contains(mOz) )
             {
@@ -381,22 +407,99 @@ void T2DMap::switchArea(QString name)
                 // mathmatical midpoint of all the rooms on the same
                 // z-coordinate.
                 QSetIterator<int> itRoom( pA->getAreaRooms() );
-                while( itRoom.hasNext() && !isAValidRoomFound )
+                QMap<int, int> roomsCountLevelMap; // key is z-coordinate, value is count of rooms on that level
+                while( itRoom.hasNext() )
                 {
                     int checkRoomId = itRoom.next();
                     TRoom * pR = mpMap->mpRoomDB->getRoom( checkRoomId );
                     if( pR )
                     {
-                        mOz = pR->z;
-                        int x_min = pA->xminEbene[mOz];
-                        int y_min = pA->yminEbene[mOz];
-                        int x_max = pA->xmaxEbene[mOz];
-                        int y_max = pA->ymaxEbene[mOz];
-                        mOx = x_min + ( abs( x_max - x_min ) / 2 );
-                        mOy = ( y_min + ( abs( y_max - y_min ) / 2 ) );
                         isAValidRoomFound = true;
+                        if( roomsCountLevelMap.contains( pR->z ) )
+                        {
+                            ++roomsCountLevelMap[ pR->z ];
+                        }
+                        else
+                        {
+                            roomsCountLevelMap[ pR->z ] = 1;
+                        }
                     }
                 }
+
+                if( isAValidRoomFound )
+                {
+                    QMapIterator<int, int> itRoomsCount( roomsCountLevelMap );
+                    itRoomsCount.toBack(); // Start at highest value and work down
+                    itRoomsCount.previous(); // This will be Okay as we KNOW there is at least one entry
+                    int maxRoomCountOnLevel = 0;
+                    int minLevelWithMaxRoomCount = itRoomsCount.key(); // Initalisation value, will get overwritten
+                    itRoomsCount.next(); // Return to the back so the previous() in the do loop works correctly
+                    do
+                    {
+                        itRoomsCount.previous();
+                        if( maxRoomCountOnLevel < itRoomsCount.value() )
+                        {
+                            maxRoomCountOnLevel = itRoomsCount.value();
+                            minLevelWithMaxRoomCount = itRoomsCount.key();
+                        }
+                    } while( itRoomsCount.hasPrevious() );
+
+                    // We now have lowest level with the highest number of rooms
+                    // Now find the geometry center of the rooms on THAT level
+                    // In a similar manner to the getCenterSelection() method
+                    itRoom.toFront();
+                    float mean_x = 0.0;
+                    float mean_y = 0.0;
+                    uint processedRoomCount = 0;
+                    QSet<TRoom *> pSRoom; // Hold on to relevent rooms for
+                                          // following step
+                    while( itRoom.hasNext() )
+                    {
+                        TRoom * pR = mpMap->mpRoomDB->getRoom( itRoom.next() );
+                        if( ! pR || pR->z != minLevelWithMaxRoomCount )
+                        {
+                            continue;
+                        }
+
+                        pSRoom.insert( pR );
+                        mean_x += (static_cast<float>(pR->x - mean_x)) / ++processedRoomCount;
+                        mean_y += (static_cast<float>(pR->y - mean_y)) / processedRoomCount;
+                    }
+
+                    // We now have the position that is the "centre" of the
+                    // rooms on this level - just need to find the room nearest
+                    // to that:
+                    QSetIterator<TRoom *> itpRoom( pSRoom );
+                    float closestSquareDistance = -1.0;
+                    TRoom * pClosestRoom = 0;
+                    while( itpRoom.hasNext() )
+                    {
+                        TRoom * pR = itpRoom.next();
+                        QVector2D meanToRoom( static_cast<float>(pR->x)-mean_x, static_cast<float>(pR->y)-mean_y);
+                        if( closestSquareDistance < -0.5 )
+                        {
+                            // Test for first time around loop - for initalisation
+                            // Don't use an equality to zero test, we are using floats so
+                            // need to allow for a little bit of fuzzzyness!
+                            closestSquareDistance = meanToRoom.lengthSquared();
+                            pClosestRoom = pR;
+                        }
+                        else
+                        {
+                            float currentRoomSquareDistance = meanToRoom.lengthSquared();
+                            if( closestSquareDistance > currentRoomSquareDistance  )
+                            {
+                                closestSquareDistance = currentRoomSquareDistance;
+                                pClosestRoom = pR;
+                            }
+                        }
+                    }
+
+                    mOx = pClosestRoom->x;
+                    mOy = - pClosestRoom->y; // Map y coordinates are reversed on 2D map!
+                    mOz = pClosestRoom->z;
+                }
+
                 if( ! isAValidRoomFound )
                 {
                     //no rooms, go to 0,0,0
@@ -407,15 +510,56 @@ void T2DMap::switchArea(QString name)
             }
             else
             {
-                int x_min = pA->xminEbene[mOz];
-                int y_min = pA->yminEbene[mOz];
-                int x_max = pA->xmaxEbene[mOz];
-                int y_max = pA->ymaxEbene[mOz];
-                mOx = x_min + ( abs( x_max - x_min ) / 2 );
-                mOy = ( y_min + ( abs( y_max - y_min ) / 2 ) );
-                mOz = 0;
+                // Else the selected area DOES have rooms on the same z-coordinate
+                // Now find the geometry center of the rooms on the given level
+                // In a similar manner to the getCenterSelection() method
+                float mean_x = 0.0;
+                float mean_y = 0.0;
+                uint processedRoomCount = 0;
+                QSet<TRoom *> pSRoom; // Hold on to relevent rooms for
+                                      // following step
+                QSetIterator<int> itRoom( pA->getAreaRooms() );
+                while( itRoom.hasNext() ) {
+                    TRoom * pR = mpMap->mpRoomDB->getRoom( itRoom.next() );
+                    if( ! pR || pR->z != mOz ) {
+                        continue;
+                    }
+
+                    pSRoom.insert( pR );
+                    mean_x += (static_cast<float>(pR->x - mean_x)) / ++processedRoomCount;
+                    mean_y += (static_cast<float>(pR->y - mean_y)) / processedRoomCount;
+                }
+
+                // We now have the position that is the "centre" of the
+                // rooms on this level - just need to find the room nearest
+                // to that:
+                QSetIterator<TRoom *> itpRoom( pSRoom );
+                float closestSquareDistance = -1.0;
+                TRoom * pClosestRoom = 0;
+                while( itpRoom.hasNext() ) {
+                    TRoom * pR = itpRoom.next();
+                    QVector2D meanToRoom( static_cast<float>(pR->x)-mean_x, static_cast<float>(pR->y)-mean_y);
+                    if( closestSquareDistance < -0.5 ) {
+                        // Test for first time around loop - for initalisation
+                        // Don't use an equality to zero test, we are using floats so
+                        // need to allow for a little bit of fuzzzyness!
+                        closestSquareDistance = meanToRoom.lengthSquared();
+                        pClosestRoom = pR;
+                    }
+                    else {
+                        float currentRoomSquareDistance = meanToRoom.lengthSquared();
+                        if( closestSquareDistance > currentRoomSquareDistance  ) {
+                            closestSquareDistance = currentRoomSquareDistance;
+                            pClosestRoom = pR;
+                        }
+                    }
+                }
+
+                mOx = pClosestRoom->x;
+                mOy = - pClosestRoom->y;  // Map y coordinates are reversed on 2D map!
             }
             repaint();
+            mpMap->set3DViewCenter( mAID, mOx, -mOy, mOz ); // Pass the coordinates to the TMap instance to pass to the 3D mapper
             return;
         }
     }
@@ -484,13 +628,14 @@ void T2DMap::paintEvent( QPaintEvent * e )
     }
     TArea * pAID;
     TRoom * pRID;
+    int playerArea = pPlayerRoom->getArea();
     if( (! __Pick && ! mShiftMode ) || mpMap->mNewMove )
     {
 
         mShiftMode = true;
         mpMap->mNewMove = false; // das ist nur hier von Interesse, weil es nur hier einen map editor gibt -> map wird unter Umstaenden nicht geupdated, deshalb force ich mit mNewRoom ein map update bei centerview()
 
-        if( !mpMap->mpRoomDB->getArea( pPlayerRoom->getArea() ) )
+        if( !mpMap->mpRoomDB->getArea( playerArea ) )
         {
             return;
         }
@@ -1859,6 +2004,8 @@ void T2DMap::paintEvent( QPaintEvent * e )
             }
         }
 
+        p.save(); // Save painter state
+        QFont f = p.font();
         TRoom * _prid = mpMap->mpRoomDB->getRoom( __rid );
         if( _prid )
         {
@@ -1880,16 +2027,44 @@ void T2DMap::paintEvent( QPaintEvent * e )
             }
 
             uint selectionSize = mMultiSelectionSet.size();
+            // Italicise the text if the current display area {mAID} is not the
+            // same as the displayed text information - which happens when NO
+            // room is selected AND the current area is NOT the one the player
+            // is in (to emphasis that the displayed data is {mostly} not about
+            // the CURRENTLY VISIBLE area)... make it bold if the player room IS
+            // in the displayed map
+
+            // If one or more rooms are selected - make the text slightly orange.
             switch( selectionSize )
             {
             case 0:
                 infoText.append( tr("Room ID: %1 (Current) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)) );
+                if( playerArea != mAID ) {
+                    f.setItalic( true );
+                }
+                else {
+                    f.setBold( true );
+                }
                 break;
             case 1:
                 infoText.append( tr("Room ID: %1 (Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)) );
+                f.setBold( true );
+                if( infoColor.lightness() > 127 ) {
+                    infoColor = QColor( 255, 223, 191 ); // Slightly orange white
+                }
+                else {
+                    infoColor = QColor( 96, 48, 0 ); // Dark, slightly orange grey
+                }
                 break;
             default:
                 infoText.append( tr("Room ID: %1 (%5 Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)).arg(QString::number(selectionSize)) );
+                f.setBold( true );
+                if( infoColor.lightness() > 127 ) {
+                    infoColor = QColor( 255, 223, 191 ); // Slightly orange white
+                }
+                else {
+                    infoColor = QColor( 96, 48, 0 ); // Dark, slightly orange grey
+                }
                 break;
             }
         }
@@ -1916,7 +2091,9 @@ void T2DMap::paintEvent( QPaintEvent * e )
 
         p.fillRect( mMapInfoRect, QColor(150,150,150,80) ); // Restore Grey translucent background, was useful for debugging!
         p.setPen( infoColor );
+        p.setFont( f );
         p.drawText( mMapInfoRect.left()+10, mMapInfoRect.top()+10, mMapInfoRect.width()-20, mMapInfoRect.height()-20, Qt::TextWordWrap|Qt::AlignLeft|Qt::AlignTop, infoText );
+        p.restore(); //forget about font size changing and bolding/italicisation
     }
 
     if( mHelpMsg.size() > 0 )

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -79,7 +79,9 @@ T2DMap::T2DMap(QWidget * parent)
     mMultiSelectionListWidget.setRootIsDecorated(false);
     QSizePolicy multiSelectionSizePolicy( QSizePolicy::Maximum, QSizePolicy::Expanding );
     mMultiSelectionListWidget.setSizePolicy( multiSelectionSizePolicy );
+#if QT_VERSION >= 0x050200
     mMultiSelectionListWidget.setSizeAdjustPolicy( QAbstractScrollArea::AdjustToContents );
+#endif
     mMultiSelectionListWidget.setFrameShape(QFrame::NoFrame);
     mMultiSelectionListWidget.setFrameShadow(QFrame::Plain);
     mMultiSelectionListWidget.header()->setProperty("showSortIndicator",QVariant(true));

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3010,7 +3010,7 @@ void T2DMap::slot_customLineProperties()
                     }
                 }
                 if( ! isFound )
-                    qWarning("T2DMap::slot_customLineProperties() - WARNING: missing command \"%s\" from custom lines for room Id %i",
+                    qWarning("T2DMap::slot_customLineProperties() - WARNING: missing command \"%s\" from custom lines for room id %i",
                              qPrintable( exit ),
                              pR->getId() );
             }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -40,6 +40,7 @@
 #include <QComboBox>
 #include <QCheckBox>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFileDialog>
 #include <QFontDialog>
 #include <QHBoxLayout>
@@ -53,20 +54,43 @@
 #include <QPushButton>
 #include <QSignalMapper>
 #include <QTreeWidget>
+#include <QTreeWidgetItem>
 #include "post_guard.h"
 
 
 T2DMap::T2DMap(QWidget * parent)
 : QWidget(parent)
-, mMultiSelectionListWidget(this)
 , mDialogLock(false)
+, mMultiSelectionListWidget(this)
+, mMultiSelectionHighlightRoomId(-1)
+, mIsSelectionSorting(true)
+, mIsSelectionSortByNames(false)
+, mIsSelectionUsingNames(false)
 {
-    mMultiSelectionListWidget.setHeaderLabel("Room Selection");
-    mMultiSelectionListWidget.setColumnCount(1);
-    mMultiSelectionListWidget.resize(100,180);
-    mMultiSelectionListWidget.move(1,1);
-    connect(&mMultiSelectionListWidget, SIGNAL(itemSelectionChanged()), this, SLOT(slot_roomSelectionChanged()));
+    mMultiSelectionListWidget.setColumnCount(2);
+    mMultiSelectionListWidget.hideColumn(1);
+    QStringList headerLabels;
+    headerLabels << tr("Room Id") << tr("Room Name");
+    mMultiSelectionListWidget.setHeaderLabels(headerLabels);
+    mMultiSelectionListWidget.setToolTip(tr("<html><head/><body><p>Click on a line to select or deselect that room number (with the given name if the rooms are named) to add or remove the room from the selection.  Click on the relevant header to sort by that method.  Note that the name column willl only show if at least one of the rooms has a name.</p></body></html>"));
+    mMultiSelectionListWidget.setUniformRowHeights(true);
+    mMultiSelectionListWidget.setItemsExpandable(false);
+    mMultiSelectionListWidget.setSelectionMode(QAbstractItemView::MultiSelection); // Was ExtendedSelection
+    mMultiSelectionListWidget.setRootIsDecorated(false);
+    QSizePolicy multiSelectionSizePolicy( QSizePolicy::Maximum, QSizePolicy::Expanding );
+    mMultiSelectionListWidget.setSizePolicy( multiSelectionSizePolicy );
+    mMultiSelectionListWidget.setSizeAdjustPolicy( QAbstractScrollArea::AdjustToContents );
+    mMultiSelectionListWidget.setFrameShape(QFrame::NoFrame);
+    mMultiSelectionListWidget.setFrameShadow(QFrame::Plain);
+    mMultiSelectionListWidget.header()->setProperty("showSortIndicator",QVariant(true));
+    mMultiSelectionListWidget.header()->setSectionsMovable(false);
+    mMultiSelectionListWidget.header()->setSectionResizeMode(0,QHeaderView::ResizeToContents);
+    mMultiSelectionListWidget.header()->setStretchLastSection(true);
+    mMultiSelectionListWidget.setSortingEnabled(mIsSelectionSorting);
+    mMultiSelectionListWidget.resize(120,100);
+    mMultiSelectionListWidget.move(0,0);
     mMultiSelectionListWidget.hide();
+    connect(&mMultiSelectionListWidget, SIGNAL(itemSelectionChanged()), this, SLOT(slot_roomSelectionChanged()));
     mMoveLabel = false;
     mLabelHilite = false;
     xzoom = 30;
@@ -93,8 +117,6 @@ T2DMap::T2DMap(QWidget * parent)
     mCustomLineSelectedPoint = -1;
     mCustomLinesRoomFrom = 0;
     mCustomLinesRoomTo = 0;
-    mMultiSelectionListWidget.setRootIsDecorated(false);
-    mMultiSelectionListWidget.setColumnWidth(0,90);
     mSizeLabel = false;
     gridMapSizeChange = true;
     isCenterViewCall = false;
@@ -349,14 +371,18 @@ void T2DMap::switchArea(QString name)
             mAID = areaID;
             mShiftMode = true;
             pA->calcSpan();
-            if( ! pA->xminEbene.contains(mOz) )
+            bool isAValidRoomFound = false;
+            if( ! pA->ebenen.contains(mOz) )
             {
-                //find the first room of the area, which will usually
-                //be the entrance and go there if it exists.
-                QList<int> rooms = pA->rooms;
-                if ( !rooms.isEmpty() )
+                // If the current map z-coordinate value is NOT one that is used
+                // for this then get the FIRST room in the area and goto the
+                // mathmatical midpoint of all the rooms on the same
+                // z-coordinate.
+                QSetIterator<int> itRoom( pA->getAreaRooms() );
+                while( itRoom.hasNext() && !isAValidRoomFound )
                 {
-                    TRoom * pR = mpMap->mpRoomDB->getRoom(rooms.first());
+                    int checkRoomId = itRoom.next();
+                    TRoom * pR = mpMap->mpRoomDB->getRoom( checkRoomId );
                     if( pR )
                     {
                         mOz = pR->z;
@@ -366,9 +392,10 @@ void T2DMap::switchArea(QString name)
                         int y_max = pA->ymaxEbene[mOz];
                         mOx = x_min + ( abs( x_max - x_min ) / 2 );
                         mOy = ( y_min + ( abs( y_max - y_min ) / 2 ) );
+                        isAValidRoomFound = true;
                     }
                 }
-                else
+                if( ! isAValidRoomFound )
                 {
                     //no rooms, go to 0,0,0
                     mOx = 0;
@@ -397,7 +424,8 @@ void T2DMap::paintEvent( QPaintEvent * e )
 {
     if( !mpMap ) return;
     bool __Pick = mPick;
-    QTime __time; __time.start();
+    QElapsedTimer __time;
+    __time.start();
 
     QPainter p( this );
     if( ! p.isActive() ) return;
@@ -610,14 +638,15 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 }
             }
         }
-        for( int i=0; i<pArea->rooms.size(); i++ )
+        QSetIterator<int> itRoom2( pArea->getAreaRooms() );
+        while( itRoom2.hasNext() )
         {
-            TRoom * pR = mpMap->mpRoomDB->getRoom(pArea->rooms[i]);
+            int _id = itRoom2.next();
+            TRoom * pR = mpMap->mpRoomDB->getRoom( _id );
             if( !pR ) continue;
             float rx = pR->x*tx+_rx;
             float ry = pR->y*-1*ty+_ry;
             int rz = pR->z;
-            int _id = pR->getId();
 
             if( rz != zEbene ) continue;
 
@@ -1212,9 +1241,13 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 }
             } // End of for( exitList )
 
-            // Indicate destination for custom exit line drawing - double size target yellow hollow circle
-            if( customLineDestinationTarget > 0 && customLineDestinationTarget == _id )
-            {
+            // Indicate destination for custom exit line drawing - double size
+            // target yellow hollow circle
+            // Similar code is now also used to indicate center target of
+            // multiple selected rooms but that must be done after all the rooms
+            // have been drawn otherwise later drawn rooms will overwrite the
+            // mark, especially on areas in gridmode.
+            if( customLineDestinationTarget > 0 && customLineDestinationTarget == _id ) {
                 QPen savePen = p.pen();
                 QBrush saveBrush = p.brush();
                 float _radius = tx * 1.2;
@@ -1238,14 +1271,18 @@ void T2DMap::paintEvent( QPaintEvent * e )
             }
         } // End of for( area Rooms )
     } // End of NOT area gridmode
-    // draw group selection box
+
+    // Draw label sizing or group selection box
     if( mSizeLabel )
         p.fillRect(mMultiRect,QColor(250,190,0,190));
     else
         p.fillRect(mMultiRect,QColor(190,190,190,60));
-    for( int i=0; i<pArea->rooms.size(); i++ )
+
+    QSetIterator<int> itRoom( pArea->getAreaRooms() );
+    while( itRoom.hasNext() )
     {
-        TRoom * pR = mpMap->mpRoomDB->getRoom(pArea->rooms[i]);
+        int currentAreaRoom = itRoom.next();
+        TRoom * pR = mpMap->mpRoomDB->getRoom( currentAreaRoom );
         if( !pR )
             continue; // Was missing this safety step to skip missing rooms
         float rx = pR->x*tx+_rx;
@@ -1333,16 +1370,19 @@ void T2DMap::paintEvent( QPaintEvent * e )
             break;
         case 16:
             c = mpHost->mLightBlack_2;
+            break;
         default: //user defined room color
-            if( ! mpMap->customEnvColors.contains(env) ) break;
-            c = mpMap->customEnvColors[env];
+            if( mpMap->customEnvColors.contains(env) )
+            {
+                c = mpMap->customEnvColors[env];
+            }
         }
         if( ( ( mPick || __Pick )
               && mPHighlight.x() >= dr.x()-(tx*rSize)
               && mPHighlight.x() <= dr.x()+(tx*rSize)
               && mPHighlight.y() >= dr.y()-(ty*rSize)
               && mPHighlight.y() <= dr.y()+(ty*rSize) )
-            || mMultiSelectionList.contains(pArea->rooms[i]) ) {
+            || mMultiSelectionSet.contains( currentAreaRoom ) ) {
             p.fillRect(dr,QColor(255,155,55));
             mPick = false;
             if( mStartSpeedWalk )
@@ -1364,13 +1404,13 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 p.drawPath(myPath);
 
 
-                mTarget = pArea->rooms[i];
+                mTarget = currentAreaRoom;
                 if( mpMap->mpRoomDB->getRoom(mTarget) )
                 {
                     mpMap->mTargetID = mTarget;
                     if( mpMap->findPath( mpMap->mRoomId, mpMap->mTargetID) )
                     {
-                       mpMap->mpHost->startSpeedWalk();
+                        mpMap->mpHost->startSpeedWalk();
                     }
                     else
                     {
@@ -1416,8 +1456,11 @@ void T2DMap::paintEvent( QPaintEvent * e )
                     p.drawPath(myPath);
                 }
                 else
+                {
                     p.fillRect(dr,c);
+                }
             }
+
             if( pR->highlight )
             {
                 float _radius = (pR->highlightRadius*tx)/2;
@@ -1432,6 +1475,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 myPath.addEllipse(_center,_radius,_radius);
                 p.drawPath(myPath);
             }
+
             if( mShowRoomID )
             {
                 QPen __pen = p.pen();
@@ -1441,10 +1485,11 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 else
                     lc=QColor(255,255,255);
                 p.setPen(QPen(lc));
-                p.drawText(dr, Qt::AlignHCenter|Qt::AlignVCenter,QString::number(pArea->rooms[i]));
+                p.drawText(dr, Qt::AlignHCenter|Qt::AlignVCenter,QString::number( currentAreaRoom ));
                 p.setPen(__pen);
             }
-            if( mShiftMode && pArea->rooms[i] == mpMap->mRoomId )
+
+            if( mShiftMode && currentAreaRoom == mpMap->mRoomId )
             {
                 float _radius = (1.2*tx)/2;
                 QPointF _center = QPointF(rx,ry);
@@ -1500,7 +1545,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 brush.setStyle( Qt::NoBrush );
                 p.setBrush( brush );
                 p.drawPolygon(_poly);
-           }
+            }
         }
 
         if( pR->getUp() > 0 )
@@ -1519,6 +1564,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             p.setBrush( brush );
             p.drawPolygon(_poly);
         }
+
         if( pR->getDown() > 0 )
         {
             QPolygonF _poly;
@@ -1535,6 +1581,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             p.setBrush( brush );
             p.drawPolygon(_poly);
         }
+
         if( pR->getIn() > 0 )
         {
             QPolygonF _poly;
@@ -1551,6 +1598,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             p.setBrush( brush );
             p.drawPolygon(_poly);
         }
+
         if( pR->getOut() > 0 )
         {
             QPolygonF _poly;
@@ -1567,6 +1615,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             p.setBrush( brush );
             p.drawPolygon(_poly);
         }
+
         if( pArea->gridMode )
         {
            QMapIterator<int, QPoint> it( mAreaExitList );
@@ -1577,21 +1626,13 @@ void T2DMap::paintEvent( QPaintEvent * e )
                int rx = P.x();
                int ry = P.y();
 
-               QRectF dr;
-               if( pArea->gridMode )
-               {
-                   dr = QRectF(rx-tx/2, ry-ty/2,tx,ty);
-               }
-               else
-               {
-                   dr = QRectF(rx-(tx*rSize)/2,ry-(ty*rSize)/2,tx*rSize,ty*rSize);
-               }
+               QRectF dr = QRectF(rx-tx/2, ry-ty/2,tx,ty);
                if( ( (mPick || __Pick)
                      && mPHighlight.x() >= dr.x()-tx/2
                      && mPHighlight.x() <= dr.x()+tx/2
                      && mPHighlight.y() >= dr.y()-ty/2
                      && mPHighlight.y() <= dr.y()+ty/2 )
-                   || mMultiSelectionList.contains(pArea->rooms[i]) ) {
+                   || mMultiSelectionSet.contains( currentAreaRoom ) ) {
                    p.fillRect(dr,QColor(50,255,50));
                    mPick = false;
                    mTarget = it.key();
@@ -1621,15 +1662,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 int rx = P.x();
                 int ry = P.y();
 
-                QRectF dr;
-                if( pArea->gridMode )
-                {
-                    dr = QRectF(rx-tx/2, ry-ty/2,tx,ty);
-                }
-                else
-                {
-                    dr = QRectF(rx,ry,tx*rSize,ty*rSize);//rx-(tx*rSize)/2,ry-(ty*rSize)/2,tx*rSize,ty*rSize);
-                }
+                QRectF dr = QRectF(rx,ry,tx*rSize,ty*rSize);//rx-(tx*rSize)/2,ry-(ty*rSize)/2,tx*rSize,ty*rSize);
                 if( ((mPick || __Pick) && mPHighlight.x() >= dr.x()-tx/3 && mPHighlight.x() <= dr.x()+tx/3 && mPHighlight.y() >= dr.y()-ty/3 && mPHighlight.y() <= dr.y()+ty/3
                     ) && mStartSpeedWalk )
                 {
@@ -1715,55 +1748,54 @@ void T2DMap::paintEvent( QPaintEvent * e )
         }
     }
 
-    QColor infoCol = mpHost->mBgColor_2;
-    QColor _infoCol;
-    if( infoCol.red()+infoCol.green()+infoCol.blue() > 200 )
-        _infoCol=QColor(0,0,0);
-    else
-        _infoCol=QColor(255,255,255);
+    // Similar code was used to indicate target of custom exit line selected for
+    // editing but this could not be done there because gridmode areas don't hit
+    // that bit of code and later rooms would overwrite the target...
+    if( mMultiSelectionHighlightRoomId > 0 && mMultiSelectionSet.size() > 1 ) {
+        TRoom * pR_multiSelectionHighlight = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
+        if( pR_multiSelectionHighlight ) {
+            float r_mSx = pR_multiSelectionHighlight->x   *tx+_rx;
+            float r_mSy = pR_multiSelectionHighlight->y*-1*ty+_ry;
+            QPen savePen = p.pen();
+            QBrush saveBrush = p.brush();
+            float _radius = tx * 1.2;
+            float _diagonal = tx * 1.2;
+            QPointF _center = QPointF( r_mSx, r_mSy );
 
-    p.setPen(_infoCol);
-
-    if( mShowInfo )
-    {
-        //p.fillRect( 0,0,width(), 3*mFontHeight, QColor(150,150,150,80) );
-        QString text;
-        int __rid = mRID;
-        if( !isCenterViewCall && mMultiSelectionList.size() == 1 )
-        {
-            if( mpMap->mpRoomDB->getRoom( mMultiSelectionList[0] ) )
-            {
-                __rid = mMultiSelectionList[0];
-            }
-        }
-        TRoom * _prid = mpMap->mpRoomDB->getRoom(__rid);
-        if( _prid )
-        {
-            int _iaid = _prid->getArea();
-            TArea * _paid = mpMap->mpRoomDB->getArea( _iaid );
-            QString _paid_name = mpMap->mpRoomDB->getAreaNamesMap().value(_iaid);
-            if( _paid )//if( mpMap->areaNamesMap.contains(__rid))
-            {
-                text = QString("Area: %1 ID:%2 x:%3-%4 y:%5-%6").arg(_paid_name).arg(_iaid).arg(_paid->min_x).arg(_paid->max_x).arg(_paid->min_y).arg(_paid->max_y);
-                p.drawText( 10, mFontHeight, text );
-            }
-            //if( mpMap->rooms.contains( __rid ) )
-            {
-                text = QString("Room Name: %1").arg(_prid->name);
-                p.drawText( 10, 2*mFontHeight, text );
-                text = QString("Room ID: %1 Position on Map: (%2/%3/%4)").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z));
-                p.drawText( 10, 3*mFontHeight, text );
-            }
+            QPen myPen( QColor( 255, 255, 50, 192 ) );  // Quarter opaque yellow pen
+            myPen.setWidth( tx * 0.1 );
+            QPainterPath myPath;
+            p.setPen( myPen );
+            p.setBrush( Qt::NoBrush );
+            myPath.addEllipse( _center, _radius, _radius );
+            myPath.addEllipse( _center, _radius / 2.0, _radius / 2.0 );
+            myPath.moveTo( r_mSx - _diagonal, r_mSy - _diagonal );
+            myPath.lineTo( r_mSx + _diagonal, r_mSy + _diagonal );
+            myPath.moveTo( r_mSx + _diagonal, r_mSy - _diagonal );
+            myPath.lineTo( r_mSx - _diagonal, r_mSy + _diagonal );
+            p.drawPath( myPath );
+            p.setPen( savePen );
+            p.setBrush( saveBrush );
         }
     }
 
-    if( mMapInfoRect == QRect(0,0,0,0) ) mMapInfoRect = QRect(0,0,width(),height()/10);
+    QColor infoColor;
+    if( mpHost->mBgColor_2.lightness() > 127 ) {
+        infoColor=QColor( Qt::black );
+    }
+    else {
+        infoColor=QColor( Qt::white );
+    }
 
+    // Draw central red circle:
     if( ! mShiftMode )
     {
-
+        p.save();
+        QPen myPen(QColor(0,0,0,0));
+        QPainterPath myPath;
         if( mpHost->mMapStrongHighlight )
-        {
+        {   // Never set, no means to except via XMLImport, as dlgMapper class's
+            // slot_toggleStrongHighlight is not wired up to anything
             QRectF dr = QRectF(px-(tx*rSize)/2,py-(ty*rSize)/2,tx*rSize,ty*rSize);
             p.fillRect(dr,QColor(255,0,0,150));
 
@@ -1775,16 +1807,12 @@ void T2DMap::paintEvent( QPaintEvent * e )
             _gradient.setColorAt(0.799,QColor(150,100,100,100));
             _gradient.setColorAt(0.7, QColor(255,0,0,200));
             _gradient.setColorAt(0, QColor(255,255,255,255));
-            QPen myPen(QColor(0,0,0,0));
-            QPainterPath myPath;
             p.setBrush(_gradient);
             p.setPen(myPen);
             myPath.addEllipse(_center,_radius,_radius);
-            p.drawPath(myPath);
         }
         else
         {
-            QPen _pen = p.pen();
             float _radius = (1.9*tx)/2;
             QPointF _center = QPointF(px,py);
             QRadialGradient _gradient(_center,_radius);
@@ -1794,21 +1822,86 @@ void T2DMap::paintEvent( QPaintEvent * e )
             _gradient.setColorAt(0.3,QColor(150,150,150,100));
             _gradient.setColorAt(0.1, QColor(255,255,255,100));
             _gradient.setColorAt(0, QColor(255,255,255,255));
-            QPen myPen(QColor(0,0,0,0));
-            QPainterPath myPath;
             p.setBrush(_gradient);
             p.setPen(myPen);
             myPath.addEllipse(_center,_radius,_radius);
-            p.drawPath(myPath);
         }
+        p.drawPath(myPath);
+        p.restore();
     }
 
 
+    // Work out text for information box, need to offset if room selection widget is present
     if( mShowInfo )
     {
-        QString text = QString("render time:%1ms mOx:%2 mOy:%3 mOz:%4").arg(QString::number(__time.elapsed())).arg(QString::number(mOx)).arg(QString::number(mOy)).arg(QString::number(mOz));
-        p.setPen(QColor(255,255,255));
-        p.drawText( 10, 4*mFontHeight, text );
+        QString infoText;
+        int __rid = mRID;
+        if( !isCenterViewCall && mMultiSelectionSet.size() )
+        {
+            if( mpMap->mpRoomDB->getRoom( *(mMultiSelectionSet.constBegin()) ) )
+            {
+                __rid = mMultiSelectionHighlightRoomId;
+            }
+        }
+
+        TRoom * _prid = mpMap->mpRoomDB->getRoom( __rid );
+        if( _prid )
+        {
+            int _iaid = _prid->getArea();
+            TArea * _paid = mpMap->mpRoomDB->getArea( _iaid );
+            QString _paid_name = mpMap->mpRoomDB->getAreaNamesMap().value( _iaid );
+            if( _paid )
+            {
+                infoText = tr( "Area: %1 ID:%2 x:%3 <-> %4 y:%5 <-> %6 z:%7 <-> %8\n").arg(_paid_name).arg(_iaid).arg(_paid->min_x).arg(_paid->max_x).arg(_paid->min_y).arg(_paid->max_y).arg(_paid->min_z).arg(_paid->max_z);
+            }
+            else
+            {
+                infoText = QStringLiteral( "\n" );
+            }
+
+            if( ! _prid->name.isEmpty() )
+            {
+                infoText.append( tr("Room Name: %1\n").arg(_prid->name) );
+            }
+
+            uint selectionSize = mMultiSelectionSet.size();
+            switch( selectionSize )
+            {
+            case 0:
+                infoText.append( tr("Room ID: %1 (Current) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)) );
+                break;
+            case 1:
+                infoText.append( tr("Room ID: %1 (Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)) );
+                break;
+            default:
+                infoText.append( tr("Room ID: %1 (%5 Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)).arg(QString::number(selectionSize)) );
+                break;
+            }
+        }
+
+        infoText.append( tr("render time: %1S mO: (%2,%3,%4)").arg( __time.nsecsElapsed() * 1.0e-9,0,'f',3).arg(QString::number(mOx)).arg(QString::number(mOy)).arg(QString::number(mOz)) );
+
+        uint infoLeftSideAvoid = 10; // Left margin for info widget
+        if( mMultiSelectionListWidget.isVisible() ) { // Room Selection Widget showing, so increase margin to avoid
+            infoLeftSideAvoid += mMultiSelectionListWidget.x() + mMultiSelectionListWidget.rect().width();
+        }
+
+        uint infoHeight = 5 + mFontHeight; // Account for first iteration
+        QRect testRect;
+        // infoRect has a 10 margin on either side and on top to widget frame.
+        mMapInfoRect = QRect( infoLeftSideAvoid, 10, width() - 10 - infoLeftSideAvoid, infoHeight );
+        do {
+            infoHeight += mFontHeight;
+            mMapInfoRect.setHeight( infoHeight );
+            // Test in a rectangle that is 10 less on all sides:
+            testRect = p.boundingRect( mMapInfoRect.left()+10, mMapInfoRect.top()+10, mMapInfoRect.width()-20, mMapInfoRect.height()-20, Qt::TextWordWrap|Qt::AlignLeft|Qt::AlignTop, infoText );
+        } while( ( testRect.height() > mMapInfoRect.height()-20
+                   || testRect.width()  > mMapInfoRect.width()-20 )
+                 && infoHeight < height() ); // Last term is needed to prevent runaway under "odd" conditions
+
+        p.fillRect( mMapInfoRect, QColor(150,150,150,80) ); // Restore Grey translucent background, was useful for debugging!
+        p.setPen( infoColor );
+        p.drawText( mMapInfoRect.left()+10, mMapInfoRect.top()+10, mMapInfoRect.width()-20, mMapInfoRect.height()-20, Qt::TextWordWrap|Qt::AlignLeft|Qt::AlignTop, infoText );
     }
 
     if( mHelpMsg.size() > 0 )
@@ -1963,7 +2056,8 @@ void T2DMap::mouseReleaseEvent(QMouseEvent * e )
 
     if( e->button() & Qt::LeftButton )
     {
-        mMultiSelection = false;
+        mMultiSelection = false; // End drag-to-select rectangle resizing
+        mHelpMsg.clear();
         if( mSizeLabel )
         {
             mSizeLabel = false;
@@ -2004,6 +2098,10 @@ bool T2DMap::event( QEvent * event )
 //            }
 //        }
     }
+    else if( event->type() == QEvent::Resize )
+    { // Tweak the room selection widget to fit
+        resizeMultiSelectionWidget();
+    }
     return QWidget::event(event);
 }
 
@@ -2040,90 +2138,93 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
         }
 
         // check click on custom exit lines
-        TArea * pA = mpMap->mpRoomDB->getArea(mAID);
-        if( pA )
-        {
-            TArea * pArea = pA;
-            QList<int> roomList = pArea->rooms;
-            float mx = event->pos().x()/mTX + mOx;
-            float my = event->pos().y()/mTY + mOy;
-            mx = mx - xspan/2;
-            my = yspan/2 - my;
-            QPointF pc = QPointF(mx,my);
-            for( int k=0; k<roomList.size(); k++ )
+        if( mMultiSelectionSet.isEmpty() )
+        { // But NOT if got one or more rooms already selected!
+            TArea * pA = mpMap->mpRoomDB->getArea(mAID);
+            if( pA )
             {
-                TRoom * pR = mpMap->mpRoomDB->getRoom(roomList[k]);
-                if( !pR ) continue;
-                QMapIterator<QString, QList<QPointF> > it(pR->customLines);
-                while( it.hasNext() )
-                {
-                    it.next();
-                    const QList<QPointF> & _pL= it.value();
-                    if( _pL.size() )
+                TArea * pArea = pA;
+                float mx = event->pos().x()/mTX + mOx;
+                float my = event->pos().y()/mTY + mOy;
+                mx = mx - xspan/2;
+                my = yspan/2 - my;
+                QPointF pc = QPointF(mx,my);
+                QSetIterator<int> itRoom = pArea->rooms;
+                while( itRoom.hasNext() ) {
+                    int currentRoomId = itRoom.next();
+                    TRoom * pR = mpMap->mpRoomDB->getRoom(currentRoomId);
+                    if( !pR ) continue;
+                    QMapIterator<QString, QList<QPointF> > it(pR->customLines);
+                    while( it.hasNext() )
                     {
-                        // The way this code is structured means that EARLIER
-                        // points are selected in preference to later ones!
-                        // This might not be intuative to the users...
-                        for( int j=0; j<_pL.size(); j++ )
+                        it.next();
+                        const QList<QPointF> & _pL= it.value();
+                        if( _pL.size() )
                         {
-                            float olx, oly, lx, ly;
-                            if( j==0 )
-                            {  // First segment of a custom line
-                               // start it at the centre of the room
-                                olx = pR->x;
-                                oly = pR->y; //FIXME: exit richtung beachten, um den Linienanfangspunkt zu berechnen
-                                lx = _pL[0].x();
-                                ly = _pL[0].y();
-                            }
-                            else
-                            {  // Not the first segment of a custom line
-                               // so start it at the end of the previous one
-                                olx = lx;
-                                oly = ly;
-                                lx = _pL[j].x();
-                                ly = _pL[j].y();
-                            }
-                            // End of each custom line segment is given
+                            // The way this code is structured means that EARLIER
+                            // points are selected in preference to later ones!
+                            // This might not be intuative to the users...
+                            for( int j=0; j<_pL.size(); j++ )
+                            {
+                                float olx, oly, lx, ly;
+                                if( j==0 )
+                                {  // First segment of a custom line
+                                   // start it at the centre of the room
+                                    olx = pR->x;
+                                    oly = pR->y; //FIXME: exit richtung beachten, um den Linienanfangspunkt zu berechnen
+                                    lx = _pL[0].x();
+                                    ly = _pL[0].y();
+                                }
+                                else
+                                {  // Not the first segment of a custom line
+                                   // so start it at the end of the previous one
+                                    olx = lx;
+                                    oly = ly;
+                                    lx = _pL[j].x();
+                                    ly = _pL[j].y();
+                                }
+                                // End of each custom line segment is given
 
-                            // click auf einen edit - punkt
-                            if( mCustomLineSelectedRoom != 0 )
-                            { // We have already choosen a line to edit
-                                if( abs(mx-lx)<=0.25 && abs(my-ly)<=0.25 )
-                                { // And this looks close enough to a point that we should edit it
-                                    mCustomLineSelectedPoint = j;
+                                // click auf einen edit - punkt
+                                if( mCustomLineSelectedRoom != 0 )
+                                { // We have already choosen a line to edit
+                                    if( abs(mx-lx)<=0.25 && abs(my-ly)<=0.25 )
+                                    { // And this looks close enough to a point that we should edit it
+                                        mCustomLineSelectedPoint = j;
+                                        return;
+                                    }
+                                }
+
+                                // We have not previously choosen a line to edit
+                                QLineF line = QLineF(olx,oly, lx,ly);
+                                QLineF normal = line.normalVector();
+                                QLineF tl;
+                                tl.setP1(pc);
+                                tl.setAngle(normal.angle());
+                                tl.setLength(0.1);
+                                QLineF tl2;
+                                tl2.setP1(pc);
+                                tl2.setAngle(normal.angle());
+                                tl2.setLength(-0.1);
+                                QPointF pi;
+                                if(    ( line.intersect( tl, &pi) == QLineF::BoundedIntersection )
+                                    || ( line.intersect( tl2, &pi) == QLineF::BoundedIntersection ) )
+                                { // Choose THIS line to edit as we have clicked close enough to it...
+                                    mCustomLineSelectedRoom = pR->getId();
+                                    mCustomLineSelectedExit = it.key();
+                                    repaint();
                                     return;
                                 }
-                            }
-
-                            // We have not previously choosen a line to edit
-                            QLineF line = QLineF(olx,oly, lx,ly);
-                            QLineF normal = line.normalVector();
-                            QLineF tl;
-                            tl.setP1(pc);
-                            tl.setAngle(normal.angle());
-                            tl.setLength(0.1);
-                            QLineF tl2;
-                            tl2.setP1(pc);
-                            tl2.setAngle(normal.angle());
-                            tl2.setLength(-0.1);
-                            QPointF pi;
-                            if(    ( line.intersect( tl, &pi) == QLineF::BoundedIntersection )
-                                || ( line.intersect( tl2, &pi) == QLineF::BoundedIntersection ) )
-                            { // Choose THIS line to edit as we have clicked close enough to it...
-                                mCustomLineSelectedRoom = pR->getId();
-                                mCustomLineSelectedExit = it.key();
-                                repaint();
-                                return;
                             }
                         }
                     }
                 }
             }
+            mCustomLineSelectedRoom = 0;
+            mCustomLineSelectedExit = "";
         }
-        mCustomLineSelectedRoom = 0;
-        mCustomLineSelectedExit = "";
 
-        if( mRoomBeingMoved )
+        if( mRoomBeingMoved ) // Moving rooms so end that
         {
             mPHighlightMove = event->pos();
             mPick = true;
@@ -2131,121 +2232,177 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
             setMouseTracking(false);
             mRoomBeingMoved = false;
         }
-        else if( ! mPopupMenu )
+        else if( ! mPopupMenu ) // Not in a context menu, so start selection mode - including drag to select
         {
             mMultiSelection = true;
             mMultiRect = QRect(event->pos(), event->pos());
-            {
-                mMultiSelection = true;
-                int _roomID = mRID;
-                if( ! mpMap->mpRoomDB->getRoom( _roomID ) ) return;
-                int _areaID = mAID;
-                TArea * pArea = mpMap->mpRoomDB->getArea(_areaID);
-                if( !pArea ) return;
-                int ox = mOx;
-                int oy = mOy;
-                float _rx;
-                float _ry;
-                if( ox*mTX > xspan/2*mTX )
-                    _rx = -(mTX*ox-xspan/2*mTX);
-                else
-                    _rx = xspan/2*mTX-mTX*ox;
-                if( oy*mTY > yspan/2*mTY )
-                    _ry = -(mTY*oy-yspan/2*mTY);
-                else
-                    _ry = yspan/2*mTY-mTY*oy;
+            int _roomID = mRID;
+            if( ! mpMap->mpRoomDB->getRoom( _roomID ) ) return;
+            int _areaID = mAID;
+            TArea * pArea = mpMap->mpRoomDB->getArea(_areaID);
+            if( !pArea ) return;
+            float _rx = xspan / 2 * mTX - mTX * mOx;
+            float _ry = yspan / 2 * mTY - mTY * mOy;
 
-                QList<int> roomList = pArea->rooms;
-                if( !( event->modifiers().testFlag(Qt::ControlModifier) ) )
-                    mMultiSelectionList.clear();
-                for( int k=0; k<roomList.size(); k++ )
+            if( ! event->modifiers().testFlag(Qt::ControlModifier ) )
+            { // If control key NOT down then clear selection, and put up helpful text
+                mHelpMsg = tr("Drag to select multiple rooms or labels, release to finish...");
+                mMultiSelectionSet.clear();
+            }
+
+            QSetIterator<int> itRoom( pArea->getAreaRooms() );
+            while( itRoom.hasNext() )
+            { // Scan to find rooms in selection
+                int currentAreaRoom = itRoom.next();
+                TRoom * pR = mpMap->mpRoomDB->getRoom( currentAreaRoom );
+                if( !pR ) continue;
+                int rx = pR->x*mTX+_rx;
+                int ry = pR->y*-1*mTY+_ry;
+                int rz = pR->z;
+
+                int mx = event->pos().x();
+                int my = event->pos().y();
+                int mz = mOz;
+                if( (abs(mx-rx)<mTX*rSize/2) && (abs(my-ry)<mTY*rSize/2) && (mz == rz) )
                 {
-                    TRoom * pR = mpMap->mpRoomDB->getRoom(pArea->rooms[k]);
-                    if( !pR ) continue;
-                    int rx = pR->x*mTX+_rx;
-                    int ry = pR->y*-1*mTY+_ry;
-                    int rz = pR->z;
+                    if(    mMultiSelectionSet.contains( currentAreaRoom )
+                        && event->modifiers().testFlag(Qt::ControlModifier) )
+                    {
+                        mMultiSelectionSet.remove( currentAreaRoom );
+                    }
+                    else
+                    {
+                        mMultiSelectionSet.insert( currentAreaRoom );
+                    }
+                    if( mMultiSelectionSet.size() > 0 )
+                    {
+                        mMultiSelection = false;
+                    }
+                }
+            }
+            switch( mMultiSelectionSet.size() )
+            {
+            case 0:
+                mMultiSelectionHighlightRoomId = -1;
+                break;
+            case 1:
+                mMultiSelection = false; // OK, found one room so stop
+                mMultiSelectionHighlightRoomId = mMultiSelectionSet.toList().first();
+                mHelpMsg.clear();
+                break;
+            default:
+                mMultiSelection = false; // OK, found more than one room so stop
+                mHelpMsg.clear();
+                getCenterSelection();
+            }
 
+            // select labels
+            if( mpMap->mapLabels.contains( mAID ) )
+            {
+                QMapIterator<int, TMapLabel> it(mpMap->mapLabels[mAID]);
+                while( it.hasNext() )
+                {
+                    it.next();
+                    if( it.value().pos.z() != mOz )
+                    {
+                        continue;
+                    }
+
+                    QPointF lpos;
+                    float _lx = it.value().pos.x()*mTX+_rx;
+                    float _ly = it.value().pos.y()*mTY*-1+_ry;
+
+                    lpos.setX( _lx );
+                    lpos.setY( _ly );
                     int mx = event->pos().x();
                     int my = event->pos().y();
-                    int mz = mOz;
-                    if( (abs(mx-rx)<mTX*rSize/2) && (abs(my-ry)<mTY*rSize/2) && (mz == rz) )
-                    {
-                        if( mMultiSelectionList.contains( pArea->rooms[k]) && event->modifiers().testFlag(Qt::ControlModifier) )
-                            mMultiSelectionList.removeAll( pArea->rooms[k] );
-                        else
-                            mMultiSelectionList << pArea->rooms[k];
-                        if( mMultiSelectionList.size() > 0 ) mMultiSelection = false;
-                    }
-                }
-
-                // select labels
-                if( mpMap->mapLabels.contains( mAID ) )
-                {
-                    QMapIterator<int, TMapLabel> it(mpMap->mapLabels[mAID]);
-                    while( it.hasNext() )
-                    {
-                        it.next();
-                        if( it.value().pos.z() != mOz ) continue;
-
-                        QPointF lpos;
-                        float _lx = it.value().pos.x()*mTX+_rx;
-                        float _ly = it.value().pos.y()*mTY*-1+_ry;
-
-                        lpos.setX( _lx );
-                        lpos.setY( _ly );
-                        int mx = event->pos().x();
-                        int my = event->pos().y();
 // N/U:                         int mz = mOz;
-                        QPoint click = QPoint(mx,my);
-                        QRectF br = QRect(_lx, _ly, it.value().clickSize.width(), it.value().clickSize.height());
-                        if( br.contains( click ))
+                    QPoint click = QPoint(mx,my);
+                    QRectF br = QRect(_lx, _ly, it.value().clickSize.width(), it.value().clickSize.height());
+                    if( br.contains( click ))
+                    {
+                        if( ! it.value().hilite )
                         {
-                            if( ! it.value().hilite )
-                            {
-                                mLabelHilite = true;
-                                mpMap->mapLabels[mAID][it.key()].hilite = true;
-                            }
-                            else
-                            {
-                                mpMap->mapLabels[mAID][it.key()].hilite = false;
-                                mLabelHilite = false;
-                            }
-                            update();
-                            return;
+                            mLabelHilite = true;
+                            mpMap->mapLabels[mAID][it.key()].hilite = true;
                         }
+                        else
+                        {
+                            mpMap->mapLabels[mAID][it.key()].hilite = false;
+                            mLabelHilite = false;
+                        }
+                        update();
+                        return;
                     }
                 }
-
-                mLabelHilite = false;
-                update();
             }
-            if( mMultiSelection && mMultiSelectionList.size() > 0 && ( event->modifiers().testFlag(Qt::ControlModifier) ) ) mMultiSelection = false;
+
+            mLabelHilite = false;
+            update();
+
+            if( mMultiSelection && mMultiSelectionSet.size() > 0 && ( event->modifiers().testFlag(Qt::ControlModifier) ) )
+            {
+                // We were dagging multi-selection rectange, we had selected at
+                // least one room and the user has <CTRL>-clicked with the mouse
+                // so switch off the dragging
+                mMultiSelection = false;
+                mHelpMsg.clear();
+            }
 
         }
         else
+        { // In popup menu, so end that
             mPopupMenu = false;
+        }
 
         // display room selection list widget if more than 1 room has been selected
-        // -> user can manually change currennt selection if rooms are overlapping
-        if( mMultiSelectionList.size() > 1 )
+        // -> user can manually change current selection if rooms are overlapping
+        if( mMultiSelectionSet.size() > 1 )
         {
+            mMultiSelectionListWidget.blockSignals(true); // We don't want to cause calls to slot_roomSelectionChanged() here!
+            mIsSelectionSorting = mMultiSelectionListWidget.isSortingEnabled();
+            mIsSelectionSortByNames = (mMultiSelectionListWidget.sortColumn() == 1);
             mMultiSelectionListWidget.clear();
-            for( int i=0; i<mMultiSelectionList.size(); i++ )
+            mMultiSelectionListWidget.setSortingEnabled(false); // Do NOT sort whilst inserting items!
+            QSetIterator<int> itRoom = mMultiSelectionSet;
+            mIsSelectionUsingNames = false;
+            while( itRoom.hasNext() )
             {
                 QTreeWidgetItem * _item = new QTreeWidgetItem;
-                _item->setText(0,QString::number(mMultiSelectionList[i]));
+                int multiSelectionRoomId = itRoom.next();
+                _item->setText(0,QStringLiteral("%1").arg(multiSelectionRoomId,7)); // Pad with spaces so sorting works
+                _item->setTextAlignment(0, Qt::AlignRight);
+                TRoom * pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
+                if( pR_multiSelection )
+                {
+                    QString multiSelectionRoomName = pR_multiSelection->name;
+                    if( ! multiSelectionRoomName.isEmpty() )
+                    {
+                        _item->setText(1,multiSelectionRoomName);
+                        _item->setTextAlignment(1, Qt::AlignLeft);
+                        mIsSelectionUsingNames = true;
+                    }
+                }
                 mMultiSelectionListWidget.addTopLevelItem( _item );
             }
-            mMultiSelectionListWidget.setSelectionMode(QAbstractItemView::ExtendedSelection);
+            mMultiSelectionListWidget.setColumnHidden(1, !mIsSelectionUsingNames );
+            // Can't sort if nothing to sort on, switch to sorting by room number
+            if( (! mIsSelectionUsingNames) && mIsSelectionSortByNames && mIsSelectionSorting )
+            {
+                mIsSelectionSortByNames = false;
+            }
+            mMultiSelectionListWidget.sortByColumn( mIsSelectionSortByNames ? 1 : 0 );
+            mMultiSelectionListWidget.setSortingEnabled(mIsSelectionSorting);
+            resizeMultiSelectionWidget();
             mMultiSelectionListWidget.selectAll();
+            mMultiSelectionListWidget.blockSignals(false);
             mMultiSelectionListWidget.show();
-
+            update();
         }
         else
+        {
             mMultiSelectionListWidget.hide();
-
-        update();
+        }
     }
 
 
@@ -2303,10 +2460,10 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
             action3->setStatusTip(tr("change room color"));
             connect( action3, SIGNAL(triggered()), this, SLOT(slot_changeColor()));
             QAction * action4 = new QAction("spread", this );
-            action4->setStatusTip(tr("increase map grid size for the selected group of rooms"));
+            action4->setStatusTip(tr("increase map X-Y spacing for the selected group of rooms"));
             connect( action4, SIGNAL(triggered()), this, SLOT(slot_spread()));
             QAction * action9 = new QAction("shrink", this );
-            action9->setStatusTip(tr("shrink map grid size for the selected group of rooms"));
+            action9->setStatusTip(tr("decrease map X-Y spacing for the selected group of rooms"));
             connect( action9, SIGNAL(triggered()), this, SLOT(slot_shrink()));
 
             //QAction * action5 = new QAction("user data", this );
@@ -2354,13 +2511,21 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
                 connect( action14, SIGNAL(triggered()), this, SLOT(slot_setCustomLine()));
             }
 
-            QAction * action15 = new QAction("Create Label", this );
+            QAction * action15 = new QAction("create Label", this );
             action15->setStatusTip(tr("Create labels to show text or images."));
             connect( action15, SIGNAL(triggered()), this, SLOT(slot_createLabel()));
 
-//            QAction * action16 = new QAction("Set Location Here", this );
-//            action16->setStatusTip(tr("Set player location here."));
-//            connect( action16, SIGNAL(triggered()), this, SLOT(slot_setPlayerLocation()));
+            QAction * action16 = new QAction("set location", this );
+            if( mMultiSelectionSet.size() == 1 )
+            { // Only enable if ONE room is highlighted
+                action16->setStatusTip(tr("set player current location to here"));
+                connect( action16, SIGNAL(triggered()), this, SLOT(slot_setPlayerLocation()));
+            }
+            else
+            {
+                action16->setEnabled(false);
+                action16->setStatusTip(tr("cannot set location when not exactly one room selected"));
+            }
 
             mPopupMenu = true;
 //            QMenu * popup = new QMenu( this );
@@ -2383,7 +2548,7 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
             popup->addAction( action13 );
 
             popup->addAction( action15 );
-            //popup->addAction( action16 );
+            popup->addAction( action16 );
 
             popup->popup( mapToGlobal( event->pos() ) );
         }
@@ -2766,7 +2931,7 @@ void T2DMap::slot_doneCustomLine()
     mCustomLinesRoomFrom = 0;
     mCustomLinesRoomTo = 0;
     mCustomLinesRoomExit.clear();
-    if( mMultiSelectionList.size()>0)
+    if( mMultiSelectionSet.size()>0)
     {
         TRoom * pR = mpMap->mpRoomDB->getRoom(mCustomLineSelectedRoom);
         if( pR )
@@ -2834,52 +2999,53 @@ void T2DMap::slot_editLabel()
 {
 }
 
-//FIXME:
 void T2DMap::slot_setPlayerLocation()
 {
-    if( mMultiSelectionList.size() <= 1 ) return;
-    TLuaInterpreter * LuaInt = mpHost->getLuaInterpreter();
-    QString t1 = "mRoomSet";
-    QString room;
-    int _rid = mMultiSelectionList[0];
-    room.setNum(_rid);
-    if( mpMap->mpRoomDB->getRoom(_rid) )
-    {
-        mpMap->mRoomId = _rid;
+    if( mMultiSelectionSet.size() != 1 ) {
+        return; // Was <= 1 but that can't be right, and >1 doesn't seem right either
+    }
+
+    int _newRoomId = *( mMultiSelectionSet.constBegin() );
+    if( mpMap->mpRoomDB->getRoom( _newRoomId ) ) {
+        // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
+        mpMap->mRoomId = _newRoomId;
         mpMap->mNewMove = true;
+        TEvent manualSetEvent;
+        manualSetEvent.mArgumentList.append( QStringLiteral( "sysManualLocationSetEvent" ) );
+        manualSetEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        manualSetEvent.mArgumentList.append( QString::number( _newRoomId ) );
+        manualSetEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mpHost->raiseEvent( manualSetEvent );
         update();
-        LuaInt->set_lua_string( t1, room );
-        QString f = "doRoomSet";
-        QString n = "";
-        LuaInt->call(f, n);
     }
 }
 
-void T2DMap::slot_userAction(QString uniqueName){
+void T2DMap::slot_userAction(QString uniqueName)
+{
     TEvent event;
     QStringList userEvent = mUserActions[uniqueName];
     event.mArgumentList.append( userEvent[0] );
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(uniqueName );
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    QList<int> roomList = mMultiSelectionList;
-    if( roomList.size() )
+    QSetIterator<int> itRoom(mMultiSelectionSet);
+    if( itRoom.hasNext() )
     {
-        QList<int> roomList = mMultiSelectionList;
-        QList<int>::iterator i;
-        for (i = roomList.begin();i != roomList.end(); ++i)
+        while( itRoom.hasNext() )
         {
-            event.mArgumentList.append(QString::number(*i));
+            event.mArgumentList.append(QString::number(itRoom.next()));
             event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
         }
         mpHost->raiseEvent( event );
     }
-    else if( mMultiSelectionList.size() > 0 )
-    {
-        event.mArgumentList.append(QString::number(mMultiSelectionList[0]));
-        event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        mpHost->raiseEvent( event );
-    }
+// Unreachable code as had effectively the same test as the previous "if"
+// mMultiSelectionList is now mMultiSelectionSet:
+//    else if( mMultiSelectionList.size() > 0 )
+//    {
+//        event.mArgumentList.append(QString::number(mMultiSelectionList[0]));
+//        event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+//        mpHost->raiseEvent( & event );
+//    }
     else
     {
         event.mArgumentList.append(uniqueName);
@@ -2895,8 +3061,16 @@ void T2DMap::slot_userAction(QString uniqueName){
 
 void T2DMap::slot_movePosition()
 {
+    if( ! getCenterSelection() )
+    {
+        return;
+    }
+
+    TRoom * pR_start = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
+    // pR has already been validated by getCenterSelection()
+
     QDialog * pD = new QDialog(this);
-    QVBoxLayout * pL = new QVBoxLayout;
+    QGridLayout * pL = new QGridLayout;
     pD->setLayout( pL );
     pD->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     pD->setContentsMargins(0,0,0,0);
@@ -2904,23 +3078,21 @@ void T2DMap::slot_movePosition()
     QLineEdit * pLEy = new QLineEdit(pD);
     QLineEdit * pLEz = new QLineEdit(pD);
 
-    if( mMultiSelectionList.size() < 1 ) return;
-    TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[0]);
-    if( !pR ) return;
-
-    pLEx->setText(QString::number(pR->x));
-    pLEy->setText(QString::number(pR->y));
-    pLEz->setText(QString::number(pR->z));
-    QLabel * pLa1 = new QLabel("x coordinate");
-    QLabel * pLa2 = new QLabel("y coordinate");
-    QLabel * pLa3 = new QLabel("z coordinate");
-    pL->addWidget(pLa1);
-    pL->addWidget(pLEx);
-    pL->addWidget(pLa2);
-    pL->addWidget(pLEy);
-    pL->addWidget(pLa3);
-    pL->addWidget(pLEz);
-
+    pLEx->setText(QString::number(pR_start->x));
+    pLEy->setText(QString::number(pR_start->y));
+    pLEz->setText(QString::number(pR_start->z));
+    QLabel * pLa0 = new QLabel( tr("Move the selection, centered on\nthe highlighted room (%1) to:").arg(mMultiSelectionHighlightRoomId) );
+    // Record the starting coordinates - can be a help when working out how to move a block of rooms!
+    QLabel * pLa1 = new QLabel( tr("x coordinate (was %1):").arg(pR_start->x) );
+    QLabel * pLa2 = new QLabel( tr("y coordinate (was %1):").arg(pR_start->y) );
+    QLabel * pLa3 = new QLabel( tr("z coordinate (was %1):").arg(pR_start->z) );
+    pL->addWidget(pLa0,0,0,1,2,Qt::AlignCenter);
+    pL->addWidget(pLa1,1,0,Qt::AlignVCenter|Qt::AlignRight);
+    pL->addWidget(pLEx,1,1,Qt::AlignVCenter|Qt::AlignLeft);
+    pL->addWidget(pLa2,2,0,Qt::AlignVCenter|Qt::AlignRight);
+    pL->addWidget(pLEy,2,1,Qt::AlignVCenter|Qt::AlignLeft);
+    pL->addWidget(pLa3,3,0,Qt::AlignVCenter|Qt::AlignRight);
+    pL->addWidget(pLEz,3,1,Qt::AlignVCenter|Qt::AlignLeft);
     QWidget * pButtonBar = new QWidget(pD);
 
     QHBoxLayout * pL2 = new QHBoxLayout;
@@ -2936,36 +3108,28 @@ void T2DMap::slot_movePosition()
     pB_abort->setText("Cancel");
     connect(pB_abort, SIGNAL(clicked()), pD, SLOT(reject()));
     pL2->addWidget(pB_abort);
-    pL->addWidget(pButtonBar);
+    pL->addWidget(pButtonBar,4,0,1,2,Qt::AlignCenter);
 
-    pD->exec();
-    int x,y,z;
-    x = pLEx->text().toInt();
-    y = pLEy->text().toInt();
-    z = pLEz->text().toInt();
-
-    if( mMultiSelectionList.size() < 1 ) return;
-    int topLeftCorner = getTopLeftSelection();
-    if( topLeftCorner < 0 || topLeftCorner >= mMultiSelectionList.size() ) return;
-
-    pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[topLeftCorner]);
-    if( ! pR ) return;
-
-    int dx,dy;
-
-    dx = x - pR->x;
-    dy = y - pR->y;
-    int dz = z - pR->z;
-
-    mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
+    if( pD->exec() == QDialog::Accepted )
     {
-        pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
-        if( pR )
+        int dx = pLEx->text().toInt() - pR_start->x;
+        int dy = pLEy->text().toInt() - pR_start->y;
+        int dz = pLEz->text().toInt() - pR_start->z;
+
+        mMultiRect = QRect(0,0,0,0);
+
+        QSetIterator<int> itRoom = mMultiSelectionSet;
+        while( itRoom.hasNext() )
         {
-            pR->x+=dx;
-            pR->y+=dy;
-            pR->z+=dz;
+            TRoom *pR = mpMap->mpRoomDB->getRoom( itRoom.next() );
+            if( ! pR )
+            {
+                continue;
+            }
+
+            pR->x += dx;
+            pR->y += dy;
+            pR->z += dz;
         }
     }
     repaint();
@@ -2980,17 +3144,211 @@ void T2DMap::slot_moveRoom()
 
 }
 
-
+// TODO: Convert pR->c (a single ASCII character) to pR->symbol (a single Unicode Grapheme, possibly containing several QChars - as a QString)
 void T2DMap::slot_setCharacter()
 {
-    if( mMultiSelectionList.size() < 1 ) return;
-    TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[0]);
-    if( pR )
+// Now analysises and reports the existing letters used in ALL the selected
+// rooms if more than once (and sorts by their frequency)
+// Also allows the existing letters to be deleted (by clearing all the displayed
+// letters) as previous code DID NOT - and the Cancel option works as well!
+    if( mMultiSelectionSet.size() < 1 )
     {
-        QString s = QInputDialog::getText(this,"enter marker letter","letter");
-        if( s.size() < 1 ) return;
-        pR->c = s[0].toLatin1();
-        repaint();
+        return;
+    }
+
+    // First scan and count all the different letters used
+    QMap<QString, uint> usedLetters;
+    QSetIterator<int> itRoom = mMultiSelectionSet;
+    TRoom * pR;
+    while( itRoom.hasNext() )
+    {
+        pR = mpMap->mpRoomDB->getRoom( itRoom.next() ) ;
+        if( !pR )
+        {
+            continue;
+        }
+
+        if( pR->c )
+        {
+            QString thisLetter = QString(pR->c);
+            if( ! thisLetter.isEmpty() )
+            {
+                if( usedLetters.contains(thisLetter) )
+                {
+                    usedLetters[thisLetter] += 1;
+                }
+                else
+                {
+                    usedLetters[thisLetter] = 1;
+                }
+            }
+        }
+    }
+
+    QString newLetterText;
+    bool isOk = false;
+    // Choose most appropriate text depending on number of rooms selected and
+    // how many of them have letters already:
+    if( mMultiSelectionSet.size() == 1)
+    {
+        if( usedLetters.isEmpty() )
+        {
+            newLetterText = QInputDialog::getText( this, // QWidget * parent
+                                               tr("Enter room marker"), // const QString & title
+                                               tr("Enter new (not space)\n"
+                                                  "marker letter:"), // const QString & label
+                                               QLineEdit::Normal, // QLineEdit::EchoMode mode = QLineEdit::Normal
+                                               QStringLiteral(""), // const QString & text = QString()
+                                               &isOk, // bool * ok = 0
+                                               0, // Qt::WindowFlags flags = 0
+                                               Qt::ImhLatinOnly ); // Qt::InputMethodHints inputMethodHints = Qt::ImhNone
+        }
+        else
+        {
+            newLetterText = QInputDialog::getText( this,
+                                               tr("Enter rooom marker"),
+                                               tr("Delete the existing, or\n"
+                                                  "enter a new (non-space),\n"
+                                                  "marker letter:"),
+                                               QLineEdit::Normal,
+                                               usedLetters.keys().first(),
+                                               &isOk,
+                                               0,
+                                               Qt::ImhLatinOnly );
+        }
+    }
+    else
+    {
+        if( usedLetters.isEmpty() )
+        {
+            newLetterText = QInputDialog::getText( this,
+                                               tr("Enter room marker"),
+                                               tr("Enter new (not space)\n"
+                                                  "marker letter:"),
+                                               QLineEdit::Normal,
+                                               QStringLiteral(""),
+                                               &isOk,
+                                               0,
+                                               Qt::ImhLatinOnly );
+        }
+        else if( usedLetters.size() == 1 )
+        {
+            newLetterText = QInputDialog::getText( this,
+                                               tr("Enter room marker"),
+                                               tr("Delete the (only)\n"
+                                                  "existing (in some rooms),\n"
+                                                  "or enter a new (not\n"
+                                                  "space) marker letter for\n"
+                                                  "all selected rooms:"),
+                                               QLineEdit::Normal,
+                                               usedLetters.keys().first(),
+                                               &isOk,
+                                               0,
+                                               Qt::ImhLatinOnly );
+        }
+        else
+        {
+            QMapIterator<QString, uint> itSymbolUsed = usedLetters;
+            QSet<uint> symbolCountsSet;
+            while( itSymbolUsed.hasNext() )
+            {
+                itSymbolUsed.next();
+                symbolCountsSet.insert( itSymbolUsed.value() );
+            }
+            QList<uint> symbolCountsList = symbolCountsSet.toList();
+            if( symbolCountsList.size() > 1 )
+            {
+                std::sort( symbolCountsList.begin(), symbolCountsList.end() );
+            }
+            QStringList displayStrings;
+            for( int i = symbolCountsList.size()-1; i >= 0; --i )
+            {
+                itSymbolUsed.toFront();
+                while( itSymbolUsed.hasNext() )
+                {
+                    itSymbolUsed.next();
+                    if( itSymbolUsed.value() == symbolCountsList.at(i) )
+                    {
+                        displayStrings.append( tr("%1 {count:%2}").arg(itSymbolUsed.key()).arg(itSymbolUsed.value()));
+                    }
+                }
+            }
+            newLetterText = QInputDialog::getItem( this, // QWidget * parent
+                                                           tr("Enter room marker"), // const QString & title
+                                                           tr("Choose an existing marker\n"
+                                                              "letter) from the list\n"
+                                                              "(sorted by most commonly\n"
+                                                              "used first) or enter a\n"
+                                                              "new single ASCII\n"
+                                                              "character (not space) for\n"
+                                                              "all selected rooms:",
+                                                              // Intentional comment to separate two strings!
+                                                              "Use line feeds to format text into a reasonable rectangle."), // const QString & label
+                                                           displayStrings, // QStringList & items
+                                                           0, // int current = 0
+                                                           true, // bool editable = true
+                                                           &isOk, // bool * ok = 0
+                                                           0, // Qt::WindowFlags flags = 0
+                                                           Qt::ImhLatinOnly); // Qt::InputMethodHints inputMethodHints = Qt::ImhNone,
+                                                              // to change when I rework the room symbols for any Unicode Grapheme!
+        }
+    }
+
+    QString newLetter;
+    if( isOk )
+    {  // Don't proceed if cancel was pressed, will need revision to extract the
+       // first grapheme when we support all printable unicode characters as room symbols!
+        if( newLetterText.isEmpty() )
+        {
+            newLetter = QStringLiteral(" ");
+        }
+        else if( ! newLetterText.at(0).isHighSurrogate() )
+        { // The first QChar of the QString is NOT the start of a Unicode character beyond the BMP!
+            if( newLetterText.at(0).row() == 0 )
+            { // The first QChar of the QString has a zero high byte
+                if( newLetterText.at(0).cell() < 128 )
+                { // The first QChar of the QString has a low byte within the range for ASCII
+                    newLetter = newLetterText.at(0);
+                }
+                else
+                {
+                    isOk = false; // Prevent any change if the value is not reasonable
+                }
+            }
+            else
+            {
+                isOk = false; // Prevent any change if the value is not reasonable
+            }
+        }
+        else
+        {
+            isOk = false; // Prevent any change if the value is not reasonable
+        }
+    }
+
+    if( isOk )
+    {
+        itRoom.toFront();
+        while( itRoom.hasNext() )
+        {
+            pR = mpMap->mpRoomDB->getRoom( itRoom.next() ) ;
+            if( !pR )
+            {
+                continue;
+            }
+
+            if( newLetter.at(0) == QStringLiteral(" ") )
+            {
+                if( pR->c )
+                {
+                    pR->c = 0;
+                }
+            }
+            else
+            {
+                pR->c = newLetter.at(0).toLatin1();
+            }
+        }
     }
 }
 
@@ -3002,8 +3360,8 @@ void T2DMap::slot_setImage()
 
 void T2DMap::slot_deleteRoom()
 {
-    mpMap->mpRoomDB->removeRoom( mMultiSelectionList );
-    // mMultiSelectionList gets cleared as rooms are removed by
+    mpMap->mpRoomDB->removeRoom( mMultiSelectionSet );
+    // mMultiSelectionSet gets cleared as rooms are removed by
     // TRoomDB::removeRoom() so no need to clear it here!
     mMultiRect = QRect(0,0,0,0);
     mMultiSelectionListWidget.clear();
@@ -3070,7 +3428,6 @@ void T2DMap::slot_changeColor()
     while( it.hasNext() )
     {
         it.next();
-// N/U:         int env = it.key();
         QColor c;
         c = it.value();
         QListWidgetItem * pI = new QListWidgetItem( pLW );
@@ -3082,127 +3439,169 @@ void T2DMap::slot_changeColor()
         pLW->addItem(pI);
     }
 
-    pD->exec();
-
-    mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
-    {
-        TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
-        if( pR )
+    if( pD->exec() == QDialog::Accepted && mpMap->customEnvColors.contains( mChosenRoomColor) )
+    { // Only proceed if OK - "abort" now prevents change AND check for a valid
+      // color here rather than inside the room change loop as before (only test
+      // once rather than for each room)
+        mMultiRect = QRect(0,0,0,0);
+        QSetIterator<int> itSelectedRoom( mMultiSelectionSet );
+        while( itSelectedRoom.hasNext() )
         {
-            if( mpMap->customEnvColors.contains( mChosenRoomColor) )
+            TRoom * pR = mpMap->mpRoomDB->getRoom( itSelectedRoom.next() );
+            if( pR )
             {
                 pR->environment = mChosenRoomColor;
             }
         }
-    }
 
-    update();
+        update();
+    }
 }
 
 void T2DMap::slot_spread()
 {
-    int spread = QInputDialog::getInt(this, "spread out selected rooms","spread out selected rooms by:",5);
-    if( spread == 0 ) return;
-    mMultiRect = QRect(0,0,0,0);
-    if( mMultiSelectionList.size() < 2 ) return;
-    int lid = getTopLeftSelection();
-    int id;
-    if( lid > -1 )
-        id = mMultiSelectionList[lid];
-    else
-    {
+    if( mMultiSelectionSet.size() < 2 )
+    { // nothing to do!
         return;
     }
-    TRoom * pR = mpMap->mpRoomDB->getRoom(id);
-    if( !pR ) return;
-    int x = pR->x;
-    int y = pR->y;
-    int dx = x - x*spread;
-    int dy = y - y*spread;
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
+
+    TRoom * pR_centerRoom = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
+    if( ! pR_centerRoom ) {
+        return;
+    }
+
+    // Move the dialog down to here so it doesn't fire up for some already
+    // determined to be null (no change) case, also handle "Cancel" being pressed
+    bool isOk = false;
+    int spread = QInputDialog::getInt( this,
+                                       tr("Spread out rooms"),
+                                       tr("Increase the spacing of\n"
+                                          "the selected rooms,\n"
+                                          "centered on the\n"
+                                          "highlighted room by a\n"
+                                          "factor of:"),
+                                       5, // Initial value
+                                       1, // Minimum value
+                                       2147483647,// Maximum value
+                                       1, // Step
+                                       &isOk );
+    if( spread == 1 || !isOk) {
+        return;
+    }
+
+    mMultiRect = QRect(0,0,0,0);
+    int dx = pR_centerRoom->x * ( 1 - spread );
+    int dy = pR_centerRoom->y * ( 1 - spread );
+    QSetIterator<int> itSelectionRoom = mMultiSelectionSet;
+    while( itSelectionRoom.hasNext() )
     {
-        pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
-        if( !pR ) continue;
-        pR->x *= spread;
-        pR->y *= spread;
-        pR->x += dx;
-        pR->y += dy;
-        QMapIterator<QString, QList<QPointF> > itk(pR->customLines);
-        QMap<QString, QList<QPointF> > newMap;
-        while( itk.hasNext() )
+        TRoom * pMovingR = mpMap->mpRoomDB->getRoom( itSelectionRoom.next() );
+        if( !pMovingR )
         {
-            itk.next();
-            QList<QPointF> _pL = itk.value();
-            for( int pk=0; pk<_pL.size(); pk++ )
-            {
-                QPointF op = _pL[pk];
-                _pL[pk].setX( (float)(op.x()*spread+dx) );
-                _pL[pk].setY( (float)(op.y()*spread+dy) );
-            }
-            newMap.insert(itk.key(), _pL );
+            continue;
         }
-        pR->customLines = newMap;
-        pR->calcRoomDimensions();
+
+        pMovingR->x *= spread;
+        pMovingR->y *= spread;
+        pMovingR->x += dx;
+        pMovingR->y += dy;
+        QMapIterator<QString, QList<QPointF> > itCustomLine( pMovingR->customLines );
+        QMap<QString, QList<QPointF> > newCustomLinePointsMap;
+        while( itCustomLine.hasNext() )
+        {
+            itCustomLine.next();
+            QList<QPointF> customLinePoints = itCustomLine.value();
+            for( int pointIndex=0; pointIndex< customLinePoints.size(); pointIndex++ )
+            {
+                QPointF movingPoint = customLinePoints.at( pointIndex );
+                customLinePoints[pointIndex].setX( (float)(movingPoint.x()*spread+dx) );
+                customLinePoints[pointIndex].setY( (float)(movingPoint.y()*spread+dy) );
+            }
+            newCustomLinePointsMap.insert( itCustomLine.key(), customLinePoints );
+        }
+        pMovingR->customLines = newCustomLinePointsMap;
+        pMovingR->calcRoomDimensions();
     }
     repaint();
 }
 
 void T2DMap::slot_shrink()
 {
-    int spread = QInputDialog::getInt(this, "spread out selected rooms","spread out selected rooms by:",5);
-    if( spread == 0 ) return;
-    mMultiRect = QRect(0,0,0,0);
-    if( mMultiSelectionList.size() < 2 ) return;
-    int lid = getTopLeftSelection();
-    int id;
-    if( lid > -1 )
-        id = mMultiSelectionList[lid];
-    else
-    {
+    if( mMultiSelectionSet.size() < 2 )
+    { // nothing to do!
         return;
     }
-    TRoom * pR = mpMap->mpRoomDB->getRoom(id);
-    if( !pR ) return;
-    int x = pR->x;
-    int y = pR->y;
-    int dx = x - x/spread;
-    int dy = y - y/spread;
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
+
+    TRoom * pR_centerRoom = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
+    if( ! pR_centerRoom ) {
+        return;
+    }
+
+    // Move the dialog down to here so it doesn't fire up for some already
+    // determined to be null (no change) case, also handle "Cancel" being pressed
+    bool isOk = false;
+    int spread = QInputDialog::getInt( this,
+                                       tr("Shrink in rooms"),
+                                       tr("Decrease the spacing of\n"
+                                          "the selected rooms,\n"
+                                          "centered on the\n"
+                                          "highlighted room by a\n"
+                                          "factor of:"),
+                                       5, // Initial value
+                                       1, // Minimum value
+                                       2147483647,// Maximum value
+                                       1, // Step
+                                       &isOk );
+    if( spread == 1 || !isOk) {
+        return;
+    }
+
+    mMultiRect = QRect(0,0,0,0);
+    int dx = pR_centerRoom->x * ( 1 - 1 / spread );
+    int dy = pR_centerRoom->y * ( 1 - 1 / spread );
+
+    QSetIterator<int> itSelectionRoom( mMultiSelectionSet );
+    while( itSelectionRoom.hasNext() )
     {
-        pR = mpHost->mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
-        if( !pR ) continue;
-        pR->x /= spread;
-        pR->y /= spread;
-        pR->x += dx;
-        pR->y += dy;
-        QMapIterator<QString, QList<QPointF> > itk(pR->customLines);
-        QMap<QString, QList<QPointF> > newMap;
-        while( itk.hasNext() )
+        TRoom * pMovingR = mpMap->mpRoomDB->getRoom( itSelectionRoom.next() );
+        if( !pMovingR )
         {
-            itk.next();
-            QList<QPointF> _pL = itk.value();
-            for( int pk=0; pk<_pL.size(); pk++ )
-            {
-                QPointF op = _pL[pk];
-                _pL[pk].setX( (float)(op.x()/spread+dx) );
-                _pL[pk].setY( (float)(op.y()/spread+dy) );
-            }
-            newMap.insert(itk.key(), _pL );
+            continue;
         }
-        pR->customLines = newMap;
-        pR->calcRoomDimensions();
+        pMovingR->x /= spread;
+        pMovingR->y /= spread;
+        pMovingR->x += dx;
+        pMovingR->y += dy;
+        QMapIterator<QString, QList<QPointF> > itCustomLine( pMovingR->customLines );
+        QMap<QString, QList<QPointF> > newCustomLinePointsMap;
+        while( itCustomLine.hasNext() )
+        {
+            itCustomLine.next();
+            QList<QPointF> customLinePoints = itCustomLine.value();
+            for( int pointIndex=0; pointIndex< customLinePoints.size(); pointIndex++ )
+            {
+                QPointF movingPoint = customLinePoints.at( pointIndex );
+                customLinePoints[pointIndex].setX( (float)(movingPoint.x()/spread+dx) );
+                customLinePoints[pointIndex].setY( (float)(movingPoint.y()/spread+dy) );
+            }
+            newCustomLinePointsMap.insert( itCustomLine.key(), customLinePoints );
+        }
+        pMovingR->customLines = newCustomLinePointsMap;
+        pMovingR->calcRoomDimensions();
     }
     repaint();
 }
 
 void T2DMap::slot_setExits()
 {
-    if( mMultiSelectionList.size() < 1 ) return;
-    if( mpMap->mpRoomDB->getRoom( mMultiSelectionList[0] ) )
+    if( mMultiSelectionSet.size() < 1 )
+    {
+        return;
+    }
+    if( mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId ) )
     {
         dlgRoomExits * pD = new dlgRoomExits( mpHost, this );
-        pD->init( mMultiSelectionList[0] );
+        pD->init( mMultiSelectionHighlightRoomId );
         pD->show();
         pD->raise();
     }
@@ -3216,10 +3615,15 @@ void T2DMap::slot_setUserData()
 
 void T2DMap::slot_lockRoom()
 {
+    if( mMultiSelectionSet.size() < 1 ) {
+        return;
+    }
+
     mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
+    QSetIterator<int> itSelectedRoom( mMultiSelectionSet );
+    while( itSelectedRoom.hasNext() )
     {
-        TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
+        TRoom * pR = mpMap->mpRoomDB->getRoom( itSelectedRoom.next() );
         if( pR )
         {
             pR->isLocked = true;
@@ -3230,10 +3634,15 @@ void T2DMap::slot_lockRoom()
 
 void T2DMap::slot_unlockRoom()
 {
+    if( mMultiSelectionSet.size() < 1 ) {
+        return;
+    }
+
     mMultiRect = QRect(0,0,0,0);
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
+    QSetIterator<int> itSelectedRoom( mMultiSelectionSet );
+    while( itSelectedRoom.hasNext() )
     {
-        TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
+        TRoom * pR = mpMap->mpRoomDB->getRoom( itSelectedRoom.next() );
         if( pR )
         {
             pR->isLocked = false;
@@ -3244,28 +3653,158 @@ void T2DMap::slot_unlockRoom()
 
 void T2DMap::slot_setRoomWeight()
 {
-
-
-    if( mMultiSelectionList.size() > 0 )
+    if( mMultiSelectionSet.isEmpty() )
     {
-        int _w;
-        TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[0]);
-        if( !pR ) return;
-        if( mMultiSelectionList.size() == 1 )
-            _w = pR->getWeight();
-        else
-            _w = 1;
-        int w = QInputDialog::getInt(this,"Enter a room weight (= travel time)","room weight:", _w);
-        mMultiRect = QRect(0,0,0,0);
-        for( int j=0; j<mMultiSelectionList.size(); j++ )
+        return;
+    }
+
+    // First scan and count all the different weights used
+    QMap<uint, uint> usedWeights; // key is weight, value is count of uses
+    QSetIterator<int> itSelectedRoom = mMultiSelectionSet;
+    TRoom * pR;
+    while( itSelectedRoom.hasNext() )
+    {
+        pR = mpMap->mpRoomDB->getRoom( itSelectedRoom.next() );
+        if( !pR )
         {
-            pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
-            if( pR )
+            continue;
+        }
+
+        int w = pR->getWeight();
+        if( w > 0 )
+        {
+            if( usedWeights.contains( w ) )
             {
-                pR->setWeight(w);
-                mpMap->mMapGraphNeedsUpdate = true;
+                usedWeights[w] += 1;
+            }
+            else
+            {
+                usedWeights[w] = 1;
             }
         }
+    }
+
+    int newWeight = 1;
+    bool isOk = false;
+    // Choose most appropriate weight dialog on number of rooms selected and
+    // how many of them have different weights already:
+    if( mMultiSelectionSet.size() == 1)
+    { // Just one room selected
+        newWeight = QInputDialog::getInt(this,
+                                         tr( "Enter room weight" ),
+                                         tr( "Enter new roomweight\n"
+                                             "(= travel time), mimimum\n"
+                                             "(and default) is 1:", "Use line feeds to format text into a reasonable rectangle." ),
+                                         usedWeights.keys().first(),
+                                         1,
+                                         2147483647,
+                                         1,
+                                         &isOk);
+    }
+    else
+    { // More than one room selected
+        if( usedWeights.size() == 1 )
+        {
+            newWeight = QInputDialog::getInt(this,
+                                             tr( "Enter room weight" ),
+                                             tr( "Enter new roomweight\n"
+                                                 "(= travel time) for all\n"
+                                                 "selected rooms, mimimum\n"
+                                                 "(and default) is 1 and\n"
+                                                 "the only current value\n"
+                                                 "used is:", "Use line feeds to format text into a reasonable rectangle." ),
+                                             usedWeights.keys().first(),
+                                             1,
+                                             2147483647,
+                                             1,
+                                             &isOk);
+        }
+        else
+        {
+            QMapIterator<uint, uint> itWeightsUsed = usedWeights;
+            // Obtain a set of "used" weights
+            QSet<uint> weightCountsSet;
+            while( itWeightsUsed.hasNext() )
+            {
+                itWeightsUsed.next();
+                weightCountsSet.insert( itWeightsUsed.value() );
+            }
+            // Obtains a list of those weights sorted in ascending count of used
+            QList<uint> weightCountsList = weightCountsSet.toList();
+            if( weightCountsList.size() > 1 )
+            {
+                std::sort( weightCountsList.begin(), weightCountsList.end() );
+            }
+            // Build a list of the "used" weights in decending count of use
+            QStringList displayStrings;
+            for( int i = weightCountsList.size()-1; i >= 0; --i )
+            {
+                itWeightsUsed.toFront();
+                while( itWeightsUsed.hasNext() )
+                {
+                    itWeightsUsed.next();
+                    if( itWeightsUsed.value() == weightCountsList.at(i) )
+                    {
+                        if( itWeightsUsed.key() == 1 )
+                        { // Indicate the "default" value which is unity weight
+                            displayStrings.append( tr("%1 {count:%2, default}").arg(itWeightsUsed.key()).arg(itWeightsUsed.value()));
+                        }
+                        else
+                        {
+                            displayStrings.append( tr("%1 {count:%2}").arg(itWeightsUsed.key()).arg(itWeightsUsed.value()));
+                        }
+                    }
+                }
+            }
+            if( ! usedWeights.contains(1) )
+            { // If unity weight was not used insert it at end of list
+                displayStrings.append( tr("1 {count 0, default}") );
+            }
+            QString newWeightText = QInputDialog::getItem( this, // QWidget * parent
+                                                           tr("Enter room weight"), // const QString & title
+                                                           tr("Choose an existing\n"
+                                                              "roomweight (= travel\n"
+                                                              "time) from the list\n"
+                                                              "(sorted by most commonly\n"
+                                                              "used first) or enter a\n"
+                                                              "new (positive) integer\n"
+                                                              "value for all selected\n"
+                                                              "rooms:", "Use line feeds to format text into a reasonable rectangle."), // const QString & label
+                                                           displayStrings, // QStringList & items
+                                                           0, // int current = 0, last value in list
+                                                           true, // bool editable = true
+                                                           &isOk, // bool * ok = 0
+                                                           0, // Qt::WindowFlags flags = 0
+                                                           Qt::ImhDigitsOnly); // Qt::InputMethodHints inputMethodHints = Qt::ImhNone
+            newWeight = 1;
+            if( isOk )
+            { // Don't do anything if cancel was pressed
+                if( newWeightText.toInt() > 0 )
+                {
+                    newWeight = newWeightText.toInt();
+                }
+                else
+                {
+                    isOk = false; // Prevent any change if the value is not reasonable
+                }
+            }
+        }
+    }
+
+    if( isOk && newWeight > 0 )
+    { // Don't proceed if cancel was pressed or the value is not valid
+        itSelectedRoom.toFront();
+        while( itSelectedRoom.hasNext() )
+        {
+            pR = mpMap->mpRoomDB->getRoom( itSelectedRoom.next() ) ;
+            if( !pR ) {
+                continue;
+            }
+
+            pR->setWeight( newWeight );
+        }
+        mpMap->mMapGraphNeedsUpdate = true;
+        repaint();
     }
 }
 
@@ -3293,19 +3832,29 @@ void T2DMap::slot_setArea()
             arealist_combobox->addItem( QStringLiteral( "%1 (%2)" ).arg( it.value() ).arg( areaID ), QVariant(areaID) );
         }
     }
-    if( set_room_area_dialog->exec() == QDialog::Rejected ) {
+
+    if( set_room_area_dialog->exec() == QDialog::Rejected )
+    { // Don't proceed if "cancel" was pressed
         return;
     }
 
     int newAreaId = arealist_combobox->itemData( arealist_combobox->currentIndex() ).toInt();
     mMultiRect = QRect(0,0,0,0);
-    int maxRoomIndex = mMultiSelectionList.size() - 1;
-    for( unsigned int j = 0; j <= maxRoomIndex; j++ ) {
-        if( j < maxRoomIndex ) {
-            mpMap->setRoomArea( mMultiSelectionList.at(j), newAreaId, true );
+    QSetIterator<int> itSelectedRoom = mMultiSelectionSet;
+    while( itSelectedRoom.hasNext() )
+    {
+        int currentRoomId = itSelectedRoom.next();
+        if( itSelectedRoom.hasNext() )
+        { // NOT the last room in set -  so defer some area related recalculations
+            mpMap->setRoomArea( currentRoomId, newAreaId, true );
         }
-        else {
-            if( ! ( mpMap->setRoomArea( mMultiSelectionList.at(j), newAreaId, false ) ) ) {
+        else
+        {
+            // Is the LAST room, so be careful to do all that is needed to clean
+            // up the affected areas (triggered by last "false" argument in next
+            // line)...
+            if( ! ( mpMap->setRoomArea( currentRoomId, newAreaId, false ) ) )
+            {
                 // Failed on the last of multiple room area move so do the missed
                 // out recalculations for the dirtied areas
                 QSetIterator<TArea *> itpArea = mpMap->mpRoomDB->getAreaPtrList().toSet();
@@ -3415,6 +3964,8 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
 
     if( (mMultiSelection && ! mRoomBeingMoved) || mSizeLabel )
     {
+        //    (The drag to select (or size) rectangle is being actively resized and rooms are not being moved)
+        // OR (We are sizing up a label)
         if( mNewMoveAction )
         {
             mMultiRect = QRect(event->pos(), event->pos());
@@ -3428,32 +3979,25 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
         int _areaID = mAID;
         TArea * pArea = mpMap->mpRoomDB->getArea(_areaID);
         if( ! pArea ) return;
-        int ox = mOx;
-        int oy = mOy;
-        float _rx;
-        float _ry;
-        if( ox*mTX > xspan/2*mTX )
-            _rx = -(mTX*ox-xspan/2*mTX);
-        else
-            _rx = xspan/2*mTX-mTX*ox;
-        if( oy*mTY > yspan/2*mTY )
-            _ry = -(mTY*oy-yspan/2*mTY);
-        else
-            _ry = yspan/2*mTY-mTY*oy;
+
+        float _rx = xspan/2*mTX-mTX*mOx;
+        float _ry = yspan/2*mTY-mTY*mOy;
 
         if( ! mSizeLabel )
-        {
-            QList<int> roomList = pArea->rooms;
-            mMultiSelectionList.clear();
-            for( int k=0; k<roomList.size(); k++ )
+        { // NOT sizing a label
+            mMultiSelectionSet.clear();
+            QSetIterator<int> itSelectedRoom( pArea->getAreaRooms() );
+            while( itSelectedRoom.hasNext() )
             {
-                TRoom * pR = mpMap->mpRoomDB->getRoom(pArea->rooms[k]);
+                int currentRoomId = itSelectedRoom.next();
+                TRoom * pR = mpMap->mpRoomDB->getRoom( currentRoomId );
                 if( !pR ) continue;
                 int rx = pR->x*mTX+_rx;
                 int ry = pR->y*-1*mTY+_ry;
                 int rz = pR->z;
 
                 // copy rooms on all z-levels if the shift key is being pressed
+                // CHECK: Consider adding z-level to multi-selection Widget?
                 if( rz != mOz && ! ( event->modifiers().testFlag(Qt::ShiftModifier)) ) continue;
 
                 QRectF dr;
@@ -3467,9 +4011,20 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
                 }
                 if( mMultiRect.contains(dr) )
                 {
-                    mMultiSelectionList << pArea->rooms[k];
+                    mMultiSelectionSet.insert( currentRoomId );
                 }
             }
+            switch( mMultiSelectionSet.size() ) {
+            case 0:
+                mMultiSelectionHighlightRoomId = -1;
+                break;
+            case 1:
+                mMultiSelectionHighlightRoomId = mMultiSelectionSet.toList().first();
+                break;
+            default:
+                getCenterSelection(); // Sets mMultiSelectionHighlightRoomId to (a) central room
+            }
+
             int mx = event->pos().x()/mTX;
             int my = event->pos().y()/mTY;
             mx = mx - xspan/2 + 1;
@@ -3482,29 +4037,58 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
                 mOldMousePos = QPoint(mx,my);
             }
 
-            if( mMultiSelectionList.size() > 1 )
+            if( mMultiSelectionSet.size() > 1 )
             {
+                mMultiSelectionListWidget.blockSignals(true); // We don't want to cause calls to slot_roomSelectionChanged() here!
+                mIsSelectionSorting = mMultiSelectionListWidget.isSortingEnabled(); // Save sorting state before we switch it off
+                mIsSelectionSortByNames = (mMultiSelectionListWidget.sortColumn() == 1);
                 mMultiSelectionListWidget.clear();
-                for( int i=0; i<mMultiSelectionList.size(); i++ )
+                mMultiSelectionListWidget.setSortingEnabled(false); // Do NOT sort whilst inserting items!
+                QSetIterator<int> itRoom = mMultiSelectionSet;
+                mIsSelectionUsingNames = false;
+                while( itRoom.hasNext() )
                 {
                     QTreeWidgetItem * _item = new QTreeWidgetItem;
-                    _item->setText(0,QString::number(mMultiSelectionList[i]));
+                    int multiSelectionRoomId = itRoom.next();
+                    _item->setText(0,QStringLiteral("%1").arg(multiSelectionRoomId,7));
+                    _item->setTextAlignment(0, Qt::AlignRight);
+                    TRoom * pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
+                    if( pR_multiSelection )
+                    {
+                        QString multiSelectionRoomName = pR_multiSelection->name;
+                        if( ! multiSelectionRoomName.isEmpty() )
+                        {
+                            _item->setText(1,multiSelectionRoomName);
+                            _item->setTextAlignment(1, Qt::AlignLeft);
+                            mIsSelectionUsingNames = true;
+                        }
+                    }
                     mMultiSelectionListWidget.addTopLevelItem( _item );
                 }
-                mMultiSelectionListWidget.setSelectionMode(QAbstractItemView::ExtendedSelection);
+                mMultiSelectionListWidget.setColumnHidden(1, !mIsSelectionUsingNames );
+                // Can't sort if nothing to sort on, switch to sorting by room number
+                if( (! mIsSelectionUsingNames ) && mIsSelectionSortByNames && mIsSelectionSorting )
+                {
+                    mIsSelectionSortByNames = false;
+                }
+                mMultiSelectionListWidget.sortByColumn( mIsSelectionSortByNames ? 1 : 0 );
+                mMultiSelectionListWidget.setSortingEnabled(mIsSelectionSorting);
+                resizeMultiSelectionWidget();
                 mMultiSelectionListWidget.selectAll();
+                mMultiSelectionListWidget.blockSignals(false);
                 mMultiSelectionListWidget.show();
-
             }
             else
+            {
                 mMultiSelectionListWidget.hide();
+            }
         }
 
         update();
         return;
     }
 
-    if( mRoomBeingMoved && !mSizeLabel && mMultiSelectionList.size() > 0 )
+    if( mRoomBeingMoved && !mSizeLabel && ! mMultiSelectionSet.isEmpty() )
     {
         mMultiRect = QRect(0,0,0,0);
         int _roomID = mRID;
@@ -3517,6 +4101,7 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
 // N/U:        int oy = mOy;
 // N/U:        float _rx;
 // N/U:        float _ry;
+// These tests are pointless - both branches produce the same results
 //        if( ox*mTX > xspan/2*mTX )
 //            _rx = -(mTX*ox-xspan/2*mTX);
 //        else
@@ -3532,19 +4117,22 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
 
         int dx,dy;
 
-        int topLeftCorner = getTopLeftSelection();
-        if( topLeftCorner < 0 || topLeftCorner >= mMultiSelectionList.size() )
+        if( ! getCenterSelection() ) {
+            return;
+        }
+
+        TRoom * pR = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
+        if( !pR )
         {
             return;
         }
 
-        TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[topLeftCorner]);
-        if( !pR ) return;
         dx = mx - pR->x;
         dy = my - pR->y;
-        for( int j=0; j<mMultiSelectionList.size(); j++ )
+        QSetIterator<int> itRoom = mMultiSelectionSet;
+        while( itRoom.hasNext() )
         {
-            pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
+            pR = mpMap->mpRoomDB->getRoom( itRoom.next() );
             if( pR )
             {
                 pR->x += dx;
@@ -3573,32 +4161,64 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
     }
 }
 
-// return -1 on error
-int T2DMap::getTopLeftSelection()
+// Replacement for getTopLeftCenter - determines a room closest to geometrical
+// mean of all the room selected, the result is stored in the class member
+// mMultiSelectionHighlightRoomId and this returns true on successfully finding
+// such a room
+bool T2DMap::getCenterSelection()
 {
-    int min_x, min_y, id;
-    id = -1;
-    if( mMultiSelectionList.size() < 1 ) return -1;
-    TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[0]);
-    if( !pR) return -1;
-    min_x = pR->x;
-    min_y = pR->y;
-    for( int j=0; j<mMultiSelectionList.size(); j++ )
-    {
-        pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[j]);
-        if( ! pR ) return -1;
-        if( pR->x <= min_x )
-        {
-            min_x = pR->x;
-            if( pR->y <= min_y )
-            {
-                min_y = pR->y;
-                id = j;
+    mMultiSelectionHighlightRoomId = -1;
+    if( mMultiSelectionSet.isEmpty() ) {
+        return false;
+    }
+
+    QSetIterator<int> itRoom = mMultiSelectionSet;
+    float mean_x = 0.0;
+    float mean_y = 0.0;
+    float mean_z = 0.0;
+    uint processedRoomCount = 0;
+    while( itRoom.hasNext() ) {
+        int currentRoomId = itRoom.next();
+        TRoom * pR = mpMap->mpRoomDB->getRoom( currentRoomId );
+        if( ! pR ) {
+            continue;
+        }
+
+        mean_x += (static_cast<float>(pR->x - mean_x)) / ++processedRoomCount;
+        mean_y += (static_cast<float>(pR->y - mean_y)) / processedRoomCount;
+        mean_z += (static_cast<float>(pR->z - mean_z)) / processedRoomCount;
+    }
+
+    if( processedRoomCount ) {
+        itRoom.toFront();
+        float closestSquareDistance = -1.0;
+        while( itRoom.hasNext() ) {
+            int currentRoomId = itRoom.next();
+            TRoom * pR = mpMap->mpRoomDB->getRoom( currentRoomId );
+            if( ! pR ) {
+                continue;
+            }
+
+            QVector3D meanToRoom( static_cast<float>(pR->x)-mean_x, static_cast<float>(pR->y)-mean_y, static_cast<float>(pR->z)-mean_z );
+            if( closestSquareDistance < -0.5 ) {
+                // Don't use an equality to zero test, we are using floats so
+                // need to allow for a little bit of fuzzzyness!
+                closestSquareDistance = meanToRoom.lengthSquared();
+                mMultiSelectionHighlightRoomId = currentRoomId;
+            }
+           else {
+                float currentRoomSquareDistance = meanToRoom.lengthSquared();
+                if( closestSquareDistance > currentRoomSquareDistance  ) {
+                    closestSquareDistance = currentRoomSquareDistance;
+                    mMultiSelectionHighlightRoomId = currentRoomId;
+                }
             }
         }
+        return true;
     }
-    return id;
-
+    else {
+        return false;
+    }
 }
 
 void T2DMap::exportAreaImage( int id )
@@ -3608,30 +4228,50 @@ void T2DMap::exportAreaImage( int id )
 
 void T2DMap::wheelEvent ( QWheelEvent * e )
 {
-    if( ! mpMap->mpRoomDB->getRoom(mRID) ) return;
-    if( ! mpMap->mpRoomDB->getArea(mAID) ) return;
-    int delta = e->delta() / 8 / 15;
-    if( delta < 0 )
+    // If the mouse wheel is scrolling up and down through the
+    // mMultiSelectionListWidget the wheelevents from that get passed up to here
+    // when the end of the list is reached (i.e when it rejects those events)
+    // - so that the mapper window doesn't THEN zoom in or out, swallow the
+    // events, i.e. accept() them and return before hitting the zoom altering
+    // code that follows.
+    // However the event "pos()" depends on the widget it came from so we have
+    // to use "globalPos()" instead and see how it lies in relation to the child
+    // widget:
+    QRect selectionListWidgetGlobalRect = QRect(mapToGlobal(mMultiSelectionListWidget.frameRect().topLeft()), mapToGlobal(mMultiSelectionListWidget.frameRect().bottomRight()));
+    if( mMultiSelectionListWidget.isVisible() && selectionListWidgetGlobalRect.contains( e->globalPos() ) )
     {
-        mPick = false;
-        xzoom += delta;
-        yzoom += delta;
-        if( yzoom < 3 || xzoom < 3 )
-        {
-            xzoom = 3;
-            yzoom = 3;
-        }
-        update();
         e->accept();
         return;
     }
-    if( delta > 0 )
+
+    if( ! (mpMap->mpRoomDB->getRoom(mRID) && mpMap->mpRoomDB->getArea(mAID) ) )
+    {
+        return;
+    }
+
+    // int delta = e->delta() / 8 / 15; // Deprecated in Qt 5.x ...!
+    int delta = e->angleDelta().y() / ( 8 * 15 );
+    if( e->modifiers() & Qt::ControlModifier )
+    { // Increase rate 10-fold if control key down - it makes scrolling through
+      // a large nuber of items in a listwidget's contents easier AND this make it
+      // easier to zoom in and out on LARGE area maps
+        delta *= 10;
+    }
+    if( delta != 0 )
     {
         mPick = false;
         xzoom += delta;
         yzoom += delta;
-        e->accept();
+        if( yzoom < 3 )
+        { // At present xzoom and yzoom alway will be the same I think
+            yzoom = 3;
+        }
+        if( xzoom < 3 )
+        {
+            xzoom = 3;
+        }
         update();
+        e->accept();
         return;
     }
     e->ignore();
@@ -3664,10 +4304,14 @@ void T2DMap::setExitSize( double f )
 
 void T2DMap::slot_setCustomLine()
 {
-    if( mMultiSelectionList.size() < 1 )
+    if( mMultiSelectionSet.isEmpty() ) {
         return;
-    if( ! mpHost->mpMap->mpRoomDB->getRoom( mMultiSelectionList[0] ) )
+    }
+    TRoom * pR = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
+    if( !pR ) {
         return;
+    }
+
     if( mpCustomLinesDialog ) {
         // Refuse to create another instance if one is already present!
         // Just show it...
@@ -3680,13 +4324,15 @@ void T2DMap::slot_setCustomLine()
     file.open(QFile::ReadOnly);
     QDialog *d = dynamic_cast<QDialog *>(loader.load(&file, this));
     file.close();
-    if( ! d )
+    if( ! d ) {
         return;
+    }
+
     d->setWindowIcon( QIcon( QStringLiteral( ":/icons/mudlet_custom_exit.png" ) ) );
-    TRoom * pR = mpMap->mpRoomDB->getRoom(mMultiSelectionList[0]);
-    if( !pR )
-        return;
-    mCustomLinesRoomFrom = mMultiSelectionList[0];
+    mpCustomLinesDialog = d;
+    mpCustomLinesDialog->setWindowIcon( QIcon( QStringLiteral( ":/icons/mudlet_custom_exit.png" ) ) );
+
+    mCustomLinesRoomFrom = mMultiSelectionHighlightRoomId;
     mCustomLinesRoomTo = 0;
     mCustomLinesRoomExit = "";
     QPushButton * b_ = d->findChild<QPushButton*>("nw");
@@ -4056,7 +4702,7 @@ void T2DMap::slot_setCustomLine2()
     pR->customLinesArrow[exit] = mCurrentLineArrow;
 //    qDebug("   ARROW: %s", mCurrentLineArrow ? "Yes" : "No");
 
-    mHelpMsg = "Left-click to add point, right-click to undo/change/finish...";
+    mHelpMsg = tr("Left-click to add point, right-click to undo/change/finish...");
     // This message was previously being put up AFTER first click to set first segment was made....
     update();
 }
@@ -4090,7 +4736,7 @@ void T2DMap::slot_setCustomLine2B(QTreeWidgetItem * special_exit, int column )
 //    qDebug("   LINE STYLE: %s", qPrintable(mCurrentLineStyle) );
     pR->customLinesArrow[exit] = mCurrentLineArrow;
 //    qDebug("   ARROW: %s", mCurrentLineArrow ? "Yes" : "No");
-    mHelpMsg = "Left-click to add point, right-click to undo/change/finish...";
+    mHelpMsg = tr("Left-click to add point, right-click to undo/change/finish...");
     // This message was previously being put up AFTER first click to set first segment was made....
     update();
 }
@@ -4099,27 +4745,31 @@ void T2DMap::slot_createLabel()
 {
     if( ! mpMap->mpRoomDB->getArea( mAID ) ) return;
 
-    mHelpMsg = "Left-click and drag a square for the size and position of your label";
+    mHelpMsg = tr("Left-click and drag a square for the size and position of your label");
     mSizeLabel = true;
     mMultiSelection = true;
     update();
-    return;
-
-
 }
 
 void T2DMap::slot_roomSelectionChanged()
 {
     QList<QTreeWidgetItem *> _sl = mMultiSelectionListWidget.selectedItems();
-    if( _sl.size() > 0 )
-    {
-        mMultiSelectionList.clear();
-        for( int i=0; i<_sl.size(); i++ )
-        {
-            mMultiSelectionList.push_back(_sl[i]->text(0).toInt());
-        }
+    mMultiSelectionSet.clear();
+    for( uint i=0; i< _sl.size(); i++ ) {
+        int currentRoomId = _sl.at(i)->text(0).toInt();
+        mMultiSelectionSet.insert( currentRoomId );
     }
-
+    switch( mMultiSelectionSet.size() ) {
+    case 0:
+        mMultiSelectionHighlightRoomId = -1;
+        break;
+    case 1:
+        mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.constBegin());
+        break;
+    default:
+        getCenterSelection();
+    }
+    update();
 }
 
 void T2DMap::paintMap()
@@ -5262,4 +5912,59 @@ void T2DMap::paintMap()
 //    QString erg = QDir::toNativeSeparators( home );
 //    pix.save(erg);
 
+}
+
+void T2DMap::resizeMultiSelectionWidget()
+{
+    int _newWidth;
+    if( mIsSelectionUsingNames )
+    {
+        if( width() <= 300 )
+        { // 0 - 300 => 0 - 200
+            _newWidth = 2 * width()/3;
+        }
+        else if( width() <= 600 )
+        { // 300 - 600 => 200 - 300
+            _newWidth = 100 + width()/3;
+        }
+        else
+        { // 600+ => 300
+            _newWidth = 300;
+        }
+    }
+    else
+    {
+        if( width() <= 300 )
+        { // 0 - 300 => 0 - 120
+            _newWidth = 2 * width()/3;
+        }
+        else
+        { // 300+ => 120
+            _newWidth = 120;
+        }
+    }
+    int _newHeight = 300;
+    if( mMultiSelectionListWidget.topLevelItemCount() > 0 )
+    {
+        QTreeWidgetItem * rowItem = mMultiSelectionListWidget.topLevelItem(1);
+        // The following factors are tweaks to ensure that the widget shows all
+        // the rows, as the header seems biggger than the value returned, statics
+        // used to enable values to be change by debugger at runtime!
+        static float headerFactor = 1.2;
+        static float rowFactor = 1.0;
+        _newHeight = headerFactor * mMultiSelectionListWidget.header()->height();
+        if( rowItem )
+        { // Have some data rows - and we have forced them to be the same height:
+            _newHeight += rowFactor * mMultiSelectionListWidget.topLevelItemCount() * mMultiSelectionListWidget.visualItemRect(rowItem).height();
+        }
+//        qDebug() << "Row count:" << mMultiSelectionListWidget.topLevelItemCount() << "header height:" << mMultiSelectionListWidget.header()->height() << "row height:" << mMultiSelectionListWidget.visualItemRect(rowItem).height();
+    }
+    if( _newHeight < height() )
+    {
+        mMultiSelectionListWidget.resize( _newWidth, _newHeight );
+    }
+    else
+    {
+        mMultiSelectionListWidget.resize( _newWidth, height() );
+    }
 }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -71,6 +71,7 @@ public:
     void     setRoomSize( double );
     void     setExitSize( double );
     void     createLabel( QRectF labelRect );
+
     TMap *   mpMap;
     QPointer<Host> mpHost;
     int      xzoom;
@@ -156,7 +157,7 @@ public slots:
     void slot_customLineColor();
     void shiftZup();
     void shiftZdown();
-    void switchArea(QString);
+    void slot_switchArea(QString);
     void toggleShiftMode();
     void shiftUp();
     void shiftDown();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,6 +27,7 @@
 #include <QColor>
 #include <QPixmap>
 #include <QPointer>
+#include <QString>
 #include <QTreeWidget>
 #include <QWidget>
 #include "post_guard.h"
@@ -60,7 +62,12 @@ public:
     void     wheelEvent ( QWheelEvent * ) override;
     void     mouseMoveEvent( QMouseEvent * event ) override;
     void     mouseReleaseEvent(QMouseEvent * e ) override;
-    int      getTopLeftSelection();
+    bool     getCenterSelection();
+    // Was getTopLeft() which returned an index into mMultiSelectionList but that
+    // has been been changed to mMultiSelectionSet which cannot be accessed via
+    // an index in the same way - this function now sets
+    // mMultiSelectionHighlightRoomId and returns a (bool) on success or failure
+    // to do so.
     void     setRoomSize( double );
     void     setExitSize( double );
     void     createLabel( QRectF labelRect );
@@ -86,10 +93,12 @@ public:
     int      mChosenRoomColor;
     float    xspan;
     float    yspan;
-    bool     mMultiSelection;
+    bool     mMultiSelection;  // Flag that the "drag to select rectangle"
+                               // (mMultiRect) is active and is being *resized*
+                               // by dragging
     QRectF   mMultiRect;
     bool     mPopupMenu;
-    QList<int> mMultiSelectionList;
+    QSet<int> mMultiSelectionSet; // was mMultiSelectList
     QPoint   mOldMousePos;
     bool     mNewMoveAction;
     QRectF   mMapInfoRect;
@@ -181,7 +190,31 @@ public slots:
     void slot_cancelCustomLineDialog();
 
 private:
-    bool    mDialogLock;
+    void resizeMultiSelectionWidget();
+
+
+    bool mDialogLock;
+    int  mMultiSelectionHighlightRoomId;
+                                // When more than zero rooms are selected this
+                                // is either the first (only) room in the set
+                                // or if getCenterSelectionId() is used the
+                                // room that is selected - this is so that it
+                                // can be painted in yellow rather than orange
+                                // when more than one room is selected to
+                                // indicate the particular room that will be
+                                // modified or be the center of those
+                                // modifications. {for slot_spread(),
+                                // slot_shrink(), slot_setUserData() - if ever
+                                // implimented, slot_setExits(),
+                                // slot_movePosition(), etc.}
+
+    bool  mIsSelectionSorting;
+    bool  mIsSelectionSortByNames;
+    bool  mIsSelectionUsingNames;
+                                // Used to keep track of if sorting the multiple
+                                // room listing/selection widget, and by what,
+                                // as we now show room names (if present) as well.
+
 };
 
 #endif // MUDLET_T2DMAP_H

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,6 +37,8 @@ class TRoomDB;
 
 class TArea
 {
+    Q_DECLARE_TR_FUNCTIONS(TArea) // Needed so we can use tr() even though TArea is NOT derived from QObject
+
     friend bool TMap::serialize( QDataStream & );
     friend bool TMap::restore( QString );
 
@@ -45,20 +47,20 @@ public:
     ~TArea();
     int getAreaID();
     void addRoom(int id);
-    const QList<int>& getAreaRooms() const { return rooms; }
+    const QSet<int>& getAreaRooms() const { return rooms; }
     const QList<int> getAreaExitRoomIds() const { return exits.uniqueKeys(); }
     const QMultiMap<int, QPair<QString, int> > getAreaExitRoomData() const ;
     void calcSpan();
     void fast_calcSpan(int);
     void determineAreaExits();
     void determineAreaExitsOfRoom(int);
-    void removeRoom(int);
+    void removeRoom(int, bool isToDeferAreaRelatedRecalculations=false);
     QList<int> getCollisionNodes();
     QList<int> getRoomsByPosition(int x, int y, int z);
     QMap<int, QMap<int, QMultiMap<int, int> > > koordinatenSystem();
 
 
-    QList<int> rooms;                       // rooms of this area
+    QSet<int> rooms;                        // rooms of this area
     QVector3D pos;                          // pos auf der map und 0 punkt des area internen koordinatensystems
     QVector3D span;
     int min_x;
@@ -67,13 +69,15 @@ public:
     int max_x;
     int max_y;
     int max_z;
+    // Key = z-level, Value = the relevent x or y extreme:
     QMap<int, int> xminEbene;
     QMap<int, int> xmaxEbene;
     QMap<int, int> yminEbene;
     QMap<int, int> ymaxEbene;
-    QMap<int, int> zminEbene;
-    QMap<int, int> zmaxEbene;
-    QList<int> ebenen;
+// Pointless:
+//    QMap<int, int> zminEbene;
+//    QMap<int, int> zmaxEbene;
+    QList<int> ebenen; // The z-levels that ARE used, not guarenteed to be in order
     bool gridMode;
     bool isZone;
     int zoneAreaRef;
@@ -86,7 +90,7 @@ private:
     TArea() { qFatal("FATAL: illegal default constructor use of TArea()"); };
     // QMap<int, TMapLabel> labelMap;
 
-
+    TMap * mpMap; // Supplied by C'tor and now needed to pass an error message upwards
     QMultiMap<int, QPair<int, int> > exits;
     // rooms that border on this area:
     // key=in_area room id, pair.first=out_of_area room id pair.second=direction

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -41,6 +41,7 @@ class TArea
 
     friend bool TMap::serialize( QDataStream & );
     friend bool TMap::restore( QString );
+    friend const bool TMap::retrieveMapFileStats( QString , QString *, int *, int *, int *, int * );
 
 public:
     TArea(TMap*, TRoomDB*);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1810,14 +1810,19 @@ bool TConsole::loadMap(const QString& location)
 
     mpHost->mpMap->mapClear();
 
+    qDebug() << "TConsole::loadMap() - restore map case 2.";
     if( mpHost->mpMap->restore( location ) ) {
         mpHost->mpMap->audit();
         mpHost->mpMap->mpMapper->mp2dMap->init();
-        mpHost->mpMap->mpMapper->show();
         mpHost->mpMap->mpMapper->updateAreaComboBox();
+        mpHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
+        mpHost->mpMap->mpMapper->show();
         return true;
     }
     else {
+        mpHost->mpMap->mpMapper->mp2dMap->init();
+        mpHost->mpMap->mpMapper->updateAreaComboBox();
+        mpHost->mpMap->mpMapper->show();
         return false;
     }
 }
@@ -2471,8 +2476,12 @@ void TConsole::createMapper( int x, int y, int width, int height )
         mpHost->mpMap->mpHost = mpHost;
         mpHost->mpMap->mpMapper = mpMapper;
         mpMapper->mpHost = mpHost;
+        qDebug() << "TConsole::createMapper() - restore map case 3.";
         if( mpHost->mpMap->restore( QString() ) ) {
             mpHost->mpMap->audit();
+            mpMapper->mp2dMap->init();
+            mpMapper->updateAreaComboBox();
+            mpMapper->resetAreaComboBoxToPlayerRoomArea();
         }
 
         TEvent mapOpenEvent;
@@ -2482,7 +2491,6 @@ void TConsole::createMapper( int x, int y, int width, int height )
     }
     mpMapper->resize( width, height );
     mpMapper->move( x, y );
-    //mpMapper->mp2dMap->init();
     mpMapper->mp2dMap->gridMapSizeChange = true; //mapper size has changed, but only init grid map when necessary
     mpMapper->show();
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1786,7 +1786,7 @@ bool TConsole::loadMap(const QString& location)
 
     if ( mpHost->mpMap->restore(location) )
     {
-        mpHost->mpMap->init( mpHost );
+        mpHost->mpMap->audit();
         mpHost->mpMap->mpMapper->mp2dMap->init();
         mpHost->mpMap->mpMapper->show();
         if( mpHost->mpMap )
@@ -2449,8 +2449,9 @@ void TConsole::createMapper( int x, int y, int width, int height )
         mpHost->mpMap->mpHost = mpHost;
         mpHost->mpMap->mpMapper = mpMapper;
         mpMapper->mpHost = mpHost;
-        mpHost->mpMap->restore("");
-        mpHost->mpMap->init( mpHost );
+        if( mpHost->mpMap->restore( QString() ) ) {
+            mpHost->mpMap->audit();
+        }
 
         TEvent mapOpenEvent;
         mapOpenEvent.mArgumentList.append( "mapOpenEvent" );

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -291,6 +291,10 @@ public slots:
       void              slot_toggleReplayRecording();
       void              slot_stop_all_triggers( bool );
       void              slot_toggleLogging();
+    void                slot_reloadMap( QList<QString> );
+                        // Used by mudlet class as told by "Profile Preferences"
+                        // =>"Copy Map" in another profile to inform a list of
+                        // profiles - asynchronously - to load in an updated map
 
 };
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7867,7 +7867,10 @@ int TLuaInterpreter::setDoor( lua_State * L )
                             .toUtf8().constData() );
             return 2;
         }
-        else if( ! pR->getOtherMap().values().contains( exitCmd ) ) {
+        else if( ! (   pR->getOtherMap().values().contains( exitCmd )
+                    || pR->getOtherMap().values().contains( QStringLiteral( "0%1" ).arg( exitCmd ) )
+                    || pR->getOtherMap().values().contains( QStringLiteral( "1%1" ).arg( exitCmd ) ) ) ) {
+
             // And NOT a special one either
             lua_pushnil( L );
             lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a special exit in direction \"%2\".)" )

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4288,7 +4288,7 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
                         .toUtf8().constData() );
         return 2;
     }
-    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+    else if( ! pHost->mpMap ) {
         lua_pushnil( L );
         lua_pushstring( L, tr( "searchRoomUserData: no map present or loaded!" )
                         .toUtf8().constData() );
@@ -4410,7 +4410,7 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
                         .toUtf8().constData() );
         return 2;
     }
-    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+    else if( ! pHost->mpMap ) {
         lua_pushnil( L );
         lua_pushstring( L, tr( "searchAreaUserData: no map present or loaded!" )
                         .toUtf8().constData() );
@@ -4445,6 +4445,7 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
     }
 
     lua_newtable(L);
+
     QMapIterator<int, TArea *> itArea( pHost->mpMap->mpRoomDB->getAreaMap() );
     // For best performance do the three different types of action in three
     // different branches each with a loop - rather than choosing a branch

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7778,97 +7778,172 @@ int TLuaInterpreter::createMapImageLabel( lua_State * L )
     return 1;
 }
 
-//SYNTAX: setDoor( roomID, exitCommand, doorStatus ) status: 0=no door, 1=open, 2=closed, 3=locked
-//        to remove a door set doorStatus = 0
+//SYNTAX: setDoor( roomId, exitCommand, doorStatus )
+// doorStatus: 0=no door, 1=open, 2=closed, 3=locked
+//        { to remove a door set doorStatus to 0 }
+// Directions for NORMAL exits:
+// * "n"
+// * "ne"
+// * "e"
+// * "se"
+// * "s"
+// * "sw"
+// * "w"
+// * "nw"
+// * "up"
+// * "down"
+// * "in"
+// * "out"
+// The command is now validated against normal exits and stub exits and special
+// exits and returns a nil + error message if there is not a valid thing for
+// given exit command.
+// Returns:
+// * nil + (string) message on run-time (value type errors)
+// * true if a change was made
+// * false if valid but ineffective (door status unchanged)
 int TLuaInterpreter::setDoor( lua_State * L )
 {
-    int roomID;
-    int doorStatus; //0= no door, 1=open, 2=closed, 3=locked
-    string exitCmd;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushstring( L, "setDoor: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        roomID = lua_tointeger( L, 1 );
-    }
-
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "setDoor: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        exitCmd = lua_tostring( L, 2 );
-    }
-
-    if( ! lua_isnumber( L, 3 ) )
-    {
-        lua_pushstring( L, "setDoor: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        doorStatus = lua_tonumber( L, 3 );
-    }
-
-    QString exit = exitCmd.c_str();
-    exit = exit.toLower();
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomID );
-    if( pR )
-    {
-        if( doorStatus == 0 )
-        {
-            pR->doors.remove( exit );
-        }
-        else
-        {
-            pR->doors[exit] = doorStatus;
-            if( pHost->mpMap->mpMapper )
-                if( pHost->mpMap->mpMapper->mp2dMap )
-                    pHost->mpMap->mpMapper->mp2dMap->update();
-        }
-        lua_pushboolean( L, true );
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setDoor: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
     }
-    else
-        lua_pushboolean( L, false );
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setDoor: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
+    TRoom * pR;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "setDoor: bad argument #1 (room Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        roomId = lua_tointeger( L, 1 );
+        pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+        if( ! pR ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setDoor: bad argument #1 value (number %1 is not a valid room Id.)" )
+                            .arg( roomId )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString exitCmd;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setDoor: bad argument #2 type (door command as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 2 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        exitCmd = QString::fromUtf8( lua_tostring( L, 2 ) );
+        if(    ( ( ! exitCmd.compare( QStringLiteral( "n" ) ) ) && ( pR->getExit( DIR_NORTH ) > 1 || pR->exitStubs.contains( DIR_NORTH ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "e" ) ) ) && pR->getExit( DIR_EAST ) > 1 || pR->exitStubs.contains( DIR_EAST ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "s" ) ) ) && pR->getExit( DIR_SOUTH ) > 1 || pR->exitStubs.contains( DIR_SOUTH ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "w" ) ) ) && pR->getExit( DIR_WEST ) > 1 || pR->exitStubs.contains( DIR_WEST ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "ne" ) ) ) && pR->getExit( DIR_NORTHEAST ) > 1 || pR->exitStubs.contains( DIR_NORTHEAST ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "se" ) ) ) && pR->getExit( DIR_SOUTHEAST ) > 1 || pR->exitStubs.contains( DIR_SOUTHEAST ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "sw" ) ) ) && pR->getExit( DIR_SOUTHWEST ) > 1 || pR->exitStubs.contains( DIR_SOUTHWEST ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "nw" ) ) ) && pR->getExit( DIR_NORTHWEST ) > 1 || pR->exitStubs.contains( DIR_NORTHWEST ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "up" ) ) ) && pR->getExit( DIR_UP ) > 1 || pR->exitStubs.contains( DIR_UP ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "down" ) ) ) && pR->getExit( DIR_DOWN ) > 1 || pR->exitStubs.contains( DIR_DOWN ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "in" ) ) ) && pR->getExit( DIR_IN ) > 1 || pR->exitStubs.contains( DIR_IN ) )
+            || ( ( ! exitCmd.compare( QStringLiteral( "out" ) ) ) && pR->getExit( DIR_OUT ) > 1 || pR->exitStubs.contains( DIR_OUT ) ) ) ) {
+
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a normal exit or a stub exit in direction \"%2\".)" )
+                            .arg( roomId ).arg( exitCmd )
+                            .toUtf8().constData() );
+            return 2;
+        }
+        else if( ! pR->getOtherMap().values().contains( exitCmd ) ) {
+            // And NOT a special one either
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a special exit in direction \"%2\".)" )
+                            .arg( roomId ).arg( exitCmd )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    int doorStatus;
+    if( ! lua_isnumber( L, 3 ) ) {
+        lua_pushstring( L, tr( "setDoor: bad argument #3 type (door type as number expected {0=\"none\", 1=\"open\", 2=\"closed\", 3=\"locked\"}, got %1!)" )
+                        .arg( luaL_typename( L, 3 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        doorStatus = lua_tointeger( L, 3 );
+        if( doorStatus < 0 || doorStatus > 3 ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setDoor: bad argument #3 value (door type %1 is not one of 0=\"none\", 1=\"open\", 2=\"closed\" or 3=\"locked\".)" )
+                            .arg( luaL_typename( L, 3 ) )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    lua_pushboolean( L, pR->setDoor( exitCmd, doorStatus ) );
     return 1;
 }
 
-//SYNTAX: doors table = getDoors( roomID )
+//SYNTAX: doors table = getDoors( roomId )
 int TLuaInterpreter::getDoors( lua_State * L )
 {
-    int roomID;
-    if( ! lua_isnumber( L, 1 ) )
-    {
-        lua_pushfstring( L, "getDoors: bad argument #1 (room ID as number expected, got %s)", luaL_typename(L, 1) );
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getDoors: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "getDoors: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
+    TRoom * pR;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "getDoors: bad argument #1 (room Id as number expected, got %1!)" )
+                        .arg( luaL_typename(L, 1) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-    {
-        roomID = lua_tointeger( L, 1 );
+    else {
+        roomId = lua_tointeger( L, 1 );
+        pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+        if( ! pR ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "getDoors: bad argument #1 value (number %1 is not a valid room Id.)" )
+                            .arg( roomId )
+                            .toUtf8().constData() );
+            return 2;
+        }
     }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    lua_newtable(L);
-    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomID );
-    if( pR )
-    {
-        QStringList keys = pR->doors.keys();
-        for( int i=0; i<keys.size(); i++ )
-        {
-            lua_pushstring( L, keys[i].toLatin1().data() );
-            lua_pushnumber( L, pR->doors[keys[i]] );
-            lua_settable(L, -3);
-        }
+    lua_newtable( L );
+    QStringList keys = pR->doors.keys();
+    for( unsigned int i = 0, total = keys.size(); i < total; ++i ) {
+        lua_pushstring( L, keys.at(i).toUtf8().constData() );
+        lua_pushnumber( L, pR->doors.value( keys.at( i ) ) );
+        lua_settable( L, -3 );
     }
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4447,7 +4447,9 @@ int TLuaInterpreter::getRoomWeight( lua_State *L )
         }
     }
     else
+    {
         roomId = pHost->mpMap->mRoomId;
+    }
 
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( pR )
@@ -4456,7 +4458,9 @@ int TLuaInterpreter::getRoomWeight( lua_State *L )
         return 1;
     }
     else
+    {
         return 0;
+    }
 
 
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4422,10 +4422,11 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     return 1;
 }
 
+// Now audits the whole map
 int TLuaInterpreter::auditAreas( lua_State * L )
 {
     Host * pH = TLuaInterpreter::luaInterpreterMap[L];
-    pH->mpMap->mpRoomDB->initAreasForOldMaps();
+    pH->mpMap->audit();
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7848,35 +7848,58 @@ int TLuaInterpreter::setDoor( lua_State * L )
     }
     else {
         exitCmd = QString::fromUtf8( lua_tostring( L, 2 ) );
-        if(    ( ( ! exitCmd.compare( QStringLiteral( "n" ) ) ) && ( pR->getExit( DIR_NORTH ) > 1 || pR->exitStubs.contains( DIR_NORTH ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "e" ) ) ) && pR->getExit( DIR_EAST ) > 1 || pR->exitStubs.contains( DIR_EAST ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "s" ) ) ) && pR->getExit( DIR_SOUTH ) > 1 || pR->exitStubs.contains( DIR_SOUTH ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "w" ) ) ) && pR->getExit( DIR_WEST ) > 1 || pR->exitStubs.contains( DIR_WEST ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "ne" ) ) ) && pR->getExit( DIR_NORTHEAST ) > 1 || pR->exitStubs.contains( DIR_NORTHEAST ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "se" ) ) ) && pR->getExit( DIR_SOUTHEAST ) > 1 || pR->exitStubs.contains( DIR_SOUTHEAST ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "sw" ) ) ) && pR->getExit( DIR_SOUTHWEST ) > 1 || pR->exitStubs.contains( DIR_SOUTHWEST ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "nw" ) ) ) && pR->getExit( DIR_NORTHWEST ) > 1 || pR->exitStubs.contains( DIR_NORTHWEST ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "up" ) ) ) && pR->getExit( DIR_UP ) > 1 || pR->exitStubs.contains( DIR_UP ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "down" ) ) ) && pR->getExit( DIR_DOWN ) > 1 || pR->exitStubs.contains( DIR_DOWN ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "in" ) ) ) && pR->getExit( DIR_IN ) > 1 || pR->exitStubs.contains( DIR_IN ) )
-            || ( ( ! exitCmd.compare( QStringLiteral( "out" ) ) ) && pR->getExit( DIR_OUT ) > 1 || pR->exitStubs.contains( DIR_OUT ) ) ) ) {
+        if(   exitCmd.compare(QStringLiteral(  "n"   ))
+           && exitCmd.compare(QStringLiteral(  "e"   ))
+           && exitCmd.compare(QStringLiteral(  "s"   ))
+           && exitCmd.compare(QStringLiteral(  "w"   ))
+           && exitCmd.compare(QStringLiteral(  "ne"  ))
+           && exitCmd.compare(QStringLiteral(  "se"  ))
+           && exitCmd.compare(QStringLiteral(  "sw"  ))
+           && exitCmd.compare(QStringLiteral(  "nw"  ))
+           && exitCmd.compare(QStringLiteral(  "up"  ))
+           && exitCmd.compare(QStringLiteral( "down" ))
+           && exitCmd.compare(QStringLiteral(  "in"  ))
+           && exitCmd.compare(QStringLiteral(  "out" )) ) {
 
-            lua_pushnil( L );
-            lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a normal exit or a stub exit in direction \"%2\".)" )
-                            .arg( roomId ).arg( exitCmd )
-                            .toUtf8().constData() );
-            return 2;
+            // One of the above WILL BE ZERO if the exitCmd is ONE of the above QStringLiterals
+            // So the above will be TRUE if NONE of above strings match - which
+            // means we must treat the exitCmd as a SPECIAL exit
+            if( ! (   pR->getOtherMap().values().contains( exitCmd )
+                                || pR->getOtherMap().values().contains( QStringLiteral( "0%1" ).arg( exitCmd ) )
+                                || pR->getOtherMap().values().contains( QStringLiteral( "1%1" ).arg( exitCmd ) ) ) ) {
+
+                        // And NOT a special one either
+                        lua_pushnil( L );
+                        lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a special exit in direction \"%2\".)" )
+                                        .arg( roomId ).arg( exitCmd )
+                                        .toUtf8().constData() );
+                        return 2;
+            }
+            // else IS a valid special exit - so fall out of if and continue
         }
-        else if( ! (   pR->getOtherMap().values().contains( exitCmd )
-                    || pR->getOtherMap().values().contains( QStringLiteral( "0%1" ).arg( exitCmd ) )
-                    || pR->getOtherMap().values().contains( QStringLiteral( "1%1" ).arg( exitCmd ) ) ) ) {
+        else {
+            // Is a normal exit so see if it is valid
+            if( ! (   ((! exitCmd.compare(QStringLiteral(  "n"   ))) && (pR->getExit(DIR_NORTH    )>0||pR->exitStubs.contains(DIR_NORTH    )))
+                   || ((! exitCmd.compare(QStringLiteral(  "e"   ))) && (pR->getExit(DIR_EAST     )>0||pR->exitStubs.contains(DIR_EAST     )))
+                   || ((! exitCmd.compare(QStringLiteral(  "s"   ))) && (pR->getExit(DIR_SOUTH    )>0||pR->exitStubs.contains(DIR_SOUTH    )))
+                   || ((! exitCmd.compare(QStringLiteral(  "w"   ))) && (pR->getExit(DIR_WEST     )>0||pR->exitStubs.contains(DIR_WEST     )))
+                   || ((! exitCmd.compare(QStringLiteral(  "ne"  ))) && (pR->getExit(DIR_NORTHEAST)>0||pR->exitStubs.contains(DIR_NORTHEAST)))
+                   || ((! exitCmd.compare(QStringLiteral(  "se"  ))) && (pR->getExit(DIR_SOUTHEAST)>0||pR->exitStubs.contains(DIR_SOUTHEAST)))
+                   || ((! exitCmd.compare(QStringLiteral(  "sw"  ))) && (pR->getExit(DIR_SOUTHWEST)>0||pR->exitStubs.contains(DIR_SOUTHWEST)))
+                   || ((! exitCmd.compare(QStringLiteral(  "nw"  ))) && (pR->getExit(DIR_NORTHWEST)>0||pR->exitStubs.contains(DIR_NORTHWEST)))
+                   || ((! exitCmd.compare(QStringLiteral(  "up"  ))) && (pR->getExit(DIR_UP       )>0||pR->exitStubs.contains(DIR_UP       )))
+                   || ((! exitCmd.compare(QStringLiteral( "down" ))) && (pR->getExit(DIR_DOWN     )>0||pR->exitStubs.contains(DIR_DOWN     )))
+                   || ((! exitCmd.compare(QStringLiteral(  "in"  ))) && (pR->getExit(DIR_IN       )>0||pR->exitStubs.contains(DIR_IN       )))
+                   || ((! exitCmd.compare(QStringLiteral(  "out" ))) && (pR->getExit(DIR_OUT      )>0||pR->exitStubs.contains(DIR_OUT      ))) ) ) {
 
-            // And NOT a special one either
-            lua_pushnil( L );
-            lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a special exit in direction \"%2\".)" )
-                            .arg( roomId ).arg( exitCmd )
-                            .toUtf8().constData() );
-            return 2;
+                // No there IS NOT a stub or real exit in the exitCmd direction
+                lua_pushnil( L );
+                lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with Id %1 does not have a normal exit or a stub exit in direction \"%2\".)" )
+                                .arg( roomId ).arg( exitCmd )
+                                .toUtf8().constData() );
+                return 2;
+            }
+            // else IS a valid stub or real normal exit -fall through to continue
         }
     }
 
@@ -7899,7 +7922,13 @@ int TLuaInterpreter::setDoor( lua_State * L )
         }
     }
 
-    lua_pushboolean( L, pR->setDoor( exitCmd, doorStatus ) );
+    bool result = pR->setDoor( exitCmd, doorStatus );
+    if( result ) {
+        if( pHost->mpMap->mpMapper && pHost->mpMap->mpMapper->mp2dMap ) {
+            pHost->mpMap->mpMapper->mp2dMap->update();
+        }
+    }
+    lua_pushboolean( L, result );
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4322,12 +4322,15 @@ int TLuaInterpreter::getAreaRooms( lua_State *L )
         return 1;
     }
     lua_newtable(L);
-    const QList<int> areaRooms = pA->getAreaRooms();
-    for( int i=0; i<areaRooms.size(); i++ )
+    QSetIterator<int> itAreaRoom( pA->getAreaRooms() );
+    int i = -1;
+    while( itAreaRoom.hasNext() )
     {
-        int roomID = areaRooms.at( i );
-        lua_pushnumber( L, i );
-        lua_pushnumber( L, roomID );
+        lua_pushnumber( L, ++i );
+        // We should have started at 1 but past code had incorrectly started
+        // with a zero index and we must maintain compatibilty with code written
+        // for that
+        lua_pushnumber( L, itAreaRoom.next() );
         lua_settable(L, -3);
     }
     return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9906,8 +9906,11 @@ int TLuaInterpreter::setGridMode( lua_State * L )
         {
             if( pHost->mpMap->mpMapper->mp2dMap )
             {
-                pHost->mpMap->mpMapper->mp2dMap->init();
-                cout << "NEW GRID MAP: init" << endl;
+// Not needed IMHO - Slysven
+//                pHost->mpMap->mpMapper->mp2dMap->init();
+//                cout << "NEW GRID MAP: init" << endl;
+// But this is:
+                pHost->mpMap->mpMapper->update();
             }
         }
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1114,37 +1114,52 @@ int TLuaInterpreter::getMapEvents(lua_State * L){
 
 int TLuaInterpreter::centerview( lua_State * L )
 {
-    int roomid;
-    if( lua_isnumber( L, 1 ) || lua_isstring( L, 1 ) )
-    {
-        roomid = lua_tointeger( L, 1 );
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "centerview: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
     }
-    else
-    {
-        lua_pushstring( L, "centerview: need a valid room ID" );
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "centerview: no map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
+
+    int roomId;
+    if( ! lua_isnumber( L, 1 ) ) {
+        lua_pushstring( L, tr( "centerview: bad argument #1 type (room Id as number required, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
+    else {
+        roomId = lua_tointeger( L, 1 );
+    }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if( pHost->mpMap && pHost->mpMap->mpRoomDB->getRoom( roomid ) )
-    {
-        pHost->mpMap->mRoomIdHash[ pHost->getName() ] = roomid;
+    TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
+    if( pR ) {
+        pHost->mpMap->mRoomIdHash[ pHost->getName() ] = roomId;
         pHost->mpMap->mNewMove = true;
-        if( pHost->mpMap->mpM )
-        {
+        if( pHost->mpMap->mpM ) {
             pHost->mpMap->mpM->update();
         }
-        if( pHost->mpMap->mpM )
-        {
+
+        if( pHost->mpMap->mpMapper->mp2dMap ) {
             pHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = true;
             pHost->mpMap->mpMapper->mp2dMap->update();
             pHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = false;
+            pHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
         }
-
+        lua_pushboolean( L, true );
+        return 1;
     }
-
-    return 0;
+    else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "centerview: bad argument #1 value (room Id %1 does not exist.)" )
+                        .arg( roomId ).toUtf8().constData() );
+        return 2;
+    }
 }
 
 int TLuaInterpreter::copy( lua_State * L )
@@ -6860,6 +6875,12 @@ int TLuaInterpreter::setAreaName( lua_State *L )
                             .arg( existingName ).toUtf8().constData() );
             return 2;
         }
+        else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( -1 ).contains( existingName ) ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area name \"%1\" is reserved and protected - it cannot be changed)." )
+                            .arg( existingName ).toUtf8().constData() );
+            return 2;
+        }
     }
     else {
         lua_pushstring( L, tr( "setAreaName: bad argument #1 type (area Id as number or area name as string expected, got %1)." )
@@ -11087,8 +11108,25 @@ int TLuaInterpreter::setDefaultAreaVisible( lua_State * L )
         lua_error( L );
     }
     else {
+        bool isToShowDefaultArea = lua_toboolean( L, 1 );
         if( pHost->mpMap->mpMapper ) {
-            pHost->mpMap->mpMapper->setDefaultAreaShown( lua_toboolean( L, 1 ) );
+            // If we are reenabled the display of the default area
+            // AND the mapper was showing the default area
+            // the area widget will NOT be showing the correct area name afterwards
+            bool isAreaWidgetInNeedOfResetting = false;
+            if(  ( ! pHost->mpMap->mpMapper->getDefaultAreaShown() )
+              && ( isToShowDefaultArea )
+              && ( pHost->mpMap->mpMapper->mp2dMap->mAID == -1 ) ) {
+                isAreaWidgetInNeedOfResetting = true;
+            }
+
+            pHost->mpMap->mpMapper->setDefaultAreaShown( isToShowDefaultArea );
+            if( isAreaWidgetInNeedOfResetting ) {
+                // Corner case fixup:
+                pHost->mpMap->mpMapper->showArea->setCurrentText( pHost->mpMap->mpRoomDB->getDefaultAreaName() );
+            }
+            pHost->mpMap->mpMapper->mp2dMap->repaint();
+            pHost->mpMap->mpMapper->update();
             lua_pushboolean( L, true );
         }
         else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1129,7 +1129,7 @@ int TLuaInterpreter::centerview( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( pHost->mpMap && pHost->mpMap->mpRoomDB->getRoom( roomid ) )
     {
-        pHost->mpMap->mRoomId = roomid;
+        pHost->mpMap->mRoomIdHash[ pHost->getName() ] = roomid;
         pHost->mpMap->mNewMove = true;
         if( pHost->mpMap->mpM )
         {
@@ -4448,7 +4448,7 @@ int TLuaInterpreter::getRoomWeight( lua_State *L )
     }
     else
     {
-        roomId = pHost->mpMap->mRoomId;
+        roomId = pHost->mpMap->mRoomIdHash.value( pHost->getName() );
     }
 
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11051,6 +11051,51 @@ int TLuaInterpreter::reloadModule( lua_State * L)
     return 0;
 }
 
+// Once a mapper has been created it will, by default, include the "Default
+// Area" associated with the reserved area Id -1 in the list of Areas shown in
+// the area selection widget.  This function will immediately hide that entry
+// if given a true argument and restore it if set to false.  The setting is NOT
+// saved and this function was created to address a specific need for that area
+// to not be immediately shown to users for one package writer who needed to
+// hide rooms until they have been "explored".  This setting is ALSO present on
+// the last "Special Options" tab of the "Profile Preferences" - although it is
+// hidden until there IS a mapper to apply the setting to.
+
+// Returns true on successfully setting the desired value or false if there is
+// (not yet) a map display to apply it to.  Also throws an Error or returned a
+// nil value - both with an accompied error string - if there are problems.
+int TLuaInterpreter::setDefaultAreaVisible( lua_State * L )
+{
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setDefaultAreaVisible: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setDefaultAreaVisible: no map present or loaded!" ).toUtf8().constData() );
+        return 2;
+    }
+
+    if( ! lua_isboolean( L, 1 ) ) {
+        lua_pushstring( L, tr( "setDefaultAreaVisible: bad argument #1 type (isToShowDefaultArea as boolean expected, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+        lua_error( L );
+    }
+    else {
+        if( pHost->mpMap->mpMapper ) {
+            pHost->mpMap->mpMapper->setDefaultAreaShown( lua_toboolean( L, 1 ) );
+            lua_pushboolean( L, true );
+        }
+        else {
+            lua_pushboolean( L, false );
+        }
+    }
+    return 1;
+}
+
+
 int TLuaInterpreter::registerAnonymousEventHandler( lua_State * L )
 {
     string event;
@@ -12522,6 +12567,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "clearAreaUserDataItem", TLuaInterpreter::clearAreaUserDataItem );
     lua_register( pGlobalLua, "clearMapUserData", TLuaInterpreter::clearMapUserData );
     lua_register( pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem );
+    lua_register( pGlobalLua, "setDefaultAreaVisible", TLuaInterpreter::setDefaultAreaVisible );
 
 
     luaopen_yajl(pGlobalLua);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -398,6 +398,7 @@ public:
     static int clearAreaUserDataItem( lua_State * );
     static int clearMapUserData( lua_State * );
     static int clearMapUserDataItem( lua_State * );
+    static int setDefaultAreaVisible( lua_State * );
 
 
     std::list<std::string> mCaptureGroupList;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -211,7 +211,10 @@ int compSign(int a, int b){
 void TMap::connectExitStub(int roomId, int dirType)
 {
     TRoom * pR = mpRoomDB->getRoom( roomId );
-    if( !pR ) return;
+    if( !pR )
+    {
+        return;
+    }
     int area = pR->getArea();
     int minDistance = 999999;
     int minDistanceRoom=0, meanSquareDistance=0;
@@ -221,44 +224,70 @@ void TMap::connectExitStub(int roomId, int dirType)
     int rx = pR->x, ry = pR->y, rz = pR->z;
     int dx=0,dy=0,dz=0;
     TArea * pA = mpRoomDB->getArea(area);
-    if( !pA ) return;
-    for( int i=0; i< pA->rooms.size(); i++ )
+    if( !pA )
     {
-        pR = mpRoomDB->getRoom( pA->rooms[i] );
-        if( !pR ) continue;
-        if( pR->getId() == roomId ) continue;
+        return;
+    }
+    QSetIterator<int> itRoom( pA->getAreaRooms() );
+    while( itRoom.hasNext() )
+    {
+        pR = mpRoomDB->getRoom( itRoom.next() );
+        if( !pR )
+        {
+            continue;
+        }
+        if( pR->getId() == roomId )
+        {
+            continue;
+        }
         if(uz)
         {
-            dz = (int)pR->z-rz;
-            if(!compSign(dz,uz) || !dz) continue;
+            dz = pR->z-rz;
+            if(!compSign(dz,uz) || !dz)
+            {
+                continue;
+            }
         }
         else
         {
             //to avoid lower/upper floors from stealing stubs
-            if((int)pR->z != rz) continue;
+            if(pR->z != rz)
+            {
+                continue;
+            }
         }
         if(ux)
         {
-            dx = (int)pR->x-rx;
+            dx = pR->x-rx;
             if (!compSign(dx,ux) || !dx) //we do !dx to make sure we have a component in the desired direction
-                continue;
+            {
+               continue;
+            }
         }
         else
         {
             //to avoid rooms on same plane from stealing stubs
-            if((int)pR->x != rx) continue;
+            if((int)pR->x != rx)
+            {
+                continue;
+            }
         }
         if(uy)
         {
-            dy = (int)pR->y-ry;
+            dy = pR->y-ry;
             //if the sign is the SAME here we keep it b/c we flip our y coordinate.
             if (compSign(dy,uy) || !dy)
+            {
                 continue;
+            }
         }
         else
         {
             //to avoid rooms on same plane from stealing stubs
-            if((int)pR->y != ry) continue;
+            if(pR->y != ry)
+            {
+                continue;
+            }
         }
         meanSquareDistance=dx*dx+dy*dy+dz*dz;
         if(meanSquareDistance < minDistance)
@@ -270,7 +299,10 @@ void TMap::connectExitStub(int roomId, int dirType)
     if(minDistanceRoom)
     {
         pR = mpRoomDB->getRoom(minDistanceRoom);
-        if( !pR ) return;
+        if( !pR )
+        {
+            return;
+        }
         if(pR->exitStubs.contains(reverseDirections[dirType]))
         {
             setExit( roomId, minDistanceRoom, dirType);
@@ -443,30 +475,34 @@ void TMap::solveRoomCollision( int id, int creationDirection, bool PCheck )
 
 QList<int> TMap::detectRoomCollisions( int id )
 {
+    QList<int> collList;
     TRoom * pR = mpRoomDB->getRoom( id );
     if( !pR )
     {
-        QList<int> l;
-        return l;
+        return collList;
     }
     int area = pR->getArea();
     int x = pR->x;
     int y = pR->y;
     int z = pR->z;
-    QList<int> collList;
     TArea * pA = mpRoomDB->getArea( area );
     if( !pA )
     {
-        QList<int> l;
-        return l;
+        return collList;
     }
-    for( int i=0; i< pA->rooms.size(); i++ )
+
+    QSetIterator<int> itRoom( pA->getAreaRooms() );
+    while( itRoom.hasNext() )
     {
-        pR = mpRoomDB->getRoom( pA->rooms[i] );
-        if( !pR ) continue;
+        int checkRoomId = itRoom.next();
+        pR = mpRoomDB->getRoom( checkRoomId );
+        if( !pR )
+        {
+            continue;
+        }
         if( pR->x == x && pR->y == y && pR->z == z )
         {
-            collList.push_back( pA->rooms[i] );
+            collList.push_back( checkRoomId );
         }
     }
 
@@ -949,24 +985,24 @@ bool TMap::serialize( QDataStream & ofs )
 {
 
     if( mSaveVersion != mVersion ) {
-        QString message = tr( "[ ALERT ]  - Saving map in a format {%1} that is different than the one it was\n"
-                                           "loaded as {%2}. This may be an issue if you want to share the resulting\n"
-                                           "map with others relying on the original format." )
+        QString message = tr( "[ ALERT ] - Saving map in a format {%1} that is different than the one it was\n"
+                                          "loaded as {%2}. This may be an issue if you want to share the resulting\n"
+                                          "map with others relying on the original format." )
                           .arg( mSaveVersion )
                           .arg( mVersion );
         mpHost->mTelnet.postMessage( message );
     }
 
     if( mSaveVersion != mDefaultVersion ) {
-        QString message = tr( "[ WARN ]   - Saving map in a format {%1} that is different than the one\n"
-                                           "recommended {%2} baring in mind the build status of the source\n"
-                                           "code.  Development code versions may offer the chance to try\n"
-                                           "experimental features needing a revised format that could be\n"
-                                           "incompatible with existing release code versions.  Conversely\n"
-                                           "a release version may allow you to downgrade to save a map in\n"
-                                           "a format compatible with others using older versions of MUDLET\n"
-                                           "however some features may be crippled or non-operational for\n"
-                                           "this version of MUDLET." )
+        QString message = tr( "[ WARN ]  - Saving map in a format {%1} that is different than the one\n"
+                                          "recommended {%2} baring in mind the build status of the source\n"
+                                          "code.  Development code versions may offer the chance to try\n"
+                                          "experimental features needing a revised format that could be\n"
+                                          "incompatible with existing release code versions.  Conversely\n"
+                                          "a release version may allow you to downgrade to save a map in\n"
+                                          "a format compatible with others using older versions of MUDLET\n"
+                                          "however some features may be crippled or non-operational for\n"
+                                          "this version of MUDLET." )
                           .arg( mSaveVersion )
                           .arg( mDefaultVersion );
         mpHost->postMessage( message );
@@ -983,8 +1019,8 @@ bool TMap::serialize( QDataStream & ofs )
     // TODO: Remove when versions < 17 are not an option...
     else {
         if( ! mUserData.isEmpty() ) {
-            QString message = tr( "[ ALERT ]  - Map User data has been lost in saved map file.  Re-save in a\n"
-                                               "format of at least 17 to preserve it before quitting!" )
+            QString message = tr( "[ ALERT ] - Map User data has been lost in saved map file.  Re-save in a\n"
+                                              "format of at least 17 to preserve it before quitting!" )
                                   .arg( mSaveVersion );
             mpHost->mTelnet.postMessage( message );
         }
@@ -1012,12 +1048,26 @@ bool TMap::serialize( QDataStream & ofs )
         ofs << pA->min_y;
         ofs << pA->min_z;
         ofs << pA->span;
-        ofs << pA->xmaxEbene;
-        ofs << pA->ymaxEbene;
-        ofs << pA->zmaxEbene;
-        ofs << pA->xminEbene;
-        ofs << pA->yminEbene;
-        ofs << pA->zminEbene;
+        if( mSaveVersion >= 17) {
+            ofs << pA->xmaxEbene;
+            ofs << pA->ymaxEbene;
+            ofs << pA->xminEbene;
+            ofs << pA->yminEbene;
+        }
+        else { // Recreate the pointless z{min|max}Ebene items
+            QMap<int, int> dummyMinMaxEbene;
+            QListIterator<int> itZ( pA->ebenen );
+            while( itZ.hasNext() ) {
+                int dummyEbenValue = itZ.next();
+                dummyMinMaxEbene.insert( dummyEbenValue, dummyEbenValue );
+            }
+            ofs << pA->xmaxEbene;
+            ofs << pA->ymaxEbene;
+            ofs << dummyMinMaxEbene;
+            ofs << pA->xminEbene;
+            ofs << pA->yminEbene;
+            ofs << dummyMinMaxEbene;
+        }
         ofs << pA->pos;
         ofs << pA->isZone;
         ofs << pA->zoneAreaRef;
@@ -1043,9 +1093,9 @@ bool TMap::serialize( QDataStream & ofs )
             areaIds.append( QString::number( areasWithData.takeFirst() ) );
         } while( ! areasWithData.isEmpty() );
 
-        QString message = tr( "[ ALERT ]  - Area User data has been lost in saved map file.  Re-save in a\n"
-                                           "format of at least 17 to preserve it before quitting!\n"
-                                           "Areas Id affected: %1." )
+        QString message = tr( "[ ALERT ] - Area User data has been lost in saved map file.  Re-save in a\n"
+                                          "format of at least 17 to preserve it before quitting!\n"
+                                          "Areas Id affected: %1." )
                               .arg( areaIds.join( tr( ", " ) ) ); // Translatable in case list separators are locale dependendent!
         mpHost->mTelnet.postMessage( message );
     }
@@ -1273,14 +1323,7 @@ bool TMap::restore(QString location)
                 ifs >> pA->rooms;
 // Can be useful when analysing suspect map files!
 //                qDebug() << "TMap::restore(...)" << "Area:" << areaID;
-// This is not essential but can help when debugging - so the rooms are in
-// ascending order
-                if( pA->rooms.count() > 1 ) {
-                    qSort( pA->rooms.begin(), pA->rooms.end() );
-                }
-// Can be useful when analysing suspect map files!
 //                qDebug() << "Rooms:" << pA->rooms;
-
                 ifs >> pA->ebenen;
                 ifs >> pA->exits;
                 ifs >> pA->gridMode;
@@ -1291,12 +1334,21 @@ bool TMap::restore(QString location)
                 ifs >> pA->min_y;
                 ifs >> pA->min_z;
                 ifs >> pA->span;
-                ifs >> pA->xmaxEbene;
-                ifs >> pA->ymaxEbene;
-                ifs >> pA->zmaxEbene;
-                ifs >> pA->xminEbene;
-                ifs >> pA->yminEbene;
-                ifs >> pA->zminEbene;
+                if( mVersion >= 17 ) {
+                    ifs >> pA->xmaxEbene;
+                    ifs >> pA->ymaxEbene;
+                    ifs >> pA->xminEbene;
+                    ifs >> pA->yminEbene;
+                }
+                else {
+                    QMap<int, int> dummyMinMaxEbene;
+                    ifs >> pA->xmaxEbene;
+                    ifs >> pA->ymaxEbene;
+                    ifs >> dummyMinMaxEbene;
+                    ifs >> pA->xminEbene;
+                    ifs >> pA->yminEbene;
+                    ifs >> dummyMinMaxEbene;
+                }
                 ifs >> pA->pos;
                 ifs >> pA->isZone;
                 ifs >> pA->zoneAreaRef;
@@ -1377,6 +1429,7 @@ bool TMap::restore(QString location)
         customEnvColors[271] = mpHost->mLightWhite_2;
         customEnvColors[272] = mpHost->mLightBlack_2;
 
+        qDebug() << "TMap::restore(...) loading time:" << _time.nsecsElapsed() * 1.0e-9 << "sec.";
         QString okMsg = tr( "[  OK  ]  - Sucessfully read map file, will now check some consistancy details." );
         mpHost->postMessage( okMsg );
         if( canRestore ) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1903,3 +1903,9 @@ void TMap::postMessage( const QString text )
         }
     }
 }
+
+// Used by the 2D mapper to send view center coordinates to 3D one
+void TMap::set3DViewCenter( const int areaId, const int xPos, const int yPos, const int zPos )
+{
+    mpM->setViewCenter( areaId, xPos, yPos, zPos );
+}

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -112,8 +112,15 @@ TMap::TMap( Host * pH )
     mRightDown = false;
 }
 
-TMap::~TMap() {
+TMap::~TMap()
+{
     delete mpRoomDB;
+    if( ! mStoredMessages.isEmpty() ) {
+        qWarning( "TMap::~TMap() Instance being destroyed before it could display some messages,\nmessages are:\n------------");
+        foreach(QString message, mStoredMessages) {
+                qWarning("%s\n------------", qPrintable( message ) );
+        }
+    }
 }
 
 void TMap::mapClear()
@@ -397,32 +404,27 @@ bool TMap::setExit( int from, int to, int dir )
     return ret;
 }
 
-void TMap::init( Host * pH )
+void TMap::audit()
 {
     // init areas
     QElapsedTimer _time;
     _time.start();
 
-    if( mVersion < 14 ) {
-        mpRoomDB->initAreasForOldMaps();
+    { // Blocked - just to limit the scope of infoMsg...!
+        QString infoMsg = tr( "[ INFO ]  - ...auditing of map starting..." );
+        postMessage( infoMsg );
     }
-    else if( mVersion < 17 ) {
-        // The second half of mpRoomDB->initAreasForOldMaps() - needed to fixup
-        // all the (TArea *)->areaExits() that were built wrongly previously,
-        // calcSpan() may not be required to be done here and now but it is in my
-        // sights as a target for revision in the future. Slysven
-        QMapIterator<int, TArea *> itArea( mpRoomDB->getAreaMap() );
-        while( itArea.hasNext() ) {
-            itArea.next();
-            itArea.value()->determineAreaExits();
-            itArea.value()->calcSpan();
-        }
-    }
-    mpRoomDB->auditRooms();
+
+    // The old mpRoomDB->initAreasForOldMaps() was a subset of these checks
+
+    QHash<int, int> roomRemapping; // These are populated by the auditRooms(...)
+    QHash<int, int> areaRemapping; // call and contain "Keys" of old Ids and
+                                   // "Values" of new Ids to use in their stead
 
     if( mVersion <16 ) {
         // convert old style labels, wasn't made version conditional in past but
         // not likely to be an issue in recent map file format versions (say 16+)
+
         QMapIterator<int, TArea *> itArea( mpRoomDB->getAreaMap() );
         while( itArea.hasNext() ) {
             itArea.next();
@@ -460,7 +462,26 @@ void TMap::init( Host * pH )
             }
         }
     }
-    qDebug() << "TMap::init() Initialize run time:" << _time.nsecsElapsed() * 1.0e-9 << "sec.";
+
+    mpRoomDB->auditRooms( roomRemapping, areaRemapping );
+
+    // The second half of old mpRoomDB->initAreasForOldMaps() - needed to fixup
+    // all the (TArea *)->areaExits() that were built wrongly previously,
+    // calcSpan() may not be required to be done here and now but it is in my
+    // sights as a target for revision in the future. Slysven
+    QMapIterator<int, TArea *> itArea( mpRoomDB->getAreaMap() );
+    while( itArea.hasNext() ) {
+        itArea.next();
+        itArea.value()->determineAreaExits();
+        itArea.value()->calcSpan();
+        itArea.value()->mIsDirty = false;
+    }
+
+    { // Blocked - just to limit the scope of infoMsg...!
+        QString infoMsg = tr( "[  OK  ]  - Auditing of map completed in %1 seconds. Enjoy your game..." )
+                              .arg( _time.nsecsElapsed() * 1.0e-9 );
+        postMessage( infoMsg );
+    }
 }
 
 
@@ -1316,9 +1337,9 @@ bool TMap::restore(QString location)
         }
         else {
             // Less than (but not less than 4) or equal to default version
-            QString infoMsg = tr( "[ INFO ]  - Reading map file: \"%1\", format version:%2, please wait..." )
-                              .arg( file.fileName() )
-                              .arg( mVersion );
+            QString infoMsg = tr( "[ INFO ]  - Reading map (format version:%1) file:\n\"%2\",\nplease wait..." )
+                                  .arg( mVersion )
+                                  .arg( file.fileName() );
             mpHost->postMessage( infoMsg );
             mSaveVersion = mVersion; // Make the save version the default one - unless the user intervenes
         }
@@ -1472,8 +1493,9 @@ bool TMap::restore(QString location)
         customEnvColors[271] = mpHost->mLightWhite_2;
         customEnvColors[272] = mpHost->mLightBlack_2;
 
-        qDebug() << "TMap::restore(...) loading time:" << _time.nsecsElapsed() * 1.0e-9 << "sec.";
-        QString okMsg = tr( "[  OK  ]  - Sucessfully read map file, will now check some consistancy details." );
+        QString okMsg = tr( "[ INFO ]  - Sucessfully read the map file in %1 seconds, will now check\n"
+                                        "some consistency details, please wait..." )
+                            .arg( _time.nsecsElapsed() * 1.0e-9 );
         mpHost->postMessage( okMsg );
         if( canRestore ) {
             return true;
@@ -1493,16 +1515,12 @@ bool TMap::restore(QString location)
             QPushButton *yesButton = msgBox.addButton("Download the map", QMessageBox::ActionRole);
             QPushButton *noButton = msgBox.addButton("Start my own", QMessageBox::ActionRole);
             msgBox.exec();
-            init( mpHost );
             if( msgBox.clickedButton() == yesButton ) {
                 mpMapper->downloadMap();
             }
             else if( msgBox.clickedButton() == noButton ) {
                 ; //No-op to avoid unused "noButton"
             }
-        }
-        else {
-            mpHost->mpMap->init( mpHost );
         }
     }
 
@@ -1865,4 +1883,15 @@ void TMap::deleteMapLabel(int area, int labelID )
     if( ! mapLabels[area].contains( labelID ) ) return;
     mapLabels[area].remove( labelID );
     if( mpMapper ) mpMapper->mp2dMap->update();
+}
+
+void TMap::postMessage( const QString text )
+{
+    mStoredMessages.append( text );
+    Host * pHost = mpHost;
+    if( pHost ) {
+        while( ! mStoredMessages.isEmpty() ) {
+            pHost->postMessage( mStoredMessages.takeFirst() );
+        }
+    }
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -439,7 +439,7 @@ void TMap::audit()
                             QString msg = tr( "[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2." )
                                           .arg(areaID)
                                           .arg(labelIDList.at(i) );
-                            mpHost->postMessage(msg);
+                            postMessage(msg);
                             mapLabels[areaID][labelIDList.at(i)] = mapLabels[areaID][newID];
                             deleteMapLabel( areaID, newID );
                         }
@@ -447,7 +447,7 @@ void TMap::audit()
                             QString msg = tr( "[ WARN ] - CONVERTING: cannot convert old style label, areaID:%1 labelID:%2." )
                                           .arg(areaID)
                                           .arg(labelIDList.at(i));
-                            mpHost->postMessage(msg);
+                            postMessage(msg);
                         }
                     }
                     if (    ( l.size.width() >  std::numeric_limits<qreal>::max() )
@@ -1030,7 +1030,7 @@ bool TMap::serialize( QDataStream & ofs )
                                           "this version of MUDLET." )
                           .arg( mSaveVersion )
                           .arg( mDefaultVersion );
-        mpHost->postMessage( message );
+        postMessage( message );
     }
 
     ofs << mSaveVersion;
@@ -1216,7 +1216,7 @@ bool TMap::serialize( QDataStream & ofs )
     return true;
 }
 
-bool TMap::restore(QString location)
+bool TMap::restore( QString location )
 {
     qDebug() << "TMap::restore(" << location << ") INFO: restoring map of Profile:"
              << mpHost->getName()
@@ -1246,7 +1246,7 @@ bool TMap::restore(QString location)
         if( ! file.open( QFile::ReadOnly ) ) {
             QString errMsg = tr( "[ ERROR ] - Unable to open (for reading) map file: \"%1\"!" )
                              .arg( file.fileName() );
-            mpHost->postMessage( errMsg );
+            postMessage( errMsg );
             return false;
         }
 
@@ -1261,7 +1261,7 @@ bool TMap::restore(QString location)
                                                  "Mudlet can handle (%2)!" )
                                  .arg( mVersion )
                                  .arg( mDefaultVersion );
-                mpHost->postMessage( errMsg );
+                postMessage( errMsg );
                 QString infoMsg = tr( "[ INFO ]  - You will need to upgrade your Mudlet or find a Map file saved in a\n"
                                                   "format that it CAN read.  As this Mudlet appears to be based on a\n"
                                                   "release version of the source code it is possible that you, or the\n"
@@ -1273,7 +1273,7 @@ bool TMap::restore(QString location)
                                                   "directory and selecting a file to load that is NOT the most recent one\n"
                                                   "(which is the one that is selected normally) though it is probable that\n"
                                                   "the stored location of the current map location will be wrong." );
-                mpHost->postMessage( infoMsg );
+                postMessage( infoMsg );
                 file.close();
                 return false;
             }
@@ -1285,7 +1285,7 @@ bool TMap::restore(QString location)
                                                      "Mudlet can handle (%2)!" )
                                      .arg( mVersion )
                                      .arg( mMaxVersion );
-                    mpHost->postMessage( errMsg );
+                    postMessage( errMsg );
                     QString infoMsg = tr( "[ INFO ]  - You will need to upgrade your Mudlet or find a Map file saved in a\n"
                                                       "format that it CAN read.  Even though this Mudlet appears to be based on a\n"
                                                       "development version of the source code it is possible that you, or the\n"
@@ -1297,7 +1297,7 @@ bool TMap::restore(QString location)
                                                       "directory and selecting a file to load that is NOT the most recent one\n"
                                                       "(which is the one that is selected normally) though it is probable that\n"
                                                       "the stored location of the current map location will be wrong." );
-                    mpHost->postMessage( infoMsg );
+                    postMessage( infoMsg );
                     file.close();
                     return false;
                 }
@@ -1306,7 +1306,7 @@ bool TMap::restore(QString location)
                                                        "the default for this version of Mudlet (%2)!" )
                                      .arg( mVersion )
                                      .arg( mDefaultVersion );
-                    mpHost->postMessage( alertMsg );
+                    postMessage( alertMsg );
                     QString infoMsg = tr( "[ INFO ]  - You are using a new, possibly experimental, map file format which this\n"
                                                       "version of Mudlet CAN read.  This Mudlet appears to be based on a\n"
                                                       "development version of the source code so it is possible that you, or the\n"
@@ -1314,7 +1314,7 @@ bool TMap::restore(QString location)
                                                       "advanced version that has additional features that need a revised format;\n"
                                                       "beware that this file may not be usable by the current release version\n"
                                                       "of Mudlet that you or others with whom you might share it have!" );
-                    mpHost->postMessage( infoMsg );
+                    postMessage( infoMsg );
                     mSaveVersion = mVersion; // Make the save version default to the loaded one
                                              // this means that each session using a particular
                                              // map file version will continue to use it unless
@@ -1327,11 +1327,11 @@ bool TMap::restore(QString location)
                                                "this version of Mudlet may not gain enough information from\n"
                                                "it but it will try!" )
                                .arg( mVersion );
-            mpHost->postMessage( alertMsg );
+            postMessage( alertMsg );
             QString infoMsg = tr( "[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
                                               "There is so much data that it DOES NOT have that you could be\n"
                                               "be better off starting again..." );
-            mpHost->postMessage( infoMsg );
+            postMessage( infoMsg );
             canRestore = false;
             mSaveVersion = mVersion; // Make the save version the default one - unless the user intervenes
         }
@@ -1340,7 +1340,7 @@ bool TMap::restore(QString location)
             QString infoMsg = tr( "[ INFO ]  - Reading map (format version:%1) file:\n\"%2\",\nplease wait..." )
                                   .arg( mVersion )
                                   .arg( file.fileName() );
-            mpHost->postMessage( infoMsg );
+            postMessage( infoMsg );
             mSaveVersion = mVersion; // Make the save version the default one - unless the user intervenes
         }
 
@@ -1411,11 +1411,19 @@ bool TMap::restore(QString location)
                 if( mVersion >= 17 ) {
                     ifs >> pA->mUserData;
                 }
-                mpRoomDB->restoreSingleArea( ifs, areaID, pA );
+                mpRoomDB->restoreSingleArea( areaID, pA );
             }
         }
 
-        if( mVersion >= 18 ) {
+        if( ! mpRoomDB->getAreaMap().keys().contains( -1 ) ) {
+            TArea * pDefaultA = new TArea( this, mpRoomDB );
+            mpRoomDB->restoreSingleArea( -1, pDefaultA );
+            QString defaultAreaInsertionMsg = tr( "[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
+                                                              "area) not found, adding reserved -1 Id." );
+            postMessage( defaultAreaInsertionMsg );
+        }
+
+            if( mVersion >= 18 ) {
             // In version 18 we changed to store the "userRoom" for each profile
             // so that when copied/shared between profiles they do not interfere
             // with each other's saved value
@@ -1473,7 +1481,7 @@ bool TMap::restore(QString location)
             ifs >> i;
             TRoom * pT = new TRoom(mpRoomDB);
             pT->restore( ifs, i, mVersion );
-            mpRoomDB->restoreSingleRoom( ifs, i, pT );
+            mpRoomDB->restoreSingleRoom( i, pT );
         }
 
         customEnvColors[257] = mpHost->mRed_2;
@@ -1496,7 +1504,7 @@ bool TMap::restore(QString location)
         QString okMsg = tr( "[ INFO ]  - Sucessfully read the map file in %1 seconds, will now check\n"
                                         "some consistency details, please wait..." )
                             .arg( _time.nsecsElapsed() * 1.0e-9 );
-        mpHost->postMessage( okMsg );
+        postMessage( okMsg );
         if( canRestore ) {
             return true;
         }
@@ -1556,7 +1564,7 @@ const bool TMap::retrieveMapFileStats( QString profile, QString * latestFileName
     if( ! file.open( QFile::ReadOnly ) ) {
         QString errMsg = tr( "[ ERROR ] - Unable to open (for reading) map file: \"%1\"!" )
                          .arg( file.fileName() );
-        mpHost->postMessage( errMsg );
+        postMessage( errMsg );
         return false;
     }
 
@@ -1570,7 +1578,7 @@ const bool TMap::retrieveMapFileStats( QString profile, QString * latestFileName
     QString infoMsg = tr( "[ INFO ]  - Checking map file: \"%1\", format version:%2, please wait..." )
                       .arg( file.fileName() )
                       .arg( otherProfileVersion );
-    mpHost->postMessage( infoMsg );
+    postMessage( infoMsg );
 
     if( otherProfileVersion > mDefaultVersion ) {
         if( QByteArray( APP_BUILD ).isEmpty() ) {

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -92,7 +92,7 @@ public:
     void astHoehenAnpassung( int id, int );
     bool setExit( int from, int to, int dir );
     bool setRoomCoordinates( int id, int x, int y, int z );
-    void init(Host*);
+    void audit(); // Was init( Host * ) but host pointer was not used and it does not initialise a map!
     QList<int> detectRoomCollisions( int id );
     void solveRoomCollision( int id, int creationDirection, bool PCheck=true );
     void setRoom( int );
@@ -107,6 +107,7 @@ public:
     void exportMapToDatabase();
     void importMapFromDatabase();
     void connectExitStub(int roomId, int dirType);
+    void postMessage( const QString text );
 
 
     TRoomDB * mpRoomDB;
@@ -163,6 +164,9 @@ public:
                       // by mMinVersion and mMaxVersion.
 
     QMap<QString, QString> mUserData;
+
+private:
+    QStringList mStoredMessages;
 };
 
 #endif // MUDLET_TMAP_H

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -108,7 +108,18 @@ public:
     void importMapFromDatabase();
     void connectExitStub(int roomId, int dirType);
     void postMessage( const QString text );
-    void set3DViewCenter( const int, const int, const int, const int ); // Used by the 2D mapper to send view center coordinates to 3D one
+    void set3DViewCenter( const int, const int, const int, const int );
+    // Used by the 2D mapper to send view center coordinates to 3D one
+
+    void appendRoomErrorMsg( const int, const QString, const bool isToSetFileViewingRecommended = false );
+    void appendAreaErrorMsg( const int, const QString, const bool isToSetFileViewingRecommended = false );
+    void appendErrorMsg( const QString, const bool isToSetFileViewingRecommended = false );
+    void appendErrorMsgWithNoLf( const QString, const bool isToSetFileViewingRecommended = false );
+    void pushErrorMessagesToFile( const QString, const bool isACleanup = false );
+    // If the argument is true does not write out any thing if there is no data
+    // to dump, intended to be used before an operation like a map load so that
+    // any messages previously recorded are not associated with a "fresh" batch
+    // from the operation.
 
 
     TRoomDB * mpRoomDB;
@@ -165,9 +176,17 @@ public:
                       // by mMinVersion and mMaxVersion.
 
     QMap<QString, QString> mUserData;
+    bool isToDisplayAuditErrorsToConsole;
 
 private:
-    QStringList mStoredMessages;
+    const QString                   createFileHeaderLine( const QString, const QChar );
+
+    QStringList                     mStoredMessages;
+
+    QMap<int, QList<QString> >      mMapAuditRoomErrors; // Key is room number (where renumbered is the original one), Value is the errors, appended as they are found
+    QMap<int, QList<QString> >      mMapAuditAreaErrors; // As for the Room ones but with key as the area number
+    QList<QString>                  mMapAuditErrors;     // For the whole map
+    bool                            mIsFileViewingRecommended; // Are things so bad the user needs to check the log (ignored if messages ARE already sent to screen)
 };
 
 #endif // MUDLET_TMAP_H

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -108,6 +108,7 @@ public:
     void importMapFromDatabase();
     void connectExitStub(int roomId, int dirType);
     void postMessage( const QString text );
+    void set3DViewCenter( const int, const int, const int, const int ); // Used by the 2D mapper to send view center coordinates to 3D one
 
 
     TRoomDB * mpRoomDB;

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -101,7 +101,8 @@ public:
     bool gotoRoom( int, int );
     void setView( float, float, float, float );
     bool serialize( QDataStream & );
-    bool restore(QString location);
+    bool restore( QString );
+    const bool retrieveMapFileStats( QString, QString *, int *, int *, int *, int * );
     void initGraph();
     void exportMapToDatabase();
     void importMapFromDatabase();
@@ -112,7 +113,9 @@ public:
     QMap<int, int> envColors;
     QVector3D span;
     QPointer<Host> mpHost;
-    int mRoomId;
+    // Was a single int mRoomId but that breaks things when maps are
+    // copied/shared between profiles - so now we track the profile name
+    QHash<QString, int> mRoomIdHash;
     bool m2DPanMode;
     bool mLeftDown;
     bool mRightDown;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -211,7 +211,7 @@ bool TRoom::setArea( int areaID, bool isToDeferAreaRelatedRecalculations )
     //remove from the old area
     TArea * pA2 = mpRoomDB->getArea( area );
     if( pA2 ) {
-        pA2->removeRoom( id );
+        pA2->removeRoom( id, isToDeferAreaRelatedRecalculations );
         // Ah, all rooms in the OLD area that led to the room now become area
         // exits for that OLD area {so must run determineAreaExits() for the
         // old area after the room has moved to the new area see other

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1169,7 +1169,7 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
 {
 
     if( roomRemapping.contains( exitRoomId ) ) {
-        QString auditKey = QStringLiteral( "audit.remapped_exit.%1" ).arg( DIR_NORTH );
+        QString auditKey = QStringLiteral( "audit.remapped_exit.%1" ).arg( dirCode );
         userData.insert( auditKey, QString::number( exitRoomId ) );
         QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 correcting exit \"%2\" that was to room with\n"
                                           "an exit to invalid room: %3 to now go to: %4." )
@@ -1185,7 +1185,7 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
         // A real exit - should have a real destination, and NOT have a stub
         if( Q_UNLIKELY( ! mpRoomDB->getRoom( exitRoomId ) ) ) {
             // But it doesn't exist
-            QString auditKey = QStringLiteral( "audit.made_stub_of_valid_but_missing_exit.%1" ).arg( DIR_NORTH );
+            QString auditKey = QStringLiteral( "audit.made_stub_of_valid_but_missing_exit.%1" ).arg( dirCode );
             QString warnMsg = tr( "[ WARN ]  - Room with Id: %1 has an exit \"%2\" with an exit to: %3 but that room\n"
                                               "does not exist.  The exit will be removed (but the destination room\n"
                                               "Id will be stored in the room user data under a key:\n"
@@ -1285,7 +1285,7 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
     }
     else {
         // either 0 or < -1 and not renumbered because the bad room Id DID NOT exist
-        QString auditKey = QStringLiteral( "audit.made_stub_of_invalid_exit.%1" ).arg( DIR_NORTH );
+        QString auditKey = QStringLiteral( "audit.made_stub_of_invalid_exit.%1" ).arg( dirCode );
         userData.insert( auditKey, QString::number( exitRoomId ) );
         QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 exit \"%2\" that was to room with an invalid\n"
                               "room: %3 that does not exist.  The exit will be removed (the bad destination\n"

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -379,25 +379,13 @@ QHash<int, int> TRoom::getExits()
 
 void TRoom::setExitLock( int exit, bool state )
 {
-    if( ! state )
-    {
-        exitLocks.removeAll( exit );
-        return;
+    if( state ) {
+        if( ( ! exitLocks.contains( exit ) ) && ( exit >= DIR_NORTH && exit <= DIR_OUT ) ) {
+            exitLocks.push_back( exit );
+        }
     }
-    switch( exit )
-    {
-        case DIR_NORTH: exitLocks.push_back(DIR_NORTH); break;
-        case DIR_NORTHEAST: exitLocks.push_back(DIR_NORTHEAST); break;
-        case DIR_NORTHWEST: exitLocks.push_back(DIR_NORTHWEST); break;
-        case DIR_SOUTHEAST: exitLocks.push_back(DIR_SOUTHEAST); break;
-        case DIR_SOUTHWEST: exitLocks.push_back(DIR_SOUTHWEST); break;
-        case DIR_SOUTH: exitLocks.push_back(DIR_SOUTH); break;
-        case DIR_EAST: exitLocks.push_back(DIR_EAST); break;
-        case DIR_WEST: exitLocks.push_back(DIR_WEST); break;
-        case DIR_UP: exitLocks.push_back(DIR_UP); break;
-        case DIR_DOWN: exitLocks.push_back(DIR_DOWN); break;
-        case DIR_IN: exitLocks.push_back(DIR_IN); break;
-        case DIR_OUT: exitLocks.push_back(DIR_OUT); break;
+    else {
+        exitLocks.removeAll( exit );
     }
 }
 
@@ -1300,7 +1288,9 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
         customLinesArrowPool.remove( customLine );
     }
     else {
-        // either 0 or < -1 and not renumbered because the bad room Id DID NOT exist
+        // either 0 or < -1 and not renumbered because the bad room Id DID NOT
+        // exist, there could be a "double fault" in that there is also a stub
+        // exit, but that will be masked as we turn the exit into a stub anyhow.
         QString auditKey = QStringLiteral( "audit.made_stub_of_invalid_exit.%1" ).arg( dirCode );
         userData.insert( auditKey, QString::number( exitRoomId ) );
         QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 exit \"%2\" that was to room with an invalid\n"
@@ -1312,18 +1302,40 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
                               .arg( displayName )
                               .arg( exitRoomId )
                               .arg( auditKey );
-        mpRoomDB->mpMap->postMessage( infoMsg );
         exitRoomId = -1;
 
         if( ! exitStubs.contains( dirCode ) ) {
             // Add the stub
             exitStubs.append( dirCode );
-            exitStubsPool.remove( dirCode ); // Remove the stub in this direction from check pool as we have handled it
+        }
+        exitStubsPool.remove( dirCode ); // Remove the stub in this direction from check pool as we have handled it
+
+        if( exitLocks.contains( dirCode ) ) {
+            QString auditKeyLocked = QStringLiteral( "audit.invalid_exit.%1.isLocked" ).arg( dirCode );
+            userData.insert( auditKeyLocked, QStringLiteral( "true" ) );
+            infoMsg.append( tr( "\nIt was locked, this is recorded as user data with key:\n"
+                                "\"%1\"." )
+                            .arg( auditKeyLocked ) );
+            exitLocks.removeAll( dirCode );
         }
 
-        exitLocks.removeAll( dirCode );
-        exitWeights.remove( doorAndWeight );
-        customLines.remove( customLine );
+        if( exitWeights.contains( doorAndWeight ) ) {
+            QString auditKeyWeight = QStringLiteral( "audit.invalid_exit.%1.weight" ).arg( dirCode );
+            userData.insert( auditKeyWeight, QString::number( exitWeights.value( doorAndWeight ) ) );
+            infoMsg.append( tr( "\nIt had a weight, this is recorded as user data with key:\n"
+                                "\"%1\"." )
+                            .arg( auditKeyWeight ) );
+            exitWeights.remove( doorAndWeight );
+        }
+
+        mpRoomDB->mpMap->postMessage( infoMsg );
+
+        if( customLines.contains( customLine ) ) {
+            QString warnMsg = tr( "[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
+                                              "it has not been possible to salvage this, it has been lost!" );
+            mpRoomDB->mpMap->postMessage( warnMsg );
+            customLines.remove( customLine );
+        }
         customLinesColor.remove( customLine );
         customLinesStyle.remove( customLine );
         customLinesArrow.remove( customLine );

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -23,6 +23,7 @@
 #include "TRoom.h"
 
 
+#include "mudlet.h"
 #include "TArea.h"
 #include "TRoomDB.h"
 
@@ -826,15 +827,19 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
             it.next();
             QString _cmd = it.value();
             if( _cmd.size() <= 0 ) {
-                QString warnMsg = tr( "[ WARN ]  - In room Id:%1 removing invalid (special) exit to %2 {with no name!}" )
-                                      .arg( id, 6, QLatin1Char( '0' ) )
-                                      .arg( it.key(), 6, QLatin1Char( '0' ) );
-                // If size is less than or equal to 0 then there is nothing to print!!!
-                /* This is wrong, must modify thing being iterated over via iterator:
-                 * other.remove( it.key(), it.value() );
-                 */
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString warnMsg = tr( "[ WARN ]  - In room id:%1 removing invalid (special) exit to %2 {with no name!}" )
+                                          .arg( id, 6, QLatin1Char( '0' ) )
+                                          .arg( it.key(), 6, QLatin1Char( '0' ) );
+                    // If size is less than or equal to 0 then there is nothing to print!!!
+                    /* This is wrong, must modify thing being iterated over via iterator:
+                     * other.remove( it.key(), it.value() );
+                     */
+                    mpRoomDB->mpMap->postMessage( warnMsg );
+                }
+                mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ WARN ]  - Room had an invalid (special) exit to %1 {with no name!} it was removed." )
+                                                             .arg( it.key(), 6, QLatin1Char( '0' ) ) );
                 it.remove();
-                mpRoomDB->mpMap->postMessage( warnMsg );
             }
             else if( ! ( _cmd.startsWith('1') || _cmd.startsWith('0') ) ) {
                 QString _nc = it.value();
@@ -848,13 +853,19 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
                  */
                 replacements.insert( _nk, _nc );
                 it.remove();
-                QString warnMsg = tr( "[ INFO ]  - In room Id:%1 patching {internal fixup} of (special) exit to\n"
-                                                  "%2, was: \"%3\" now: \"%4\"." )
-                                      .arg( id, 6, QLatin1Char( '0' ) )
-                                      .arg( _nk, 6, QLatin1Char( '0' ) )
-                                      .arg( _cmd )
-                                      .arg( _nc );
-                mpRoomDB->mpMap->postMessage( warnMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString warnMsg = tr( "[ INFO ]  - In room id:%1 patching {internal fixup} of (special) exit to\n"
+                                                      "%2, was: \"%3\" now: \"%4\"." )
+                                          .arg( id, 6, QLatin1Char( '0' ) )
+                                          .arg( _nk, 6, QLatin1Char( '0' ) )
+                                          .arg( _cmd )
+                                          .arg( _nc );
+                    mpRoomDB->mpMap->postMessage( warnMsg );
+                }
+                mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room needed patching {internal fixup} of (special) exit to %1, was: \"%2\" now: \"%3\"." )
+                                                             .arg( _nk, 6, QLatin1Char( '0' ) )
+                                                             .arg( _cmd )
+                                                             .arg( _nc ) );
             }
         }
         // Now finished with (mutable) iterator, can re-insert changed things
@@ -879,14 +890,20 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
             if( roomRemapping.contains( exitRoomId ) ) {
                 QString auditKey = QStringLiteral( "audit.remapped_special_exit.%1" ).arg( exitName );
                 userData.insert( auditKey, QString::number( exitRoomId ) );
-                QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 correcting special exit \"%2\" that\n"
-                                                  "was to room with an exit to invalid room: %3 to now go\n"
-                                                  "to: %4." )
-                                      .arg( id )
-                                      .arg( exitName )
-                                      .arg( exitRoomId )
-                                      .arg( roomRemapping.value( exitRoomId ) );
-                mpRoomDB->mpMap->postMessage( infoMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString infoMsg = tr( "[ INFO ]  - In room with id: %1 correcting special exit \"%2\" that\n"
+                                                      "was to room with an exit to invalid room: %3 to now go\n"
+                                                      "to: %4." )
+                                          .arg( id )
+                                          .arg( exitName )
+                                          .arg( exitRoomId )
+                                          .arg( roomRemapping.value( exitRoomId ) );
+                    mpRoomDB->mpMap->postMessage( infoMsg );
+                }
+                mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room needed correcting of special exit \"%1\" that was to room with an exit to invalid room: %2 to now go to: %3." )
+                                                             .arg( exitName )
+                                                             .arg( exitRoomId )
+                                                             .arg( roomRemapping.value( exitRoomId ) ) );
                 replacements.insert( roomRemapping.value( exitRoomId ), exitText );
                 it.remove();
                 exitRoomId = roomRemapping.value( exitRoomId );
@@ -912,16 +929,24 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
                 if( Q_UNLIKELY( ! mpRoomDB->getRoom( exitRoomId ) ) ) {
                     // But it doesn't exist
                     QString auditKey = QStringLiteral( "audit.removed_valid_but_missing_special_exit.%1" ).arg( exitName );
-                    QString warnMsg = tr( "[ WARN ]  - Room with Id: %1 has a special exit \"%2\" with an\n"
-                                                      "exit to: %3 but that room does not exist.  The exit will\n"
-                                                      "be removed (but the destination room Id will be stored in\n"
-                                                      "the room user data under a key:\n"
-                                                      "\"%4\")." )
-                                          .arg( id )
-                                          .arg( exitName )
-                                          .arg( exitRoomId )
-                                          .arg( auditKey );
-                    mpRoomDB->mpMap->postMessage( warnMsg );
+                    if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                        QString warnMsg = tr( "[ WARN ]  - Room with id: %1 has a special exit \"%2\" with an\n"
+                                                          "exit to: %3 but that room does not exist.  The exit will\n"
+                                                          "be removed (but the destination room id will be stored in\n"
+                                                          "the room user data under a key:\n"
+                                                          "\"%4\")." )
+                                              .arg( id )
+                                              .arg( exitName )
+                                              .arg( exitRoomId )
+                                              .arg( auditKey );
+                        mpRoomDB->mpMap->postMessage( warnMsg );
+                    }
+                    mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ WARN ]  - Room has a special exit \"%1\" with an exit to: %2 but that room does not exist."
+                                                                 "  The exit will be removed (but the destination room id will be stored in the room user data under a key:"
+                                                                 "\"%3\")." )
+                                                                 .arg( exitName )
+                                                                 .arg( exitRoomId )
+                                                                 .arg( auditKey ), true );
                     userData.insert( auditKey, QString::number( exitRoomId ) );
                     it.remove();
 
@@ -957,16 +982,24 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
                 // < 1 and not renumbered because the bad room Id DID NOT exist
                 QString auditKey = QStringLiteral( "audit.removed_invalid_special_exit.%1" ).arg( exitName );
                 userData.insert( auditKey, QString::number( exitRoomId ) );
-                QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 special exit \"%2\"\n"
-                                      "that was to room with an invalid room: %3 that does not exist.\n"
-                                      "The exit will be removed (the bad destination room Id will be stored in the\n"
-                                      "room user data under a key:\n"
-                                      "\"%4\")." )
-                                      .arg( id )
-                                      .arg( exitName )
-                                      .arg( exitRoomId )
-                                      .arg( auditKey );
-                mpRoomDB->mpMap->postMessage( infoMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString infoMsg = tr( "[ INFO ]  - In room with id: %1 special exit \"%2\"\n"
+                                          "that was to room with an invalid room: %3 that does not exist.\n"
+                                          "The exit will be removed (the bad destination room id will be stored in the\n"
+                                          "room user data under a key:\n"
+                                          "\"%4\")." )
+                                          .arg( id )
+                                          .arg( exitName )
+                                          .arg( exitRoomId )
+                                          .arg( auditKey );
+                    mpRoomDB->mpMap->postMessage( infoMsg );
+                }
+                mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room had special exit \"%1\" that was to room with an invalid room: %2 that does not exist."
+                                                             "  The exit will be removed (the bad destination room id will be stored in the room user data under a key:"
+                                                             "\"%3\")." )
+                                                             .arg( exitName )
+                                                             .arg( exitRoomId )
+                                                             .arg( auditKey ), true );
                 it.remove();
                 // We cannot have a door or anything else on a non-existant special exit
                 doors.remove( exitName );
@@ -1010,29 +1043,17 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
                 extras.append( tr( "%1 {invalid}" ).arg( itSpareDoors.key() ) );
             }
         }
-        QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 found one or more surplus door items that were removed:\n"
-                                          "%2." )
-                              .arg( id )
-                              .arg( extras.join( QStringLiteral( ", " ) ) );
-        mpRoomDB->mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString infoMsg = tr( "[ INFO ]  - In room with id: %1 found one or more surplus door items that were removed:\n"
+                                              "%2." )
+                                  .arg( id )
+                                  .arg( extras.join( QStringLiteral( ", " ) ) );
+            mpRoomDB->mpMap->postMessage( infoMsg );
+        }
+        mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room had one or more surplus door items that were removed:"
+                                                     "%1." )
+                                                     .arg( extras.join( QStringLiteral( ", " ) ) ), true );
     }
-
-    // ExitStubs - cannot validate like this as can be present without an exit
-    // in fact cannot be present WITH an exit
-//    if( ! exitStubsCopy.isEmpty() ) {
-//        QStringList extras;
-//        QSetIterator<int> itSpareStubs( exitStubsCopy );
-//        while( itSpareStubs.hasNext() ) {
-//            int dirCode = itSpareStubs.next();
-//        ...
-//            extras.append( dirCodeToDisplayName( dirCode ) );
-//        }
-//        QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 found one or more exit stubs:\n"
-//                                          "%2." )
-//                              .arg( id )
-//                              .arg( extras.join( QStringLiteral( ", " ) ) );
-//        mpRoomDB->mpMap->postMessage( infoMsg );
-//    }
 
     // ExitWeights:
     if( ! exitWeightsCopy.isEmpty() ) {
@@ -1045,11 +1066,16 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
                                .arg( itSpareExitWeight.key() )
                                .arg( itSpareExitWeight.value() ) );
         }
-        QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 found one or more surplus weight items that were removed:\n"
-                                          "%2." )
-                              .arg( id )
-                              .arg( extras.join( QStringLiteral( ", " ) ) );
-        mpRoomDB->mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString infoMsg = tr( "[ INFO ]  - In room with id: %1 found one or more surplus weight items that were removed:\n"
+                                              "%2." )
+                                  .arg( id )
+                                  .arg( extras.join( QStringLiteral( ", " ) ) );
+            mpRoomDB->mpMap->postMessage( infoMsg );
+        }
+        mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room had one or more surplus weight items that were removed: "
+                                                     "%1." )
+                                                     .arg( extras.join( QStringLiteral( ", " ) ) ), true );
     }
 
     // ExitLocks:
@@ -1061,11 +1087,16 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
             extras.append( dirCodeToDisplayName( dirCode ) );
             exitLocks.removeAll( dirCode );
         }
-        QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 found one or more surplus exit lock items that were removed:\n"
-                                          "%2." )
-                              .arg( id )
-                              .arg( extras.join( QStringLiteral( ", " ) ) );
-        mpRoomDB->mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString infoMsg = tr( "[ INFO ]  - In room with id: %1 found one or more surplus exit lock items that were removed:\n"
+                                              "%2." )
+                                  .arg( id )
+                                  .arg( extras.join( QStringLiteral( ", " ) ) );
+            mpRoomDB->mpMap->postMessage( infoMsg );
+        }
+        mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room had one or more surplus exit lock items that were removed: "
+                                                     "%1." )
+                                                     .arg( extras.join( QStringLiteral( ", " ) ) ), true );
     }
 
     // Custom Lines - points - the master element - if the entry for an exit is
@@ -1144,11 +1175,15 @@ void TRoom::auditExits( const QHash<int, int> roomRemapping )
         }
 
         if( ! extras.isEmpty() ) {
-            QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 found one or more surplus custom line elements that\n"
-                                              "were removed: %2." )
-                                  .arg( id )
-                                  .arg( extras.join( QStringLiteral( ", " ) ) );
-            mpRoomDB->mpMap->postMessage( infoMsg );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                QString infoMsg = tr( "[ INFO ]  - In room with id: %1 found one or more surplus custom line elements that\n"
+                                                  "were removed: %2." )
+                                      .arg( id )
+                                      .arg( extras.join( QStringLiteral( ", " ) ) );
+                mpRoomDB->mpMap->postMessage( infoMsg );
+            }
+            mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room had one or more surplus custom line elements that were removed: %1." )
+                                                         .arg( extras.join( QStringLiteral( ", " ) ) ), true );
         }
     }
 }
@@ -1172,13 +1207,19 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
     if( roomRemapping.contains( exitRoomId ) ) {
         QString auditKey = QStringLiteral( "audit.remapped_exit.%1" ).arg( dirCode );
         userData.insert( auditKey, QString::number( exitRoomId ) );
-        QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 correcting exit \"%2\" that was to room with\n"
-                                          "an exit to invalid room: %3 to now go to: %4." )
-                              .arg( id )
-                              .arg( displayName )
-                              .arg( exitRoomId )
-                              .arg( roomRemapping.value( exitRoomId ) );
-        mpRoomDB->mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString infoMsg = tr( "[ INFO ]  - In room with id: %1 correcting exit \"%2\" that was to room with\n"
+                                              "an exit to invalid room: %3 to now go to: %4." )
+                                  .arg( id )
+                                  .arg( displayName )
+                                  .arg( exitRoomId )
+                                  .arg( roomRemapping.value( exitRoomId ) );
+            mpRoomDB->mpMap->postMessage( infoMsg );
+        }
+        mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Correcting exit \"%1\" that was to invalid room id: %2 to now go to: %3." )
+                                                     .arg( displayName )
+                                                     .arg( exitRoomId )
+                                                     .arg( roomRemapping.value( exitRoomId ) ), true );
         exitRoomId = roomRemapping.value( exitRoomId );
     }
 
@@ -1187,16 +1228,24 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
         if( Q_UNLIKELY( ! mpRoomDB->getRoom( exitRoomId ) ) ) {
             // But it doesn't exist
             QString auditKey = QStringLiteral( "audit.made_stub_of_valid_but_missing_exit.%1" ).arg( dirCode );
-            QString warnMsg = tr( "[ WARN ]  - Room with Id: %1 has an exit \"%2\" with an exit to: %3 but that room\n"
-                                              "does not exist.  The exit will be removed (but the destination room\n"
-                                              "Id will be stored in the room user data under a key:\n"
-                                              "\"%4\")\n"
-                                              "and the exit will be turned into a stub." )
-                                  .arg( id )
-                                  .arg( displayName )
-                                  .arg( exitRoomId )
-                                  .arg( auditKey );
-            mpRoomDB->mpMap->postMessage( warnMsg );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                QString warnMsg = tr( "[ WARN ]  - Room with id: %1 has an exit \"%2\" to: %3 but that room\n"
+                                                  "does not exist.  The exit will be removed (but the destination room\n"
+                                                  "Id will be stored in the room user data under a key:\n"
+                                                  "\"%4\")\n"
+                                                  "and the exit will be turned into a stub." )
+                                      .arg( id )
+                                      .arg( displayName )
+                                      .arg( exitRoomId )
+                                      .arg( auditKey );
+                mpRoomDB->mpMap->postMessage( warnMsg );
+            }
+            mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ WARN ]  - Room has an exit \"%1\" to: %2 but that room does not exist."
+                                                         "  The exit will be removed (but the destination room id will be stored in the room user data under a key: "
+                                                         "\"%4\") and the exit will be turned into a stub." )
+                                                         .arg( displayName )
+                                                         .arg( exitRoomId )
+                                                         .arg( auditKey ), true );
             userData.insert( auditKey, QString::number( exitRoomId ) );
             if( ! exitStubs.contains( dirCode ) ) {
                 exitStubs.append( dirCode ); // Add a stub (this is so we can retain doors, though exit weights, custom lines and locks will go)
@@ -1234,12 +1283,18 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
 
             // We cannot allow a stub exit at the same time as a real exit:
             if( exitStubs.contains( dirCode ) ) {
-                QString warnMsg = tr( "[ ALERT ] - Room with Id: %1 has an exit \"%2\" with an exit to: %3 but also\n"
-                                                  "has a record of a stub exit!  That stub will be removed." )
-                                      .arg( id )
-                                      .arg( displayName )
-                                      .arg( exitRoomId );
-                mpRoomDB->mpMap->postMessage( warnMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString warnMsg = tr( "[ ALERT ] - Room with id: %1 has an exit \"%2\" to: %3 but also\n"
+                                                      "has a stub exit!  As a real exit precludes a stub, the latter will\n"
+                                                      "be removed." )
+                                          .arg( id )
+                                          .arg( displayName )
+                                          .arg( exitRoomId );
+                    mpRoomDB->mpMap->postMessage( warnMsg );
+                }
+                mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ ALERT ] - Room has an exit \"%1\" to: %2 but also has a stub exit in the same direction!  As a real exit precludes a stub, the latter will be removed." )
+                                                             .arg( displayName )
+                                                             .arg( exitRoomId ), true );
                 exitStubs.removeAll( dirCode );
                 exitStubsPool.remove( dirCode ); // Remove the stub in this direction from check pool as we have handled it
             }
@@ -1293,15 +1348,23 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
         // exit, but that will be masked as we turn the exit into a stub anyhow.
         QString auditKey = QStringLiteral( "audit.made_stub_of_invalid_exit.%1" ).arg( dirCode );
         userData.insert( auditKey, QString::number( exitRoomId ) );
-        QString infoMsg = tr( "[ INFO ]  - In room with Id: %1 exit \"%2\" that was to room with an invalid\n"
-                              "room: %3 that does not exist.  The exit will be removed (the bad destination\n"
-                              "room Id will be stored in the room user data under a key:\n"
-                              "\"%4\")\n"
-                              "and the exit will be turned into a stub." )
-                              .arg( id )
-                              .arg( displayName )
-                              .arg( exitRoomId )
-                              .arg( auditKey );
+        QString infoMsg;
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            infoMsg = tr( "[ INFO ]  - In room with id: %1 exit \"%2\" that was to room with an invalid\n"
+                                      "room: %3 that does not exist.  The exit will be removed (the bad destination\n"
+                                      "room id will be stored in the room user data under a key:\n"
+                                      "\"%4\")\n"
+                                      "and the exit will be turned into a stub." )
+                          .arg( id )
+                          .arg( displayName )
+                          .arg( exitRoomId )
+                          .arg( auditKey );
+        }
+        QString logMsg = tr( "[ INFO ]  - Room exit \"%1\" that was to a room with an invalid id: %2 that does not exist."
+                             "  The exit will be removed (the bad destination room id will be stored in the room user data under a key:\"%4\") and the exit will be turned into a stub." )
+                             .arg( displayName )
+                             .arg( exitRoomId )
+                             .arg( auditKey );
         exitRoomId = -1;
 
         if( ! exitStubs.contains( dirCode ) ) {
@@ -1313,27 +1376,41 @@ void TRoom::auditExit( int & exitRoomId,                    // Reference to wher
         if( exitLocks.contains( dirCode ) ) {
             QString auditKeyLocked = QStringLiteral( "audit.invalid_exit.%1.isLocked" ).arg( dirCode );
             userData.insert( auditKeyLocked, QStringLiteral( "true" ) );
-            infoMsg.append( tr( "\nIt was locked, this is recorded as user data with key:\n"
-                                "\"%1\"." )
-                            .arg( auditKeyLocked ) );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                infoMsg.append( tr( "\nIt was locked, this is recorded as user data with key:\n"
+                                    "\"%1\"." )
+                                .arg( auditKeyLocked ) );
+            }
+            logMsg.append( tr( "  It was locked, this is recorded as user data with key: \"%1\"." )
+                               .arg( auditKeyLocked ) );
             exitLocks.removeAll( dirCode );
         }
 
         if( exitWeights.contains( doorAndWeight ) ) {
             QString auditKeyWeight = QStringLiteral( "audit.invalid_exit.%1.weight" ).arg( dirCode );
             userData.insert( auditKeyWeight, QString::number( exitWeights.value( doorAndWeight ) ) );
-            infoMsg.append( tr( "\nIt had a weight, this is recorded as user data with key:\n"
-                                "\"%1\"." )
-                            .arg( auditKeyWeight ) );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                infoMsg.append( tr( "\nIt had a weight, this is recorded as user data with key:\n"
+                                    "\"%1\"." )
+                                .arg( auditKeyWeight ) );
+            }
+            logMsg.append( tr( "  It had a weight, this is recorded as user data with key: \"%1\"." )
+                               .arg( auditKeyWeight ) );
             exitWeights.remove( doorAndWeight );
         }
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            mpRoomDB->mpMap->postMessage( infoMsg );
+        }
+        mpRoomDB->mpMap->appendRoomErrorMsg( id, logMsg, true );
 
-        mpRoomDB->mpMap->postMessage( infoMsg );
 
         if( customLines.contains( customLine ) ) {
-            QString warnMsg = tr( "[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
-                                              "it has not been possible to salvage this, it has been lost!" );
-            mpRoomDB->mpMap->postMessage( warnMsg );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                QString warnMsg = tr( "[ WARN ]  - There was a custom exit line associated with the invalid exit but\n"
+                                                  "it has not been possible to salvage this, it has been lost!" );
+                mpRoomDB->mpMap->postMessage( warnMsg );
+            }
+            mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ WARN ]  - There was a custom exit line associated with the invalid exit but it has not been possible to salvage this, it has been lost!" ), true );
             customLines.remove( customLine );
         }
         customLinesColor.remove( customLine );

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -77,8 +77,8 @@ public:
     const QMap<QString, int> & getExitWeights() const { return exitWeights; }
     void setExitWeight(const QString& cmd, int w );
     bool hasExitWeight(const QString& cmd );
-    void setDoor(const QString& cmd, int doorStatus );//0=no door, 1=open door, 2=closed, 3=locked
-    int getDoor(const QString& cmd );
+    const bool setDoor( const QString & cmd, const int doorStatus );//0=no door, 1=open door, 2=closed, 3=locked
+    int getDoor( const QString & cmd );
     bool hasExitStub( int direction );
     void setExitStub( int direction, bool status );
     void calcRoomDimensions();

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -26,6 +26,7 @@
 #include "TMap.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QColor>
 #include <QMap>
 #include <QVector3D>
@@ -53,6 +54,8 @@ class TRoomDB;
 
 class TRoom
 {
+    Q_DECLARE_TR_FUNCTIONS(TRoom) // Needed so we can use tr() even though TRoom is NOT derived from QObject
+
 public:
     TRoom( TRoomDB* pRDB );
     ~TRoom();
@@ -109,8 +112,18 @@ public:
     void setOut( int id ) { out=id; }
     int getId() { return id; }
     int getArea() { return area; }
-    void auditExits();
+    void audit( const QHash<int, int>, const QHash<int, int> );
+    void auditExits( const QHash<int, int> );
     /*bool*/ void restore( QDataStream & ifs, int roomID, int version );
+    void auditExit( int &, const int, const QString, const QString, const QString,
+                    QMap<QString, int> &, QSet<int> &, QSet<int> &,
+                    QMap<QString, int> &, QMap<QString, QList<QPointF> > &,
+                    QMap<QString, QList<int> > &, QMap<QString, QString> &,
+                    QMap<QString, bool> &,
+                    const QHash<int, int> );
+    const QString dirCodeToDisplayName( const int dirCode );
+
+
     int x;
     int y;
     int z;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -453,7 +453,7 @@ TArea * TRoomDB::getRawArea( int id, bool * isValid = 0 )
         if( isValid ) {
             *isValid = false;
         }
-        return nullptr;
+        return 0;
     }
 }
 

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -279,8 +279,13 @@ bool TRoomDB::__removeRoom( int id )
 bool TRoomDB::removeRoom( int id )
 {
     if( rooms.contains( id ) && id > 0 ) {
-        if( mpMap->mRoomId == id ) {
-            mpMap->mRoomId = 0;
+        if( mpMap->mRoomIdHash.value( mpMap->mpHost->getName() ) == id ) {
+            // Now we store mRoomId for each profile, we must remove any where
+            // this room was used
+            QList<QString> profilesWithUserInThisRoom = mpMap->mRoomIdHash.keys( id );
+            foreach( QString key, profilesWithUserInThisRoom ) {
+                mpMap->mRoomIdHash[ key ] = 0;
+            }
         }
         if( mpMap->mTargetID == id ) {
             mpMap->mTargetID = 0;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -38,6 +38,7 @@ TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
 , mpTempRoomDeletionSet( 0 )
 , mUnnamedAreaName( tr( "Unnamed Area" ) )
+, mDefaultAreaName( tr( "Default Area" ) )
 {
 }
 
@@ -943,6 +944,8 @@ void TRoomDB::clearMapDB()
         delete areaList.at(i);
     }
     assert( areas.size() == 0 );
+    // Must now reinsert areaId -1 name = "Default Area"
+    addArea( -1, mDefaultAreaName );
     qDebug() << "TRoomDB::clearMapDB() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
@@ -1090,14 +1093,22 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
             mpMap->mpHost->postMessage( detailText );
         }
     }
+
+    if( ! areaNamesMap.contains( -1 ) ) {
+        areaNamesMap.insert( -1, mDefaultAreaName );
+        QString defaultAreaNameInsertionMsg = tr( "[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
+                                                              "area) not found, adding \"%1\" against the reserved -1 Id." )
+                                              .arg( mDefaultAreaName );
+        mpMap->mpHost->postMessage( defaultAreaNameInsertionMsg );
+    }
 }
 
-void TRoomDB::restoreSingleArea(QDataStream & ifs, int areaID, TArea * pA )
+void TRoomDB::restoreSingleArea( int areaID, TArea * pA )
 {
     areas[areaID] = pA;
 }
 
-void TRoomDB::restoreSingleRoom(QDataStream & ifs, int i, TRoom *pT)
+void TRoomDB::restoreSingleRoom( int i, TRoom * pT )
 {
-    addRoom(i, pT, true);
+    addRoom( i, pT, true);
 }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -37,7 +37,7 @@
 TRoomDB::TRoomDB( TMap * pMap )
 : mpMap( pMap )
 , mpTempRoomDeletionSet( 0 )
-, mUnnamedAreaName( qApp->translate( "TRoomDB", "Unnamed Area" ) )
+, mUnnamedAreaName( tr( "Unnamed Area" ) )
 {
 }
 
@@ -440,6 +440,23 @@ TArea * TRoomDB::getArea( int id )
     }
 }
 
+// Used by TMap::audit() - can detect and return areas with normally invalids Id (less than -1 or zero)!
+TArea * TRoomDB::getRawArea( int id, bool * isValid = 0 )
+{
+    if( areas.contains( id ) ) {
+        if( isValid ) {
+            *isValid = true;
+        }
+        return areas.value( id );
+    }
+    else {
+        if( isValid ) {
+            *isValid = false;
+        }
+        return nullptr;
+    }
+}
+
 bool TRoomDB::setAreaName( int areaID, QString name )
 {
     if( areaID < 1 ) {
@@ -488,7 +505,7 @@ bool TRoomDB::addArea( int id )
         return true;
     }
     else {
-        QString error = qApp->translate( "TRoomDB", "Area with ID=%1 already exists!" ).arg(id);
+        QString error = tr( "Area with ID=%1 already exists!" ).arg(id);
         mpMap->logError(error);
         return false;
     }
@@ -507,12 +524,12 @@ int TRoomDB::addArea( QString name )
 {
     // reject it if area name already exists or is empty
     if( name.isEmpty() ) {
-        QString error = qApp->translate( "TRoomDB", "An Unnamed Area is (no longer) permitted!" );
+        QString error = tr( "An Unnamed Area is (no longer) permitted!" );
         mpMap->logError(error);
         return 0;
     }
     else if( areaNamesMap.values().contains( name ) ) {
-        QString error = qApp->translate( "TRoomDB", "An area called %1 already exists!" ).arg(name);
+        QString error = tr( "An area called %1 already exists!" ).arg(name);
         mpMap->logError(error);
         return 0;
     }
@@ -562,43 +579,346 @@ QList<int> TRoomDB::getAreaIDList()
     return areas.keys();
 }
 
-void TRoomDB::auditRooms()
+/*
+ * Tasks to perform
+ * 1) Validate all room Ids and remap any problem ones ( <1 ), retaining
+ *    remappings for fixups later on
+ * 2) Find all areas that the rooms demand
+ * 3) Find all areas that the areanames demand
+ * 4) Validate all existing area Ids and remap any problem one
+ * 5) Merge in area Ids that rooms and areanames demand, remapping any problem
+ *    ones
+ * 6) If rooms have been remapped, fixup rooms' exits' to use the new room Ids
+ * 7) If areas have been remapped, fixup rooms to use new area Ids
+ * 8) Validate area::rooms - adding or removing roomId based on the rooms' idea
+ *    of the area they should be in - not forgetting any remappings of area/room
+ *    Ids..
+ * 9) Validate TRoom elements: exits, stubs (beware of duplicate QList<T>
+ *    elements), doors (must have a real or stub in that direction), custom
+ *    lines (no key for an normal or special exit that isn't there), locks
+ *    (beware of duplicate QList<T> elements), room and exit weights (can only
+ *    have a weight on an actual exit).
+ *10) Validate TArea elements: ebenen (beware of duplicate QList<T> elements)
+ */
+void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & areaRemapping )
 {
     QElapsedTimer timer;
     timer.start();
-    // rooms konsolidieren
-    QHashIterator<int, TRoom* > itRooms( rooms );
-    while( itRooms.hasNext() )
-    {
-        itRooms.next();
-        TRoom * pR = itRooms.value();
-        pR->auditExits();
 
-    }
-    qDebug() << "TRoomDB::auditRooms() run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
-}
+    QSet<int> validUsedRoomIds; // Used good ids (>= 1)
+    QSet<int> validUsedAreaIds; // As rooms
 
-void TRoomDB::initAreasForOldMaps()
-{
-    buildAreas();
+    // START OF TASK 1 & 2:
+    // Scan through all rooms and record their idea of which area they
+    // should be in.  Note invalid room Ids those will be fixed up later...
+    QHash<int, int> roomAreaHash; // Key: room Id, Value: area it believes it should be in
+    QMultiHash<int, int> areaRoomMultiHash; // Key: areaId, ValueS: rooms that believe they belong there
 
-    // area mit raeumen fuellen
-    QHashIterator<int, TRoom *> it( rooms );
-    while( it.hasNext() )
-    {
-        it.next();
-        int roomID = it.key();
-        int areaID = rooms[roomID]->getArea();
-        if( areas.contains(areaID)) areas[areaID]->rooms.insert( roomID );
+    { // Block this code to limit scope of iterator
+        QMutableHashIterator<int, TRoom *> itRoom( rooms );
+        while( itRoom.hasNext() ) {
+            itRoom.next();
+            TRoom * pR = itRoom.value();
+            if( ! pR ) {
+                QString warnMsg = tr( "[ WARN ]  - Problem with data structure associated with room Id: %1 - that\n"
+                                                  "room's data has been lost so the Id is now being deleted.  This\n"
+                                                  "suggests serious problems with the currently running version of\n"
+                                                  "Mudlet - is your system running out of memory?" )
+                                      .arg( itRoom.key() );
+                mpMap->postMessage( warnMsg );
+                itRoom.remove();
+            }
+            else {
+                if( itRoom.key() >= 1 ) {
+                    validUsedRoomIds.insert( itRoom.key() );
+                }
+                else {
+                    roomRemapping.insert( itRoom.key(), itRoom.key() );
+                    //Store them for now, will assign new values when we have the
+                    // set of good ones already used
+                }
+            }
+
+            int areaId = pR->getArea();
+            areaRoomMultiHash.insert( areaId, itRoom.key() );
+            roomAreaHash.insert( itRoom.key(), areaId );
+        }
     }
-    QMapIterator<int, TArea *> it2( areas );
-    while( it2.hasNext() )
-    {
-        it2.next();
-        TArea * pA = it2.value();
-        pA->determineAreaExits();
-        pA->calcSpan();
+
+    // Check for existance of all areas needed by rooms
+    QSet<int> areaIdSet = areaRoomMultiHash.keys().toSet();
+
+    // START OF TASK 3
+    // Throw in the area Ids from the areaNamesMap:
+    areaIdSet.unite( areaNamesMap.keys().toSet() );
+
+    // And the area Ids used by the map labels:
+    areaIdSet.unite( mpMap->mapLabels.keys().toSet() );
+
+    // Check the set of area Ids against the ones we actually have:
+    QSetIterator<int> itUsedArea( areaIdSet );
+    while( itUsedArea.hasNext() ) {
+        int usedAreaId = itUsedArea.next();
+        if( usedAreaId < -1 || ! usedAreaId ) {
+            areaRemapping.insert( usedAreaId, usedAreaId ); // Will find new value to use later
+        }
+        else {
+            validUsedAreaIds.insert( usedAreaId );
+        }
+
+        if( ! areas.contains( usedAreaId ) ) {
+            QString warnMsg = tr( "[ ALERT ] - Area with id: %1 expected but not found, will be created." )
+                                  .arg( usedAreaId );
+            mpMap->postMessage( warnMsg );
+        }
     }
+
+    // START OF TASK 4
+    // Check for any problem Id in original areas
+    QMapIterator<int, TArea *> itArea( areas );
+    while( itArea.hasNext() ) {
+        itArea.next();
+        int areaId = itArea.key();
+        if( areaId < -1 || ! areaId ) {
+            areaRemapping.insert( areaId, areaId ); // Will find new value to use later
+        }
+        else {
+            validUsedAreaIds.insert( areaId );
+        }
+    }
+
+    // START OF TASK 5
+    // Now process problem areaIds
+    if( ! areaRemapping.isEmpty() ) {
+        QString alertMsg = tr( "[ ALERT ] - Bad, (less than +1 and not the reserved -1) area Ids found (count: %1)\n"
+                                           "in map, now working out what new Id numbers to use..." )
+                               .arg( areaRemapping.count() );
+        mpMap->postMessage( alertMsg );
+
+        QString infoMsg = tr( "[ INFO ]  - The renumbered area Ids will be:\n"
+                                          "Old ==> New" );
+        QMutableHashIterator<int, int> itRemappedArea( areaRemapping );
+        while( itRemappedArea.hasNext() ) {
+            itRemappedArea.next();
+            int faultyAreaId = itRemappedArea.key();
+            int replacementAreaId = 0;
+            do {
+                ; // No-op, increment done in test
+            } while( areas.contains( ++replacementAreaId ) );
+            // Insert replacement value into hash
+            itRemappedArea.setValue( replacementAreaId );
+            infoMsg.append( QStringLiteral( "\n%1 ==> %2" )
+                                .arg( faultyAreaId )
+                                .arg( replacementAreaId ) );
+
+            TArea * pA = 0;
+            if( areas.contains( faultyAreaId ) ) {
+                pA = areas.take( faultyAreaId );
+            }
+            else {
+                pA = new TArea( mpMap, this );
+            }
+            if( areaNamesMap.contains( faultyAreaId ) ) {
+                QString areaName = areaNamesMap.value( faultyAreaId );
+                areaNamesMap.remove( faultyAreaId );
+                areaNamesMap.insert( replacementAreaId, areaName );
+            }
+            else {
+                // I think this is unlikely but better provide code to cover it
+                // if it does arise that we need a new area but do not have a
+                // provided name
+                QString newAreaName = mUnnamedAreaName;
+                if( areaNamesMap.values().contains( newAreaName ) ) {
+                    // We already have an "unnamed area"
+                    uint deduplicateSuffix = 0;
+                    do {
+                        newAreaName = QStringLiteral( "%1_%2" ).arg( mUnnamedAreaName ).arg( ++deduplicateSuffix, 3, 10, QLatin1Char('0') );
+                    } while ( areaNamesMap.values().contains( newAreaName ) );
+                }
+                areaNamesMap.insert( replacementAreaId, newAreaName );
+            }
+            pA->mUserData.insert( QStringLiteral( "audit.remapped_id" ), QString::number( faultyAreaId ) );
+            validUsedAreaIds.insert( replacementAreaId );
+            areas.insert( replacementAreaId, pA );
+
+            // Fixup map labels as well
+            if( mpMap->mapLabels.contains( faultyAreaId ) ) {
+                QMap<qint32, TMapLabel> areaMapLabels = mpMap->mapLabels.take( faultyAreaId );
+                mpMap->mapLabels.insert( replacementAreaId, areaMapLabels );
+            }
+
+            pA->mIsDirty = true;
+        }
+        mpMap->postMessage( infoMsg );
+    }
+    else {
+        QString infoMsg = tr( "[ INFO ]  - Area Id numbering is satisfactory." );
+        mpMap->postMessage( infoMsg );
+    }
+    // END OF TASK 2,3,4,5 - all needed areas exist and remap details are in
+    // areaRemapping - still need to update rooms and areaNames and mapLabels
+
+    // Now complete TASK 1 - find the new room Ids to use
+    if( ! roomRemapping.isEmpty() ) {
+        QString alertMsg = tr( "[ ALERT ] - Bad, (less than +1) room Ids found (count: %1) in map, now working\n"
+                                           "out what new Id numbers to use." )
+                               .arg( roomRemapping.count() );
+        mpMap->postMessage( alertMsg );
+
+        QString infoMsg = tr( "[ INFO ]  - The renumbered rooms will be:\n" );
+        QMutableHashIterator<int, int> itRenumberedRoomId( roomRemapping );
+        while( itRenumberedRoomId.hasNext() ) {
+            itRenumberedRoomId.next();
+            unsigned int newRoomId = 0;
+            do {
+                ; // Noop - needed increment is done in test condition!
+            } while( validUsedRoomIds.contains( ++newRoomId ) );
+
+            itRenumberedRoomId.setValue( newRoomId ); // Update the QHash
+            validUsedRoomIds.insert( newRoomId );
+            infoMsg.append( QStringLiteral( "%1 ==> %2" )
+                                .arg( itRenumberedRoomId.key() )
+                                .arg( itRenumberedRoomId.value() ) );
+
+        }
+        mpMap->postMessage( infoMsg );
+
+        QSet<TRoom *> holdingSet;
+        { // Block this code to limit scope of iterator
+            QMutableHashIterator<int, TRoom* > itRoom( rooms );
+            // Although this is "mutable" we can only changed the VALUE not the KEY
+            // Also we cannot directly change the collection being iterated over -
+            // though we can REMOVE items via the iterator - so pull the
+            // affected TRoom instances out of the Hash, renumber them and then
+            // hold onto them before reinserting them after we have finished
+            // this iteration
+            while( itRoom.hasNext() ) {
+                itRoom.next();
+                TRoom * pR = itRoom.value();
+                if( roomRemapping.contains( itRoom.key() ) ) {
+                    pR->userData.insert( QStringLiteral( "audit.remapped_id" ), QString::number( itRoom.key() ) );
+                    pR->setId( roomRemapping.value( itRoom.key() ) );
+                    itRoom.remove();
+                    holdingSet.insert( pR );
+                }
+            }
+        }
+
+        // Now stuff the modified values back in under the new key values
+        QSetIterator<TRoom *> itModifiedRoom( holdingSet );
+        while( itModifiedRoom.hasNext() ) {
+            TRoom * pR = itModifiedRoom.next();
+            int newRoomId = pR->getId();
+            rooms.insert( newRoomId, pR );
+        }
+    }
+    else {
+        QString infoMsg = tr( "[ INFO ]  - Room Id numbering is satisfactory." );
+        mpMap->postMessage( infoMsg );
+    }
+    // END OF TASK 1
+
+    // START OF TASK 6,7 & 9
+    { // Block the following code to limit the scope of the itRoom iterator
+        QMutableHashIterator<int, TRoom *> itRoom( rooms );
+        while( itRoom.hasNext() ) {
+            itRoom.next();
+            TRoom * pR = itRoom.value();
+
+            // Purges any duplicates that a QList structure DOES permit, but a QSet does NOT:
+            // Exit stubs:
+            unsigned int _listCount = pR->exitStubs.count();
+            QSet<int> _set = pR->exitStubs.toSet();
+            if( _set.count() < _listCount ) {
+                QString infoMsg = tr( "[ INFO ]  - Duplicate exit stub identifiers found in room Id: %1, this is an\n"
+                                                  "anomoly but has been cleaned up easily." )
+                                       .arg( itRoom.key() );
+                mpMap->postMessage( infoMsg );
+            }
+            pR->exitStubs = _set.toList();
+
+            // Exit locks:
+            _listCount = pR->exitLocks.count();
+            _set = pR->exitLocks.toSet();
+            if( _set.count() < _listCount ) {
+                QString infoMsg = tr( "[ INFO ]  - Duplicate exit lock identifiers found in room Id: %1, this is an\n"
+                                                  "anomoly but has been cleaned up easily." )
+                                       .arg( itRoom.key() );
+                mpMap->postMessage( infoMsg );
+            }
+            pR->exitLocks = _set.toList();
+
+            // TASK 9 IS DONE INSIDE THIS METHOD:
+            pR->audit(roomRemapping, areaRemapping);
+        }
+    }
+    // END OF TASK 6,7 & 9
+
+    // START TASK 8
+    {
+        QMapIterator<int, TArea *> itArea(areas);
+        while( itArea.hasNext() ) {
+            itArea.next();
+            TArea * pA = itArea.value();
+            QSet<int> replacementRoomsSet;
+            { // Block code to limit scope of iterator, find and pull out renumbered rooms
+                QMutableSetIterator<int> itAreaRoom( pA->rooms );
+                if( ! roomRemapping.isEmpty() ) {
+                    while( itAreaRoom.hasNext() ) {
+                        int originalRoomId = itAreaRoom.next();
+                        if( roomRemapping.contains( originalRoomId ) ) {
+                            itAreaRoom.remove();
+                            replacementRoomsSet.insert( roomRemapping.value( originalRoomId ) );
+                        }
+                    }
+                }
+            }
+            // Merge back in the renumbered rooms
+            if( ! replacementRoomsSet.isEmpty() ) {
+                pA->rooms.unite( replacementRoomsSet );
+            }
+
+            // Now compare pA->rooms to areaRoomMultiHash.values( itArea.key() )
+            QSet<int> foundRooms = areaRoomMultiHash.values( itArea.key() ).toSet();
+//            QSet<int> correctRooms = pA->rooms.intersect( foundRooms );
+            QSet<int> extraRooms = pA->rooms;
+            extraRooms.subtract( foundRooms );
+            QSet<int> missingRooms = foundRooms;
+            missingRooms.subtract( pA->rooms );
+            if( ! missingRooms.isEmpty() ) {
+                QStringList roomList;
+                QSetIterator<int> itMissingRoom( missingRooms );
+                while( itMissingRoom.hasNext() ) {
+                    roomList.append( QString::number( itMissingRoom.next() ) );
+                }
+                QString infoMsg = tr( "[ INFO ]  - In area with Id: %1 there were %2 rooms missing from those it\n"
+                                                  "should be recording as possessing, they were:\n%3\nthey have been added." )
+                                      .arg( itArea.key() )
+                                      .arg( missingRooms.count() )
+                                      .arg( roomList.join( QStringLiteral( ", " ) ) );
+                mpMap->postMessage( infoMsg );
+                pA->mIsDirty = true;
+            }
+            if( ! extraRooms.isEmpty() ) {
+                QStringList roomList;
+                QSetIterator<int> itExtraRoom( extraRooms );
+                while( itExtraRoom.hasNext() ) {
+                    roomList.append( QString::number( itExtraRoom.next() ) );
+                }
+                QString infoMsg = tr( "[ INFO ]  - In area with Id: %1 there were %2 extra rooms compared to those it\n"
+                                                  "should be recording as possessing, they were:\n%3\nthey have been removed." )
+                                      .arg( itArea.key() )
+                                      .arg( extraRooms.count() )
+                                      .arg( roomList.join( QStringLiteral( ", " ) ) );
+                mpMap->postMessage( infoMsg );
+                pA->mIsDirty = true;
+            }
+            pA->rooms = foundRooms;
+        }
+    }
+    // END OF TASK 8
+
+    qDebug() << "TRoomDB::auditRooms(...) run time:" << timer.nsecsElapsed() * 1.0e-9 << "sec.";
 }
 
 void TRoomDB::clearMapDB()
@@ -687,82 +1007,82 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
         QString extraTextForMatchingSuffixAlreadyUsed;
         QString detailText;
         if( isMatchingSuffixAlreadyPresent ) {
-            extraTextForMatchingSuffixAlreadyUsed = qApp->translate( "TRoomDB", "It has been detected that \"_###\" form suffixes have already been used, for "
-                                                                                "simplicity in the renaming algorithm these will have been removed and possibly "
-                                                                                "changed as Mudlet sorts this matter out, if a number assigned in this way "
-                                                                                "<b>is</b> important to you, you can change it back, provided you rename the area "
-                                                                                "that has been allocated the suffix that was wanted first...!</p>" );
+            extraTextForMatchingSuffixAlreadyUsed = tr( "It has been detected that \"_###\" form suffixes have already been used, for "
+                                                        "simplicity in the renaming algorithm these will have been removed and possibly "
+                                                        "changed as Mudlet sorts this matter out, if a number assigned in this way "
+                                                        "<b>is</b> important to you, you can change it back, provided you rename the area "
+                                                        "that has been allocated the suffix that was wanted first...!</p>" );
         }
         if( renamedMap.size() ) {
-            detailText = qApp->translate( "TRoomDB", "[  OK  ]  - The changes made are:\n"
-                                                                 "(ID) \"old name\" ==> \"new name\"\n" );
+            detailText = tr( "[  OK  ]  - The changes made are:\n"
+                                         "(ID) \"old name\" ==> \"new name\"\n" );
             QMapIterator<QString, QString> itRemappedNames = renamedMap;
             itRemappedNames.toBack();
             // Seems to look better if we iterate through backwards!
             while( itRemappedNames.hasPrevious() ) {
                 itRemappedNames.previous();
                 detailText.append( QStringLiteral( "(%1) \"%2\" ==> \"%3\"\n" )
-                                   .arg( areaNamesMap.key( itRemappedNames.value() ) )
-                                   .arg( itRemappedNames.key().isEmpty() ? qApp->translate( "TRoomDB", "<nothing>" ) : itRemappedNames.key() )
-                                   .arg( itRemappedNames.value() ) );
+                                       .arg( areaNamesMap.key( itRemappedNames.value() ) )
+                                       .arg( itRemappedNames.key().isEmpty() ? tr( "<nothing>" ) : itRemappedNames.key() )
+                                       .arg( itRemappedNames.value() ) );
             }
             detailText.chop(1); // Trim last "\n" off
         }
         if( renamedMap.size() && isEmptyAreaNamePresent ) {
             // At least one unnamed area and at least one duplicate area name
             // - may be the same items
-            alertText = qApp->translate( "TRoomDB", "[ ALERT ] - Empty and duplicate area names detected in Map file!" );
-            informativeText = qApp->translate( "TRoomDB", "[ INFO ]  - Due to some situations not being checked in the past,  Mudlet had\n"
-                                                                      "allowed the map to have more than one area with the same or no name.\n"
-                                                                      "These make some things confusing and are now disallowed.\n"
-                                                                      "  To resolve these cases, an area without a name here (or created in\n"
-                                                                      "the future) will automatically be assigned the name \"%1\".\n"
-                                                                      "  Duplicated area names will cause all but the first encountered one\n"
-                                                                      "to gain a \"_###\" style suffix where each \"###\" is an increasing\n"
-                                                                      "number; you may wish to change these, perhaps by replacing them with\n"
-                                                                      "a \"(sub-area name)\" but it is entirely up to you how you do this,\n"
-                                                                      "other then you will not be able to set one area's name to that of\n"
-                                                                      "another that exists at the time.\n"
-                                                                      "  If there were more than one area without a name then all but the\n"
-                                                                      "first will also gain a suffix in this manner.\n"
-                                                                      "%2")
-                              .arg( mUnnamedAreaName )
-                              .arg( extraTextForMatchingSuffixAlreadyUsed );
+            alertText = tr( "[ ALERT ] - Empty and duplicate area names detected in Map file!" );
+            informativeText = tr( "[ INFO ]  - Due to some situations not being checked in the past,  Mudlet had\n"
+                                              "allowed the map to have more than one area with the same or no name.\n"
+                                              "These make some things confusing and are now disallowed.\n"
+                                              "  To resolve these cases, an area without a name here (or created in\n"
+                                              "the future) will automatically be assigned the name \"%1\".\n"
+                                              "  Duplicated area names will cause all but the first encountered one\n"
+                                              "to gain a \"_###\" style suffix where each \"###\" is an increasing\n"
+                                              "number; you may wish to change these, perhaps by replacing them with\n"
+                                              "a \"(sub-area name)\" but it is entirely up to you how you do this,\n"
+                                              "other then you will not be able to set one area's name to that of\n"
+                                              "another that exists at the time.\n"
+                                              "  If there were more than one area without a name then all but the\n"
+                                              "first will also gain a suffix in this manner.\n"
+                                              "%2" )
+                                  .arg( mUnnamedAreaName )
+                                  .arg( extraTextForMatchingSuffixAlreadyUsed );
         }
         else if( renamedMap.size() ) {
             // Duplicates but no unnnamed area
-            alertText = qApp->translate( "TRoomDB", "[ ALERT ] - Duplicate area names detected in the Map file!" );
-            informativeText = qApp->translate( "TRoomDB", "[ INFO ]  - Due to some situations not being checked in the past, Mudlet had\n"
-                                                                      "allowed the user to have more than one area with the same name.\n"
-                                                                      "These make some things confusing and are now disallowed.\n"
-                                                                      "  Duplicated area names will cause all but the first encountered one\n"
-                                                                      "to gain a \"_###\" style suffix where each \"###\" is an increasing\n"
-                                                                      "number; you may wish to change these, perhaps by replacing them with\n"
-                                                                      "a \"(sub-area name)\" but it is entirely up to you how you do this,\n"
-                                                                      "other then you will not be able to set one area's name to that of\n"
-                                                                      "another that exists at the time.\n"
-                                                                      "  If there were more than one area without a name then all but the\n"
-                                                                      "first will also gain a suffix in this manner.\n"
-                                                                      "%1)")
-                              .arg( extraTextForMatchingSuffixAlreadyUsed );
+            alertText = tr( "[ ALERT ] - Duplicate area names detected in the Map file!" );
+            informativeText = tr( "[ INFO ]  - Due to some situations not being checked in the past, Mudlet had\n"
+                                              "allowed the user to have more than one area with the same name.\n"
+                                              "These make some things confusing and are now disallowed.\n"
+                                              "  Duplicated area names will cause all but the first encountered one\n"
+                                              "to gain a \"_###\" style suffix where each \"###\" is an increasing\n"
+                                              "number; you may wish to change these, perhaps by replacing them with\n"
+                                              "a \"(sub-area name)\" but it is entirely up to you how you do this,\n"
+                                              "other then you will not be able to set one area's name to that of\n"
+                                              "another that exists at the time.\n"
+                                              "  If there were more than one area without a name then all but the\n"
+                                              "first will also gain a suffix in this manner.\n"
+                                              "%1)")
+                                  .arg( extraTextForMatchingSuffixAlreadyUsed );
         }
         else {
             // A single unnamed area found
-            alertText = qApp->translate( "TRoomDB", "[ ALERT ] - An empty area name was detected in the Map file!" );
+            alertText = tr( "[ ALERT ] - An empty area name was detected in the Map file!" );
             // Use OK for this one because it is the last part and indicates the
             // sucessful end of something, whereas INFO is an intermediate step
-            informativeText = qApp->translate( "TRoomDB", "[  OK  ]  - Due to some situations not being checked in the past, Mudlet had\n"
-                                                                      "allowed the map to have an area with no name. This can make some\n"
-                                                                      "things confusing and is now disallowed.\n"
-                                                                      "  To resolve this case, the area without a name here (or one created\n"
-                                                                      "in the future) will automatically be assigned the name \"%1\".\n"
-                                                                      "  If this happens more then once the duplication of area names will\n"
-                                                                      "cause all but the first encountered one to gain a \"_###\" style\n"
-                                                                      "suffix where each \"###\" is an increasing number; you may wish to\n"
-                                                                      "change these, perhaps by adding more meaningful area names but it is\n"
-                                                                      "entirely up to you what is used, other then you will not be able to\n"
-                                                                      "set one area's name to that of another that exists at the time.")
-                              .arg( mUnnamedAreaName );
+            informativeText = tr( "[  OK  ]  - Due to some situations not being checked in the past, Mudlet had\n"
+                                              "allowed the map to have an area with no name. This can make some\n"
+                                              "things confusing and is now disallowed.\n"
+                                              "  To resolve this case, the area without a name here (or one created\n"
+                                              "in the future) will automatically be assigned the name \"%1\".\n"
+                                              "  If this happens more then once the duplication of area names will\n"
+                                              "cause all but the first encountered one to gain a \"_###\" style\n"
+                                              "suffix where each \"###\" is an increasing number; you may wish to\n"
+                                              "change these, perhaps by adding more meaningful area names but it is\n"
+                                              "entirely up to you what is used, other then you will not be able to\n"
+                                              "set one area's name to that of another that exists at the time.")
+                                  .arg( mUnnamedAreaName );
         }
         mpMap->mpHost->postMessage( alertText );
         mpMap->mpHost->postMessage( informativeText );

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -22,10 +22,12 @@
 
 #include "TRoomDB.h"
 
+#include "mudlet.h"
+#include "Host.h"
 #include "TArea.h"
 #include "TMap.h"
 #include "TRoom.h"
-#include "Host.h"
+
 
 #include "pre_guard.h"
 #include <QApplication>
@@ -170,10 +172,16 @@ void TRoomDB::updateEntranceMap(TRoom * pR, bool isMapLoading)
                 values.chop(1);
             }
             if( values.isEmpty() ) {
-                qDebug( "TRoomDB::updateEntranceMap(TRoom * pR) called for room with Id:%i, it is not an Entrance for any Rooms.", id );
+                qDebug() << "TRoomDB::updateEntranceMap(TRoom * pR) called for room with id:"
+                << id
+                << ", it is not an Entrance for any Rooms.";
             }
             else {
-                qDebug( "TRoomDB::updateEntranceMap(TRoom * pR) called for room with Id:%i, it is an Entrance for Room(s): %s.", id, values.toLatin1().constData() );
+                qDebug() << "TRoomDB::updateEntranceMap(TRoom * pR) called for room with id:"
+                         << id
+                         << ", it is an Entrance for Room(s):"
+                         << values
+                         << ".";
             }
         }
     }
@@ -367,7 +375,7 @@ bool TRoomDB::removeArea( QString name )
 void TRoomDB::removeArea( TArea * pA )
 {
     if( ! pA ) {
-        qWarning( "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area with a NULL TArea pointer!" );
+        qWarning() << "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area with a NULL TArea pointer!";
         return;
     }
 
@@ -378,7 +386,7 @@ void TRoomDB::removeArea( TArea * pA )
         removeArea( areaId );
     }
     else {
-        qWarning( "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area NOT in TRoomDB::areas!" );
+        qWarning() << "TRoomDB::removeArea(TArea *) Warning - attempt to remove an area NOT in TRoomDB::areas!";
     }
 }
 
@@ -461,11 +469,13 @@ TArea * TRoomDB::getRawArea( int id, bool * isValid = 0 )
 bool TRoomDB::setAreaName( int areaID, QString name )
 {
     if( areaID < 1 ) {
-        qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Suspect areaID: %d supplied.", areaID );
+        qWarning() << "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Suspect area id:"
+                   << areaID
+                   << "supplied.";
         return false;
     }
     if( name.isEmpty() ) {
-        qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Empty name supplied." );
+        qWarning() << "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Empty name supplied.";
         return false;
     }
     else if( areaNamesMap.values().count(name) > 0 ) {
@@ -475,7 +485,9 @@ bool TRoomDB::setAreaName( int areaID, QString name )
             return true;
         }
         else {
-            qWarning( "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Duplicate name supplied \"%s\"- that is not a good idea!", name.toUtf8().constData() );
+            qWarning() << "TRoomDB::setAreaName((int)areaID, (QString)name): WARNING: Duplicate name supplied"
+                       << name
+                       << "- that is not permitted any longer!";
             return false;
         }
     }
@@ -621,12 +633,18 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
             itRoom.next();
             TRoom * pR = itRoom.value();
             if( ! pR ) {
-                QString warnMsg = tr( "[ WARN ]  - Problem with data structure associated with room Id: %1 - that\n"
-                                                  "room's data has been lost so the Id is now being deleted.  This\n"
-                                                  "suggests serious problems with the currently running version of\n"
-                                                  "Mudlet - is your system running out of memory?" )
-                                      .arg( itRoom.key() );
-                mpMap->postMessage( warnMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString warnMsg = tr( "[ WARN ]  - Problem with data structure associated with room id: %1 - that\n"
+                                                      "room's data has been lost so the id is now being deleted.  This\n"
+                                                      "suggests serious problems with the currently running version of\n"
+                                                      "Mudlet - is your system running out of memory?" )
+                                          .arg( itRoom.key() );
+                    mpMap->postMessage( warnMsg );
+                }
+                mpMap->appendRoomErrorMsg( itRoom.key(), tr( "[ WARN ]  - Problem with data structure associated with this room."
+                                                             "  The room's data has been lost so the id is now being deleted."
+                                                             "  This suggests serious problems with the currently running version of Mudlet"
+                                                             " - is your system running out of memory?"), true );
                 itRoom.remove();
             }
             else {
@@ -668,9 +686,12 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
         }
 
         if( ! areas.contains( usedAreaId ) ) {
-            QString warnMsg = tr( "[ ALERT ] - Area with id: %1 expected but not found, will be created." )
-                                  .arg( usedAreaId );
-            mpMap->postMessage( warnMsg );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                QString warnMsg = tr( "[ ALERT ] - Area with id: %1 expected but not found, will be created." )
+                                      .arg( usedAreaId );
+                mpMap->postMessage( warnMsg );
+            }
+            mpMap->appendAreaErrorMsg( usedAreaId, tr( "[ ALERT ] - Area with this id expected but not found, will be created." ), true );
         }
     }
 
@@ -691,13 +712,22 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
     // START OF TASK 5
     // Now process problem areaIds
     if( ! areaRemapping.isEmpty() ) {
-        QString alertMsg = tr( "[ ALERT ] - Bad, (less than +1 and not the reserved -1) area Ids found (count: %1)\n"
-                                           "in map, now working out what new Id numbers to use..." )
-                               .arg( areaRemapping.count() );
-        mpMap->postMessage( alertMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString alertMsg = tr( "[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1)\n"
+                                               "in map, now working out what new id numbers to use..." )
+                                   .arg( areaRemapping.count() );
+            mpMap->postMessage( alertMsg );
+        }
+        mpMap->appendErrorMsg( tr( "[ ALERT ] - Bad, (less than +1 and not the reserved -1) area ids found (count: %1) in map!"
+                                   "  Look for further messsages related to this for each affected area ..." )
+                                   .arg( areaRemapping.count() ), true );
 
-        QString infoMsg = tr( "[ INFO ]  - The renumbered area Ids will be:\n"
-                                          "Old ==> New" );
+        QString infoMsg;
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            infoMsg = tr( "[ INFO ]  - The renumbered area ids will be:\n"
+                                      "Old ==> New" );
+        }
+
         QMutableHashIterator<int, int> itRemappedArea( areaRemapping );
         while( itRemappedArea.hasNext() ) {
             itRemappedArea.next();
@@ -708,9 +738,14 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
             } while( areas.contains( ++replacementAreaId ) );
             // Insert replacement value into hash
             itRemappedArea.setValue( replacementAreaId );
-            infoMsg.append( QStringLiteral( "\n%1 ==> %2" )
-                                .arg( faultyAreaId )
-                                .arg( replacementAreaId ) );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                infoMsg.append( QStringLiteral( "\n%1 ==> %2" )
+                                    .arg( faultyAreaId )
+                                    .arg( replacementAreaId ) );
+            }
+
+            mpMap->appendAreaErrorMsg( faultyAreaId, tr( "[ INFO ]  - The area with this bad id was renumbered to: %1." ).arg( replacementAreaId ), true );
+            mpMap->appendAreaErrorMsg( replacementAreaId, tr( "[ INFO ]  - This area was renumbered from the bad id: %1." ).arg( faultyAreaId ), true );
 
             TArea * pA = 0;
             if( areas.contains( faultyAreaId ) ) {
@@ -750,23 +785,36 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
 
             pA->mIsDirty = true;
         }
-        mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            mpMap->postMessage( infoMsg );
+        }
     }
     else {
-        QString infoMsg = tr( "[ INFO ]  - Area Id numbering is satisfactory." );
-        mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString infoMsg = tr( "[ INFO ]  - Area id numbering is satisfactory." );
+            mpMap->postMessage( infoMsg );
+        }
+        mpMap->appendErrorMsg( tr( "[ INFO ]  - Area id numbering is satisfactory." ), false );
     }
     // END OF TASK 2,3,4,5 - all needed areas exist and remap details are in
     // areaRemapping - still need to update rooms and areaNames and mapLabels
 
     // Now complete TASK 1 - find the new room Ids to use
     if( ! roomRemapping.isEmpty() ) {
-        QString alertMsg = tr( "[ ALERT ] - Bad, (less than +1) room Ids found (count: %1) in map, now working\n"
-                                           "out what new Id numbers to use." )
-                               .arg( roomRemapping.count() );
-        mpMap->postMessage( alertMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString alertMsg = tr( "[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map, now working\n"
+                                               "out what new id numbers to use." )
+                                   .arg( roomRemapping.count() );
+            mpMap->postMessage( alertMsg );
+        }
+        mpMap->appendErrorMsg( tr( "[ ALERT ] - Bad, (less than +1) room ids found (count: %1) in map!"
+                                   "  Look for further messsages related to this for each affected room ..." )
+                                   .arg( roomRemapping.count() ), true );
 
-        QString infoMsg = tr( "[ INFO ]  - The renumbered rooms will be:\n" );
+        QString infoMsg;
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            infoMsg = tr( "[ INFO ]  - The renumbered rooms will be:\n" );
+        }
         QMutableHashIterator<int, int> itRenumberedRoomId( roomRemapping );
         while( itRenumberedRoomId.hasNext() ) {
             itRenumberedRoomId.next();
@@ -777,12 +825,19 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
 
             itRenumberedRoomId.setValue( newRoomId ); // Update the QHash
             validUsedRoomIds.insert( newRoomId );
-            infoMsg.append( QStringLiteral( "%1 ==> %2" )
-                                .arg( itRenumberedRoomId.key() )
-                                .arg( itRenumberedRoomId.value() ) );
+            if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                infoMsg.append( QStringLiteral( "%1 ==> %2" )
+                                    .arg( itRenumberedRoomId.key() )
+                                    .arg( itRenumberedRoomId.value() ) );
+            }
+
+            mpMap->appendRoomErrorMsg( itRenumberedRoomId.key(), tr( "[ INFO ]  - This room with the bad id was renumbered to: %1." ).arg( itRenumberedRoomId.value() ), true );
+            mpMap->appendRoomErrorMsg( itRenumberedRoomId.value(), tr( "[ INFO ]  - This room was renumbered from the bad id: %1." ).arg( itRenumberedRoomId.key() ),true  );
 
         }
-        mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            mpMap->postMessage( infoMsg );
+        }
 
         QSet<TRoom *> holdingSet;
         { // Block this code to limit scope of iterator
@@ -814,8 +869,11 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
         }
     }
     else {
-        QString infoMsg = tr( "[ INFO ]  - Room Id numbering is satisfactory." );
-        mpMap->postMessage( infoMsg );
+        if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+            QString infoMsg = tr( "[ INFO ]  - Room id numbering is satisfactory." );
+            mpMap->postMessage( infoMsg );
+        }
+        mpMap->appendErrorMsg( tr( "[ INFO ]  - Room id numbering is satisfactory." ), false );
     }
     // END OF TASK 1
 
@@ -831,10 +889,13 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
             unsigned int _listCount = pR->exitStubs.count();
             QSet<int> _set = pR->exitStubs.toSet();
             if( _set.count() < _listCount ) {
-                QString infoMsg = tr( "[ INFO ]  - Duplicate exit stub identifiers found in room Id: %1, this is an\n"
-                                                  "anomoly but has been cleaned up easily." )
-                                       .arg( itRoom.key() );
-                mpMap->postMessage( infoMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString infoMsg = tr( "[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
+                                                      "anomaly but has been cleaned up easily." )
+                                           .arg( itRoom.key() );
+                    mpMap->postMessage( infoMsg );
+                }
+                mpMap->appendRoomErrorMsg( itRoom.key(), tr( "[ INFO ]  - Duplicate exit stub identifiers found in room, this is an anomaly but has been cleaned up easily." ), false );
             }
             pR->exitStubs = _set.toList();
 
@@ -842,10 +903,13 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
             _listCount = pR->exitLocks.count();
             _set = pR->exitLocks.toSet();
             if( _set.count() < _listCount ) {
-                QString infoMsg = tr( "[ INFO ]  - Duplicate exit lock identifiers found in room Id: %1, this is an\n"
-                                                  "anomoly but has been cleaned up easily." )
-                                       .arg( itRoom.key() );
-                mpMap->postMessage( infoMsg );
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString infoMsg = tr( "[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
+                                                      "anomaly but has been cleaned up easily." )
+                                           .arg( itRoom.key() );
+                    mpMap->postMessage( infoMsg );
+                }
+                mpMap->appendRoomErrorMsg( itRoom.key(), tr( "[ INFO ]  - Duplicate exit lock identifiers found in room, this is an anomaly but has been cleaned up easily." ), false );
             }
             pR->exitLocks = _set.toList();
 
@@ -881,37 +945,89 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
 
             // Now compare pA->rooms to areaRoomMultiHash.values( itArea.key() )
             QSet<int> foundRooms = areaRoomMultiHash.values( itArea.key() ).toSet();
-//            QSet<int> correctRooms = pA->rooms.intersect( foundRooms );
-            QSet<int> extraRooms = pA->rooms;
-            extraRooms.subtract( foundRooms );
-            QSet<int> missingRooms = foundRooms;
-            missingRooms.subtract( pA->rooms );
+            QSetIterator<int> itFoundRoom( foundRooms );
+// Original form of code which was slower because the two sets of rooms were
+// compared TWICE:
+//            extraRooms = pA->rooms;
+//            extraRooms.subtract( foundRooms );
+//            missingRooms = foundRooms;
+//            missingRooms.subtract( pA->rooms );
+
+            // Revised code that only makes one pass
+            QSet<int> extraRooms( pA->rooms ); //Take common rooms from here so that any left are the "extras"
+            extraRooms.detach(); // We'll need a deep copy so might as well explicitly say so to make the copy
+            QSet<int> missingRooms; // Add rooms not in pA->room to here
+            int checkRoom;
+            while( itFoundRoom.hasNext() ) {
+                checkRoom = itFoundRoom.next();
+                if( pA->rooms.contains( checkRoom ) ) {
+                    extraRooms.remove( checkRoom );
+                }
+                else {
+                    missingRooms.insert( checkRoom );
+                }
+            }
+
+            // Report differences:
             if( ! missingRooms.isEmpty() ) {
                 QStringList roomList;
-                QSetIterator<int> itMissingRoom( missingRooms );
-                while( itMissingRoom.hasNext() ) {
-                    roomList.append( QString::number( itMissingRoom.next() ) );
+                QList<int> missingRoomsList = missingRooms.toList();
+                if( missingRoomsList.size() > 1 ) {
+                    // The on-screen listing are clearer if we sort the rooms
+                    std::sort( missingRoomsList.begin(), missingRoomsList.end() );
                 }
-                QString infoMsg = tr( "[ INFO ]  - In area with Id: %1 there were %2 rooms missing from those it\n"
-                                                  "should be recording as possessing, they were:\n%3\nthey have been added." )
-                                      .arg( itArea.key() )
-                                      .arg( missingRooms.count() )
-                                      .arg( roomList.join( QStringLiteral( ", " ) ) );
-                mpMap->postMessage( infoMsg );
+                QListIterator<int> itMissingRoom( missingRoomsList );
+                while( itMissingRoom.hasNext() ) {
+                    int missingRoomId = itMissingRoom.next();
+                    roomList.append( QString::number( missingRoomId ) );
+                    mpMap->appendRoomErrorMsg( missingRoomId, tr( "[ INFO ]  - This room claims to be in area id: %1, but that did not have a record of it."
+                                                                  "  The area has been updated to include this room." )
+                                                                  .arg( itArea.key() ), true );
+                }
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString infoMsg = tr( "[ INFO ]  - In area with id: %1 there were %2 rooms missing from those it\n"
+                                                      "should be recording as possessing, they were:\n%3\nthey have been added." )
+                                          .arg( itArea.key() )
+                                          .arg( missingRooms.count() )
+                                          .arg( roomList.join( QStringLiteral( ", " ) ) );
+                    mpMap->postMessage( infoMsg );
+                }
+                mpMap->appendAreaErrorMsg( itArea.key(), tr( "[ INFO ]  - In this area there were %1 rooms missing from those it should be recorded as possessing."
+                                                             "  They are: %2."
+                                                             "  They have been added." )
+                                                             .arg( missingRooms.count() )
+                                                             .arg( roomList.join( QStringLiteral( ", " ) ) ), true );
+
                 pA->mIsDirty = true;
             }
+
             if( ! extraRooms.isEmpty() ) {
                 QStringList roomList;
-                QSetIterator<int> itExtraRoom( extraRooms );
-                while( itExtraRoom.hasNext() ) {
-                    roomList.append( QString::number( itExtraRoom.next() ) );
+                QList<int> extraRoomsList = extraRooms.toList();
+                if( extraRoomsList.size() > 1 ) {
+                    std::sort( extraRoomsList.begin(), extraRoomsList.end() );
                 }
-                QString infoMsg = tr( "[ INFO ]  - In area with Id: %1 there were %2 extra rooms compared to those it\n"
-                                                  "should be recording as possessing, they were:\n%3\nthey have been removed." )
-                                      .arg( itArea.key() )
-                                      .arg( extraRooms.count() )
-                                      .arg( roomList.join( QStringLiteral( ", " ) ) );
-                mpMap->postMessage( infoMsg );
+                QListIterator<int> itExtraRoom( extraRoomsList );
+                while( itExtraRoom.hasNext() ) {
+                    int extraRoomId = itExtraRoom.next();
+                    roomList.append( QString::number( extraRoomId ) );
+                    mpMap->appendRoomErrorMsg( extraRoomId, tr( "[ INFO ]  - This room was claimed by id: %1, but it does not belong there."
+                                                                "  The area has been updated to not include this room." )
+                                                                .arg( itArea.key() ), true );
+                }
+                if( mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
+                    QString infoMsg = tr( "[ INFO ]  - In area with id: %1 there were %2 extra rooms compared to those it\n"
+                                                      "should be recording as possessing, they were:\n%3\nthey have been removed." )
+                                          .arg( itArea.key() )
+                                          .arg( extraRooms.count() )
+                                          .arg( roomList.join( QStringLiteral( ", " ) ) );
+                    mpMap->postMessage( infoMsg );
+                }
+                mpMap->appendAreaErrorMsg( itArea.key(), tr( "[ INFO ]  - In this area there were %1 extra rooms that it should not be recorded as possessing."
+                                                             "  They were: %2."
+                                                             "  They have been removed." )
+                                                             .arg( extraRooms.count() )
+                                                             .arg( roomList.join( QStringLiteral( ", " ) ) ), true );
                 pA->mIsDirty = true;
             }
             pA->rooms = foundRooms;
@@ -1024,10 +1140,17 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
             // Seems to look better if we iterate through backwards!
             while( itRemappedNames.hasPrevious() ) {
                 itRemappedNames.previous();
+                QString oldName = itRemappedNames.key().isEmpty() ? tr( "<nothing>" ) : itRemappedNames.key();
                 detailText.append( QStringLiteral( "(%1) \"%2\" ==> \"%3\"\n" )
                                        .arg( areaNamesMap.key( itRemappedNames.value() ) )
-                                       .arg( itRemappedNames.key().isEmpty() ? tr( "<nothing>" ) : itRemappedNames.key() )
+                                       .arg( oldName )
                                        .arg( itRemappedNames.value() ) );
+                mpMap->appendAreaErrorMsg( areaNamesMap.key( itRemappedNames.value() ),
+                                           tr( "[ INFO ]  - Area name changed to prevent duplicates or unnamed ones; old name: \"%1\", new name: \"%2\"." )
+                                               .arg( oldName )
+                                               .arg( itRemappedNames.value() ),
+                                           true );
+                        ;
             }
             detailText.chop(1); // Trim last "\n" off
         }
@@ -1088,7 +1211,9 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
                                   .arg( mUnnamedAreaName );
         }
         mpMap->mpHost->postMessage( alertText );
+        mpMap->appendErrorMsgWithNoLf( alertText, true );
         mpMap->mpHost->postMessage( informativeText );
+        mpMap->appendErrorMsgWithNoLf( informativeText, true );
         if( ! detailText.isEmpty() ) {
             mpMap->mpHost->postMessage( detailText );
         }
@@ -1097,9 +1222,10 @@ void TRoomDB::restoreAreaMap( QDataStream & ifs )
     if( ! areaNamesMap.contains( -1 ) ) {
         areaNamesMap.insert( -1, mDefaultAreaName );
         QString defaultAreaNameInsertionMsg = tr( "[ INFO ]  - Default (reset) area name (for rooms that have not been assigned to an\n"
-                                                              "area) not found, adding \"%1\" against the reserved -1 Id." )
+                                                              "area) not found, adding \"%1\" against the reserved -1 id." )
                                               .arg( mDefaultAreaName );
         mpMap->mpHost->postMessage( defaultAreaNameInsertionMsg );
+        mpMap->appendErrorMsgWithNoLf( defaultAreaNameInsertionMsg, false );
     }
 }
 

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -79,6 +79,7 @@ public:
     void restoreAreaMap( QDataStream & );
     void restoreSingleArea( int, TArea * );
     void restoreSingleRoom( int, TRoom * );
+    const QString   getDefaultAreaName() { return mDefaultAreaName; }
 
 
     QMap<QString,int> hashTable;

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -77,8 +77,8 @@ public:
     bool addRoom(int id, TRoom *pR, bool isMapLoading = false);
     int  getAreaID(TArea * pA);
     void restoreAreaMap( QDataStream & );
-    void restoreSingleArea( QDataStream &, int, TArea * );
-    void restoreSingleRoom( QDataStream &, int, TRoom * );
+    void restoreSingleArea( int, TArea * );
+    void restoreSingleRoom( int, TRoom * );
 
 
     QMap<QString,int> hashTable;
@@ -96,6 +96,7 @@ private:
     TMap * mpMap;
     QSet<int> * mpTempRoomDeletionSet; // Used during bulk room deletion
     QString mUnnamedAreaName;
+    QString mDefaultAreaName;
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -46,7 +46,7 @@ public:
     bool addRoom( int id );
     int size() { return rooms.size(); }
     bool removeRoom( int );
-    void removeRoom( QList<int> & );
+    void removeRoom( QSet<int> & );
     bool removeArea( int id );
     bool removeArea( QString name );
     void removeArea( TArea * );
@@ -72,12 +72,13 @@ public:
     void initAreasForOldMaps();
     void auditRooms();
     bool addRoom(int id, TRoom *pR, bool isMapLoading = false);
-    int getAreaID(TArea * pA);
+    int  getAreaID(TArea * pA);
     void restoreAreaMap( QDataStream & );
     void restoreSingleArea( QDataStream &, int, TArea * );
     void restoreSingleRoom( QDataStream &, int, TRoom * );
-    QMap<QString,int> hashTable;
 
+
+    QMap<QString,int> hashTable;
 
 
 private:
@@ -86,12 +87,12 @@ private:
     bool __removeRoom( int id );
 
     QHash<int, TRoom *> rooms;
-    QMultiHash<int, int> entranceMap;
+    QMultiHash<int, int> entranceMap; // key is exit target, value is exit source
     QMap<int, TArea *> areas;
     QMap<int, QString> areaNamesMap;
     TMap * mpMap;
+    QSet<int> * mpTempRoomDeletionSet; // Used during bulk room deletion
     QString mUnnamedAreaName;
-    QList<int> * mpTempRoomDeletionList; // Used during bulk room deletion
 
     friend class TRoom;//friend TRoom::~TRoom();
     //friend class TMap;//bool TMap::restore(QString location);

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -24,6 +24,7 @@
 
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QHash>
 #include <QMultiHash>
 #include <QMap>
@@ -37,12 +38,15 @@ class TRoom;
 
 class TRoomDB
 {
+    Q_DECLARE_TR_FUNCTIONS(TRoomDB) // Needed so we can use tr() even though TRoomDB is NOT derived from QObject
+
 public:
     TRoomDB( TMap * );
 
     TRoom * getRoom( int id );
     TArea * getArea( int id );
 //     int getArea( TArea * pA ); use duplicate int getAreaID( TArea * pA ) instead
+    TArea * getRawArea( int, bool * );
     bool addRoom( int id );
     int size() { return rooms.size(); }
     bool removeRoom( int );
@@ -69,8 +73,7 @@ public:
 
     void buildAreas();
     void clearMapDB();
-    void initAreasForOldMaps();
-    void auditRooms();
+    void auditRooms( QHash<int, int> &, QHash<int, int> & );
     bool addRoom(int id, TRoom *pR, bool isMapLoading = false);
     int  getAreaID(TArea * pA);
     void restoreAreaMap( QDataStream & );

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -43,8 +43,6 @@
 
 
 int maxRooms;
-int maxAreas;
-QMap<int,int> areaMap;
 
 XMLimport::XMLimport( Host * pH )
 : mpHost( pH )
@@ -148,9 +146,7 @@ bool XMLimport::importPackage( QIODevice * device, QString packName, int moduleF
             }
             else if( name() == "map" )
             {
-                maxAreas = 0;
                 maxRooms = 0;
-                areaMap.clear();
                 readMap();
                 mpHost->mpMap->audit();
             }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -528,7 +529,8 @@ void XMLimport::readUnknownRoomElement()
     {
 
         readNext();
-        qDebug()<<"[ERROR]: UNKNOWN room element:name="<<name().toString();
+        qDebug() << "[ERROR]: UNKNOWN room element: name="
+                 << name().toString();
 
         if( isEndElement() )
         {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -152,7 +152,7 @@ bool XMLimport::importPackage( QIODevice * device, QString packName, int moduleF
                 maxRooms = 0;
                 areaMap.clear();
                 readMap();
-                mpHost->mpMap->init(mpHost);
+                mpHost->mpMap->audit();
             }
             else
             {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1118,7 +1118,7 @@ void cTelnet::setATCPVariables(const QString & msg )
     {
         if( mpHost->mpMap )
         {
-            mpHost->mpMap->mRoomId = arg.toInt();
+            mpHost->mpMap->mRoomIdHash[ mpHost->getName() ] = arg.toInt();
             if( mpHost->mpMap->mpM && mpHost->mpMap->mpMapper && mpHost->mpMap->mpMapper->mp2dMap )
             {
                 mpHost->mpMap->mpM->update();

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -288,7 +288,10 @@ void dlgMapper::choseRoom(QListWidgetItem * pT )
         it.next();
         int i = it.key();
         TRoom * pR = mpMap->mpRoomDB->getRoom(i);
-        if( !pR ) continue;
+        if( !pR )
+        {
+            continue;
+        }
         if( pR->name == txt )
         {
             qDebug()<<"found room id="<<i;
@@ -299,7 +302,9 @@ void dlgMapper::choseRoom(QListWidgetItem * pT )
                 mpHost->mpConsole->printSystemMessage(msg);
             }
             else
+            {
                 mpMap->mpHost->startSpeedWalk();
+            }
             break;
         }
     }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -43,6 +43,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 : QWidget( parent )
 , mpMap( pM )
 , mpHost( pH )
+, mShowDefaultArea( true )
 {
     setupUi(this);
 
@@ -159,6 +160,10 @@ void dlgMapper::updateAreaComboBox()
     QMap <QString, QString> _areaNames;
     while( itAreaNamesA.hasNext() ) {
         itAreaNamesA.next();
+        if( itAreaNamesA.key() == -1 && ! mShowDefaultArea ) {
+            continue; // Skip the default area from the listing if so directed
+        }
+
         uint deduplicate = 0;
         QString _name;
         do {
@@ -373,4 +378,12 @@ void dlgMapper::slot_info()
     mp2dMap->mShowInfo = showInfo->isChecked();
     mp2dMap->mpHost->mShowInfo = mp2dMap->mShowInfo;
     mp2dMap->update();
+}
+
+void dlgMapper::setDefaultAreaShown( bool state )
+{
+    if( mShowDefaultArea != state ) {
+        mShowDefaultArea = state;
+        updateAreaComboBox();
+    }
 }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -155,6 +155,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 
 void dlgMapper::updateAreaComboBox()
 {
+    QString oldValue = showArea->currentText();  // Remember where we were
     QMapIterator<int, QString> itAreaNamesA( mpMap->mpRoomDB->getAreaNamesMap() );
     //insert sort them alphabetically (case INsensitive)
     QMap <QString, QString> _areaNames;
@@ -180,6 +181,7 @@ void dlgMapper::updateAreaComboBox()
         itAreaNamesB.next();
         showArea->addItem( itAreaNamesB.value() );
     }
+    showArea->setCurrentText( oldValue ); // Try and reset to previous value
 }
 
 void dlgMapper::slot_toggleShowRoomIDs(int s)

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -234,7 +234,6 @@ void dlgMapper::cancel()
     qDebug()<<"download was cancalled";
     mpProgressDialog->close();
     mpReply->abort();
-    mpHost->mpMap->init( mpHost );
     glWidget->updateGL();
 }
 
@@ -264,7 +263,7 @@ void dlgMapper::replyFinished( QNetworkReply * reply )
     XMLimport reader( mpHost );
     reader.importPackage( & file );
 
-    mpHost->mpMap->init( mpHost );
+    mpHost->mpMap->audit();
     glWidget->updateGL();
 
     if( mpHost->mpMap )

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -118,6 +118,18 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     mpDownloader = new QNetworkAccessManager( this );
     connect(mpDownloader, SIGNAL(finished(QNetworkReply*)),this, SLOT(replyFinished(QNetworkReply*)));
     connect(showRoomIDs, SIGNAL(stateChanged(int)), this, SLOT(slot_toggleShowRoomIDs(int)));
+    QFont mapperFont = QFont( mpHost->mDisplayFont.family() );
+    if( mpHost->mNoAntiAlias )
+    {
+        mapperFont.setStyleStrategy( QFont::NoAntialias );
+    }
+    else
+    {
+        mapperFont.setStyleStrategy( static_cast<QFont::StyleStrategy>(QFont::PreferAntialias | QFont::PreferQuality) );
+    }
+    setFont( mapperFont );
+    // Explicitly set the font otherwise it changes between the Application and
+    // the default System one as the mapper is docked and undocked!
     mp2dMap->mFontHeight = QFontMetrics( mpHost->mDisplayFont ).height();
     glWidget->hide();
     mpMap->customEnvColors[257] = mpHost->mRed_2;

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -296,7 +296,7 @@ void dlgMapper::choseRoom(QListWidgetItem * pT )
         {
             qDebug()<<"found room id="<<i;
             mpMap->mTargetID = i;
-            if( ! mpMap->findPath( mpMap->mRoomId, i ) )
+            if( ! mpMap->findPath( mpMap->mRoomIdHash.value( mpMap->mpHost->getName() ), i ) )
             {
                 QString msg = "Cannot find a path to this room.\n";
                 mpHost->mpConsole->printSystemMessage(msg);

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -45,6 +45,9 @@ public:
         dlgMapper( QWidget *, Host *, TMap * );
         void downloadMap();
         void updateAreaComboBox();
+    void                setDefaultAreaShown( const bool );
+    const bool          getDefaultAreaShown() { return mShowDefaultArea; }
+
         TMap * mpMap;
         QPointer<Host> mpHost;
         QNetworkAccessManager * mpDownloader;
@@ -66,6 +69,9 @@ public slots:
         void choseRoom( QListWidgetItem * );
         void slot_roomSize(int d);
         void slot_lineSize(int d);
+
+private:
+    bool                mShowDefaultArea;
 };
 
 #endif // MUDLET_DLGMAPPER_H

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -47,6 +48,7 @@ public:
         void updateAreaComboBox();
     void                setDefaultAreaShown( const bool );
     const bool          getDefaultAreaShown() { return mShowDefaultArea; }
+    void                resetAreaComboBoxToPlayerRoomArea();
 
         TMap * mpMap;
         QPointer<Host> mpHost;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -325,6 +325,15 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
                 comboBox_mapFileSaveFormatVersion->setCurrentIndex( _indexForCurrentSaveFormat );
             }
         }
+        if( pHost->mpMap->mpMapper ) {
+            checkBox_showDefaultArea->show();
+            checkBox_showDefaultArea->setText( tr( "If checked (normal case) the \"%1\" IS shown in the map Area selection control." )
+                                               .arg( pHost->mpMap->mpRoomDB->getDefaultAreaName() ) );
+            checkBox_showDefaultArea->setChecked( pHost->mpMap->mpMapper->getDefaultAreaShown() );
+        }
+        else {
+            checkBox_showDefaultArea->hide();
+        }
     }
 }
 
@@ -1125,9 +1134,10 @@ void dlgProfilePreferences::slot_save_and_exit()
     pHost->mEnableGMCP = mEnableGMCP->isChecked();
     pHost->mEnableMSDP = mEnableMSDP->isChecked();
     pHost->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
-    if( pHost->mpMap )
-        if( pHost->mpMap->mpMapper )
-            pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
+    if( pHost->mpMap && pHost->mpMap->mpMapper ) {
+        pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
+        pHost->mpMap->mpMapper->setDefaultAreaShown( checkBox_showDefaultArea->isChecked() );
+    }
     pHost->mBorderTopHeight = topBorderHeight->value();
     pHost->mBorderBottomHeight = bottomBorderHeight->value();
     pHost->mBorderLeftWidth = leftBorderWidth->value();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -270,8 +270,6 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
 
         pushButton_chooseProfiles->setMenu( pMenu );
         connect(pMenu, SIGNAL(triggered(QAction *)), this, SLOT(slot_chooseProfilesChanged(QAction *)));
-        connect(this, SIGNAL(signal_otherProfilesToReloadMaps(QList<QString>)),
-                mudlet::self(), SLOT(slot_requestProfilesToReloadMaps(QList<QString>)));
 
         connect(pushButton_copyMap, SIGNAL(clicked()), this, SLOT(copyMap()));
 
@@ -1094,7 +1092,7 @@ void dlgProfilePreferences::copyMap()
     }
 
     // Finally, signal the other profiles to reload their maps:
-    emit signal_otherProfilesToReloadMaps( toProfilesRoomIdMap.keys() );
+    mudlet::self()->requestProfilesToReloadMaps( toProfilesRoomIdMap.keys() );
     // GOTCHA: keys() is a QList<QString>, however, though it IS equivalent to a
     // QStringList in many ways, the SLOT/SIGNAL system treats them as different
     // - I thinK - so use QList<QString> thoughout the SIGNAL/SLOT links Slysven!

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -849,10 +849,6 @@ void dlgProfilePreferences::loadMap()
         label_mapFileActionResult->setText( tr( "Could not load map from %1." ).arg( fileName ) );
         QTimer::singleShot(10*1000, this, SLOT(hideActionLabel()));
     }
-    if( mpHost->mpMap && mpHost->mpMap->mpMapper )
-    {
-            mpHost->mpMap->mpMapper->updateAreaComboBox();
-    }
 }
 
 void dlgProfilePreferences::saveMap()

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1132,7 +1132,20 @@ void dlgProfilePreferences::slot_save_and_exit()
     pHost->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
     if( pHost->mpMap && pHost->mpMap->mpMapper ) {
         pHost->mpMap->mpMapper->mp2dMap->mMapperUseAntiAlias = mMapperUseAntiAlias->isChecked();
+        bool isAreaWidgetInNeedOfResetting = false;
+        if(  ( ! pHost->mpMap->mpMapper->getDefaultAreaShown() )
+          && ( checkBox_showDefaultArea->isChecked() )
+          && ( pHost->mpMap->mpMapper->mp2dMap->mAID == -1 ) ) {
+            isAreaWidgetInNeedOfResetting = true;
+        }
+
         pHost->mpMap->mpMapper->setDefaultAreaShown( checkBox_showDefaultArea->isChecked() );
+        if( isAreaWidgetInNeedOfResetting ) {
+            // Corner case fixup:
+            pHost->mpMap->mpMapper->showArea->setCurrentText( pHost->mpMap->mpRoomDB->getDefaultAreaName() );
+        }
+        pHost->mpMap->mpMapper->mp2dMap->repaint(); // Forceably redraw it as we ARE currently showing default area
+        pHost->mpMap->mpMapper->update();
     }
     pHost->mBorderTopHeight = topBorderHeight->value();
     pHost->mBorderBottomHeight = bottomBorderHeight->value();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -187,6 +187,7 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
         comboBox_statusBarSetting->setCurrentIndex( _indexForStatusBarSetting );
     }
 
+    checkBox_reportMapIssuesOnScreen->setChecked( mudlet::self()->getAuditErrorsToConsoleEnabled() );
     Host * pHost = mpHost;
     if( pHost )
     {
@@ -839,6 +840,10 @@ void dlgProfilePreferences::loadMap()
     label_mapFileActionResult->setText( tr( "Loading map - please wait..." ) );
     qApp->processEvents(); // Needed to make the above message show up when loading big maps
 
+    // Ensure the setting is already made as the loadMap(...) uses the set value
+    bool savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->getAuditErrorsToConsoleEnabled();
+    mudlet::self()->setAuditErrorsToConsoleEnabled( checkBox_reportMapIssuesOnScreen->isChecked() );
+
     if ( mpHost->mpConsole->loadMap(fileName) )
     {
         label_mapFileActionResult->setText( tr( "Loaded map from %1." ).arg( fileName ) );
@@ -849,6 +854,8 @@ void dlgProfilePreferences::loadMap()
         label_mapFileActionResult->setText( tr( "Could not load map from %1." ).arg( fileName ) );
         QTimer::singleShot(10*1000, this, SLOT(hideActionLabel()));
     }
+    // Restore setting immediately before we used it
+    mudlet::self()->setAuditErrorsToConsoleEnabled( savedOldAuditErrorsToConsoleEnabledSetting );
 }
 
 void dlgProfilePreferences::saveMap()
@@ -881,6 +888,11 @@ void dlgProfilePreferences::saveMap()
 #else
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->itemData( comboBox_mapFileSaveFormatVersion->currentIndex() ).toInt();
 #endif
+
+    // Ensure the setting is already made as the saveMap(...) uses the set value
+    bool savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->getAuditErrorsToConsoleEnabled();
+    mudlet::self()->setAuditErrorsToConsoleEnabled( checkBox_reportMapIssuesOnScreen->isChecked() );
+
     if( pHost->mpConsole->saveMap(fileName) ) {
         label_mapFileActionResult->setText( tr( "Saved map to %1." ).arg( fileName ) );
     } else {
@@ -888,6 +900,7 @@ void dlgProfilePreferences::saveMap()
     }
     // Then restore prior version
     pHost->mpMap->mSaveVersion = oldSaveVersionFormat;
+    mudlet::self()->setAuditErrorsToConsoleEnabled( savedOldAuditErrorsToConsoleEnabledSetting );
 
     QTimer::singleShot(10*1000, this, SLOT(hideActionLabel()));
 }
@@ -954,6 +967,11 @@ void dlgProfilePreferences::copyMap()
     }
     // otherProfileCurrentRoomId will be -1 if tried and failed to get it from
     // current running profile, > 0 on sucess or 0 if not running as another profile
+
+    // Ensure the setting is already made as the value could be used in the
+    // code following after
+    bool savedOldAuditErrorsToConsoleEnabledSetting = mudlet::self()->getAuditErrorsToConsoleEnabled();
+    mudlet::self()->setAuditErrorsToConsoleEnabled( checkBox_reportMapIssuesOnScreen->isChecked() );
 
     // We now KNOW there are places where the destination profiles will/have
     // stored their maps - if we do not already know where the player is in the
@@ -1103,6 +1121,10 @@ void dlgProfilePreferences::copyMap()
     // - I thinK - so use QList<QString> thoughout the SIGNAL/SLOT links Slysven!
     label_mapFileActionResult->setText( tr( "Map copied, now signalling other profiles to reload it." ) );
     QTimer::singleShot( 10*1000, this, SLOT( hideActionLabel() ) );
+
+    // CHECK: Race condition? We might be changing this whilst other profile
+    // are accessing it...
+    mudlet::self()->setAuditErrorsToConsoleEnabled( savedOldAuditErrorsToConsoleEnabledSetting );
 }
 
 void dlgProfilePreferences::slot_save_and_exit()
@@ -1236,6 +1258,7 @@ void dlgProfilePreferences::slot_save_and_exit()
 //qDebug()<<"after console refresh: Left border width:"<<pHost->mBorderLeftWidth<<" right:"<<pHost->mBorderRightWidth;
     }
     mudlet::self()->setEditorTextoptions( checkBox_showSpacesAndTabs->isChecked(), checkBox_showLineFeedsAndParagraphs->isChecked() );
+    mudlet::self()->setAuditErrorsToConsoleEnabled( checkBox_reportMapIssuesOnScreen->isChecked() );
     close();
 }
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -41,11 +41,6 @@ public:
 
     int mFontSize;
 
-signals:
-    // Used by "Copy Map" to inform a list of profiles - asynchronously, via
-    // mudlet class - to load in an updated map
-    void    signal_otherProfilesToReloadMaps( QList<QString> );
-
 
 public slots:
     // Fonts.

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -42,6 +42,9 @@ public:
     int mFontSize;
 
 signals:
+    // Used by "Copy Map" to inform a list of profiles - asynchronously, via
+    // mudlet class - to load in an updated map
+    void    signal_otherProfilesToReloadMaps( QList<QString> );
 
 
 public slots:
@@ -101,6 +104,7 @@ public slots:
     void loadMap();
     void saveMap();
     void copyMap();
+    void slot_chooseProfilesChanged(QAction *);
 
     // Save.
     void slot_save_and_exit();

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -1712,7 +1712,13 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
     case 2: closed->setChecked(true); break;
     case 3: locked->setChecked(true); break;
     default:
-        qWarning()<<"dlgRoomExits::initExit(...) in room Id("<<roomId<<") unexpected doors["<<doorAndWeightText<<"] value:"<<pR->getDoor( doorAndWeightText )<<"found for room!";
+        qWarning() << "dlgRoomExits::initExit(...) in room id("
+                   << roomId
+                   << ") unexpected doors["
+                   << doorAndWeightText
+                   << "] value:"
+                   << pR->getDoor( doorAndWeightText )
+                   << "found for room!";
     }
 
     TRoom * pExitR;
@@ -1720,7 +1726,11 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
         pExitR = mpHost->mpMap->mpRoomDB->getRoom( exitId );
         if( ! pExitR ) {
             // Recover from a missing exit room - not doing this was causing seg. faults
-            qWarning()<<"dlgRoomExits::initExit(...): Warning: missing exit to"<<exitId<<"in direction "<<exitText<<", resetting exit.";
+            qWarning() << "dlgRoomExits::initExit(...): Warning: missing exit to"
+                       << exitId
+                       << "in direction"
+                       << exitText
+                       << ", resetting exit.";
             exitId = -1;
         }
     }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -325,30 +325,16 @@ void GLWidget::initializeGL()
     is2DView = false;
 }
 
-void GLWidget::showArea(QString name)
+// Replaces setArea() - now fed the coordinates of the room choosen as the
+// view center in the area given from the set operation in the 2D Map
+void GLWidget::setViewCenter( int areaId, int xPos, int yPos, int zPos )
 {
-    if( !mpMap ) {
-        return;
-    }
-    QMapIterator<int, QString> it( mpMap->mpRoomDB->getAreaNamesMap() );
-    while( it.hasNext() )
-    {
-        it.next();
-        int areaID = it.key();
-        QString _n = it.value();
-        if( name == _n )
-        {
-            mAID = areaID;
-            mRID = mpMap->mRoomIdHash.value( mpMap->mpHost->getName() );
-            mShiftMode = true;
-            mOx = 0;
-            mOy = 0;
-            mOz = 0;
-            updateGL();
-            break;
-        }
-    }
-
+    mAID = areaId;
+    mShiftMode = true;
+    mOx = xPos;
+    mOy = yPos;
+    mOz = zPos;
+    updateGL();
 }
 
 void GLWidget::paintGL()

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -327,7 +327,9 @@ void GLWidget::initializeGL()
 
 void GLWidget::showArea(QString name)
 {
-    if( !mpMap ) return;
+    if( !mpMap ) {
+        return;
+    }
     QMapIterator<int, QString> it( mpMap->mpRoomDB->getAreaNamesMap() );
     while( it.hasNext() )
     {
@@ -351,7 +353,9 @@ void GLWidget::showArea(QString name)
 
 void GLWidget::paintGL()
 {
-    if( ! mpMap ) return;
+    if( ! mpMap ) {
+        return;
+    }
     float px,py,pz;
     if( mRID != mpMap->mRoomId && mShiftMode )  mShiftMode = false;
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -528,9 +528,10 @@ void GLWidget::paintGL()
                 break;
             }
         }
-        for( int i=0; i<pArea->rooms.size(); i++ )
+        QSetIterator<int> itRoom( pArea->getAreaRooms() );
+        while( itRoom.hasNext() )
         {
-            TRoom * pR = mpMap->mpRoomDB->getRoom(pArea->rooms[i]);
+            TRoom * pR = mpMap->mpRoomDB->getRoom(itRoom.next());
             if( !pR ) continue;
             float rx = static_cast<float>(pR->x);
             float ry = static_cast<float>(pR->y);
@@ -1307,10 +1308,12 @@ void GLWidget::paintGL()
         {
             break;
         }
-        for( int i=0; i<pArea->rooms.size(); i++ )
+        QSetIterator<int> itRoom( pArea->getAreaRooms() );
+        while( itRoom.hasNext() )
         {
             glDisable(GL_LIGHT1);
-            TRoom * pR = mpMap->mpRoomDB->getRoom( pArea->rooms[i] );
+            int currentRoomId = itRoom.next();
+            TRoom * pR = mpMap->mpRoomDB->getRoom( currentRoomId );
             if( !pR ) continue;
             float rx = static_cast<float>(pR->x);
             float ry = static_cast<float>(pR->y);
@@ -1337,7 +1340,7 @@ void GLWidget::paintGL()
                 glMateriali(GL_FRONT, GL_SHININESS, 36);
                 glColor4f(1.0, 0.0, 0.0, 1.0);
             }
-            else if( pArea->rooms[i] == mTarget )
+            else if( currentRoomId == mTarget )
             {
                 glDisable(GL_BLEND);
                 glEnable( GL_LIGHTING );
@@ -1384,7 +1387,7 @@ void GLWidget::paintGL()
                     glTranslatef( rx, ry, rz );
                 }
 
-                glLoadName( pArea->rooms[i] );
+                glLoadName( currentRoomId );
                 quads++;
                 glBegin( GL_QUADS );
                 glNormal3f(0.57735, -0.57735, 0.57735);
@@ -1631,7 +1634,7 @@ void GLWidget::paintGL()
                 glTranslatef( rx, ry, rz );
             }
 
-            glLoadName( pArea->rooms[i] );
+            glLoadName( currentRoomId );
             quads++;
             glBegin( GL_QUADS );
             glNormal3f(0.57735, -0.57735, 0.57735);

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -339,7 +339,7 @@ void GLWidget::showArea(QString name)
         if( name == _n )
         {
             mAID = areaID;
-            mRID = mpMap->mRoomId;//FIXME:
+            mRID = mpMap->mRoomIdHash.value( mpMap->mpHost->getName() );
             mShiftMode = true;
             mOx = 0;
             mOy = 0;
@@ -357,14 +357,16 @@ void GLWidget::paintGL()
         return;
     }
     float px,py,pz;
-    if( mRID != mpMap->mRoomId && mShiftMode )  mShiftMode = false;
+    if( mRID != mpMap->mRoomIdHash.value( mpMap->mpHost->getName() ) && mShiftMode ) {
+        mShiftMode = false;
+    }
 
     int ox, oy, oz;
     if( ! mShiftMode )
     {
 
 
-        mRID = mpMap->mRoomId;
+        mRID = mpMap->mRoomIdHash.value( mpMap->mpHost->getName() );
         TRoom * pRID = mpMap->mpRoomDB->getRoom( mRID );
         if( !pRID  )
         {
@@ -1986,7 +1988,7 @@ void GLWidget::mousePressEvent(QMouseEvent *event)
         if( mpMap->mpRoomDB->getRoom(mTarget) )
         {
             mpMap->mTargetID = mTarget;
-            if( mpMap->findPath( mpMap->mRoomId, mpMap->mTargetID) )
+            if( mpMap->findPath( mpMap->mRoomIdHash.value( mpMap->mpHost->getName() ), mpMap->mTargetID) )
             {
                mpMap->mpHost->startSpeedWalk();
             }

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2010-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -40,6 +41,7 @@ public:
     GLWidget(TMap * pM, QWidget *parent = 0);
     ~GLWidget();
     void wheelEvent( QWheelEvent * e ) override;
+    void setViewCenter( int, int, int, int );
 
     bool is2DView;
 
@@ -64,7 +66,6 @@ public slots:
     void shiftRight();
     void shiftZup();
     void shiftZdown();
-    void showArea(QString);
     void setXRotation(int angle);
     void setYRotation(int angle);
     void setZRotation(int angle);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1869,7 +1869,7 @@ void mudlet::slot_mapper()
         return;
     }
 
-    QDockWidget * pDock = new QDockWidget("Mudlet Mapper");
+    QDockWidget * pDock = new QDockWidget( tr("Map - %1").arg(pHost->getName()) );
     pHost->mpMap->mpMapper = new dlgMapper( pDock, pHost, pHost->mpMap.data() );//FIXME: mpHost definieren
     pHost->mpMap->mpM = pHost->mpMap->mpMapper->glWidget;
     pDock->setWidget( pHost->mpMap->mpMapper );

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1874,13 +1874,16 @@ void mudlet::slot_mapper()
     pHost->mpMap->mpM = pHost->mpMap->mpMapper->glWidget;
     pDock->setWidget( pHost->mpMap->mpMapper );
 
-    if( pHost->mpMap->mpRoomDB->getRoomIDList().size() < 1 )
+    if( pHost->mpMap->mpRoomDB->getRoomIDList().isEmpty() )
     {
+        qDebug() << "mudlet::slot_mapper() - restore map case 4.";
         if( pHost->mpMap->restore( QString() ) ) {
             pHost->mpMap->audit();
+            pHost->mpMap->mpMapper->mp2dMap->init();
+            pHost->mpMap->mpMapper->updateAreaComboBox();
+            pHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
+            pHost->mpMap->mpMapper->show();
         }
-        pHost->mpMap->mpMapper->mp2dMap->init();
-        pHost->mpMap->mpMapper->show();
     }
     else
     {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2378,7 +2378,8 @@ void mudlet::slot_statusBarMessageChanged( QString text )
     }
 }
 
-void mudlet::slot_requestProfilesToReloadMaps( QList<QString> affectedProfiles )
+// Originally a slot_ but it does not actually need to be - Slysven
+void mudlet::requestProfilesToReloadMaps( QList<QString> affectedProfiles )
 {
     emit signal_profileMapReloadRequested( affectedProfiles );
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1876,8 +1876,9 @@ void mudlet::slot_mapper()
 
     if( pHost->mpMap->mpRoomDB->getRoomIDList().size() < 1 )
     {
-        pHost->mpMap->restore("");
-        pHost->mpMap->init( pHost );
+        if( pHost->mpMap->restore( QString() ) ) {
+            pHost->mpMap->audit();
+        }
         pHost->mpMap->mpMapper->mp2dMap->init();
         pHost->mpMap->mpMapper->show();
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2377,3 +2377,8 @@ void mudlet::slot_statusBarMessageChanged( QString text )
         }
     }
 }
+
+void mudlet::slot_requestProfilesToReloadMaps( QList<QString> affectedProfiles )
+{
+    emit signal_profileMapReloadRequested( affectedProfiles );
+}

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -113,6 +113,7 @@ mudlet::mudlet()
 , replayToolBar( 0 )
 , moduleTable( 0 )
 , mStatusBarState( statusBarAlwaysShown )
+, mIsToDisplayMapAuditErrorsToConsole( false )
 {
     setupUi(this);
     setUnifiedTitleAndToolBarOnMac( true );
@@ -1682,6 +1683,7 @@ void mudlet::readSettings()
     // installations - if the user wants the status bar shown either all the
     // time or when it has something to show, they will have to enable that
     // themselves, but that only has to be done once! - Slysven
+    mIsToDisplayMapAuditErrorsToConsole = settings.value( "reportMapIssuesToConsole", QVariant(false)).toBool();
     resize( size );
     move( pos );
     setIcoSize( mMainIconSize );
@@ -1734,6 +1736,7 @@ void mudlet::writeSettings()
     settings.setValue("maximized", isMaximized());
     settings.setValue("editorTextOptions", static_cast<int>(mEditorTextOptions) );
     settings.setValue("statusBarOptions", static_cast<int>(mStatusBarState) );
+    settings.setValue("reportMapIssuesToConsole", mIsToDisplayMapAuditErrorsToConsole );
 }
 
 void mudlet::connectToServer()
@@ -1876,7 +1879,9 @@ void mudlet::slot_mapper()
 
     if( pHost->mpMap->mpRoomDB->getRoomIDList().isEmpty() )
     {
-        qDebug() << "mudlet::slot_mapper() - restore map case 4.";
+        qDebug() << "mudlet::slot_mapper() - restore map case 3.";
+        pHost->mpMap->pushErrorMessagesToFile( tr( "Pre-Map loading(3) report" ), true );
+        QDateTime now( QDateTime::currentDateTime() );
         if( pHost->mpMap->restore( QString() ) ) {
             pHost->mpMap->audit();
             pHost->mpMap->mpMapper->mp2dMap->init();
@@ -1884,6 +1889,9 @@ void mudlet::slot_mapper()
             pHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
             pHost->mpMap->mpMapper->show();
         }
+
+        pHost->mpMap->pushErrorMessagesToFile( tr( "Loading map(3) at %1 report" ).arg( now.toString( Qt::ISODate ) ), true );
+
     }
     else
     {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -224,6 +224,10 @@ public slots:
    void                          slot_module_manager();
    void                          layoutModules();
    void                          slot_help_module();
+   void                          slot_requestProfilesToReloadMaps( QList<QString> );
+                                 // Used by a profile to tell the mudlet class
+                                 // to tell other profiles to reload the updated
+                                 // maps (via signal_profileMapReloadRequested(...))
 
 protected:
 
@@ -232,6 +236,7 @@ protected:
 signals:
 
    void                         signal_editorTextOptionsChanged( QTextOption::Flags );
+   void                         signal_profileMapReloadRequested( QList<QString> );
 
 private slots:
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -188,6 +188,9 @@ public:
                                 // to tell other profiles to reload the updated
                                 // maps (via signal_profileMapReloadRequested(...))
 
+    const bool                  getAuditErrorsToConsoleEnabled() { return mIsToDisplayMapAuditErrorsToConsole; }
+    void                        setAuditErrorsToConsoleEnabled( const bool state ) { mIsToDisplayMapAuditErrorsToConsole = state; }
+
 
 public slots:
 
@@ -297,6 +300,8 @@ private:
 
    HostManager                   mHostManager;
    QStatusBar *                 mpMainStatusBar;
+
+   bool                         mIsToDisplayMapAuditErrorsToConsole;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::StatusBarOptions)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -183,6 +183,11 @@ public:
    Q_DECLARE_FLAGS(StatusBarOptions, StatusBarOption)
    StatusBarOptions             mStatusBarState;
 
+   void                         requestProfilesToReloadMaps( QList<QString> );
+                                // Used by a profile to tell the mudlet class
+                                // to tell other profiles to reload the updated
+                                // maps (via signal_profileMapReloadRequested(...))
+
 
 public slots:
 
@@ -224,10 +229,6 @@ public slots:
    void                          slot_module_manager();
    void                          layoutModules();
    void                          slot_help_module();
-   void                          slot_requestProfilesToReloadMaps( QList<QString> );
-                                 // Used by a profile to tell the mudlet class
-                                 // to tell other profiles to reload the updated
-                                 // maps (via signal_profileMapReloadRequested(...))
 
 protected:
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -285,9 +285,12 @@ HEADERS += \
     irc/include/irc.h \
     irc/include/irccodecplugin.h \
     irc/include/irccommand.h \
+    irc/include/ircglobal.h \
     irc/include/ircmessage.h \
     irc/include/ircsession.h \
     irc/include/ircutil.h \
+    irc/include/IrcGlobal \
+    irc/include/IrcSender \
     KeyUnit.h \
     LuaInterface.h \
     mudlet.h \

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1522,6 +1522,16 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="checkBox_reportMapIssuesOnScreen">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mudlet now does some sanity checking and repairing to clean up issues that may have arisen in previous version due to faulty code or badly documented commands.&lt;/p&gt;&lt;p&gt;However if significant problems are found the report can be quite extensive, particular for larger maps. In order to reduce the amount of on-screen messages this option (if not set) will cause most of the text to not be displayed - except for a suggestion to review the '&lt;b&gt;&lt;i&gt;./log/errors.txt&lt;/i&gt;&lt;/b&gt;' file in the specific profile's directory which will contain the equivelent details and can be referred to if other manual changes are felt necessary.&lt;/p&gt;&lt;p&gt;&lt;i&gt;This file is appended to and each report it contains should be date and time stamped and (unlike the on-screen version that reports issues as they occur) is sorted so that issues specific to a particular map area or room are collected in one part in each report.&lt;/i&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Report map issues on screen</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2047,6 +2047,16 @@
             </item>
            </widget>
           </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBox_showDefaultArea">
+            <property name="text">
+             <string>Show (-1) area {this message should have been overwritten by initialisation code - report if not!}</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -350,7 +350,7 @@
              <string>Command line minimum height in pixels:</string>
             </property>
             <property name="buddy">
-             <cstring>command_separator_lineedit</cstring>
+             <cstring>commandLineMinimumHeight</cstring>
             </property>
            </widget>
           </item>
@@ -1324,72 +1324,6 @@
        <string>Mapper</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_24">
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_3">
-         <property name="title">
-          <string>Map files</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Load another map file in:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QPushButton" name="load_map_button">
-            <property name="text">
-             <string>Pick map file</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mapper_profiles_combobox"/>
-          </item>
-          <item row="2" column="3">
-           <widget class="QPushButton" name="copy_map_profile">
-            <property name="text">
-             <string>Copy</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_12">
-            <property name="text">
-             <string>Copy map to another profile:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QPushButton" name="save_map_button">
-            <property name="text">
-             <string>Pick location</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Save your current map:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="4">
-           <widget class="QLabel" name="map_file_action">
-            <property name="font">
-             <font>
-              <pointsize>8</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>An action above happened</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="1" column="0">
         <widget class="QGroupBox" name="downloadMapOptions">
          <property name="title">
@@ -1403,6 +1337,9 @@
             </property>
             <property name="text">
              <string>Download latest map provided by your MUD:</string>
+            </property>
+            <property name="buddy">
+             <cstring>buttonDownloadMap</cstring>
             </property>
            </widget>
           </item>
@@ -1433,6 +1370,9 @@
             <property name="text">
              <string>Delete map backups older than:</string>
             </property>
+            <property name="buddy">
+             <cstring>comboBox</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -1446,6 +1386,9 @@
            <widget class="QLabel" name="label_14">
             <property name="text">
              <string>days since today, keeping newer and monthly backups</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox</cstring>
             </property>
            </widget>
           </item>
@@ -1483,6 +1426,104 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox_mapFiles">
+         <property name="title">
+          <string>Map files</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_mapFileActionResult">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>An action above happened</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QPushButton" name="pushButton_chooseProfiles">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this button to bring up a menu which lists the other profiles in your system. Click on each one that you want to copy the current map &lt;i&gt;as it &lt;b&gt;now is&lt;/b&gt; in &lt;b&gt;this profile&lt;/b&gt;&lt;/i&gt; to those profiles. You can return here and change the selection whilst this dialog is still open but no changes or copies will be made &lt;b&gt;until you press the &amp;quot;&lt;/b&gt;&lt;i&gt;Copy to Destination(s)&amp;quot; button&lt;/i&gt;&lt;/b&gt;. When that button is pressed each of the selected profiles will be examined to determine the room where the player is located in each of those profiles: for profiles that are not loaded, the most recently saved map file is used; for profiles that &lt;b&gt;are&lt;/b&gt; currently loaded at this time, the room where the player is currently is is noted. All of the room numbers for those locations are then written out in the save of the map for &lt;b&gt;this&lt;/b&gt; profile with the normal &lt;i&gt;date-time-stamped&lt;/i&gt; name which is then copied to where the maps are stored for the other profiles. For the other profiles that are active they will then reload the new map and then should replace the player in the location noted - if it still exists; this may be not exactly the right place if there has been movement in the other profile in the meantime so this is best done when all active profiles to be so updated are quiesent!&lt;/p&gt;&lt;p&gt;To enable all the individual instances of a map that is shared between profiles to be kept in step it is best if all the profiles are updated in this manner at the same time rather than separately as previous versions of Mudlet did. If the map iteself is being edited it is essential for that to be done in one active profile at a time otherwise unsaved changes in one profile will get lost when a new map from a different profile is copied over and loaded!&lt;/p&gt;&lt;p&gt;&lt;i&gt;The previous control at this point in the &amp;quot;Profile Preferences&amp;quot; has been changed because it did not lend itself to modifications to enabling multiple profiles to be selected at once.&lt;/i&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Press to pick destination(s)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QPushButton" name="pushButton_copyMap">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this button to make the copy of the current map in &lt;b&gt;this profile&lt;/b&gt; to each of the &lt;i&gt;profiles&lt;/i&gt; selected via the control to the left. Those profiles will be examined to determine the room where the player is located in each of those profiles: for profiles that are not loaded, the most recently saved map file is used; for profiles that &lt;b&gt;are&lt;/b&gt; currently loaded at this time, the room where the player is currently located is noted. All of the room numbers for those locations are then included in the saved data of the map for &lt;b&gt;this&lt;/b&gt; profile with the normal &lt;i&gt;date-time-stamped&lt;/i&gt; name which is then copied to where the maps are stored for the other profiles. For the other profiles that are active they will then reload the new map and then they should replace the player in the location noted automatically - if it still exists; (this may be not exactly the right place if there has been movement in the other profile in the meantime so this is best done when all active profiles to be so updated are quiesent!)&lt;/p&gt;&lt;p&gt;To enable all the individual instances of a map that is shared between profiles to be kept in step it is best if all the profiles are updated this manner at the same time rather than separately as previous versions of Mudlet did. If the map iteself is being edited it is essential for that to be done in one active profile at a time otherwise unsaved changes in one profile will get lost when a new map from a different profile is copied over and loaded!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Copy to destination(s)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="pushButton_saveMap">
+            <property name="text">
+             <string>Press to chose location and save</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_loadMap">
+            <property name="text">
+             <string>Load another map file in:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_loadMap</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_saveMap">
+            <property name="text">
+             <string>Save your current map:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_saveMap</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPushButton" name="pushButton_loadMap">
+            <property name="text">
+             <string>Press to chose file and load</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_copyMap">
+            <property name="text">
+             <string>Copy map to other profile(s):</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_chooseProfiles</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="Line" name="line_aboveCopyMap">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1433,7 +1433,7 @@
           <string>Map files</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="4" column="0">
+          <item row="4" column="0" colspan="3">
            <widget class="QLabel" name="label_mapFileActionResult">
             <property name="font">
              <font>


### PR DESCRIPTION
A bit of a big one here but it does do something for [bug 1500927](https://bugs.launchpad.net/mudlet/+bug/1500927) as mentioned in the [forums](http://forums.mudlet.org/viewtopic.php?f=13&t=4857&p=23095). It also has a thorough map auditing/cleaner which should help to fix the sort of issues that past TArea::rooms addition/removal code introduced (particularly the removal part! :smile: ) and the custom exit line drawing code that would start to draw lines on an anonymous exit direction.  E.g. [this](http://forums.mudlet.org/viewtopic.php?f=0&t=4695&p=23384&hilit=QList#p23383).

As I had to touch up the mapper drawing code the 2D one in particular has gained a bit of a tidy up for the room list selection widget - and it should be a bit faster because of the QList to QSet changes. Ssaliss' Aetherspace map (that +280MB map with a >2M room count, from "Lusternia" ? ) does load for me now (it does need at least 4GB of memory I think) and it works - slowly - which is better than before.  The code also displays room **names** if there are any and the widget allows sorted on room number (or room names if they exist).  The room selection code is also a bit more user friendly as the centre room (that single room operations on multi room selections and the spacing altering ones are centred on) is shown.  Code to reposition the map on a new (singly selected, non-current) room is in-place (and sends a ***sysManualLocationSetEvent*** that lua scripts can detect if they want!)

Users who use the same map on multiple profiles (possibly even at the same time - i.e. multiplying) may like the changes I have just made in that area which (provided the latest map file format **18** is selected on the last tab of the profile preferences) means that the map stores the current player location on a per profile basis rather than just as a single value - and gets the most upto date values for that from the profiles to which a map file is "shared" (well duplicated and copied).  That has meant a revision to the map copying code which now needs to be told all the destination profiles to which it is to be sent and does them all in a single operation (and uses slots & signals to tell the active ones to reload the new map).

I have further code that hangs off of this that will improve the XML map file handling (will allow local loading of XML files that cannot be currently be done - much to the [chagrin of some users](http://forums.mudlet.org/viewtopic.php?f=5&t=5100&p=23810)).

I intend to:
+ get that working on development and then intend to port both across to release_30.
+ then fix up some of the zip file handling that may intersect with this and is a show-hinderer/stopper at the moment [bug 1413069](https://bugs.launchpad.net/mudlet/+bug/1413069) I think it may also intersect with module handling!
+ do a *quick & dirty* fix on buttons missing command up & down command entries - but the button code does need a much bigger clean up as packaging of toolbars is broken IMHO - but that will need some XML handling changes (revision to Mudlet **non-**map file format sadly).