### PR TITLE
(release_30)BugFix: fix a logic error that may be causing a hang on startup

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1910,6 +1910,7 @@ void TBuffer::append( QString & text,
         buffer.back().push_back( c );
         if( firstChar ) {
             timeBuffer.back() = QTime::currentTime().toString( QStringLiteral( "hh:mm:ss.zzz   " ) );
+            firstChar = false;
         }
     }
 }


### PR DESCRIPTION
Whilst debugging other code I found that the flag that is set when a line
is started in a TConsole/TBuffer that records the timestamp is not reset
after it does it's job of getting the time and pushing it into the
(QStringList) TBuffer::timeBuffer - the symptom I was getting was with
an "empty" profile and adding a script that caused a line of text (I think)
ending with a line feed "\n" character - the code seemed to be stuck in a
busy loop.  From the structure of the code in the area of this commit I see
that after the flag has been used IT IS NOT RESET and so the assignment of
a time string as the backmost entry in TBuffer::timebuffer will be repeated
until the end of the buffer that is being timestamped is reached.

I do not know for sure if this is the whole story - I thought it seemed to
happen at the point where "*** starting new session ***\n" is being put
into the Editor "errors" widget, but I cannot reproduce it reliably.  It
does seem to happen when timebuffer contains just a single (empty) string.
I was wondering whether, during my hacking I had done something that cause
this code to be run when that structure (or one of the other QStringList)
entities in the application is in fact empty - the TBuffer code does
make use of QStringList::back() which, like other accessor members, MUST
NOT be used when the QStringList is empty.  I have put some Q_ASSERT_X
tests in my working copy of the code but so far have not encountered such
an error!

Anyhow this is a fix - it just may not be the fix we are looking for.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>