### PR TITLE
Enhance: Add ability to specify starting room number to createRoomID()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7275,7 +7275,39 @@ int TLuaInterpreter::addRoom( lua_State * L )
 int TLuaInterpreter::createRoomID( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    lua_pushnumber( L, pHost->mpMap->createNewRoomID() );
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "createRoomID: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+    else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "createRoomID: no map present or loaded!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    if( lua_gettop( L ) > 0 ) {
+        if( ! lua_isnumber( L, 1 ) ) {
+            lua_pushstring( L, tr( "createRoomID: bad argument #1 type (minimum room Id as number is optional, got %1!)" )
+                            .arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+            lua_error( L );
+        }
+        else {
+            int minId = lua_tointeger( L, 1 );
+            if( minId <  1 ) {
+                lua_pushnil( L );
+                lua_pushstring( L, tr( "createRoomID: bad argument #1 value (bad minimum room Id %1, an optional value but if provided it must be greater than zero.)" )
+                                .arg( minId ).toUtf8().constData() );
+                return 2;
+            }
+        }
+        lua_pushnumber( L, pHost->mpMap->createNewRoomID( lua_tointeger( L, 1 ) ) );
+    }
+    else {
+        lua_pushnumber( L, pHost->mpMap->createNewRoomID() );
+    }
     return 1;
 }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -279,17 +279,18 @@ void TMap::connectExitStub(int roomId, int dirType)
     }
 }
 
-int TMap::createNewRoomID()
+int TMap::createNewRoomID( int minimumId )
 {
-    int _id = 1;
-    for( ; ; _id++ )
-    {
-        if( ! mpRoomDB->getRoom( _id ) )
-        {
-            return _id;
-        }
+    int _id = 0;
+    if( minimumId > 0 ) {
+        _id = minimumId - 1;
     }
-    return -1;
+
+    do {
+        ; // Empty loop as increment done in test
+    } while( mpRoomDB->getRoom( ++_id ) );
+
+    return _id;
 }
 
 bool TMap::setExit( int from, int to, int dir )

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -81,7 +81,7 @@ public:
     bool setRoomArea( int id, int area, bool isToDeferAreaRelatedRecalculations = false );
     // void deleteRoom( int id );
     void deleteArea( int id );
-    int createNewRoomID();
+    int createNewRoomID( int minimumId = 1 );
     void logError(QString &msg);
     void tidyMap( int area );
     void getConnectedNodesGreaterThanX( int id, int x );


### PR DESCRIPTION
About to start a real session of MUD playing I noted that there is no quick
way to assign ranges of room numbers when mapping out areas - it is useful
to some map-makers to group ranges of numbers to areas.  Since we do not
provide an implicit ways to renumber rooms (have to create new instance and
copy data across in a script) I think some would find it useful to be able
to supply a starting room number to the Lua command createRoomID and for
that to return the next available number past that.

{This will be familiar to a TinTin++ MUD Client user which behaves in the
same manner as I propose here - IIRC!}

The Lua createRoomID() has been updated (to current code/message
guidelines) - it will return a nil AND an error message instead of a
number if the optionally supplied first argument is less than 1.  Otherwise
it behaves as before - new scripts written to take advantage of this
functionality may wish to check the returned number IS greater than the
specified value if they need to guarantee the result and provide fall-back
functionality with prior versions of the application {start iterating
through room Ids with getRoom( roomId ) to find first non-existent room} -
as in that case the supplied argument will be ignored and just the lowest
free positive number will be returned as for previous versions.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>