### PR TITLE
Bugfix for spawn() in TForkedProcess::slotRecievedData()

### DIFF
--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2009 by Benjamin Lerman - mudlet@ambre.net              *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Christer Oscarsson-christer.oscarsson@gmail.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -77,7 +78,7 @@ void TForkedProcess::slotFinish() {
 }
 
 void TForkedProcess::slotReceivedData() {
-    if(canReadLine ()) {
+    while(canReadLine ()) {
         QByteArray line = readLine();
         // Call lua function by stored Reference
         lua_rawgeti(interpreter->pGlobalLua, LUA_REGISTRYINDEX, callBackFunctionRef);


### PR DESCRIPTION
The read function for spawn() is only called once every time we get a chunk of output, even if that chunk containes multiple lines.
This is caused since TForkedProcess::slotReceivedData() doesn't get called for every line that it sent for it, but rather each time the output from the process is flushed.

You try this out by running 'ls' for example: `spawn(function(s) echo(s) end, "ls")`

The fix makes slotReceivedData() read all the lines that it can from the process before returning.