### PR TITLE
BugFix: TLuaInterpreter::downloadFile() not working for https URLs

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -431,7 +431,7 @@ signals:
 
 public slots:
 
-    void replyFinished(QNetworkReply * reply );
+    void slot_replyFinished( QNetworkReply * );
     void slotOpenUserWindow( int, const QString& );
     void slotEchoUserWindow( int, const QString&, const QString& );
     void slotClearUserWindow( int, const QString& );


### PR DESCRIPTION
As per the original poster on:
https://bugs.launchpad.net/mudlet/+bug/1427364
With a forum mention on:
http://forums.mudlet.org/viewtopic.php?f=9&t=4728

This seems to be caused by a code error that checked the wrong string (the name to give to the downloaded file) rather than the URL.

As well as fixing that error in:
`(int)TLuaInterpreter::downloadFile(lua_State *)`, this revision also validates and will produce a ___nil___ + _relevant error message_ return if the given URL does not seem valid; will handle non-ASCII characters in both strings and is more tolerant in parsing the string given as a URL.  It also returns a `true` value on a successful request creation and the URL that is
used to perform the request which may NOT be the same as the one the user give.

The related `(void)TLuaInterpreter::replyFinished(QNetworkReply *)` method which has been renamed to `slot_replyFinished(...)` because it IS a SLOT has been improved to give better error handling of the local downloaded file (the `sysDownloadError` event has a `failureToWriteLocalFile` value and, with the local filename as the existing third argument) a forth value is now also produce which is one of:
* `unableToOpenLocalFileForWriting`
* `unableToWriteLocalFile`
* or a `QFile::errorString()` for any other issues

It also does NOT attempt to write out the downloaded file BEFORE it has checked that there was not an error in getting the file...!

In addition the previous code did not clean up after itself and as the `QNetworkReply` that it handles contains the data that was downloaded, this represents resource leakage - this revision now disposes of each instance of that class that it handles in an appropriate manner.

Also this commit should fix: https://bugs.launchpad.net/mudlet/+bug/1366781 which is an issue with some remote hosts running the Apache HTTP server not liking the generic User-Agent string that Qt uses - possibly because it IS so generic!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>