### PR TITLE
(release_30)bugFix: TLuaInterpreter::downloadFile() not working for https URLs

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -106,7 +106,7 @@ TLuaInterpreter::TLuaInterpreter( Host * pH, int id )
     connect(&purgeTimer, SIGNAL(timeout()), this, SLOT(slotPurge()));
 
     mpFileDownloader = new QNetworkAccessManager( this );
-    connect(mpFileDownloader, SIGNAL(finished(QNetworkReply*)), this, SLOT(replyFinished(QNetworkReply*)));
+    connect(mpFileDownloader, SIGNAL(finished(QNetworkReply*)), this, SLOT(slot_replyFinished(QNetworkReply*)));
 
     initLuaGlobals();
 
@@ -131,35 +131,111 @@ lua_State * TLuaInterpreter::getLuaExecutionUnit( int unit )
     return 0;
 }
 
-void TLuaInterpreter::replyFinished(QNetworkReply * reply )
+// Previous code didn't tell the Qt libraries when we had finished with a
+// QNetworkReply so all the data downloaded would be held in memory until the
+// profile was closed - importantly the documentation for the signal
+// QNetworkReply::finished() which is connected to this SLOT stresses that
+// delete() must NOT be called in this slot (it wasn't as it happens), but
+// deleteLater() - which is now done to free the reasources when appropriate...
+// - Slysven
+// The code now raises additional sysDownloadError Events on failure to process
+// the local file, the second argument is "failureToWriteLocalFile" and besides
+// the file to be written being the third argument (as multiple downloads are
+// supported) a fourth argument gives the local file problem, one of:
+// * "unableToOpenLocalFileForWriting"
+// * "unableToWriteLocalFile"
+// or a QFile::errorString() for the issue at hand
+// Upon success we now give an additional (third value) which gives the number
+// of bytes written into the downloaded file.
+void TLuaInterpreter::slot_replyFinished(QNetworkReply * reply )
 {
-    if( ! downloadMap.contains(reply) ) return;
-    QString name = downloadMap[reply];
-    QFile file(name);
-    file.open( QFile::WriteOnly );
-    file.write( reply->readAll() );
-    file.flush();
-    file.close();
-
-    TEvent * e = new TEvent;
-    if( reply->error() == 0 )
-    {
-        e->mArgumentList << "sysDownloadDone";
-        e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        e->mArgumentList << name;
-        e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+    Host * pHost = mpHost;
+    if( ! pHost ) {
+        qWarning() << "TLuaInterpreter::slot_replyFinished(...) ERROR: NULL Host pointer!";
+        return; // Uh, oh!
     }
-    else
-    {
-        e->mArgumentList << "sysDownloadError";
+
+    if( ! downloadMap.contains(reply) ) {
+        reply->deleteLater();
+        return;
+    }
+
+    QString localFileName = downloadMap.value( reply );
+    TEvent * e = new TEvent;
+    if( reply->error() != QNetworkReply::NoError ) {
+        e->mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
         e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
         e->mArgumentList << reply->errorString();
         e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        e->mArgumentList << name;
+        e->mArgumentList << localFileName;
         e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
-    }
 
-    mpHost->raiseEvent( e );
+        reply->deleteLater();
+        downloadMap.remove( reply );
+        pHost->raiseEvent( e );
+        return;
+    }
+    else { // reply IS ok...
+        QFile localFile( localFileName );
+        if( ! localFile.open( QFile::WriteOnly ) ) {
+            e->mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << localFileName;
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << tr( "unableToOpenLocalFileForWriting", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+
+            reply->deleteLater();
+            downloadMap.remove( reply );
+            pHost->raiseEvent( e );
+            return;
+        }
+
+        qint64 bytesWritten = localFile.write( reply->readAll() );
+        if( bytesWritten == -1 ) {
+            e->mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << localFileName;
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << tr( "unableToWriteLocalFile", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+
+            reply->deleteLater();
+            downloadMap.remove( reply );
+            pHost->raiseEvent( e );
+            return;
+        }
+
+        localFile.flush();
+
+        if( localFile.error() == QFile::NoError ) {
+            e->mArgumentList << "sysDownloadDone";
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << localFileName;
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << QString::number( bytesWritten );
+            e->mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
+        }
+        else {
+            e->mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << localFileName;
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            e->mArgumentList << localFile.errorString();
+            e->mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        }
+
+        localFile.close();
+        reply->deleteLater();
+        downloadMap.remove( reply );
+        pHost->raiseEvent( e );
+    }
 }
 
 void TLuaInterpreter::slotDeleteSender() {
@@ -9965,41 +10041,67 @@ int TLuaInterpreter::getAllMapUserData( lua_State * L )
 
 int TLuaInterpreter::downloadFile( lua_State * L )
 {
-    string path, url;
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "downloadFile: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        path = lua_tostring( L, 1 );
-    }
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "downloadFile: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        url = lua_tostring( L, 2 );
-    }
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString _url = url.c_str();
-    QString _path = path.c_str();
-    QNetworkRequest request = QNetworkRequest( QUrl( _url ) );
+    if( ! pHost ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "downloadFile: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    QString localFile;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "downloadFile: bad argument #1 type (local filename as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        localFile = QString::fromUtf8( lua_tostring( L, 1 ) );
+    }
+
+    QString urlString;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "downloadFile: bad argument #1 type (remote url as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 2 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+    else {
+        urlString = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    QUrl url = QUrl::fromUserInput( urlString );
+
+    if( ! url.isValid() ) {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "downloadFile: bad argument #2 value (url is not deemed valid), validation\n"
+                               "produced the following error message:\n%1." )
+                        .arg( url.errorString() )
+                        .toUtf8().constData() );
+        return 2;
+    }
+
+    QNetworkRequest request = QNetworkRequest( url );
+    // This should fix: https://bugs.launchpad.net/mudlet/+bug/1366781
+    request.setRawHeader( QByteArray( "User-Agent" ),
+                          QByteArray( QStringLiteral( "Mozilla/5.0 (Mudlet/%1%2)" )
+                                      .arg( APP_VERSION )
+                                      .arg( APP_BUILD )
+                                      .toUtf8().constData() ) );
 #ifndef QT_NO_OPENSSL
-    if ( _path.contains("https") )
-    {
+    if( url.scheme() == QStringLiteral( "https" ) ) {
         QSslConfiguration config( QSslConfiguration::defaultConfiguration() );
         request.setSslConfiguration( config );
     }
 #endif
     QNetworkReply * reply = pHost->mLuaInterpreter.mpFileDownloader->get( request );
-    pHost->mLuaInterpreter.downloadMap[reply] = _path;
-    return 0;
+    pHost->mLuaInterpreter.downloadMap.insert( reply, localFile );
+    lua_pushboolean( L, true );
+    lua_pushstring( L, reply->url().toString().toUtf8().constData() ); // Returns the Url that was ACTUALLY used
+    return 2;
 
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -427,7 +427,7 @@ signals:
 
 public slots:
 
-    void replyFinished(QNetworkReply * reply );
+    void slot_replyFinished( QNetworkReply * );
     void slotOpenUserWindow( int, QString );
     void slotEchoUserWindow( int, QString, QString );
     void slotClearUserWindow( int, QString );


### PR DESCRIPTION
As per the original poster on:
https://bugs.launchpad.net/mudlet/+bug/1427364
With a forum mention on:
http://forums.mudlet.org/viewtopic.php?f=9&t=4728

This seems to be caused by a code error that checked the wrong string (the name to give to the downloaded file) rather than the URL.

As well as fixing that error in:
`(int)TLuaInterpreter::downloadFile(lua_State *)`, this revision also validates and will produce a ___nil___ + _relevant error message_ return if the given URL does not seem valid; will handle non-ASCII characters in both strings and is more tolerant in parsing the string given as a URL.  It also returns a `true` value on a successful request creation and the URL that is
used to perform the request which may NOT be the same as the one the user give.

The related `(void)TLuaInterpreter::replyFinished(QNetworkReply *)` method which has been renamed to `slot_replyFinished(...)` because it IS a SLOT has been improved to give better error handling of the local downloaded file (the `sysDownloadError` event has a `failureToWriteLocalFile` value and, with the local filename as the existing third argument) a forth value is now also produce which is one of:
* `unableToOpenLocalFileForWriting`
* `unableToWriteLocalFile`
* or a `QFile::errorString()` for any other issues

It also does NOT attempt to write out the downloaded file BEFORE it has checked that there was not an error in getting the file...!

In addition the previous code did not clean up after itself and as the `QNetworkReply` that it handles contains the data that was downloaded, this represents resource leakage - this revision now disposes of each instance of that class that it handles in an appropriate manner.

Also this commit should fix: https://bugs.launchpad.net/mudlet/+bug/1366781
which is an issue with some remote hosts running the Apache HTTP server not liking the generic User-Agent string that Qt uses - possibly because it IS so generic!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>