### PR TITLE
(release_30)bugFix: Make TLabel class safe in regard to TEvent attachment

### DIFF
--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,6 +21,10 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
+#include "pre_guard.h"
+#include <QStringList>
+#include "post_guard.h"
 
 #define ARGUMENT_TYPE_NUMBER 0
 #define ARGUMENT_TYPE_STRING 1

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -31,12 +32,10 @@
 
 TLabel::TLabel( QWidget * pW )
 : QLabel( pW )
-, mpHost( 0 )
+, mpHost( Q_NULLPTR )
 {
     setMouseTracking( true );
 }
-
-QString nothing = "";
 
 void TLabel::mousePressEvent( QMouseEvent * event )
 {
@@ -44,7 +43,7 @@ void TLabel::mousePressEvent( QMouseEvent * event )
     {
         if( mpHost )
         {
-            mpHost->getLuaInterpreter()->callEventHandler( mScript, mpParameters );
+            mpHost->getLuaInterpreter()->callEventHandler( mScript, & mParameters );
         }
         event->accept();
         return;
@@ -55,10 +54,10 @@ void TLabel::mousePressEvent( QMouseEvent * event )
 
 void TLabel::leaveEvent( QEvent * event )
 {
-    if (mLeave != ""){
+    if ( ! mLeave.isEmpty() ){
         if( mpHost )
         {
-            mpHost->getLuaInterpreter()->callEventHandler( mLeave, mLeaveParams );
+            mpHost->getLuaInterpreter()->callEventHandler( mLeave, & mLeaveParams );
         }
         event->accept();
         return;
@@ -68,10 +67,10 @@ void TLabel::leaveEvent( QEvent * event )
 
 void TLabel::enterEvent( QEvent * event )
 {
-    if (mEnter != ""){
+    if ( ! mEnter.isEmpty() ){
         if( mpHost )
         {
-            mpHost->getLuaInterpreter()->callEventHandler( mEnter, mEnterParams );
+            mpHost->getLuaInterpreter()->callEventHandler( mEnter, & mEnterParams );
         }
         event->accept();
         return;

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,6 +26,7 @@
 #include "pre_guard.h"
 #include <QLabel>
 #include <QString>
+#include "TEvent.h"
 #include "post_guard.h"
 
 class Host;
@@ -39,10 +41,40 @@ Q_OBJECT
 
 public:
 
-                  TLabel( QWidget * pW=0 );
-void              setScript( Host * pHost, QString & func, TEvent * args ){ mpHost = pHost; mScript = func; mpParameters = args; }
-void              setEnter( Host * pHost, QString & func, TEvent * args ){ mpHost = pHost; mEnter = func; mEnterParams = args; }
-void              setLeave( Host * pHost, QString & func, TEvent * args ){ mpHost = pHost; mLeave = func; mLeaveParams = args; }
+                  TLabel( QWidget * pW = Q_NULLPTR );
+
+void              setScript( Host * pHost, QString & func, TEvent * args )
+                  {
+                      mpHost = pHost;
+                      mScript = func;
+                      mParameters.mArgumentList = args->mArgumentList;
+                      mParameters.mArgumentTypeList = args->mArgumentTypeList;
+                      mParameters.mArgumentList.detach();
+                      mParameters.mArgumentTypeList.detach();
+                      // Must take a local copy of these as the caller's TEvent
+                      // that args point to is likely an automatic
+                      // (Stack allocated) instance that will not persist as
+                      // long as this label...
+                  }
+
+void              setEnter( Host * pHost, QString & func, TEvent * args )
+                  {   mpHost = pHost;
+                      mEnter = func;
+                      mEnterParams.mArgumentList = args->mArgumentList;
+                      mEnterParams.mArgumentTypeList = args->mArgumentTypeList;
+                      mEnterParams.mArgumentList.detach();
+                      mEnterParams.mArgumentTypeList.detach();
+                  }
+
+void              setLeave( Host * pHost, QString & func, TEvent * args )
+                  {   mpHost = pHost;
+                      mLeave = func;
+                      mLeaveParams.mArgumentList = args->mArgumentList;
+                      mLeaveParams.mArgumentTypeList = args->mArgumentTypeList;
+                      mLeaveParams.mArgumentList.detach();
+                      mLeaveParams.mArgumentTypeList.detach();
+                  }
+
 void              mousePressEvent( QMouseEvent *  );
 void              leaveEvent(QEvent *);
 void              enterEvent(QEvent *);
@@ -51,9 +83,9 @@ Host *            mpHost;
 QString           mScript;
 QString           mEnter;
 QString           mLeave;
-TEvent *          mpParameters;
-TEvent *          mLeaveParams;
-TEvent *          mEnterParams;
+TEvent            mParameters;
+TEvent            mLeaveParams;
+TEvent            mEnterParams;
 bool              mouseInside;
 };
 


### PR DESCRIPTION
The methods that attach an event (effectively Click, OnEnter and OnLeave) to a `TLabel` use a pointer to the relevant `TEvent` - however that is likely to be a stack (automatic) allocated instance which will go out of scope when the caller of these methods end - leaving dangling pointers in the `TLabel`.  This commit forces the `TLabel` to take a deep copy of the pointed
to `TEvent`'s parameters which it uses instead of the originals.
