### PR TITLE
(release_30)revert: remove previous code added to suppress some Timer debug output

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -154,7 +154,6 @@ Host::Host( int port, QString hostname, QString login, QString pass, int id )
 , mCommandLineBgColor( QColor(  0,  0,  0) )
 , mFORCE_MXP_NEGOTIATION_OFF( false )
 , mHaveMapperScript( false )
-, mTimerDebugOutputSuppressionInterval( 10 * 1000 ) // 10 seconds was suggested
 {
    // mLogStatus = mudlet::self()->mAutolog;
     mLuaInterface = new LuaInterface(this);

--- a/src/Host.h
+++ b/src/Host.h
@@ -323,14 +323,6 @@ public:
     bool               mFORCE_MXP_NEGOTIATION_OFF;
     bool               mHaveMapperScript;
     QSet<QChar>         mDoubleClickIgnore;
-    int                 mTimerDebugOutputSuppressionInterval;
-                        // Set from last page of profile preferences if the
-                        // timer interval is less than this in milliseconds then
-                        // the normal reoccuring debug output of the entire
-                        // command and script for any timer with a timeout LESS
-                        // than this is NOT shown - this is so the spammy output
-                        // from short timeout timers can be suppressed.  The
-                        // single execute OK line will still be shown.
 };
 
 #endif // MUDLET_HOST_H

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -242,19 +242,6 @@ void TTimer::execute()
         return;
     }
 
-    if( mudlet::debugMode
-     && mpTimer->interval() > mpHost->mTimerDebugOutputSuppressionInterval ) {
-        // Second term is to suppress execution debug output from short interval timers
-        TDebug( QColor(Qt::darkYellow), QColor(Qt::darkBlue) ) << "\n[TIMER EXECUTES]: "
-                                                               << mName
-                                                               << " fired. Executing command="
-                                                               << mCommand
-                                                               << " and executing script:"
-                                                               << mScript
-                                                               << "\n"
-                                                               >> 0;
-    }
-
     if( mIsTempTimer ) {
         if( mScript.isEmpty() ) {
             mpHost->mLuaInterpreter.call_luafunction( this );

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -96,9 +96,6 @@ public slots:
     void slot_save_and_exit();
     void slot_chooseProfilesChanged(QAction *);
 
-private slots:
-    void slot_timeValueChanged(QTime);
-
 private:
     void setColors();
     Host * mpHost;

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1983,47 +1983,6 @@
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <item row="0" column="0">
-           <widget class="QLabel" name="label_timerDebugOutputMinimumInterval">
-            <property name="text">
-             <string>Minimum interval for a Timer to show execution output in debug window:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QTimeEdit" name="timeEdit_timerDebugOutputMinimumInterval">
-            <property name="maximumSize">
-             <size>
-              <width>200</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When a Timer fires and the Debugging console or the Editor Error are showing, the code for the timer is displayed as it is executed. For Timers of a short duration this output can obscure the output from less frequent Timers or other elements in a user or package item.  This control will attempt to reduce the &lt;i&gt;spam&lt;/i&gt; by hiding the code for Timers for an interval less than the specified interval - a line will still be shown for each timer firing but not all the output.  By default this is set for a &lt;i&gt;10 second&lt;/i&gt; period but it can be reduced to zero to show all output - the control will display &amp;quot;&lt;i&gt;Show all&lt;/i&gt;&amp;quot; in that case.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="buttonSymbols">
-             <enum>QAbstractSpinBox::PlusMinus</enum>
-            </property>
-            <property name="specialValueText">
-             <string>show all</string>
-            </property>
-            <property name="accelerated">
-             <bool>true</bool>
-            </property>
-            <property name="showGroupSeparator" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="currentSection">
-             <enum>QDateTimeEdit::HourSection</enum>
-            </property>
-            <property name="displayFormat">
-             <string notr="true">h:mm:ss.zzz</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
            <widget class="QLabel" name="label_mapFileSaveFormatVersion">
             <property name="text">
              <string>Override map file format version:</string>
@@ -2033,7 +1992,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="0" column="1">
            <widget class="QComboBox" name="comboBox_mapFileSaveFormatVersion">
             <property name="maximumSize">
              <size>
@@ -2057,7 +2016,7 @@
             </item>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
+          <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="checkBox_showDefaultArea">
             <property name="text">
              <string>Show (-1) area {this message should have been overwritten by initialisation code - report if not!}</string>


### PR DESCRIPTION
It also removes the code that produces the output that it was removing if
the timer interval was below it's threshold...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>