### PR TITLE
Enhance: add sysInterProfileEvent to enable inter-profile signalling

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -628,21 +628,26 @@ void Host::unregisterEventHandler(const QString & name, TScript * pScript )
 
 void Host::raiseEvent( const TEvent & pE )
 {
-    if( pE.mArgumentList.size() < 1 ) return;
-    if( mEventHandlerMap.contains( pE.mArgumentList[0] ) )
+    if( pE.mArgumentList.isEmpty() )
     {
-        QList<TScript *> scriptList = mEventHandlerMap[pE.mArgumentList[0]];
-        for( int i=0; i<scriptList.size(); i++ )
+        return;
+    }
+
+    if( mEventHandlerMap.contains( pE.mArgumentList.at( 0 ) ) )
+    {
+        QList<TScript *> scriptList = mEventHandlerMap.value( pE.mArgumentList.at( 0 ) );
+        for( int i=0, total = scriptList.size(); i<total; ++i )
         {
             scriptList[i]->callEventHandler( pE );
         }
     }
-    if( mAnonymousEventHandlerFunctions.contains( pE.mArgumentList[0] ) )
+
+    if( mAnonymousEventHandlerFunctions.contains( pE.mArgumentList.at( 0 ) ) )
     {
-        QStringList funList = mAnonymousEventHandlerFunctions[pE.mArgumentList[0]];
-        for( int i=0; i<funList.size(); i++ )
+        QStringList functionsList = mAnonymousEventHandlerFunctions.value( pE.mArgumentList.at( 0 ) );
+        for( int i=0, total = functionsList.size(); i<total; ++i )
         {
-            mLuaInterpreter.callEventHandler( funList[i], pE );
+            mLuaInterpreter.callEventHandler( functionsList.at( i ), pE );
         }
     }
 }

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -174,8 +174,7 @@ void HostManager::postIrcMessage( QString a, QString b, QString c )
 // The slightly convoluted way we step through the list of hosts is so that we
 // send out the events to the other hosts in a predictable and consistant order
 // and so that no one host gets an unfair advantage when emitting events. The
-// sending profile host gets the event LAST so it knows that all other profiles
-// have received it before it does.
+// sending profile host does NOT get the event!
 void HostManager::postInterHostEvent( const Host * pHost, const TEvent & event )
 {
     if( ! pHost ) {
@@ -186,7 +185,7 @@ void HostManager::postInterHostEvent( const Host * pHost, const TEvent & event )
     mPoolReadWriteLock.lockForRead(); // Will block if a write lock is in place
     const QList<QSharedPointer<Host> > hostList = mHostPool.values();
     mPoolReadWriteLock.unlock();
-    qDebug() << "HostManager::postInterHostEvent(...) INFO: ...got read access and sending Event to" << hostList.count() << "Hosts.";
+    qDebug() << "HostManager::postInterHostEvent(...) INFO: ...got read access and sending Event to" << hostList.count() - 1 << "Hosts.";
 
     int i = 0;
     QList<int> beforeSendingHost;
@@ -214,12 +213,6 @@ void HostManager::postInterHostEvent( const Host * pHost, const TEvent & event )
     QList<int> allValidHosts;
     allValidHosts = afterSendingHost;
     allValidHosts.append( beforeSendingHost );
-    if( sendingHost >= 0 ) {
-        allValidHosts.append( sendingHost );
-    }
-    else {
-        qWarning() << "HostManager::postInterHostEvent(...) Warning: That's weird, the source of the event does not seem to exist any more!";
-    }
 
     for( int j = 0, total = allValidHosts.size(); j < total; ++j ) {
         hostList.at( allValidHosts.at( j ) )->raiseEvent( event );

--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -19,6 +19,14 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+/*
+ * Revised to allow concurrent read access to mHostPool but as some methods
+ * were not used they have been commented out - if they are needed again they
+ * will need to be rewritten to use the (QReadWriteLock) mPoolReadWriteLock
+ * that is now used instead of the previous (QMutex) mPoolLock which was used
+ * with a QMutexLocker - the latter is not suitable for a QReadWriteLock I
+ * think - SlySven Dec 2016
+ */
 
 #include "HostManager.h"
 
@@ -32,105 +40,134 @@
 
 bool HostManager::deleteHost( QString hostname )
 {
-    QMutexLocker locker(& mPoolLock);
+    qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") INFO: trying to delete host from host pool, getting write lock...";
+    mPoolReadWriteLock.lockForWrite(); // Will block until gets lock
 
-    qDebug() << "---> trying to delete host <"<<hostname.toLatin1().data()<<"> from host pool.";
+    qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") INFO: ...got write lock...";
     // make sure this is really a new host
     if( ! mHostPool.contains( hostname ) )
     {
-        qDebug() << "[CRITICAL ERROR]: cannot delete host:"<<hostname.toLatin1().data()<<" it is not a member of host pool.";
+        mPoolReadWriteLock.unlock();
+        qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") ERROR: it is not a member of host pool... releasing lock and aborting, returning false!";
         return false;
     }
     else
     {
-        qDebug() << "[OK] Host deleted removing pool entry ...";
         int ret = mHostPool.remove( hostname );
-        qDebug() << "[OK] deleted Host:"<<hostname.toLatin1().data()<<" ret="<<ret;
-
+        mPoolReadWriteLock.unlock();
+        qDebug() << "HostManager::deleteHost(" << hostname.toUtf8().constData() << ") INFO: found" << ret << "times in host pool and all of them were removed... releasing lock and returning true!";
+        return true;
     }
-    return true;
 }
 
-bool HostManager::renameHost( QString hostname )
-{
-    QMutexLocker locker(& mPoolLock);
+// Not Used - if resurrected MUST re-write to use mPoolReadWriteLock.lockForWrite() as in deleteHost(...)/addHost(...)!
+//bool HostManager::renameHost( QString hostname )
+//{
+//    QMutexLocker locker(& mPoolLock);
 
-    // make sure this is really a new host
-    if( mHostPool.find( hostname ) == mHostPool.end() )
-    {
-        return false;
-    }
-    else
-    {
-        //Host * pNewHost = getHost( hostname ); // see why it doesn't work
-        QSharedPointer<Host> pNewHost = mHostPool[hostname];
-        mHostPool.remove( hostname );
-        mHostPool.insert(pNewHost->getName(), pNewHost);
-    }
+//    // make sure this is really a new host
+//    if( mHostPool.find( hostname ) == mHostPool.end() )
+//    {
+//        return false;
+//    }
+//    else
+//    {
+//        //Host * pNewHost = getHost( hostname ); // see why it doesn't work
+//        QSharedPointer<Host> pNewHost = mHostPool[hostname];
+//        mHostPool.remove( hostname );
+//        mHostPool.insert(pNewHost->getName(), pNewHost);
+//    }
 
-    return true;
+//    return true;
 
-}
+//}
 
 bool HostManager::addHost( QString hostname, QString port, QString login, QString pass )
 {
-    QMutexLocker locker(&mPoolLock);
-
-    // make sure this is really a new host
-    if( mHostPool.find( hostname ) != mHostPool.end() )
+    if( hostname.isEmpty() )
     {
+        qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") ERROR: an unnamed Host is not permitted, aborting and returning false!";
         return false;
     }
-    if( hostname.size() < 1 )
-        return false;
 
     int portnumber = 23;
-    if( port.size() >= 1 )
+    if( ! port.isEmpty() && port.toInt() > 0 && port.toInt() << 65536 )
     {
         portnumber = port.toInt();
     }
 
-    int id = createNewHostID();
+    qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") INFO: trying to add host to host pool, getting write lock...";
+    mPoolReadWriteLock.lockForWrite(); // Will block until gets lock
+
+    qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") INFO: ...got write lock...";
+    // make sure this is really a new host
+    if( mHostPool.contains( hostname ) )
+    {
+        qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") ERROR: is already a member of host pool... releasing lock and aborting, returning false!";
+        mPoolReadWriteLock.unlock();
+        return false;
+    }
+
+
+    // Was an ONLY use of a createNewHostID() method here but that extra
+    // function call was unnecessary and wastes time while we are locking access
+    // to the host pool
+    int id = mHostPool.size() + 1;
     QSharedPointer<Host> pNewHost( new Host( portnumber, hostname, login, pass, id ) );
 
-    mHostPool.insert( hostname, pNewHost );
-    mpActiveHost = mHostPool.begin().value().data();
-    return true;
-}
+    if( Q_UNLIKELY( !pNewHost ) )
+    {
+        qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") ERROR: failed to create new Host for the host pool... releasing lock and aborting, returning false!";
+        mPoolReadWriteLock.unlock();
+        return false;
+    }
 
-int HostManager::createNewHostID()
-{
-    return (mHostPool.size() + 1);
+    mHostPool.insert( hostname, pNewHost );
+// Not Used:    mpActiveHost = mHostPool.begin().value().data();
+    mPoolReadWriteLock.unlock();
+    qDebug() << "HostManager::addHost(" << hostname.toUtf8().constData() << ") INFO: new Host created and added to host pool... releasing lock and returning true!";
+    return true;
 }
 
 QStringList HostManager::getHostList()
 {
-    QMutexLocker locker(& mPoolLock);
+    qDebug() << "HostManager::getHostList() INFO: trying to read host pool, getting shared read access...";
+    mPoolReadWriteLock.lockForRead(); // Will block if a write lock is in place
 
     QStringList strlist;
-    const QList<QString> hostList = mHostPool.keys();
+    const QList<QString> hostList = mHostPool.keys(); // As this is a QMap the list will be sorted alphabetically
+    mPoolReadWriteLock.unlock();
     if( ! hostList.isEmpty() ) {
         strlist << hostList;
     }
 
+    qDebug() << "HostManager::getHostList() INFO: ...got read access, and returning" << hostList.count() << "Host name(s).";
     return strlist;
 }
 
-QList<QString> HostManager::getHostNameList()
-{
-    QMutexLocker locker(& mPoolLock);
+// Not Used - if resurrected MUST re-write to use mPoolReadWriteLock.lockForRead()
+// and take a const local copy of mHostPool.keys() to return!
+//QList<QString> HostManager::getHostNameList()
+//{
+//    QMutexLocker locker(& mPoolLock);
 
-    return mHostPool.keys();
-}
+//    return mHostPool.keys();
+//}
 
 void HostManager::postIrcMessage( QString a, QString b, QString c )
 {
-    QMutexLocker locker(& mPoolLock);
+    qDebug() << "HostManager::postIrcMessage(...) INFO: trying to read host pool, getting shared read access...";
+    mPoolReadWriteLock.lockForRead(); // Will block if a write lock is in place
 
-    QList<QSharedPointer<Host> > hostList = mHostPool.values();
+    const QList<QSharedPointer<Host> > hostList = mHostPool.values();
+    mPoolReadWriteLock.unlock();
+    qDebug() << "HostManager::postIrcMessage(...) INFO: ...got read access and sending IRC message to" << hostList.count() << "Hosts.";
     for( int i=0; i<hostList.size(); i++ )
     {
-        hostList[i]->postIrcMessage( a, b, c );
+        if( hostList.at( i ) )
+        {
+            hostList.at( i )->postIrcMessage( a, b, c );
+        }
     }
 }
 
@@ -145,9 +182,12 @@ void HostManager::postInterHostEvent( const Host * pHost, const TEvent & event )
         return;
     }
 
-    QMutexLocker locker(& mPoolLock);
+    qDebug() << "HostManager::postInterHostEvent(...) INFO: trying to read host pool, getting shared read access...";
+    mPoolReadWriteLock.lockForRead(); // Will block if a write lock is in place
+    const QList<QSharedPointer<Host> > hostList = mHostPool.values();
+    mPoolReadWriteLock.unlock();
+    qDebug() << "HostManager::postInterHostEvent(...) INFO: ...got read access and sending Event to" << hostList.count() << "Hosts.";
 
-    QList<QSharedPointer<Host> > hostList = mHostPool.values();
     int i = 0;
     QList<int> beforeSendingHost;
     int sendingHost = -1;
@@ -178,7 +218,7 @@ void HostManager::postInterHostEvent( const Host * pHost, const TEvent & event )
         allValidHosts.append( sendingHost );
     }
     else {
-        qWarning( "HostManager::postInterHostEvent(...) Warning: That's weird, the source of the event does not seem to exist any more!" );
+        qWarning() << "HostManager::postInterHostEvent(...) Warning: That's weird, the source of the event does not seem to exist any more!";
     }
 
     for( int j = 0, total = allValidHosts.size(); j < total; ++j ) {
@@ -188,36 +228,42 @@ void HostManager::postInterHostEvent( const Host * pHost, const TEvent & event )
 
 Host * HostManager::getHost( QString hostname )
 {
-    QMutexLocker locker(& mPoolLock);
-    if( mHostPool.find( hostname ) != mHostPool.end() )
+    qDebug() << "HostManager::getHost(" << hostname.toUtf8().constData() << ") INFO: trying to read host pool, getting shared read access...";
+    mPoolReadWriteLock.lockForRead(); // Will block if a write lock is in place
+    Host * pHost = mHostPool.value( hostname ).data();
+    mPoolReadWriteLock.unlock();
+    if( pHost )
     {
-        // host exists
-        return mHostPool[hostname].data();
+        qDebug() << "HostManager::getHost(" << hostname.toUtf8().constData() << ") INFO: ...got read access and found this name in host pool, returning Host pointer.";
     }
     else
     {
-        return 0;
+        qDebug() << "HostManager::getHost(" << hostname.toUtf8().constData() << ") INFO: ...got read access and but did not find this name in host pool, returning Null pointer.";
     }
+
+    return pHost;
 }
 
-Host * HostManager::getHostFromHostID( int id )
-{
-    QMutexLocker locker( & mPoolLock );
-    QMapIterator<QString, QSharedPointer<Host> > it(mHostPool);
-    while( it.hasNext() )
-    {
-        it.next();
-        if( it.value()->getHostID() == id )
-        {
-            return it.value().data();
-        }
-    }
-    qDebug()<<"ERROR: didnt find requested id in hostpool";
-    return 0;
-}
+// Not Used:
+//Host * HostManager::getHostFromHostID( int id )
+//{
+//    QMutexLocker locker( & mPoolLock );
+//    QMapIterator<QString, QSharedPointer<Host> > it(mHostPool);
+//    while( it.hasNext() )
+//    {
+//        it.next();
+//        if( it.value()->getHostID() == id )
+//        {
+//            return it.value().data();
+//        }
+//    }
+//    qDebug()<<"ERROR: didnt find requested id in hostpool";
+//    return 0;
+//}
 
-Host * HostManager::getFirstHost()
-{
-    QMutexLocker locker(& mPoolLock);
-    return mHostPool.begin().value().data();
-}
+// Not Used:
+//Host * HostManager::getFirstHost()
+//{
+//    QMutexLocker locker(& mPoolLock);
+//    return mHostPool.begin().value().data();
+//}

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -28,7 +28,7 @@
 #include "pre_guard.h"
 #include <QList>
 #include <QMap>
-#include <QMutex>
+#include <QReadWriteLock>
 #include <QString>
 #include <QStringList>
 #include "post_guard.h"
@@ -41,24 +41,23 @@ class HostManager
 {
 public:
 
-                       HostManager() : mpActiveHost() {}
+                       HostManager()
+                       /* : mpActiveHost() - Not needed */ {}
     Host *             getHost( QString hostname );
     QStringList        getHostList();
-    QList<QString>     getHostNameList();
-    Host *             getFirstHost();
+// Not Used:    QList<QString>     getHostNameList();
+// Not Used:    Host *             getFirstHost();
     bool               addHost( QString name, QString port, QString login, QString pass );
     bool               deleteHost( QString );
-    bool               renameHost( QString );
-    Host *             getHostFromHostID( int id );
+// Not Used:    bool               renameHost( QString );
+// Not Used:    Host *             getHostFromHostID( int id );
     void               postIrcMessage(QString, QString, QString );
     void               postInterHostEvent( const Host *, const TEvent & );
 
 private:
-    int createNewHostID();
-
-    QMutex              mPoolLock;
+    QReadWriteLock      mPoolReadWriteLock; // Was QMutex, but we needed to allow concurrent read access
     QMap<QString, QSharedPointer<Host> > mHostPool;
-    Host *              mpActiveHost;
+// Not Used:    Host *             mpActiveHost;
 
 };
 

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -33,6 +34,9 @@
 #include "post_guard.h"
 
 
+class TEvent;
+
+
 class HostManager
 {
 public:
@@ -47,6 +51,7 @@ public:
     bool               renameHost( QString );
     Host *             getHostFromHostID( int id );
     void               postIrcMessage(QString, QString, QString );
+    void               postInterHostEvent( const Host *, const TEvent & );
 
 private:
     int createNewHostID();

--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
+ *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,10 +24,13 @@
 
 
 #include "pre_guard.h"
+#include <QDebug>
+#if QT_VERSION >= 0x050100
+#include <QDebugStateSaver>
+#endif
 #include <QStringList>
 #include <QList>
 #include "post_guard.h"
-
 
 #define ARGUMENT_TYPE_NUMBER 0
 #define ARGUMENT_TYPE_STRING 1
@@ -39,5 +43,60 @@ public:
     QStringList mArgumentList;
     QList<int> mArgumentTypeList;
 };
+
+#ifndef QT_NO_DEBUG_STREAM
+// Note "inline" is REQUIRED:
+inline QDebug & operator<<( QDebug & debug, const TEvent & event )
+{
+#if QT_VERSION >= 0x050100
+    QDebugStateSaver saver(debug);
+#endif
+    const int argCount = event.mArgumentList.count();
+    const int typeCount = event.mArgumentTypeList.count();
+    int i = 0;
+    QString result( "TEvent(" );
+    while( i < argCount && i < typeCount ) {
+        if( Q_UNLIKELY( i >= typeCount ) ) {
+            result.append( QStringLiteral( "[%1{missing}%2]" ).arg( i ).arg( event.mArgumentList.at( i ) ) );
+        }
+        else {
+            if( Q_UNLIKELY( i >=argCount ) ) {
+                switch( event.mArgumentTypeList.at( i ) ) {
+                case ARGUMENT_TYPE_NUMBER:
+                    result.append( QStringLiteral( "[%1{number}missing]" ).arg( i ) );
+                    break;
+                case ARGUMENT_TYPE_BOOLEAN:
+                    result.append( QStringLiteral( "[%1{bool}missing]" ).arg( i ) );
+                    break;
+                case ARGUMENT_TYPE_NIL:
+                    result.append( QStringLiteral( "[%1{nil}missing]" ).arg( i ) );
+                    break;
+                default:
+                    result.append( QStringLiteral( "[%1{string}missing]" ).arg( i ) );
+                }
+            }
+            else {
+                switch( event.mArgumentTypeList.at( i ) ) {
+                case ARGUMENT_TYPE_NUMBER:
+                    result.append( QStringLiteral( "[%1{number}%2]" ).arg( i ).arg( event.mArgumentList.at( i ).toDouble() ) );
+                    break;
+                case ARGUMENT_TYPE_BOOLEAN:
+                    result.append( QStringLiteral( "[%1{bool}%2]" ).arg( i ).arg( event.mArgumentList.at( i ).toInt() ? "true" : "false" ) );
+                    break;
+                case ARGUMENT_TYPE_NIL:
+                    result.append( QStringLiteral( "[%1{nil}nil]" ).arg( i ) );
+                    break;
+                default:
+                    result.append( QStringLiteral( "[%1{string}%2]" ).arg( i ).arg( event.mArgumentList.at( i ) ) );
+                }
+            }
+            ++i;
+        }
+    }
+    result.append( QStringLiteral( ")" ) );
+    debug.nospace() << result;
+    return debug;
+}
+#endif // QT_NO_DEBUG_STREAM
 
 #endif // MUDLET_TEVENT_H

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -446,10 +446,10 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
 
     int n = lua_gettop( L );
     if( ! n ) {
-        lua_pushnil( L );
         lua_pushstring( L, tr( "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)" )
                         .toUtf8().constData() );
-        return 2;
+        lua_error( L );
+        return 1;
     }
 
     TEvent event;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -374,10 +374,10 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushnil( L );
-        lua_pushstring( L, tr( "raiseEvent: ERROR: NULL Host pointer!" )
+        lua_pushstring( L, tr( "raiseEvent: NULL Host pointer - something is wrong!" )
                         .toUtf8().constData() );
-        return 2;
+        lua_error( L );
+        return 1;
     }
 
     TEvent event;
@@ -412,9 +412,8 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
     }
 
     pHost->raiseEvent( event );
-    lua_pushnumber( L, n ); // Return number of supplied arguments put out.
 
-    return 1;
+    return 0;
 }
 
 int TLuaInterpreter::getProfileName( lua_State * L )
@@ -439,11 +438,11 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushnil( L );
-        lua_pushstring( L, tr( "raiseGlobalEvent: ERROR: NULL Host pointer!" ).toUtf8().constData() );
-        return 2;
+        lua_pushstring( L, tr( "raiseGlobalEvent: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
     }
-
 
     int n = lua_gettop( L );
     if( ! n ) {
@@ -494,9 +493,8 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
     event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
 
     mudlet::self()->getHostManager()->postInterHostEvent( pHost, event );
-    lua_pushnumber( L, n ); // Return number of supplied arguments put out, which is one less than the handler will receive!
 
-    return 1;
+    return 0;
 }
 
 int TLuaInterpreter::resetProfile( lua_State * L )

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -91,17 +91,17 @@ TLuaInterpreter::TLuaInterpreter( Host * pH, int id )
 {
     pGlobalLua = 0;
 
-    connect(this, SIGNAL(signalEchoMessage(int, QString)), this, SLOT(slotEchoMessage(int, QString)));
-    connect(this, SIGNAL(signalNewCommand(int, QString)), this, SLOT(slotNewCommand(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalEchoMessage(int, QString)), this, SLOT(slotEchoMessage(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalNewCommand(int, QString)), this, SLOT(slotNewCommand(int, QString)));
 
-    connect(this, SIGNAL(signalOpenUserWindow(int, QString)), this, SLOT(slotOpenUserWindow(int, QString)));
-    connect(this, SIGNAL(signalEchoUserWindow(int, QString, QString)), this, SLOT(slotEchoUserWindow(int, QString, QString)));
-    connect(this, SIGNAL(signalEnableTimer(int, QString)), this, SLOT(slotEnableTimer(int, QString)));
-    connect(this, SIGNAL(signalDisableTimer(int, QString)), this, SLOT(slotDisableTimer(int, QString)));
-    connect(this, SIGNAL(signalClearUserWindow(int, QString)), this, SLOT(slotClearUserWindow(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalOpenUserWindow(int, QString)), this, SLOT(slotOpenUserWindow(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalEchoUserWindow(int, QString, QString)), this, SLOT(slotEchoUserWindow(int, QString, QString)));
+// Not Used:    connect(this, SIGNAL(signalEnableTimer(int, QString)), this, SLOT(slotEnableTimer(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalDisableTimer(int, QString)), this, SLOT(slotDisableTimer(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalClearUserWindow(int, QString)), this, SLOT(slotClearUserWindow(int, QString)));
 
-    connect(this, SIGNAL(signalTempTimer(int, double, QString, QString)), this, SLOT(slotTempTimer(int, double, QString, QString)));
-    connect(this, SIGNAL(signalReplace(int, QString)), this, SLOT(slotReplace(int, QString)));
+// Not Used:    connect(this, SIGNAL(signalTempTimer(int, double, QString, QString)), this, SLOT(slotTempTimer(int, double, QString, QString)));
+// Not Used:    connect(this, SIGNAL(signalReplace(int, QString)), this, SLOT(slotReplace(int, QString)));
 
     connect(&purgeTimer, SIGNAL(timeout()), this, SLOT(slotPurge()));
 
@@ -118,23 +118,24 @@ TLuaInterpreter::~TLuaInterpreter()
     lua_close(pGlobalLua);
 }
 
-lua_State * TLuaInterpreter::getLuaExecutionUnit( int unit )
-{
-    switch( unit )
-    {
-    case 1:
-        return pGlobalLua;
-    case 2:
-        return pGlobalLua;
-    case 3:
-        return pGlobalLua;
-    case 4:
-        return pGlobalLua;
-    case 5:
-        return pGlobalLua;
-    };
-    return 0;
-}
+// Not Used:
+//lua_State * TLuaInterpreter::getLuaExecutionUnit( int unit )
+//{
+//    switch( unit )
+//    {
+//    case 1:
+//        return pGlobalLua;
+//    case 2:
+//        return pGlobalLua;
+//    case 3:
+//        return pGlobalLua;
+//    case 4:
+//        return pGlobalLua;
+//    case 5:
+//        return pGlobalLua;
+//    };
+//    return 0;
+//}
 
 // Previous code didn't tell the Qt libraries when we had finished with a
 // QNetworkReply so all the data downloaded would be held in memory until the
@@ -429,12 +430,12 @@ int TLuaInterpreter::getProfileName( lua_State * L )
     return 1;
 }
 
-int TLuaInterpreter::raiseInterProfileEvent( lua_State * L )
+int TLuaInterpreter::sendGlobalEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "raiseInterProfileEvent: ERROR: NULL Host pointer!" ).toUtf8().constData() );
+        lua_pushstring( L, tr( "sendGlobalEvent: ERROR: NULL Host pointer!" ).toUtf8().constData() );
         return 2;
     }
 
@@ -447,7 +448,7 @@ int TLuaInterpreter::raiseInterProfileEvent( lua_State * L )
     int n = lua_gettop( L );
     if( ! n ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "raiseInterProfileEvent: missing at least one argument (a string, number, boolean, or nil\n"
+        lua_pushstring( L, tr( "sendGlobalEvent: missing at least one argument (a string, number, boolean, or nil\n"
                                "expected, got nothing!)" )
                         .toUtf8().constData() );
         return 2;
@@ -471,7 +472,7 @@ int TLuaInterpreter::raiseInterProfileEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushstring( L, tr( "raiseInterProfileEvent: bad argument type #%1 (boolean, number, string or nil\n"
+            lua_pushstring( L, tr( "sendGlobalEvent: bad argument type #%1 (boolean, number, string or nil\n"
                                    "expected, got a %2!)" )
                             .arg( i )
                             .arg( luaL_typename( L, i ) )
@@ -12778,30 +12779,30 @@ int TLuaInterpreter::check_for_mappingscript()
     return r;
 }
 
+// Not Used:
+//void TLuaInterpreter::threadLuaInterpreterExec( string code )
+//{
+//    /* cout << "TLuaMainThread::threadLuaInterpreterExec(code) executing following code:" << endl;
+//     cout << "--------------------------------------------snip<" <<endl;
+//     cout << code << endl;
+//     cout << ">snip--------------------------------------------" <<endl;*/
+//     lua_State * L = pGlobalLua;
+//     int error = luaL_dostring(L,code.c_str());
+//     QString n;
+//     if( error != 0 )
+//     {
+//        string e = "no error message available from Lua";
+//        if( lua_isstring( L, 1 ) )
+//        {
+//            e = "Lua error:";
+//            e += lua_tostring( L, 1 );
+//        }
+//        emit signalEchoMessage( mHostID, QString( e.c_str() ) );
+//        qDebug()<< "LUA_ERROR:"<<e.c_str();
+//     }
 
-void TLuaInterpreter::threadLuaInterpreterExec( string code )
-{
-    /* cout << "TLuaMainThread::threadLuaInterpreterExec(code) executing following code:" << endl;
-     cout << "--------------------------------------------snip<" <<endl;
-     cout << code << endl;
-     cout << ">snip--------------------------------------------" <<endl;*/
-     lua_State * L = pGlobalLua;
-     int error = luaL_dostring(L,code.c_str());
-     QString n;
-     if( error != 0 )
-     {
-        string e = "no error message available from Lua";
-        if( lua_isstring( L, 1 ) )
-        {
-            e = "Lua error:";
-            e += lua_tostring( L, 1 );
-        }
-        emit signalEchoMessage( mHostID, QString( e.c_str() ) );
-        qDebug()<< "LUA_ERROR:"<<e.c_str();
-     }
-
-     cout << "cRunningScript::threadLuaInterpreterExec() done" << endl;
-}
+//     cout << "cRunningScript::threadLuaInterpreterExec() done" << endl;
+//}
 
 
 
@@ -13157,7 +13158,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem );
     lua_register( pGlobalLua, "setDefaultAreaVisible", TLuaInterpreter::setDefaultAreaVisible );
     lua_register( pGlobalLua, "getProfileName", TLuaInterpreter::getProfileName );
-    lua_register( pGlobalLua, "raiseInterProfileEvent", TLuaInterpreter::raiseInterProfileEvent );
+    lua_register( pGlobalLua, "sendGlobalEvent", TLuaInterpreter::sendGlobalEvent );
 
 
     luaopen_yajl(pGlobalLua);
@@ -13349,64 +13350,72 @@ void TLuaInterpreter::loadGlobal()
     }
 }
 
-void TLuaInterpreter::slotEchoMessage(int hostID, const QString& msg)
-{
-    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
-    mudlet::self()->print( pHost, msg );
-}
+// Not Used:
+//void TLuaInterpreter::slotEchoMessage(int hostID, const QString& msg)
+//{
+//    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
+//    mudlet::self()->print( pHost, msg );
+//}
 
+// Not Used:
+//void TLuaInterpreter::slotNewCommand(int hostID, const QString& cmd)
+//{
+//    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
+//    pHost->send( cmd );
+//}
 
-void TLuaInterpreter::slotNewCommand(int hostID, const QString& cmd)
-{
-    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
-    pHost->send( cmd );
-}
+// Not Used:
+//void TLuaInterpreter::slotOpenUserWindow(int hostID, const QString& windowName )
+//{
+//}
 
-void TLuaInterpreter::slotOpenUserWindow(int hostID, const QString& windowName )
-{
-}
+// Not Used:
+//void TLuaInterpreter::slotClearUserWindow(int hostID, const QString& windowName )
+//{
+//}
 
-void TLuaInterpreter::slotClearUserWindow(int hostID, const QString& windowName )
-{
-}
+// Not Used:
+//void TLuaInterpreter::slotEnableTimer(int hostID, const QString& windowName )
+//{
+//    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
+//    pHost->enableTimer( windowName );
+//}
 
-void TLuaInterpreter::slotEnableTimer(int hostID, const QString& windowName )
-{
-    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
-    pHost->enableTimer( windowName );
-}
+// Not Used:
+//void TLuaInterpreter::slotDisableTimer(int hostID, const QString& windowName )
+//{
+//    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
+//    pHost->disableTimer( windowName );
+//}
 
-void TLuaInterpreter::slotDisableTimer(int hostID, const QString& windowName )
-{
-    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
-    pHost->disableTimer( windowName );
-}
+// Not Used:
+//void TLuaInterpreter::slotReplace(int hostID, const QString& text)
+//{
+//}
 
-void TLuaInterpreter::slotReplace(int hostID, const QString& text)
-{
-}
+// Not Used:
+//void TLuaInterpreter::slotEchoUserWindow(int hostID, const QString& windowName, const QString& text )
+//{
+//}
 
-void TLuaInterpreter::slotEchoUserWindow(int hostID, const QString& windowName, const QString& text )
-{
-}
-
-void TLuaInterpreter::slotTempTimer( int hostID, double timeout, const QString& function, const QString& timerName )
-{
-    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
-    QTime time(0,0,0,0);
-    int msec = static_cast<int>(timeout * 1000);
-    QTime time2 = time.addMSecs( msec );
-    TTimer * pT;
-    pT = new TTimer( timerName, time2, pHost );
-    pT->setName( timerName );
-    pT->setTime( time2 );
-    //qDebug()<<"setting time of tempTimer to "<<time2.minute()<<":"<<time2.second()<<":"<<time2.msec()<<" timeout="<<timeout;
-    pT->setScript( function );
-    pT->setIsFolder( false );
-    pT->setIsActive( true );
-    pT->setIsTempTimer( true );
-    pT->registerTimer();
-}
+// Not Used:
+//void TLuaInterpreter::slotTempTimer( int hostID, double timeout, const QString& function, const QString& timerName )
+//{
+//    Host * pHost = mudlet::self()->getHostManager()->getHostFromHostID( hostID );
+//    QTime time(0,0,0,0);
+//    int msec = static_cast<int>(timeout * 1000);
+//    QTime time2 = time.addMSecs( msec );
+//    TTimer * pT;
+//    pT = new TTimer( timerName, time2, pHost );
+//    pT->setName( timerName );
+//    pT->setTime( time2 );
+//    //qDebug()<<"setting time of tempTimer to "<<time2.minute()<<":"<<time2.second()<<":"<<time2.msec()<<" timeout="<<timeout;
+//    pT->setScript( function );
+//    pT->setIsFolder( false );
+//    pT->setIsActive( true );
+//    pT->setIsTempTimer( true );
+//    pT->registerTimer();
+//}
 
 int TLuaInterpreter::startPermTimer(const QString & name, const QString & parent, double timeout, const QString & function )
 {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -431,9 +431,10 @@ int TLuaInterpreter::getProfileName( lua_State * L )
 }
 
 // raiseGlobalEvent( "eventName", ...optional arguments... )
-// eventName is manditory and should be a string, further arguements of t
-// sends an event to OTHER but not this profile (for internal events use
-// raiseEvent(...) instead.
+// sends an event to OTHER but not THIS profile {for internal events use
+// raiseEvent(...) instead!}
+// eventName is mandatory and should be a string though could be what further
+// arguments can be, i.e. strings, numbers, booleans or nils.
 int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -9841,7 +9842,7 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
 }
 
 // Derived from setRoomUserData(...)
-// But as there is only one instance there is only two arguements, key and value
+// But as there is only one instance there is only two arguments, key and value
 int TLuaInterpreter::setMapUserData( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -430,60 +430,85 @@ int TLuaInterpreter::getProfileName( lua_State * L )
     return 1;
 }
 
-int TLuaInterpreter::sendGlobalEvent( lua_State * L )
+// raiseGlobalEvent( "eventName", ...optional arguments... )
+// eventName is manditory and should be a string, further arguements of t
+// sends an event to OTHER but not this profile (for internal events use
+// raiseEvent(...) instead.
+int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "sendGlobalEvent: ERROR: NULL Host pointer!" ).toUtf8().constData() );
+        lua_pushstring( L, tr( "raiseGlobalEvent: ERROR: NULL Host pointer!" ).toUtf8().constData() );
         return 2;
     }
 
-    TEvent event;
-    event.mArgumentList.append( QStringLiteral( "sysInterProfileEvent" ) );
-    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    event.mArgumentList.append( pHost->getName() );
-    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
 
     int n = lua_gettop( L );
     if( ! n ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "sendGlobalEvent: missing at least one argument (a string, number, boolean, or nil\n"
-                               "expected, got nothing!)" )
+        lua_pushstring( L, tr( "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)" )
                         .toUtf8().constData() );
         return 2;
     }
 
+    TEvent event;
+
     for( int i=1; i<=n; i++) {
-        if( lua_isnumber( L, i ) ) {
-            event.mArgumentList.append( QString::number( lua_tonumber( L, i ) ) );
-            event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        }
-        else if( lua_isstring( L, i ) ) {
-            event.mArgumentList.append( QString::fromUtf8( lua_tostring( L, i ) ) );
+        if( i==2 ) {
+            // It was agreed to make the second argument always be the name of
+            // sending profile - but the first argument which is the event "name"
+            // can be anything the sending profile wants - as per the
+            // raiseEvent( "eventName", ...other optional arguments... )
+            //
+            // This will, of course, break any existing handlers in the receiving
+            // profile that has been configured to handle an event with the same
+            // name but only from within the same profile and which is not
+            // expecting an extra string argument in the second position.
+            //
+            // The sending profile of the event does not receive the event if
+            // sent via this command but if the same eventName is to be used for
+            // an event within a profile and to other profiles it is safest to
+            // insert a string like "local" or "self" or the profile name from
+            // getProfileName() as the second argument after the eventName so
+            // the handler can tell it is handling a local event from
+            // raiseEvent(...) and not one from another profile! - Slysven
+            event.mArgumentList.append( pHost->getName() );
             event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
         }
-        else if( lua_isboolean( L, i ) ) {
-            event.mArgumentList.append( QString::number( lua_toboolean( L, i ) ) );
-            event.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
-        }
-        else if( lua_isnil( L, i ) ) {
-            event.mArgumentList.append( QString() );
-            event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
-        }
         else {
-            lua_pushstring( L, tr( "sendGlobalEvent: bad argument type #%1 (boolean, number, string or nil\n"
-                                   "expected, got a %2!)" )
-                            .arg( i )
-                            .arg( luaL_typename( L, i ) )
-                            .toUtf8().constData() );
-            lua_error( L );
-            return 1;
+            // Need to take one from the index for all but the first argument:
+            int j = (i == 1 ? 1 : i-1);
+            if( lua_isnumber( L, j ) ) {
+                event.mArgumentList.append( QString::number( lua_tonumber( L, j ) ) );
+                event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+            }
+            else if( lua_isstring( L, j ) ) {
+                event.mArgumentList.append( QString::fromUtf8( lua_tostring( L, j ) ) );
+                event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+            }
+            else if( lua_isboolean( L, j ) ) {
+                event.mArgumentList.append( QString::number( lua_toboolean( L, j ) ) );
+                event.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+            }
+            else if( lua_isnil( L, j ) ) {
+                event.mArgumentList.append( QString() );
+                event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
+            }
+            else {
+                lua_pushstring( L, tr( "raiseGlobalEvent: bad argument type #%1 (boolean, number, string or nil\n"
+                                       "expected, got a %2!)" )
+                                .arg( i )
+                                .arg( luaL_typename( L, j ) )
+                                .toUtf8().constData() );
+                lua_error( L );
+                return 1;
+            }
         }
     }
 
     mudlet::self()->getHostManager()->postInterHostEvent( pHost, event );
-    lua_pushnumber( L, n ); // Return number of supplied arguments put out.
+    lua_pushnumber( L, n ); // Return number of supplied arguments put out, which is one less than the handler will receive!
 
     return 1;
 }
@@ -13158,7 +13183,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem );
     lua_register( pGlobalLua, "setDefaultAreaVisible", TLuaInterpreter::setDefaultAreaVisible );
     lua_register( pGlobalLua, "getProfileName", TLuaInterpreter::getProfileName );
-    lua_register( pGlobalLua, "sendGlobalEvent", TLuaInterpreter::sendGlobalEvent );
+    lua_register( pGlobalLua, "raiseGlobalEvent", TLuaInterpreter::raiseGlobalEvent );
 
 
     luaopen_yajl(pGlobalLua);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -400,7 +400,7 @@ public:
     static int clearMapUserDataItem( lua_State * );
     static int setDefaultAreaVisible( lua_State * );
     static int getProfileName( lua_State * );
-    static int sendGlobalEvent( lua_State * );
+    static int raiseGlobalEvent( lua_State * );
 
 
     std::list<std::string> mCaptureGroupList;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -81,7 +81,7 @@ public:
     void parseJSON(QString & key, const QString & string_data, const QString& protocol);
     void startLuaExecThread();
     void msdp2Lua(char *src, int srclen);
-    void threadLuaInterpreterExec( std::string code );
+// Not Used:    void threadLuaInterpreterExec( std::string code );
     void initLuaGlobals();
     bool call(const QString & function, const QString & mName );
     bool callMulti(const QString & function, const QString & mName );
@@ -400,7 +400,7 @@ public:
     static int clearMapUserDataItem( lua_State * );
     static int setDefaultAreaVisible( lua_State * );
     static int getProfileName( lua_State * );
-    static int raiseInterProfileEvent( lua_State * );
+    static int sendGlobalEvent( lua_State * );
 
 
     std::list<std::string> mCaptureGroupList;
@@ -415,43 +415,43 @@ public:
 
 signals:
 
-    void signalOpenUserWindow( int, const QString& );
-    void signalEchoUserWindow( int, const QString&, const QString& );
-    void signalClearUserWindow( int, const QString& );
-    void signalEnableTimer( int, const QString& );
-    void signalDisableTimer( int, const QString& );
-    void signalNewJob(const QString& );
-    void signalEchoMessage( int, const QString& );
-    void signalSelect( int, const QString&, int );
-    void signalSelectSection( int, int, int );
-    void signalReplace( int, const QString& );
-    void signalSetFgColor( int, int, int, int );
-    void signalSetBgColor( int, int, int, int );
-    void signalTempTimer( int, double, const QString&, const QString& );
-    void signalNewCommand( int, const QString& ); //signal of the lua thread unit command dispatcher for the main event loop to post events
-    void signalNewLuaCodeToExecute(const QString& );
+// Not Used:    void signalOpenUserWindow( int, const QString& );
+// Not Used:    void signalEchoUserWindow( int, const QString&, const QString& );
+// Not Used:    void signalClearUserWindow( int, const QString& );
+// Not Used:    void signalEnableTimer( int, const QString& );
+// Not Used:    void signalDisableTimer( int, const QString& );
+// Not Used:    void signalNewJob(const QString& );
+// Not Used:    void signalEchoMessage( int, const QString& );
+// Not Used:    void signalSelect( int, const QString&, int );
+// Not Used:    void signalSelectSection( int, int, int );
+// Not Used:    void signalReplace( int, const QString& );
+// Not Used:    void signalSetFgColor( int, int, int, int );
+// Not Used:    void signalSetBgColor( int, int, int, int );
+// Not Used:    void signalTempTimer( int, double, const QString&, const QString& );
+// Not Used:    void signalNewCommand( int, const QString& ); //signal of the lua thread unit command dispatcher for the main event loop to post events
+// Not Used:    void signalNewLuaCodeToExecute(const QString& );
 
 public slots:
 
     void slot_replyFinished( QNetworkReply * );
-    void slotOpenUserWindow( int, const QString& );
-    void slotEchoUserWindow( int, const QString&, const QString& );
-    void slotClearUserWindow( int, const QString& );
-    void slotEnableTimer( int, const QString& );
-    void slotDisableTimer( int, const QString& );
-    void slotReplace( int, const QString& );
-    void slotEchoMessage( int, const QString& );
-    void slotNewCommand( int, const QString& );
-    void slotTempTimer( int hostID, double timeout, const QString& function, const QString& timerName );
+// Not Used:    void slotOpenUserWindow( int, const QString& );
+// Not Used:    void slotEchoUserWindow( int, const QString&, const QString& );
+// Not Used:    void slotClearUserWindow( int, const QString& );
+// Not Used:    void slotEnableTimer( int, const QString& );
+// Not Used:    void slotDisableTimer( int, const QString& );
+// Not Used:    void slotReplace( int, const QString& );
+// Not Used:    void slotEchoMessage( int, const QString& );
+// Not Used:    void slotNewCommand( int, const QString& );
+// Not Used:    void slotTempTimer( int hostID, double timeout, const QString& function, const QString& timerName );
     void slotPurge();
     void slotDeleteSender();
 
-        //void slotNewEcho(int,QString);
+// Not Used:    void slotNewEcho(int,QString);
 
     //public:
 private:
 
-    lua_State * getLuaExecutionUnit( int unit );
+// Not Used:    lua_State * getLuaExecutionUnit( int unit );
     lua_State* pGlobalLua;
     TLuaMainThread * mpLuaSessionThread;
 
@@ -462,11 +462,11 @@ private:
     QTimer purgeTimer;
 
 
-    lua_State * pGlobalLuaAliasExecutionUnit;
-    lua_State * pGlobalLuaTriggerExecutionUnit;
-    lua_State * pGlobalLuaGuiExecutionUnit;
-    lua_State * pGlobalLuaScriptExecutionUnit;
-    lua_State * pGlobalLuaTimerExecutionUnit;
+// Not Used:    lua_State * pGlobalLuaAliasExecutionUnit;
+// Not Used:    lua_State * pGlobalLuaTriggerExecutionUnit;
+// Not Used:    lua_State * pGlobalLuaGuiExecutionUnit;
+// Not Used:    lua_State * pGlobalLuaScriptExecutionUnit;
+// Not Used:    lua_State * pGlobalLuaTimerExecutionUnit;
 };
 
 /*
@@ -489,52 +489,56 @@ class TLuaMainThread : public QThread
 public:
 
   TLuaMainThread( TLuaInterpreter * pL ){ pLuaInterpreter = pL;  }
-  void run() override
-  {
-     std::cout << "TLuaMainThread::run() called. Initializing Gatekeeper..."<<std::endl;
-      //pLuaInterpreter->initLuaGlobals();
-     exit=false;
-     while( ! exit )
-     {
-         if( ! mJobQueue.empty() )
-         {
-             pLuaInterpreter->threadLuaInterpreterExec( getJob() );
-         }
-         else
-         {
-             msleep(100);
-         }
-     }
-     std::cout << "TLuaMainThread::run() done exit." << std::endl;
-  }
 
-  std::string getJob()
-  {
-      mutex.lock();
-      std::string job = mJobQueue.front();
-      mJobQueue.pop();
-      mutex.unlock();
-      return job;
-  }
+// Not Used:
+//  void run() override
+//  {
+//     std::cout << "TLuaMainThread::run() called. Initializing Gatekeeper..."<<std::endl;
+//      //pLuaInterpreter->initLuaGlobals();
+//     exit=false;
+//     while( ! exit )
+//     {
+//         if( ! mJobQueue.empty() )
+//         {
+//             pLuaInterpreter->threadLuaInterpreterExec( getJob() );
+//         }
+//         else
+//         {
+//             msleep(100);
+//         }
+//     }
+//     std::cout << "TLuaMainThread::run() done exit." << std::endl;
+//  }
 
-  void postJob(QString code)
-  {
-     std::cout << "posting new job <"<<code.toLatin1().data()<<">"<<std::endl;
-     std::string job = code.toLatin1().data();
-     mutex.lock();
-     mJobQueue.push(job);
-     mutex.unlock();
-     std::cout << "DONE posting new job"<<std::endl;
-  }
+// Not Used {was in code above}:
+//  std::string getJob()
+//  {
+//      mutex.lock();
+//      std::string job = mJobQueue.front();
+//      mJobQueue.pop();
+//      mutex.unlock();
+//      return job;
+//  }
 
-  void callExit(){ exit = true; }
+// Not Used:
+//  void postJob(QString code)
+//  {
+//     std::cout << "posting new job <"<<code.toLatin1().data()<<">"<<std::endl;
+//     std::string job = code.toLatin1().data();
+//     mutex.lock();
+//     mJobQueue.push(job);
+//     mutex.unlock();
+//     std::cout << "DONE posting new job"<<std::endl;
+//  }
+
+// Not Used:  void callExit(){ exit = true; }
 
 private:
 
   TLuaInterpreter * pLuaInterpreter;
   QString code;
-  QMutex mutex;
-  std::queue<std::string> mJobQueue;
+// Not Used:  QMutex mutex;
+// Not Used:  std::queue<std::string> mJobQueue;
 
   bool exit;
 };

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -399,6 +399,8 @@ public:
     static int clearMapUserData( lua_State * );
     static int clearMapUserDataItem( lua_State * );
     static int setDefaultAreaVisible( lua_State * );
+    static int getProfileName( lua_State * );
+    static int raiseInterProfileEvent( lua_State * );
 
 
     std::list<std::string> mCaptureGroupList;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1296,42 +1296,43 @@ void dlgConnectionProfiles::slot_connectToServer()
     emit signal_establish_connection( profile_name, 0 );
 }
 
-void dlgConnectionProfiles::slot_chose_history()
-{
-    QString profile_name = profile_name_entry->text().trimmed();
-    if( profile_name.size() < 1 )
-    {
-        QMessageBox::warning(this, tr("Browse Profile History:"),
-                             tr("You have not selected a profile yet.\nWhich profile history do you want to browse?\nPlease select a profile first."));
-        return;
-    }
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Chose Mudlet Profile"),
-                                                    QStringLiteral( "%1/.config/mudlet/profiles/%2" )
-                                                        .arg( QDir::homePath() )
-                                                        .arg( profile_name ),
-                                                    tr("*.xml"));
+// Not Used:
+//void dlgConnectionProfiles::slot_chose_history()
+//{
+//    QString profile_name = profile_name_entry->text().trimmed();
+//    if( profile_name.size() < 1 )
+//    {
+//        QMessageBox::warning(this, tr("Browse Profile History:"),
+//                             tr("You have not selected a profile yet.\nWhich profile history do you want to browse?\nPlease select a profile first."));
+//        return;
+//    }
+//    QString fileName = QFileDialog::getOpenFileName(this, tr("Chose Mudlet Profile"),
+//                                                    QStringLiteral( "%1/.config/mudlet/profiles/%2" )
+//                                                        .arg( QDir::homePath() )
+//                                                        .arg( profile_name ),
+//                                                    tr("*.xml"));
 
-    if( fileName.isEmpty() ) return;
+//    if( fileName.isEmpty() ) return;
 
-    QFile file(fileName);
-    if( ! file.open(QFile::ReadOnly | QFile::Text) )
-    {
-        QMessageBox::warning(this, tr("Import Mudlet Package:"),
-                             tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
-        return;
-    }
+//    QFile file(fileName);
+//    if( ! file.open(QFile::ReadOnly | QFile::Text) )
+//    {
+//        QMessageBox::warning(this, tr("Import Mudlet Package:"),
+//                             tr("Cannot read file %1:\n%2.")
+//                             .arg(fileName)
+//                             .arg(file.errorString()));
+//        return;
+//    }
 
-    mudlet::self()->getHostManager()->addHost( profile_name, port_entry->text().trimmed(), QString(), QString() );
-    Host * pHost = mudlet::self()->getHostManager()->getHost( profile_name );
-    if( ! pHost ) return;
-    XMLimport importer( pHost );
-    importer.importPackage( & file );
+//    mudlet::self()->getHostManager()->addHost( profile_name, port_entry->text().trimmed(), QString(), QString() );
+//    Host * pHost = mudlet::self()->getHostManager()->getHost( profile_name );
+//    if( ! pHost ) return;
+//    XMLimport importer( pHost );
+//    importer.importPackage( & file );
 
-    emit signal_establish_connection( profile_name, -1 );
-    QDialog::accept();
-}
+//    emit signal_establish_connection( profile_name, -1 );
+//    QDialog::accept();
+//}
 
 bool dlgConnectionProfiles::validateConnect()
 {

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -46,7 +46,7 @@ signals:
 
 public slots:
 
-    void slot_chose_history();
+// Not Used:    void slot_chose_history();
     void slot_update_name( const QString ) ;
     void slot_save_name() ;
     void slot_update_url( const QString ) ;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -721,19 +721,27 @@ void mudlet::slot_close_profile()
     {
         if( mConsoleMap.contains( mpCurrentActiveHost ) )
         {
-            QString name = mpCurrentActiveHost->getName();
             Host * pH = mpCurrentActiveHost;
-            mpCurrentActiveHost->mpEditorDialog->close();
-            mConsoleMap[mpCurrentActiveHost]->close();
-            if( mTabMap.contains( pH->getName() ) )
+            if( pH )
             {
-                mpTabBar->removeTab( mpTabBar->currentIndex() );
-                mConsoleMap.remove( pH );
-                getHostManager()->deleteHost( pH->getName() );
-                mTabMap.remove( pH->getName() );
+                QString name = pH->getName();
+                mpCurrentActiveHost->mpEditorDialog->close();
+                mConsoleMap[ pH ]->close();
+                if( mTabMap.contains( name ) )
+                {
+                    mpTabBar->removeTab( mpTabBar->currentIndex() );
+                    mConsoleMap.remove( pH );
+                    getHostManager()->deleteHost( name );
+                    mTabMap.remove( name );
+                }
+                mpCurrentActiveHost = Q_NULLPTR;
             }
-            if( !mpCurrentActiveHost ) disableToolbarButtons();
         }
+
+    }
+    else
+    {
+        disableToolbarButtons();
     }
 }
 


### PR DESCRIPTION
This ~~experimental~~ working system allows a script in one profile to: `raiseInterProfileEvent( data )` where data is one or more number, string, boolean or nil values that can be detected by a declared `sysInterProfileEvent` event handler in all active profiles.  The host order for reception of the event is maintained in a circular manner so that the profile that emitted the event is the one to receive it last.  The first argument received after the `sysInterProfileEvent` one is the name of the sending host, then the subsequent ones are the arguments supplied to the invoking function.

Also, as the data to be sent as an event has to be passed up to the main mudlet class this does have to lock some resources whilst the event is propagated to the other profiles which means it probably isn't a good idea for a high volume of traffic.  It, by definition and design, also breaks the sand-boxing that normally exists between separate profiles.

As the TLuaInterpreter code for this is very similar to the related `raiseEvent(...)` function I took the opportunity to "tart-up" that one so the code is to the same style/standard - that now handles Utf8 encoded strings correctly and, like the new event now also returns the number of user/script supplied arguments sent in the event.

Whilst coding this function it became clear that there was not a simple way for a script to establish which Profile it was running in - which is something that may well be needed when writing scripts for multi-playing so I have also added a Lua command `getProfileName()` which takes no arguments and returns the (possibly Utf-8) string for the profile on which
it is running.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
