### PR TITLE
(release_30)compatibilityHack: restore empty string response on no room user data

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9467,6 +9467,17 @@ int TLuaInterpreter::getRoomEnv( lua_State * L )
     return 0;
 }
 
+// Past code returned an empty string if room or user data item with given key
+// didn't exist - to enable the more modern behaviour that produces a
+// nil + error message (recommended) in those cases a third (boolean)true is
+// required. This "correct" behaviour being non-default is to retain backwards
+// compatibility with existing scripts/packages that expect an empty string,
+// even though the past code would allow the user to assign such an empty string
+// against a key which cannot be distinguished in such circumstances.
+// This fix is specific to the Room User Data as the need for it was introduced
+// at the same time as Area and Map User Data was added but they were not
+// documented until later and their Wiki entries did/will not mention returning
+// an empty string in the cases of no room with id or no key with given name.
 int TLuaInterpreter::getRoomUserData( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -9506,13 +9517,35 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
     else {
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
     }
+
+    bool isBackwardCompatibilityRequired = true;
+    if( lua_gettop( L ) > 2 ) {
+        if( ! lua_isboolean( L, 3 ) ) {
+            lua_pushstring( L, tr( "getRoomUserData: bad argument #3 (enableFullErrorReporting as boolean {default\n"
+                                   "= false} is optional, got %1!)" )
+                            .arg( luaL_typename( L, 3 ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+        else {
+            isBackwardCompatibilityRequired = ! lua_toboolean( L, 3 );
+        }
+    }
+
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
-        lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomUserData: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg(roomId)
-                        .toUtf8().constData() );
-        return 2;
+        if( isBackwardCompatibilityRequired ) {
+            lua_pushstring( L, QString().toUtf8().constData() );
+            return 1;
+        }
+        else {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "getRoomUserData: bad argument #1 value (number %1 is not a valid room id)." )
+                            .arg( roomId )
+                            .toUtf8().constData() );
+            return 2;
+        }
     }
     else {
         if( pR->userData.contains( key ) ) {
@@ -9520,12 +9553,18 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
             return 1;
         }
         else {
-            lua_pushnil( L );
-            lua_pushstring( L, tr( "getRoomUserData: bad argument #2 value (no user data with key:\"%1\" in room with id:%2 )." )
-                            .arg( key )
-                            .arg(roomId)
-                            .toUtf8().constData() );
-            return 2;
+            if( isBackwardCompatibilityRequired ) {
+                lua_pushstring( L, QString().toUtf8().constData() );
+                return 1;
+            }
+            else {
+                lua_pushnil( L );
+                lua_pushstring( L, tr( "getRoomUserData: bad argument #2 value (no user data with key:\"%1\" in room with id: %2)." )
+                                .arg( key )
+                                .arg( roomId )
+                                .toUtf8().constData() );
+                return 2;
+            }
         }
     }
 }


### PR DESCRIPTION
When I introduced area and map user data storage I also revised the room user data code - specifically `TLuaInterpreter::getRoomUserData(...)` to provide informative error messages on various failures, unintentionally though, this introduced an incompatibility with the documented behaviour for this function in that, as of commit-https://github.com/Mudlet/Mudlet/commit/79a8905c391d33ee3a7756a4b20afbe99cdf75c3 it was expected to return an empty string if the given room id (first argument) number did not exist or the data key (second argument) string was not found for that room.

As it happens the past and current code DOES allow an empty string to be stored against a given key but the past code did not allow the user to differentiate it from the case where the room didn't exist (though that could be found out with other code) or the case where the key was not present - no workaround.

This commit adds an optional third argument `(bool) enableFullErrorReporting` that enables a nil + error message if provided and is true, but which is false otherwise so that previous scripts retain their expected results from using the two-argument usage.

Obviously new scripts should use the third option and set it to be true but they may wish to check for the availability of `getAreaUserData()` as an indication that they will get a nil response if the room does not exist or does not contain the requested key if they anticipate being used on older version of Mudlet with the non-ideal `getRoomUserData()` code.

Signed-off-by: Stephen Lyons slysven@virginmedia.com
