### PR TITLE
Bugfix package installation and revise server gui handling

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -802,15 +802,14 @@ bool Host::installPackage(const QString& fileName, int module )
                 pLabel->setText( tr( "Unpacking package:\n\"%1\"\nplease wait..." ).arg( packageName ) );
             }
         }
+        pUnzipDialog->hide(); // Must hide to change WindowModality
         pUnzipDialog->setWindowTitle( tr( "Unpacking" ) );
-        pUnzipDialog->hide();
         pUnzipDialog->setWindowModality( Qt::ApplicationModal );
         pUnzipDialog->show();
         qApp->processEvents();
         pUnzipDialog->raise();
-        pUnzipDialog->show(); // Must do this to ensure modality is applied
-        pUnzipDialog->update();
-        qApp->processEvents(); // Try to ensure we are on top of any other dialogs
+        pUnzipDialog->repaint(); // Force a redraw
+        qApp->processEvents(); // Try to ensure we are on top of any other dialogs and freshly drawn
 
         int err = 0;
         //from: https://gist.github.com/mobius/1759816

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -725,21 +725,24 @@ bool Host::installPackage(const QString& fileName, int module )
 //     a script.  This separation is necessary to be able to reuse code
 //     while avoiding infinite loops from script installations.
 
-    if( fileName.isEmpty() ) return false;
+    if( fileName.isEmpty() )
+    {
+        return false;
+    }
 
     QFile file(fileName);
     if( ! file.open(QFile::ReadOnly | QFile::Text) )
     {
         return false;
     }
-    QString packageName = fileName.section("/", -1);
-    packageName.replace( ".zip" , "" );
-    packageName.replace( "trigger", "" );
-    packageName.replace( "xml", "" );
-    packageName.replace( ".mpackage" , "" );
-    packageName.replace( '/' , "" );
-    packageName.replace( '\\' , "" );
-    packageName.replace( '.' , "" );
+
+    QString packageName = fileName.section( QStringLiteral( "/" ), -1 );
+    packageName.remove( QStringLiteral( ".trigger" ), Qt::CaseInsensitive );
+    packageName.remove( QStringLiteral( ".xml" ), Qt::CaseInsensitive );
+    packageName.remove( QStringLiteral( ".zip" ), Qt::CaseInsensitive );
+    packageName.remove( QStringLiteral( ".mpackage" ), Qt::CaseInsensitive );
+    packageName.remove( QLatin1Char( '\\' ) );
+    packageName.remove( QLatin1Char( '.' ) );
     if ( module )
     {
         if( (module == 2) && (mActiveModules.contains( packageName ) ))
@@ -764,33 +767,57 @@ bool Host::installPackage(const QString& fileName, int module )
         mpEditorDialog->doCleanReset();
     }
     QFile file2;
-    if( fileName.endsWith(".zip") || fileName.endsWith(".mpackage") )
+    if(  fileName.endsWith( QStringLiteral( ".zip" ), Qt::CaseInsensitive )
+      || fileName.endsWith( QStringLiteral( ".mpackage"), Qt::CaseInsensitive ) )
     {
-        QString _home = QDir::homePath();
-        _home.append( "/.config/mudlet/profiles/" );
-        _home.append( getName() );
-        QString _dest = QString( "%1/%2/").arg( _home ).arg( packageName );
-        QDir _tmpDir;
-        _tmpDir.mkpath(_dest);
+        QString _home = QStringLiteral( "%1/.config/mudlet/profiles/%2" )
+                        .arg( QDir::homePath() )
+                        .arg( getName() );
+        QString _dest = QStringLiteral( "%1/%2/" )
+                        .arg( _home )
+                        .arg( packageName );
+        QDir _tmpDir( _home ); // home directory for the PROFILE
+        _tmpDir.mkpath( _dest );
+        // TODO: report failure to create destination folder for package/module in profile
 
-        QUiLoader loader;
-        QFile file(":/ui/package_manager_unpack.ui");
-        file.open(QFile::ReadOnly);
-        pUnzipDialog = dynamic_cast<QDialog *>(loader.load( &file, 0 ) );
-        file.close();
-        if( ! pUnzipDialog ) return false;
+        QUiLoader loader( this );
+        QFile uiFile( QStringLiteral( ":/ui/package_manager_unpack.ui" ) );
+        uiFile.open(QFile::ReadOnly);
+        pUnzipDialog = dynamic_cast<QDialog *>(loader.load( &uiFile, 0 ) );
+        uiFile.close();
+        if( ! pUnzipDialog )
+        {
+            return false;
+        }
 
-        pUnzipDialog->setWindowTitle( tr( "Unpacking package: %1" ).arg( fileName ) );
+        QLabel * pLabel = pUnzipDialog->findChild<QLabel*>( QStringLiteral( "label" ) );
+        if( pLabel )
+        {
+            if( module )
+            {
+                pLabel->setText( tr( "Unpacking module:\n\"%1\"\nplease wait..." ).arg( packageName ) );
+            }
+            else
+            {
+                pLabel->setText( tr( "Unpacking package:\n\"%1\"\nplease wait..." ).arg( packageName ) );
+            }
+        }
+        pUnzipDialog->setWindowTitle( tr( "Unpacking" ) );
+        pUnzipDialog->hide();
+        pUnzipDialog->setWindowModality( Qt::ApplicationModal );
         pUnzipDialog->show();
-        pUnzipDialog->raise();
         qApp->processEvents();
+        pUnzipDialog->raise();
+        pUnzipDialog->show(); // Must do this to ensure modality is applied
+        pUnzipDialog->update();
+        qApp->processEvents(); // Try to ensure we are on top of any other dialogs
 
         int err = 0;
         //from: https://gist.github.com/mobius/1759816
         struct zip_stat zs;
         struct zip_file *zf;
-        long long sum;
-        char buf[100];
+        zip_uint64_t bytesRead = 0;
+        char buf[4096]; // Was 100 but that seems unduely stingy...!
         zip* archive = zip_open( fileName.toStdString().c_str(), 0, &err);
         if ( err != 0 )
         {
@@ -803,72 +830,177 @@ bool Host::installPackage(const QString& fileName, int module )
             }
             return false;
         }
-        for (int i=0;i<zip_get_num_entries( archive, 0 );i++ )
+
+        // We now scan for directories first, and gather needed ones first, not
+        // just relying on (zero length) archive entries ending in '/' as some
+        // (possibly broken) archive building libraries seem to forget to
+        // include them.
+        QMap<QString, QString> directoriesNeededMap;
+        //   Key is: relative path stored in archive
+        // Value is: absolute path needed when extracting files
+        for ( zip_int64_t i = 0, total = zip_get_num_entries( archive, 0 ); i < total; ++i )
         {
-            int zsi = zip_stat_index( archive, i, 0, &zs );
-            if( zsi == 0 )
+            if ( ! zip_stat_index( archive, static_cast<zip_uint64_t>( i ), 0, &zs )  )
             {
-                if ( zs.name[strlen( zs.name )-1] == '/' )
+                QString entryInArchive( QString::fromUtf8( zs.name ) );
+                QString pathInArchive( entryInArchive.section( QLatin1Literal( "/" ), 0, -2 ) );
+                // TODO: We are supposed to validate the fields (except the
+                // "valid" one itself) in zs before using them:
+                // i.e. check that zs.name is valid ( zs.valid & ZIP_STAT_NAME )
+                if ( entryInArchive.endsWith( QLatin1Char( '/' ) ) )
                 {
-                    QDir dir = QDir( _dest );
-                    if ( !dir.exists( zs.name ) )
-                    {
-                        if ( dir.mkdir( zs.name ) == false )
-                        {
-                            //FIXME: report error to user
-                            //qDebug()<<"error creating subdirectory: "<<QString(zs.name);
-                        }
+//                    qDebug() << "Host::installPackage() Scanning archive (for directories) found item:" << i << "called:" << entryInArchive << "this is a DIRECTORY...!";
+                    if ( ! directoriesNeededMap.contains( pathInArchive ) ) {
+                        QString pathInProfile( QStringLiteral( "%1/%2" )
+                                               .arg( packageName )
+                                               .arg( pathInArchive ) );
+                        directoriesNeededMap.insert( pathInArchive, pathInProfile );
+//                        qDebug() << "Added:" << pathInArchive << "to list of sub-directories to be made.";
                     }
+//                    else
+//                    {
+//                        qDebug() << "No need to add:" << pathInArchive << "we have already spotted the need for it!";
+//                    }
                 }
                 else
                 {
-                    zf = zip_fopen_index( archive, i, 0 );
-                    if ( !zf )
-                    {
-                        int sep = 0;
-                        zip_error_get( archive, &err, &sep);
-                        zip_error_to_str(buf, sizeof(buf), err, errno);
-                        //FIXME: report error to user
-                        if ( pUnzipDialog )
-                        {
-                            pUnzipDialog->deleteLater();
-                            pUnzipDialog = Q_NULLPTR;
-                        }
-                        return false;
+//                    qDebug() << "Host::installPackage() Scanning archive (for directories) found item:" << i << "called:" << entryInArchive << "this is a FILE...!";
+                    // Extract needed path from name for archives that do NOT
+                    // explicitly list directories
+                    if( ! pathInArchive.isEmpty() && ! directoriesNeededMap.contains( pathInArchive ) ) {
+                        QString pathInProfile( QStringLiteral( "%1/%2" )
+                                               .arg( packageName )
+                                               .arg( pathInArchive ) );
+                        directoriesNeededMap.insert( pathInArchive, pathInProfile );
+//                        qDebug() << "Added:" << pathInArchive << "to list of sub-directories to be made.";
                     }
-                    QFile fd(_dest+QString(zs.name));
-                    fd.open(QIODevice::ReadWrite|QIODevice::Truncate);
-                    if ( !fd.isOpen() )
-                    {
-                        //FIXME: report error to user qDebug()<<"error opening"<<_dest+QString(zs.name);
-                        if ( pUnzipDialog )
-                        {
-                            pUnzipDialog->deleteLater();
-                            pUnzipDialog = Q_NULLPTR;
-                        }
-                        return false;
-                    }
-                    sum = 0;
-                    //HEIKO: comparison between signed and unsigned
-                    while( static_cast<zip_uint64_t>(sum) != zs.size )
-                    {
-                        int len = zip_fread( zf, buf, 100 );
-                        if ( len < 0 )
-                        {
-                            //FIXME: report error to user qDebug()<<"zip_fread error"<<len;
-                            if ( pUnzipDialog )
-                            {
-                                pUnzipDialog->deleteLater();
-                                pUnzipDialog = Q_NULLPTR;
-                            }
-                            return false;
-                        }
-                        fd.write( buf, len );
-                        sum += len;
-                    }
-                    fd.close();
-                    zip_fclose( zf );
+//                    else
+//                    {
+//                        qDebug() << "No need to add:" << pathInArchive << "we have already spotted the need for it!";
+//                    }
                 }
+            }
+            else
+            {
+                // TODO: Report failure to obtain an archive entry to parse
+            }
+        }
+
+        // Now create the needed directories:
+        QMapIterator<QString, QString> itPath( directoriesNeededMap );
+        while( itPath.hasNext() )
+        {
+            itPath.next();
+//            qDebug() << "Host::installPackage(...)    INFO testing for presence of:"
+//                     << itPath.value()
+//                     << "relative to:"
+//                     << _home;
+            if( ! _tmpDir.exists( itPath.value() ) )
+            {
+                if( ! _tmpDir.mkpath( itPath.value() ) )
+                {
+                    // TODO: report failure to create needed sub-directory
+                    // within package destination directory in profile directory
+
+                    zip_close( archive );
+                    if( pUnzipDialog ) {
+                        pUnzipDialog->deleteLater();
+                        pUnzipDialog = Q_NULLPTR;
+                        // Previously we forgot to close the dialog if we aborted
+                    }
+                    return false; // Abort reading rest of archive
+                }
+                _tmpDir.refresh();
+            }
+        }
+
+        // Now extract the files
+        for ( zip_int64_t i = 0, total = zip_get_num_entries( archive, 0 ); i < total; ++i )
+        {
+            // No need to check return value as we've already done it first time
+            zip_stat_index( archive, static_cast<zip_uint64_t>( i ), 0, &zs );
+            QString entryInArchive( QString::fromUtf8( zs.name ) );
+            if ( ! entryInArchive.endsWith( QLatin1Char( '/' ) ) )
+            {
+                // TODO: check that zs.size is valid ( zs.valid & ZIP_STAT_SIZE )
+                zf = zip_fopen_index( archive, static_cast<zip_uint64_t>( i ), 0 );
+                if ( !zf )
+                {
+                    int sep = 0;
+                    zip_error_get( archive, &err, &sep );
+                    zip_error_to_str(buf, sizeof(buf), err, errno);
+                    // FIXME: report error to user, zip_error_to_str(...) is
+                    // already deprecated, if not obsoleted...! - Slysven
+                    zip_close( archive );
+                    if ( pUnzipDialog )
+                    {
+                        pUnzipDialog->deleteLater();
+                        pUnzipDialog = Q_NULLPTR;
+                    }
+                    return false;
+                }
+
+                QFile fd( QStringLiteral( "%1%2" )
+                          .arg( _dest )
+                          .arg( entryInArchive ) );
+
+                if ( !fd.open( QIODevice::ReadWrite|QIODevice::Truncate ) )
+                {
+                    //FIXME: report error to user
+                    qDebug() << "Host::installPackage("
+                             << fileName
+                             << ","
+                             << module
+                             << ")\n    ERROR opening:"
+                             << QStringLiteral( "%1%2" ).arg( _dest ).arg( entryInArchive )
+                             << "!\n    Reported error was:"
+                             << fd.errorString();
+                    zip_fclose( zf );
+                    zip_close( archive );
+                    if ( pUnzipDialog )
+                    {
+                        pUnzipDialog->deleteLater();
+                        pUnzipDialog = Q_NULLPTR;
+                    }
+                    return false;
+                }
+
+                bytesRead = 0;
+                zip_uint64_t bytesExpected = zs.size;
+                while( bytesRead < bytesExpected && fd.error() == QFileDevice::NoError )
+                {
+                    zip_int64_t len = zip_fread( zf, buf, sizeof( buf ) );
+                    if ( len < 0 )
+                    {
+                        //FIXME: report error to user qDebug()<<"zip_fread error"<<len;
+                        fd.close();
+                        zip_fclose( zf );
+                        zip_close( archive );
+                        if ( pUnzipDialog )
+                        {
+                            pUnzipDialog->deleteLater();
+                            pUnzipDialog = Q_NULLPTR;
+                        }
+                        return false;
+                    }
+
+                    if( fd.write( buf, len ) == -1 )
+                    {
+                        // TODO: Report failure to write data to actual file
+                        fd.close();
+                        zip_fclose( zf );
+                        zip_close( archive );
+                        if ( pUnzipDialog )
+                        {
+                            pUnzipDialog->deleteLater();
+                            pUnzipDialog = Q_NULLPTR;
+                        }
+                        return false;
+                    }
+                    bytesRead += static_cast<zip_uint64_t>( len );
+                }
+                fd.close();
+                zip_fclose( zf );
             }
         }
 
@@ -899,10 +1031,10 @@ bool Host::installPackage(const QString& fileName, int module )
         QDir _dir( _dest );
         // before we start importing xmls in, see if the config.lua manifest file exists
         // - if it does, update the packageName from it
-        if (_dir.exists("config.lua"))
+        if ( _dir.exists( QStringLiteral( "config.lua" ) ) )
         {
             // read in the new packageName from Lua. Should be expanded in future to whatever else config.lua will have
-            readPackageConfig(_dir.absoluteFilePath("config.lua"), packageName);
+            readPackageConfig( _dir.absoluteFilePath( QStringLiteral( "config.lua" ) ), packageName );
             // now that the packageName changed, redo relevant checks to make sure it's still valid
             if (module)
             {
@@ -921,12 +1053,12 @@ bool Host::installPackage(const QString& fileName, int module )
                 }
             }
             // continuing, so update the folder name on disk
-            QString newpath(QString( "%1/%2/").arg( _home ).arg( packageName ));
+            QString newpath( QStringLiteral( "%1/%2/" ).arg( _home ).arg( packageName ));
             _dir.rename(_dir.absolutePath(), newpath);
             _dir = QDir( newpath );
         }
         QStringList _filterList;
-        _filterList << "*.xml" << "*.trigger";
+        _filterList << QStringLiteral( "*.xml" ) << QStringLiteral( "*.trigger" );
         QFileInfoList entries = _dir.entryInfoList( _filterList, QDir::Files );
         for( int i=0; i<entries.size(); i++ )
         {
@@ -940,12 +1072,14 @@ bool Host::installPackage(const QString& fileName, int module )
             {
                 QStringList moduleEntry;
                 moduleEntry << fileName;
-                moduleEntry << "0";
-                mInstalledModules[packageName] = moduleEntry;//.append( packageName );
+                moduleEntry << QStringLiteral( "0" );
+                mInstalledModules[packageName] = moduleEntry;
                 mActiveModules.append(packageName);
             }
             else
+            {
                 mInstalledPackages.append( packageName );
+            }
             reader.importPackage( & file2, packageName, module);
             setName( profileName );
             setLogin( login );
@@ -966,12 +1100,14 @@ bool Host::installPackage(const QString& fileName, int module )
         {
             QStringList moduleEntry;
             moduleEntry << fileName;
-            moduleEntry << "0";
-            mInstalledModules[packageName] = moduleEntry;//.append( packageName );
+            moduleEntry << moduleEntry << QStringLiteral( "0" );
+            mInstalledModules[packageName] = moduleEntry;
             mActiveModules.append(packageName);
         }
         else
+        {
             mInstalledPackages.append( packageName );
+        }
         reader.importPackage( & file2, packageName, module);
         setName( profileName );
         setLogin( login );

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1100,7 +1100,7 @@ bool Host::installPackage(const QString& fileName, int module )
         {
             QStringList moduleEntry;
             moduleEntry << fileName;
-            moduleEntry << moduleEntry << QStringLiteral( "0" );
+            moduleEntry << QStringLiteral( "0" );
             mInstalledModules[packageName] = moduleEntry;
             mActiveModules.append(packageName);
         }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -703,60 +703,6 @@ void Host::connectToServer()
     mTelnet.connectIt( mUrl, mPort );
 }
 
-bool Host::serialize()
-{
-    return false;
-    if( ! mSaveProfileOnExit )
-    {
-        return true;
-    }
-    QString directory_xml = QDir::homePath()+"/.config/mudlet/profiles/"+mHostName+"/current";
-    QString filename_xml = directory_xml + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss")+".xml";
-    QDir dir_xml;
-    if( ! dir_xml.exists( directory_xml ) )
-    {
-        dir_xml.mkpath( directory_xml );
-    }
-    QDir dir_map;
-    QString directory_map = QDir::homePath()+"/.config/mudlet/profiles/"+mHostName+"/map";
-    QString filename_map = directory_map + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss")+"map.dat";
-    if( ! dir_map.exists( directory_map ) )
-    {
-        dir_map.mkpath( directory_map );
-    }
-
-    QFile file_xml( filename_xml );
-    if ( file_xml.open( QIODevice::WriteOnly ) )
-    {
-        modulesToWrite.clear();
-        XMLexport writer( this );
-        writer.exportHost( & file_xml );
-        file_xml.close();
-        saveModules(0);
-    }
-    else
-    {
-        QMessageBox::critical( 0, "Profile Save Failed", "Failed to save "+mHostName+" to location "+filename_xml+" because of the following error: "+file_xml.errorString() );
-    }
-
-    if( mpMap->mpRoomDB->size() > 10 )
-    {
-        QFile file_map( filename_map );
-        if ( file_map.open( QIODevice::WriteOnly ) )
-        {
-            QDataStream out( & file_map );
-            mpMap->serialize( out );
-            file_map.close();
-        }
-        else
-        {
-            QMessageBox::critical( 0, "Profile Save Failed", "Failed to save "+mHostName+" to location "+filename_xml+" because of the following error: "+file_xml.errorString() );
-        }
-    }
-    return true;
-}
-
-
 bool Host::closingDown()
 {
     QMutexLocker locker(& mLock);

--- a/src/Host.h
+++ b/src/Host.h
@@ -301,8 +301,8 @@ public:
     QStringList        mActiveModules;
     bool               mModuleSaveBlock;
 
-    void               showUnpackingProgress( QString  txt );
-    QDialog *          mpUnzipDialog;
+    // There was a QDialog *          mpUnzipDialog; but to avoid issues of
+    // reentrancy it needed to be made local to the method that used it.
     QPushButton *      uninstallButton;
     QListWidget *      packageList;
     QListWidget *                 moduleList;

--- a/src/Host.h
+++ b/src/Host.h
@@ -116,7 +116,6 @@ public:
     void               startSpeedWalk();
     //QStringList        getBufferTable( int, int );
     //QString            getBufferLine( int );
-    bool               serialize();
     void               saveModules(int);
     void               reloadModule(const QString& moduleName);
     bool               blockScripts() { return mBlockScriptCompile; }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5058,23 +5058,14 @@ int TLuaInterpreter::setAppStyleSheet( lua_State *L )
     return 0;
 }
 
-// this is an internal only function used by the package system
+// this was an internal only function used by the package system, but it was
+// inactive and has been removed
 int TLuaInterpreter::showUnzipProgress( lua_State * L )
 {
-    string luaSendText="";
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "showUnzipProgress: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaSendText = lua_tostring( L, 1 );
-    }
-    QString txt = luaSendText.c_str();
-    mudlet::self()->showUnzipProgress( txt );
-    return 0;
+    lua_pushnil( L );
+    lua_pushstring( L, tr( "showUnzipProgress: removed command, this function is now inactive and does nothing!" )
+                    .toUtf8().constData() );
+    return 2;
 }
 
 int TLuaInterpreter::playSoundFile( lua_State * L )

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3205,16 +3205,6 @@ void dlgTriggerEditor::addScript( bool isFolder )
     slot_scripts_selected( treeWidget_scripts->currentItem() );
 }
 
-void dlgTriggerEditor::slot_saveVarAfterEdit()
-{
-    return saveVar();
-}
-
-void dlgTriggerEditor::slot_saveTriggerAfterEdit()
-{
-    return saveTrigger();
-}
-
 void dlgTriggerEditor::saveTrigger()
 {
     QTime t;
@@ -3376,11 +3366,6 @@ void dlgTriggerEditor::saveTrigger()
     }
 }
 
-void dlgTriggerEditor::slot_saveTimerAfterEdit()
-{
-    return saveTimer();
-}
-
 void dlgTriggerEditor::saveTimer()
 {
     QTreeWidgetItem * pItem = mCurrentTimer;
@@ -3470,12 +3455,6 @@ void dlgTriggerEditor::saveTimer()
 
         }
     }
-}
-
-
-void dlgTriggerEditor::slot_saveAliasAfterEdit()
-{
-    return saveAlias();
 }
 
 void dlgTriggerEditor::saveAlias()
@@ -3606,12 +3585,6 @@ void dlgTriggerEditor::saveAlias()
     }
 }
 
-void dlgTriggerEditor::slot_saveActionAfterEdit()
-{
-    return saveAction();
-
-}
-
 void dlgTriggerEditor::saveAction()
 {
     QTreeWidgetItem * pItem = mCurrentAction;
@@ -3724,12 +3697,6 @@ void dlgTriggerEditor::saveAction()
     mudlet::self()->processEventLoopHack();
 }
 
-
-void dlgTriggerEditor::slot_saveScriptAfterEdit()
-{
-    return saveScript();
-}
-
 void dlgTriggerEditor::saveScript()
 {
     QTreeWidgetItem * pItem = mCurrentScript;
@@ -3831,12 +3798,6 @@ void dlgTriggerEditor::saveScript()
             }
         }
     }
-}
-
-
-void dlgTriggerEditor::slot_saveKeyAfterEdit()
-{
-    return saveKey();
 }
 
 int dlgTriggerEditor::canRecast(QTreeWidgetItem * pItem, int nameType, int valueType)
@@ -6345,30 +6306,31 @@ void dlgTriggerEditor::slot_save_edit()
     switch( mCurrentView )
     {
         case cmTriggerView:
-            slot_saveTriggerAfterEdit();
+            saveTrigger();
             break;
         case cmTimerView:
-            slot_saveTimerAfterEdit();
+            saveTimer();
             break;
         case cmAliasView:
-            slot_saveAliasAfterEdit();
+            saveAlias();
             break;
         case cmScriptView:
-            slot_saveScriptAfterEdit();
+            saveScript();
             break;
         case cmActionView:
-            slot_saveActionAfterEdit();
+            saveAction();
             break;
         case cmKeysView:
-            slot_saveKeyAfterEdit();
+            saveKey();
             break;
         case cmVarsView:
-            slot_saveVarAfterEdit();
+            saveVar();
             break;
         default: qWarning()<<"ERROR: dlgTriggerEditor::slot_save_edit() undefined view";
     };
 
-    mpHost->serialize();
+// There was a mpHost->serialize() call here, but that code was
+// "short-circuited" and returned without doing anything;
 }
 
 void dlgTriggerEditor::slot_add_new()

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -108,7 +108,6 @@ public slots:
     void                        slot_toggleHiddenVar( bool );
     void                        slot_addVar();
     void                        slot_addVarGroup();
-    void                        slot_saveVarAfterEdit();
     void                        slot_deleteVar();
     void                        slot_var_selected( QTreeWidgetItem * );
     void                        slot_var_changed( QTreeWidgetItem * );
@@ -125,12 +124,6 @@ public slots:
     void                        slot_import();
     void                        slot_viewStatsAction();
     void                        slot_debug_mode();
-    void                        slot_saveTriggerAfterEdit();
-    void                        slot_saveTimerAfterEdit();
-    void                        slot_saveScriptAfterEdit();
-    void                        slot_saveAliasAfterEdit();
-    void                        slot_saveActionAfterEdit();
-    void                        slot_saveKeyAfterEdit();
     void                        slot_show_timers();
     void                        slot_show_triggers();
     void                        slot_show_scripts();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -653,13 +653,6 @@ void mudlet::slot_install_package()
     packageList->addItems( pH->mInstalledPackages );
 }
 
-void mudlet::showUnzipProgress(const QString& txt )
-{
-    Host * pH = getActiveHost();
-    if( ! pH ) return;
-    pH->showUnpackingProgress( txt );
-}
-
 void mudlet::slot_uninstall_package()
 {
     Host * pH = getActiveHost();


### PR DESCRIPTION
This fix will allow modules with sub-directories to be parsed and installed (which the prior code did not always do) as it scans archived packages/modules to establish any sub-directories needed and does not just rely on archive entries with a zero length file size ending in `/` which is the __defined__ method for indicating them - some (possible compressed) archive creation systems do not always seem to insert them.

This should also make significant improvements to package/module installation as it finally cleans up the "Unpacking" dialogue that previously was left in view should the un-archiving or other operation fail - the previous failure to do this was giving the impression that the operation had hung rather than failed!

Whilst preparing this I found some chunks of ineffective or unused code that I excised as a preliminary commit.  The code layout in the Host class is still wide of what I would like to see but that is a separate issue.

Note that although this now detects more error situation when working with packages it still does not report them.  This will need separate work because the Host::instalPackage(...)
method is used in several different parts of the Mudlet application, they have potentially different ways to indicate problems and handling them here would make this PR significantly larger and thus harder to assess.

This should address the issues raised in [Bug 1413069](https://bugs.launchpad.net/mudlet/+bug/1413069) which has been tagged as one of the 3.0.0 release blockers!