### PR TITLE
Change version from zeta to iota

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ ELSE()
 ENDIF()
 
 SET(APP_VERSION 3.0.0)
-SET(APP_BUILD "-zeta")
+SET(APP_BUILD "-iota")
 # APP_BUILD should only be empty/null in official "release" builds,
 # developers may like to set it to their user and branch names to make it easier
 # to tell different builds apart!

--- a/src/src.pro
+++ b/src/src.pro
@@ -56,7 +56,7 @@ QT += network opengl uitools multimedia gui
 # (it is NOT a Qt built-in variable) for a release build or, if you are
 # distributing modified code, it would be useful if you could put something to
 # distinguish the version:
-BUILD = "-zeta"
+BUILD = "-iota"
 
 # Changing the above pair of values affects: ctelnet.cpp, main.cpp, mudlet.cpp
 # dlgAboutDialog.cpp and TLuaInterpreter.cpp.  It does NOT cause those files to


### PR DESCRIPTION
While this was originally intended to make Debian packaging easier, Debian packaging is not longer a problem. Still sticking with the change however as it'll be easier to explain that zeta isn't the last preview version.

This makes the version naming follow the Latin alphabet using Greek letters.