### PR TITLE
(release_30)refactor: eliminate duplicated set of pointers in dlgTriggerEditor class

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -104,14 +104,7 @@ const QString msgInfoAddKey = "To add a new key binding <b>1.</b> add a new key 
 const QString msgInfoAddVar = "Add a new variable (can be a string, integer, boolean -- delete a variable to set it to nil).";
 
 dlgTriggerEditor::dlgTriggerEditor( Host * pH )
-: mCurrentAlias( 0 )
-, mCurrentTrigger( 0 )
-, mCurrentTimer( 0 )
-, mCurrentAction( 0 )
-, mCurrentScript( 0 )
-, mCurrentKey( 0 )
-, mCurrentVar( 0 )
-, mpCurrentActionItem( 0 )
+: mpCurrentActionItem( 0 )
 , mpCurrentKeyItem( 0 )
 , mpCurrentTimerItem( 0 )
 , mpCurrentScriptItem( 0 )
@@ -1736,13 +1729,13 @@ void dlgTriggerEditor::slot_addAction()
 
 void dlgTriggerEditor::slot_addVar()
 {
-    if (mCurrentVar)
+    if (mpCurrentVarItem)
         addVar(false); //add normal action
 }
 
 void dlgTriggerEditor::slot_addVarGroup()
 {
-    if (mCurrentVar)
+    if (mpCurrentVarItem)
         addVar(true);
 }
 
@@ -1815,7 +1808,7 @@ void dlgTriggerEditor::slot_deleteAlias()
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteAlias() child to be deleted doesnt have a parent";
     }
     delete pT;
-    mCurrentAlias = 0;
+    mpCurrentAliasItem = 0;
 }
 
 void dlgTriggerEditor::slot_deleteAction()
@@ -1835,15 +1828,15 @@ void dlgTriggerEditor::slot_deleteAction()
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteAction() child to be deleted doesnt have a parent";
     }
     delete pT;
-    mCurrentAction = 0;
+    mpCurrentActionItem = 0;
     mpHost->getActionUnit()->updateToolbar();
 }
 
 void dlgTriggerEditor::slot_deleteVar()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_variables->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_variables->currentItem();
     if( ! pItem ) return;
-    QTreeWidgetItem * pParent = (QTreeWidgetItem *)pItem->parent();
+    QTreeWidgetItem * pParent = pItem->parent();
     LuaInterface * lI = mpHost->getLuaInterface();
     VarUnit * vu = lI->getVarUnit();
     TVar * var = vu->getWVar( pItem );
@@ -1864,7 +1857,7 @@ void dlgTriggerEditor::slot_deleteVar()
     {
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteAction() child to be deleted doesnt have a parent";
     }
-    mCurrentVar = 0;
+    mpCurrentVarItem = 0;
 }
 
 void dlgTriggerEditor::slot_deleteScript()
@@ -1884,7 +1877,7 @@ void dlgTriggerEditor::slot_deleteScript()
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteScript() child to be deleted doesnt have a parent";
     }
     delete pT;
-    mCurrentScript = 0;
+    mpCurrentScriptItem = 0;
 }
 
 void dlgTriggerEditor::slot_deleteKey()
@@ -1905,7 +1898,7 @@ void dlgTriggerEditor::slot_deleteKey()
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteScript() child to be deleted doesnt have a parent";
     }
     delete pT;
-    mCurrentKey = 0;
+    mpCurrentKeyItem = 0;
 }
 
 void dlgTriggerEditor::slot_deleteTrigger()
@@ -1926,7 +1919,7 @@ void dlgTriggerEditor::slot_deleteTrigger()
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteTrigger() child to be deleted doesnt have a parent";
     }
     delete pT;
-    mCurrentTrigger = 0;
+    mpCurrentTriggerItem = 0;
 }
 
 void dlgTriggerEditor::slot_deleteTimer()
@@ -1949,13 +1942,13 @@ void dlgTriggerEditor::slot_deleteTimer()
         qDebug()<<"ERROR: dlgTriggerEditor::slot_deleteTimer() child to be deleted doesnt have a parent";
     }
     delete pT;
-    mCurrentTimer = 0;
+    mpCurrentTimerItem = 0;
 }
 
 
 void dlgTriggerEditor::slot_trigger_toggle_active()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_triggers->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_triggers->currentItem();
     if( ! pItem ) return;
     QIcon icon;
 
@@ -2152,7 +2145,7 @@ void dlgTriggerEditor::children_icon_triggers( QTreeWidgetItem * pWidgetItemPare
 
 void dlgTriggerEditor::slot_timer_toggle_active()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_timers->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_timers->currentItem();
     if( ! pItem ) return;
     QIcon icon;
 
@@ -2237,7 +2230,7 @@ void dlgTriggerEditor::slot_timer_toggle_active()
 
 void dlgTriggerEditor::slot_alias_toggle_active()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_aliases->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_aliases->currentItem();
     if( ! pItem ) return;
     QIcon icon;
 
@@ -2373,7 +2366,7 @@ void dlgTriggerEditor::children_icon_alias( QTreeWidgetItem * pWidgetItemParent 
 
 void dlgTriggerEditor::slot_script_toggle_active()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_scripts->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_scripts->currentItem();
     if( ! pItem ) return;
     QIcon icon;
 
@@ -2424,7 +2417,7 @@ void dlgTriggerEditor::slot_script_toggle_active()
 
 void dlgTriggerEditor::slot_action_toggle_active()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_actions->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_actions->currentItem();
     if( ! pItem ) return;
     QIcon icon;
 
@@ -2476,7 +2469,7 @@ void dlgTriggerEditor::slot_action_toggle_active()
 
 void dlgTriggerEditor::slot_key_toggle_active()
 {
-    QTreeWidgetItem * pItem = (QTreeWidgetItem *)treeWidget_keys->currentItem();
+    QTreeWidgetItem * pItem = treeWidget_keys->currentItem();
     if( ! pItem ) return;
     QIcon icon;
 
@@ -2621,7 +2614,7 @@ void dlgTriggerEditor::addTrigger( bool isFolder )
     QStringList nameL;
     nameL << name;
 
-    QTreeWidgetItem * pParent = (QTreeWidgetItem*)treeWidget_triggers->currentItem();
+    QTreeWidgetItem * pParent = treeWidget_triggers->currentItem();
     QTreeWidgetItem * pNewItem = 0;
     TTrigger * pT = 0;
 
@@ -2708,7 +2701,7 @@ void dlgTriggerEditor::addTrigger( bool isFolder )
     mpTriggersMainArea->pushButtonBgColor->setChecked( false );
     mpTriggersMainArea->colorizerTrigger->setChecked( false );
 
-    mCurrentTrigger = pNewItem;
+    mpCurrentTriggerItem = pNewItem;
     treeWidget_triggers->setCurrentItem( pNewItem );
     showInfo( msgInfoAddTrigger );
     slot_trigger_selected( treeWidget_triggers->currentItem() );
@@ -2728,7 +2721,7 @@ void dlgTriggerEditor::addTimer( bool isFolder )
     QStringList nameL;
     nameL << name;
 
-    QTreeWidgetItem * pParent = (QTreeWidgetItem*)treeWidget_timers->currentItem();
+    QTreeWidgetItem * pParent = treeWidget_timers->currentItem();
     QTreeWidgetItem * pNewItem = 0;
     TTimer * pT = 0;
 
@@ -2802,7 +2795,7 @@ void dlgTriggerEditor::addTimer( bool isFolder )
     //mpOptionsAreaTriggers->lineEdit_trigger_name->clear();
     mpTimersMainArea->lineEdit_command->clear();
     mpSourceEditor->clear();
-    mCurrentTimer = pNewItem;
+    mpCurrentTimerItem = pNewItem;
     treeWidget_timers->setCurrentItem( pNewItem );
     showInfo( msgInfoAddTimer );
     slot_timer_selected( treeWidget_timers->currentItem() );
@@ -2833,7 +2826,7 @@ void dlgTriggerEditor::addVar( bool isFolder )
     }
     QStringList nameL;
     nameL << name;
-    QTreeWidgetItem * cItem = (QTreeWidgetItem*)treeWidget_variables->currentItem();
+    QTreeWidgetItem * cItem = treeWidget_variables->currentItem();
     LuaInterface * lI = mpHost->getLuaInterface();
     VarUnit * vu = lI->getVarUnit();
     TVar * cVar = vu->getWVar( cItem );
@@ -2875,10 +2868,10 @@ void dlgTriggerEditor::addVar( bool isFolder )
     newItem->setFlags(newItem->flags() & ~(Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled ));
     if (newItem)
     {
-        mCurrentVar = (QTreeWidgetItem*)newItem;
+        mpCurrentVarItem = newItem;
         treeWidget_variables->setCurrentItem( newItem );
         showInfo( msgInfoAddVar );
-        slot_var_selected( (QTreeWidgetItem*)treeWidget_variables->currentItem() );
+        slot_var_selected( treeWidget_variables->currentItem() );
     }
 }
 
@@ -2892,7 +2885,7 @@ void dlgTriggerEditor::addKey( bool isFolder )
     QStringList nameL;
     nameL << name;
 
-    QTreeWidgetItem * pParent = (QTreeWidgetItem*)treeWidget_keys->currentItem();
+    QTreeWidgetItem * pParent = treeWidget_keys->currentItem();
     QTreeWidgetItem * pNewItem = 0;
     TKey * pT = 0;
 
@@ -2966,7 +2959,7 @@ void dlgTriggerEditor::addKey( bool isFolder )
     mpKeysMainArea->lineEdit_command->clear();
     mpKeysMainArea->lineEdit_key->setText("no key chosen");
     mpSourceEditor->clear();
-    mCurrentKey = pNewItem;
+    mpCurrentKeyItem = pNewItem;
     treeWidget_keys->setCurrentItem( pNewItem );
     showInfo( msgInfoAddKey );
     slot_key_selected( treeWidget_keys->currentItem() );
@@ -2985,7 +2978,7 @@ void dlgTriggerEditor::addAlias( bool isFolder )
     QStringList nameL;
     nameL << name;
 
-    QTreeWidgetItem * pParent = (QTreeWidgetItem*)treeWidget_aliases->currentItem();
+    QTreeWidgetItem * pParent = treeWidget_aliases->currentItem();
     QTreeWidgetItem * pNewItem = 0;
     TAlias * pT = 0;
 
@@ -3065,7 +3058,7 @@ ROOT_ALIAS:
 
     mpAliasMainArea->lineEdit_alias_name->setText( name );
 
-    mCurrentAlias = pNewItem;
+    mpCurrentAliasItem = pNewItem;
     treeWidget_aliases->setCurrentItem( pNewItem );
     showInfo(msgInfoAddAlias);
     slot_alias_selected( treeWidget_aliases->currentItem() );
@@ -3083,7 +3076,7 @@ void dlgTriggerEditor::addAction( bool isFolder )
     QStringList nameL;
     nameL << name;
 
-    QTreeWidgetItem * pParent = (QTreeWidgetItem*)treeWidget_actions->currentItem();
+    QTreeWidgetItem * pParent = treeWidget_actions->currentItem();
     QTreeWidgetItem * pNewItem = 0;
     TAction * pT = 0;
 
@@ -3168,7 +3161,6 @@ void dlgTriggerEditor::addAction( bool isFolder )
 
     mpHost->getActionUnit()->updateToolbar();
     mpCurrentActionItem = pNewItem;
-    mCurrentAction = pNewItem;
     treeWidget_actions->setCurrentItem( pNewItem );
     showInfo( msgInfoAddButton );
     slot_action_selected( treeWidget_actions->currentItem() );
@@ -3191,7 +3183,7 @@ void dlgTriggerEditor::addScript( bool isFolder )
     QStringList nameL;
     nameL << name;
 
-    QTreeWidgetItem * pParent = (QTreeWidgetItem*)treeWidget_scripts->currentItem();
+    QTreeWidgetItem * pParent = treeWidget_scripts->currentItem();
     QTreeWidgetItem * pNewItem = 0;
     TScript * pT = 0;
 
@@ -3264,7 +3256,7 @@ void dlgTriggerEditor::addScript( bool isFolder )
     mpScriptsMainArea->lineEdit_scripts_name->clear();
     //FIXME mpScriptsMainArea->pattern_textedit->clear();
     mpSourceEditor->setPlainText( script );
-    mCurrentScript = pNewItem;
+    mpCurrentScriptItem = pNewItem;
     treeWidget_scripts->setCurrentItem( pNewItem );
     slot_scripts_selected( treeWidget_scripts->currentItem() );
 }
@@ -3283,7 +3275,7 @@ void dlgTriggerEditor::saveTrigger()
 {
     QTime t;
     t.start();
-    QTreeWidgetItem * pItem = mCurrentTrigger;
+    QTreeWidgetItem * pItem = mpCurrentTriggerItem;
     if( ! pItem ) return;
     if( ! pItem->parent() ) return;
 
@@ -3447,7 +3439,7 @@ void dlgTriggerEditor::slot_saveTimerAfterEdit()
 
 void dlgTriggerEditor::saveTimer()
 {
-    QTreeWidgetItem * pItem = mCurrentTimer;
+    QTreeWidgetItem * pItem = mpCurrentTimerItem;
     if( ! pItem ) return;
     QString name = mpTimersMainArea->lineEdit_timer_name->text();
     QString script = mpSourceEditor->toPlainText();
@@ -3544,7 +3536,7 @@ void dlgTriggerEditor::slot_saveAliasAfterEdit()
 
 void dlgTriggerEditor::saveAlias()
 {
-    QTreeWidgetItem * pItem = mCurrentAlias;
+    QTreeWidgetItem * pItem = mpCurrentAliasItem;
     if( ! pItem )
     {
         return;
@@ -3678,7 +3670,7 @@ void dlgTriggerEditor::slot_saveActionAfterEdit()
 
 void dlgTriggerEditor::saveAction()
 {
-    QTreeWidgetItem * pItem = mCurrentAction;
+    QTreeWidgetItem * pItem = mpCurrentActionItem;
     if( ! pItem ) return;
 
     QString name = mpActionsMainArea->lineEdit_action_name->text();
@@ -3796,7 +3788,7 @@ void dlgTriggerEditor::slot_saveScriptAfterEdit()
 
 void dlgTriggerEditor::saveScript()
 {
-    QTreeWidgetItem * pItem = mCurrentScript;
+    QTreeWidgetItem * pItem = mpCurrentScriptItem;
     if( ! pItem ) return;
 
     QString old_name;
@@ -3946,10 +3938,10 @@ void dlgTriggerEditor::saveVar()
     // we add a new variable
     // we switch away from a variable (so we are saving the old variable)
 
-    if (!mCurrentVar)
+    if (!mpCurrentVarItem)
         return;
-    QTreeWidgetItem * pItem = (QTreeWidgetItem*)mCurrentVar;
-    if (!pItem || !pItem->parent() )
+    QTreeWidgetItem * pItem = mpCurrentVarItem;
+    if (!pItem->parent())
         return;
     LuaInterface * lI = mpHost->getLuaInterface();
     VarUnit * vu = lI->getVarUnit();
@@ -4008,7 +4000,7 @@ void dlgTriggerEditor::saveVar()
             vu->addTreeItem( pItem, var );
             vu->removeTempVar( pItem );
             pItem->setText( 0, newName );
-            mCurrentVar = 0;
+            mpCurrentVarItem = 0;
         }
         else if ( var )
         {
@@ -4054,7 +4046,7 @@ void dlgTriggerEditor::saveVar()
                     if ( ( var->getValueType() != LUA_TTABLE && change&0x2 ) || newVar )
                         lI->setValue( var );
                     pItem->setText( 0, newName );
-                    mCurrentVar = 0;
+                    mpCurrentVarItem = 0;
                 }
                 else
                     var->clearNewName();
@@ -4074,7 +4066,7 @@ void dlgTriggerEditor::saveVar()
             vu->addVariable(var);
             vu->addTreeItem( pItem, var );
             pItem->setText( 0, newName );
-            mCurrentVar = 0;
+            mpCurrentVarItem = 0;
         }
         else if ( var )
         {
@@ -4115,7 +4107,7 @@ void dlgTriggerEditor::saveVar()
                 if ( change&0x2 || newVar )
                     lI->setValue( var );
                 pItem->setText( 0, newName );
-                mCurrentVar = 0;
+                mpCurrentVarItem = 0;
             }
         }
     }
@@ -4154,7 +4146,7 @@ void dlgTriggerEditor::saveVar()
 
 void dlgTriggerEditor::saveKey()
 {
-    QTreeWidgetItem * pItem = mCurrentKey;
+    QTreeWidgetItem * pItem = mpCurrentKeyItem;
     if( ! pItem ) return;
 
     QString name = mpKeysMainArea->lineEdit_name->text();
@@ -4300,10 +4292,10 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current trigger before switching to the new one
-    if ( pItem != mCurrentTrigger )
+    if ( pItem != mpCurrentTriggerItem )
         saveTrigger();
 
-    mCurrentTrigger = pItem;
+    mpCurrentTriggerItem = pItem;
     mpTriggersMainArea->show();
     mpSourceEditorArea->show();
     mpSystemMessageArea->hide();
@@ -4313,7 +4305,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem *pItem)
     mpTriggersMainArea->perlSlashGOption->setChecked( false );
     mpTriggersMainArea->filterTrigger->setChecked( false );
     mpTriggersMainArea->spinBox_linemargin->setValue( 1 );
-    if( pItem == 0 ) return;
+
     int ID = pItem->data( 0, Qt::UserRole ).toInt();
     TTrigger * pT = mpHost->getTriggerUnit()->getTrigger( ID );
     if( pT )
@@ -4454,10 +4446,10 @@ void dlgTriggerEditor::slot_alias_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current alias before switching to the new one
-    if ( pItem != mCurrentAlias )
+    if ( pItem != mpCurrentAliasItem )
         saveAlias();
 
-    mCurrentAlias = pItem;
+    mpCurrentAliasItem = pItem;
     mpAliasMainArea->show();
     mpSourceEditorArea->show();
     mpSystemMessageArea->hide();
@@ -4466,10 +4458,6 @@ void dlgTriggerEditor::slot_alias_selected(QTreeWidgetItem *pItem)
     mpAliasMainArea->substitution->clear();
     mpSourceEditor->setPlainText( "" );
 
-    if( pItem == 0 )
-    {
-        return;
-    }
     mpAliasMainArea->lineEdit_alias_name->setText(pItem->text(0));
     int ID = pItem->data(0,Qt::UserRole).toInt();
     TAlias * pT = mpHost->getAliasUnit()->getAlias(ID);
@@ -4498,10 +4486,10 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current key before switching to the new one
-    if ( pItem != mCurrentKey )
+    if ( pItem != mpCurrentKeyItem )
         saveKey();
 
-    mCurrentKey = pItem;
+    mpCurrentKeyItem = pItem;
     mpKeysMainArea->show();
     mpSourceEditorArea->show();
     mpSystemMessageArea->hide();
@@ -4509,10 +4497,7 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem *pItem)
     mpKeysMainArea->lineEdit_key->clear();
     mpKeysMainArea->lineEdit_name->clear();
     mpSourceEditor->setPlainText( "" );
-    if( pItem == 0 )
-    {
-        return;
-    }
+
     mpKeysMainArea->lineEdit_key->setText( pItem->text(0) );
     int ID = pItem->data( 0, Qt::UserRole ).toInt();
     TKey * pT = mpHost->getKeyUnit()->getKey(ID);
@@ -4531,7 +4516,8 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem *pItem)
     }
 }
 
-void dlgTriggerEditor::recurseVariablesUp( QTreeWidgetItem *pItem, QList< QTreeWidgetItem * > & list)
+// This should not modify the contents of what pItem points at:
+void dlgTriggerEditor::recurseVariablesUp( QTreeWidgetItem * const pItem, QList< QTreeWidgetItem * > & list)
 {
     QTreeWidgetItem * pParent = pItem->parent();
     if ( pParent && pParent != mpVarBaseItem )
@@ -4541,7 +4527,8 @@ void dlgTriggerEditor::recurseVariablesUp( QTreeWidgetItem *pItem, QList< QTreeW
     }
 }
 
-void dlgTriggerEditor::recurseVariablesDown( QTreeWidgetItem *pItem, QList< QTreeWidgetItem * > & list)
+// This should not modify the contents of what pItem points at:
+void dlgTriggerEditor::recurseVariablesDown( QTreeWidgetItem * const pItem, QList< QTreeWidgetItem * > & list)
 {
     list.append( pItem );
     for(int i=0;i<pItem->childCount();++i)
@@ -4626,7 +4613,7 @@ void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current variable before switching to the new one
-    if ( pItem != mCurrentVar )
+    if ( pItem != mpCurrentVarItem )
         saveVar();
 
     mChangingVar = true;
@@ -4636,11 +4623,11 @@ void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *pItem)
     {
         LuaInterface * lI = mpHost->getLuaInterface();
         VarUnit * vu = lI->getVarUnit();
-        TVar * var = vu->getWVar(pItem);
+        TVar * var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
         if ( var )
             vu->addSavedVar( var );
         QList< QTreeWidgetItem * > list;
-        recurseVariablesUp( pItem, list );
+        recurseVariablesUp( pItem, list ); // This does NOT modify pItem or what it points at
         for(int i=0;i<list.size();i++)
         {
             TVar * v = vu->getWVar( list[i] );
@@ -4649,7 +4636,7 @@ void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *pItem)
                 vu->addSavedVar( v );
         }
         list.clear();
-        recurseVariablesDown( pItem, list );
+        recurseVariablesDown( pItem, list ); // This does NOT modify pItem or what it points at
         for(int i=0;i<list.size();i++)
         {
             TVar * v = vu->getWVar( list[i] );
@@ -4662,11 +4649,11 @@ void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *pItem)
     {
         LuaInterface * lI = mpHost->getLuaInterface();
         VarUnit * vu = lI->getVarUnit();
-        TVar * var = vu->getWVar(pItem);
+        TVar * var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
         if ( var )
             vu->removeSavedVar( var );
         QList< QTreeWidgetItem * > list;
-        recurseVariablesUp( pItem, list );
+        recurseVariablesUp( pItem, list ); // This does NOT modify pItem or what it points at
         for(int i=0;i<list.size();i++)
         {
             TVar * v = vu->getWVar( list[i] );
@@ -4676,7 +4663,7 @@ void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *pItem)
             }
         }
         list.clear();
-        recurseVariablesDown( pItem, list );
+        recurseVariablesDown( pItem, list ); // This does NOT modify pItem or what it points at
         for(int i=0;i<list.size();i++)
         {
             TVar * v = vu->getWVar( list[i] );
@@ -4688,13 +4675,15 @@ void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *pItem)
     }
     mpVarsMainArea->show();
 
-    mCurrentVar = pItem;
-    if( (pItem == 0) || (column != 0) )
+    mpCurrentVarItem = pItem; //remember what has been clicked to save it
+    // There was repeated test for pItem being null here but we have NOT altered
+    // it since the start of the function where it was already tested for not
+    // being zero so we don't need to retest it! - Slysven
+    if( column )
     {
         mChangingVar = false;
         return;
     }
-    mpCurrentVarItem = pItem; //remember what has been clicked to save it
     LuaInterface * lI = mpHost->getLuaInterface();
     VarUnit * vu = lI->getVarUnit();
     TVar * var = vu->getWVar(pItem);
@@ -4790,10 +4779,9 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current action before switching to the new one
-    if ( pItem != mCurrentAction )
+    if ( pItem != mpCurrentActionItem )
         saveAction();
 
-    mCurrentAction = pItem;
     mpActionsMainArea->show();
     mpSourceEditor->show();
 
@@ -4805,10 +4793,7 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem *pItem)
     mpActionsMainArea->checkBox_pushdownbutton->setChecked( false );
     mpActionsMainArea->buttonColumns->clear();
     mpActionsMainArea->css->clear();
-    if( pItem == 0 )
-    {
-        return;
-    }
+
     mpCurrentActionItem = pItem; //remember what has been clicked to save it
     int ID = pItem->data(0,Qt::UserRole).toInt();
     TAction * pT = mpHost->getActionUnit()->getAction(ID);
@@ -4875,20 +4860,17 @@ void dlgTriggerEditor::slot_scripts_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current script before switching to the new one
-    if ( pItem != mCurrentScript )
+    if ( pItem != mpCurrentScriptItem )
         saveScript();
 
-    mCurrentScript = pItem;
+    mpCurrentScriptItem = pItem;
     mpScriptsMainArea->show();
     mpSourceEditorArea->show();
     mpSystemMessageArea->hide();
     mpSourceEditor->setPlainText( "" );
     mpScriptsMainArea->lineEdit_scripts_name->clear();
     mpScriptsMainArea->listWidget_registered_event_handlers->clear();
-    if( pItem == 0 )
-    {
-        return;
-    }
+
     mpScriptsMainArea->listWidget_registered_event_handlers->clear();
     mpScriptsMainArea->lineEdit_scripts_name->setText(pItem->text(0));
     int ID = pItem->data(0,Qt::UserRole).toInt();
@@ -4916,10 +4898,10 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem *pItem)
     if( ! pItem ) return;
 
     // save the current timer before switching to the new one
-    if ( pItem != mCurrentTimer )
+    if ( pItem != mpCurrentTimerItem )
         saveTimer();
 
-    mCurrentTimer = pItem;
+    mpCurrentTimerItem = pItem;
     mpTimersMainArea->show();
     mpSourceEditorArea->show();
     mpSystemMessageArea->hide();
@@ -4930,10 +4912,7 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem *pItem)
     mpTimersMainArea->timeEdit_minutes->clear();
     mpTimersMainArea->timeEdit_seconds->clear();
     mpTimersMainArea->timeEdit_msecs->clear();
-    if( pItem == 0 )
-    {
-        return;
-    }
+
     mpTimersMainArea->lineEdit_timer_name->setText(pItem->text(0));
     int ID = pItem->data( 0, Qt::UserRole ).toInt();
     TTimer * pT = mpHost->getTimerUnit()->getTimer( ID );
@@ -4975,18 +4954,18 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem *pItem)
 void dlgTriggerEditor::fillout_form()
 {
     mCurrentView = 0;
-    mCurrentTrigger = 0;
-    mCurrentAlias = 0;
-    mCurrentKey = 0;
-    mCurrentAction = 0;
-    mCurrentScript = 0;
-    mCurrentTimer = 0;
-    mCurrentVar = 0;
+    mpCurrentTriggerItem = 0;
+    mpCurrentAliasItem = 0;
+    mpCurrentKeyItem = 0;
+    mpCurrentActionItem = 0;
+    mpCurrentScriptItem = 0;
+    mpCurrentTimerItem = 0;
+    mpCurrentVarItem = 0;
 
     mNeedUpdateData = false;
     QStringList sL;
     sL << "Triggers";
-    mpTriggerBaseItem = new QTreeWidgetItem( (QTreeWidgetItem*)0, sL );
+    mpTriggerBaseItem = new QTreeWidgetItem( static_cast<QTreeWidgetItem *>(0), sL );
     mpTriggerBaseItem->setBackground(0,QColor(255,254,215,255));
     QIcon mainIcon;
     mainIcon.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-wizard.png" ) ), QIcon::Normal, QIcon::Off );
@@ -5007,7 +4986,7 @@ void dlgTriggerEditor::fillout_form()
         QIcon icon;
         if( pT->hasChildren() )
         {
-            expand_child_triggers( pT, (QTreeWidgetItem*)pItem );
+            expand_child_triggers( pT, pItem );
         }
         if( pT->state() )
         {
@@ -5112,7 +5091,7 @@ void dlgTriggerEditor::fillout_form()
 
     QStringList sL2;
     sL2 << "Timers";
-    mpTimerBaseItem = new QTreeWidgetItem( (QTreeWidgetItem*)0, sL2 );
+    mpTimerBaseItem = new QTreeWidgetItem( static_cast<QTreeWidgetItem *>(0), sL2 );
     mpTimerBaseItem->setBackground(0,QColor(255,254,215,255));
     QIcon mainIcon2;
     mainIcon2.addPixmap( QPixmap( QStringLiteral( ":/icons/chronometer.png" ) ), QIcon::Normal, QIcon::Off );
@@ -5134,7 +5113,7 @@ void dlgTriggerEditor::fillout_form()
         QIcon icon;
         if( pT->hasChildren() )
         {
-            expand_child_timers( pT, (QTreeWidgetItem*)pItem );
+            expand_child_timers( pT, pItem );
         }
         if( pT->state() )
         {
@@ -5200,7 +5179,7 @@ void dlgTriggerEditor::fillout_form()
 
     QStringList sL3;
     sL3 << "Scripts";
-    mpScriptsBaseItem = new QTreeWidgetItem( (QTreeWidgetItem*)0, sL3 );
+    mpScriptsBaseItem = new QTreeWidgetItem( static_cast<QTreeWidgetItem *>(0), sL3 );
     mpScriptsBaseItem->setBackground(0,QColor(255,254,215,255));
     QIcon mainIcon3;
     mainIcon3.addPixmap( QPixmap( QStringLiteral( ":/icons/accessories-text-editor.png" ) ), QIcon::Normal, QIcon::Off );
@@ -5222,7 +5201,7 @@ void dlgTriggerEditor::fillout_form()
         QIcon icon;
         if( pT->hasChildren() )
         {
-            expand_child_scripts( pT, (QTreeWidgetItem*)pItem );
+            expand_child_scripts( pT, pItem );
         }
         if( pT->state() )
         {
@@ -5273,7 +5252,7 @@ void dlgTriggerEditor::fillout_form()
 
     QStringList sL4;
     sL4 << "Aliases - Input Triggers";
-    mpAliasBaseItem = new QTreeWidgetItem( (QTreeWidgetItem*)0, sL4 );
+    mpAliasBaseItem = new QTreeWidgetItem( static_cast<QTreeWidgetItem *>(0), sL4 );
     mpAliasBaseItem->setBackground(0,QColor(255,254,215,255));
     QIcon mainIcon4;
     mainIcon4.addPixmap( QPixmap( QStringLiteral( ":/icons/system-users.png" ) ), QIcon::Normal, QIcon::Off );
@@ -5294,7 +5273,7 @@ void dlgTriggerEditor::fillout_form()
         QIcon icon;
         if( pT->hasChildren() )
         {
-            expand_child_alias( pT, (QTreeWidgetItem*)pItem );
+            expand_child_alias( pT, pItem );
         }
         if( pT->state() )
         {
@@ -5373,7 +5352,7 @@ void dlgTriggerEditor::fillout_form()
 
     QStringList sL5;
     sL5 << "Buttons";
-    mpActionBaseItem = new QTreeWidgetItem( (QTreeWidgetItem*)0, sL5 );
+    mpActionBaseItem = new QTreeWidgetItem( static_cast<QTreeWidgetItem *>(0), sL5 );
     mpActionBaseItem->setBackground(0,QColor(255,254,215,255));
     QIcon mainIcon5;
     mainIcon5.addPixmap( QPixmap( QStringLiteral( ":/icons/bookmarks.png" ) ), QIcon::Normal, QIcon::Off );
@@ -5394,7 +5373,7 @@ void dlgTriggerEditor::fillout_form()
         QIcon icon;
         if( pT->hasChildren() )
         {
-            expand_child_action( pT, (QTreeWidgetItem*)pItem );
+            expand_child_action( pT, pItem );
         }
         if( pT->state() )
         {
@@ -5470,7 +5449,7 @@ void dlgTriggerEditor::fillout_form()
 
     QStringList sL6;
     sL6 << "Action Key Bindings";
-    mpKeyBaseItem = new QTreeWidgetItem( (QTreeWidgetItem*)0, sL6 );
+    mpKeyBaseItem = new QTreeWidgetItem( static_cast<QTreeWidgetItem *>(0), sL6 );
     mpKeyBaseItem->setBackground(0,QColor(255,254,215,255));
     QIcon mainIcon6;
     mainIcon6.addPixmap( QPixmap( QStringLiteral( ":/icons/preferences-desktop-keyboard.png" ) ), QIcon::Normal, QIcon::Off );
@@ -5491,7 +5470,7 @@ void dlgTriggerEditor::fillout_form()
         QIcon icon;
         if( pT->hasChildren() )
         {
-            expand_child_key( pT, (QTreeWidgetItem*)pItem );
+            expand_child_key( pT, pItem );
         }
         if( pT->state() )
         {
@@ -5581,7 +5560,7 @@ void dlgTriggerEditor::repopulateVars()
     mainIcon5.addPixmap( QPixmap( QStringLiteral( ":/icons/variables.png" ) ), QIcon::Normal, QIcon::Off );
     mpVarBaseItem->setIcon( 0, mainIcon5 );
     treeWidget_variables->clear();
-    mCurrentVar = 0;
+    mpCurrentVarItem = 0;
     treeWidget_variables->insertTopLevelItem( 0, mpVarBaseItem );
     mpVarBaseItem->setExpanded( true );
     LuaInterface * lI = mpHost->getLuaInterface();
@@ -6106,27 +6085,27 @@ void dlgTriggerEditor::focusInEvent( QFocusEvent * pE )
 
     if( ! mCurrentView )
     {
-        mCurrentTrigger = 0;
-        mCurrentAlias = 0;
-        mCurrentKey = 0;
-        mCurrentAction = 0;
-        mCurrentScript = 0;
-        mCurrentTimer = 0;
+        mpCurrentTriggerItem = 0;
+        mpCurrentAliasItem = 0;
+        mpCurrentKeyItem = 0;
+        mpCurrentActionItem = 0;
+        mpCurrentScriptItem = 0;
+        mpCurrentTimerItem = 0;
         return;
     }
 
-    if( mCurrentTrigger )
-        mCurrentTrigger->setSelected( true );
-    if( mCurrentTimer )
-        mCurrentTimer->setSelected( true );
-    if( mCurrentAlias )
-        mCurrentAlias->setSelected( true );
-    if( mCurrentScript )
-        mCurrentScript->setSelected( true );
-    if( mCurrentAction )
-        mCurrentAction->setSelected( true );
-    if( mCurrentKey )
-        mCurrentKey->setSelected( true );
+    if( mpCurrentTriggerItem )
+        mpCurrentTriggerItem->setSelected( true );
+    if( mpCurrentTimerItem )
+        mpCurrentTimerItem->setSelected( true );
+    if( mpCurrentAliasItem )
+        mpCurrentAliasItem->setSelected( true );
+    if( mpCurrentScriptItem )
+        mpCurrentScriptItem->setSelected( true );
+    if( mpCurrentActionItem )
+        mpCurrentActionItem->setSelected( true );
+    if( mpCurrentKeyItem )
+        mpCurrentKeyItem->setSelected( true );
 }
 
 void dlgTriggerEditor::focusOutEvent( QFocusEvent * pE )
@@ -6295,7 +6274,7 @@ void dlgTriggerEditor::slot_show_vars( )
 {
     changeView( cmVarsView );
     repopulateVars();
-    mCurrentVar = 0;
+    mpCurrentVarItem = 0;
     mpSourceEditorArea->show();
     button_displayAllVariables->show();
     button_displayAllVariables->setChecked( showHiddenVars );
@@ -6305,7 +6284,7 @@ void dlgTriggerEditor::slot_show_vars( )
         if( pI->childCount() > 0 )
         {
             mpVarsMainArea->show();
-            slot_var_selected( (QTreeWidgetItem*)treeWidget_variables->currentItem() );
+            slot_var_selected( treeWidget_variables->currentItem() );
         }
         else
         {
@@ -6325,7 +6304,7 @@ void dlgTriggerEditor::show_vars( )
 {
     //no repopulation of variables
     changeView( cmVarsView );
-    mCurrentVar = 0;
+    mpCurrentVarItem = 0;
     mpSourceEditorArea->show();
     button_displayAllVariables->show();
     button_displayAllVariables->setChecked( showHiddenVars );
@@ -6335,7 +6314,7 @@ void dlgTriggerEditor::show_vars( )
         if( pI->childCount() > 0 )
         {
             mpVarsMainArea->show();
-            slot_var_selected( (QTreeWidgetItem*)treeWidget_variables->currentItem() );
+            slot_var_selected( treeWidget_variables->currentItem() );
         }
         else
         {
@@ -7023,12 +7002,12 @@ void dlgTriggerEditor::slot_import()
 
     fillout_form();
 
-    mCurrentTrigger = 0;
-    mCurrentTimer = 0;
-    mCurrentAlias = 0;
-    mCurrentScript = 0;
-    mCurrentAction = 0;
-    mCurrentKey = 0;
+    mpCurrentTriggerItem = 0;
+    mpCurrentTimerItem = 0;
+    mpCurrentAliasItem = 0;
+    mpCurrentScriptItem = 0;
+    mpCurrentActionItem = 0;
+    mpCurrentKeyItem = 0;
 
     slot_show_triggers();
 }
@@ -7066,12 +7045,12 @@ void dlgTriggerEditor::doCleanReset()
     treeWidget_keys->clear();
     treeWidget_scripts->clear();
     fillout_form();
-    mCurrentTrigger = 0;
-    mCurrentTimer = 0;
-    mCurrentAlias = 0;
-    mCurrentScript = 0;
-    mCurrentAction = 0;
-    mCurrentKey = 0;
+    mpCurrentTriggerItem = 0;
+    mpCurrentTimerItem = 0;
+    mpCurrentAliasItem = 0;
+    mpCurrentScriptItem = 0;
+    mpCurrentActionItem = 0;
+    mpCurrentKeyItem = 0;
     slot_show_triggers();
 }
 
@@ -7188,7 +7167,7 @@ void dlgTriggerEditor::slot_chose_action_icon()
 
 void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
 {
-    QTreeWidgetItem * pItem = mCurrentTrigger;
+    QTreeWidgetItem * pItem = mpCurrentTriggerItem;
     if( ! pItem ) return;
     if( ! pItem->parent() ) return;
 
@@ -7205,7 +7184,7 @@ void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
 
 void dlgTriggerEditor::slot_colorizeTriggerSetBgColor()
 {
-    QTreeWidgetItem * pItem = mCurrentTrigger;
+    QTreeWidgetItem * pItem = mpCurrentTriggerItem;
     if( ! pItem ) return;
     if( ! pItem->parent() ) return;
 
@@ -7230,7 +7209,7 @@ void dlgTriggerEditor::slot_soundTrigger()
 
 void dlgTriggerEditor::slot_color_trigger_fg()
 {
-    QTreeWidgetItem * pItem = mCurrentTrigger;
+    QTreeWidgetItem * pItem = mpCurrentTriggerItem;
     if( ! pItem )
     {
         return;
@@ -7282,7 +7261,7 @@ void dlgTriggerEditor::slot_color_trigger_fg()
 
 void dlgTriggerEditor::slot_color_trigger_bg()
 {
-    QTreeWidgetItem * pItem = mCurrentTrigger;
+    QTreeWidgetItem * pItem = mpCurrentTriggerItem;
     if( ! pItem )
     {
         return;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -103,8 +103,8 @@ public:
     bool                        showHiddenVars;
     TConsole *                  mpErrorConsole;
     void                        changeView( int );
-    void                        recurseVariablesUp( QTreeWidgetItem *, QList< QTreeWidgetItem * > & );
-    void                        recurseVariablesDown( QTreeWidgetItem *, QList< QTreeWidgetItem * > & );
+    void                        recurseVariablesUp( QTreeWidgetItem * const, QList< QTreeWidgetItem * > & );
+    void                        recurseVariablesDown( QTreeWidgetItem * const, QList< QTreeWidgetItem * > & );
     void                        recurseVariablesDown( TVar *, QList< TVar * > &, bool );
     void                        show_vars( );
 
@@ -235,13 +235,6 @@ private:
     void                        exportAction( QFile & );
     void                        exportScript( QFile & );
     void                        exportKey( QFile & );
-    QTreeWidgetItem *           mCurrentAlias;
-    QTreeWidgetItem *           mCurrentTrigger;
-    QTreeWidgetItem *           mCurrentTimer;
-    QTreeWidgetItem *           mCurrentAction;
-    QTreeWidgetItem *           mCurrentScript;
-    QTreeWidgetItem *           mCurrentKey;
-    QTreeWidgetItem *           mCurrentVar;
 
     QTreeWidgetItem *           mpAliasBaseItem;
     QTreeWidgetItem *           mpTriggerBaseItem;


### PR DESCRIPTION
Whilst looking at a different issue I spotted that there were two sets of pointers in the `dlgTriggerEditor` class that were intended to track the "current" item in each of Aliases, Buttons ("Actions"), Keys, Scripts, Timers, Triggers and Variables.  The more appropriately named `mpCurrentXXXXItem` ones were largely unused and the `mCurrentXXXX` ones were mainly used.  However in the case of the ones for Variables the mixing of the use of both of them, may, I thought, have resulted in some oddities in hiding and un-hiding of variables that I previously remembered happening.

In fact it doesn't but that is another story...

Also:
* Found some systematic duplicate checks in code for Aliases, Keys etc. for a `QTreeWidgetItem` pointer being non-null which I was able to remove. I then spotted a similar test in some Variable handling code in:
`(void) dlgTriggerEditor::slot_var_selected(QTreeWidgetItem *)`
but there were several calls to other methods which used the pointer as an argument and it was not immediately clear whether they would modify the pointer value or it's pointee.  Further investigation enable me to add some `const` qualifiers to those methods which revealed that the address stored in the pointer was not going to be changed so that the second test in the method was redundant.

* There was some unneeded C-Style casts in this class and in the cases where a cast was needed to resolve signature ambiguities for the compiler it is better to use a `static_cast` in C++ code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>