### PR TITLE
Added: ctrl/timestamp + click to select entire lines

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2014, 2016 by Stephen Lyons - slysven@virginmedia.com   *
- *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -983,18 +983,7 @@ void TTextEdit::mouseMoveEvent( QMouseEvent * event )
     {
         mpConsole->scrollDown( 3 );
     }
-
-    int timeOffset = 0;
-    y = ( event->y() / mFontHeight ) + imageTopLine();
-    if( mShowTimeStamps )
-    {
-        if( mpBuffer->timeBuffer.size() > y )
-        {
-            timeOffset = 13;
-        }
-    }
-    x = ( event->x() / mFontWidth ) - timeOffset;
-    if( ( y < 0 ) || ( y > (int) mpBuffer->size()-1 ) )
+    if( ( y > (int) mpBuffer->size()-1 ) )
     {
         return;
     }
@@ -1006,14 +995,14 @@ void TTextEdit::mouseMoveEvent( QMouseEvent * event )
         int oldAY = mPA.y();
         int oldBY = mPB.y();
         if( PC.y() == mDragStartY ){
-          mPA.setY( PC.y() );
-          mPB.setY( PC.y() );
+            mPA.setY( PC.y() );
+            mPB.setY( PC.y() );
         } else if( PC.y() < mDragStartY ){
-          mPA.setY( PC.y() );
-          mPB.setY( mDragStartY );
+            mPA.setY( PC.y() );
+            mPB.setY( mDragStartY );
         } else if( PC.y() > mDragStartY ){
-          mPA.setY( mDragStartY );
-          mPB.setY( PC.y() );
+            mPA.setY( mDragStartY );
+            mPB.setY( PC.y() );
         }
         
         if( oldAY < mPA.y() ){
@@ -1024,11 +1013,11 @@ void TTextEdit::mouseMoveEvent( QMouseEvent * event )
           }
         }
         if( oldBY > mPB.y() ){
-          for( int y = mPB.y()+1; y <= oldBY; y++ ){
-            for( int x = 0; x < static_cast<int>(mpBuffer->buffer[y].size()); x++ ){
-              mpBuffer->buffer[y][x].flags &= ~(TCHAR_INVERSE);
+            for( int y = mPB.y()+1; y <= oldBY; y++ ){
+                for( int x = 0; x < static_cast<int>(mpBuffer->buffer[y].size()); x++ ){
+                    mpBuffer->buffer[y][x].flags &= ~(TCHAR_INVERSE);
+                }
             }
-          }
         }
         
         mPA.setX( 0 );
@@ -1189,12 +1178,14 @@ void TTextEdit::mousePressEvent( QMouseEvent * event )
     if( event->button() == Qt::LeftButton )
     {
         if( QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier) ) {
-          mCtrlSelecting = true;
+            mCtrlSelecting = true;
         }
         int x = event->x() / mFontWidth;
         if( mShowTimeStamps )
         {
-            if( x < 13 ) mCtrlSelecting = true;
+            if( x < 13 ) {
+                mCtrlSelecting = true;
+            }
             x -= 13;
         }
         int y = ( event->y() / mFontHeight ) + imageTopLine();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2,6 +2,7 @@
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2014, 2016 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1177,7 +1177,7 @@ void TTextEdit::mousePressEvent( QMouseEvent * event )
     }
     if( event->button() == Qt::LeftButton )
     {
-        if( QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier) ) {
+        if( event->modifiers() & Qt::ControlModifier ) {
             mCtrlSelecting = true;
         }
         int x = event->x() / mFontWidth;
@@ -1239,8 +1239,8 @@ void TTextEdit::mousePressEvent( QMouseEvent * event )
             if ( xind > 0 ||
                  mpHost->mDoubleClickIgnore.contains(mpBuffer->lineBuffer[yind].at( xind ) ) )
                 mPA.setX ( xind+1 );
-            else if ( xind > 0 )
-                mPA.setX ( xind );
+            else
+                mPA.setX ( qMax( 0, xind ) );
             mPA.setY ( yind );
             highlight();
             event->accept();

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -141,6 +141,8 @@ private:
     int               mLastRenderBottom;
     int               mLeftMargin;
     bool              mMouseTracking;
+    bool              mCtrlSelecting;
+    int               mDragStartY;
     int               mOldScrollPos;
     QPoint            mP_aussen;
     QPoint            mPA;


### PR DESCRIPTION
This PR adds the ability to select entire lines at a time through ctrl+click and timestamp clicking. Dragging across lines is functional as well.

(also includes the bugfix in
https://bugs.launchpad.net/mudlet/+bug/1408198 that was never added to
the development branch)