### PR TITLE
Bugfix: equalizes mouse-drag scroll margins on TConsoles

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -978,7 +978,7 @@ void TTextEdit::mouseMoveEvent( QMouseEvent * event )
     {
         mpConsole->scrollUp( 3 );
     }
-    if( event->y() > height()-10 )
+    if( event->y() >= height()-10 )
     {
         mpConsole->scrollDown( 3 );
     }


### PR DESCRIPTION
The set of conditionals that control when the mouse is close enough to the edge to scroll a console was uneven. Because height() is not zero-based, the scrollDown margin was 9.