### PR TITLE
Enhance: restore version check to Mudlet XMLimport code

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,6 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,6 +37,10 @@
 
 
 using namespace std;
+
+const QString XMLexport::scmMudletXmlVersionString = QString::number( 1.0f, 'f', 3 );
+// Previously hardcode to "1.0" and not tested/used, now uses three decimal
+// places, can be "0.000" to "255.999"
 
 XMLexport::XMLexport( Host * pH )
 : mpHost( pH )
@@ -94,13 +99,14 @@ XMLexport::XMLexport( TKey * pT )
     setAutoFormatting(true);
 }
 
-bool XMLexport::writeModuleXML( QIODevice * device, QString moduleName){
+bool XMLexport::writeModuleXML( QIODevice * device, QString moduleName)
+{
     setDevice(device);
     writeStartDocument();
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "TriggerPackage" );
     Host * pT = mpHost;
@@ -216,7 +222,7 @@ bool XMLexport::exportHost( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "HostPackage" );
     writeHost( mpHost );
@@ -495,7 +501,7 @@ bool XMLexport::exportGenericPackage( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeGenericPackage( mpHost );
 
@@ -578,7 +584,7 @@ bool XMLexport::exportTrigger( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "TriggerPackage" );
     writeTrigger( mpTrigger );
@@ -663,7 +669,7 @@ bool XMLexport::exportAlias( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "AliasPackage" );
     writeAlias( mpAlias );
@@ -717,7 +723,7 @@ bool XMLexport::exportAction( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "ActionPackage" );
     writeAction( mpAction );
@@ -787,7 +793,7 @@ bool XMLexport::exportTimer( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "TimerPackage" );
     writeTimer( mpTimer );
@@ -844,7 +850,7 @@ bool XMLexport::exportScript( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "ScriptPackage" );
     writeScript( mpScript );
@@ -904,7 +910,7 @@ bool XMLexport::exportKey( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "KeyPackage" );
     writeKey( mpKey );

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -81,6 +82,7 @@ public:
     bool            exportKey( TKey * );
 
 private:
+    static const QString    scmMudletXmlVersionString;
     QPointer<Host>  mpHost;
     TTrigger *      mpTrigger;
     TTimer *        mpTimer;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -41,6 +41,7 @@
 #include "pre_guard.h"
 #include <QStringList>
 #include <QDebug>
+#include <QtMath>
 #include "post_guard.h"
 
 
@@ -63,10 +64,12 @@ XMLimport::XMLimport( Host * pH )
 , module( 0 )
 , mMaxRoomId( 0 )
 , mMaxAreaId( -1 )
+, mVersionMajor( 0 ) // 0 to 255
+, mVersionMinor( 0 ) // 0 to 999 for 3 digit decimal value
 {
 }
 
-bool XMLimport::importPackage( QIODevice * device, QString packName, int moduleFlag )
+bool XMLimport::importPackage( QIODevice * device, QString packName, int moduleFlag, QString * pVersionString )
 {
     mPackageName = packName;
     setDevice( device );
@@ -151,8 +154,47 @@ bool XMLimport::importPackage( QIODevice * device, QString packName, int moduleF
 
         if( isStartElement() )
         {
-            if( name() == "MudletPackage" )
+            if( name() == QStringLiteral( "MudletPackage" ) )
             {
+                QString versionString;
+                if( attributes().hasAttribute( QStringLiteral( "version" ) ) ) {
+                    versionString = attributes().value( QStringLiteral( "version" ) ).toString();
+                    if( ! versionString.isEmpty() ) {
+                        bool isOk = false;
+                        float versionNumber = versionString.toFloat( &isOk );
+                        if( isOk ) {
+                            mVersionMajor = qFloor( versionNumber );
+                            mVersionMinor = qRound( 1000.0 * versionNumber ) - ( 1000 * mVersionMajor );
+                        }
+                        if( pVersionString ) {
+                            *pVersionString = versionString;
+                        }
+                    }
+                }
+
+                if( ( mVersionMajor > 1 )
+                 || ( mVersionMajor == 1 && mVersionMinor ) ) {
+
+                    // Non-previous default of "1.0" encountered
+                    // since we currently haven't coded anything for
+                    // higher then moan, but do not stop, processing
+                    QString moanMsg = tr( "[ ALERT ] - detected file being read is a later version (%1) than this version\n"
+                                                      "of Mudlet expects!  It is possible that further issues may be found\n"
+                                                      "or it may still load and work properly, this is merely an advisory\n"
+                                                      "message!" )
+                                      .arg( versionString );
+                    mpHost->postMessage( moanMsg );
+                }
+                else if( !( mVersionMajor || mVersionMinor ) ) {
+
+                    // No version string in Xml data - also moan
+                    QString moanMsg = tr( "[ ALERT ] - detected file being read has no version data whereas this version\n"
+                                                      "of Mudlet expects a marking of 1.000!  This is merely an advisory\n"
+                                                      "message coming about because this detail is now checked in case\n"
+                                                      "changes are made in the future that would cause problems for then\n"
+                                                      "older forms such as this current instance of the Mudlet application." );
+                    mpHost->postMessage( moanMsg );
+                }
                 readPackage();
             }
             else if( name() == "map" )
@@ -2112,4 +2154,11 @@ void XMLimport::readIntegerList( QList<int> & list )
             }
         }
     }
+}
+
+// This will be a string representation of a decimal float with three places of
+// decimals
+void XMLimport::getVersionString( QString & versionString )
+{
+    versionString = QString::number( static_cast<float>( mVersionMajor + 1000.0f * mVersionMinor ), 'f', 3 );
 }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -41,7 +41,11 @@
 #include "pre_guard.h"
 #include <QStringList>
 #include <QDebug>
+#if QT_VERSION > 0x050002
 #include <QtMath>
+#else
+#include <QtCore/qmath.h>
+#endif
 #include "post_guard.h"
 
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -2164,5 +2164,5 @@ void XMLimport::readIntegerList( QList<int> & list )
 // decimals
 void XMLimport::getVersionString( QString & versionString )
 {
-    versionString = QString::number( static_cast<float>( mVersionMajor + 1000.0f * mVersionMinor ), 'f', 3 );
+    versionString = QString::number( ( mVersionMajor * 1000 + mVersionMinor ) / 1000.0, 'f', 3 );
 }

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -48,7 +48,7 @@ class XMLimport : public QXmlStreamReader
 public:
               XMLimport( Host * );
 
-    bool      importPackage( QIODevice *device, QString packageName = QString(), int moduleFlag = 0 );
+    bool      importPackage( QIODevice *device, QString packageName = QString(), int moduleFlag = 0, QString * pVersionString = Q_NULLPTR );
 
 private:
 
@@ -96,7 +96,9 @@ private:
     void      readStringList( QStringList & );
     void      readIntegerList( QList<int> & );
     void      readMapList( QMap<QString, QStringList> & );
-    //void      readMapList( QMap<QString, QString> &);
+
+    void        getVersionString( QString & );
+
 
     QPointer<Host> mpHost;
     QString   mPackageName;
@@ -119,6 +121,8 @@ private:
 
     int         mMaxRoomId;
     int         mMaxAreaId; // Could be useful when iterating through map data
+    quint8      mVersionMajor;
+    quint16     mVersionMinor; // Cannot be a quint6 as that only allows x.255 for the decimal
 };
 
 #endif // MUDLET_XMLEXPORT_H


### PR DESCRIPTION
I foresee the need to tweak the Xml format in the future, however though
there once was some checks for this in the code in the past it was
commented out.  This commit - which should go into both development and
release_30 branches despite it not being technically a "BugFix" will now
alert the user if they load any code which does not have a "version"
attribute with a numeric value equivalent to 1.000f in the "MudletPackage"
element of the Xml.

It will not STOP the code being loaded, just issue the alert!

This is to cover the CURRENT code against problems that might arise in the
future if the XML format/structure gets changed which will otherwise go
*undetected* by the Mudlet application as it is currently.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>