### PR TITLE
(release_30)enhance: restore version check to Mudlet XMLimport code

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,6 +36,10 @@
 
 
 using namespace std;
+
+const QString XMLexport::scmMudletXmlVersionString = QString::number( 1.0f, 'f', 3 );
+// Previously hardcode to "1.0" and not tested/used, now uses three decimal
+// places, can be "0.000" to "255.999"
 
 XMLexport::XMLexport( Host * pH )
 : mpHost( pH )
@@ -93,13 +98,14 @@ XMLexport::XMLexport( TKey * pT )
     setAutoFormatting(true);
 }
 
-bool XMLexport::writeModuleXML( QIODevice * device, QString moduleName){
+bool XMLexport::writeModuleXML( QIODevice * device, QString moduleName)
+{
     setDevice(device);
     writeStartDocument();
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "TriggerPackage" );
     Host * pT = mpHost;
@@ -221,7 +227,7 @@ bool XMLexport::exportHost( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "HostPackage" );
     writeHost( mpHost );
@@ -507,7 +513,7 @@ bool XMLexport::exportGenericPackage( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeGenericPackage( mpHost );
 
@@ -596,7 +602,7 @@ bool XMLexport::exportTrigger( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "TriggerPackage" );
     writeTrigger( mpTrigger );
@@ -684,7 +690,7 @@ bool XMLexport::exportAlias( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "AliasPackage" );
     writeAlias( mpAlias );
@@ -739,7 +745,7 @@ bool XMLexport::exportAction( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "ActionPackage" );
     writeAction( mpAction );
@@ -810,7 +816,7 @@ bool XMLexport::exportTimer( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "TimerPackage" );
     writeTimer( mpTimer );
@@ -868,7 +874,7 @@ bool XMLexport::exportScript( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "ScriptPackage" );
     writeScript( mpScript );
@@ -929,7 +935,7 @@ bool XMLexport::exportKey( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute( QStringLiteral( "version" ), scmMudletXmlVersionString );
 
     writeStartElement( "KeyPackage" );
     writeKey( mpKey );

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -80,6 +81,7 @@ public:
     bool            exportKey( TKey * );
 
 private:
+    static const QString    scmMudletXmlVersionString;
     Host *          mpHost;
     TTrigger *      mpTrigger;
     TTimer *        mpTimer;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -40,7 +40,11 @@
 #include "pre_guard.h"
 #include <QStringList>
 #include <QDebug>
+#if QT_VERSION > 0x050002
 #include <QtMath>
+#else
+#include <QtCore/qmath.h>
+#endif
 #include "post_guard.h"
 
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -2175,5 +2175,5 @@ void XMLimport::readIntegerList( QList<int> & list )
 // decimals
 void XMLimport::getVersionString( QString & versionString )
 {
-    versionString = QString::number( static_cast<float>( mVersionMajor + 1000.0f * mVersionMinor ), 'f', 3 );
+    versionString = QString::number( ( mVersionMajor * 1000 + mVersionMinor ) / 1000.0, 'f', 3 );
 }

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -47,7 +47,7 @@ class XMLimport : public QXmlStreamReader
 public:
               XMLimport( Host * );
 
-    bool      importPackage( QIODevice *device, QString packageName = QString(), int moduleFlag = 0 );
+    bool      importPackage( QIODevice *device, QString packageName = QString(), int moduleFlag = 0, QString * pVersionString = Q_NULLPTR );
 
 private:
 
@@ -96,7 +96,9 @@ private:
     void      readStringList( QStringList & );
     void      readIntegerList( QList<int> & );
     void      readMapList( QMap<QString, QStringList> & );
-    //void      readMapList( QMap<QString, QString> &);
+
+    void        getVersionString( QString & );
+
 
     Host *    mpHost;
     QString   mPackageName;
@@ -118,6 +120,8 @@ private:
     int  module;
     int         mMaxRoomId;
     int         mMaxAreaId; // Could be useful when iterating through map data
+    quint8      mVersionMajor;
+    quint16     mVersionMinor; // Cannot be a quint6 as that only allows x.255 for the decimal
 };
 
 #endif // MUDLET_XMLEXPORT_H


### PR DESCRIPTION
I foresee the need to tweak the Xml format in the future, however though
there once was some checks for this in the code in the past it was
commented out.  This commit - which should go into both development and
release_30 branches despite it not being technically a "BugFix" will now
alert the user if they load any code which does not have a "version"
attribute with a numeric value equivalent to 1.000f in the "MudletPackage"
element of the Xml.

It will not STOP the code being loaded, just issue the alert!

This is to cover the CURRENT code against problems that might arise in the
future if the XML format/structure gets changed which will otherwise go
*undetected* by the Mudlet application as it is currently.

This performs the same changes as #369 does to the development branch.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>