### PR TITLE
(release_30) Bugfix: equalizes mouse-drag scroll margins on TConsoles

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1051,7 +1051,7 @@ void TTextEdit::mouseMoveEvent( QMouseEvent * event )
     {
         mpConsole->scrollUp( 3 );
     }
-    if( event->y() > height()-10 )
+    if( event->y() >= height()-10 )
     {
         mpConsole->scrollDown( 3 );
     }


### PR DESCRIPTION
Conditional has been fixed so that it hits the same 10 pixel range on
either side when you drag the mouse up and down a console.

See: #366