### PR TITLE
Bugfix: remove Spam output from Lua [c|d|h]echo commands

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -437,7 +437,7 @@ int TLuaInterpreter::selectString( lua_State * L )
     QString windowName; // only for 3 argument case, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 2 ) {
         if( ! lua_isstring( L, s ) ) {
-            lua_pushstring( L, tr( "selectString: bad argument %1 type (window name as string, is optional {defaults"
+            lua_pushstring( L, tr( "selectString: bad argument #%1 type (window name as string, is optional {defaults"
                                    "to \"main\" if omitted}, got %2!)" )
                             .arg( s )
                             .arg( luaL_typename( L, s ) )
@@ -459,7 +459,7 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     QString searchText;
     if( ! lua_isstring( L, s ) ) {
-        lua_pushstring( L, tr( "selectString: bad argument %1 type (text to search for as string expected, got %2!)" )
+        lua_pushstring( L, tr( "selectString: bad argument #%1 type (text to select as string expected, got %2!)" )
                         .arg( s )
                         .arg( luaL_typename( L, s ) )
                         .toUtf8().constData() );
@@ -474,7 +474,7 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     qint64 numOfMatch = 0;
     if( ! lua_isnumber( L, s ) ) {
-        lua_pushstring( L, tr( "selectString: bad argument %1 type (match number as number expected, got %2!)" )
+        lua_pushstring( L, tr( "selectString: bad argument #%1 type (match count as number {1 for first} expected, got %2!)" )
                         .arg( s )
                         .arg( luaL_typename( L, s ) )
                         .toUtf8().constData() );
@@ -5112,11 +5112,11 @@ int TLuaInterpreter::deselect( lua_State *L )
     return 1;
 }
 
-int TLuaInterpreter::reset( lua_State *L )
+int TLuaInterpreter::resetFormat( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "reset: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring( L, tr( "resetFormat: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
         lua_error( L );
         return 1;
     }
@@ -5124,7 +5124,7 @@ int TLuaInterpreter::reset( lua_State *L )
     QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "reset: bad argument #1 type (window name as string, is optional {defaults"
+            lua_pushstring( L, tr( "resetFormat: bad argument #1 type (window name as string, is optional {defaults"
                                    "to \"main\" if omitted}, got %1!)" )
                             .arg( luaL_typename( L, 1 ) )
                             .toUtf8().constData() );
@@ -13047,7 +13047,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "debugc", TLuaInterpreter::debug );
     lua_register( pGlobalLua, "setWindowWrap", TLuaInterpreter::setWindowWrap );
     lua_register( pGlobalLua, "setWindowWrapIndent", TLuaInterpreter::setWindowWrapIndent );
-    lua_register( pGlobalLua, "resetFormat", TLuaInterpreter::reset );
+    lua_register( pGlobalLua, "resetFormat", TLuaInterpreter::resetFormat );
     lua_register( pGlobalLua, "moveCursorEnd", TLuaInterpreter::moveCursorEnd );
     lua_register( pGlobalLua, "getLastLineNumber", TLuaInterpreter::getLastLineNumber );
     lua_register( pGlobalLua, "getNetworkLatency", TLuaInterpreter::getNetworkLatency );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -418,62 +418,80 @@ int TLuaInterpreter::resetProfile( lua_State * L )
 
 
 // cursorPositionInLine = select( text ) if not found -1
-int TLuaInterpreter::select( lua_State * L )
+// Was called select but that may clash with the Lua built-in command with the
+// same name
+// selectString( [windowName], text, number_of_match )
+// Will now consider an EMPTY window name or the literal "main" as being the
+// same as an omitted windowName - i.e. is the main console window.
+int TLuaInterpreter::selectString( lua_State * L )
 {
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushstring( L, tr( "selectString: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
+
     int s = 1;
-    int n = lua_gettop( L );
-    string a1;
-    if( n > 2 )
-    {
-        if( ! lua_isstring( L, s ) )
-        {
-            lua_pushstring( L, "select: wrong argument type" );
-          lua_error( L );
-          return 1;
+    QString windowName; // only for 3 argument case, will be null if not assigned to which is different from being empty
+    if( lua_gettop( L ) > 2 ) {
+        if( ! lua_isstring( L, s ) ) {
+            lua_pushstring( L, tr( "selectString: bad argument %1 type (window name as string, is optional {defaults"
+                                   "to \"main\" if omitted}, got %2!)" )
+                            .arg( s )
+                            .arg( luaL_typename( L, s ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
         }
-        else
-        {
-            a1 = lua_tostring( L, s );
+        else {
+            // We cannot yet properly handle non-ASCII windows names but we will eventually!
+            windowName = QString::fromUtf8( lua_tostring( L, s ) );
+            if( ! windowName.compare( tr( "main" ), Qt::CaseSensitive ) ) {
+                // This matches the identifier for the main window - so make it
+                // appear so by emptying it...
+                windowName = QString();
+            }
             s++;
         }
     }
-    string luaSendText="";
-    if( ! lua_isstring( L, s ) )
-    {
-        lua_pushstring( L, "select: wrong argument type" );
+
+    QString searchText;
+    if( ! lua_isstring( L, s ) ) {
+        lua_pushstring( L, tr( "selectString: bad argument %1 type (text to search for as string expected, got %2!)" )
+                        .arg( s )
+                        .arg( luaL_typename( L, s ) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-    {
-        luaSendText = lua_tostring( L, s );
+    else {
+        searchText = QString::fromUtf8( lua_tostring( L, s ) );
+        // CHECK: Do we need to qualify this for a non-blank string?
         s++;
     }
-    int luaNumOfMatch;
-    if( ! lua_isnumber( L, s ) )
-    {
-        lua_pushstring( L, "select: wrong argument type" );
+
+    qint64 numOfMatch = 0;
+    if( ! lua_isnumber( L, s ) ) {
+        lua_pushstring( L, tr( "selectString: bad argument %1 type (match number as number expected, got %2!)" )
+                        .arg( s )
+                        .arg( luaL_typename( L, s ) )
+                        .toUtf8().constData() );
         lua_error( L );
         return 1;
     }
-    else
-    {
-        luaNumOfMatch = lua_tointeger( L, s );
+    else {
+        numOfMatch = lua_tointeger( L, s );
     }
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    if( n == 2 )
-    {
-        int pos = pHost->mpConsole->select( QString( luaSendText.c_str() ), luaNumOfMatch );
-        lua_pushnumber( L, pos );
-        return 1;
+
+    if( windowName.isEmpty() ) {
+        lua_pushnumber( L, pHost->mpConsole->select( searchText, numOfMatch ) );
     }
-    else
-    {
-        QString _name(a1.c_str());
-        int pos = mudlet::self()->selectString( pHost, _name, QString( luaSendText.c_str() ), luaNumOfMatch );
-        lua_pushnumber( L, pos );
-        return 1;
+    else {
+        lua_pushnumber( L, mudlet::self()->selectString( pHost, windowName, searchText, numOfMatch ) );
     }
+    return 1;
 }
 
 int TLuaInterpreter::selectCurrentLine( lua_State * L )
@@ -5055,44 +5073,84 @@ int TLuaInterpreter::getPath( lua_State *L )
 
 int TLuaInterpreter::deselect( lua_State *L )
 {
-    string luaWindowName="";
-    if( lua_isstring( L, 1 ) )
-    {
-        luaWindowName = lua_tostring( L, 1 );
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushstring( L, tr( "deselect: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_error( L );
+        return 1;
     }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString name = luaWindowName.c_str();
-    if( luaWindowName.size() < 1 || luaWindowName == "main" )
-    {
+    QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
+    if( lua_gettop( L ) > 0 ) {
+        if( ! lua_isstring( L, 1 ) ) {
+            lua_pushstring( L, tr( "deselect: bad argument #1 type (window name as string, is optional {defaults"
+                                   "to \"main\" if omitted}, got %1!)" )
+                            .arg( luaL_typename( L, 1 ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+        else {
+            // We cannot yet properly handle non-ASCII windows names but we will eventually!
+            windowName = QString::fromUtf8( lua_tostring( L, 1 ) );
+            if( ! windowName.compare( tr( "main" ), Qt::CaseSensitive ) ) {
+                // This matches the identifier for the main window - so make it
+                // appear so by emptying it...
+                windowName = QString();
+            }
+        }
+    }
+
+    if( windowName.isEmpty() ) {
         pHost->mpConsole->deselect();
+        lua_pushboolean( L, true );
     }
-    else
-    {
-        mudlet::self()->deselect( pHost, name );
+    else {
+        lua_pushboolean( L, mudlet::self()->deselect( pHost, windowName ) );
     }
-    return 0;
+
+    return 1;
 }
 
 int TLuaInterpreter::reset( lua_State *L )
 {
-    string luaWindowName="";
-    if( lua_isstring( L, 1 ) )
-    {
-        luaWindowName = lua_tostring( L, 1 );
+    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if( ! pHost ) {
+        lua_pushstring( L, tr( "reset: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_error( L );
+        return 1;
     }
 
-    Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString name = luaWindowName.c_str();
-    if( luaWindowName.size() < 1 || luaWindowName == "main" )
-    {
+    QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
+    if( lua_gettop( L ) > 0 ) {
+        if( ! lua_isstring( L, 1 ) ) {
+            lua_pushstring( L, tr( "reset: bad argument #1 type (window name as string, is optional {defaults"
+                                   "to \"main\" if omitted}, got %1!)" )
+                            .arg( luaL_typename( L, 1 ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+        else {
+            // We cannot yet properly handle non-ASCII windows names but we will eventually!
+            windowName = QString::fromUtf8( lua_tostring( L, 1 ) );
+            if( ! windowName.compare( tr( "main" ), Qt::CaseSensitive ) ) {
+                // This matches the identifier for the main window - so make it
+                // appear so by emptying it...
+                windowName = QString();
+            }
+        }
+    }
+
+    if( windowName.isEmpty() ) {
         pHost->mpConsole->reset();
+        lua_pushboolean( L, true );
     }
-    else
-    {
-        mudlet::self()->resetFormat( pHost, name );
+    else {
+        lua_pushboolean( L, mudlet::self()->resetFormat( pHost, windowName ) );
     }
-    return 0;
+
+    return 1;
 }
 
 int TLuaInterpreter::hasFocus( lua_State *L )
@@ -12947,7 +13005,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "wait", TLuaInterpreter::Wait );
     lua_register( pGlobalLua, "expandAlias", TLuaInterpreter::Send );
     lua_register( pGlobalLua, "echo", TLuaInterpreter::Echo );
-    lua_register( pGlobalLua, "selectString", TLuaInterpreter::select );
+    lua_register( pGlobalLua, "selectString", TLuaInterpreter::selectString );
     lua_register( pGlobalLua, "selectSection", TLuaInterpreter::selectSection );
     lua_register( pGlobalLua, "replace", TLuaInterpreter::replace );
     lua_register( pGlobalLua, "setBgColor", TLuaInterpreter::setBgColor );

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -284,7 +284,7 @@ public:
     static int debug( lua_State * L );
     static int setWindowWrap( lua_State * );
     static int setWindowWrapIndent( lua_State * );
-    static int reset( lua_State * );
+    static int resetFormat( lua_State * );
     static int moveCursorEnd( lua_State * );
     static int getLastLineNumber( lua_State * );
     static int getNetworkLatency( lua_State * );

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -233,7 +233,7 @@ public:
     static int Send( lua_State * L );
     static int sendRaw( lua_State * L );
     static int Echo( lua_State * L );
-    static int select( lua_State * L );
+    static int selectString( lua_State * L ); // Was select but I think it clashes with the Lua command with that name
     static int getMainConsoleWidth( lua_State * L );
     static int selectSection( lua_State * L );
     static int replace( lua_State * L );

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -611,24 +611,6 @@ function handleWindowResizeEvent()
 end
 
 
--- NOTE: NOW ALL CASES ARE HANDLED IN MUDLET CORE
---- Clears the current selection in the main window or miniConsole window. <br/>
---- (Note: <i>deselect(windowName)</i> is implemented in Core Mudlet.)
----
---- @usage Clear selection in main window.
----   <pre>
----   deselect()
----   </pre>
---- @usage Clear selection in myMiniConsole window.
----   <pre>
----   deselect("myMiniConsole")
----   </pre>
---function deselect()
---	selectString("", 1)
---end
-
-
-
 --- Sets current background color to a named color.
 ---
 --- @usage Set background color to magenta.

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -611,7 +611,7 @@ function handleWindowResizeEvent()
 end
 
 
-
+-- NOTE: NOW ALL CASES ARE HANDLED IN MUDLET CORE
 --- Clears the current selection in the main window or miniConsole window. <br/>
 --- (Note: <i>deselect(windowName)</i> is implemented in Core Mudlet.)
 ---
@@ -623,9 +623,9 @@ end
 ---   <pre>
 ---   deselect("myMiniConsole")
 ---   </pre>
-function deselect()
-	selectString("", 1)
-end
+--function deselect()
+--	selectString("", 1)
+--end
 
 
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1199,18 +1199,16 @@ bool mudlet::setConsoleBufferSize( Host * pHost, const QString & name, int x1, i
         return false;
 }
 
-
-
 bool mudlet::resetFormat( Host * pHost, QString & name )
 {
     QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
-    if( dockWindowConsoleMap.contains( name ) )
-    {
+    if( dockWindowConsoleMap.contains( name ) ) {
         dockWindowConsoleMap[name]->reset();
         return true;
     }
-    else
+    else {
         return false;
+    }
 }
 
 bool mudlet::moveWindow( Host * pHost, const QString & name, int x1, int y1 )
@@ -1490,13 +1488,17 @@ int mudlet::selectSection( Host * pHost, const QString & name, int f, int t )
         return -1;
 }
 
-void mudlet::deselect( Host * pHost, const QString & name )
+// Added a return value to indicate whether the give windows name was found
+bool mudlet::deselect( Host * pHost, const QString & name )
 {
     QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
-    if( dockWindowConsoleMap.contains( name ) )
-    {
+    if( dockWindowConsoleMap.contains( name ) ) {
         TConsole * pC = dockWindowConsoleMap[name];
         pC->deselect();
+        return true;
+    }
+    else {
+        return false;
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1488,7 +1488,7 @@ int mudlet::selectSection( Host * pHost, const QString & name, int f, int t )
         return -1;
 }
 
-// Added a return value to indicate whether the give windows name was found
+// Added a return value to indicate whether the given windows name was found
 bool mudlet::deselect( Host * pHost, const QString & name )
 {
     QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -152,7 +152,7 @@ public:
    bool                          moduleTableVisible();
    bool                          mWindowMinimized;
    void                          doAutoLogin( const QString & );
-   void                          deselect( Host * pHost, const QString & name );
+   bool                          deselect( Host * pHost, const QString & name );
    void                          stopSounds();
    void                          playSound( QString s );
    QTime                         mReplayTime;


### PR DESCRIPTION
I was trying to determine why my script was spamming the Central Debug Console with lines associate with the use of:
`TConsole::select(const QString &, int)`
at first I thought it was because we register `TLuaInterpreter::select()` as the user Lua command: `selectString` - to avoid any confusion with the built-in lua command of the same name that is used with variable length argument lists (often represented by `...` and meaning "all the remaining arguments") I have taken the opportunity to bring the function up to current style for error messages and argument handling (it will take three arguments where the first is an empty string or the translated equivalent to "main" to behave the same as the two argument case which acts on the main profile console window.)

This did not "cure" my original concern and then I detected that it was coming about with the use of `cecho(...)`, `decho(...)` and `hecho(...)` but it was happening inside the Mudlet Lua that is external to the C++ core.  It transpires that the `deselect(...)` command, although defined in the Core was being by-passed/replaced by Lua code in the `GUIUtils.lua`
file which although documented as:
"Clears the current selection in the main window or miniConsole window.
 (Note: deselect(windowName) is implemented in Core Mudlet.)"
was being used instead - possibly all the time - to call `selectString("", 1)` which was what was producing the spam I was seeing.

I have refactored the Core `deselect([<windowName>])` and the related `reset([<windowName>])` functions to also bring them up to current standards. The internal `mudlet::resetFormat(...)` command that handles the latter was returning an unused `true`/`false` value to indicate whether the given sub-window/console was found or not but the related `mudlet::resetFormat(...)` that handles the former did not - so I have revised that and both `TLuaInterpreter` class intermediates to now also return a single boolean value on success.  For the main console which uses different direct `TConsole` class methods for these actions the command will always succeed so a hard-code true value will be returned for those.

Note that `deselect()` is now entirely commented out in the external Lua file `GUIUtils.lua` but this change will also have to be carried out in the separate Mudlet-Lua repository holding the "production" version of this file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>