### PR TITLE
Added: errors in compileScript now report which script they were generated from

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -138,7 +138,7 @@ bool TAction::compileScript()
     mFuncName = QString("Action")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -138,7 +138,7 @@ bool TAction::compileScript()
     mFuncName = QString("Action")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, QString("Button: ") + getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -337,7 +337,7 @@ bool TAlias::compileScript()
     mFuncName = QString("Alias")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, QString("Alias: ") + getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -337,7 +337,7 @@ bool TAlias::compileScript()
     mFuncName = QString("Alias")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -165,7 +165,7 @@ bool TKey::compileScript()
     mFuncName = QString("Key")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, QString("Key: ") + getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -165,7 +165,7 @@ bool TKey::compileScript()
     mFuncName = QString("Key")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12029,6 +12029,7 @@ bool TLuaInterpreter::compile(const QString & code, QString & errorMsg )
     }
 
     int error = luaL_dostring( L, code.toLatin1().data() );
+
     QString n;
     if( error != 0 )
     {
@@ -12051,6 +12052,41 @@ bool TLuaInterpreter::compile(const QString & code, QString & errorMsg )
     if( error == 0 ) return true;
     else return false;
 }
+
+bool TLuaInterpreter::compile(const QString & code, QString & errorMsg, const QString & name)
+{
+    lua_State * L = pGlobalLua;
+    if( ! L )
+    {
+        qDebug()<< "LUA CRITICAL ERROR: no suitable Lua execution unit found.";
+        return false;
+    }
+
+    int error = (luaL_loadbuffer( L, code.toLatin1().data(), strlen(code.toLatin1().data()), name.toLatin1().data() ) || lua_pcall(L, 0, 0, 0));
+
+    QString n;
+    if( error != 0 )
+    {
+        string e = "Lua syntax error:";
+        if( lua_isstring( L, 1 ) )
+        {
+            e.append( lua_tostring( L, 1 ) );
+        }
+        errorMsg = "<b><font color='blue'>";
+        errorMsg.append( e.c_str() );
+        errorMsg.append("</b></font>");
+        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::red))<<"\n "<<e.c_str()<<"\n">>0;}
+    }
+    else
+    {
+        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"\nLUA: code compiled without errors. OK\n" >> 0;}
+    }
+    lua_pop( L, lua_gettop( L ) );
+
+    if( error == 0 ) return true;
+    else return false;
+}
+
 
 void TLuaInterpreter::setMultiCaptureGroups( const std::list< std::list<std::string> > & captureList,
                                              const std::list< std::list<int> > & posList )

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11988,71 +11988,6 @@ bool TLuaInterpreter::compileScript(const QString & code )
     else return false;
 }
 
-bool TLuaInterpreter::compile(const QString & code )
-{
-    lua_State * L = pGlobalLua;
-    if( ! L )
-    {
-        qDebug()<< "LUA CRITICAL ERROR: no suitable Lua execution unit found.";
-        return false;
-    }
-
-    int error = luaL_dostring( L, code.toLatin1().data() );
-    QString n;
-    if( error != 0 )
-    {
-        string e = "no error message available from Lua";
-        if( lua_isstring( L, 1 ) )
-        {
-            e = "Lua error:";
-            e+=lua_tostring( L, 1 );
-        }
-        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::red))<<"LUA: code did not compile: ERROR:"<<e.c_str()<<"\n">>0;}
-    }
-    else
-    {
-        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"LUA: code compiled without errors. OK\n" >> 0;}
-    }
-    lua_pop( L, lua_gettop( L ) );
-
-    if( error == 0 ) return true;
-    else return false;
-}
-
-bool TLuaInterpreter::compile(const QString & code, QString & errorMsg )
-{
-    lua_State * L = pGlobalLua;
-    if( ! L )
-    {
-        qDebug()<< "LUA CRITICAL ERROR: no suitable Lua execution unit found.";
-        return false;
-    }
-
-    int error = luaL_dostring( L, code.toLatin1().data() );
-
-    QString n;
-    if( error != 0 )
-    {
-        string e = "Lua syntax error:";
-        if( lua_isstring( L, 1 ) )
-        {
-            e.append( lua_tostring( L, 1 ) );
-        }
-        errorMsg = "<b><font color='blue'>";
-        errorMsg.append( e.c_str() );
-        errorMsg.append("</b></font>");
-        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::red))<<"\n "<<e.c_str()<<"\n">>0;}
-    }
-    else
-    {
-        if( mudlet::debugMode ){ TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"\nLUA: code compiled without errors. OK\n" >> 0;}
-    }
-    lua_pop( L, lua_gettop( L ) );
-
-    if( error == 0 ) return true;
-    else return false;
-}
-
 bool TLuaInterpreter::compile(const QString & code, QString & errorMsg, const QString & name)
 {
     lua_State * L = pGlobalLua;
@@ -12062,7 +11997,7 @@ bool TLuaInterpreter::compile(const QString & code, QString & errorMsg, const QS
         return false;
     }
 
-    int error = (luaL_loadbuffer( L, code.toLatin1().data(), strlen(code.toLatin1().data()), name.toLatin1().data() ) || lua_pcall(L, 0, 0, 0));
+    int error = (luaL_loadbuffer( L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), name.toUtf8().constData() ) || lua_pcall(L, 0, 0, 0));
 
     QString n;
     if( error != 0 )
@@ -12086,7 +12021,6 @@ bool TLuaInterpreter::compile(const QString & code, QString & errorMsg, const QS
     if( error == 0 ) return true;
     else return false;
 }
-
 
 void TLuaInterpreter::setMultiCaptureGroups( const std::list< std::list<std::string> > & captureList,
                                              const std::list< std::list<int> > & posList )

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -90,6 +90,7 @@ public:
     bool call_luafunction( void * );
     bool compile(const QString & );
     bool compile(const QString & code, QString & error );
+    bool compile(const QString & code, QString & error, const QString & name );
     bool compileScript(const QString & );
     void setAtcpTable(const QString &, const QString & );
     void setGMCPTable(QString &, const QString & );

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -88,8 +88,6 @@ public:
     bool callMulti(const QString & function, const QString & mName );
     bool callConditionFunction( std::string & function, const QString & mName );
     bool call_luafunction( void * );
-    bool compile(const QString & );
-    bool compile(const QString & code, QString & error );
     bool compile(const QString & code, QString & error, const QString & name );
     bool compileScript(const QString & );
     void setAtcpTable(const QString &, const QString & );

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -137,7 +137,7 @@ bool TScript::setScript(const QString & script )
 bool TScript::compileScript()
 {
     QString error;
-    if( mpHost->mLuaInterpreter.compile( mScript, error, getName() ) )
+    if( mpHost->mLuaInterpreter.compile( mScript, error, QString("Script: ") + getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -137,7 +137,7 @@ bool TScript::setScript(const QString & script )
 bool TScript::compileScript()
 {
     QString error;
-    if( mpHost->mLuaInterpreter.compile( mScript, error ) )
+    if( mpHost->mLuaInterpreter.compile( mScript, error, getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -209,7 +209,7 @@ bool TTimer::compileScript()
     mFuncName = QString("Timer")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -209,7 +209,7 @@ bool TTimer::compileScript()
     mFuncName = QString("Timer")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpHost->mLuaInterpreter.compile( code, error, getName() ) )
+    if( mpHost->mLuaInterpreter.compile( code, error, "Timer: " + getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -200,7 +200,7 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
              funcName = func.str();
              QString code = QString("function ")+funcName.c_str()+QString("()\n")+regexList[i]+QString("\nend\n");
              QString error;
-             if( ! mpLua->compile( code, error ) )
+             if( ! mpLua->compile( code, error, QString::fromStdString(funcName) ) )
              {
                  setError( QString("pattern type Lua condition function '")+regexList[i]+QString("' failed to compile.")+error);
                  state = false;
@@ -1325,7 +1325,7 @@ bool TTrigger::compileScript()
     mFuncName = QString("Trigger")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpLua->compile( code, error, getName() ) )
+    if( mpLua->compile( code, error, QString("Trigger: ") + getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1325,7 +1325,7 @@ bool TTrigger::compileScript()
     mFuncName = QString("Trigger")+QString::number( mID );
     QString code = QString("function ")+ mFuncName + QString("()\n") + mScript + QString("\nend\n");
     QString error;
-    if( mpLua->compile( code, error ) )
+    if( mpLua->compile( code, error, getName() ) )
     {
         mNeedsToBeCompiled = false;
         mOK_code = true;


### PR DESCRIPTION
Updates the code of each type of object to use an overloaded form of TLuaCompile::compile() that replaces `luaL_dostring` with `luaL_loadbuffer` followed by `lua_pcall` so that the name of the object is assigned to the chunk when it's compiled. In the case of a function erroring that is defined in one object but called in another, it causes the error message from the LuaInterpreter to properly report the name of the object that defined the function that the error is contained in. This eliminated the annoying `<[string "-------------------...": <line number>: <error>` style messages that often confuse new users of Mudlet.