### PR TITLE
(release_30)bugFix: make searches/checks for "xml" extension files not case sensi…

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -211,7 +211,9 @@ void Host::saveModules(int sync)
         QString tempDir;
         QString zipName;
         zip * zipFile = 0;
-        if ( filename_xml.endsWith( "mpackage" ) || filename_xml.endsWith( "zip" ) )
+        // Filename extension tests should be case insensitive to work on MacOS Platforms...! - Slysven
+        if(  filename_xml.endsWith( QStringLiteral( "mpackage" ), Qt::CaseInsensitive )
+          || filename_xml.endsWith( QStringLiteral( "zip" ), Qt::CaseInsensitive ) )
         {
             tempDir = QDir::homePath()+"/.config/mudlet/profiles/"+mHostName+"/"+moduleName;
             filename_xml = tempDir + "/" + moduleName + ".xml";

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -338,22 +338,24 @@ void dlgPackageExporter::slot_addFiles(){
     QDesktopServices::openUrl(QUrl(_pn, QUrl::TolerantMode));
 }
 
-void dlgPackageExporter::slot_browse_button(){
-    QFileDialog dialog(this);
-    dialog.setFileMode(QFileDialog::AnyFile);
-    dialog.setNameFilter(tr("Mudlet Packages (*.xml)"));
-    dialog.setViewMode(QFileDialog::Detail);
-    QString fileName;
-    if (dialog.exec()) {
-        fileName = dialog.selectedFiles().first();
+// Not Used - otherwise might need to tweak search for *.xml to ensure it worked
+// on MacOS:
+//void dlgPackageExporter::slot_browse_button(){
+//    QFileDialog dialog(this);
+//    dialog.setFileMode(QFileDialog::AnyFile);
+//    dialog.setNameFilter(tr("Mudlet Packages (*.xml)"));
+//    dialog.setViewMode(QFileDialog::Detail);
+//    QString fileName;
+//    if (dialog.exec()) {
+//        fileName = dialog.selectedFiles().first();
 
-        if (!fileName.endsWith(".xml"))
-            fileName.append(".xml");
+//        if (!fileName.endsWith(".xml"))
+//            fileName.append(".xml");
 
-        ui->filePath->setText(fileName);
-        exportButton->setDisabled(false);
-    }
-}
+//        ui->filePath->setText(fileName);
+//        exportButton->setDisabled(false);
+//    }
+//}
 
 void dlgPackageExporter::recurseTriggers(TTrigger* trig, QTreeWidgetItem* qTrig){
     list<TTrigger *> * childList = trig->getChildrenList();

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -81,7 +81,7 @@ private:
     QString zipFile;
 public slots:
     void slot_addFiles();
-    void slot_browse_button();
+// Not used:    void slot_browse_button();
     void slot_export_package();
 };
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6816,8 +6816,17 @@ void dlgTriggerEditor::slot_export()
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Triggers"),
                                                     QDir::currentPath(),
                                                     tr("Mudlet packages (*.xml)"));
-    if(fileName.isEmpty()) return;
-    fileName.append(".xml");
+    if( fileName.isEmpty() )
+    {
+        return;
+    }
+
+    // Must be case insensitive to work on MacOS platforms, possibly a cause of
+    // https://bugs.launchpad.net/mudlet/+bug/1417234
+    if( ! fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+    {
+        fileName.append( QStringLiteral( ".xml" ) );
+    }
 
 
     QFile file(fileName);
@@ -7046,8 +7055,17 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
                                                     QDir::homePath(),
                                                     tr("trigger files (*.trigger *.xml)"));
 
-    if(fileName.isEmpty()) return;
-    fileName.append(".xml");
+    if( fileName.isEmpty() )
+    {
+        return;
+    }
+    // Must be case insensitive to work on MacOS platforms, possibly a cause of
+    // https://bugs.launchpad.net/mudlet/+bug/1417234
+    if(  ! fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive )
+      && ! fileName.endsWith( QStringLiteral( ".trigger" ), Qt::CaseInsensitive ) )
+    {
+        fileName.append( QStringLiteral( ".xml" ) );
+    }
 
     QFile file(fileName);
     if( ! file.open(QFile::WriteOnly | QFile::Text) )


### PR DESCRIPTION
…tive
This should address the cause of [bug 1417234](https://bugs.launchpad.net/mudlet/+bug/1417234) which is where a suitable file is having an extra xml extension added, probably because the MacOS File system and native file dialogues are not necessarily case sensitive and could produce a file with an extension XML rather than xml that would fail checks for the latter in the past.

This is regarded as a "ShowStopper" bug for Mudlet 3.0 release...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>