### PR TITLE
BugFix: make searches/checks for "xml" extension files not case sensi…

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -215,7 +215,9 @@ void Host::saveModules(int sync)
         QString tempDir;
         QString zipName;
         zip * zipFile = 0;
-        if ( filename_xml.endsWith( "mpackage" ) || filename_xml.endsWith( "zip" ) )
+        // Filename extension tests should be case insensitive to work on MacOS Platforms...! - Slysven
+        if(  filename_xml.endsWith( QStringLiteral( "mpackage" ), Qt::CaseInsensitive )
+          || filename_xml.endsWith( QStringLiteral( "zip" ), Qt::CaseInsensitive ) )
         {
             tempDir = QDir::homePath()+"/.config/mudlet/profiles/"+mHostName+"/"+moduleName;
             filename_xml = tempDir + "/" + moduleName + ".xml";

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -339,22 +339,24 @@ void dlgPackageExporter::slot_addFiles(){
     QDesktopServices::openUrl(QUrl(_pn, QUrl::TolerantMode));
 }
 
-void dlgPackageExporter::slot_browse_button(){
-    QFileDialog dialog(this);
-    dialog.setFileMode(QFileDialog::AnyFile);
-    dialog.setNameFilter(tr("Mudlet Packages (*.xml)"));
-    dialog.setViewMode(QFileDialog::Detail);
-    QString fileName;
-    if (dialog.exec()) {
-        fileName = dialog.selectedFiles().first();
+// Not Used - otherwise might need to tweak search for *.xml to ensure it worked
+// on MacOS:
+//void dlgPackageExporter::slot_browse_button(){
+//    QFileDialog dialog(this);
+//    dialog.setFileMode(QFileDialog::AnyFile);
+//    dialog.setNameFilter(tr("Mudlet Packages (*.xml)"));
+//    dialog.setViewMode(QFileDialog::Detail);
+//    QString fileName;
+//    if (dialog.exec()) {
+//        fileName = dialog.selectedFiles().first();
 
-        if (!fileName.endsWith(".xml"))
-            fileName.append(".xml");
+//        if (!fileName.endsWith(".xml"))
+//            fileName.append(".xml");
 
-        ui->filePath->setText(fileName);
-        exportButton->setDisabled(false);
-    }
-}
+//        ui->filePath->setText(fileName);
+//        exportButton->setDisabled(false);
+//    }
+//}
 
 void dlgPackageExporter::recurseTriggers(TTrigger* trig, QTreeWidgetItem* qTrig){
     list<TTrigger *> * childList = trig->getChildrenList();

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -81,7 +81,7 @@ private:
     QString zipFile;
 public slots:
     void slot_addFiles();
-    void slot_browse_button();
+// Not used:    void slot_browse_button();
     void slot_export_package();
 };
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6723,11 +6723,16 @@ void dlgTriggerEditor::slot_export()
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Triggers"),
                                                     QDir::currentPath(),
                                                     tr("Mudlet packages (*.xml)"));
-    if(fileName.isEmpty()) return;
-
-    if ( !fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+    if( fileName.isEmpty() )
     {
-        fileName.append(".xml");
+        return;
+    }
+
+    // Must be case insensitive to work on MacOS platforms, possibly a cause of
+    // https://bugs.launchpad.net/mudlet/+bug/1417234
+    if( ! fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+    {
+        fileName.append( QStringLiteral( ".xml" ) );
     }
 
 
@@ -6957,11 +6962,16 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
                                                     QDir::homePath(),
                                                     tr("trigger files (*.trigger *.xml)"));
 
-    if(fileName.isEmpty()) return;
-
-    if ( !fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive ) )
+    if( fileName.isEmpty() )
     {
-        fileName.append(".xml");
+        return;
+    }
+    // Must be case insensitive to work on MacOS platforms, possibly a cause of
+    // https://bugs.launchpad.net/mudlet/+bug/1417234
+    if(  ! fileName.endsWith( QStringLiteral( ".xml" ), Qt::CaseInsensitive )
+      && ! fileName.endsWith( QStringLiteral( ".trigger" ), Qt::CaseInsensitive ) )
+    {
+        fileName.append( QStringLiteral( ".xml" ) );
     }
 
     QFile file(fileName);


### PR DESCRIPTION
…tive

This is likely a fix for [bug 1417234](https://bugs.launchpad.net/mudlet/+bug/1417234) which is where a suitable file is having an extra xml extension added, probably because the MacOS File system and native file dialogues are not necessarily case sensitive and could produce a file with an extension XML rather than xml that would fail checks for the latter in the past.

This bug regarded as a "ShowStopper" for Mudlet 3.0 release; this fix ported from that branch slightly overwrites existing modifications in `dlgTriggerExport::slot_export()` but is functionally the same there and also in `dlgTriggerEditor::slot_profileSaveAsAction()` however in the latter there was a (minor) logic error in the prior code that would misbehave if the user manually specified a (valid, but old) file extension of `.trigger` instead of `.xml` - the code should now work sensibly.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

This matches/duplicates the effects of #378 on the release_30 branch.