### PR TITLE
GMCP is now enabled by default on new profiles

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -73,7 +73,7 @@ Host::Host( int port, const QString& hostname, const QString& login, const QStri
 , mCommandSeperator  ( QString(";") )
 , mDisableAutoCompletion( false )
 , mDisplayFont       ( QFont("Bitstream Vera Sans Mono", 10, QFont::Normal ) )//, mDisplayFont       ( QFont("Bitstream Vera Sans Mono", 10, QFont:://( QFont("Monospace", 10, QFont::Courier) ), mPort              ( port )
-, mEnableGMCP( false )
+, mEnableGMCP( true )
 , mEnableMSDP( false )
 , mFORCE_GA_OFF( false )
 , mFORCE_NO_COMPRESSION( false )


### PR DESCRIPTION
GMCP has clearly eclipsed ATCP at this point by popularity and it has also been rock-solid for a couple of years now, so we can safely enable it by default and save people having to do the whole 'enable GMCP & reconnect' dance on a new profile.

Haven't got that much information about MSDP so it's not enabled yet.