### PR TITLE
QSettings config directory

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -655,7 +655,11 @@ void dlgTriggerEditor::readSettings()
 {
     QSettings settings("mudlet", "Mudlet 1.0");
 
-    //For compatibility with older settings, if no config is loaded from the config directory "mudlet", we try to load from the config directory "Mudlet".
+    /*In case sensitive environments, two different config directories 
+    were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
+    For compatibility with older settings, if no config is loaded 
+    from the config directory "mudlet", we try to load from the config 
+    directory "Mudlet".*/
     if(settings.value("pos") == 0)
     {
         QSettings settings("Mudlet","Mudlet 1.0");

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -653,7 +653,7 @@ void dlgTriggerEditor::closeEvent(QCloseEvent *event)
 
 void dlgTriggerEditor::readSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "Mudlet 1.0");
     QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize( size );
@@ -662,7 +662,7 @@ void dlgTriggerEditor::readSettings()
 
 void dlgTriggerEditor::writeSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "Mudlet 1.0");
     settings.setValue("script_editor_pos", pos());
     settings.setValue("script_editor_size", size());
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -654,6 +654,14 @@ void dlgTriggerEditor::closeEvent(QCloseEvent *event)
 void dlgTriggerEditor::readSettings()
 {
     QSettings settings("mudlet", "Mudlet 1.0");
+
+    //Check if loaded. Otherwise, try to load from Mudlet directory instead of mudlet.
+    if(settings.value("pos") == 0)
+    {
+        QSettings settings("Mudlet","Mudlet 1.0");
+    }
+
+
     QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();
     resize( size );

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -655,7 +655,7 @@ void dlgTriggerEditor::readSettings()
 {
     QSettings settings("mudlet", "Mudlet 1.0");
 
-    //Check if loaded. Otherwise, try to load from Mudlet directory instead of mudlet.
+    //For compatibility with older settings, if no config is loaded from the config directory "mudlet", we try to load from the config directory "Mudlet".
     if(settings.value("pos") == 0)
     {
         QSettings settings("Mudlet","Mudlet 1.0");

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -653,13 +653,14 @@ void dlgTriggerEditor::closeEvent(QCloseEvent *event)
 
 void dlgTriggerEditor::readSettings()
 {
-    QSettings settings("mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "Mudlet");
 
     /*In case sensitive environments, two different config directories 
     were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
+    Furthermore, we skip the version from the application name to follow the convention.
     For compatibility with older settings, if no config is loaded 
-    from the config directory "mudlet", we try to load from the config 
-    directory "Mudlet".*/
+    from the config directory "mudlet", application "Mudlet", we try to load from the config 
+    directory "Mudlet", application "Mudlet 1.0". */
     if(settings.value("pos") == 0)
     {
         QSettings settings("Mudlet","Mudlet 1.0");
@@ -674,7 +675,11 @@ void dlgTriggerEditor::readSettings()
 
 void dlgTriggerEditor::writeSettings()
 {
-    QSettings settings("mudlet", "Mudlet 1.0");
+    /*In case sensitive environments, two different config directories 
+    were used: "Mudlet" for QSettings, and "mudlet" anywhere else. We change the QSettings directory 
+    (the organization name) to "mudlet".
+    Furthermore, we skip the version from the application name to follow the convention.*/
+    QSettings settings("mudlet", "Mudlet");
     settings.setValue("script_editor_pos", pos());
     settings.setValue("script_editor_size", size());
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1686,7 +1686,7 @@ void mudlet::closeEvent(QCloseEvent *event)
 
 void mudlet::readSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "Mudlet 1.0");
     QPoint pos = settings.value("pos", QPoint(0, 0)).toPoint();
     QSize size = settings.value("size", QSize(750, 550)).toSize();
     mMainIconSize = settings.value("mainiconsize",QVariant(3)).toInt();
@@ -1742,7 +1742,7 @@ void mudlet::setIcoSize( int s )
 
 void mudlet::writeSettings()
 {
-    QSettings settings("Mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "Mudlet 1.0");
     settings.setValue("pos", pos());
     settings.setValue("size", size());
     settings.setValue("mainiconsize", mMainIconSize);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1688,7 +1688,7 @@ void mudlet::readSettings()
 {
     QSettings settings("mudlet", "Mudlet 1.0");
     
-    //Check if loaded. Otherwise, try to load from Mudlet directory instead of mudlet.
+    //For compatibility with older settings, if no config is loaded from the config directory "mudlet", we try to load from the config directory "Mudlet".
     if(settings.value("pos") == 0)
     {
         QSettings settings("Mudlet","Mudlet 1.0");

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1688,7 +1688,11 @@ void mudlet::readSettings()
 {
     QSettings settings("mudlet", "Mudlet 1.0");
     
-    //For compatibility with older settings, if no config is loaded from the config directory "mudlet", we try to load from the config directory "Mudlet".
+    /*In case sensitive environments, two different config directories 
+    were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
+    For compatibility with older settings, if no config is loaded 
+    from the config directory "mudlet", we try to load from the config 
+    directory "Mudlet".*/
     if(settings.value("pos") == 0)
     {
         QSettings settings("Mudlet","Mudlet 1.0");

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1687,6 +1687,13 @@ void mudlet::closeEvent(QCloseEvent *event)
 void mudlet::readSettings()
 {
     QSettings settings("mudlet", "Mudlet 1.0");
+    
+    //Check if loaded. Otherwise, try to load from Mudlet directory instead of mudlet.
+    if(settings.value("pos") == 0)
+    {
+        QSettings settings("Mudlet","Mudlet 1.0");
+    }
+    
     QPoint pos = settings.value("pos", QPoint(0, 0)).toPoint();
     QSize size = settings.value("size", QSize(750, 550)).toSize();
     mMainIconSize = settings.value("mainiconsize",QVariant(3)).toInt();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1686,13 +1686,14 @@ void mudlet::closeEvent(QCloseEvent *event)
 
 void mudlet::readSettings()
 {
-    QSettings settings("mudlet", "Mudlet 1.0");
+    QSettings settings("mudlet", "Mudlet");
     
     /*In case sensitive environments, two different config directories 
     were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
+    Furthermore, we skip the version from the application name to follow the convention.
     For compatibility with older settings, if no config is loaded 
-    from the config directory "mudlet", we try to load from the config 
-    directory "Mudlet".*/
+    from the config directory "mudlet", application "Mudlet", we try to load from the config 
+    directory "Mudlet", application "Mudlet 1.0". */
     if(settings.value("pos") == 0)
     {
         QSettings settings("Mudlet","Mudlet 1.0");
@@ -1753,7 +1754,10 @@ void mudlet::setIcoSize( int s )
 
 void mudlet::writeSettings()
 {
-    QSettings settings("mudlet", "Mudlet 1.0");
+    /*In case sensitive environments, two different config directories 
+    were used: "Mudlet" for QSettings, and "mudlet" anywhere else. We change the QSettings directory to "mudlet".
+    Furthermore, we skip the version from the application name to follow the convention.*/
+    QSettings settings("mudlet", "Mudlet");
     settings.setValue("pos", pos());
     settings.setValue("size", size());
     settings.setValue("mainiconsize", mMainIconSize);


### PR DESCRIPTION
To save the settings, the config folder in QSettings across the source was set to "Mudlet".
For any other config file, the folder is "mudlet". 
Therefore, in case-sensitive systems (i.e. Linux), we were creating two config directories.

To fix it, I changed "Mudlet" to "mudlet" in the QSettings instanciations.