### PR TITLE
(dev) Fix accidental shift instead of compare

### DIFF
--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -91,7 +91,7 @@ bool HostManager::addHost( QString hostname, QString port, QString login, QStrin
     }
 
     int portnumber = 23;
-    if( ! port.isEmpty() && port.toInt() > 0 && port.toInt() << 65536 )
+    if( ! port.isEmpty() && port.toInt() > 0 && port.toInt() < 65536 )
     {
         portnumber = port.toInt();
     }


### PR DESCRIPTION
I don't think we mean to shift here.

It wasn't an actual problem though because the UI did the correct check beforehand.