### PR TITLE
BugFix: fixup recent change to ./src/XMLimport.cpp

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -36,14 +36,14 @@
 #include "VarUnit.h"
 #include "mudlet.h"
 
-// clang-format off
+// clang-format: off
 #include "pre_guard.h"
-// clang-format on
+// clang-format: on
 #include <QDebug>
 #include <QStringList>
-// clang-format off
-#include "pre_guard.h"
-// clang-format on
+// clang-format: off
+#include "post_guard.h"
+// clang-format: on
 
 XMLimport::XMLimport(Host* pH)
     : mpHost(pH)


### PR DESCRIPTION
With the use of Clang-format I found that it was necessary to disable the automagic header sorting that this utility does to the MSVC specific Qt library include guarding header files "pre_guard.h" and "post_guard.h", unfortunately when cloning the changes from the release_30 branch to this the development branch it seems I entered the wrong filename in the above
file.

Note that there is a similar name commit to be applied to the release_30 branch HOWEVER that fixes an entire different c**k-up in that branch (though the source was ALSO partly brought about by the same usage of code reformatting tools on the SAME file)... 8-(

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>