### PR TITLE
(release_30)bugFix: fixup recent change to ./src/XMLimport.cpp

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1180,9 +1180,9 @@ void XMLimport::readAliasPackage()
                 } else {
                     readAliasGroup(mpAlias);
                 }
+            } else {
+                readUnknownAliasElement();
             }
-        } else {
-            readUnknownAliasElement();
         }
     }
 }


### PR DESCRIPTION
With the use of Clang-format I found that it does not include the ability to insert/remove '{' and '}' around single statement code blocks in condition/loop construct.  I was inserting those manually but was thrown awry by the new/different layout for '} else {' that was chosen to be used and ended up paring a nested "else" code block with the wrong nested "if(...)" in (void) XMLimport::readAliasPackage() which breaks the parsing of many packages including the default ones so that they are not installed correctly.

Note that there is a similar name commit to be applied to the development branch HOWEVER that fixes an entire different c**k-up in that branch (though the source was ALSO partly brought about by the same usage of code reformatting tools on the SAME file)... 8-(

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>