### PR TITLE
(dev) Fix setExitStub to allow in/out stubs

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1939,7 +1939,7 @@ int TLuaInterpreter::setExitStub( lua_State * L  ){
         lua_error( L );
         return 1;
     }
-    if(dirType>10 || dirType < 1)
+    if(dirType>12 || dirType < 1)
     {
         lua_pushstring( L, "setExitStub: dirType must be between 1 and 10" );
         lua_error( L );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1941,7 +1941,7 @@ int TLuaInterpreter::setExitStub( lua_State * L  ){
     }
     if(dirType>12 || dirType < 1)
     {
-        lua_pushstring( L, "setExitStub: dirType must be between 1 and 10" );
+        lua_pushstring( L, "setExitStub: dirType must be between 1 and 12" );
         lua_error( L );
         return 1;
     }


### PR DESCRIPTION
See http://forums.mudlet.org/viewtopic.php?f=9&t=14770&p=34560#p34644

This actually reveals another bug; if you pass it 13 the error message will be "setExitStub: Need a dir number as 2nd argument" - which while being technically true as 13 is not a recognised dir number, it in reality pretty annoying to see because an unaware user might be thinking that they -are- passing in a dir number. That said, keeping scope of the PRs small for digestibility and don't want to do refactorings of functions before 3.0 final. See https://bugs.launchpad.net/mudlet/+bug/1670245

(cherry picked from commit cd8c25861feb9cc243b76c38d414d879987dce0b)