### PR TITLE
(dev) Bug fix report regexp errors correctly

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -273,6 +274,8 @@ void TAlias::setRegexCode(const QString& code )
     if( re == NULL )
     {
         mOK_init = false;
+        QString errorString = tr( "Error: in \"Pattern:\", faulty regular expression, reason: \"%1\"." ).arg( error );
+        setError( errorString );
     }
     else
     {

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -265,8 +265,13 @@ static void pcre_deleter(pcre* pointer)
 void TAlias::setRegexCode(const QString& code )
 {
     mRegexCode = code;
+    compileRegex();
+}
+
+void TAlias::compileRegex()
+{
     const char *error;
-    const QByteArray& local8Bit = code.toLocal8Bit();
+    const QByteArray& local8Bit = mRegexCode.toLocal8Bit(); // TODO: add PCRE_UTF8 to options in pcre_compile() below and change to mRegexCode.toUft8()
     int erroffset;
 
     QSharedPointer<pcre> re(pcre_compile(local8Bit.constData(), 0, &error, &erroffset, NULL), pcre_deleter);
@@ -274,12 +279,30 @@ void TAlias::setRegexCode(const QString& code )
     if( re == NULL )
     {
         mOK_init = false;
-        QString errorString = tr( "Error: in \"Pattern:\", faulty regular expression, reason: \"%1\"." ).arg( error );
-        setError( errorString );
+        if( mudlet::debugMode ) {
+            TDebug( QColor(Qt::white), QColor(Qt::red) ) << "REGEX ERROR: failed to compile, reason:\n"
+                                                         << error
+                                                         << "\n"
+                                                         >> 0;
+            TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "in: \""
+                                                        << mRegexCode
+                                                        << "\"\n"
+                                                        >> 0;
+        }
+        setError( tr( "Error: in \"Pattern:\", faulty regular expression, reason: \"%1\"." )
+                  .arg( error ) );
     }
     else
     {
         mOK_init = true;
+        if( mudlet::debugMode ) {
+            TDebug( QColor(Qt::white), QColor(Qt::darkGreen) ) << "REGEX OK: successful compilation of:\n"
+                                                               >> 0;
+            TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "\""
+                                                        << mRegexCode
+                                                        << "\"\n"
+                                                        >> 0;
+        }
     }
 
     mpRegex = re;
@@ -300,9 +323,22 @@ void TAlias::compileAll()
     mNeedsToBeCompiled = true;
     if( ! compileScript() )
     {
-        if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: Lua compile error. compiling script of alias:"<<mName<<"\n">>0;}
+        if( mudlet::debugMode ) {
+            TDebug( QColor(Qt::white), QColor(Qt::red) ) << "LUA ERROR: when compiling script of alias:"
+                                                         << mName
+                                                         << "\n"
+                                                         >> 0;
+        }
         mOK_code = false;
     }
+    else
+    {
+        TDebug( QColor(Qt::white), QColor(Qt::red) ) << "LUA OK: when compiling script of alias:"
+                                                     << mName
+                                                     << "\n"
+                                                     >> 0;
+    }
+    compileRegex(); // Effectively will repost the error if there was a problem in the regex
     for(auto it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
     {
         TAlias * pChild = *it;
@@ -310,22 +346,23 @@ void TAlias::compileAll()
     }
 }
 
-void TAlias::compile()
-{
-    if( mNeedsToBeCompiled )
-    {
-        if( ! compileScript() )
-        {
-            if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: Lua compile error. compiling script of alias:"<<mName<<"\n">>0;}
-            mOK_code = false;
-        }
-    }
-    for(auto it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
-    {
-        TAlias * pChild = *it;
-        pChild->compile();
-    }
-}
+// Not used - so commented out rather than updating error/success messages
+//void TAlias::compile()
+//{
+//    if( mNeedsToBeCompiled )
+//    {
+//        if( ! compileScript() )
+//        {
+//            if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: Lua compile error. compiling script of alias:"<<mName<<"\n">>0;}
+//            mOK_code = false;
+//        }
+//    }
+//    for(auto it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
+//    {
+//        TAlias * pChild = *it;
+//        pChild->compile();
+//    }
+//}
 
 bool TAlias::setScript(const QString & script )
 {

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,6 +26,7 @@
 #include "Tree.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QPointer>
 #include <QSharedPointer>
 #include "post_guard.h"
@@ -36,6 +38,7 @@ class Host;
 
 class TAlias : public Tree<TAlias>
 {
+    Q_DECLARE_TR_FUNCTIONS(TAlias) // Needed so we can use tr() even though TAlias is NOT derived from QObject
     friend class XMLexport;
     friend class XMLimport;
 

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -49,9 +49,10 @@ public:
                      TAlias( TAlias * parent, Host * pHost );
                      TAlias(const QString& name, Host * pHost );
     void             compileAll();
+    void            compileRegex();
     QString          getName()                       { return mName; }
     void             setName(const QString& name );
-    void             compile();
+// Not Used:    void             compile();
     bool             compileScript();
     void             execute();
     QString          getScript()                     { return mScript; }
@@ -69,7 +70,7 @@ public:
 
 
 
-                     TAlias(){};
+                     TAlias(){}
     QString          mName;
     QString          mCommand;
     QString          mRegexCode;

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,6 +26,7 @@
 #include "Tree.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QColor>
 #include <QMap>
 #include <QPointer>
@@ -65,7 +67,7 @@ struct TColorTable
 
 class TTrigger : public Tree<TTrigger>
 {
-
+    Q_DECLARE_TR_FUNCTIONS(TTrigger) // Needed so we can use tr() even though TTrigger is NOT derived from QObject
     friend class XMLexport;
     friend class XMLimport;
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -2977,7 +2977,7 @@ void dlgTriggerEditor::addAlias( bool isFolder )
         //insert a new root item
 ROOT_ALIAS:
         pT = new TAlias( name, mpHost );
-        pT->setRegexCode( regex );
+        pT->setRegexCode( regex ); // Empty regex will always succeed to compile
         pNewItem = new QTreeWidgetItem( mpAliasBaseItem, nameL );
         treeWidget_aliases->insertTopLevelItem( 0, pNewItem );
     }
@@ -2986,7 +2986,7 @@ ROOT_ALIAS:
 
     pT->setName( name );
     pT->setCommand( command );
-    pT->setRegexCode( regex );
+    pT->setRegexCode( regex ); // Empty regex will always succeed to compile
     pT->setScript( script );
     pT->setIsFolder( isFolder );
     pT->setIsActive( false );
@@ -3367,7 +3367,7 @@ void dlgTriggerEditor::saveTrigger()
                 iconError.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
                 pItem->setIcon( 0, iconError );
                 pT->setIsActive( false );
-
+                showError( pT->getError() );
             }
         }
     }
@@ -3506,7 +3506,7 @@ void dlgTriggerEditor::saveAlias()
             QString old_name = pT->getName();
             pT->setName( name );
             pT->setCommand( substitution );
-            pT->setRegexCode( regex );
+            pT->setRegexCode( regex ); // This could generate an error state if regex does not compile
             pT->setScript( script );
 
             QIcon icon;
@@ -3591,6 +3591,7 @@ void dlgTriggerEditor::saveAlias()
                 iconError.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
                 pItem->setIcon( 0, iconError );
                 pItem->setText( 0, name );
+                showError( pT->getError() );
             }
         }
     }


### PR DESCRIPTION
Fixes a long standing [bug 583584](https://bugs.launchpad.net/mudlet/+bug/583584).

Although original problem was with `TAlias` items (which use a regexp) to match against user keystrokes it also minded me to take a look at the behaviour of `TTrigger` items that had Perl regexp type entries, and I have updated the error messages for those to also report the error details should there be any in a regexp.

Second commit added error messages for failure to compile the regexp in the TAlias class instances to the editor window they did not show in the Debug Console if it was enabled - given that a successful Lua compilation message can be shown in such situations it can be misleading
that everything is alright, even when it isn't.