### PR TITLE
(release 30)bug fix report regexp errors correctly

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -315,20 +315,13 @@ void TAlias::compileRegex()
                                                         << "\"\n"
                                                         >> 0;
         }
-        setError( tr( "Error: in \"Pattern:\", faulty regular expression, reason: \"%1\"." )
-                  .arg( error ) );
+        setError( QStringLiteral( "<b><font color='blue'>%1</font></b>" )
+                  .arg( tr( "Error: in \"Pattern:\", faulty regular expression, reason: \"%1\"." )
+                        .arg( error ) ) );
     }
     else
     {
         mOK_init = true;
-        if( mudlet::debugMode ) {
-            TDebug( QColor(Qt::white), QColor(Qt::darkGreen) ) << "REGEX OK: successful compilation of:\n"
-                                                               >> 0;
-            TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "\""
-                                                        << mRegexCode
-                                                        << "\"\n"
-                                                        >> 0;
-        }
     }
 
     mpRegex = re;
@@ -350,19 +343,12 @@ void TAlias::compileAll()
     if( ! compileScript() )
     {
         if( mudlet::debugMode ) {
-            TDebug( QColor(Qt::white), QColor(Qt::red) ) << "LUA ERROR: when compiling script of alias:"
+            TDebug( QColor(Qt::white), QColor(Qt::red) ) << "ERROR: Lua compile error. compiling script of alias:"
                                                          << mName
                                                          << "\n"
                                                          >> 0;
         }
         mOK_code = false;
-    }
-    else
-    {
-        TDebug( QColor(Qt::white), QColor(Qt::red) ) << "LUA OK: when compiling script of alias:"
-                                                     << mName
-                                                     << "\n"
-                                                     >> 0;
     }
     compileRegex(); // Effectively will repost the error if there was a problem in the regex
     typedef list<TAlias *>::const_iterator I;
@@ -373,24 +359,23 @@ void TAlias::compileAll()
     }
 }
 
-// Not used - so commented out rather than updating error/success messages
-//void TAlias::compile()
-//{
-//    if( mNeedsToBeCompiled )
-//    {
-//        if( ! compileScript() )
-//        {
-//            if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: Lua compile error. compiling script of alias:"<<mName<<"\n">>0;}
-//            mOK_code = false;
-//        }
-//    }
-//    typedef list<TAlias *>::const_iterator I;
-//    for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
-//    {
-//        TAlias * pChild = *it;
-//        pChild->compile();
-//    }
-//}
+void TAlias::compile()
+{
+    if( mNeedsToBeCompiled )
+    {
+        if( ! compileScript() )
+        {
+            if( mudlet::debugMode ) {TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: Lua compile error. compiling script of alias:"<<mName<<"\n">>0;}
+            mOK_code = false;
+        }
+    }
+    typedef list<TAlias *>::const_iterator I;
+    for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
+    {
+        TAlias * pChild = *it;
+        pChild->compile();
+    }
+}
 
 bool TAlias::setScript( const QString & script )
 {

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -299,6 +300,8 @@ void TAlias::setRegexCode( QString code )
     if( re == NULL )
     {
         mOK_init = false;
+        QString errorString = tr( "Error: in \"Pattern:\", faulty regular expression, reason: \"%1\"." ).arg( error );
+        setError( errorString );
     }
     else
     {

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -50,7 +50,7 @@ public:
     void            compileRegex();
     QString          getName()                       { return mName; }
     void             setName( QString name );
-// Not Used:    void             compile();
+    void             compile();
     bool             compileScript();
     void             execute();
     QString          getScript()                     { return mScript; }

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +25,10 @@
 
 #include "Tree.h"
 
+#include "pre_guard.h"
+#include <QApplication>
+#include "post_guard.h"
+
 #include <pcre.h>
 
 class Host;
@@ -31,6 +36,7 @@ class Host;
 
 class TAlias : public Tree<TAlias>
 {
+    Q_DECLARE_TR_FUNCTIONS(TAlias) // Needed so we can use tr() even though TAlias is NOT derived from QObject
     friend class XMLexport;
     friend class XMLimport;
 

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -47,9 +47,10 @@ public:
                      TAlias( TAlias * parent, Host * pHost );
                      TAlias( QString name, Host * pHost );
     void             compileAll();
+    void            compileRegex();
     QString          getName()                       { return mName; }
     void             setName( QString name );
-    void             compile();
+// Not Used:    void             compile();
     bool             compileScript();
     void             execute();
     QString          getScript()                     { return mScript; }
@@ -67,7 +68,7 @@ public:
 
 
 
-                     TAlias(){};
+                     TAlias(){}
     QString          mName;
     QString          mCommand;
     QString          mRegexCode;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -174,14 +175,23 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
                                &erroffset,
                                0 );
 
-            if (re == 0)
+            if (!re)
             {
                 if( mudlet::debugMode )
                 {
-                    TDebug(QColor(Qt::white),QColor(Qt::red))<<"REGEX COMPILE ERROR:">>0;
-                    TDebug(QColor(Qt::red),QColor(Qt::gray))<<pattern<<"\n">>0;
+                    TDebug( QColor(Qt::white), QColor(Qt::red) ) << "REGEX ERROR: failed to compile, reason:\n"
+                                                                 << error
+                                                                 << "\n"
+                                                                 >> 0;
+                    TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "in: \""
+                                                                << pattern
+                                                                << "\"\n"
+                                                                >> 0;
                 }
-                setError( QString( "Pattern '" )+QString(pattern)+QString( "' failed to compile. Correct the pattern.") );
+                setError( tr( "Error: in item %1, perl regex: \"%2\", it failed to compile, reason: \"%3\"." )
+                          .arg( i )
+                          .arg( pattern )
+                          .arg( error ) );
                 state = false;
                 //printf("PCRE compilation failed at offset %d: %s\n", erroffset, error);
             }
@@ -189,27 +199,56 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
             {
                 if( mudlet::debugMode )
                 {
-                    TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"[OK]: REGEX_COMPILE OK\n">>0;
+                    TDebug( QColor(Qt::white), QColor(Qt::darkGreen) ) << "REGEX OK: successful compilation of:\n"
+                                                                       >> 0;
+                    TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "\""
+                                                                << pattern
+                                                                << "\"\n"
+                                                                >> 0;
                 }
             }
             mRegexMap[i] = re;
             mTriggerContainsPerlRegex = true;
         }
-        if( propertyList[i] == REGEX_LUA_CODE )
+
+        if( propertyList.at(i) == REGEX_LUA_CODE )
         {
              std::string funcName;
              std::stringstream func;
              func << "trigger" << mID << "condition" << i;
              funcName = func.str();
-             QString code = QString("function ")+funcName.c_str()+QString("()\n")+regexList[i]+QString("\nend\n");
+             QString code = QStringLiteral("function %1()\n%2\nend\n").arg( funcName.c_str() ).arg( regexList[i] );
              QString error;
              if( ! mpLua->compile( code, error ) )
              {
-                 setError( QString("pattern type Lua condition function '")+regexList[i]+QString("' failed to compile.")+error);
+                 setError( tr("Error: in item %1, lua condition function \"%2\" failed to compile, reason:%3.")
+                           .arg( i )
+                           .arg( regexList.at( i ) )
+                           .arg( error ) );
                  state = false;
+                 if( mudlet::debugMode )
+                 {
+                     TDebug( QColor(Qt::white), QColor(Qt::red) ) << "LUA ERROR: failed to compile, reason:\n"
+                                                                  << error
+                                                                  << "\n"
+                                                                  >> 0;
+                     TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "in lua condition function: \""
+                                                                 << regexList.at( i )
+                                                                 << "\"\n"
+                                                                 >> 0;
+                 }
              }
              else
              {
+                 if( mudlet::debugMode )
+                 {
+                     TDebug( QColor(Qt::white), QColor(Qt::darkGreen) ) << "LUA OK: successful compilation of:\n"
+                                                                        >> 0;
+                     TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "lua condition function: \""
+                                                                 << regexList.at( i )
+                                                                 << "\"\n"
+                                                                 >> 0;
+                 }
                  mLuaConditionMap[i] = funcName;
              }
         }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -188,23 +188,18 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
                                                                 << "\"\n"
                                                                 >> 0;
                 }
-                setError( tr( "Error: in item %1, perl regex: \"%2\", it failed to compile, reason: \"%3\"." )
-                          .arg( i )
-                          .arg( pattern )
-                          .arg( error ) );
+                setError( QStringLiteral( "<b><font color='blue'>%1</font></b>" )
+                          .arg( tr( "Error: in item %1, perl regex: \"%2\", it failed to compile, reason: \"%3\"." )
+                                .arg( i )
+                                .arg( pattern )
+                                .arg( error ) ) );
                 state = false;
-                //printf("PCRE compilation failed at offset %d: %s\n", erroffset, error);
             }
             else
             {
                 if( mudlet::debugMode )
                 {
-                    TDebug( QColor(Qt::white), QColor(Qt::darkGreen) ) << "REGEX OK: successful compilation of:\n"
-                                                                       >> 0;
-                    TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "\""
-                                                                << pattern
-                                                                << "\"\n"
-                                                                >> 0;
+                    TDebug(QColor(Qt::white),QColor(Qt::darkGreen))<<"[OK]: REGEX_COMPILE OK\n">>0;
                 }
             }
             mRegexMap[i] = re;
@@ -221,10 +216,11 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
              QString error;
              if( ! mpLua->compile( code, error ) )
              {
-                 setError( tr("Error: in item %1, lua condition function \"%2\" failed to compile, reason:%3.")
-                           .arg( i )
-                           .arg( regexList.at( i ) )
-                           .arg( error ) );
+                 setError( QStringLiteral( "<b><font color='blue'>%1</font></b>" )
+                           .arg( tr("Error: in item %1, lua condition function \"%2\" failed to compile, reason:%3.")
+                                 .arg( i )
+                                 .arg( regexList.at( i ) )
+                                 .arg( error ) ) );
                  state = false;
                  if( mudlet::debugMode )
                  {
@@ -240,18 +236,10 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
              }
              else
              {
-                 if( mudlet::debugMode )
-                 {
-                     TDebug( QColor(Qt::white), QColor(Qt::darkGreen) ) << "LUA OK: successful compilation of:\n"
-                                                                        >> 0;
-                     TDebug( QColor(Qt::red), QColor(Qt::gray) ) << "lua condition function: \""
-                                                                 << regexList.at( i )
-                                                                 << "\"\n"
-                                                                 >> 0;
-                 }
                  mLuaConditionMap[i] = funcName;
              }
         }
+
         if( propertyList[i] == REGEX_COLOR_PATTERN )
         {
             QRegExp regex = QRegExp("FG(\\d+)BG(\\d+)");

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,6 +26,7 @@
 #include "Tree.h"
 
 #include "pre_guard.h"
+#include <QApplication>
 #include <QColor>
 #include <QMap>
 #include "post_guard.h"
@@ -63,7 +65,7 @@ struct TColorTable
 
 class TTrigger : public Tree<TTrigger>
 {
-
+    Q_DECLARE_TR_FUNCTIONS(TTrigger) // Needed so we can use tr() even though TTrigger is NOT derived from QObject
     friend class XMLexport;
     friend class XMLimport;
 

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -153,7 +153,7 @@ public:
     bool            mModuleMasterFolder;
 private:
 
-                                           TTrigger(){};
+                                           TTrigger(){}
     void                                   updateMultistates( int regexNumber,
                                                               std::list<std::string> & captureList,
                                                               std::list<int> & posList );

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3023,7 +3023,7 @@ void dlgTriggerEditor::addAlias( bool isFolder )
         //insert a new root item
 ROOT_ALIAS:
         pT = new TAlias( name, mpHost );
-        pT->setRegexCode( regex );
+        pT->setRegexCode( regex ); // Empty regex will always succeed to compile
         pNewItem = new QTreeWidgetItem( mpAliasBaseItem, nameL );
         treeWidget_aliases->insertTopLevelItem( 0, pNewItem );
     }
@@ -3032,7 +3032,7 @@ ROOT_ALIAS:
 
     pT->setName( name );
     pT->setCommand( command );
-    pT->setRegexCode( regex );
+    pT->setRegexCode( regex ); // Empty regex will always succeed to compile
     pT->setScript( script );
     pT->setIsFolder( isFolder );
     pT->setIsActive( false );
@@ -3412,7 +3412,7 @@ void dlgTriggerEditor::saveTrigger()
                 iconError.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
                 pItem->setIcon( 0, iconError );
                 pT->setIsActive( false );
-
+                showError( pT->getError() );
             }
         }
     }
@@ -3551,7 +3551,7 @@ void dlgTriggerEditor::saveAlias()
             QString old_name = pT->getName();
             pT->setName( name );
             pT->setCommand( substitution );
-            pT->setRegexCode( regex );
+            pT->setRegexCode( regex ); // This could generate an error state if regex does not compile
             pT->setScript( script );
 
             QIcon icon;
@@ -3636,6 +3636,7 @@ void dlgTriggerEditor::saveAlias()
                 iconError.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
                 pItem->setIcon( 0, iconError );
                 pItem->setText( 0, name );
+                showError( pT->getError() );
             }
         }
     }


### PR DESCRIPTION
Fixes a long standing [bug 583584](https://bugs.launchpad.net/mudlet/+bug/583584).

Although original problem was with `TAlias` items (which use a regexp) to match against user keystrokes it also minded me to take a look at the behaviour of `TTrigger` items that had perl regexp type entries, and I have updated the error messages for those to also report the error details should there be any in a regexp.
