### PR TITLE
(release_30)bugFix: fix missing icon from replay toolbar and a spammy replay qDebug

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1652,10 +1652,10 @@ void cTelnet::readPipe()
     int datalen = loadedBytes;
     string cleandata = "";
     recvdGA = false;
+    qDebug("Replay data: \"%s\"", loadBuffer);
     for( int i = 0; i < datalen; i++ )
     {
         char ch = loadBuffer[i];
-        qDebug() << "GOT REPLAY:"<<loadBuffer;
         if( iac || iac2 || insb || (ch == TN_IAC) )
         {
             #ifdef DEBUG

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2310,7 +2310,7 @@ void mudlet::replayStart()
     actionReplaySpeedUp->setStatusTip(tr("Replay Speed Up"));
     replayToolBar->addAction( actionReplaySpeedUp );
 
-    actionReplaySpeedDown = new QAction( QIcon( QStringLiteral( ":/icons/port.png" ) ), tr("Slower"), this);
+    actionReplaySpeedDown = new QAction( QIcon( QStringLiteral( ":/icons/import.png" ) ), tr("Slower"), this);
     actionReplaySpeedDown->setStatusTip(tr("Replay Speed Down"));
     replayToolBar->addAction( actionReplaySpeedDown );
     replaySpeedDisplay = new QLabel( this );


### PR DESCRIPTION
I spotted the missing icon recently and I recall it was something that had already been ddressed in the development branch (by AC in commit: 9d52886268cfbb77498bedced2dc52ce6da1c815 ) but was not done for the release_30 branch for some reason.

There is also a `qDebug()` in `(void)cTelnet::_loadreplay()` that is in the wrong place and which grossly fills up any debugging output as a result, it seems I (or more likely Heiko) may have introduced it in commit: 1a6106aa21cdfcb053a25eb0722de87325a24bbc though AC did refactor it to use `qDebug()` when it previously used a `std::cout` - unfortunately he did not spot that it would dump the entire content of a replay chunk as many times as there were characters in that chunk!

These fixes only have to go into the release_30 branch - they have been addressed in other revisions to the development branch code by other development work (_I think_).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>