### PR TITLE
(release 30) Linux generic installer fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -400,6 +400,23 @@ ADD_SUBDIRECTORY(irc)
 
 ADD_DEFINITIONS(-DAPP_VERSION="${APP_VERSION}" -DAPP_BUILD="${APP_BUILD}" -DAPP_TARGET="${APP_TARGET}")
 
+IF(UNIX)
+    SET(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/share" CACHE STRING "The platform-specific directory in which read-only data is generally installed")
+    SET(DATADIR "${DATAROOTDIR}/mudlet" CACHE STRING "Directory in which mudlet installs its read-only data")
+    SET(LUA_DEFAULT_DIR "${DATADIR}/lua" CACHE STRING "Directory in which mudlet installs its read-only lua scripts")
+ENDIF(UNIX)
+
+# Define a preprocessor symbol with the default fallback location from which
+# to load installed mudlet lua files. Set LUA_DEFAULT_DIR to a
+# platform-specific value. If LUA_DEFAULT_DIR is unset, the root directory
+# will be used.
+ADD_DEFINITIONS(-DLUA_DEFAULT_PATH="${LUA_DEFAULT_DIR}")
+
+# Enable leak detection for MSVC debug builds.
+if(MSVC)
+  SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -FItestdbg.h")
+endif()
+
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 INCLUDE_DIRECTORIES(
     ${Qt5Core_INCLUDE_DIRS}

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5199,7 +5199,7 @@ int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
     lua_rawseti(L, -2, index++);
 #if defined(Q_OS_MAC)
     // add macOS lua path relative to the binary itself, which is part of the Mudlet.app package
-    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "../Resources/mudlet-lua/lua/" );
+    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/../Resources/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
     lua_rawseti(L, -2, index++);
 #endif

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5186,20 +5186,27 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
 // follows the principle of closest paths to the binary first, furthest away lasy
 int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
 {
+    int index = 1;
     lua_newtable( L );
+#if defined(Q_OS_MAC)
     lua_createtable(L,3,0);
+#else
+    lua_createtable(L,2,0);
+#endif
     // add filepath relative to the binary itself (one usecase is AppImage on Linux)
     QString nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,1);
+    lua_rawseti(L, -2,i++);
+#if defined(Q_OS_MAC)
     // add macOS lua path relative to the binary itself, which is part of the Mudlet.app package
-    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "../Resources//mudlet-lua/lua/" );
+    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "../Resources/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,2);
+    lua_rawseti(L, -2,i++);
+#endif
     // add the default search path as specified by build file
     nativePath = QDir::toNativeSeparators( LUA_DEFAULT_PATH "/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,3);
+    lua_rawseti(L, -2,i++);
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5182,6 +5182,14 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
     return 1;
 }
 
+int TLuaInterpreter::getMudletLuaDefaultPath( lua_State * L )
+{
+    QString path = LUA_DEFAULT_PATH "/";
+    QString nativePath = QDir::toNativeSeparators( path );
+    lua_pushstring( L, nativePath.toUtf8().constData() );
+    return 1;
+}
+
 int TLuaInterpreter::disconnect( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
@@ -12936,6 +12944,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "tempButton", TLuaInterpreter::tempButton );
     lua_register( pGlobalLua, "reconnect", TLuaInterpreter::reconnect );
     lua_register( pGlobalLua, "getMudletHomeDir", TLuaInterpreter::getMudletHomeDir );
+    lua_register( pGlobalLua, "getMudletLuaDefaultPath", TLuaInterpreter::getMudletLuaDefaultPath );
     lua_register( pGlobalLua, "setTriggerStayOpen", TLuaInterpreter::setTriggerStayOpen );
     lua_register( pGlobalLua, "wrapLine", TLuaInterpreter::wrapLine );
     lua_register( pGlobalLua, "getFgColor", TLuaInterpreter::getFgColor );
@@ -13290,25 +13299,36 @@ void TLuaInterpreter::loadGlobal()
         path = "mudlet-lua/lua/LuaGlobal.lua";
 #endif
         error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
-        if( error != 0 ) {
-            string e = "no error message available from Lua";
-            if( lua_isstring( pGlobalLua, -1 ) )
-            {
-                e = "[ ERROR ] - LuaGlobal.lua compile error - please report!\n"
-                                "Error from Lua: ";
-                e += lua_tostring( pGlobalLua, -1 );
-            }
-            mpHost->postMessage( e.c_str() );
-        }
-        else {
+        if( error == 0 ) {
             mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+            return;
         }
     }
     else
     {
         mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+        return;
     }
 
+    // Finally try loading from LUA_DEFAULT_PATH
+    path = LUA_DEFAULT_PATH "/LuaGlobal.lua";
+    error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
+    if( error != 0 )
+    {
+        string e = "no error message available from Lua";
+        if( lua_isstring( pGlobalLua, -1 ) )
+        {
+            e = "[ ERROR ] - LuaGlobal.lua compile error - please report!\n"
+                "Error from Lua: ";
+            e += lua_tostring( pGlobalLua, -1 );
+        }
+        mpHost->postMessage( e.c_str() );
+    }
+    else
+    {
+        mpHost->postMessage( "[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded." );
+        return;
+    }
 }
 
 void TLuaInterpreter::slotEchoMessage(int hostID, QString msg)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5183,7 +5183,7 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
 }
 
 // returns search paths for LuaGlobal itself to look at when loading other modules
-// follows the principle of closest paths to the binary first, furthest away lasy
+// follows the principle of closest paths to the binary first, furthest away last
 int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
 {
     int index = 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5187,15 +5187,19 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
 int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
 {
     lua_newtable( L );
-    lua_createtable(L,2,0);
+    lua_createtable(L,3,0);
     // add filepath relative to the binary itself (one usecase is AppImage on Linux)
     QString nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
     lua_rawseti(L, -2,1);
+    // add macOS lua path relative to the binary itself, which is part of the Mudlet.app package
+    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "../Resources//mudlet-lua/lua/" );
+    lua_pushstring( L, nativePath.toUtf8().constData() );
+    lua_rawseti(L, -2,2);
     // add the default search path as specified by build file
     nativePath = QDir::toNativeSeparators( LUA_DEFAULT_PATH "/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,2);
+    lua_rawseti(L, -2,3);
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5183,17 +5183,17 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
 }
 
 // returns search paths for LuaGlobal itself to look at when loading other modules
+// follows the principle of closest paths to the binary first, furthest away lasy
 int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
 {
     lua_newtable( L );
     lua_createtable(L,2,0);
-    // add the default search path as specified by build file
-    QString path = LUA_DEFAULT_PATH "/";
-    QString nativePath = QDir::toNativeSeparators( path );
+    // add filepath relative to the binary itself (one usecase is AppImage on Linux)
+    QString nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
     lua_rawseti(L, -2,1);
-    // as well as the filepath relative to the binary itself (one usecase is AppImage on Linux)
-    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/" );
+    // add the default search path as specified by build file
+    nativePath = QDir::toNativeSeparators( LUA_DEFAULT_PATH "/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
     lua_rawseti(L, -2,2);
     return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5196,17 +5196,17 @@ int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
     // add filepath relative to the binary itself (one usecase is AppImage on Linux)
     QString nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,i++);
+    lua_rawseti(L, -2, index++);
 #if defined(Q_OS_MAC)
     // add macOS lua path relative to the binary itself, which is part of the Mudlet.app package
     nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "../Resources/mudlet-lua/lua/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,i++);
+    lua_rawseti(L, -2, index++);
 #endif
     // add the default search path as specified by build file
     nativePath = QDir::toNativeSeparators( LUA_DEFAULT_PATH "/" );
     lua_pushstring( L, nativePath.toUtf8().constData() );
-    lua_rawseti(L, -2,i++);
+    lua_rawseti(L, -2, index++);
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5182,11 +5182,20 @@ int TLuaInterpreter::getMudletHomeDir( lua_State * L )
     return 1;
 }
 
-int TLuaInterpreter::getMudletLuaDefaultPath( lua_State * L )
+// returns search paths for LuaGlobal itself to look at when loading other modules
+int TLuaInterpreter::getMudletLuaDefaultPaths( lua_State * L )
 {
+    lua_newtable( L );
+    lua_createtable(L,2,0);
+    // add the default search path as specified by build file
     QString path = LUA_DEFAULT_PATH "/";
     QString nativePath = QDir::toNativeSeparators( path );
     lua_pushstring( L, nativePath.toUtf8().constData() );
+    lua_rawseti(L, -2,1);
+    // as well as the filepath relative to the binary itself (one usecase is AppImage on Linux)
+    nativePath = QDir::toNativeSeparators( QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/" );
+    lua_pushstring( L, nativePath.toUtf8().constData() );
+    lua_rawseti(L, -2,2);
     return 1;
 }
 
@@ -12944,7 +12953,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "tempButton", TLuaInterpreter::tempButton );
     lua_register( pGlobalLua, "reconnect", TLuaInterpreter::reconnect );
     lua_register( pGlobalLua, "getMudletHomeDir", TLuaInterpreter::getMudletHomeDir );
-    lua_register( pGlobalLua, "getMudletLuaDefaultPath", TLuaInterpreter::getMudletLuaDefaultPath );
+    lua_register( pGlobalLua, "getMudletLuaDefaultPaths", TLuaInterpreter::getMudletLuaDefaultPaths );
     lua_register( pGlobalLua, "setTriggerStayOpen", TLuaInterpreter::setTriggerStayOpen );
     lua_register( pGlobalLua, "wrapLine", TLuaInterpreter::wrapLine );
     lua_register( pGlobalLua, "getFgColor", TLuaInterpreter::getFgColor );

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -321,7 +321,7 @@ public:
     static int disconnect( lua_State * );
     static int reconnect( lua_State * );
     static int getMudletHomeDir( lua_State * );
-    static int getMudletLuaDefaultPath( lua_State * );
+    static int getMudletLuaDefaultPaths( lua_State * );
     static int setTriggerStayOpen( lua_State * );
     static int wrapLine( lua_State * );
     static int getFgColor( lua_State * );

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -321,6 +321,7 @@ public:
     static int disconnect( lua_State * );
     static int reconnect( lua_State * );
     static int getMudletHomeDir( lua_State * );
+    static int getMudletLuaDefaultPath( lua_State * );
     static int setTriggerStayOpen( lua_State * );
     static int wrapLine( lua_State * );
     static int getFgColor( lua_State * );

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -128,7 +128,8 @@ local packages = {
 -- TODO: extend to support common Lua code being placed in system shared directory
 -- tree as ought to happen for *nix install builds.
 local prefixes = {"../src/mudlet-lua/lua/", "../Resources/mudlet-lua/lua/",
-    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua"}
+    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua",
+    getMudletLuaDefaultPath()}
 
 local prefix
 for i = 1, #prefixes do

--- a/src/src.pro
+++ b/src/src.pro
@@ -135,8 +135,6 @@ unix:!macx {
 # installation details for the unix case:
         LUA.path = $${LUA_DEFAULT_DIR}
         LUA_GEYSER.path = $${LUA.path}/geyser
-# and define a preprocessor symbol LUA_DEFAULT_PATH with the value:
-        DEFINES += LUA_DEFAULT_PATH=\\\"$${LUA_DEFAULT_DIR}\\\"
 # and say what will happen:
         message("Lua files will be installed to "$${LUA.path}"...")
         message("Geyser lua files will be installed to "$${LUA_GEYSER.path}"...")
@@ -156,6 +154,12 @@ macx {
 macx:LIBS += \
     -lz \
     -lzzip
+
+# Define a preprocessor symbol with the default fallback location from which
+# to load installed mudlet lua files. Set LUA_DEFAULT_DIR to a
+# platform-specific value. If LUA_DEFAULT_DIR is unset, the root directory
+# will be used.
+DEFINES += LUA_DEFAULT_PATH=\\\"$${LUA_DEFAULT_DIR}\\\"
 
 INCLUDEPATH += irc/include
 


### PR DESCRIPTION
Need to fix the Linux generic installer - as the current one does not work, _at all_, for anybody. Switching over to using [AppImage](http://appimage.org/) instead of BitRock as I've validated AppImage with two random Ubuntu users and it at least seems to work better. Plus, it seems to be a better thing for the Linux ecosystem in general.

These fixes cherrypick 7922a3a4e3c71eae84fcfc1027d5c48ebaeb79ff from the ``development`` branch, improve that function to return multiple paths, and in general, make Mudlet also search things relative to its binary using an _absolute_ path. This is because AppImage does not set the current working directory for us unlike what Mudlet has been used to.

Merging this will also require merging which is a fix to LuaGlobal to also load stuff relative to the executable using a relative path.