### PR TITLE
(release_30)partialRevert: restore compilation order on profile loading

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1002,7 +1002,6 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
     pT->mColorTriggerBg = (attributes().value("isColorTriggerBg") == "yes");
     pT->mColorTriggerFg = (attributes().value("isColorTriggerFg") == "yes");
 
-    QString tempScript;
     while (!atEnd()) {
         readNext();
         // qDebug()<<"[INFO] element:"<<name().toString()<<" text:"<<text().toString();
@@ -1012,11 +1011,14 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
 
         if (isStartElement()) {
             if (name() == "name") {
-
                 pT->setName(readElementText());
                 continue;
             } else if (name() == "script") {
-                tempScript = readElementText();
+                QString tempScript = readElementText();
+                if (!pT->setScript(tempScript)) {
+                    qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not compile trigger's lua code for: " << pT->getName();
+                }
+                continue;
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
                 continue;
@@ -1032,9 +1034,7 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
             } else if (name() == "mCommand") {
                 pT->mCommand = readElementText();
                 continue;
-            }
-
-            else if (name() == "mFgColor") {
+            } else if (name() == "mFgColor") {
                 pT->mFgColor.setNamedColor(readElementText());
                 continue;
             } else if (name() == "mBgColor") {
@@ -1049,12 +1049,11 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
             } else if (name() == "mSoundFile") {
                 pT->mSoundFile = readElementText();
                 continue;
-            }
-            // The next two ought to be combined into a single element in the
-            // next revision - sample code for "RegexCode" elements inside a
-            // "RegexList" container (with a "size" attribute) is commented out
-            // in the XMLexporter class.
-            else if (name() == "regexCodeList") {
+            } else if (name() == "regexCodeList") {
+                // This and the next one ought to be combined into a single element
+                // in the next revision - sample code for "RegexCode" elements
+                // inside a "RegexList" container (with a "size" attribute) is
+                // commented out in the XMLexporter class.
                 readStringList(pT->mRegexCodeList);
                 continue;
             } else if (name() == "regexCodePropertyList") {
@@ -1074,10 +1073,6 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
 
     if (!pT->setRegexCodeList(pT->mRegexCodeList, pT->mRegexCodePropertyList)) {
         qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not initialize pattern list for trigger: " << pT->getName();
-    }
-
-    if (!pT->setScript(tempScript)) {
-        qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not compile trigger's script for: " << pT->getName();
     }
 }
 
@@ -1118,7 +1113,6 @@ void XMLimport::readTimerGroup(TTimer* pParent)
         pT->mModuleMember = true;
     }
 
-    QString tempScript;
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1134,7 +1128,10 @@ void XMLimport::readTimerGroup(TTimer* pParent)
                 pT->mPackageName = readElementText();
                 continue;
             } else if (name() == "script") {
-                tempScript = readElementText();
+                QString tempScript = readElementText();
+                if (!pT->setScript(tempScript)) {
+                    qDebug().nospace() << "XMLimport::readTimerGroup(...): ERROR: can not compile timer's lua code for: " << pT->getName();
+                }
                 continue;
             } else if (name() == "command") {
                 pT->mCommand = readElementText();
@@ -1150,10 +1147,6 @@ void XMLimport::readTimerGroup(TTimer* pParent)
                 readUnknownTimerElement();
             }
         }
-    }
-
-    if (!pT->setScript(tempScript)) {
-        qDebug().nospace() << "XMLimport::readTimerGroup(...): ERROR: can not compile timer's script for: " << pT->getName();
     }
 
     mudlet::self()->registerTimer(pT, pT->mpTimer);
@@ -1198,7 +1191,6 @@ void XMLimport::readAliasGroup(TAlias* pParent)
         pT->mModuleMember = true;
     }
 
-    QString tempScript;
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1213,7 +1205,10 @@ void XMLimport::readAliasGroup(TAlias* pParent)
                 pT->mPackageName = readElementText();
                 continue;
             } else if (name() == "script") {
-                tempScript = readElementText();
+                QString tempScript = readElementText();
+                if (!pT->setScript(tempScript)) {
+                    qDebug().nospace() << "XMLimport::readAliasGroup(...): ERROR: can not compile alias's lua code for: " << pT->getName();
+                }
                 continue;
             } else if (name() == "command") {
                 pT->mCommand = readElementText();
@@ -1227,10 +1222,6 @@ void XMLimport::readAliasGroup(TAlias* pParent)
                 readUnknownAliasElement();
             }
         }
-    }
-
-    if (!pT->setScript(tempScript)) {
-        qDebug().nospace() << "XMLimport::readAliasGroup(...): ERROR: can not compile alias's script for: " << pT->getName();
     }
 }
 
@@ -1270,7 +1261,6 @@ void XMLimport::readActionGroup(TAction* pParent)
         pT->mModuleMember = true;
     }
 
-    QString tempScript;
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1285,7 +1275,10 @@ void XMLimport::readActionGroup(TAction* pParent)
                 pT->mPackageName = readElementText();
                 continue;
             } else if (name() == "script") {
-                tempScript = readElementText();
+                QString tempScript = readElementText();
+                if (!pT->setScript(tempScript)) {
+                    qDebug().nospace() << "XMLimport::readActionGroup(...): ERROR: can not compile action's lua code for: " << pT->getName();
+                }
                 continue;
             } else if (name() == "css") {
                 pT->css = readElementText();
@@ -1336,10 +1329,6 @@ void XMLimport::readActionGroup(TAction* pParent)
             }
         }
     }
-
-    if (!pT->setScript(tempScript)) {
-        qDebug().nospace() << "XMLimport::readActionGroup(...): ERROR: can not compile action's script for: " << pT->getName();
-    }
 }
 
 void XMLimport::readScriptPackage()
@@ -1376,7 +1365,6 @@ void XMLimport::readScriptGroup(TScript* pParent)
         pT->mModuleMember = true;
     }
 
-    QString tempScript;
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1391,7 +1379,10 @@ void XMLimport::readScriptGroup(TScript* pParent)
                 pT->mPackageName = readElementText();
                 continue;
             } else if (name() == "script") {
-                tempScript = readElementText();
+                QString tempScript = readElementText();
+                if (!pT->setScript(tempScript)) {
+                    qDebug().nospace() << "XMLimport::readScriptGroup(...): ERROR: can not compile script's lua code for: " << pT->getName();
+                }
                 continue;
             } else if (name() == "eventHandlerList") {
                 readStringList(pT->mEventHandlerList);
@@ -1403,10 +1394,6 @@ void XMLimport::readScriptGroup(TScript* pParent)
                 readUnknownScriptElement();
             }
         }
-    }
-
-    if (!pT->setScript(tempScript)) {
-        qDebug().nospace() << "XMLimport::readScriptGroup(...): ERROR: can not compile script's script for: " << pT->getName();
     }
 }
 
@@ -1444,7 +1431,6 @@ void XMLimport::readKeyGroup(TKey* pParent)
         pT->mModuleMember = true;
     }
 
-    QString tempScript;
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -1459,7 +1445,10 @@ void XMLimport::readKeyGroup(TKey* pParent)
                 pT->mPackageName = readElementText();
                 continue;
             } else if (name() == "script") {
-                tempScript = readElementText();
+                QString tempScript = readElementText();
+                if (!pT->setScript(tempScript)) {
+                    qDebug().nospace() << "XMLimport::readKeyGroup(...): ERROR: can not compile key's lua code for: " << pT->getName();
+                }
                 continue;
             } else if (name() == "command") {
                 pT->mCommand = readElementText();
@@ -1476,10 +1465,6 @@ void XMLimport::readKeyGroup(TKey* pParent)
                 readUnknownKeyElement();
             }
         }
-    }
-
-    if (!pT->setScript(tempScript)) {
-        qDebug().nospace() << "XMLimport::readKeyGroup(...): ERROR: can not compile key's script for: " << pT->getName();
     }
 }
 


### PR DESCRIPTION
In commit 18750755c8a8acbb35a5dd65478333923da6a8e1 (Pull Request #373) a change was made that reordered the compilation of the Lua scripts for Mudlet items.  This commit reverts that aspect to restore the compilation of parent (e.g. folder/container) items before their children.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>