### PR TITLE
(release_30) Undo call to getMudletLuaDefaultPath()

### DIFF
--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -128,8 +128,7 @@ local packages = {
 -- TODO: extend to support common Lua code being placed in system shared directory
 -- tree as ought to happen for *nix install builds.
 local prefixes = {"../src/mudlet-lua/lua/", "../Resources/mudlet-lua/lua/",
-    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua",
-    getMudletLuaDefaultPath()}
+    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua"}
 
 -- add default search paths coming from the C++ side as well
 if getMudletLuaDefaultPaths then


### PR DESCRIPTION
7922a3a4e3c71eae84fcfc1027d5c48ebaeb79ff added getMudletLuaDefaultPath() that returned a single path, whereas the PR #414 changed function to be getMudletLuaDefaultPaths() and made it return an indexed table.

This fixes the wrong call that got left behind between cherrypicking and merging.