### PR TITLE
(release_30) fix mccp toggling

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -5,7 +5,8 @@
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2015 by Florian Scheel - keneanung@googlemail.com       *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
- *   Copyright (C) 2017 by Michael Hupp (Darksix) - darksix@northfire.org  *
+ *   Copyright (C) 2017 by Michael Hupp - darksix@northfire.org            *
+ *   Copyright (C) 2017 by Colton Rasbury - rasbury.colton@gmail.com       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -960,7 +961,7 @@ void cTelnet::processTelnetCommand( const string & command )
               return;
           }
 
-          // Original fix by RockHound, second revision by Darksix - To take out normal MCCP version 1 option and 2, no need for them now. // 
+          // Original fix by CR, second revision by MH - To take out normal MCCP version 1 option and 2, no need for them now. //
           if ((mWaitingForCompressedStreamToStart) && (!mpHost->mFORCE_NO_COMPRESSION))
           {
             mNeedDecompression = true;
@@ -1595,9 +1596,9 @@ int cTelnet::decompressBuffer( char *& in_buffer, int& length, char* out_buffer 
         hisOptionState[static_cast<int>(OPT_COMPRESS)] = false;
         hisOptionState[static_cast<int>(OPT_COMPRESS2)] = false;
 
-        // To finish off this old code, here is a fix to make it stay working. -Darksix //
+        // To finish off this old code, here is a fix to make it stay working. -MH //
         qDebug() << "Listening for new compression sequences or Z_OK.";
-        mWaitingForCompressedStreamToStart = true; // Was an unused boolean, thanks RockHound //
+        mWaitingForCompressedStreamToStart = true; // Was an unused boolean, thanks CR //
     }
     else
     {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -4,6 +4,8 @@
  *   Copyright (C) 2013-2014 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2015 by Florian Scheel - keneanung@googlemail.com       *
+ *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2017 by Michael Hupp (Darksix) - darksix@northfire.org  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -733,13 +735,13 @@ void cTelnet::processTelnetCommand( const string & command )
                   {
                       //MCCP->setMCCP1 (false);
                       mMCCP_version_1 = false;
-                      mWaitingForCompressedStreamToStart = false; // Setting to false since it isn't ever supposed to turn back on -Darksix //
+                      mWaitingForCompressedStreamToStart = false; // Setting to false since it isn't ever supposed to turn back on
                       qDebug() << "MCCP v1 disabled !";
                   }
                   if( option == OPT_COMPRESS2 )
                   {
                       mMCCP_version_2 = false;
-                      mWaitingForCompressedStreamToStart = false; // Setting to false since it isn't ever supposed to turn back on -Darksix //
+                      mWaitingForCompressedStreamToStart = false; // Setting to false since it isn't ever supposed to turn back on
                       //MCCP->setMCCP2 (false);
                       qDebug() << "MCCP v1 disabled !";
                   }
@@ -1601,7 +1603,7 @@ int cTelnet::decompressBuffer( char *& in_buffer, int& length, char* out_buffer 
     {
         if( zval < 0 )
         {
-            mWaitingForCompressedStreamToStart = true; // Wasn't needed before, but is now. -Darksix //
+            mWaitingForCompressedStreamToStart = true; // Wasn't needed before, but is now (fixes MCCP toggling on/off)
             initStreamDecompressor();
             return -1;
         }

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -128,8 +128,7 @@ local packages = {
 -- TODO: extend to support common Lua code being placed in system shared directory
 -- tree as ought to happen for *nix install builds.
 local prefixes = {"../src/mudlet-lua/lua/", "../Resources/mudlet-lua/lua/",
-    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua",
-    getMudletLuaDefaultPath()}
+    "mudlet.app/Contents/Resources/mudlet-lua/lua/", "mudlet-lua/lua"}
 
 -- add default search paths coming from the C++ side as well
 if getMudletLuaDefaultPaths then


### PR DESCRIPTION
Applies second patch from https://bugs.launchpad.net/mudlet/+bug/1119884.

Confirmed fixes test case for darklord.evils.in:9100 (create a character and type 'compress' to toggle MCCP on/off)

Confirmed fixes test case in http://www.mudbytes.net/forum/comment/72091/#c72091

Test case works on coffeemud.net port:2323 as well