### PR TITLE
(release_30) Modify the package.cpath for MacOS as well

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13164,6 +13164,10 @@ void TLuaInterpreter::initLuaGlobals()
     //AppInstaller on Linux would like the search path to also be set to the current binary directory
     luaL_dostring (pGlobalLua, QString("package.cpath = package.cpath .. ';%1/lib/?.so'").arg( QCoreApplication::applicationDirPath()).toUtf8().constData() );
 #endif
+#ifdef Q_OS_MAC
+    //macOS app bundle would like the search path to also be set to the current binary directory
+    luaL_dostring (pGlobalLua, QString("package.cpath = package.cpath .. ';%1/?.so'").arg( QCoreApplication::applicationDirPath()).toUtf8().constData() );
+#endif
 
     error = luaL_dostring( pGlobalLua, "require \"rex_pcre\"" );
     if( error != 0 )


### PR DESCRIPTION
With this change, we can get rid of the run_mudlet helper script in the macOS
app bundle.

This is similar to a part of #414