### PR TITLE
(release 30)BugFix: fix mButtonState behaviour for non-Push-Down "Buttons"

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -320,7 +321,7 @@ std::list<TToolBar *> ActionUnit::getToolBarList()
                 {
                     pTB->setHorizontalOrientation();
                 }
-                constructToolbar( *it3, mudlet::self(), pTB );
+                constructToolbar( *it3, pTB );
                 (*it3)->mpToolBar = pTB;
                 pTB->setStyleSheet( pTB->mpTAction->css );
             }
@@ -350,7 +351,7 @@ std::list<TToolBar *> ActionUnit::getToolBarList()
         {
             pTB->setHorizontalOrientation();
         }
-        constructToolbar( *it, mudlet::self(), pTB );
+        constructToolbar( *it, pTB );
         (*it)->mpToolBar = pTB;
         pTB->setStyleSheet( pTB->mpTAction->css );
     }
@@ -395,7 +396,7 @@ std::list<TEasyButtonBar *> ActionUnit::getEasyButtonBarList()
                 {
                     pTB->setHorizontalOrientation();
                 }
-                constructToolbar( *it3, mudlet::self(), pTB );
+                constructToolbar( *it3, pTB );
                 (*it3)->mpEasyButtonBar = pTB;
                 pTB->setStyleSheet( pTB->mpTAction->css );
             }
@@ -427,7 +428,7 @@ std::list<TEasyButtonBar *> ActionUnit::getEasyButtonBarList()
         {
             pTB->setHorizontalOrientation();
         }
-        constructToolbar( *it, mudlet::self(), pTB );
+        constructToolbar( *it, pTB );
         (*it)->mpEasyButtonBar = pTB;
         pTB->setStyleSheet( pTB->mpTAction->css );
     }
@@ -484,7 +485,7 @@ void ActionUnit::hideToolBar( QString & name )
 
 }
 
-void ActionUnit::constructToolbar( TAction * pA, mudlet * pMainWindow, TToolBar * pTB )
+void ActionUnit::constructToolbar( TAction * pA, TToolBar * pTB )
 {
     pTB->clear();
     if( ( pA->mLocation != 4 ) || ( ! pA->isActive() ) )
@@ -496,7 +497,7 @@ void ActionUnit::constructToolbar( TAction * pA, mudlet * pMainWindow, TToolBar 
 
     if( pA->mLocation == 4 )
     {
-        pA->expandToolbar( pMainWindow, pTB, 0 );
+        pA->expandToolbar( pTB, 0 );
         pTB->setTitleBarWidget( 0 );
     }
     /*else
@@ -550,7 +551,7 @@ TAction * ActionUnit::getHeadAction( TEasyButtonBar * pT )
     return 0;
 }
 
-void ActionUnit::constructToolbar( TAction * pA, mudlet * pMainWindow, TEasyButtonBar * pTB )
+void ActionUnit::constructToolbar( TAction * pA, TEasyButtonBar * pTB )
 {
     pTB->clear();
     if( pA->mLocation == 4 ) return; //floating toolbars are handled differently
@@ -560,7 +561,7 @@ void ActionUnit::constructToolbar( TAction * pA, mudlet * pMainWindow, TEasyButt
         return;
     }
 
-    pA->expandToolbar( pMainWindow, pTB, 0 );
+    pA->expandToolbar( pTB, 0 );
     pTB->finalize();
     if( pA->mOrientation == 0 )
         pTB->setHorizontalOrientation();

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -497,7 +497,7 @@ void ActionUnit::constructToolbar( TAction * pA, TToolBar * pTB )
 
     if( pA->mLocation == 4 )
     {
-        pA->expandToolbar( pTB, 0 );
+        pA->expandToolbar( pTB );
         pTB->setTitleBarWidget( 0 );
     }
     /*else
@@ -561,7 +561,7 @@ void ActionUnit::constructToolbar( TAction * pA, TEasyButtonBar * pTB )
         return;
     }
 
-    pA->expandToolbar( pTB, 0 );
+    pA->expandToolbar( pTB );
     pTB->finalize();
     if( pA->mOrientation == 0 )
         pTB->setHorizontalOrientation();

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -60,8 +61,8 @@ public:
     TAction *             getHeadAction( TToolBar * );
     TAction *             getHeadAction( TEasyButtonBar * );
     void                  processDataStream( QString & );
-    void                  constructToolbar( TAction *, mudlet * pMainWindow, TToolBar * pTB );
-    void                  constructToolbar( TAction *, mudlet * pMainWindow, TEasyButtonBar * pTB );
+    void                  constructToolbar( TAction *, TToolBar * pTB );
+    void                  constructToolbar( TAction *, TEasyButtonBar * pTB );
     void                  showToolBar( QString & );
     void                  hideToolBar( QString & );
 

--- a/src/EAction.cpp
+++ b/src/EAction.cpp
@@ -39,14 +39,6 @@ EAction::EAction( QIcon & icon, QString & name )
 
 void EAction::slot_execute(bool checked)
 {
-    if( checked )
-    {
-        mpHost->getActionUnit()->getAction( mID )->mButtonState = 2;
-    }
-    else
-    {
-        mpHost->getActionUnit()->getAction( mID )->mButtonState = 1;
-    }
-
+    mpHost->getActionUnit()->getAction( mID )->mButtonState = checked;
     mpHost->getActionUnit()->getAction( mID )->execute();
 }

--- a/src/EAction.cpp
+++ b/src/EAction.cpp
@@ -28,8 +28,8 @@
 #include "TAction.h"
 
 
-EAction::EAction( QIcon & icon, QString & name, mudlet * parent )
-: QAction( icon, name, parent )
+EAction::EAction( QIcon & icon, QString & name )
+    : QAction( icon, name, mudlet::self() )
 {
     setText( name );
     setObjectName( name );

--- a/src/EAction.cpp
+++ b/src/EAction.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -46,6 +47,6 @@ void EAction::slot_execute(bool checked)
     {
         mpHost->getActionUnit()->getAction( mID )->mButtonState = 1;
     }
-    QStringList sL;
-    mpHost->getActionUnit()->getAction( mID )->_execute( sL );
+
+    mpHost->getActionUnit()->getAction( mID )->execute();
 }

--- a/src/EAction.h
+++ b/src/EAction.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,7 +36,7 @@ class EAction : public QAction
     Q_OBJECT
 
 public:
-                    EAction(QIcon &, QString &, mudlet * );
+                    EAction( QIcon &, QString & );
     QWidget *       createWidget( QWidget * );
 
     int             mID;

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -181,7 +181,7 @@ void TAction::execute()
     mpHost->mpConsole->setFocus();
 }
 
-void TAction::expandToolbar( TToolBar * pT, QMenu * menu )
+void TAction::expandToolbar( TToolBar * pT )
 {
    typedef list<TAction *>::const_iterator I;
    for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
@@ -190,7 +190,7 @@ void TAction::expandToolbar( TToolBar * pT, QMenu * menu )
 
        QIcon icon( pChild->mIcon );
        QString name = pChild->getName();
-       TFlipButton * button = new TFlipButton( pT,pChild, pChild->mID, mpHost );
+       TFlipButton * button = new TFlipButton( pChild, mpHost );
        button->setIcon( icon );
        button->setText( name );
        button->setCheckable( pChild->mIsPushDownButton );
@@ -243,7 +243,7 @@ void TAction::insertActions( TToolBar * pT, QMenu * menu )
 }
 
 
-void TAction::expandToolbar( TEasyButtonBar * pT, QMenu * menu )
+void TAction::expandToolbar( TEasyButtonBar * pT )
 {
    typedef list<TAction *>::const_iterator I;
    for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
@@ -252,7 +252,7 @@ void TAction::expandToolbar( TEasyButtonBar * pT, QMenu * menu )
        if( ! pChild->isActive() ) continue;
        QIcon icon( pChild->mIcon );
        QString name = pChild->getName();
-       TFlipButton * button = new TFlipButton( pT,pChild, pChild->mID, mpHost );
+       TFlipButton * button = new TFlipButton( pChild, mpHost );
        button->setIcon( icon );
        button->setText( name );
        button->setCheckable( pChild->mIsPushDownButton );

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -154,12 +155,7 @@ bool TAction::compileScript()
     }
 }
 
-void TAction::execute(QStringList & list )
-{
-    qDebug()<<"TAction::execute() called: depricated!";
-}
-
-void TAction::_execute(QStringList & list)
+void TAction::execute()
 {
     if( ( mCommandButtonUp.size() > 0 ) && ( mButtonState == 1 ) )
     {
@@ -265,8 +261,7 @@ void TAction::expandToolbar( mudlet * pMainWindow, TEasyButtonBar * pT, QMenu * 
        if( pChild->mIsPushDownButton && mpHost->mIsProfileLoadingSequence ) //&& pChild->mButtonState == 2 )
        {
            qDebug()<<"expandToolBar() name="<<pChild->mName<<" executing script";
-           QStringList bla;
-           pChild->_execute(bla);
+           pChild->execute();
        }
 
        pT->addButton( button );
@@ -300,8 +295,7 @@ void TAction::fillMenu( TEasyButtonBar * pT, QMenu * menu )
         if( pChild->mIsPushDownButton && mpHost->mIsProfileLoadingSequence )//&& pChild->mButtonState == 2 )
         {
             qDebug()<<"fillMenu() name="<<pChild->mName<<" executing script";
-            QStringList bla;
-            pChild->_execute(bla);
+            pChild->execute();
         }
         menu->addAction( action );
         if( pChild->mIsFolder )

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -181,7 +181,7 @@ void TAction::execute()
     mpHost->mpConsole->setFocus();
 }
 
-void TAction::expandToolbar( mudlet * pMainWindow, TToolBar * pT, QMenu * menu )
+void TAction::expandToolbar( TToolBar * pT, QMenu * menu )
 {
    typedef list<TAction *>::const_iterator I;
    for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
@@ -206,17 +206,17 @@ qDebug()<<"button="<<pChild->mName<<" checked="<<(pChild->mButtonState==2);
            QMenu * newMenu = new QMenu( pT );
            button->setMenu( newMenu );
            newMenu->setStyleSheet( css );
-           pChild->insertActions( pMainWindow, pT, newMenu );
+           pChild->insertActions( pT, newMenu );
        }
    }
 }
 
 
-void TAction::insertActions( mudlet * pMainWindow, TToolBar * pT, QMenu * menu )
+void TAction::insertActions( TToolBar * pT, QMenu * menu )
 {
     mpToolBar = pT;
     QIcon icon( mIcon );
-    EAction * action = new EAction( icon, mName, pMainWindow );
+    EAction * action = new EAction( icon, mName );
     action->setCheckable( mIsPushDownButton );
     action->mID = mID;
     action->mpHost = mpHost;
@@ -227,7 +227,9 @@ void TAction::insertActions( mudlet * pMainWindow, TToolBar * pT, QMenu * menu )
 
     if( mIsFolder )
     {
-        QMenu * newMenu = new QMenu( pMainWindow );
+        // The use of mudlet::self() here means that the QMenu is not destroyed
+        // until the mudlet instance is at the end of the application!
+        QMenu * newMenu = new QMenu( mudlet::self() );
         newMenu->setStyleSheet( css );
         action->setMenu( newMenu );
 
@@ -235,13 +237,13 @@ void TAction::insertActions( mudlet * pMainWindow, TToolBar * pT, QMenu * menu )
         for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
         {
             TAction * pChild = *it;
-            pChild->insertActions( pMainWindow, pT, newMenu );
+            pChild->insertActions( pT, newMenu );
         }
     }
 }
 
 
-void TAction::expandToolbar( mudlet * pMainWindow, TEasyButtonBar * pT, QMenu * menu )
+void TAction::expandToolbar( TEasyButtonBar * pT, QMenu * menu )
 {
    typedef list<TAction *>::const_iterator I;
    for( I it = mpMyChildrenList->begin(); it != mpMyChildrenList->end(); it++)
@@ -285,7 +287,7 @@ void TAction::fillMenu( TEasyButtonBar * pT, QMenu * menu )
         if( ! pChild->isActive() ) continue;
         mpEasyButtonBar = pT;
         QIcon icon( mIcon );
-        EAction * action = new EAction( icon, pChild->mName, mudlet::self() );
+        EAction * action = new EAction( icon, pChild->mName );
         action->setCheckable( pChild->mIsPushDownButton );
         action->mID = pChild->mID;
         action->mpHost = mpHost;
@@ -309,11 +311,11 @@ void TAction::fillMenu( TEasyButtonBar * pT, QMenu * menu )
     }
 }
 
-void TAction::insertActions( mudlet * pMainWindow, TEasyButtonBar * pT, QMenu * menu )
+void TAction::insertActions( TEasyButtonBar * pT, QMenu * menu )
 {
     mpEasyButtonBar = pT;
     QIcon icon( mIcon );
-    EAction * action = new EAction( icon, mName, pMainWindow );
+    EAction * action = new EAction( icon, mName );
     action->setCheckable( mIsPushDownButton );
     action->mID = mID;
     action->mpHost = mpHost;

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -70,8 +71,7 @@ public:
     void             fillMenu( TEasyButtonBar * pT, QMenu * menu );
     void             compile();
     bool             compileScript();
-    void             execute(QStringList &);
-    void             _execute(QStringList &);
+    void             execute();
     QString          getIcon()                                 { return mIcon; }
     void             setIcon( QString & icon )                 { mIcon = icon; }
     QString          getScript()                               { return mScript; }

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -87,12 +87,10 @@ public:
     bool             registerAction();
     void             insertActions( TToolBar * pT,
                                     QMenu * menu );
-    void             expandToolbar( TToolBar * pT,
-                                    QMenu * menu );
+    void             expandToolbar( TToolBar * pT );
     void             insertActions( TEasyButtonBar * pT,
                                     QMenu * menu );
-    void             expandToolbar( TEasyButtonBar * pT,
-                                    QMenu * menu );
+    void             expandToolbar( TEasyButtonBar * pT );
     TToolBar *       mpToolBar;
     TEasyButtonBar * mpEasyButtonBar;
     int              mButtonState;

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -85,17 +85,13 @@ public:
     void             setIsPushDownButton( bool b )             { mIsPushDownButton = b; }
     void             setIsFolder( bool b )                     { mIsFolder = b; }
     bool             registerAction();
-    void             insertActions( mudlet * pMainWindow,
-                                    TToolBar * pT,
+    void             insertActions( TToolBar * pT,
                                     QMenu * menu );
-    void             expandToolbar( mudlet * pMainWindow,
-                                    TToolBar * pT,
+    void             expandToolbar( TToolBar * pT,
                                     QMenu * menu );
-    void             insertActions( mudlet * pMainWindow,
-                                    TEasyButtonBar * pT,
+    void             insertActions( TEasyButtonBar * pT,
                                     QMenu * menu );
-    void             expandToolbar( mudlet * pMainWindow,
-                                    TEasyButtonBar * pT,
+    void             expandToolbar( TEasyButtonBar * pT,
                                     QMenu * menu );
     TToolBar *       mpToolBar;
     TEasyButtonBar * mpEasyButtonBar;

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -93,7 +93,14 @@ public:
     void             expandToolbar( TEasyButtonBar * pT );
     TToolBar *       mpToolBar;
     TEasyButtonBar * mpEasyButtonBar;
-    int              mButtonState;
+    // The following was an int but there was confusion over:
+    // EITHER: "1" = released/unclicked/up & "2" = pressed/clicked/down
+    // OR:     "1" = pressed/clicked/down  & "0" = released/unclicked/up
+    // The Wiki says it should be "1" and "2" but the code sort of did "0"/"1"
+    // in some places.
+    // Now uses a boolean:
+    // "true" = pressed/clicked/down & "false" = released/unclicked/up
+    bool             mButtonState;
     int              mPosX;
     int              mPosY;
     int              mOrientation;

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -131,11 +131,12 @@ void TEasyButtonBar::addButton( TFlipButton * pB )
         pB->move( pB->mpTAction->mPosX, pB->mpTAction->mPosY );
     }
 
-    connect( pB, SIGNAL(released()), this, SLOT(slot_pressed()) );
+
+    // Was using released() signal but now we want to track the ACTUAL state of
+    // the underlying QAbstractButton
+    connect( pB, SIGNAL(clicked(const bool)), this, SLOT(slot_pressed(const bool)) );
     mButtonList.push_back( pB );
-    pB->setChecked( (pB->mpTAction->mButtonState==2) );
-
-
+    pB->setChecked( pB->mpTAction->mButtonState );
 }
 
 
@@ -163,7 +164,9 @@ void TEasyButtonBar::finalize()
     }
 }
 
-void TEasyButtonBar::slot_pressed()
+// Used by buttons directly on an TEasyButtonBar instance - we now retrieve the
+// button state to ensure the visible representation is used.
+void TEasyButtonBar::slot_pressed(const bool isChecked)
 {
     TFlipButton * pB = dynamic_cast<TFlipButton *>( sender() );
     if( ! pB )
@@ -172,22 +175,27 @@ void TEasyButtonBar::slot_pressed()
     }
 
     TAction * pA = pB->mpTAction;
+
+    // NOTE: This function blocks until an item is selected from the menu, and,
+    // as the action to "pop-up" the menu is the same as "buttons" use to
+    // perform their command/scripts is why "commands" are (no longer) permitted
+    // on a "menu".  It also means that the script for a "menu" is run every
+    // time it is "clicked" upon to display the pop-up containing the menu
+    // entries...
     pB->showMenu();
 
-    if( pA->mButtonState == 2 )
+    if( pA->mIsPushDownButton )
     {
-        pA->mButtonState = 1;
-        pB->setChecked( false );
+        // DO NOT MANIPULATE THE BUTTON STATE OURSELF NOW
+        pA->mButtonState = isChecked;
+        pA->mpHost->mpConsole->mButtonState = ( pA->mButtonState ? 2 : 1 );
     }
     else
     {
-        pA->mButtonState = 2;
-        pB->setChecked( true );
+        pA->mButtonState = false; // Forces a fixup if not correct
+        pB->setChecked( false ); // This does NOT invoke the clicked() signal!
+        pA->mpHost->mpConsole->mButtonState = 1; // Was effectively 0 but that is wrong
     }
-    if( pB->isChecked() )
-        pA->mpHost->mpConsole->mButtonState = 1;
-    else
-        pA->mpHost->mpConsole->mButtonState = 0;
 
     pA->execute();
 }
@@ -195,10 +203,10 @@ void TEasyButtonBar::slot_pressed()
 void TEasyButtonBar::clear()
 {
     QWidget * pW = new QWidget;
-       typedef std::list<TFlipButton *>::iterator IT;
+    typedef std::list<TFlipButton *>::iterator IT;
     for( IT it = mButtonList.begin(); it != mButtonList.end(); it++ )
     {
-        disconnect( *it, SIGNAL(released()), this, SLOT(slot_pressed()) );
+        disconnect( *it, SIGNAL(clicked(const bool)), this, SLOT(slot_pressed(const bool)) );
     }
     mButtonList.clear();
     mpWidget->deleteLater();

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -187,8 +188,8 @@ void TEasyButtonBar::slot_pressed()
         pA->mpHost->mpConsole->mButtonState = 1;
     else
         pA->mpHost->mpConsole->mButtonState = 0;
-    QStringList sL;
-    pA->_execute( sL );
+
+    pA->execute();
 }
 
 void TEasyButtonBar::clear()

--- a/src/TEasyButtonBar.h
+++ b/src/TEasyButtonBar.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -64,8 +65,7 @@ signals:
 
 public slots:
 
-    void slot_pressed();
-
+    void            slot_pressed( const bool );
 };
 
 #endif // MUDLET_TEASYBUTTONBAR_H

--- a/src/TFlipButton.cpp
+++ b/src/TFlipButton.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2009 by Heiko Koehn - KoehnHeiko@googlemail.com         *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,6 +26,7 @@
 #include "Host.h"
 #include "TEasyButtonBar.h"
 #include "TToolBar.h"
+#include "TAction.h"
 
 #include "pre_guard.h"
 #include <QMenu>
@@ -32,29 +34,14 @@
 #include <QStylePainter>
 #include "post_guard.h"
 
-
-TFlipButton::TFlipButton( TToolBar * parent, TAction * pTAction, int id, Host * pHost )
+TFlipButton::TFlipButton( TAction * pTAction, Host * pHost )
 : QPushButton( 0 )
 , mpTAction( pTAction )
-, mID( id )
+, mID( pTAction->getID() )
 , mpHost( pHost )
+, mOrientation( Qt::Horizontal )
+, mMirrored( false )
 {
-    init();
-}
-
-TFlipButton::TFlipButton( TEasyButtonBar * parent, TAction * pTAction, int id, Host * pHost )
-: QPushButton( 0 )
-, mpTAction( pTAction )
-, mID( id )
-, mpHost( pHost )
-{
-    init();
-}
-
-void TFlipButton::init()
-{
-    mOrientation = Qt::Horizontal;
-    mMirrored = false;
 }
 
 Qt::Orientation TFlipButton::orientation() const

--- a/src/TFlipButton.h
+++ b/src/TFlipButton.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,38 +29,32 @@
 
 class Host;
 class TAction;
-class TEasyButtonBar;
-class TToolBar;
 
 class TFlipButton : public QPushButton
 {
 public:
-    TFlipButton( TToolBar *, TAction *, int, Host * );
-    TFlipButton( TEasyButtonBar *, TAction *, int, Host * );
-    TFlipButton( const QString & text, QWidget* parent = 0);
-    TFlipButton( const QIcon & icon, const QString & text, QWidget * parent = 0 );
+    TFlipButton( TAction *, Host * );
 
     Qt::Orientation orientation() const;
-    void setOrientation( Qt::Orientation orientation );
+    void            setOrientation( Qt::Orientation orientation );
 
-    bool mirrored() const;
-    void setMirrored( bool mirrored );
+    bool            mirrored() const;
+    void            setMirrored( bool mirrored );
 
-    QSize sizeHint() const;
-    QSize minimumSizeHint() const;
+    QSize           sizeHint() const;
+    QSize           minimumSizeHint() const;
 
 protected:
-    void paintEvent( QPaintEvent * event );
+    void            paintEvent( QPaintEvent * );
 
 public:
-    QStyleOptionButton getStyleOption() const;
-    void init();
+    QStyleOptionButton  getStyleOption() const;
 
+    TAction *       mpTAction;
+    int             mID;
+    Host *          mpHost;
     Qt::Orientation mOrientation;
-    bool mMirrored;
-    TAction * mpTAction;
-    int mID;
-    Host * mpHost;
+    bool            mMirrored;
 };
 
 #endif // MUDLET_TFLIPBUTTON_H

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -43,7 +43,6 @@ TToolBar::TToolBar( TAction * pA, QString name, QWidget * pW )
 , mRecordMove( false )
 , mpLayout( 0 )
 , mItemCount( 0 )
-
 {
     setFeatures( QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable );
     setWidget( mpWidget );
@@ -130,7 +129,10 @@ void TToolBar::addButton( TFlipButton * pB )
     {
         pB->move( pB->mpTAction->mPosX, pB->mpTAction->mPosY );
     }
-    connect( pB, SIGNAL(pressed()), this, SLOT(slot_pressed()) );
+
+    // Was using pressed() signal but now we want to track the ACTUAL state of
+    // the underlying QAbstractButton
+    connect( pB, SIGNAL(clicked(const bool)), this, SLOT(slot_pressed(const bool)) );
 }
 
 void TToolBar::finalize()
@@ -153,7 +155,9 @@ void TToolBar::finalize()
 //    mpLayout->addWidget( fillerWidget, ++mItemCount/columns, mItemCount%columns );
 }
 
-void TToolBar::slot_pressed()
+// Used by buttons directly on a TToolBar instance but NOT on sub-menu item - we
+// now retrieve the button state to ensure the visible representation is used.
+void TToolBar::slot_pressed(const bool isChecked)
 {
     TFlipButton * pB = dynamic_cast<TFlipButton *>( sender() );
     if( ! pB )
@@ -162,20 +166,25 @@ void TToolBar::slot_pressed()
     }
 
     TAction * pA = pB->mpTAction;
-    pB->showMenu();
+    // NOTE: This function blocks until an item is selected from the menu, and,
+    // as the action to "pop-up" the menu is the same as "buttons" use to
+    // perform their command/scripts is why "commands" are (no longer) permitted
+    // on a "menu".  It also means that the script for a "menu" is run every
+    // time it is "clicked" upon to display the pop-up containing the menu
+    // entries...
+    pB->menu();
 
-    if( pB->isChecked() )
+    if( pA->mIsPushDownButton )
     {
-        pA->mButtonState = 2;
+        pA->mButtonState = isChecked;
+        pA->mpHost->mpConsole->mButtonState = ( pA->mButtonState ? 2 : 1 ); // Was using 1 and 0 but that was wrong
     }
     else
     {
-        pA->mButtonState = 1;
+        pA->mButtonState = false;
+        pB->setChecked( false ); // This does NOT invoke the clicked()!
+        pA->mpHost->mpConsole->mButtonState = 1; // Was effectively 0 but that is wrong
     }
-    if( pB->isChecked() )
-        pA->mpHost->mpConsole->mButtonState = 1;
-    else
-        pA->mpHost->mpConsole->mButtonState = 0;
 
     pA->execute();
 }

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -175,8 +176,8 @@ void TToolBar::slot_pressed()
         pA->mpHost->mpConsole->mButtonState = 1;
     else
         pA->mpHost->mpConsole->mButtonState = 0;
-    QStringList sL;
-    pA->_execute( sL );
+
+    pA->execute();
 }
 
 void TToolBar::clear()

--- a/src/TToolBar.h
+++ b/src/TToolBar.h
@@ -55,14 +55,10 @@ public:
     bool             mRecordMove;
     QGridLayout *    mpLayout;
     int              mItemCount;
-    
-signals:
-    
-    
+
+
 public slots:
-    
-    void slot_pressed();    
-    
+    void             slot_pressed( const bool );
 };
 
 #endif // MUDLET_TTOOLBAR_H

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -867,7 +867,9 @@ bool XMLexport::writeAction( TAction * pT )
     writeTextElement( "location", QString::number(pT->mLocation) );
     writeTextElement( "posX", QString::number(pT->mPosX) );
     writeTextElement( "posY", QString::number(pT->mPosY) );
-    writeTextElement( "mButtonState", QString::number(pT->mButtonState) );
+    // We now use a boolean but file must use original "1" (false)
+    // or "2" (true) for backward compatibility
+    writeTextElement( "mButtonState", QString::number( pT->mButtonState ? 2 : 1 ) );
     writeTextElement( "sizeX", QString::number(pT->mSizeX) );
     writeTextElement( "sizeY", QString::number(pT->mSizeY) );
     writeTextElement( "buttonColumn", QString::number(pT->mButtonColumns) );

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1308,7 +1308,9 @@ void XMLimport::readActionGroup(TAction* pParent)
                 pT->mSizeY = readElementText().toInt();
                 continue;
             } else if (name() == "mButtonState") {
-                pT->mButtonState = readElementText().toInt();
+                // We now use a boolean but file must use original "1" (false)
+                // or "2" (true) for backward compatibility
+                pT->mButtonState = ( readElementText().toInt() == 2 );
                 continue;
             } else if (name() == "buttonColor") {
                 pT->mButtonColor.setNamedColor(readElementText());


### PR DESCRIPTION
The first three commits do a fair amount of de-crufting which make it easier to find the salient issues which are addressed in the fourth commit.  This PR fixes: [Bug 1673672](https://bugs.launchpad.net/mudlet/+bug/1673672) "_Disabling button up still keeps the command toggle_". :grinning: 