### PR TITLE
Version: advance master to form start point for future work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
-#    Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    #
+#    Copyright (C) 2015-2017 by Stephen Lyons - slysven@virginmedia.com    #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -40,7 +40,7 @@ ELSE()
 ENDIF()
 
 SET(APP_VERSION 3.0.0)
-SET(APP_BUILD "")
+SET(APP_BUILD "-dev")
 # APP_BUILD should only be empty/null in official "release" builds,
 # developers may like to set it to their user and branch names to make it easier
 # to tell different builds apart!

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,6 +1,7 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
-#    Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    #
+#    Copyright (C) 2013-2015, 2017 by Stephen Lyons                        #
+#                                                - slysven@virginmedia.com #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -56,7 +57,7 @@ QT += network opengl uitools multimedia gui
 # (it is NOT a Qt built-in variable) for a release build or, if you are
 # distributing modified code, it would be useful if you could put something to
 # distinguish the version:
-BUILD =
+BUILD = "-dev"
 
 # Changing the above pair of values affects: ctelnet.cpp, main.cpp, mudlet.cpp
 # dlgAboutDialog.cpp and TLuaInterpreter.cpp.  It does NOT cause those files to


### PR DESCRIPTION
It is my understanding that urgent bug fixes for the Release 3.0.0 need to be based on a version with the same version major.minor.patch "Sematic Version" string but, until actually "released" will carry a "-dev" build suffix. This commit will introduce the change so that the resultant point in the repository becomes the start point for such fixes and other work.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>