### PR TITLE
Bump development to 3.0.0-dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ ELSE()
     SET(APP_TARGET mudlet)
 ENDIF()
 
-SET(APP_VERSION 3.0.1)
+SET(APP_VERSION 3.0.0)
 SET(APP_BUILD "-dev")
 # APP_BUILD should only be empty/null in official "release" builds,
 # developers may like to set it to their user and branch names to make it easier

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,7 +24,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
 
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 3.0.1
+VERSION = 3.0.0
 
 # disable Qt adding -Wall for us, insert it ourselves so we can add -Wno-* after.
 !msvc:CONFIG += warn_off


### PR DESCRIPTION
This follows http://wiki.mudlet.org/w/Manual:Versioning.

We always had development on ``3.0.1-dev`` but that was in lieu of a proper versioning strategy...