### PR TITLE
Resolve all conflicts in TRoom and TRoomDB classes [ci skip]

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -189,11 +189,7 @@ void TRoom::setExitWeight(const QString& cmd, int w )
 //
 // also: up, down, in, out or any unprefixed special exit command
 // all of which can be stored but aren't (yet?) showable on the 2D mapper
-<<<<<<< HEAD
 const bool TRoom::setDoor( const QString & cmd, const int doorStatus )
-=======
-const bool TRoom::setDoor( const QString cmd, const int doorStatus )
->>>>>>> SlySven/release_30
 {
     if( doorStatus > 0 && doorStatus <=3 ) {
         if( doors.value( cmd, 0 ) != doorStatus ) {
@@ -589,12 +585,8 @@ void TRoom::setSpecialExit( int to, const QString& cmd )
     mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;
 }
 
-<<<<<<< HEAD
 void TRoom::clearSpecialExits()
 {
-=======
-void TRoom::clearSpecialExits(){
->>>>>>> SlySven/release_30
     other.clear();
     mpRoomDB->updateEntranceMap(this);
     mpRoomDB->mpMap->mMapGraphNeedsUpdate = true;

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -71,7 +71,6 @@ public:
     bool hasExitLock( int to );
     bool hasSpecialExitLock( int, const QString& );
     void removeAllSpecialExitsToRoom(int _id );
-<<<<<<< HEAD
     void setSpecialExit( int to, const QString& cmd );
     void clearSpecialExits();
     const QMultiMap<int, QString> & getOtherMap() const { return other; }
@@ -85,21 +84,6 @@ public:
     void calcRoomDimensions();
     bool setArea( int , bool isToDeferAreaRelatedRecalculations = false );
     int getExitWeight(const QString& cmd );
-=======
-    void setSpecialExit( int to, QString cmd );
-    void clearSpecialExits();
-    const QMultiMap<int, QString> & getOtherMap() const { return other; }
-    const QMap<QString, int> & getExitWeights() const { return exitWeights; }
-    void setExitWeight( QString cmd, int w );
-    bool hasExitWeight( QString cmd );
-    const bool setDoor( const QString cmd, const int doorStatus ); //0=no door, 1=open door, 2=closed, 3=locked
-    int getDoor( QString cmd );
-    bool hasExitStub( int direction );
-    void setExitStub( int direction, bool status );
-    void calcRoomDimensions();
-    int getExitWeight( QString cmd );
-    bool setArea( int , bool isToDeferAreaRelatedRecalculations = false );
->>>>>>> SlySven/release_30
 
     int getWeight() { return weight; }
     int getNorth() { return north; }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -140,11 +140,7 @@ void TRoomDB::updateEntranceMap(TRoom * pR, bool isMapLoading)
     // room b and c efficiently.
     // So we create a mapping like: {room_a: room_b, room_a: room_c}. This allows us to delete
     // rooms and know which other rooms are impacted by this change in a single lookup.
-<<<<<<< HEAD
     if( pR ) {
-=======
-    if(pR){
->>>>>>> SlySven/release_30
         int id = pR->getId();
         QHash<int, int> exits = pR->getExits();
         QList<int> toExits = exits.keys();
@@ -624,7 +620,6 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
 
     QSet<int> validUsedRoomIds; // Used good ids (>= 1)
     QSet<int> validUsedAreaIds; // As rooms
-<<<<<<< HEAD
 
     // START OF TASK 1 & 2:
     // Scan through all rooms and record their idea of which area they
@@ -632,15 +627,6 @@ void TRoomDB::auditRooms( QHash<int, int> & roomRemapping, QHash<int, int> & are
     QHash<int, int> roomAreaHash; // Key: room Id, Value: area it believes it should be in
     QMultiHash<int, int> areaRoomMultiHash; // Key: areaId, ValueS: rooms that believe they belong there
 
-=======
-
-    // START OF TASK 1 & 2:
-    // Scan through all rooms and record their idea of which area they
-    // should be in.  Note invalid room Ids those will be fixed up later...
-    QHash<int, int> roomAreaHash; // Key: room Id, Value: area it believes it should be in
-    QMultiHash<int, int> areaRoomMultiHash; // Key: areaId, ValueS: rooms that believe they belong there
-
->>>>>>> SlySven/release_30
     { // Block this code to limit scope of iterator
         QMutableHashIterator<int, TRoom *> itRoom( rooms );
         while( itRoom.hasNext() ) {


### PR DESCRIPTION
Generally choose `QString` argument passing by `const` reference as opposed to
by value...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>