### PR TITLE
Resolve all conflicts in XMLimport and XML export classes [ci skip]

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -1,10 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
-<<<<<<< HEAD
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
-=======
->>>>>>> SlySven/release_30
  *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -343,10 +340,7 @@ bool XMLexport::writeHost( Host * pHost )
     writeAttribute( "mUSE_FORCE_LF_AFTER_PROMPT", pHost->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no" );
     writeAttribute( "mUSE_UNIX_EOL", pHost->mUSE_UNIX_EOL ? "yes" : "no" );
     writeAttribute( "mNoAntiAlias", pHost->mNoAntiAlias ? "yes" : "no" );
-<<<<<<< HEAD
     writeAttribute( "mEchoLuaErrors", pHost->mEchoLuaErrors ? "yes" : "no" );
-=======
->>>>>>> SlySven/release_30
     // FIXME: Change to a string or integer property when possible to support more
     // than false (perhaps 0 or "PlainText") or true (perhaps 1 or "HTML") in the
     // future - phpBB code might be useful if it can be done.
@@ -364,30 +358,19 @@ bool XMLexport::writeHost( Host * pHost )
     writeAttribute( "mAcceptServerGUI", pHost->mAcceptServerGUI ? "yes" : "no" );
     writeAttribute( "mMapperUseAntiAlias", pHost->mMapperUseAntiAlias ? "yes" : "no" );
     writeAttribute( "mFORCE_MXP_NEGOTIATION_OFF", pHost->mFORCE_MXP_NEGOTIATION_OFF ? "yes" : "no" );
-<<<<<<< HEAD
     writeAttribute( "mRoomSize", QString::number(pHost->mRoomSize, 'f', 1) );
     writeAttribute( "mLineSize", QString::number(pHost->mLineSize, 'f', 1) );
-=======
-    writeAttribute( "mRoomSize", QString::number(pHost->mRoomSize));
-    writeAttribute( "mLineSize", QString::number(pHost->mLineSize));
->>>>>>> SlySven/release_30
     writeAttribute( "mBubbleMode", pHost->mBubbleMode ? "yes" : "no");
     writeAttribute( "mShowRoomIDs", pHost->mShowRoomID ? "yes" : "no");
     writeAttribute( "mShowPanel", pHost->mShowPanel ? "yes" : "no");
     writeAttribute( "mHaveMapperScript", pHost->mHaveMapperScript ? "yes" : "no");
     QString ignore;
     QSetIterator<QChar> it(pHost->mDoubleClickIgnore);
-<<<<<<< HEAD
     while( it.hasNext() ) {
-=======
-    while( it.hasNext() )
-    {
->>>>>>> SlySven/release_30
         ignore = ignore.append(it.next());
     }
     writeAttribute( "mDoubleClickIgnore", ignore);
 
-<<<<<<< HEAD
     { // Blocked so that indentation reflects that of the XML file
         writeTextElement( "name", pHost->mHostName );
 
@@ -611,222 +594,6 @@ bool XMLexport::writeHost( Host * pHost )
     }
 
     return ( isOk && ( ! hasError() ) );
-=======
-    writeTextElement( "name", pHost->mHostName );
-    //writeTextElement( "login", pHost->mLogin );
-    //writeTextElement( "pass", pHost->mPass );
-    writeStartElement( "mInstalledPackages" );
-    for( int i=0; i<pHost->mInstalledPackages.size(); i++ )
-    {
-        writeTextElement( "string", pHost->mInstalledPackages[i] );
-    }
-    writeEndElement();
-    if (pHost->mInstalledModules.size()){
-        writeStartElement( "mInstalledModules" );
-        QMapIterator<QString, QStringList> it(pHost->mInstalledModules);
-        pHost->modulesToWrite.clear();
-        while( it.hasNext() )
-        {
-            it.next();
-            writeTextElement("key", it.key());
-            QStringList entry = it.value();
-            writeTextElement("filepath", entry[0]);
-            writeTextElement("globalSave", entry[1]);
-            if (entry[1].toInt()){
-                pHost->modulesToWrite[it.key()] = entry;
-            }
-            writeTextElement("priority", QString::number(pHost->mModulePriorities[it.key()]));
-        }
-        writeEndElement();
-    }
-    writeTextElement( "url", pHost->mUrl );
-    writeTextElement( "serverPackageName", pHost->mServerGUI_Package_name );
-    writeTextElement( "serverPackageVersion", QString::number(pHost->mServerGUI_Package_version ) );
-    writeTextElement( "port", QString::number(pHost->mPort) );
-    writeTextElement( "borderTopHeight", QString::number(pHost->mBorderTopHeight) );
-    writeTextElement( "borderBottomHeight", QString::number(pHost->mBorderBottomHeight) );
-    writeTextElement( "borderLeftWidth", QString::number(pHost->mBorderLeftWidth) );
-    writeTextElement( "borderRightWidth", QString::number(pHost->mBorderRightWidth) );
-    writeTextElement( "wrapAt", QString::number(pHost->mWrapAt) );
-    writeTextElement( "wrapIndentCount", QString::number(pHost->mWrapIndentCount) );
-    writeTextElement( "mFgColor", pHost->mFgColor.name() );
-    writeTextElement( "mBgColor", pHost->mBgColor.name() );
-    writeTextElement( "mCommandFgColor", pHost->mCommandFgColor.name() );
-    writeTextElement( "mCommandBgColor", pHost->mCommandBgColor.name() );
-    writeTextElement( "mCommandLineFgColor", pHost->mCommandLineFgColor.name() );
-    writeTextElement( "mCommandLineBgColor", pHost->mCommandLineBgColor.name() );
-    writeTextElement( "mBlack", pHost->mBlack.name() );
-    writeTextElement( "mLightBlack", pHost->mLightBlack.name() );
-    writeTextElement( "mRed", pHost->mRed.name() );
-    writeTextElement( "mLightRed", pHost->mLightRed.name() );
-    writeTextElement( "mBlue", pHost->mBlue.name() );
-    writeTextElement( "mLightBlue", pHost->mLightBlue.name() );
-    writeTextElement( "mGreen", pHost->mGreen.name() );
-    writeTextElement( "mLightGreen", pHost->mLightGreen.name() );
-    writeTextElement( "mYellow", pHost->mYellow.name() );
-    writeTextElement( "mLightYellow", pHost->mLightYellow.name() );
-    writeTextElement( "mCyan", pHost->mCyan.name() );
-    writeTextElement( "mLightCyan", pHost->mLightCyan.name() );
-    writeTextElement( "mMagenta", pHost->mMagenta.name() );
-    writeTextElement( "mLightMagenta", pHost->mLightMagenta.name() );
-    writeTextElement( "mWhite", pHost->mWhite.name() );
-    writeTextElement( "mLightWhite", pHost->mLightWhite.name() );
-    writeTextElement( "mDisplayFont", pHost->mDisplayFont.toString() );
-    writeTextElement( "mCommandLineFont", pHost->mCommandLineFont.toString() );
-    // There was a mis-spelt duplicate commandSeperator above but it is now gone
-    writeTextElement( "mCommandSeparator", pHost->mCommandSeparator );
-    writeTextElement( "commandLineMinimumHeight", QString::number(pHost->commandLineMinimumHeight) );
-
-    writeTextElement( "mFgColor2", pHost->mFgColor_2.name() );
-    writeTextElement( "mBgColor2", pHost->mBgColor_2.name() );
-    writeTextElement( "mBlack2", pHost->mBlack_2.name() );
-    writeTextElement( "mLightBlack2", pHost->mLightBlack_2.name() );
-    writeTextElement( "mRed2", pHost->mRed_2.name() );
-    writeTextElement( "mLightRed2", pHost->mLightRed_2.name() );
-    writeTextElement( "mBlue2", pHost->mBlue_2.name() );
-    writeTextElement( "mLightBlue2", pHost->mLightBlue_2.name() );
-    writeTextElement( "mGreen2", pHost->mGreen_2.name() );
-    writeTextElement( "mLightGreen2", pHost->mLightGreen_2.name() );
-    writeTextElement( "mYellow2", pHost->mYellow_2.name() );
-    writeTextElement( "mLightYellow2", pHost->mLightYellow_2.name() );
-    writeTextElement( "mCyan2", pHost->mCyan_2.name() );
-    writeTextElement( "mLightCyan2", pHost->mLightCyan_2.name() );
-    writeTextElement( "mMagenta2", pHost->mMagenta_2.name() );
-    writeTextElement( "mLightMagenta2", pHost->mLightMagenta_2.name() );
-    writeTextElement( "mWhite2", pHost->mWhite_2.name() );
-    writeTextElement( "mLightWhite2", pHost->mLightWhite_2.name() );
-    writeTextElement( "mSpellDic", pHost->mSpellDic );
-    // TODO: Consider removing these sub-elements that duplicate the same
-    // attributes - which WERE bugged - when we update the XML format, must leave
-    // them in place for now even though we no longer use them for compatibility
-    // with older version of Mudlet
-    writeTextElement( "mLineSize", QString::number(pHost->mLineSize, 'f', 1) );
-    writeTextElement( "mRoomSize", QString::number(pHost->mRoomSize, 'f', 1) );
-
-    writeEndElement(); // end Host tag
-    writeEndElement(); // end HostPackage tag
-
-    writeStartElement( "TriggerPackage" );
-    bool ret = true;
-    typedef list<TTrigger *>::const_iterator ItTriggerUnit;
-    for( ItTriggerUnit it1 = pHost->mTriggerUnit.mTriggerRootNodeList.begin(); it1 != pHost->mTriggerUnit.mTriggerRootNodeList.end(); it1++)
-    {
-        TTrigger * pChildTrigger = *it1;
-        if( ! pChildTrigger || pChildTrigger->mModuleMember) continue;
-        if( ! pChildTrigger->isTempTrigger())
-        {
-            if( ! writeTrigger( pChildTrigger ) )
-            {
-                ret = false;
-            }
-        }
-    }
-    writeEndElement(); //end trigger package tag
-
-    writeStartElement("TimerPackage");
-    typedef list<TTimer *>::const_iterator ItTimerUnit;
-    for( ItTimerUnit it2 = pHost->mTimerUnit.mTimerRootNodeList.begin(); it2 != pHost->mTimerUnit.mTimerRootNodeList.end(); it2++)
-    {
-        TTimer * pChildTimer = *it2;
-        if (pChildTimer->mModuleMember) continue;
-        if( ! pChildTimer->isTempTimer())
-        {
-            if( ! writeTimer( pChildTimer ) )
-            {
-                ret = false;
-            }
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("AliasPackage");
-    typedef list<TAlias *>::const_iterator ItAliasUnit;
-    for( ItAliasUnit it3 = pHost->mAliasUnit.mAliasRootNodeList.begin(); it3 != pHost->mAliasUnit.mAliasRootNodeList.end(); it3++)
-    {
-        TAlias * pChildAlias = *it3;
-        if (pChildAlias->mModuleMember) continue;
-        if( ! pChildAlias->isTempAlias())
-        {
-            if( ! writeAlias( pChildAlias ) )
-            {
-                ret = false;
-            }
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("ActionPackage");
-    typedef list<TAction *>::const_iterator ItActionUnit;
-    for( ItActionUnit it4 = pHost->mActionUnit.mActionRootNodeList.begin(); it4 != pHost->mActionUnit.mActionRootNodeList.end(); it4++)
-    {
-        TAction * pChildAction = *it4;
-        if (pChildAction->mModuleMember) continue;
-        if( ! writeAction( pChildAction ) )
-        {
-            ret = false;
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("ScriptPackage");
-    typedef list<TScript *>::const_iterator ItScriptUnit;
-    for( ItScriptUnit it5 = pHost->mScriptUnit.mScriptRootNodeList.begin(); it5 != pHost->mScriptUnit.mScriptRootNodeList.end(); it5++)
-    {
-        TScript * pChildScript = *it5;
-        if (pChildScript->mModuleMember) continue;
-        if( ! writeScript( pChildScript ) )
-        {
-            ret = false;
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("KeyPackage");
-    typedef list<TKey *>::const_iterator ItKeyUnit;
-    for( ItKeyUnit it6 = pHost->mKeyUnit.mKeyRootNodeList.begin(); it6 != pHost->mKeyUnit.mKeyRootNodeList.end(); it6++)
-    {
-        TKey * pChildKey = *it6;
-        if (pChildKey->mModuleMember) continue;
-        if( ! writeKey( pChildKey ) )
-        {
-            ret = false;
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("VariablePackage");
-    LuaInterface * lI = pHost->getLuaInterface();
-    VarUnit * vu = lI->getVarUnit();
-    //do hidden variables first
-    writeStartElement("HiddenVariables");
-    QSetIterator<QString> it8( vu->hiddenByUser );
-    while( it8.hasNext() )
-    {
-        writeTextElement( "name", it8.next() );
-    }
-    writeEndElement();
-    TVar * base = vu->getBase();
-    if ( !base )
-    {
-        lI->getVars( false );
-        base = vu->getBase();
-    }
-    if ( base )
-    {
-        QListIterator<TVar *> it7( base->getChildren(false) );
-        while( it7.hasNext() )
-        {
-            TVar * var = it7.next();
-            if( ! writeVariable( var, lI, vu ) )
-            {
-                ret = false;
-            }
-        }
-    }
-    writeEndElement();
-
-    return ret;
->>>>>>> SlySven/release_30
 }
 
 bool XMLexport::writeVariable( TVar * pVar, LuaInterface * pLuaInterface, VarUnit * pVariableUnit )
@@ -835,7 +602,6 @@ bool XMLexport::writeVariable( TVar * pVar, LuaInterface * pLuaInterface, VarUni
     if( pVariableUnit->isSaved( pVar ) ) {
         if( pVar->getValueType() == LUA_TTABLE ) {
             writeStartElement( "VariableGroup" );
-<<<<<<< HEAD
             writeTextElement( "name", pVar->getName() );
             writeTextElement( "keyType", QString::number( pVar->getKeyType() ) );
             writeTextElement( "value", pLuaInterface->getValue( pVar ) );
@@ -849,25 +615,6 @@ bool XMLexport::writeVariable( TVar * pVar, LuaInterface * pLuaInterface, VarUni
             writeEndElement(); // </VariableGroup>
         }
         else {
-=======
-            writeTextElement( "name", var->getName() );
-            writeTextElement( "keyType", QString::number( var->getKeyType() ) );
-            writeTextElement( "value", lI->getValue( var ) );
-            writeTextElement( "valueType", QString::number( var->getValueType() ) );
-            QListIterator<TVar *> it( var->getChildren(false) );
-            while( it.hasNext() )
-            {
-                TVar * var = it.next();
-                writeVariable( var, lI, vu );
-            }
-            writeEndElement();
-        }
-    }
-    else
-    {
-        if ( vu->isSaved( var ) )
-        {
->>>>>>> SlySven/release_30
             writeStartElement( "Variable" );
             writeTextElement( "name", pVar->getName() );
             writeTextElement( "keyType", QString::number( pVar->getKeyType() ) );
@@ -904,7 +651,6 @@ bool XMLexport::exportGenericPackage( QIODevice * device )
 
 bool XMLexport::writeGenericPackage( Host * pHost )
 {
-<<<<<<< HEAD
     bool isOk = true;
     if( isOk ) {
         writeStartElement( "TriggerPackage" );
@@ -970,93 +716,6 @@ bool XMLexport::writeGenericPackage( Host * pHost )
         }
         writeEndElement(); // </ScriptPackage>
     }
-=======
-    writeStartElement( "TriggerPackage" );
-    bool ret = true;
-    typedef list<TTrigger *>::const_iterator ItTriggerUnit;
-    for( ItTriggerUnit it1 = pHost->mTriggerUnit.mTriggerRootNodeList.begin(); it1 != pHost->mTriggerUnit.mTriggerRootNodeList.end(); it1++)
-    {
-        TTrigger * pChildTrigger = *it1;
-        if( ! pChildTrigger ) continue;
-        if( ! pChildTrigger->isTempTrigger())
-        {
-            if( ! writeTrigger( pChildTrigger ) )
-            {
-                ret = false;
-            }
-        }
-    }
-    writeEndElement(); //end trigger package tag
-
-    writeStartElement("TimerPackage");
-    typedef list<TTimer *>::const_iterator ItTimerUnit;
-    for( ItTimerUnit it2 = pHost->mTimerUnit.mTimerRootNodeList.begin(); it2 != pHost->mTimerUnit.mTimerRootNodeList.end(); it2++)
-    {
-        TTimer * pChildTimer = *it2;
-        if( ! pChildTimer->isTempTimer())
-        {
-            if( ! writeTimer( pChildTimer ) )
-            {
-                ret = false;
-            }
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("AliasPackage");
-    typedef list<TAlias *>::const_iterator ItAliasUnit;
-    for( ItAliasUnit it3 = pHost->mAliasUnit.mAliasRootNodeList.begin(); it3 != pHost->mAliasUnit.mAliasRootNodeList.end(); it3++)
-    {
-        TAlias * pChildAlias = *it3;
-        if( ! pChildAlias->isTempAlias())
-        {
-            if( ! writeAlias( pChildAlias ) )
-            {
-                ret =false;
-            }
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("ActionPackage");
-    typedef list<TAction *>::const_iterator ItActionUnit;
-    for( ItActionUnit it4 = pHost->mActionUnit.mActionRootNodeList.begin(); it4 != pHost->mActionUnit.mActionRootNodeList.end(); it4++)
-    {
-        TAction * pChildAction = *it4;
-        if( ! writeAction( pChildAction ) )
-        {
-            ret = false;
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("ScriptPackage");
-    typedef list<TScript *>::const_iterator ItScriptUnit;
-    for( ItScriptUnit it5 = pHost->mScriptUnit.mScriptRootNodeList.begin(); it5 != pHost->mScriptUnit.mScriptRootNodeList.end(); it5++)
-    {
-        TScript * pChildScript = *it5;
-        if( ! writeScript( pChildScript ) )
-        {
-            ret = false;
-        }
-    }
-    writeEndElement();
-
-    writeStartElement("KeyPackage");
-    typedef list<TKey *>::const_iterator ItKeyUnit;
-    for( ItKeyUnit it6 = pHost->mKeyUnit.mKeyRootNodeList.begin(); it6 != pHost->mKeyUnit.mKeyRootNodeList.end(); it6++)
-    {
-        TKey * pChildKey = *it6;
-        if( ! writeKey( pChildKey ) )
-        {
-            ret = false;
-        }
-    }
-    writeEndElement();
-
-    return ret;
-}
->>>>>>> SlySven/release_30
 
     if( isOk ) {
         writeStartElement( "KeyPackage" );
@@ -1101,7 +760,6 @@ bool XMLexport::exportTrigger( QIODevice * device )
 
 bool XMLexport::writeTrigger( TTrigger * pT )
 {
-<<<<<<< HEAD
     bool isOk = true;
     if( !pT->mModuleMasterFolder && pT->exportItem ) {
 
@@ -1171,84 +829,6 @@ bool XMLexport::writeTrigger( TTrigger * pT )
     }
 
     return ( isOk && ( ! hasError() ) );
-=======
-    if (!pT->mModuleMasterFolder && pT->exportItem){
-    //qDebug()<<"trigger written"<<pT->mModuleMember;
-    QString tag;
-    if( pT->mIsFolder )
-    {
-        tag = "TriggerGroup";
-    }
-    else
-    {
-        tag = "Trigger";
-    }
-    writeStartElement( tag );
-    writeAttribute( "isActive", pT->shouldBeActive() ? "yes" : "no" );
-    writeAttribute( "isFolder", pT->mIsFolder ? "yes" : "no" );
-    writeAttribute( "isTempTrigger", pT->mIsTempTrigger ? "yes" : "no" );
-    writeAttribute( "isMultiline", pT->mIsMultiline ? "yes" : "no" );
-    writeAttribute( "isPerlSlashGOption", pT->mPerlSlashGOption ? "yes" : "no" );
-    writeAttribute( "isColorizerTrigger", pT->mIsColorizerTrigger ? "yes" : "no" );
-    writeAttribute( "isFilterTrigger", pT->mFilterTrigger ? "yes" : "no" );
-    writeAttribute( "isSoundTrigger", pT->mSoundTrigger ? "yes" : "no" );
-    writeAttribute( "isColorTrigger", pT->mColorTrigger ? "yes" : "no" );
-    writeAttribute( "isColorTriggerFg", pT->mColorTriggerFg ? "yes" : "no" );
-    writeAttribute( "isColorTriggerBg", pT->mColorTriggerBg ? "yes" : "no" );
-
-
-    writeTextElement( "name", pT->mName );
-    writeTextElement( "script", pT->mScript );
-    writeTextElement( "triggerType", QString::number( pT->mTriggerType ) );
-    writeTextElement( "conditonLineDelta", QString::number( pT->mConditionLineDelta ) );
-    writeTextElement( "mStayOpen", QString::number( pT->mStayOpen ) );
-    writeTextElement( "mCommand", pT->mCommand );
-    writeTextElement( "packageName", pT->mPackageName );
-    writeTextElement( "mFgColor", pT->mFgColor.name() );
-    writeTextElement( "mBgColor", pT->mBgColor.name() );
-    writeTextElement( "mSoundFile", pT->mSoundFile );
-    writeTextElement( "colorTriggerFgColor", pT->mColorTriggerFgColor.name() );
-    writeTextElement( "colorTriggerBgColor", pT->mColorTriggerBgColor.name() );
-
-// TODO: The next bit could be revised for a new - not BACKWARD COMPATIBLE form
-// if/when we get 'version' checking enforced in the 'MudletPackage' element:
-//    int elementCount = qMin( pTt->mRegexCodeList.size(), pT->mRegexCodePropertyList.size() ):
-//    writeStartElement( "RegexList" );
-//    writeAttribute( "size", QString::number( elementCount ) );
-//    for( int i = 0; i < elementCount; ++i ) {
-//        writeEmptyElement( "RegexCode" );
-//        writeAttribute( "index", QString::number( i ) );
-//        writeAttribute( "type", QString::number( pT->mRegexCodePropertyList.at(i) ) );
-//        writeAttribute( "data", pT->mRegexCodeList.at(i) );
-//    }
-//    writeEndElement(); // </RegexList>
-
-    writeStartElement( "regexCodeList" );
-    for( int i=0; i<pT->mRegexCodeList.size(); i++ )
-    {
-        writeTextElement( "string", pT->mRegexCodeList[i] );
-    }
-    writeEndElement();
-
-    writeStartElement( "regexCodePropertyList" );
-    for( int i=0; i<pT->mRegexCodePropertyList.size(); i++ )
-    {
-        writeTextElement( "integer", QString::number( pT->mRegexCodePropertyList[i] ) );
-    }
-    writeEndElement();
-    }
-    typedef list<TTrigger *>::const_iterator I;
-    for( I it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); it++)
-    {
-        TTrigger * pChild = *it;
-      //  if (pChild->mModuleMember) continue;
-        writeTrigger( pChild );
-    }
-    if (pT->exportItem)
-        writeEndElement();
-
-    return true;
->>>>>>> SlySven/release_30
 }
 
 
@@ -1336,7 +916,6 @@ bool XMLexport::exportAction( QIODevice * device )
 
 bool XMLexport::writeAction( TAction * pT )
 {
-<<<<<<< HEAD
     bool isOk = true;
     if( !pT->mModuleMasterFolder && pT->exportItem ) {
 
@@ -1360,7 +939,9 @@ bool XMLexport::writeAction( TAction * pT )
             writeTextElement( "location", QString::number(pT->mLocation) );
             writeTextElement( "posX", QString::number(pT->mPosX) );
             writeTextElement( "posY", QString::number(pT->mPosY) );
-            writeTextElement( "mButtonState", QString::number(pT->mButtonState) );
+            // We now use a boolean but file must use original "1" (false)
+            // or "2" (true) for backward compatibility
+            writeTextElement( "mButtonState", QString::number( pT->mButtonState ? 2 : 1 ) );
             writeTextElement( "sizeX", QString::number(pT->mSizeX) );
             writeTextElement( "sizeY", QString::number(pT->mSizeY) );
             writeTextElement( "buttonColumn", QString::number(pT->mButtonColumns) );
@@ -1369,52 +950,6 @@ bool XMLexport::writeAction( TAction * pT )
         }
 
         isOk = ! hasError();
-=======
-    if (!pT->mModuleMasterFolder && pT->exportItem){
-    QString tag;
-    if( pT->mIsFolder )
-    {
-        tag = "ActionGroup";
-    }
-    else
-    {
-        tag = "Action";
-    }
-
-    writeStartElement( tag );
-
-    writeAttribute( "isActive", pT->shouldBeActive() ? "yes" : "no" );
-    writeAttribute( "isFolder", pT->mIsFolder ? "yes" : "no" );
-    writeAttribute( "isPushButton", pT->mIsPushDownButton ? "yes" : "no" );
-    writeAttribute( "isFlatButton", pT->mButtonFlat ? "yes" : "no" );
-    writeAttribute( "useCustomLayout", pT->mUseCustomLayout ? "yes" : "no" );
-
-    writeTextElement( "name", pT->mName );
-    writeTextElement( "packageName", pT->mPackageName );
-    writeTextElement( "script", pT->mScript );
-    writeTextElement( "css", pT->css );
-    writeTextElement( "commandButtonUp", pT->mCommandButtonUp );
-    writeTextElement( "commandButtonDown", pT->mCommandButtonDown );
-    writeTextElement( "icon", pT->mIcon );
-    writeTextElement( "orientation", QString::number(pT->mOrientation) );
-    writeTextElement( "location", QString::number(pT->mLocation) );
-    writeTextElement( "posX", QString::number(pT->mPosX) );
-    writeTextElement( "posY", QString::number(pT->mPosY) );
-    // We now use a boolean but file must use original "1" (false)
-    // or "2" (true) for backward compatibility
-    writeTextElement( "mButtonState", QString::number( pT->mButtonState ? 2 : 1 ) );
-    writeTextElement( "sizeX", QString::number(pT->mSizeX) );
-    writeTextElement( "sizeY", QString::number(pT->mSizeY) );
-    writeTextElement( "buttonColumn", QString::number(pT->mButtonColumns) );
-    writeTextElement( "buttonRotation", QString::number(pT->mButtonRotation) );
-    writeTextElement( "buttonColor", pT->mButtonColor.name() );
-}
-    typedef list<TAction *>::const_iterator I;
-    for( I it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); it++)
-    {
-        TAction * pChild = *it;
-        writeAction( pChild );
->>>>>>> SlySven/release_30
     }
 
     for( auto it = pT->mpMyChildrenList->begin(); isOk && it != pT->mpMyChildrenList->end(); ++it ) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -2,10 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
-<<<<<<< HEAD
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
-=======
->>>>>>> SlySven/release_30
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -99,26 +96,14 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
         mpTrigger->setIsFolder(true);
 
         mpTimer = new TTimer(0, mpHost);
-<<<<<<< HEAD
-=======
-        mpTimer->setIsFolder(true);
-
->>>>>>> SlySven/release_30
         if (module) {
             mpTimer->mModuleMasterFolder = true;
             mpTimer->mModuleMember = true;
         }
-<<<<<<< HEAD
         mpTimer->setPackageName(mPackageName);
         mpTimer->setIsActive(true);
         mpTimer->setName(mPackageName);
         mpTimer->setIsFolder(true);
-=======
-
-        mpTimer->setPackageName(mPackageName);
-        mpTimer->setName(mPackageName);
-        mpTimer->setIsActive(true);
->>>>>>> SlySven/release_30
 
         mpAlias = new TAlias(0, mpHost);
         if (module) {
@@ -126,19 +111,11 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
             mpAlias->mModuleMember = true;
         }
         mpAlias->setPackageName(mPackageName);
-<<<<<<< HEAD
         mpAlias->setIsActive(true);
         mpAlias->setName(mPackageName);
         mpAlias->setScript(QString());
         mpAlias->setRegexCode(QString());
         mpAlias->setIsFolder(true);
-=======
-        mpAlias->setName(mPackageName);
-        mpAlias->setIsFolder(true);
-        mpAlias->setScript(QString());
-        mpAlias->setRegexCode(QString());
-        mpAlias->setIsActive(true);
->>>>>>> SlySven/release_30
 
         mpAction = new TAction(0, mpHost);
         if (module) {
@@ -149,10 +126,7 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
         mpAction->setIsActive(true);
         mpAction->setName(mPackageName);
         mpAction->setIsFolder(true);
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
         mpScript = new TScript(0, mpHost);
         if (module) {
             mpScript->mModuleMasterFolder = true;
@@ -162,10 +136,7 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
         mpScript->setIsActive(true);
         mpScript->setName(mPackageName);
         mpScript->setIsFolder(true);
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
         mpHost->getTriggerUnit()->registerTrigger(mpTrigger);
         mpHost->getTimerUnit()->registerTimer(mpTimer);
         mpHost->getAliasUnit()->registerAlias(mpAlias);
@@ -173,10 +144,7 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
         mpHost->getKeyUnit()->registerKey(mpKey);
         mpHost->getScriptUnit()->registerScript(mpScript);
     }
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
     while (!atEnd()) {
         readNext();
 
@@ -187,18 +155,13 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
                 readMap();
                 mpHost->mpMap->audit();
             } else {
-<<<<<<< HEAD
                 qDebug().nospace() << "XMLimport::importPackage(...) ERROR: "
                                       "unrecognised element with name: "
                                    << name().toString() << " and content: " << text().toString();
-=======
-                qDebug().nospace() << "XMLimport::importPackage(...) ERROR: unrecognised element with name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
             }
         }
     }
 
-<<<<<<< HEAD
     if (!packName.isEmpty()) {
         if (!gotTrigger) {
             mpHost->getTriggerUnit()->unregisterTrigger(mpTrigger);
@@ -238,60 +201,19 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
         }
     }
 
-=======
-    if (gotTimer && !packName.isEmpty()) {
-        mpTimer->setIsActive(true);
-        mpTimer->enableTimer(mpTimer->getID());
-    }
-
-    if (gotAlias && !packName.isEmpty()) {
-        mpAlias->setIsActive(true);
-    }
-
-    if (gotAction && !packName.isEmpty()) {
-        mpHost->getActionUnit()->updateToolbar();
-    }
-
-    if (!packName.isEmpty()) {
-        if (!gotTrigger) {
-            mpHost->getTriggerUnit()->unregisterTrigger(mpTrigger);
-        }
-        if (!gotTimer) {
-            mpHost->getTimerUnit()->unregisterTimer(mpTimer);
-        }
-        if (!gotAlias) {
-            mpHost->getAliasUnit()->unregisterAlias(mpAlias);
-        }
-        if (!gotAction) {
-            mpHost->getActionUnit()->unregisterAction(mpAction);
-        }
-        if (!gotKey) {
-            mpHost->getKeyUnit()->unregisterKey(mpKey);
-        }
-        if (!gotScript) {
-            mpHost->getScriptUnit()->unregisterScript(mpScript);
-        }
-    }
->>>>>>> SlySven/release_30
     return !error();
 }
 
 void XMLimport::readVariableGroup(TVar* pParent)
 {
     TVar* var = new TVar(pParent);
-<<<<<<< HEAD
-=======
 
->>>>>>> SlySven/release_30
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     QString keyName, value;
     int keyType = 0;
     int valueType;
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -326,10 +248,7 @@ void XMLimport::readHiddenVariables()
 {
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
@@ -350,10 +269,7 @@ void XMLimport::readVariablePackage()
 {
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
     mpVar = vu->getBase();
     while (!atEnd()) {
         readNext();
@@ -390,7 +306,6 @@ void XMLimport::readMap()
                 readEnvColors();
             }
             mpHost->mpMap->reportProgressToProgressDialog(3, 3);
-<<<<<<< HEAD
         }
     }
 
@@ -407,8 +322,6 @@ void XMLimport::readMap()
             // It is known for map files to have rooms with area Ids that are
             // not in the listed areas - this cures that:
             mpHost->mpMap->mpRoomDB->addArea(areaId);
-=======
->>>>>>> SlySven/release_30
         }
 
         mpHost->mpMap->mpRoomDB->setAreaRooms(areaId, areaRoomsSet);
@@ -441,10 +354,7 @@ void XMLimport::readEnvColors()
 {
     while (!atEnd()) {
         readNext();
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
         if (name() == "environment") {
             readEnvColor();
         }
@@ -463,21 +373,12 @@ void XMLimport::readAreas()
 {
     while (!atEnd()) {
         readNext();
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
         if (name() == "areas") {
             break;
         } else if (name() == "area") {
             readArea();
         }
-<<<<<<< HEAD
-=======
-        if (name() == "area") {
-            readArea();
-        }
->>>>>>> SlySven/release_30
     }
 }
 
@@ -485,16 +386,12 @@ void XMLimport::readArea()
 {
     int id = attributes().value("id").toString().toInt();
     QString name = attributes().value("name").toString();
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
     mpHost->mpMap->mpRoomDB->addArea(id, name);
 }
 
 void XMLimport::readRooms(QMultiHash<int, int>& areaRoomsHash)
 {
-<<<<<<< HEAD
     unsigned int roomCount = 0;
 
     while (!atEnd()) {
@@ -504,19 +401,6 @@ void XMLimport::readRooms(QMultiHash<int, int>& areaRoomsHash)
             if (Q_LIKELY(name() == QStringLiteral("room"))) {
                 readRoom(areaRoomsHash, &roomCount);
             } else {
-=======
-
-    unsigned int roomCount = 0;
-    while (!atEnd()) {
-        readNext();
-
-        if (Q_LIKELY(isStartElement())) {
-            if (Q_LIKELY(name() == QStringLiteral("room"))) {
-                readRoom(areaRoomsHash, &roomCount);
-            }
-
-            else {
->>>>>>> SlySven/release_30
                 readUnknownMapElement();
             }
         } else if (isEndElement()) {
@@ -530,10 +414,7 @@ void XMLimport::readRooms(QMultiHash<int, int>& areaRoomsHash)
 void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int* roomCount)
 {
     TRoom* pT = new TRoom(mpHost->mpMap->mpRoomDB);
-<<<<<<< HEAD
 
-=======
->>>>>>> SlySven/release_30
     pT->id = attributes().value(QStringLiteral("id")).toString().toInt();
     pT->area = attributes().value(QStringLiteral("area")).toString().toInt();
     pT->name = attributes().value(QStringLiteral("title")).toString();
@@ -544,12 +425,8 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
 
         if (Q_UNLIKELY(pT->id < 1)) {
             continue; // Skip further tests on exits as we'd have to throw away
-<<<<<<< HEAD
                       // this invalid room and it would mess up the
                       // entranceMultiHash
-=======
-                      // this invalid room and it would mess up the entranceMultiHash
->>>>>>> SlySven/release_30
         } else if (Q_LIKELY(name() == QStringLiteral("exit"))) {
             QString dir = attributes().value(QStringLiteral("direction")).toString();
             int e = attributes().value(QStringLiteral("target")).toString().toInt();
@@ -581,22 +458,7 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
                 pT->out = e;
             } else {
                 // TODO: Handle Special Exits
-<<<<<<< HEAD
             }
-        } else if (name() == QStringLiteral("coord")) {
-            if (attributes().value("x").toString().isEmpty()) {
-                continue;
-=======
->>>>>>> SlySven/release_30
-            }
-
-            pT->x = attributes().value(QStringLiteral("x")).toString().toInt();
-            pT->y = attributes().value(QStringLiteral("y")).toString().toInt();
-            pT->z = attributes().value(QStringLiteral("z")).toString().toInt();
-        } else if (Q_UNLIKELY(name().isEmpty())) {
-            continue;
-<<<<<<< HEAD
-=======
         } else if (name() == QStringLiteral("coord")) {
             if (attributes().value("x").toString().isEmpty()) {
                 continue;
@@ -608,7 +470,6 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
             continue;
         } else if (Q_UNLIKELY(name().isEmpty())) {
             continue;
->>>>>>> SlySven/release_30
         }
 
         if (isEndElement()) {
@@ -630,28 +491,14 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
     }
 }
 
-<<<<<<< HEAD
 void XMLimport::readUnknownMapElement()
 {
     while (!atEnd()) {
-=======
-
-void XMLimport::readUnknownMapElement()
-{
-    while (!atEnd()) {
-
->>>>>>> SlySven/release_30
         readNext();
 
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
-=======
-        }
-
-        if (isStartElement()) {
->>>>>>> SlySven/release_30
             readMap();
         }
     }
@@ -661,7 +508,6 @@ void XMLimport::readPackage()
 {
     while (!atEnd()) {
         readNext();
-<<<<<<< HEAD
 
         if (isEndElement()) {
             break;
@@ -682,38 +528,6 @@ void XMLimport::readPackage()
                 readKeyPackage();
             } else if (name() == "HelpPackage") {
                 readHelpPackage();
-=======
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
-            if (name() == "HostPackage") {
-                readHostPackage();
-                continue;
-            }
-            if (name() == "TriggerPackage") {
-                readTriggerPackage();
-                continue;
-            } else if (name() == "TimerPackage") {
-                readTimerPackage();
-                continue;
-            } else if (name() == "AliasPackage") {
-                readAliasPackage();
-                continue;
-            } else if (name() == "ActionPackage") {
-                readActionPackage();
-                continue;
-            } else if (name() == "ScriptPackage") {
-                readScriptPackage();
-                continue;
-            } else if (name() == "KeyPackage") {
-                readKeyPackage();
-                continue;
-            } else if (name() == "HelpPackage") {
-                readHelpPackage();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "VariablePackage") {
                 readVariablePackage();
             } else {
@@ -727,17 +541,10 @@ void XMLimport::readHelpPackage()
 {
     while (!atEnd()) {
         readNext();
-<<<<<<< HEAD
 
         if (isEndElement()) {
             break;
         } else if (isStartElement()) {
-=======
-        if (isEndElement()) {
-            break;
-        }
-        if (isStartElement()) {
->>>>>>> SlySven/release_30
             if (name() == "helpURL") {
                 QString contents = readElementText();
                 mpHost->moduleHelp[mPackageName].insert("helpURL", contents);
@@ -749,16 +556,10 @@ void XMLimport::readHelpPackage()
 void XMLimport::readUnknownPackage()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownPackage(): ERROR: UNKNOWN "
                               "Package Element name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownPackage(): ERROR: UNKNOWN Package Element name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -773,16 +574,10 @@ void XMLimport::readUnknownPackage()
 void XMLimport::readUnknownHostElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Host Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN Host Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -797,16 +592,10 @@ void XMLimport::readUnknownHostElement()
 void XMLimport::readUnknownTriggerElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Trigger Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownTriggerElement() ERROR: UNKNOWN Trigger Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -821,16 +610,10 @@ void XMLimport::readUnknownTriggerElement()
 void XMLimport::readUnknownTimerElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Timer Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownTimerElement() ERROR: UNKNOWN Timer Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -845,16 +628,10 @@ void XMLimport::readUnknownTimerElement()
 void XMLimport::readUnknownAliasElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Alias Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownAliasElement() ERROR: UNKNOWN Alias Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -869,16 +646,10 @@ void XMLimport::readUnknownAliasElement()
 void XMLimport::readUnknownActionElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Action Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownActionElement() ERROR: UNKNOWN Action Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -893,16 +664,10 @@ void XMLimport::readUnknownActionElement()
 void XMLimport::readUnknownScriptElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Script Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownScriptElement() ERROR: UNKNOWN Script Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -917,16 +682,10 @@ void XMLimport::readUnknownScriptElement()
 void XMLimport::readUnknownKeyElement()
 {
     while (!atEnd()) {
-<<<<<<< HEAD
         readNext();
         qDebug().nospace() << "XMLimport::readUnknownHostElement() ERROR: UNKNOWN "
                               "Key Package Element, name: "
                            << name().toString() << " and content: " << text().toString();
-=======
-
-        readNext();
-        qDebug().nospace() << "XMLimport::readUnknownKeyElement() ERROR: UNKNOWN Key Package Element, name: " << name().toString() << " and content: " << text().toString();
->>>>>>> SlySven/release_30
 
         if (isEndElement()) {
             break;
@@ -1010,7 +769,6 @@ void XMLimport::readHostPackage(Host* pHost)
 
                 readModulesDetailsMap(entry);
 
-<<<<<<< HEAD
                 QMapIterator<QString, QStringList> it(entry);
                 while (it.hasNext()) {
                     it.next();
@@ -1158,8 +916,6 @@ void XMLimport::readHostPackage(Host* pHost)
     }
 }
 
-=======
->>>>>>> SlySven/release_30
 void XMLimport::readTriggerPackage()
 {
     while (!atEnd()) {
@@ -1171,15 +927,7 @@ void XMLimport::readTriggerPackage()
         if (isStartElement()) {
             if (name() == "TriggerGroup" || name() == "Trigger") {
                 gotTrigger = true;
-<<<<<<< HEAD
                 readTriggerGroup(mPackageName.isEmpty() ? 0 : mpTrigger);
-=======
-                if (mPackageName.isEmpty()) {
-                    readTriggerGroup(0);
-                } else {
-                    readTriggerGroup(mpTrigger);
-                }
->>>>>>> SlySven/release_30
             } else {
                 readUnknownTriggerElement();
             }
@@ -1189,7 +937,6 @@ void XMLimport::readTriggerPackage()
 
 void XMLimport::readTriggerGroup(TTrigger* pParent)
 {
-<<<<<<< HEAD
     TTrigger* pT = new TTrigger(pParent, mpHost);
 
     if (module) {
@@ -1213,10 +960,6 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
     while (!atEnd()) {
         readNext();
 
-=======
-    while (!atEnd()) {
-        readNext();
->>>>>>> SlySven/release_30
         if (isEndElement()) {
             break;
         } else if (isStartElement()) {
@@ -1270,7 +1013,6 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
         }
     }
 
-<<<<<<< HEAD
     if (!pT->setRegexCodeList(pT->mRegexCodeList, pT->mRegexCodePropertyList)) {
         qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not "
                               "initialize pattern list for trigger: "
@@ -1290,19 +1032,11 @@ void XMLimport::readTimerPackage()
                 readTimerGroup(mPackageName.isEmpty() ? 0 : mpTimer);
             } else {
                 readUnknownTimerElement();
-=======
-        if (isStartElement()) {
-            if (name() == "Host") {
-                readHostPackage(mpHost);
-            } else {
-                readUnknownHostElement();
->>>>>>> SlySven/release_30
             }
         }
     }
 }
 
-<<<<<<< HEAD
 void XMLimport::readTimerGroup(TTimer* pParent)
 {
     TTimer* pT = new TTimer(pParent, mpHost);
@@ -1339,441 +1073,6 @@ void XMLimport::readTimerGroup(TTimer* pParent)
                 readTimerGroup(pT);
             } else {
                 readUnknownTimerElement();
-=======
-void XMLimport::readHostPackage(Host* pHost)
-{
-    pHost->mAutoClearCommandLineAfterSend = (attributes().value("autoClearCommandLineAfterSend") == "yes");
-    pHost->mDisableAutoCompletion = (attributes().value("disableAutoCompletion") == "yes");
-    pHost->mPrintCommand = (attributes().value("printCommand") == "yes");
-    pHost->set_USE_IRE_DRIVER_BUGFIX(attributes().value("USE_IRE_DRIVER_BUGFIX") == "yes");
-    pHost->mUSE_FORCE_LF_AFTER_PROMPT = (attributes().value("mUSE_FORCE_LF_AFTER_PROMPT") == "yes");
-    pHost->mUSE_UNIX_EOL = (attributes().value("mUSE_UNIX_EOL") == "yes");
-    pHost->mNoAntiAlias = (attributes().value("mNoAntiAlias") == "yes");
-    pHost->mIsNextLogFileInHtmlFormat = (attributes().value("mRawStreamDump") == "yes");
-    pHost->mAlertOnNewData = (attributes().value("mAlertOnNewData") == "yes");
-    pHost->mFORCE_NO_COMPRESSION = (attributes().value("mFORCE_NO_COMPRESSION") == "yes");
-    pHost->mFORCE_GA_OFF = (attributes().value("mFORCE_GA_OFF") == "yes");
-    pHost->mFORCE_SAVE_ON_EXIT = (attributes().value("mFORCE_SAVE_ON_EXIT") == "yes");
-    pHost->mEnableGMCP = (attributes().value("mEnableGMCP") == "yes");
-    pHost->mEnableMSDP = (attributes().value("mEnableMSDP") == "yes");
-    pHost->mMapStrongHighlight = (attributes().value("mMapStrongHighlight") == "yes");
-    pHost->mLogStatus = (attributes().value("mLogStatus") == "yes");
-    pHost->mEnableSpellCheck = (attributes().value("mEnableSpellCheck") == "yes");
-    pHost->mShowInfo = (attributes().value("mShowInfo") == "yes");
-    pHost->mAcceptServerGUI = (attributes().value("mAcceptServerGUI") == "yes");
-    pHost->mMapperUseAntiAlias = (attributes().value("mMapperUseAntiAlias") == "yes");
-    pHost->mFORCE_MXP_NEGOTIATION_OFF = (attributes().value("mFORCE_MXP_NEGOTIATION_OFF") == "yes");
-    pHost->mRoomSize = attributes().value("mRoomSize").toString().toFloat();
-    if (qFuzzyCompare(1.0 + pHost->mRoomSize, 1.0)) {
-        // The value is a float/double and the prior code using "== 0" is a BAD
-        // THING to do with non-integer number types!
-        pHost->mRoomSize = 0.5f; // Same value as is in Host class initalizer list
-    }
-    pHost->mLineSize = attributes().value("mLineSize").toString().toFloat();
-    if (qFuzzyCompare(1.0 + pHost->mLineSize, 1.0)) {
-        pHost->mLineSize = 1.0f; // Same value as is in Host class initalizer list
-    }
-    pHost->mBubbleMode = (attributes().value("mBubbleMode") == "yes");
-    pHost->mShowRoomID = (attributes().value("mShowRoomIDs") == "yes");
-    pHost->mShowPanel = (attributes().value("mShowPanel") == "yes");
-    pHost->mHaveMapperScript = (attributes().value("mHaveMapperScript") == "yes");
-    QStringRef ignore = attributes().value("mDoubleClickIgnore");
-    for (int i = 0; i < ignore.size(); i++) {
-        pHost->mDoubleClickIgnore.insert(ignore.at(i));
-    }
-
-    while (!atEnd()) {
-        readNext();
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-                pHost->mHostName = readElementText();
-                continue;
-            } else if (name() == "mInstalledModules") {
-                QMap<QString, QStringList> entry;
-                readModulesDetailsMap(entry);
-                QMapIterator<QString, QStringList> it(entry);
-                while (it.hasNext()) {
-                    it.next();
-                    QStringList moduleList;
-                    QStringList entryList = it.value();
-                    moduleList << entryList[0];
-                    moduleList << entryList[1];
-                    pHost->mInstalledModules[it.key()] = moduleList;
-                    pHost->mModulePriorities[it.key()] = entryList[2].toInt();
-                }
-                continue;
-            } else if (name() == "mInstalledPackages") {
-                readStringList(pHost->mInstalledPackages);
-                continue;
-            } else if (name() == "url") {
-                pHost->mUrl = readElementText();
-                continue;
-            } else if (name() == "serverPackageName") {
-                pHost->mServerGUI_Package_name = readElementText();
-                continue;
-            } else if (name() == "serverPackageVersion") {
-                pHost->mServerGUI_Package_version = readElementText().toInt();
-                continue;
-            } else if (name() == "port") {
-                pHost->mPort = readElementText().toInt();
-                continue;
-            } else if (name() == "borderTopHeight") {
-                pHost->mBorderTopHeight = readElementText().toInt();
-                continue;
-            } else if (name() == "commandLineMinimumHeight") {
-                pHost->commandLineMinimumHeight = readElementText().toInt();
-                continue;
-            } else if (name() == "borderBottomHeight") {
-                pHost->mBorderBottomHeight = readElementText().toInt();
-                continue;
-            } else if (name() == "borderLeftWidth") {
-                pHost->mBorderLeftWidth = readElementText().toInt();
-                continue;
-            } else if (name() == "borderRightWidth") {
-                pHost->mBorderRightWidth = readElementText().toInt();
-                continue;
-            } else if (name() == "wrapAt") {
-                pHost->mWrapAt = readElementText().toInt();
-                continue;
-            } else if (name() == "wrapIndentCount") {
-                pHost->mWrapIndentCount = readElementText().toInt();
-                continue;
-            } else if (name() == "mCommandSeparator") {
-                pHost->mCommandSeparator = readElementText();
-                continue;
-            } else if (name() == "mCommandLineFgColor") {
-                pHost->mCommandLineFgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mCommandLineBgColor") {
-                pHost->mCommandLineBgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mFgColor") {
-                pHost->mFgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBgColor") {
-                pHost->mBgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mCommandFgColor") {
-                pHost->mCommandFgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mCommandBgColor") {
-                pHost->mCommandBgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBlack") {
-                pHost->mBlack.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightBlack") {
-                pHost->mLightBlack.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mRed") {
-                pHost->mRed.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightRed") {
-                pHost->mLightRed.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBlue") {
-                pHost->mBlue.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightBlue") {
-                pHost->mLightBlue.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mGreen") {
-                pHost->mGreen.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightGreen") {
-                pHost->mLightGreen.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mYellow") {
-                pHost->mYellow.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightYellow") {
-                pHost->mLightYellow.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mCyan") {
-                pHost->mCyan.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightCyan") {
-                pHost->mLightCyan.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mMagenta") {
-                pHost->mMagenta.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightMagenta") {
-                pHost->mLightMagenta.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mWhite") {
-                pHost->mWhite.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightWhite") {
-                pHost->mLightWhite.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mDisplayFont") {
-                pHost->mDisplayFont.fromString(readElementText());
-                pHost->mDisplayFont.setFixedPitch(true);
-                continue;
-            } else if (name() == "mCommandLineFont") {
-                pHost->mCommandLineFont.fromString(readElementText());
-                continue;
-            } else if (name() == "commandSeperator") {
-                // Ignore this misspelled duplicate, it has been removed from
-                // the Xml format but will appear in older files and trip the
-                // QDebug() error reporting associated with the following
-                // readUnknownHostElement() for "anything not otherwise parsed"
-                Q_UNUSED(readElementText());
-            } else if (name() == "mFgColor2") {
-                pHost->mFgColor_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBgColor2") {
-                pHost->mBgColor_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBlack2") {
-                pHost->mBlack_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightBlack2") {
-                pHost->mLightBlack_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mRed2") {
-                pHost->mRed_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightRed2") {
-                pHost->mLightRed_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBlue2") {
-                pHost->mBlue_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightBlue2") {
-                pHost->mLightBlue_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mGreen2") {
-                pHost->mGreen_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightGreen2") {
-                pHost->mLightGreen_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mYellow2") {
-                pHost->mYellow_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightYellow2") {
-                pHost->mLightYellow_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mCyan2") {
-                pHost->mCyan_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightCyan2") {
-                pHost->mLightCyan_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mMagenta2") {
-                pHost->mMagenta_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightMagenta2") {
-                pHost->mLightMagenta_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mWhite2") {
-                pHost->mWhite_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mLightWhite2") {
-                pHost->mLightWhite_2.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mSpellDic") {
-                pHost->mSpellDic = readElementText();
-                continue;
-            } else if (name() == "mLineSize" || name() == "mRoomSize") {
-                // These two have been dropped from the Xml format as these are
-                // duplicates of attributes that were being incorrected read in
-                // the parent <Host ...> element as integers {they are stored as
-                // decimals but for the first one at least, it is a decimal
-                // number n, where 0.1 <= n <= 1.1 so was being read as "0" for
-                // all but the greatest 2 values where it was read as "1"!}
-                // We still check for them so that we avoid falling into the
-                // QDebug() error reporting associated with the following
-                // readUnknownHostElement() for "anything not otherwise parsed"
-                Q_UNUSED(readElementText());
-            } else {
-                readUnknownHostElement();
->>>>>>> SlySven/release_30
-            }
-        }
-    }
-
-    mudlet::self()->registerTimer(pT, pT->mpTimer);
-
-<<<<<<< HEAD
-    if (!pT->mpParent && pT->shouldBeActive()) {
-        pT->setIsActive(true);
-        pT->enableTimer(pT->getID());
-    }
-}
-
-=======
-void XMLimport::readTriggerGroup(TTrigger* pParent)
-{
-    TTrigger* pT = new TTrigger(pParent, mpHost);
-
-    if (module) {
-        pT->mModuleMember = true;
-    }
-
-    mpHost->getTriggerUnit()->registerTrigger(pT);
-
-    pT->setIsActive((attributes().value("isActive") == "yes"));
-    pT->mIsFolder = (attributes().value("isFolder") == "yes");
-    pT->mIsTempTrigger = (attributes().value("isTempTrigger") == "yes");
-    pT->mIsMultiline = (attributes().value("isMultiline") == "yes");
-    pT->mPerlSlashGOption = (attributes().value("isPerlSlashGOption") == "yes");
-    pT->mIsColorizerTrigger = (attributes().value("isColorizerTrigger") == "yes");
-    pT->mFilterTrigger = (attributes().value("isFilterTrigger") == "yes");
-    pT->mSoundTrigger = (attributes().value("isSoundTrigger") == "yes");
-    pT->mColorTrigger = (attributes().value("isColorTrigger") == "yes");
-    pT->mColorTriggerBg = (attributes().value("isColorTriggerBg") == "yes");
-    pT->mColorTriggerFg = (attributes().value("isColorTriggerFg") == "yes");
-
-    while (!atEnd()) {
-        readNext();
-        // qDebug()<<"[INFO] element:"<<name().toString()<<" text:"<<text().toString();
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-                pT->setName(readElementText());
-                continue;
-            } else if (name() == "script") {
-                QString tempScript = readElementText();
-                if (!pT->setScript(tempScript)) {
-                    qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not compile trigger's lua code for: " << pT->getName();
-                }
-                continue;
-            } else if (name() == "packageName") {
-                pT->mPackageName = readElementText();
-                continue;
-            } else if (name() == "triggerType") {
-                pT->mTriggerType = readElementText().toInt();
-                continue;
-            } else if (name() == "conditonLineDelta") {
-                pT->mConditionLineDelta = readElementText().toInt();
-                continue;
-            } else if (name() == "mStayOpen") {
-                pT->mStayOpen = readElementText().toInt();
-                continue;
-            } else if (name() == "mCommand") {
-                pT->mCommand = readElementText();
-                continue;
-            } else if (name() == "mFgColor") {
-                pT->mFgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mBgColor") {
-                pT->mBgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "colorTriggerFgColor") {
-                pT->mColorTriggerFgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "colorTriggerBgColor") {
-                pT->mColorTriggerBgColor.setNamedColor(readElementText());
-                continue;
-            } else if (name() == "mSoundFile") {
-                pT->mSoundFile = readElementText();
-                continue;
-            } else if (name() == "regexCodeList") {
-                // This and the next one ought to be combined into a single element
-                // in the next revision - sample code for "RegexCode" elements
-                // inside a "RegexList" container (with a "size" attribute) is
-                // commented out in the XMLexporter class.
-                readStringList(pT->mRegexCodeList);
-                continue;
-            } else if (name() == "regexCodePropertyList") {
-                readIntegerList(pT->mRegexCodePropertyList, pT->getName());
-                if (Q_UNLIKELY(pT->mRegexCodeList.count() != pT->mRegexCodePropertyList.count())) {
-                    qWarning().nospace() << "XMLimport::readTriggerGroup(...) ERROR: mis-match in regexCode details for Trigger: " << pT->getName() << " there were " << pT->mRegexCodeList.count()
-                                         << " 'regexCodeList' sub-elements and " << pT->mRegexCodePropertyList.count() << " 'regexCodePropertyList' sub-elements so something is broken!";
-                }
-                continue;
-            } else if (name() == "TriggerGroup" || name() == "Trigger") {
-                readTriggerGroup(pT);
-            } else {
-                readUnknownTriggerElement();
-            }
-        }
-    }
-
-    if (!pT->setRegexCodeList(pT->mRegexCodeList, pT->mRegexCodePropertyList)) {
-        qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not initialize pattern list for trigger: " << pT->getName();
-    }
-}
-
-void XMLimport::readTimerPackage()
-{
-    while (!atEnd()) {
-        readNext();
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
-            if (name() == "TimerGroup" || name() == "Timer") {
-                gotTimer = true;
-                if (mPackageName.isEmpty()) {
-                    readTimerGroup(0);
-                } else {
-                    readTimerGroup(mpTimer);
-                }
-            } else {
-                readUnknownTimerElement();
-            }
-        }
-    }
-}
-
-void XMLimport::readTimerGroup(TTimer* pParent)
-{
-    TTimer* pT = new TTimer(pParent, mpHost);
-
-    pT->mIsFolder = (attributes().value("isFolder") == "yes");
-    pT->mIsTempTimer = (attributes().value("isTempTimer") == "yes");
-
-    mpHost->getTimerUnit()->registerTimer(pT);
-    pT->setShouldBeActive((attributes().value("isActive") == "yes"));
-
-    if (module) {
-        pT->mModuleMember = true;
-    }
-
-    while (!atEnd()) {
-        readNext();
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-
-                pT->setName(readElementText());
-                continue;
-            } else if (name() == "packageName") {
-                pT->mPackageName = readElementText();
-                continue;
-            } else if (name() == "script") {
-                QString tempScript = readElementText();
-                if (!pT->setScript(tempScript)) {
-                    qDebug().nospace() << "XMLimport::readTimerGroup(...): ERROR: can not compile timer's lua code for: " << pT->getName();
-                }
-                continue;
-            } else if (name() == "command") {
-                pT->mCommand = readElementText();
-                continue;
-            } else if (name() == "time") {
-                QString timeString = readElementText();
-                QTime time = QTime::fromString(timeString, "hh:mm:ss.zzz");
-                pT->setTime(time);
-                continue;
-            } else if (name() == "TimerGroup" || name() == "Timer") {
-                readTimerGroup(pT);
-            } else {
-                readUnknownTimerElement();
             }
         }
     }
@@ -1786,30 +1085,16 @@ void XMLimport::readTimerGroup(TTimer* pParent)
     }
 }
 
->>>>>>> SlySven/release_30
 void XMLimport::readAliasPackage()
 {
     while (!atEnd()) {
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "AliasGroup" || name() == "Alias") {
                 gotAlias = true;
                 readAliasGroup(mPackageName.isEmpty() ? 0 : mpAlias);
-=======
-        }
-
-        if (isStartElement()) {
-            if (name() == "AliasGroup" || name() == "Alias") {
-                gotAlias = true;
-                if (mPackageName.isEmpty()) {
-                    readAliasGroup(0);
-                } else {
-                    readAliasGroup(mpAlias);
-                }
->>>>>>> SlySven/release_30
             } else {
                 readUnknownAliasElement();
             }
@@ -1822,11 +1107,7 @@ void XMLimport::readAliasGroup(TAlias* pParent)
     TAlias* pT = new TAlias(pParent, mpHost);
 
     mpHost->getAliasUnit()->registerAlias(pT);
-<<<<<<< HEAD
     pT->setIsActive(attributes().value("isActive") == "yes");
-=======
-    pT->setIsActive((attributes().value("isActive") == "yes"));
->>>>>>> SlySven/release_30
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     if (module) {
         pT->mModuleMember = true;
@@ -1834,7 +1115,6 @@ void XMLimport::readAliasGroup(TAlias* pParent)
 
     while (!atEnd()) {
         readNext();
-<<<<<<< HEAD
 
         if (isEndElement()) {
             break;
@@ -1843,38 +1123,15 @@ void XMLimport::readAliasGroup(TAlias* pParent)
                 pT->setName(readElementText());
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
-=======
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-                pT->setName(readElementText());
-                continue;
-            } else if (name() == "packageName") {
-                pT->mPackageName = readElementText();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "script") {
                 QString tempScript = readElementText();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readAliasGroup(...): ERROR: can not compile alias's lua code for: " << pT->getName();
                 }
-<<<<<<< HEAD
             } else if (name() == "command") {
                 pT->mCommand = readElementText();
             } else if (name() == "regex") {
                 pT->setRegexCode(readElementText());
-=======
-                continue;
-            } else if (name() == "command") {
-                pT->mCommand = readElementText();
-                continue;
-            } else if (name() == "regex") {
-                pT->setRegexCode(readElementText());
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "AliasGroup" || name() == "Alias") {
                 readAliasGroup(pT);
             } else {
@@ -1890,22 +1147,10 @@ void XMLimport::readActionPackage()
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "ActionGroup" || name() == "Action") {
                 gotAction = true;
                 readActionGroup(mPackageName.isEmpty() ? 0 : mpAction);
-=======
-        }
-        if (isStartElement()) {
-            if (name() == "ActionGroup" || name() == "Action") {
-                gotAction = true;
-                if (mPackageName.isEmpty()) {
-                    readActionGroup(0);
-                } else {
-                    readActionGroup(mpAction);
-                }
->>>>>>> SlySven/release_30
             } else {
                 readUnknownActionElement();
             }
@@ -1917,21 +1162,13 @@ void XMLimport::readActionGroup(TAction* pParent)
 {
     TAction* pT = new TAction(pParent, mpHost);
 
-<<<<<<< HEAD
-=======
-    mpHost->getActionUnit()->registerAction(pT);
-    pT->setIsActive((attributes().value("isActive") == "yes"));
->>>>>>> SlySven/release_30
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     pT->mIsPushDownButton = (attributes().value("isPushButton") == "yes");
     pT->mButtonFlat = (attributes().value("isFlatButton") == "yes");
     pT->mUseCustomLayout = (attributes().value("useCustomLayout") == "yes");
-<<<<<<< HEAD
     mpHost->getActionUnit()->registerAction(pT);
     pT->setIsActive(attributes().value("isActive") == "yes");
 
-=======
->>>>>>> SlySven/release_30
     if (module) {
         pT->mModuleMember = true;
     }
@@ -1940,29 +1177,16 @@ void XMLimport::readActionGroup(TAction* pParent)
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "name") {
                 pT->mName = readElementText();
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
-=======
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-                pT->mName = readElementText();
-                continue;
-            } else if (name() == "packageName") {
-                pT->mPackageName = readElementText();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "script") {
                 QString tempScript = readElementText();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readActionGroup(...): ERROR: can not compile action's lua code for: " << pT->getName();
                 }
-<<<<<<< HEAD
             } else if (name() == "css") {
                 pT->css = readElementText();
             } else if (name() == "commandButtonUp") {
@@ -1981,63 +1205,18 @@ void XMLimport::readActionGroup(TAction* pParent)
                 pT->mSizeX = readElementText().toInt();
             } else if (name() == "sizeY") {
                 pT->mSizeY = readElementText().toInt();
-            } else if (name() == "mButtonState") {
-                pT->mButtonState = readElementText().toInt();
-            } else if (name() == "buttonColor") {
-                pT->mButtonColor.setNamedColor(readElementText());
-            } else if (name() == "buttonColumn") {
-                pT->mButtonColumns = readElementText().toInt();
-            } else if (name() == "posX") {
-                pT->mPosX = readElementText().toInt();
-            } else if (name() == "posY") {
-                pT->mPosY = readElementText().toInt();
-=======
-                continue;
-            } else if (name() == "css") {
-                pT->css = readElementText();
-                continue;
-            } else if (name() == "commandButtonUp") {
-                pT->mCommandButtonUp = readElementText();
-                continue;
-            } else if (name() == "commandButtonDown") {
-                pT->mCommandButtonDown = readElementText();
-                continue;
-            } else if (name() == "icon") {
-                pT->mIcon = readElementText();
-                continue;
-            } else if (name() == "orientation") {
-                pT->mOrientation = readElementText().toInt();
-                continue;
-            } else if (name() == "location") {
-                pT->mLocation = readElementText().toInt();
-                continue;
-            } else if (name() == "buttonRotation") {
-                pT->mButtonRotation = readElementText().toInt();
-                continue;
-            } else if (name() == "sizeX") {
-                pT->mSizeX = readElementText().toInt();
-                continue;
-            } else if (name() == "sizeY") {
-                pT->mSizeY = readElementText().toInt();
-                continue;
             } else if (name() == "mButtonState") {
                 // We now use a boolean but file must use original "1" (false)
                 // or "2" (true) for backward compatibility
                 pT->mButtonState = ( readElementText().toInt() == 2 );
-                continue;
             } else if (name() == "buttonColor") {
                 pT->mButtonColor.setNamedColor(readElementText());
-                continue;
             } else if (name() == "buttonColumn") {
                 pT->mButtonColumns = readElementText().toInt();
-                continue;
             } else if (name() == "posX") {
                 pT->mPosX = readElementText().toInt();
-                continue;
             } else if (name() == "posY") {
                 pT->mPosY = readElementText().toInt();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "ActionGroup" || name() == "Action") {
                 readActionGroup(pT);
             } else {
@@ -2053,23 +1232,10 @@ void XMLimport::readScriptPackage()
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "ScriptGroup" || name() == "Script") {
                 gotScript = true;
                 readScriptGroup(mPackageName.isEmpty() ? 0 : mpScript);
-=======
-        }
-
-        if (isStartElement()) {
-            if (name() == "ScriptGroup" || name() == "Script") {
-                gotScript = true;
-                if (mPackageName.isEmpty()) {
-                    readScriptGroup(0);
-                } else {
-                    readScriptGroup(mpScript);
-                }
->>>>>>> SlySven/release_30
             } else {
                 readUnknownScriptElement();
             }
@@ -2081,16 +1247,10 @@ void XMLimport::readScriptGroup(TScript* pParent)
 {
     TScript* pT = new TScript(pParent, mpHost);
 
-<<<<<<< HEAD
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     mpHost->getScriptUnit()->registerScript(pT);
     pT->setIsActive(attributes().value("isActive") == "yes");
 
-=======
-    mpHost->getScriptUnit()->registerScript(pT);
-    pT->setIsActive((attributes().value("isActive") == "yes"));
-    pT->mIsFolder = (attributes().value("isFolder") == "yes");
->>>>>>> SlySven/release_30
     if (module) {
         pT->mModuleMember = true;
     }
@@ -2099,39 +1259,19 @@ void XMLimport::readScriptGroup(TScript* pParent)
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "name") {
                 pT->mName = readElementText();
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
-=======
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-                pT->mName = readElementText();
-                continue;
-            } else if (name() == "packageName") {
-                pT->mPackageName = readElementText();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "script") {
                 QString tempScript = readElementText();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readScriptGroup(...): ERROR: can not compile script's lua code for: " << pT->getName();
                 }
-<<<<<<< HEAD
             } else if (name() == "eventHandlerList") {
                 readStringList(pT->mEventHandlerList);
                 pT->setEventHandlerList(pT->mEventHandlerList);
-=======
-                continue;
-            } else if (name() == "eventHandlerList") {
-                readStringList(pT->mEventHandlerList);
-                pT->setEventHandlerList(pT->mEventHandlerList);
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "ScriptGroup" || name() == "Script") {
                 readScriptGroup(pT);
             } else {
@@ -2147,23 +1287,10 @@ void XMLimport::readKeyPackage()
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "KeyGroup" || name() == "Key") {
                 gotKey = true;
                 readKeyGroup(mPackageName.isEmpty() ? 0 : mpKey);
-=======
-        }
-
-        if (isStartElement()) {
-            if (name() == "KeyGroup" || name() == "Key") {
-                gotKey = true;
-                if (mPackageName.isEmpty()) {
-                    readKeyGroup(0);
-                } else {
-                    readKeyGroup(mpKey);
-                }
->>>>>>> SlySven/release_30
             } else {
                 readUnknownKeyElement();
             }
@@ -2175,16 +1302,10 @@ void XMLimport::readKeyGroup(TKey* pParent)
 {
     TKey* pT = new TKey(pParent, mpHost);
 
-<<<<<<< HEAD
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     mpHost->getKeyUnit()->registerKey(pT);
     pT->setIsActive(attributes().value("isActive") == "yes");
 
-=======
-    mpHost->getKeyUnit()->registerKey(pT);
-    pT->setIsActive((attributes().value("isActive") == "yes"));
-    pT->mIsFolder = (attributes().value("isFolder") == "yes");
->>>>>>> SlySven/release_30
     if (module) {
         pT->mModuleMember = true;
     }
@@ -2193,47 +1314,22 @@ void XMLimport::readKeyGroup(TKey* pParent)
         readNext();
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
             if (name() == "name") {
                 pT->mName = readElementText();
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
-=======
-        }
-
-        if (isStartElement()) {
-            if (name() == "name") {
-                pT->mName = readElementText();
-                continue;
-            } else if (name() == "packageName") {
-                pT->mPackageName = readElementText();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "script") {
                 QString tempScript = readElementText();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readKeyGroup(...): ERROR: can not compile key's lua code for: " << pT->getName();
                 }
-<<<<<<< HEAD
             } else if (name() == "command") {
                 pT->mCommand = readElementText();
             } else if (name() == "keyCode") {
                 pT->mKeyCode = readElementText().toInt();
             } else if (name() == "keyModifier") {
                 pT->mKeyModifier = readElementText().toInt();
-=======
-                continue;
-            } else if (name() == "command") {
-                pT->mCommand = readElementText();
-                continue;
-            } else if (name() == "keyCode") {
-                pT->mKeyCode = readElementText().toInt();
-                continue;
-            } else if (name() == "keyModifier") {
-                pT->mKeyModifier = readElementText().toInt();
-                continue;
->>>>>>> SlySven/release_30
             } else if (name() == "KeyGroup" || name() == "Key") {
                 readKeyGroup(pT);
             } else {
@@ -2247,7 +1343,6 @@ void XMLimport::readModulesDetailsMap(QMap<QString, QStringList>& map)
 {
     QString key;
     QStringList entry;
-<<<<<<< HEAD
 
     while (!atEnd()) {
         readNext();
@@ -2255,32 +1350,15 @@ void XMLimport::readModulesDetailsMap(QMap<QString, QStringList>& map)
         if (isEndElement()) {
             break;
         } else if (isStartElement()) {
-=======
-    while (!atEnd()) {
-        readNext();
-
-        if (isEndElement()) {
-            break;
-        }
-
-        if (isStartElement()) {
->>>>>>> SlySven/release_30
             if (name() == "key") {
                 key = readElementText();
             } else if (name() == "filepath") {
                 entry << readElementText();
-<<<<<<< HEAD
             } else if (name() == "globalSave") {
                 entry << readElementText();
             } else if (name() == "priority") {
                 // The last expected detail for the entry - so store this
                 // completed entry into the QMap
-=======
-                // map[key] = readElementText();
-            } else if (name() == "globalSave") {
-                entry << readElementText();
-            } else if (name() == "priority") {
->>>>>>> SlySven/release_30
                 entry << readElementText();
                 map[key] = entry;
                 entry.clear();
@@ -2291,10 +1369,6 @@ void XMLimport::readModulesDetailsMap(QMap<QString, QStringList>& map)
     }
 }
 
-<<<<<<< HEAD
-=======
-
->>>>>>> SlySven/release_30
 void XMLimport::readStringList(QStringList& list)
 {
     while (!atEnd()) {
@@ -2302,13 +1376,7 @@ void XMLimport::readStringList(QStringList& list)
 
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
-=======
-        }
-
-        if (isStartElement()) {
->>>>>>> SlySven/release_30
             if (name() == "string") {
                 list << readElementText();
             } else {
@@ -2325,13 +1393,7 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName)
 
         if (isEndElement()) {
             break;
-<<<<<<< HEAD
         } else if (isStartElement()) {
-=======
-        }
-
-        if (isStartElement()) {
->>>>>>> SlySven/release_30
             if (name() == "integer") {
                 QString numberText = readElementText();
                 bool ok = false;
@@ -2342,15 +1404,10 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName)
                     // Using qFatal() seems a little, erm, fatalistic but it
                     // seems no lesser one will always be detectable on the
                     // RELEASE version on Windows? - Slysven
-<<<<<<< HEAD
                     qFatal("XMLimport::readIntegerList(...) ERROR: unable to "
                            "convert: \"%s\" to a number when reading the "
                            "'regexCodePropertyList' element of the 'Trigger' "
                            "or 'TriggerGroup' element \"%s\"!",
-=======
-                    qFatal("XMLimport::readIntegerList(...) ERROR: unable to convert: \"%s\" to a number when reading the 'regexCodePropertyList' element of the 'Trigger' or 'TriggerGroup' element "
-                           "\"%s\"!",
->>>>>>> SlySven/release_30
                            numberText.toUtf8().constData(), parentName.toUtf8().constData());
                 }
             } else {

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -22,7 +22,6 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-<<<<<<< HEAD
 
 // clang-format off
 #include "pre_guard.h"
@@ -35,18 +34,6 @@
 // clang-format off
 #include "post_guard.h"
 // clang-format on
-=======
-// clang-format: off
-#include "pre_guard.h"
-// clang-format: on
-#include <QApplication>
-#include <QMap>
-#include <QMultiHash>
-#include <QXmlStreamReader>
-// clang-format: off
-#include "post_guard.h"
-// clang-format: on
->>>>>>> SlySven/release_30
 
 class Host;
 class TAction;
@@ -64,10 +51,7 @@ class XMLimport : public QXmlStreamReader
 
 public:
     XMLimport(Host*);
-<<<<<<< HEAD
-=======
 
->>>>>>> SlySven/release_30
     bool importPackage(QIODevice* device, QString packageName = QString(), int moduleFlag = 0);
 
 private:
@@ -114,11 +98,7 @@ private:
     void readIntegerList(QList<int>&, const QString&);
     void readModulesDetailsMap(QMap<QString, QStringList>&);
 
-<<<<<<< HEAD
     QPointer<Host> mpHost;
-=======
-    Host* mpHost;
->>>>>>> SlySven/release_30
     QString mPackageName;
     TTrigger* mpTrigger;
     TTimer* mpTimer;


### PR DESCRIPTION
In XMLimport / XMLexport classes generally retain the HEAD version except for the bit that supports `TAction::mButtonState` conversion to `bool` from `int`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>