### PR TITLE
Resolve conflicts in dlgConnectionProfile class [ci skip]

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1227,11 +1227,7 @@ void dlgConnectionProfiles::slot_connectToServer()
     if( profile_name.isEmpty() )
         return;
 
-<<<<<<< HEAD
     Host * pHost = mudlet::self()->getHostManager()->getHost( profile_name );
-=======
-    Host * pHost = HostManager::self()->getHost( profile_name );
->>>>>>> SlySven/release_30
     if( pHost )
     {
         pHost->mTelnet.connectIt( pHost->getUrl(), pHost->getPort() );
@@ -1239,13 +1235,8 @@ void dlgConnectionProfiles::slot_connectToServer()
         return;
     }
     // load an old profile if there is any
-<<<<<<< HEAD
     mudlet::self()->getHostManager()->addHost( profile_name, port_entry->text().trimmed(), QString(), QString() );
     pHost = mudlet::self()->getHostManager()->getHost( profile_name );
-=======
-    HostManager::self()->addHost( profile_name, port_entry->text().trimmed(), QString(), QString() );
-    pHost = HostManager::self()->getHost( profile_name );
->>>>>>> SlySven/release_30
 
     if( ! pHost ) return;
 
@@ -1325,83 +1316,6 @@ void dlgConnectionProfiles::slot_connectToServer()
 
     emit signal_establish_connection( profile_name, 0 );
 }
-
-<<<<<<< HEAD
-// Not Used:
-//void dlgConnectionProfiles::slot_chose_history()
-//{
-//    QString profile_name = profile_name_entry->text().trimmed();
-//    if( profile_name.size() < 1 )
-//    {
-//        QMessageBox::warning(this, tr("Browse Profile History:"),
-//                             tr("You have not selected a profile yet.\nWhich profile history do you want to browse?\nPlease select a profile first."));
-//        return;
-//    }
-//    QString fileName = QFileDialog::getOpenFileName(this, tr("Chose Mudlet Profile"),
-//                                                    QStringLiteral( "%1/.config/mudlet/profiles/%2" )
-//                                                        .arg( QDir::homePath() )
-//                                                        .arg( profile_name ),
-//                                                    tr("*.xml"));
-
-//    if( fileName.isEmpty() ) return;
-
-//    QFile file(fileName);
-//    if( ! file.open(QFile::ReadOnly | QFile::Text) )
-//    {
-//        QMessageBox::warning(this, tr("Import Mudlet Package:"),
-//                             tr("Cannot read file %1:\n%2.")
-//                             .arg(fileName)
-//                             .arg(file.errorString()));
-//        return;
-//    }
-
-//    mudlet::self()->getHostManager()->addHost( profile_name, port_entry->text().trimmed(), QString(), QString() );
-//    Host * pHost = mudlet::self()->getHostManager()->getHost( profile_name );
-//    if( ! pHost ) return;
-//    XMLimport importer( pHost );
-//    importer.importPackage( & file );
-
-//    emit signal_establish_connection( profile_name, -1 );
-//    QDialog::accept();
-//}
-=======
-void dlgConnectionProfiles::slot_chose_history()
-{
-    QString profile_name = profile_name_entry->text().trimmed();
-    if( profile_name.size() < 1 )
-    {
-        QMessageBox::warning(this, tr("Browse Profile History:"),
-                             tr("You have not selected a profile yet.\nWhich profile history do you want to browse?\nPlease select a profile first."));
-        return;
-    }
-    QString fileName = QFileDialog::getOpenFileName(this, tr("Chose Mudlet Profile"),
-                                                    QStringLiteral( "%1/.config/mudlet/profiles/%2" )
-                                                        .arg( QDir::homePath() )
-                                                        .arg( profile_name ),
-                                                    tr("*.xml"));
-
-    if( fileName.isEmpty() ) return;
-
-    QFile file(fileName);
-    if( ! file.open(QFile::ReadOnly | QFile::Text) )
-    {
-        QMessageBox::warning(this, tr("Import Mudlet Package:"),
-                             tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
-        return;
-    }
-
-    HostManager::self()->addHost( profile_name, port_entry->text().trimmed(), QString(), QString() );
-    Host * pHost = HostManager::self()->getHost( profile_name );
-    if( ! pHost ) return;
-    XMLimport importer( pHost );
-    importer.importPackage( & file );
-
-    emit signal_establish_connection( profile_name, -1 );
-    QDialog::accept();
-}
->>>>>>> SlySven/release_30
 
 bool dlgConnectionProfiles::validateConnect()
 {

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -46,7 +46,6 @@ signals:
 
 public slots:
 
-// Not Used:    void slot_chose_history();
     void slot_update_name( const QString ) ;
     void slot_save_name() ;
     void slot_update_url( const QString ) ;


### PR DESCRIPTION
Removed (Host *)HostManager::self() as per AC's changes in: https://github.com/Mudlet/Mudlet/commit/2555505ec897d3ebc72ce87bfbe156ac40d990f8
a.k.a. commit-2555505ec897d3ebc72ce87bfbe156ac40d990f8

Removed `dlgConnectionProfile::slot_chose_history()` as it was commented out in header file and in the HEAD version in `dlgConnectionProfile.cpp`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>