### PR TITLE
Resolve conflicts in TBuffer, TConsole, dlgMapper classes [ci skip]

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1,11 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
-<<<<<<< HEAD
  *   Copyright (C) 2014, 2016 by Stephen Lyons - slysven@virginmedia.com   *
-=======
  *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
->>>>>>> SlySven/release_30
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -361,265 +358,6 @@ void TBuffer::addLink( bool trigMode, const QString & text, QStringList & comman
     }
 }
 
-<<<<<<< HEAD
-inline void TBuffer::set_text_properties(int tag)
-{
-    if( mWaitingForHighColorCode )
-    {
-        if( mHighColorModeForeground )
-        {
-            if( tag < 16 )
-            {
-                mHighColorModeForeground = false;
-                mWaitingForHighColorCode = false;
-                mIsHighColorMode = false;
-                goto NORMAL_ANSI_COLOR_TAG;
-            }
-            if( tag < 232 )
-            {
-                tag-=16; // because color 1-15 behave like normal ANSI colors
-                // 6x6 RGB color space
-                int r = tag / 36;
-                int g = (tag-(r*36)) / 6;
-                int b = (tag-(r*36))-(g*6);
-                fgColorR = r*42;
-                fgColorG = g*42;
-                fgColorB = b*42;
-            }
-            else
-            {
-                // black + 23 tone grayscale from dark to light gray
-                tag -= 232;
-                fgColorR = tag*10;
-                fgColorG = tag*10;
-                fgColorB = tag*10;
-            }
-            mHighColorModeForeground = false;
-            mWaitingForHighColorCode = false;
-            mIsHighColorMode = false;
-
-            return;
-        }
-        if( mHighColorModeBackground )
-        {
-            if( tag < 16 )
-            {
-                mHighColorModeBackground = false;
-                mWaitingForHighColorCode = false;
-                mIsHighColorMode = false;
-                goto NORMAL_ANSI_COLOR_TAG;
-            }
-            if( tag < 232 )
-            {
-                tag-=16;
-                int r = tag / 36;
-                int g = (tag-(r*36)) / 6;
-                int b = (tag-(r*36))-(g*6);
-                bgColorR = r*42;
-                bgColorG = g*42;
-                bgColorB = b*42;
-            }
-            else
-            {
-                // black + 23 tone grayscale from dark to light gray
-                tag -= 232;
-                fgColorR = tag*10;
-                fgColorG = tag*10;
-                fgColorB = tag*10;
-            }
-            mHighColorModeBackground = false;
-            mWaitingForHighColorCode = false;
-            mIsHighColorMode = false;
-
-            return;
-        }
-    }
-
-    if( tag == 38 )
-    {
-        mIsHighColorMode = true;
-        mHighColorModeForeground = true;
-        return;
-    }
-    if( tag == 48 )
-    {
-        mIsHighColorMode = true;
-        mHighColorModeBackground = true;
-    }
-    if( ( mIsHighColorMode ) && ( tag == 5 ) )
-    {
-        mWaitingForHighColorCode = true;
-        return;
-    }
-
-    // we are dealing with standard ANSI colors
-NORMAL_ANSI_COLOR_TAG:
-
-    switch( tag )
-    {
-    case 0:
-        mHighColorModeForeground = false;
-        mHighColorModeBackground = false;
-        mWaitingForHighColorCode = false;
-        mIsHighColorMode = false;
-        mIsDefaultColor = true;
-        resetFontSpecs();
-        break;
-    case 1:
-        mBold = true;
-        break;
-    case 2:
-        mBold = false;
-        break;
-    case 3:
-        mItalics = true;
-        break;
-    case 4:
-        mUnderline = true;
-    case 5:
-        break; //FIXME support blinking
-    case 6:
-        break; //FIXME support fast blinking
-    case 7:
-        break; //FIXME support inverse
-    case 9:
-        mStrikeOut = true;
-        break; 
-    case 22:
-        mBold = false;
-        break;
-    case 23:
-        mItalics = false;
-        break;
-    case 24:
-        mUnderline = false;
-        break;
-    case 27:
-        break; //FIXME inverse off
-    case 29:
-        mStrikeOut = false;
-        break;
-    case 30:
-        fgColorR = mBlackR;
-        fgColorG = mBlackG;
-        fgColorB = mBlackB;
-        fgColorLightR = mLightBlackR;
-        fgColorLightG = mLightBlackG;
-        fgColorLightB = mLightBlackB;
-        mIsDefaultColor = false;
-        break;
-    case 31:
-        fgColorR = mRedR;
-        fgColorG = mRedR;
-        fgColorB = mRedB;
-        fgColorLightR = mLightRedR;
-        fgColorLightG = mLightRedG;
-        fgColorLightB = mLightRedB;
-        mIsDefaultColor = false;
-        break;
-    case 32:
-        fgColorR = mGreenR;
-        fgColorG = mGreenG;
-        fgColorB = mGreenB;
-        fgColorLightR = mLightGreenR;
-        fgColorLightG = mLightGreenR;
-        fgColorLightB = mLightGreenB;
-        mIsDefaultColor = false;
-        break;
-    case 33:
-        fgColorR = mYellowR;
-        fgColorG = mYellowG;
-        fgColorB = mYellowB;
-        fgColorLightR = mLightYellowR;
-        fgColorLightG = mLightYellowG;
-        fgColorLightB = mLightYellowB;
-        mIsDefaultColor = false;
-        break;
-    case 34:
-        fgColorR = mBlueR;
-        fgColorG = mBlueG;
-        fgColorB = mBlueB;
-        fgColorLightR = mLightBlueR;
-        fgColorLightG = mLightBlueG;
-        fgColorLightB = mLightBlueB;
-        mIsDefaultColor = false;
-        break;
-    case 35:
-        fgColorR = mMagentaR;
-        fgColorG=mMagentaG;
-        fgColorB=mMagentaB;
-        fgColorLightR=mLightMagentaR;
-        fgColorLightG=mLightMagentaG;
-        fgColorLightB=mLightMagentaB;
-        mIsDefaultColor = false;
-        break;
-    case 36:
-        fgColorR = mCyanR;
-        fgColorG = mCyanG;
-        fgColorB = mCyanB;
-        fgColorLightR = mLightCyanR;
-        fgColorLightG = mLightCyanG;
-        fgColorLightB = mLightCyanB;
-        mIsDefaultColor = false;
-        break;
-    case 37:
-        fgColorR = mWhiteR;
-        fgColorG = mWhiteG;
-        fgColorB = mWhiteB;
-        fgColorLightR = mLightWhiteR;
-        fgColorLightG = mLightWhiteG;
-        fgColorLightB = mLightWhiteB;
-        mIsDefaultColor = false;
-        break;
-    case 39:
-        bgColorR = mBgColorR;
-        bgColorG = mBgColorG;
-        bgColorB = mBgColorB;
-        break;
-    case 40:
-        bgColorR = mBlackR;
-        bgColorG = mBlackG;
-        bgColorB = mBlackB;
-        break;
-    case 41:
-        bgColorR = mRedR;
-        bgColorG = mRedG;
-        bgColorB = mRedB;
-        break;
-    case 42:
-        bgColorR = mGreenR;
-        bgColorG = mGreenG;
-        bgColorB = mGreenB;
-        break;
-    case 43:
-        bgColorR = mYellowR;
-        bgColorG = mYellowG;
-        bgColorB = mYellowB;
-        break;
-    case 44:
-        bgColorR = mBlueR;
-        bgColorG = mBlueG;
-        bgColorB = mBlueB;
-        break;
-    case 45:
-        bgColorR = mMagentaR;
-        bgColorG = mMagentaG;
-        bgColorB = mMagentaB;
-        break;
-    case 46:
-        bgColorR = mCyanR;
-        bgColorG = mCyanG;
-        bgColorB = mCyanB;
-        break;
-    case 47:
-        bgColorR = mWhiteR;
-        bgColorG = mWhiteG;
-        bgColorB = mWhiteB;
-        break;
-    };
-}
-
-=======
 //void TBuffer::appendLink( QString & text,
 //                          int sub_start,
 //                          int sub_end,
@@ -724,7 +462,6 @@ NORMAL_ANSI_COLOR_TAG:
 
 
 //int speedTP;
->>>>>>> SlySven/release_30
 
 /* ANSI color codes: sequence = "ESCAPE + [ code_1; ... ; code_n m"
       -----------------------------------------
@@ -1374,11 +1111,7 @@ void TBuffer::translateToPlainText( std::string & s )
                             break; //inverse off
                         case 29:
                             mStrikeOut = false;
-<<<<<<< HEAD
-                            break; //not crossed out text (strikethrough)
-=======
                             break; //not crossed out (strikethrough) text
->>>>>>> SlySven/release_30
                         case 30:
                             fgColorR = mBlackR;
                             fgColorG = mBlackG;
@@ -2151,11 +1884,7 @@ void TBuffer::append(const QString & text,
                     log(size()-2, size()-2);
                     // Was absent causing loss of all but last line of wrapped
                     // long lines of user input and some other console displayed
-<<<<<<< HEAD
-                    // test from log file.
-=======
                     // text from log file.
->>>>>>> SlySven/release_30
                     break;
                 }
             }
@@ -2173,23 +1902,7 @@ void TBuffer::append(const QString & text,
     }
 }
 
-<<<<<<< HEAD
-void TBuffer::appendLine(const QString & text,
-                        int sub_start,
-                        int sub_end,
-                        int fgColorR,
-                        int fgColorG,
-                        int fgColorB,
-                        int bgColorR,
-                        int bgColorG,
-                        int bgColorB,
-                        bool bold,
-                        bool italics,
-                        bool underline,
-                        bool strikeout,
-                        int linkID )
-=======
-void TBuffer::appendLine( QString & text,
+void TBuffer::appendLine( const QString & text,
                           int sub_start,
                           int sub_end,
                           int fgColorR,
@@ -2203,7 +1916,6 @@ void TBuffer::appendLine( QString & text,
                           bool underline,
                           bool strikeout,
                           int linkID )
->>>>>>> SlySven/release_30
 {
     if( sub_end < 0 ) return;
     if( static_cast<int>(buffer.size()) > mLinesLimit )
@@ -2244,11 +1956,7 @@ void TBuffer::appendLine( QString & text,
     }
 }
 
-<<<<<<< HEAD
 QPoint TBuffer::insert( QPoint & where, const QString& text, int fgColorR, int fgColorG, int fgColorB, int bgColorR, int bgColorG, int bgColorB, bool bold, bool italics, bool underline, bool strikeout )
-=======
-QPoint TBuffer::insert( QPoint & where, QString text, int fgColorR, int fgColorG, int fgColorB, int bgColorR, int bgColorG, int bgColorB, bool bold, bool italics, bool underline, bool strikeout )
->>>>>>> SlySven/release_30
 {
     QPoint P(-1, -1);
 
@@ -2280,12 +1988,7 @@ QPoint TBuffer::insert( QPoint & where, QString text, int fgColorR, int fgColorG
         }
         lineBuffer[y].insert( x, text.at( i ) );
         TChar c(fgColorR,fgColorG,fgColorB,bgColorR,bgColorG,bgColorB,bold,italics,underline,strikeout);
-<<<<<<< HEAD
         auto it = buffer[y].begin();
-=======
-        typedef std::deque<TChar>::iterator IT;
-        IT it = buffer[y].begin();
->>>>>>> SlySven/release_30
         buffer[y].insert( it+x, c );
     }
     dirty[y] = true;
@@ -2356,15 +2059,10 @@ TBuffer TBuffer::copy( QPoint & P1, QPoint & P2 )
                      buffer[y][x].bgB,
                      (buffer[y][x].flags & TCHAR_BOLD),
                      (buffer[y][x].flags & TCHAR_ITALICS),
-<<<<<<< HEAD
-                     (buffer[y][x].flags & TCHAR_UNDERLINE), 
-                     (buffer[y][x].flags & TCHAR_STRIKEOUT)  );
-=======
                      (buffer[y][x].flags & TCHAR_UNDERLINE),
                      (buffer[y][x].flags & TCHAR_STRIKEOUT) );
->>>>>>> SlySven/release_30
-        }
-        return slice;
+    }
+    return slice;
 }
 
 TBuffer TBuffer::cut( QPoint & P1, QPoint & P2 )
@@ -3442,9 +3140,9 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
     bool bold = false;
     bool italics = false;
     bool underline = false;
-    bool overline = false;
+//    bool overline = false;
     bool strikeout = false;
-    bool inverse = false;
+//    bool inverse = false;
     int fgR=0;
     int fgG=0;
     int fgB=0;
@@ -3505,7 +3203,7 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
             else {
                 fontStyle = "normal";
             }
-            if( ! (underline || strikeout || overline) ) {
+            if( ! (underline || strikeout /* || overline */ ) ) {
                 textDecoration = "normal";
             }
             else {
@@ -3516,20 +3214,12 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
                 if( strikeout ) {
                     textDecoration += "line-through ";
                 }
-                if( overline ) {
-                    textDecoration += "overline ";
-                }
+//                if( overline ) {
+//                    textDecoration += "overline ";
+//                }
                 textDecoration = textDecoration.trimmed();
             }
             s += "<span style=\"";
-<<<<<<< HEAD
-            s += "color: rgb(" + QString::number(inverse ? bgR : fgR) + ","
-                               + QString::number(inverse ? bgG : fgG) + ","
-                               + QString::number(inverse ? bgB : fgB) + ");";
-            s += " background: rgb(" + QString::number(inverse ? fgR : bgR) + ","
-                                     + QString::number(inverse ? fgG : bgG) + ","
-                                     + QString::number(inverse ? fgB : bgB) + ");";
-=======
 //            if( inverse )
 //            {
 //                s += "color: rgb(" + QString::number(bgR) + ","
@@ -3548,7 +3238,6 @@ QString TBuffer::bufferToHtml( QPoint P1, QPoint P2 )
                                      + QString::number(bgG) + ","
                                      + QString::number(bgB) + ");";
 //            }
->>>>>>> SlySven/release_30
             s += " font-weight: " + fontWeight +
                  "; font-style: " + fontStyle +
                  "; text-decoration: " + textDecoration + "\">";

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -42,8 +42,6 @@
 #define TCHAR_INVERSE 8
 #define TCHAR_ECHO 16
 #define TCHAR_STRIKEOUT 32
-<<<<<<< HEAD
-=======
 // TODO: {Reserve for} use the next four bits for extensions...
 // Next one is for ANSI CSI SGR Overline (53 on, 55 off)
 //#define TCHAR_OVERLINE 64
@@ -59,7 +57,6 @@
 //#define TCHAR_FASTBLINK 512
 // Convience for testing for both Blink types
 //#define TCHAR_BLINKMASK 768
->>>>>>> SlySven/release_30
 
 class Host;
 
@@ -103,13 +100,8 @@ class TBuffer
 public:
 
     TBuffer( Host * pH );
-<<<<<<< HEAD
     QPoint insert( QPoint &, const QString& text, int,int,int, int, int, int, bool bold, bool italics, bool underline, bool strikeout );
     bool insertInLine( QPoint & cursor, const QString & what, TChar & format );
-=======
-    QPoint insert( QPoint &, QString text, int,int,int, int, int, int, bool bold, bool italics, bool underline, bool strikeout );
-    bool insertInLine( QPoint & cursor, QString & what, TChar & format );
->>>>>>> SlySven/release_30
     void expandLine( int y, int count, TChar & );
     int wrapLine( int startLine, int screenWidth, int indentSize, TChar & format );
     void log( int, int );
@@ -143,16 +135,9 @@ public:
     void resetFontSpecs();
     QPoint getEndPos();
     void translateToPlainText( std::string & s );
-<<<<<<< HEAD
     void append(const QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID=0 );
     void appendLine(const QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID=0 );
     int lookupColor(const QString & s, int pos );
-    void set_text_properties(int tag);
-=======
-    void append( QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID=0 );
-    void appendLine( QString & chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID=0 );
-    int lookupColor( QString & s, int pos );
->>>>>>> SlySven/release_30
     void setWrapAt( int i ){ mWrapAt = i; }
     void setWrapIndent( int i ){ mWrapIndent = i; }
     void updateColors();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,10 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
-<<<<<<< HEAD
- *   Copyright (C) 2014, 2016 by Stephen Lyons - slysven@virginmedia.com   *
-=======
  *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
->>>>>>> SlySven/release_30
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -401,16 +397,11 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     logButton->setCheckable( true );
     logButton->setSizePolicy( sizePolicy5 );
     logButton->setFocusPolicy( Qt::NoFocus );
-<<<<<<< HEAD
     logButton->setToolTip(tr("<html><head/><body><p>Start logging MUD output to log file.</p></body></html>"));
     QIcon logIcon;
     logIcon.addPixmap( QPixmap( QStringLiteral( ":/icons/folder-downloads.png" ) ), QIcon::Normal, QIcon::Off );
     logIcon.addPixmap( QPixmap( QStringLiteral( ":/icons/folder-downloads-red-cross.png" ) ), QIcon::Normal, QIcon::On );
     logButton->setIcon( logIcon );
-=======
-    logButton->setToolTip( tr("<html><head/><body><p>Start logging MUD output to log file.</p></body></html>") );
-    logButton->setIcon( QIcon( QStringLiteral( ":/icons/folder-downloads.png" ) ) );
->>>>>>> SlySven/release_30
     connect( logButton, SIGNAL(pressed()), this, SLOT(slot_toggleLogging()));
 
     networkLatency->setReadOnly( true );
@@ -885,40 +876,19 @@ void TConsole::toggleLogging( bool isMessageEnabled )
         // We don't support logging anything other than main console (at present?)
     }
 
-<<<<<<< HEAD
-    if( ! mLogToLogFile ) {
-        QFile file( QDir::homePath()+"/.config/mudlet/autolog" );
-=======
     QFile file( QStringLiteral( "%1/.config/mudlet/autolog" ).arg( QDir::homePath() ) );
     if( ! mLogToLogFile ) {
->>>>>>> SlySven/release_30
         file.open( QIODevice::WriteOnly | QIODevice::Text );
         QTextStream out(&file);
         file.close();
 
-<<<<<<< HEAD
-        QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-        mLogFileName = directoryLogFile + "/"+QDateTime::currentDateTime().toString("yyyy-MM-dd#hh-mm-ss");
-=======
         QString directoryLogFile = QStringLiteral( "%1/.config/mudlet/profiles/%2/log" ).arg( QDir::homePath() ).arg( profile_name );
         mLogFileName = QStringLiteral( "%1/%2" ).arg( directoryLogFile ).arg( QDateTime::currentDateTime().toString( QStringLiteral( "yyyy-MM-dd#hh-mm-ss" ) ) );
->>>>>>> SlySven/release_30
         // Revised file name derived from time so that alphabetical filename and
         // date sort order are the same...
         QDir dirLogFile;
         if( ! dirLogFile.exists( directoryLogFile ) ) {
             dirLogFile.mkpath( directoryLogFile );
-<<<<<<< HEAD
-        }
-
-        mpHost->mIsCurrentLogFileInHtmlFormat = mpHost->mIsNextLogFileInHtmlFormat;
-        if( mpHost->mIsCurrentLogFileInHtmlFormat ) {
-            mLogFileName.append(".html");
-        }
-        else {
-            mLogFileName.append(".txt");
-=======
->>>>>>> SlySven/release_30
         }
 
         mpHost->mIsCurrentLogFileInHtmlFormat = mpHost->mIsNextLogFileInHtmlFormat;
@@ -931,7 +901,6 @@ void TConsole::toggleLogging( bool isMessageEnabled )
         mLogFile.setFileName( mLogFileName );
         mLogFile.open( QIODevice::WriteOnly );
         mLogStream.setDevice( &mLogFile );
-<<<<<<< HEAD
         if( isMessageEnabled ) {
             QString message = QString("Logging has started. Log file is ") + mLogFile.fileName() + "\n";
             printSystemMessage( message );
@@ -941,7 +910,6 @@ void TConsole::toggleLogging( bool isMessageEnabled )
         mLogToLogFile = true;
     }
     else {
-        QFile file( QDir::homePath()+"/.config/mudlet/autolog" );
         file.remove();
         mLogToLogFile = false;
         if( isMessageEnabled ) {
@@ -1011,76 +979,6 @@ void TConsole::slot_toggleLogging()
     if( mIsDebugConsole || mIsSubConsole ) {
         return;
         // We don't support logging anything other than main console (at present?)
-=======
-        QString message = tr( "Logging has started. Log file is %1.\n" ).arg( mLogFile.fileName() );
-        printSystemMessage( message );
-        // This puts text onto console that WOULD IMMEDIATELY BE POSTED into log
-        // file so must be done BEFORE logging starts - or actually mLogToLogFile gets set!
-        mLogToLogFile = true;
-    }
-    else {
-        file.remove();
-        mLogToLogFile = false;
-    }
-
-    if( mLogToLogFile ) {
-        if( mpHost->mIsCurrentLogFileInHtmlFormat ) {
-            QStringList fontsList; // List of fonts to become the font-family entry for
-                                   // the master css in the header
-            fontsList << this->fontInfo().family(); // Seems to be the best way to get the
-                                                // font in use, as different TConsole
-                                                // instances within the same profile
-                                                // might have different fonts in future,
-                                                // and although the font is settable for
-                                                // the main profile window, it is not yet
-                                                // for user miniConsoles, or the Debug one
-            fontsList << QStringLiteral( "Courier New" );
-            fontsList << QStringLiteral( "Monospace" );
-            fontsList << QStringLiteral( "Courier" );
-            fontsList.removeDuplicates(); // In case the actual one is one of the defaults here
-
-            mLogStream << QStringLiteral( "<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>\n" );
-            mLogStream << QStringLiteral( "<html>\n" );
-            mLogStream << QStringLiteral( " <head>\n" );
-            mLogStream << QStringLiteral( "  <meta http-equiv='content-type' content='text/html; charset=utf-8'>\n" );
-            // put the charset as early as possible as the parser MUST restart when it
-            // switches away from the ASCII default
-            mLogStream << QStringLiteral( "  <meta name='generator' content='Mudlet MUD Client version: %1%2'>\n" ).arg( APP_VERSION ).arg( APP_BUILD );
-            // Nice to identify what made the file!
-            mLogStream << QStringLiteral( "  <title>%1</title>\n" ).arg( tr( "Mudlet, log from %1 profile" ).arg(profile_name) );
-             // Web-page title
-            mLogStream << QStringLiteral( "  <style type='text/css'>\n" );
-            mLogStream << QStringLiteral( "   <!-- body { font-family: '%1'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb(%2,%3,%4); background-color:rgb(%5,%6,%7);}\n" )
-                          .arg( fontsList.join( QStringLiteral( "', '" ) ) )
-                          .arg( mpHost->mFgColor.red() )
-                          .arg( mpHost->mFgColor.green() )
-                          .arg( mpHost->mFgColor.blue() )
-                          .arg( mpHost->mBgColor.red() )
-                          .arg( mpHost->mBgColor.green() )
-                          .arg( mpHost->mBgColor.blue() );
-            mLogStream << QStringLiteral( "        span { white-space: pre; } -->\n" );
-            mLogStream << QStringLiteral( "  </style>\n" );
-            mLogStream << QStringLiteral( "  </head>\n" );
-            mLogStream << QStringLiteral( "  <body><div>" );
-            // <div></div> tags required around outside of the body <span></spans> for
-            // strict HTML 4 as we do not use <p></p>s or anything else
-            mLogFile.flush();
-        }
-        logButton->setToolTip( QStringLiteral("<html><head/><body><p>%1</p></body></html>")
-                               .arg( tr( "Stop logging MUD output to log file." ) ) );
-    }
-    else {
-        if( mpHost->mIsCurrentLogFileInHtmlFormat ) {
-            mLogStream << QStringLiteral( "</div></body>\n" );
-            mLogStream << QStringLiteral( "</html>\n" );
-        }
-        mLogFile.flush();
-        mLogFile.close();
-        QString message = tr( "Logging has been stopped. Log file is %1.\n" ).arg( mLogFile.fileName() );
-        printSystemMessage( message );
-        logButton->setToolTip( QStringLiteral("<html><head/><body><p>%1</p></body></html>")
-                               .arg( tr( "Start logging MUD output to log file." ) ) );
->>>>>>> SlySven/release_30
     }
 
     toggleLogging( true );
@@ -1476,13 +1374,9 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                 buffer.insertInLine( P, text, mFormatCurrent );
             else
             {
-<<<<<<< HEAD
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
-=======
                 TChar _f = TChar( 0, 0, 255,
                                   mBgColor.red(), mBgColor.green(), mBgColor.blue(),
                                   false, false, true, false );
->>>>>>> SlySven/release_30
                 buffer.insertInLine( P, text, _f );
             }
             buffer.applyLink( P, P2, text, func, hint );
@@ -1494,13 +1388,9 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                 buffer.insertInLine( P, text, mFormatCurrent );
             else
             {
-<<<<<<< HEAD
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
-=======
                 TChar _f = TChar( 0, 0, 255,
                                   mBgColor.red(), mBgColor.green(), mBgColor.blue(),
                                   false, false, true, false );
->>>>>>> SlySven/release_30
                 buffer.insertInLine( P, text, _f );
             }
             buffer.applyLink( P, P2, text, func, hint );
@@ -1515,13 +1405,9 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                 buffer.addLink( mTriggerEngineMode, text, func, hint, mFormatCurrent );
             else
             {
-<<<<<<< HEAD
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
-=======
                 TChar _f = TChar( 0, 0, 255,
                                   mBgColor.red(), mBgColor.green(), mBgColor.blue(),
                                   false, false, true, false );
->>>>>>> SlySven/release_30
                 buffer.addLink( mTriggerEngineMode, text, func, hint, _f );
             }
 
@@ -1549,13 +1435,9 @@ void TConsole::insertLink(const QString& text, QStringList & func, QStringList &
                                      mFormatCurrent );
             else
             {
-<<<<<<< HEAD
-                TChar _f = TChar(0,0,255,mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false );
-=======
                 TChar _f = TChar( 0, 0, 255,
                                   mBgColor.red(), mBgColor.green(), mBgColor.blue(),
                                   false, false, true, false );
->>>>>>> SlySven/release_30
                 buffer.insertInLine( mUserCursor,
                                      text,
                                      _f );
@@ -1701,11 +1583,7 @@ void TConsole::skipLine()
 
 // TODO: It may be worth considering moving the (now) three following methods
 // to the TMap class...?
-<<<<<<< HEAD
 bool TConsole::saveMap(const QString& location)
-=======
-bool TConsole::saveMap(QString location)
->>>>>>> SlySven/release_30
 {
     QDir dir_map;
     QString filename_map;
@@ -1792,11 +1670,7 @@ bool TConsole::loadMap(const QString& location)
 // to match "loadMap: XXXXX." format) - the presence of a non-null pointer here
 // should be used to suppress the writing of error messages direct to the
 // console - if possible!
-<<<<<<< HEAD
 bool TConsole::importMap( const QString & location, QString * errMsg )
-=======
-bool TConsole::importMap( QString location, QString * errMsg )
->>>>>>> SlySven/release_30
 {
     Host * pHost = mpHost;
     if( ! pHost ) {
@@ -2364,24 +2238,16 @@ void TConsole::echoLink(const QString & text, QStringList & func, QStringList & 
     {
         if( ! mIsSubConsole && ! mIsDebugConsole )
         {
-<<<<<<< HEAD
-            TChar f = TChar(0, 0, 255, mpHost->mBgColor.red(), mpHost->mBgColor.green(), mpHost->mBgColor.blue(), false, false, true, false);
-=======
             TChar f = TChar( 0, 0, 255,
                              mpHost->mBgColor.red(), mpHost->mBgColor.green(), mpHost->mBgColor.blue(),
                              false, false, true, false );
->>>>>>> SlySven/release_30
             buffer.addLink( mTriggerEngineMode, text, func, hint, f );
         }
         else
         {
-<<<<<<< HEAD
-            TChar f = TChar(0, 0, 255, mBgColor.red(), mBgColor.green(), mBgColor.blue(), false, false, true, false);
-=======
             TChar f = TChar(0, 0, 255,
                             mBgColor.red(), mBgColor.green(), mBgColor.blue(),
                             false, false, true, false);
->>>>>>> SlySven/release_30
             buffer.addLink( mTriggerEngineMode, text, func, hint, f );
         }
     }
@@ -2403,11 +2269,7 @@ void TConsole::echo(const QString & msg )
                            mFormatCurrent.flags & TCHAR_BOLD,
                            mFormatCurrent.flags & TCHAR_ITALICS,
                            mFormatCurrent.flags & TCHAR_UNDERLINE,
-<<<<<<< HEAD
-                           mFormatCurrent.flags & TCHAR_STRIKEOUT ); 
-=======
                            mFormatCurrent.flags & TCHAR_STRIKEOUT );
->>>>>>> SlySven/release_30
     }
     else
     {
@@ -2429,13 +2291,8 @@ void TConsole::print( const char * txt )
                    mFormatCurrent.bgB,
                    mFormatCurrent.flags & TCHAR_BOLD,
                    mFormatCurrent.flags & TCHAR_ITALICS,
-<<<<<<< HEAD
-                   mFormatCurrent.flags & TCHAR_UNDERLINE, 
-                   mFormatCurrent.flags & TCHAR_STRIKEOUT ); 
-=======
                    mFormatCurrent.flags & TCHAR_UNDERLINE,
                    mFormatCurrent.flags & TCHAR_STRIKEOUT );
->>>>>>> SlySven/release_30
     console->showNewLines();
     console2->showNewLines();
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -4,12 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
-<<<<<<< HEAD
- *   Copyright (C) 2014, 2016 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
-=======
- *   Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    *
->>>>>>> SlySven/release_30
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -55,38 +51,6 @@ class TSplitter;
 class dlgNotepad;
 
 
-<<<<<<< HEAD
-class TFontSpecsLogger
-{
-public:
-    TFontSpecsLogger(){ reset(); }
-    QString getFontWeight() { return (bold) ? QString("bold") : QString("normal"); }
-    QString getFontStyle() { return (italics) ? QString("italic") : QString("normal"); }
-    QString getTextDecoration() { return (underline) ? QString("underline") : QString("normal"); }
-    void reset()
-    {
-        bold = false;
-        italics = false;
-        underline = false;
-        m_bgColorHasChanged = false;
-        m_fgColorHasChanged = false;
-    }
-    void bg_color_change(){ m_bgColorHasChanged=true; }
-    void fg_color_change(){ m_fgColorHasChanged=true; }
-    QColor fgColor;
-    QColor fgColorLight;
-    QColor bgColor;
-    bool m_bgColorHasChanged;
-    bool m_fgColorHasChanged;
-    bool bold;
-    bool italics;
-    bool underline;
-
-};
-
-
-=======
->>>>>>> SlySven/release_30
 class TConsole : public QWidget
 {
 Q_OBJECT

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -27,10 +27,7 @@
 #include "ui_mapper.h"
 #include <QDir>
 #include <QMainWindow>
-<<<<<<< HEAD
 #include <QPointer>
-=======
->>>>>>> SlySven/release_30
 #include "post_guard.h"
 
 
@@ -46,19 +43,11 @@ public:
         dlgMapper( QWidget *, Host *, TMap * );
         void updateAreaComboBox();
     void                setDefaultAreaShown( const bool );
-<<<<<<< HEAD
-    const bool          getDefaultAreaShown() { return mShowDefaultArea; }
-    void                resetAreaComboBoxToPlayerRoomArea();
-
-        TMap * mpMap;
-        QPointer<Host> mpHost;
-=======
     bool                getDefaultAreaShown() { return mShowDefaultArea; }
     void                resetAreaComboBoxToPlayerRoomArea();
 
-        TMap * mpMap;
-        Host * mpHost;
->>>>>>> SlySven/release_30
+    TMap *              mpMap;
+    QPointer<Host>      mpHost;
 
 
 public slots:


### PR DESCRIPTION
Although unused `(void)TBuffer::set_text_properties(int)` was removed from cpp file it was still declared in header file - so I whipped it out in passing.

The `TBuffer` class also contains some currently commented out code to provide HTML support for over-line and inverse which are both ANSI ESC code-able SGR effects but which we do not currently provide.

The code changes for `TConsole::toggleLogging(...)` is slightly confusing at first because some code was shifted to a separate `TConsole::slot_toggleLogging()` wrapper used by the GUI but not by the Lua subsystem that only calls the "wrapped" method.  This is so that on-console logging starting and stopping messages could be avoided in the latter usage, nevertheless the OTHER merge branch contained some `QStringLiteral(...)` wrapped text strings that are better to use looking forward to I18n.  Note that there are still some lines of text used to build HTML source that also need such wrapping in the future.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>