### PR TITLE
BugFix: allow south-east exit to be cleared on 2D map Room-Exits dialog

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -520,7 +520,7 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("se"), 0);
     } else {
-        if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
+        if( originalExits.value( DIR_SOUTHEAST )->destination > 0 ) {
             pR->setExit( -1, DIR_SOUTHEAST );
         }
         if (stub_se->isChecked() != pR->hasExitStub(DIR_SOUTHEAST))


### PR DESCRIPTION
Fixes: [Bug 1676086](https://bugs.launchpad.net/mudlet/+bug/1676086) "Unable to clear south-east exit from 2D map "Room Exits" dialog".

This is a year or more old bug that I recently discovered in "both" code branches...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>