### PR TITLE
(release_3_0_1)Enhance: restore misfeature eliminated in Editor show/hide search results

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -243,6 +243,7 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     pHB2->addWidget( mpOptionsAreaTimers );
 
     connect( button_searchAreaClose, SIGNAL(clicked()), this, SLOT( slot_show_search_area()));
+    connect( button_toggleSearchAreaResults, SIGNAL(clicked(const bool)), this, SLOT( slot_showSearchAreaResults(const bool)));
 
     // additional settings
     treeWidget_triggers->setColumnCount(1);
@@ -319,7 +320,6 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
 
     QAction * viewAliasAction = new QAction( QIcon( QStringLiteral( ":/icons/system-users.png" ) ), tr("Aliases"), this);
     viewAliasAction->setStatusTip(tr("Show Aliases"));
-    viewAliasAction->setEnabled( true );
     connect( viewAliasAction, SIGNAL(triggered()), this, SLOT( slot_show_aliases()));
 
 
@@ -327,20 +327,16 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     showTimersAction->setStatusTip(tr("Show Timers"));
     connect( showTimersAction, SIGNAL(triggered()), this, SLOT( slot_show_timers()));
 
-
     QAction * viewScriptsAction = new QAction( QIcon( QStringLiteral( ":/icons/document-properties.png" ) ), tr("Scripts"), this);
-    viewScriptsAction->setEnabled( true );
     viewScriptsAction->setStatusTip(tr("Show Scripts"));
     connect( viewScriptsAction, SIGNAL(triggered()), this, SLOT( slot_show_scripts()));
 
     QAction * viewKeysAction = new QAction( QIcon( QStringLiteral( ":/icons/preferences-desktop-keyboard.png" ) ), tr("Keys"), this);
-    viewKeysAction->setStatusTip(tr("Keybindings"));
-    viewKeysAction->setEnabled( true );
+    viewKeysAction->setStatusTip(tr("Show Keybindings"));
     connect( viewKeysAction, SIGNAL(triggered()), this, SLOT( slot_show_keys()));
 
     QAction * viewVarsAction = new QAction( QIcon( QStringLiteral( ":/icons/variables.png" ) ), tr("Variables"), this);
-    viewVarsAction->setStatusTip(tr("Variables"));
-    viewVarsAction->setEnabled( true );
+    viewVarsAction->setStatusTip(tr("Show Variables"));
     connect( viewVarsAction, SIGNAL(triggered()), this, SLOT( slot_show_vars( )));
 
     QAction * toggleActiveAction = new QAction( QIcon( QStringLiteral( ":/icons/document-encrypt.png" ) ), tr("Activate"), this);
@@ -368,14 +364,14 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
 
     QAction * showSearchAreaAction = new QAction( QIcon( QStringLiteral( ":/icons/edit-find-user.png" ) ), tr("Search"), this);
     //showSearchAreaAction->setShortcut(tr("Ctrl+F"));
-    showSearchAreaAction->setStatusTip(tr("Show Search Results List"));
+    showSearchAreaAction->setStatusTip(tr("Show/Hide search feature"));
     connect( showSearchAreaAction, SIGNAL(triggered()), this, SLOT( slot_show_search_area()));
 
     QAction * saveAction = new QAction( QIcon( QStringLiteral( ":/icons/document-save-as.png" ) ), tr("Save Item"), this);
     //saveAction->setShortcut(tr("Ctrl+S"));
-    saveAction->setToolTip(tr("Saves the selected trigger, script, alias or etc, so new changes take effect.\nIt will not save to disk, so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure)"));
-    saveAction->setStatusTip(tr("Saves the selected trigger, script, alias or etc, so new changes take effect.\nIt will not save to disk, so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure)"));
-
+    saveAction->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                           .arg(tr("Saves the selected trigger, script, alias or etc, so new changes take effect.\nIt will not save to disk, so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)")));
+    saveAction->setStatusTip(tr("Saves the selected trigger, script, alias, etc, so new changes take effect - does not save to disk though..."));
     connect( saveAction, SIGNAL(triggered()), this, SLOT( slot_save_edit() ));
 
     QAction * importAction = new QAction( QIcon( QStringLiteral( ":/icons/import.png" ) ), tr("Import"), this);
@@ -386,18 +382,14 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     exportAction->setEnabled( true );
     connect( exportAction, SIGNAL(triggered()), this, SLOT( slot_export()));
 
-    QAction * saveMenu = new QAction( QIcon( QStringLiteral( ":/icons/document-save-all.png" ) ), tr("Save Profile"), this);
-    saveMenu->setEnabled( true );
-    saveMenu->setToolTip(tr("Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings)\nto your computer disk, so in case of a computer or program crash, all changes you've done will stay.\nIt also makes a backup of your profile, you can load an older version of it when connecting."));
-    saveMenu->setStatusTip(tr("Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings)\nto your computer disk, so in case of a computer or program crash, all changes you've done will stay.\nIt also makes a backup of your profile, you can load an older version of it when connecting."));
-
-    connect( saveMenu, SIGNAL(triggered()), this, SLOT( slot_profileSaveAction()));
-
     QAction * profileSaveAction = new QAction( QIcon ( QStringLiteral( ":/icons/document-save-all.png" ) ), tr("Save Profile"), this);
     profileSaveAction->setEnabled( true );
-    profileSaveAction->setToolTip(tr("Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings)\nto your computer disk, so in case of a computer or program crash, all changes you've done will stay.\nIt also makes a backup of your profile, you can load an older version of it when connecting."));
-    profileSaveAction->setStatusTip(tr("Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings)\nto your computer disk, so in case of a computer or program crash, all changes you've done will stay.\nIt also makes a backup of your profile, you can load an older version of it when connecting."));
-
+    profileSaveAction->setShortcut(tr("Ctrl+Shift+S"));
+    profileSaveAction->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                  .arg(tr("Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings) to your computer disk, so in case of a computer or program crash, all changes you have done will be retained.</p>"
+                                          "<p>It also makes a backup of your profile, you can load an older version of it when connecting.</p>"
+                                          "<p>Should there be any modules that are marked to be \"<i>synced</i>\" this will also cause them to be saved and reloaded into other profiles if they too are active.")));
+    profileSaveAction->setStatusTip(tr("Saves your entire profile (triggers, aliases, etc, but not the map); also \"synchronizes\" modules that are so marked."));
     connect( profileSaveAction, SIGNAL(triggered()), this, SLOT( slot_profileSaveAction()));
 
     QAction * saveProfileAsAction = new QAction( QIcon( QStringLiteral( ":/icons/utilities-file-archiver.png" ) ), tr("Save Profile As"), this);
@@ -405,78 +397,17 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     connect( saveProfileAsAction, SIGNAL(triggered()), this, SLOT( slot_profileSaveAsAction()));
 
     QAction * viewStatsAction = new QAction( QIcon( QStringLiteral( ":/icons/view-statistics.png" ) ), tr("Statistics"), this);
-    viewStatsAction->setEnabled( true );
+    viewStatsAction->setStatusTip(tr("Generates a statics summary display on the main profile console."));
     connect( viewStatsAction, SIGNAL(triggered()), this, SLOT( slot_viewStatsAction()));
 
     QAction * viewErrorsAction = new QAction( QIcon( QStringLiteral( ":/icons/errors.png" ) ), tr("errors"), this);
-    viewErrorsAction->setEnabled( true );
+    viewErrorsAction->setStatusTip(tr("Shows/Hides the errors console in the bottom right of this editor."));
     connect( viewErrorsAction, SIGNAL(triggered()), this, SLOT( slot_viewErrorsAction()));
 
     QAction * showDebugAreaAction = new QAction( QIcon( QStringLiteral( ":/icons/tools-report-bug.png" ) ), tr("Debug"), this);
-    showDebugAreaAction->setEnabled( true );
-    showDebugAreaAction->setToolTip(tr("Activates Debug Messages -> system will be *MUCH* slower"));
+    showDebugAreaAction->setToolTip(tr("Activates Debug Messages -> system will be <b><i>slower</i></b>."));
+    showDebugAreaAction->setStatusTip(tr("Shows/Hides the separate Central Debug Console - when being displayed the system will be slower."));
     connect( showDebugAreaAction, SIGNAL(triggered()), this, SLOT( slot_debug_mode() ));
-
-    QAction * addTriggerMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/tools-wizard.png" ) ), tr("Triggers"), this);
-    viewTriggerAction->setStatusTip(tr("Add Trigger"));
-    connect(addTriggerMenuAction, SIGNAL(triggered()), this, SLOT(slot_addTrigger()));
-
-    QAction * addAliasMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/system-users.png" ) ), tr("Aliases"), this);
-    addAliasMenuAction->setStatusTip(tr("Add Alias"));
-    addAliasMenuAction->setEnabled( true );
-    connect( addAliasMenuAction, SIGNAL(triggered()), this, SLOT( slot_addAlias()));
-
-    QAction * addTimersMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/chronometer.png" ) ), tr("Timers"), this);
-    addTimersMenuAction->setStatusTip(tr("Add Timer"));
-    addTimersMenuAction->setEnabled( true );
-    connect( addTimersMenuAction, SIGNAL(triggered()), this, SLOT( slot_addTimer()));
-
-    QAction * addVarsMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/chronometer.png" ) ), tr("Variables"), this);
-    addVarsMenuAction->setStatusTip(tr("View Variables"));
-    addVarsMenuAction->setEnabled( true );
-    connect( addVarsMenuAction, SIGNAL(triggered()), this, SLOT( slot_addVar()));
-
-    QAction * addScriptsMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/document-properties.png" ) ), tr("Scripts"), this);
-    addScriptsMenuAction->setStatusTip(tr("Add Script"));
-    addScriptsMenuAction->setEnabled( true );
-    connect( addScriptsMenuAction, SIGNAL(triggered()), this, SLOT( slot_addScript()));
-
-    QAction * addKeysMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/preferences-desktop-keyboard.png" ) ), tr("Keys"), this);
-    addKeysMenuAction->setStatusTip(tr("Add Keys"));
-    addKeysMenuAction->setEnabled( true );
-    connect( addKeysMenuAction, SIGNAL(triggered()), this, SLOT( slot_addKey()));
-
-    QMenu * addTriggerMenu = new QMenu( this );
-    addTriggerMenu->addAction( addTriggerMenuAction );
-    addTriggerMenu->addAction( addTimersMenuAction );
-    addTriggerMenu->addAction( addScriptsMenuAction );
-    addTriggerMenu->addAction( addAliasMenuAction );
-    addTriggerMenu->addAction( addKeysMenuAction );
-
-    QAction * addTriggerGroupMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/tools-wizard.png" ) ), tr("Triggers"), this);
-    addTriggerGroupMenuAction->setStatusTip(tr("Add Trigger Group"));
-    connect(addTriggerGroupMenuAction, SIGNAL(triggered()), this, SLOT(slot_addTriggerGroup()));
-
-    QAction * addAliasGroupMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/system-users.png" ) ), tr("Aliases"), this);
-    addAliasGroupMenuAction->setStatusTip(tr("Add Alias Group"));
-    addAliasGroupMenuAction->setEnabled( true );
-    connect( addAliasGroupMenuAction, SIGNAL(triggered()), this, SLOT( slot_addAliasGroup()));
-
-    QAction * addTimersGroupMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/chronometer.png" ) ), tr("Timers"), this);
-    addTimersGroupMenuAction->setStatusTip(tr("Add Timer Group"));
-    addTimersGroupMenuAction->setEnabled( true );
-    connect( addTimersGroupMenuAction, SIGNAL(triggered()), this, SLOT( slot_addTimerGroup()));
-
-    QAction * addScriptsGroupMenuAction = new QAction( QIcon( QStringLiteral( ":/icons/document-properties.png" ) ), tr("Scripts"), this);
-    addScriptsGroupMenuAction->setStatusTip(tr("Add Script Group"));
-    addScriptsGroupMenuAction->setEnabled( true );
-    connect( addScriptsGroupMenuAction, SIGNAL(triggered()), this, SLOT( slot_addScriptGroup()));
-
-    QMenu * addTriggerGroupMenu = new QMenu( this );
-    addTriggerGroupMenu->addAction( addTriggerGroupMenuAction );
-    addTriggerGroupMenu->addAction( addTimersGroupMenuAction );
-    addTriggerGroupMenu->addAction( addScriptsGroupMenuAction );
-    addTriggerGroupMenu->addAction( addAliasGroupMenuAction );
 
     toolBar = new QToolBar();
     toolBar->setIconSize(QSize(mudlet::self()->mMainIconSize*8,mudlet::self()->mMainIconSize*8));
@@ -583,6 +514,9 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     QStringList labelList;
     labelList << "Type" << "Name" << "Where" << "What";
     treeWidget_searchResults->setHeaderLabels( labelList );
+    // Hides the above treeWidget_searchResults and sets the icon on the
+    // show/hide button:
+    slot_showSearchAreaResults(false);
     mpScrollArea = mpTriggersMainArea->scrollArea;
     HpatternList = new QWidget;
     QVBoxLayout * lay1 = new QVBoxLayout( HpatternList );
@@ -875,7 +809,7 @@ void dlgTriggerEditor::slot_search_triggers( const QString s )
     QRegExp pattern = QRegExp( s );
 
     treeWidget_searchResults->clear();
-    treeWidget_searchResults->show();
+    slot_showSearchAreaResults(true);
     treeWidget_searchResults->setUpdatesEnabled( false );
 
     // type   | name | line number/pattern/name what has been found
@@ -6082,6 +6016,32 @@ void dlgTriggerEditor::slot_show_search_area()
     }
     else {
         widget_searchArea->show();
+    }
+}
+
+void dlgTriggerEditor::slot_showSearchAreaResults(const bool isChecked)
+{
+    if( isChecked )
+    {
+        if( ! button_toggleSearchAreaResults->isChecked() )
+        {
+            // If this slot is called "manually" the checked state of the button
+            // may not match the setting, so make it do so, note that the
+            // setChecked(bool) method does NOT invoke the clicked(bool) signal
+            // that is connected to here in the constructor, but it does the
+            // toggled(bool) one, which is why we use the former...
+            button_toggleSearchAreaResults->setChecked( true );
+        }
+        button_toggleSearchAreaResults->setArrowType(Qt::DownArrow);
+        treeWidget_searchResults->show();
+    }
+    else {
+        if( button_toggleSearchAreaResults->isChecked() )
+        {
+            button_toggleSearchAreaResults->setChecked( false );
+        }
+        button_toggleSearchAreaResults->setArrowType(Qt::RightArrow);
+        treeWidget_searchResults->hide();
     }
 }
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -182,6 +182,7 @@ public slots:
     void                        slot_save_edit();
     void                        slot_chose_action_icon();
     void                        slot_show_search_area();
+    void                        slot_showSearchAreaResults(const bool);
     void                        slot_script_main_area_delete_handler();
     void                        slot_script_main_area_add_handler();
     void                        slot_script_main_area_edit_handler(QListWidgetItem*);

--- a/src/ui/trigger_editor.ui
+++ b/src/ui/trigger_editor.ui
@@ -724,6 +724,9 @@
                    <property name="focusPolicy">
                     <enum>Qt::NoFocus</enum>
                    </property>
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Closes the entire search area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
                    <property name="text">
                     <string>...</string>
                    </property>
@@ -733,6 +736,22 @@
                    </property>
                    <property name="autoRaise">
                     <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QToolButton" name="button_toggleSearchAreaResults">
+                   <property name="toolTip">
+                    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Toggles the display of the search results area.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   </property>
+                   <property name="text">
+                    <string>...</string>
+                   </property>
+                   <property name="checkable">
+                    <bool>true</bool>
+                   </property>
+                   <property name="arrowType">
+                    <enum>Qt::RightArrow</enum>
                    </property>
                   </widget>
                  </item>


### PR DESCRIPTION
In: https://github.com/Mudlet/Mudlet/commit/10649019416655df3e6499d83862b09e88f803ed I attempted to give meaningful names to many elements that made up the main Editor screen and to fix what looked like coding errors.  One of these was the dodgy reuse of a pointer variable that was originally declared in the `trigger_editor.ui` file and which pointed to the whole of the "Search" part of the editor; it got reassigned to have the address of the "Results" part only of what it originally pointed at.  The effect being that when its hide() method was called only the "Results" part of the search area got hidden.  I traced this behaviour back to the commit:
https://github.com/Mudlet/Mudlet/commit/fba7d68a77aa7b8eaf31891fba3bbf0ed69b2fe8 of 2009-11-12 17:0343 by Heiko which had the deeply meaningful commit message of: "misc"!!!

My change returned the action of the button then called "messageAreaCloseButton" which was (confusingly) connected to the SLOT slot_show_search_area() and which I renamed then to "button_searchAreaClose" to do what it seemed that it should do i.e. hide (it could not be used to show the area as it was ON that area).

In the recent bug report:
https://bugs.launchpad.net/mudlet/+bug/1675988 "3.0 regression: search field no longer stays visible" evidence was offered that some users wanted the functionality of being able to hide just the results area of the search function on the Editor.  This commit provides that by the addition of a new SLOT that takes a boolean argument with the meaning of "show the search results widget if true".  By connecting this to a new clickable tool-button that I have positioned under the existing "close" button we can now offer the wanted functionality.

To clarify the detail of this enhancement I added and revised some texts that appear as tool- or status- tips.  Unfortunately in doing so it became clear that there were some unused `QActions` / `QMenu` instances created in the dlgTriggerEditor class constructor and that the at least one of them had a tool-tip message that was erroneously being applied to a Editor Toolbar button.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>