### PR TITLE
(release_3_0_1)bugFix: allow south-east exit to be cleared on 2D map Room-Exits dialog

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -520,7 +520,7 @@ void dlgRoomExits::save()
         else
             pR->setExitWeight( QStringLiteral("se"), 0);
     } else {
-        if( originalExits.value( DIR_SOUTHWEST )->destination > 0 ) {
+        if( originalExits.value( DIR_SOUTHEAST )->destination > 0 ) {
             pR->setExit( -1, DIR_SOUTHEAST );
         }
         if (stub_se->isChecked() != pR->hasExitStub(DIR_SOUTHEAST))


### PR DESCRIPTION
A typo in: https://github.com/Mudlet/Mudlet/commit/f2fa6f4e51381e06beb0ac20509e03031060a71d (from 2015-02-07 10:57:12) for release_30 and in: https://github.com/Mudlet/Mudlet/commit/11b9331133208ea70097dc805ebae8e1397dc58e (from 2015-08-15 22:15:39) when it was ported to the development branch causes issues in trying to clear an exit in the south east direction.

Fixes: https://bugs.launchpad.net/mudlet/+bug/1676086 now recorded as https://github.com/Mudlet/Mudlet/issues/480.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>