### PR TITLE
Fix a memory leak that happened when loading checked variables

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -242,6 +242,8 @@ void XMLimport::readVariableGroup(TVar* pParent)
             }
         }
     }
+
+    delete var;
 }
 
 void XMLimport::readHiddenVariables()


### PR DESCRIPTION
Coverity ID 1415070.

Tagging @Mudlet/core-cpp for review.