### PR TITLE
Fixed dead code in mudlet.cpp and dlgTriggerEditor.cpp regarding the …

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -665,19 +665,15 @@ void dlgTriggerEditor::closeEvent(QCloseEvent *event)
 
 void dlgTriggerEditor::readSettings()
 {
-    QSettings settings("mudlet", "Mudlet");
-
     /*In case sensitive environments, two different config directories 
     were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
     Furthermore, we skip the version from the application name to follow the convention.
     For compatibility with older settings, if no config is loaded 
     from the config directory "mudlet", application "Mudlet", we try to load from the config 
     directory "Mudlet", application "Mudlet 1.0". */
-    if(settings.value("pos") == 0)
-    {
-        QSettings settings("Mudlet","Mudlet 1.0");
-    }
-
+    QSettings settings_new("mudlet","Mudlet");
+    QSettings settings((settings_new.value("pos")==0? "Mudlet":"mudlet"),(settings_new.value("pos")==0? "Mudlet 1.0":"Mudlet"));
+    
 
     QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();
     QSize size = settings.value("script_editor_size", QSize(600, 400)).toSize();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -672,7 +672,7 @@ void dlgTriggerEditor::readSettings()
     from the config directory "mudlet", application "Mudlet", we try to load from the config 
     directory "Mudlet", application "Mudlet 1.0". */
     QSettings settings_new("mudlet","Mudlet");
-    QSettings settings((settings_new.value("pos")==0? "Mudlet":"mudlet"),(settings_new.value("pos")==0? "Mudlet 1.0":"Mudlet"));
+    QSettings settings((settings_new.contains("pos")? "mudlet":"Mudlet"),(settings_new.contains("pos")? "Mudlet":"Mudlet 1.0"));
     
 
     QPoint pos = settings.value("script_editor_pos", QPoint(10, 10)).toPoint();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1707,18 +1707,14 @@ void mudlet::closeEvent(QCloseEvent *event)
 
 void mudlet::readSettings()
 {
-    QSettings settings("mudlet", "Mudlet");
-
     /*In case sensitive environments, two different config directories
     were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
     Furthermore, we skip the version from the application name to follow the convention.
     For compatibility with older settings, if no config is loaded
     from the config directory "mudlet", application "Mudlet", we try to load from the config
     directory "Mudlet", application "Mudlet 1.0". */
-    if(settings.value("pos") == 0)
-    {
-        QSettings settings("Mudlet","Mudlet 1.0");
-    }
+    QSettings settings_new("mudlet","Mudlet");
+    QSettings settings((settings_new.value("pos")==0? "Mudlet":"mudlet"),(settings_new.value("pos")==0? "Mudlet 1.0":"Mudlet"));
 
     QPoint pos = settings.value("pos", QPoint(0, 0)).toPoint();
     QSize size = settings.value("size", QSize(750, 550)).toSize();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1714,7 +1714,7 @@ void mudlet::readSettings()
     from the config directory "mudlet", application "Mudlet", we try to load from the config
     directory "Mudlet", application "Mudlet 1.0". */
     QSettings settings_new("mudlet","Mudlet");
-    QSettings settings((settings_new.value("pos")==0? "Mudlet":"mudlet"),(settings_new.value("pos")==0? "Mudlet 1.0":"Mudlet"));
+    QSettings settings((settings_new.contains("pos")? "mudlet":"Mudlet"),(settings_new.contains("pos")? "Mudlet":"Mudlet 1.0"));
 
     QPoint pos = settings.value("pos", QPoint(0, 0)).toPoint();
     QSize size = settings.value("size", QSize(750, 550)).toSize();


### PR DESCRIPTION
The code to provide compatibility with older versions was not working due to the scope of the variable.

See https://github.com/Mudlet/Mudlet/pull/391#discussion_r109273532 for details.