### PR TITLE
Change PR builds to a different suffix

### DIFF
--- a/CI/travis.after_success.sh
+++ b/CI/travis.after_success.sh
@@ -13,9 +13,13 @@ if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
   . CI/travis.osx.after_success.sh;
 fi
 
+if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+  prId=" ,#${TRAVIS_PULL_REQUEST}"
+fi
+
 if [ ! -z "${DEPLOY_URL}" ]; then
   curl \
-    --data-urlencode "message=Deployed Mudlet \`${VERSION}${BUILD}\` (${TRAVIS_OS_NAME}) to [${DEPLOY_URL}](${DEPLOY_URL})" \
+    --data-urlencode "message=Deployed Mudlet \`${VERSION}${BUILD}\` (${TRAVIS_OS_NAME}${prId}) to [${DEPLOY_URL}](${DEPLOY_URL})" \
     https://webhooks.gitter.im/e/cc99072d43b642c4673a
 fi
 

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -6,7 +6,7 @@ if [ -z "${TRAVIS_TAG}" ]; then
   BUILD="-testing"
   if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then # building for a PR
     COMMIT=$(git rev-parse --short "${TRAVIS_PULL_REQUEST_SHA}")
-    BUILD="${BUILD}-CI-${COMMIT}"
+    BUILD="${BUILD}-PR${TRAVIS_PULL_REQUEST}-${COMMIT}"
   else
     COMMIT=$(git rev-parse --short HEAD)
     BUILD="${BUILD}-${COMMIT}"


### PR DESCRIPTION
The former suffix made it hard to identify the actual PR and commit, even though
it was mentioned. The new build part is now PR{PR-ID}-{SHORT_SHA1}.