### PR TITLE
Modernised iterator declaration to use 'auto'

### DIFF
--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -157,7 +157,7 @@ QList<int> TArea::getCollisionNodes()
                 {
                     if( ! problems.contains( node ) )
                     {
-                        QMultiMap<int, int>::iterator it4 = y_val.find(z);
+                        auto it4 = y_val.find(z);
                         problems.append( it4.value() );
                         //qDebug()<<"problem node="<<node;
                     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -882,8 +882,8 @@ int TLuaInterpreter::selectCaptureGroup( lua_State * L )
     if( luaNumOfMatch < static_cast<int>(pHost->getLuaInterpreter()->mCaptureGroupList.size()) )
     {
         TLuaInterpreter * pL = pHost->getLuaInterpreter();
-        auto its = pL->mCaptureGroupList.begin();
         auto iti = pL->mCaptureGroupPosList.begin();
+        auto its = pL->mCaptureGroupList.begin();
 
         for( int i=0; iti!=pL->mCaptureGroupPosList.end(); ++iti,++i )
         {
@@ -12719,8 +12719,7 @@ bool TLuaInterpreter::call(const QString & function, const QString & mName )
 
         // set values
         int i=1; // Lua indexes start with 1 as a general convention
-        auto it = mCaptureGroupList.begin();
-        for( ; it!=mCaptureGroupList.end(); it++, i++ )
+        for(auto it = mCaptureGroupList.begin(); it!=mCaptureGroupList.end(); it++, i++ )
         {
             //if( (*it).length() < 1 ) continue; //have empty capture groups to be undefined keys i.e. machts[emptyCapGroupNumber] = nil otherwise it's = "" i.e. an empty string
             lua_pushnumber( L, i );
@@ -12850,16 +12849,14 @@ bool TLuaInterpreter::callMulti(const QString & function, const QString & mName 
     if( mMultiCaptureGroupList.size() > 0 )
     {
         int k=1; // Lua indexes start with 1 as a general convention
-        auto mit = mMultiCaptureGroupList.begin();
         lua_newtable( L );//multimatches
-        for( ; mit!=mMultiCaptureGroupList.end(); mit++, k++ )
+        for( auto mit = mMultiCaptureGroupList.begin(); mit!=mMultiCaptureGroupList.end(); mit++, k++ )
         {
             // multimatches{ trigger_idx{ table_matches{ ... } } }
             lua_pushnumber( L, k );
             lua_newtable( L );//regex-value => table matches
             int i=1; // Lua indexes start with 1 as a general convention
-            auto it = (*mit).begin();
-            for( ; it!=(*mit).end(); it++, i++ )
+            for( auto it = (*mit).begin(); it!=(*mit).end(); it++, i++ )
             {
                 lua_pushnumber( L, i );
                 lua_pushstring( L, (*it).c_str() );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -882,8 +882,8 @@ int TLuaInterpreter::selectCaptureGroup( lua_State * L )
     if( luaNumOfMatch < static_cast<int>(pHost->getLuaInterpreter()->mCaptureGroupList.size()) )
     {
         TLuaInterpreter * pL = pHost->getLuaInterpreter();
-        std::list<std::string>::iterator its = pL->mCaptureGroupList.begin();
-        std::list<int>::iterator iti = pL->mCaptureGroupPosList.begin();
+        auto its = pL->mCaptureGroupList.begin();
+        auto iti = pL->mCaptureGroupPosList.begin();
 
         for( int i=0; iti!=pL->mCaptureGroupPosList.end(); ++iti,++i )
         {
@@ -12719,7 +12719,7 @@ bool TLuaInterpreter::call(const QString & function, const QString & mName )
 
         // set values
         int i=1; // Lua indexes start with 1 as a general convention
-        std::list<std::string>::iterator it = mCaptureGroupList.begin();
+        auto it = mCaptureGroupList.begin();
         for( ; it!=mCaptureGroupList.end(); it++, i++ )
         {
             //if( (*it).length() < 1 ) continue; //have empty capture groups to be undefined keys i.e. machts[emptyCapGroupNumber] = nil otherwise it's = "" i.e. an empty string
@@ -12850,7 +12850,7 @@ bool TLuaInterpreter::callMulti(const QString & function, const QString & mName 
     if( mMultiCaptureGroupList.size() > 0 )
     {
         int k=1; // Lua indexes start with 1 as a general convention
-        std::list< std::list<std::string> >::iterator mit = mMultiCaptureGroupList.begin();
+        auto mit = mMultiCaptureGroupList.begin();
         lua_newtable( L );//multimatches
         for( ; mit!=mMultiCaptureGroupList.end(); mit++, k++ )
         {
@@ -12858,7 +12858,7 @@ bool TLuaInterpreter::callMulti(const QString & function, const QString & mName 
             lua_pushnumber( L, k );
             lua_newtable( L );//regex-value => table matches
             int i=1; // Lua indexes start with 1 as a general convention
-            std::list<std::string>::iterator it = (*mit).begin();
+            auto it = (*mit).begin();
             for( ; it!=(*mit).end(); it++, i++ )
             {
                 lua_pushnumber( L, i );

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -48,7 +48,7 @@ TRoom * TRoomDB::getRoom( int id )
 {
     if (id < 0)
         return 0;
-    QHash< int, TRoom * >::iterator i = rooms.find( id );
+    auto i = rooms.find(id );
     if ( i != rooms.end() && i.key() == id )
         return i.value();
     return 0;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -513,8 +513,7 @@ bool TTrigger::match_begin_of_line_substring( const QString & toMatch, const QSt
             int b2 = mFgColor.blue();
             TConsole * pC = mpHost->mpConsole;
             auto its = captureList.begin();
-            auto iti = posList.begin();
-            for( ; iti!=posList.end(); ++iti, ++its )
+            for( auto iti = posList.begin(); iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
                 std::string & s = *its;
@@ -636,8 +635,7 @@ bool TTrigger::match_substring( const QString & toMatch, const QString & regex, 
             TConsole * pC = mpHost->mpConsole;
             pC->deselect();
             auto its = captureList.begin();
-            auto iti = posList.begin();
-            for( ; iti!=posList.end(); ++iti, ++its )
+            for( auto iti = posList.begin(); iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
                 std::string & s = *its;
@@ -744,8 +742,7 @@ bool TTrigger::match_color_pattern( int line, int regexNumber )
             TConsole * pC = mpHost->mpConsole;
             pC->deselect();
             auto its = captureList.begin();
-            auto iti = posList.begin();
-            for( ; iti!=posList.end(); ++iti, ++its )
+            for( auto iti = posList.begin(); iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
                 std::string & s = *its;
@@ -860,8 +857,7 @@ bool TTrigger::match_exact_match( const QString & toMatch, const QString & line,
             int b2 = mFgColor.blue();
             TConsole * pC = mpHost->mpConsole;
             auto its = captureList.begin();
-            auto iti = posList.begin();
-            for( ; iti!=posList.end(); ++iti, ++its )
+            for( auto iti = posList.begin(); iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
                 std::string & s = *its;
@@ -1017,8 +1013,7 @@ bool TTrigger::match( char * subject, const QString & toMatch, int line, int pos
                         multiCaptureList = (*it).second->multiCaptureList;
                         if( multiCaptureList.size() > 0 )
                         {
-                            auto mit = multiCaptureList.begin();
-                            for( ; mit!=multiCaptureList.end(); mit++, k++ )
+                            for( auto mit = multiCaptureList.begin(); mit!=multiCaptureList.end(); mit++, k++ )
                             {
                                 int total = (*mit).size();
                                 auto its = (*mit).begin();

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -421,8 +421,8 @@ END:
         int total = captureList.size();
         TConsole * pC = mpHost->mpConsole;
         pC->deselect();
-        std::list<std::string>::iterator its = captureList.begin();
-        std::list<int>::iterator iti = posList.begin();
+        auto its = captureList.begin();
+        auto iti = posList.begin();
         for( int i=1; iti!=posList.end(); ++iti, ++its, i++ )
         {
             int begin = *iti;
@@ -465,8 +465,8 @@ END:
              if( captureList.size() > 1 )
              {
                  int total = captureList.size();
-                 std::list<std::string>::iterator its = captureList.begin();
-                 std::list<int>::iterator iti = posList.begin();
+                 auto its = captureList.begin();
+                 auto iti = posList.begin();
                  for( int i=1; iti!=posList.end(); ++iti, ++its, i++ )
                  {
                      int begin = *iti;
@@ -512,8 +512,8 @@ bool TTrigger::match_begin_of_line_substring( const QString & toMatch, const QSt
             int g2 = mFgColor.green();
             int b2 = mFgColor.blue();
             TConsole * pC = mpHost->mpConsole;
-            std::list<std::string>::iterator its = captureList.begin();
-            std::list<int>::iterator iti = posList.begin();
+            auto its = captureList.begin();
+            auto iti = posList.begin();
             for( ; iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
@@ -635,7 +635,7 @@ bool TTrigger::match_substring( const QString & toMatch, const QString & regex, 
             int b2 = mFgColor.blue();
             TConsole * pC = mpHost->mpConsole;
             pC->deselect();
-            std::list<std::string>::iterator its = captureList.begin();
+            auto its = captureList.begin();
             std::list<int>::iterator iti = posList.begin();
             for( ; iti!=posList.end(); ++iti, ++its )
             {
@@ -743,8 +743,8 @@ bool TTrigger::match_color_pattern( int line, int regexNumber )
             int b2 = mFgColor.blue();
             TConsole * pC = mpHost->mpConsole;
             pC->deselect();
-            std::list<std::string>::iterator its = captureList.begin();
-            std::list<int>::iterator iti = posList.begin();
+            auto its = captureList.begin();
+            auto iti = posList.begin();
             for( ; iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
@@ -859,8 +859,8 @@ bool TTrigger::match_exact_match( const QString & toMatch, const QString & line,
             int g2 = mFgColor.green();
             int b2 = mFgColor.blue();
             TConsole * pC = mpHost->mpConsole;
-            std::list<std::string>::iterator its = captureList.begin();
-            std::list<int>::iterator iti = posList.begin();
+            auto its = captureList.begin();
+            auto iti = posList.begin();
             for( ; iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;
@@ -1017,11 +1017,11 @@ bool TTrigger::match( char * subject, const QString & toMatch, int line, int pos
                         multiCaptureList = (*it).second->multiCaptureList;
                         if( multiCaptureList.size() > 0 )
                         {
-                            std::list< std::list<std::string> >::iterator mit = multiCaptureList.begin();
+                            auto mit = multiCaptureList.begin();
                             for( ; mit!=multiCaptureList.end(); mit++, k++ )
                             {
                                 int total = (*mit).size();
-                                std::list<std::string>::iterator its = (*mit).begin();
+                                auto its = (*mit).begin();
                                 for( int i=1; its!=(*mit).end(); ++its, i++ )
                                 {
                                     std::string s = *its;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -636,7 +636,7 @@ bool TTrigger::match_substring( const QString & toMatch, const QString & regex, 
             TConsole * pC = mpHost->mpConsole;
             pC->deselect();
             auto its = captureList.begin();
-            std::list<int>::iterator iti = posList.begin();
+            auto iti = posList.begin();
             for( ; iti!=posList.end(); ++iti, ++its )
             {
                 int begin = *iti;


### PR DESCRIPTION
I've replaced obvious iterator declarations where the data structure of the iterator wasn't relevant to code with auto. In cases where it does matter, such as TTrigger matching, it's useful to keep it in so you can know what data structures are you working with.

In general, would like strive to modernise all of the codebase to C++11 - while keeping in mind that C++14 and C++17 are already available and C++11 is 6 years old, so we should be moving onto the newer stuff.

Tagging @Mudlet/core-cpp for review.