### PR TITLE
Applied auto to variable declaration

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -713,7 +713,7 @@ void LuaInterface::iterateTable(lua_State * L, int index, TVar * tVar, bool hide
         lua_pushvalue(L, -2);//we do this because extracting the key with tostring changes it
         QString keyName;
         QString valueName;
-        TVar * var = new TVar();
+        auto var = new TVar();
         if ( kType == LUA_TTABLE ){
             keyName = QString::number(luaL_ref(L, LUA_REGISTRYINDEX));//this function pops the top item
             lrefs.append(keyName.toInt());
@@ -798,7 +798,7 @@ void LuaInterface::getVars( bool hide ){
     L = interpreter->pGlobalLua;
     lua_pushnil(L);
     depth = 0;
-    TVar * g = new TVar();
+    auto g = new TVar();
     g->setName("_G", LUA_TSTRING);
     g->setValue("{}", LUA_TTABLE);
     QListIterator<int> it(lrefs);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2593,7 +2593,7 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
             mIsSelectionUsingNames = false;
             while( itRoom.hasNext() )
             {
-                QTreeWidgetItem * _item = new QTreeWidgetItem;
+                auto _item = new QTreeWidgetItem;
                 int multiSelectionRoomId = itRoom.next();
                 _item->setText(0,QStringLiteral("%1").arg(multiSelectionRoomId,7)); // Pad with spaces so sorting works
                 _item->setTextAlignment(0, Qt::AlignRight);
@@ -2633,7 +2633,7 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
 
     if( event->buttons() & Qt::RightButton )
     {
-        QMenu * popup = new QMenu( this );
+        auto popup = new QMenu( this );
 
         if( mCustomLinesRoomFrom > 0 )
         {
@@ -2872,7 +2872,7 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
             it.next();
             QStringList menuInfo = it.value();
             QString displayName = menuInfo[1];
-            QMenu * userMenu = new QMenu(displayName, this);
+            auto userMenu = new QMenu(displayName, this);
             userMenus.insert(it.key(), userMenu);
         }
         it.toFront();
@@ -2889,11 +2889,11 @@ void T2DMap::mousePressEvent(QMouseEvent *event)
         }
         //add our actions
         QMapIterator<QString, QStringList> it2(mUserActions);
-        QSignalMapper* mapper = new QSignalMapper(this);
+        auto mapper = new QSignalMapper(this);
         while (it2.hasNext()){
             it2.next();
             QStringList actionInfo = it2.value();
-            QAction * action = new QAction(actionInfo[2], this );
+            auto action = new QAction(actionInfo[2], this );
             if (actionInfo[1] == "")//no parent
                 popup->addAction(action);
             else if (userMenus.contains(actionInfo[1]))
@@ -3296,14 +3296,14 @@ void T2DMap::slot_movePosition()
     TRoom * pR_start = mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId );
     // pR has already been validated by getCenterSelection()
 
-    QDialog * pD = new QDialog(this);
-    QGridLayout * pL = new QGridLayout;
+    auto pD = new QDialog(this);
+    auto pL = new QGridLayout;
     pD->setLayout( pL );
     pD->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     pD->setContentsMargins(0,0,0,0);
-    QLineEdit * pLEx = new QLineEdit(pD);
-    QLineEdit * pLEy = new QLineEdit(pD);
-    QLineEdit * pLEz = new QLineEdit(pD);
+    auto pLEx = new QLineEdit(pD);
+    auto pLEy = new QLineEdit(pD);
+    auto pLEz = new QLineEdit(pD);
 
     pLEx->setText(QString::number(pR_start->x));
     pLEy->setText(QString::number(pR_start->y));
@@ -3320,18 +3320,18 @@ void T2DMap::slot_movePosition()
     pL->addWidget(pLEy,2,1,Qt::AlignVCenter|Qt::AlignLeft);
     pL->addWidget(pLa3,3,0,Qt::AlignVCenter|Qt::AlignRight);
     pL->addWidget(pLEz,3,1,Qt::AlignVCenter|Qt::AlignLeft);
-    QWidget * pButtonBar = new QWidget(pD);
+    auto pButtonBar = new QWidget(pD);
 
-    QHBoxLayout * pL2 = new QHBoxLayout;
+    auto pL2 = new QHBoxLayout;
     pButtonBar->setLayout( pL2 );
     pButtonBar->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
 
-    QPushButton * pB_ok = new QPushButton(pButtonBar);
+    auto pB_ok = new QPushButton(pButtonBar);
     pB_ok->setText("Ok");
     pL2->addWidget(pB_ok);
     connect(pB_ok, SIGNAL(clicked()), pD, SLOT(accept()));
 
-    QPushButton * pB_abort = new QPushButton(pButtonBar);
+    auto pB_abort = new QPushButton(pButtonBar);
     pB_abort->setText("Cancel");
     connect(pB_abort, SIGNAL(clicked()), pD, SLOT(reject()));
     pL2->addWidget(pB_abort);
@@ -3615,24 +3615,24 @@ void T2DMap::slot_defineNewColor()
 void T2DMap::slot_changeColor()
 {
     mChosenRoomColor = 5;
-    QDialog * pD = new QDialog(this);
-    QVBoxLayout * pL = new QVBoxLayout;
+    auto pD = new QDialog(this);
+    auto pL = new QVBoxLayout;
     pD->setLayout( pL );
     pD->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     pD->setContentsMargins(0,0,0,0);
-    QListWidget * pLW = new QListWidget(pD);
+    auto pLW = new QListWidget(pD);
     pLW->setViewMode(QListView::IconMode);
 
     connect(pLW, SIGNAL(itemDoubleClicked(QListWidgetItem*)), pD, SLOT(accept()));
     connect(pLW, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(slot_selectRoomColor(QListWidgetItem*)));
 
     pL->addWidget(pLW);
-    QWidget * pButtonBar = new QWidget(pD);
+    auto pButtonBar = new QWidget(pD);
 
-    QHBoxLayout * pL2 = new QHBoxLayout;
+    auto pL2 = new QHBoxLayout;
     pButtonBar->setLayout( pL2 );
     pButtonBar->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
-    QPushButton * pB_newColor = new QPushButton(pButtonBar);
+    auto pB_newColor = new QPushButton(pButtonBar);
     pB_newColor->setText("define new color");
 
     connect(pB_newColor, SIGNAL(clicked()), pD, SLOT(reject()));
@@ -3640,12 +3640,12 @@ void T2DMap::slot_changeColor()
 
     pL2->addWidget(pB_newColor);
 
-    QPushButton * pB_ok = new QPushButton(pButtonBar);
+    auto pB_ok = new QPushButton(pButtonBar);
     pB_ok->setText("ok");
     pL2->addWidget(pB_ok);
     connect(pB_ok, SIGNAL(clicked()), pD, SLOT(accept()));
 
-    QPushButton * pB_abort = new QPushButton(pButtonBar);
+    auto pB_abort = new QPushButton(pButtonBar);
     pB_abort->setText("abort");
     connect(pB_abort, SIGNAL(clicked()), pD, SLOT(reject()));
     pL2->addWidget(pB_abort);
@@ -3657,7 +3657,7 @@ void T2DMap::slot_changeColor()
         it.next();
         QColor c;
         c = it.value();
-        QListWidgetItem * pI = new QListWidgetItem( pLW );
+        auto pI = new QListWidgetItem( pLW );
         QPixmap pix = QPixmap(50,50);
         pix.fill( c );
         QIcon mi( pix );
@@ -3827,7 +3827,7 @@ void T2DMap::slot_setExits()
     }
     if( mpMap->mpRoomDB->getRoom( mMultiSelectionHighlightRoomId ) )
     {
-        dlgRoomExits * pD = new dlgRoomExits( mpHost, this );
+        auto pD = new dlgRoomExits( mpHost, this );
         pD->init( mMultiSelectionHighlightRoomId );
         pD->show();
         pD->raise();
@@ -4275,7 +4275,7 @@ void T2DMap::mouseMoveEvent( QMouseEvent * event )
                 mIsSelectionUsingNames = false;
                 while( itRoom.hasNext() )
                 {
-                    QTreeWidgetItem * _item = new QTreeWidgetItem;
+                    auto _item = new QTreeWidgetItem;
                     int multiSelectionRoomId = itRoom.next();
                     _item->setText(0,QStringLiteral("%1").arg(multiSelectionRoomId,7));
                     _item->setTextAlignment(0, Qt::AlignRight);
@@ -4792,7 +4792,7 @@ void T2DMap::slot_setCustomLine()
         if( dir.size() > 1 )
             if( dir.startsWith('0')|| dir.startsWith('1') )
                 dir = dir.mid(1);
-        QTreeWidgetItem * pI = new QTreeWidgetItem(specialExits);
+        auto pI = new QTreeWidgetItem(specialExits);
         if( pR->customLines.contains(dir) )
             pI->setCheckState( 0, Qt::Checked );
         else

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -215,7 +215,7 @@ void TAction::expandToolbar( TToolBar * pT )
        }
        QIcon icon( pChild->mIcon );
        QString name = pChild->getName();
-       TFlipButton * button = new TFlipButton( pChild, mpHost );
+       auto button = new TFlipButton( pChild, mpHost );
        button->setIcon( icon );
        button->setText( name );
        button->setCheckable( pChild->mIsPushDownButton );
@@ -248,7 +248,7 @@ void TAction::expandToolbar( TToolBar * pT )
 
        if( pChild->mIsFolder )
        {
-           QMenu * newMenu = new QMenu( pT );
+           auto newMenu = new QMenu( pT );
            // This applies the CSS for THIS TAction to a CHILD's own menu - is this right
            newMenu->setStyleSheet( css );
            // CHECK: Use the Child's CSS instead for a menu on it? - Slysven:
@@ -275,7 +275,7 @@ void TAction::insertActions( TToolBar * pT, QMenu * menu )
 {
     mpToolBar = pT;
     QIcon icon( mIcon );
-    EAction * action = new EAction( icon, mName );
+    auto action = new EAction( icon, mName );
     action->setCheckable( mIsPushDownButton );
     action->mID = mID;
     action->mpHost = mpHost;
@@ -287,7 +287,7 @@ void TAction::insertActions( TToolBar * pT, QMenu * menu )
         // The use of mudlet::self() here meant that the QMenu was not destroyed
         // until the mudlet instance is at the end of the application!
         // Changed to use pT, the toolbar
-        QMenu * newMenu = new QMenu( pT );
+        auto newMenu = new QMenu( pT );
         newMenu->setStyleSheet( css );
         action->setMenu( newMenu );
 
@@ -311,7 +311,7 @@ void TAction::expandToolbar( TEasyButtonBar * pT )
        }
        QIcon icon( pChild->mIcon );
        QString name = pChild->getName();
-       TFlipButton * button = new TFlipButton( pChild, mpHost );
+       auto button = new TFlipButton( pChild, mpHost );
        button->setIcon( icon );
        button->setText( name );
        button->setCheckable( pChild->mIsPushDownButton );
@@ -341,7 +341,7 @@ void TAction::expandToolbar( TEasyButtonBar * pT )
 
        if( pChild->mIsFolder )
        {
-           QMenu * newMenu = new QMenu( button );
+           auto newMenu = new QMenu( button );
            // This applied the CSS for THIS TAction to a CHILD's own menu - is this right
            newMenu->setStyleSheet( css );
            // CHECK: consider using the Child's CSS instead for a menu on it
@@ -376,7 +376,7 @@ void TAction::fillMenu( TEasyButtonBar * pT, QMenu * menu )
         }
         mpEasyButtonBar = pT;
         QIcon icon( mIcon );
-        EAction * action = new EAction( icon, pChild->mName );
+        auto action = new EAction( icon, pChild->mName );
         action->mID = pChild->mID;
         action->mpHost = mpHost;
         action->setStatusTip( pChild->mName );
@@ -402,7 +402,7 @@ void TAction::fillMenu( TEasyButtonBar * pT, QMenu * menu )
             // Adding a QWidget derived pointer to new QMenu() means the menu
             // will be destroyed when the pointed to item is, we just need to
             // find the item that it is attached to - ah ha, try the toolbar...
-            QMenu * newMenu = new QMenu( pT );
+            auto newMenu = new QMenu( pT );
             action->setMenu( newMenu );
             newMenu->setStyleSheet( css );
             // CHECK: consider using the Child's CSS instead for a menu on it
@@ -422,7 +422,7 @@ void TAction::insertActions( TEasyButtonBar * pT, QMenu * menu )
 {
     mpEasyButtonBar = pT;
     QIcon icon( mIcon );
-    EAction * action = new EAction( icon, mName );
+    auto action = new EAction( icon, mName );
     action->setCheckable( mIsPushDownButton );
     action->mID = mID;
     action->mpHost = mpHost;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -497,7 +497,7 @@ void TCommandLine::mousePressEvent( QMouseEvent * event )
         {
             char ** sl;
             mHunspellSuggestionNumber = Hunspell_suggest( mpHunspell, &sl, c.selectedText().toLatin1().data() );
-            QMenu * popup = new QMenu( this );
+            auto popup = new QMenu( this );
             for( int i=0; i<mHunspellSuggestionNumber; i++ )
             {
                 QAction * pA;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -103,7 +103,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
 , mCurrentSearchResult( 0 )
 , mSearchQuery("")
 {
-    QShortcut * ps = new QShortcut(this);
+    auto ps = new QShortcut(this);
     ps->setKey(Qt::CTRL + Qt::Key_W);
     ps->setContext(Qt::WidgetShortcut);
 
@@ -201,14 +201,14 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     mpMainFrame->setPalette( framePalette );
     mpMainFrame->setAutoFillBackground(true);
     mpMainFrame->setContentsMargins(0,0,0,0);
-    QVBoxLayout * centralLayout = new QVBoxLayout;
+    auto centralLayout = new QVBoxLayout;
     setLayout( centralLayout );
-    QVBoxLayout * baseVFrameLayout = new QVBoxLayout;
+    auto baseVFrameLayout = new QVBoxLayout;
     mpBaseVFrame->setLayout( baseVFrameLayout );
     baseVFrameLayout->setMargin( 0 );
     baseVFrameLayout->setSpacing( 0 );
     centralLayout->addWidget( mpBaseVFrame );
-    QHBoxLayout * baseHFrameLayout = new QHBoxLayout;
+    auto baseHFrameLayout = new QHBoxLayout;
     mpBaseHFrame->setLayout( baseHFrameLayout );
     baseHFrameLayout->setMargin( 0 );
     baseHFrameLayout->setSpacing( 0 );
@@ -216,7 +216,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     layout()->setMargin( 0 );
     setContentsMargins( 0, 0, 0, 0 );
 
-    QHBoxLayout * topBarLayout = new QHBoxLayout;
+    auto topBarLayout = new QHBoxLayout;
     mpTopToolBar->setLayout( topBarLayout );
     mpTopToolBar->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
     mpTopToolBar->setContentsMargins(0,0,0,0);
@@ -231,14 +231,14 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
 
     topBarLayout->setMargin( 0 );
     topBarLayout->setSpacing(0);
-    QVBoxLayout * leftBarLayout = new QVBoxLayout;
+    auto leftBarLayout = new QVBoxLayout;
     mpLeftToolBar->setLayout( leftBarLayout );
     mpLeftToolBar->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding));
     mpLeftToolBar->setAutoFillBackground(true);
     leftBarLayout->setMargin( 0 );
     leftBarLayout->setSpacing(0);
     mpLeftToolBar->setContentsMargins(0,0,0,0);
-    QVBoxLayout * rightBarLayout = new QVBoxLayout;
+    auto rightBarLayout = new QVBoxLayout;
     mpRightToolBar->setLayout( rightBarLayout );
     mpRightToolBar->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding));
     mpRightToolBar->setAutoFillBackground(true);
@@ -252,8 +252,8 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     baseVFrameLayout->addWidget( mpTopToolBar );
     baseVFrameLayout->addWidget( mpBaseHFrame );
     baseHFrameLayout->addWidget( mpLeftToolBar );
-    QWidget * mpCorePane = new QWidget( mpBaseHFrame );
-    QVBoxLayout * coreSpreadLayout = new QVBoxLayout;
+    auto mpCorePane = new QWidget( mpBaseHFrame );
+    auto coreSpreadLayout = new QVBoxLayout;
     mpCorePane->setLayout( coreSpreadLayout );
     mpCorePane->setContentsMargins(0,0,0,0);
     coreSpreadLayout->setMargin(0);
@@ -276,7 +276,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     mpMainDisplay->show();
     mpMainFrame->setContentsMargins(0,0,0,0);
     mpMainDisplay->setContentsMargins(0,0,0,0);
-    QVBoxLayout * layout = new QVBoxLayout;
+    auto layout = new QVBoxLayout;
     mpMainDisplay->setLayout(layout);
     layout->setContentsMargins(0,0,0,0);
     layout->setSpacing(0);
@@ -301,7 +301,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     layer->setSizePolicy( sizePolicy );
     layer->setFocusPolicy( Qt::NoFocus );
 
-    QHBoxLayout * layoutLayer = new QHBoxLayout;
+    auto layoutLayer = new QHBoxLayout;
     layer->setLayout( layoutLayer );
     layoutLayer->setMargin( 0 );//neu rc1
     layoutLayer->setSpacing( 0 );//neu rc1
@@ -347,31 +347,31 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     layerCommandLine->setMaximumHeight(31);
     layerCommandLine->setMinimumHeight(31);
 
-    QHBoxLayout * layoutLayer2 = new QHBoxLayout( layerCommandLine );
+    auto layoutLayer2 = new QHBoxLayout( layerCommandLine );
     layoutLayer2->setMargin(0);
     layoutLayer2->setSpacing(0);
 
-    QWidget * buttonMainLayer = new QWidget;//( layerCommandLine );
+    auto buttonMainLayer = new QWidget;//( layerCommandLine );
     buttonMainLayer->setSizePolicy(sizePolicy);
     buttonMainLayer->setContentsMargins(0,0,0,0);
-    QVBoxLayout * layoutButtonMainLayer = new QVBoxLayout( buttonMainLayer );
+    auto layoutButtonMainLayer = new QVBoxLayout( buttonMainLayer );
     layoutButtonMainLayer->setMargin(0);
     layoutButtonMainLayer->setContentsMargins(0,0,0,0);
 
     layoutButtonMainLayer->setSpacing(0);
     /*buttonMainLayer->setMinimumHeight(31);
     buttonMainLayer->setMaximumHeight(31);*/
-    QWidget * buttonLayer = new QWidget;
-    QGridLayout * layoutButtonLayer = new QGridLayout( buttonLayer );
+    auto buttonLayer = new QWidget;
+    auto layoutButtonLayer = new QGridLayout( buttonLayer );
     layoutButtonLayer->setMargin(0);
     layoutButtonLayer->setSpacing(0);
 
-    QWidget * buttonLayerSpacer = new QWidget(buttonLayer);
+    auto buttonLayerSpacer = new QWidget(buttonLayer);
     buttonLayerSpacer->setSizePolicy( sizePolicy4 );
     layoutButtonMainLayer->addWidget( buttonLayerSpacer );
     layoutButtonMainLayer->addWidget( buttonLayer );
 
-    QToolButton * timeStampButton = new QToolButton;
+    auto timeStampButton = new QToolButton;
     timeStampButton->setCheckable( true );
     timeStampButton->setMinimumSize(QSize(30,30));
     timeStampButton->setMaximumSize(QSize(30,30));
@@ -381,7 +381,7 @@ TConsole::TConsole( Host * pH, bool isDebugConsole, QWidget * parent )
     timeStampButton->setIcon( QIcon( QStringLiteral( ":/icons/dialog-information.png" ) ) );
     connect( timeStampButton, SIGNAL(pressed()), console, SLOT(slot_toggleTimeStamps()));
 
-    QToolButton * replayButton = new QToolButton;
+    auto replayButton = new QToolButton;
     replayButton->setCheckable( true );
     replayButton->setMinimumSize(QSize(30,30));
     replayButton->setMaximumSize(QSize(30,30));
@@ -2322,7 +2322,7 @@ TConsole * TConsole::createBuffer(const QString & name )
     std::string key = name.toLatin1().data();
     if( mSubConsoleMap.find( key ) == mSubConsoleMap.end() )
     {
-        TConsole * pC = new TConsole( mpHost, false );
+        auto pC = new TConsole( mpHost, false );
         mSubConsoleMap[key] = pC;
         pC->setWindowTitle(name);
         pC->setContentsMargins(0,0,0,0);
@@ -2367,7 +2367,7 @@ TConsole * TConsole::createMiniConsole(const QString & name, int x, int y, int w
     std::string key = name.toLatin1().data();
     if( mSubConsoleMap.find( key ) == mSubConsoleMap.end() )
     {
-        TConsole * pC = new TConsole(mpHost, false, mpMainFrame );
+        auto pC = new TConsole(mpHost, false, mpMainFrame );
         if( ! pC )
         {
             return 0;
@@ -2399,7 +2399,7 @@ TLabel * TConsole::createLabel(const QString & name, int x, int y, int width, in
     std::string key = name.toLatin1().data();
     if( mLabelMap.find( key ) == mLabelMap.end() )
     {
-        TLabel * pC = new TLabel( mpMainFrame );
+        auto pC = new TLabel( mpMainFrame );
         mLabelMap[key] = pC;
         pC->setObjectName( name );
         pC->setAutoFillBackground( fillBackground );
@@ -2453,7 +2453,7 @@ bool TConsole::createButton(const QString & name, int x, int y, int width, int h
     std::string key = name.toLatin1().data();
     if( mLabelMap.find( key ) == mLabelMap.end() )
     {
-        TLabel * pC = new TLabel( mpMainFrame );
+        auto pC = new TLabel( mpMainFrame );
         mLabelMap[key] = pC;
         pC->setObjectName( name );
         pC->setAutoFillBackground( fillBackground );

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -45,7 +45,7 @@ TEasyButtonBar::TEasyButtonBar( TAction * pA, QString name, QWidget * pW )
 , mpBar( pW )
 {
     mButtonList.clear();
-    QVBoxLayout * layout = new QVBoxLayout;
+    auto layout = new QVBoxLayout;
     setLayout( layout );
     layout->setContentsMargins(0,0,0,0);
     layout->setMargin(0);
@@ -145,7 +145,7 @@ void TEasyButtonBar::finalize()
     {
         return;
     }
-    QWidget * fillerWidget = new QWidget;
+    auto fillerWidget = new QWidget;
 
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding );
     fillerWidget->setSizePolicy( sizePolicy );
@@ -198,7 +198,7 @@ void TEasyButtonBar::slot_pressed(const bool isChecked)
 
 void TEasyButtonBar::clear()
 {
-    QWidget * pW = new QWidget;
+    auto pW = new QWidget;
     for(auto it = mButtonList.begin(); it != mButtonList.end(); it++ )
     {
         disconnect( *it, SIGNAL(clicked(const bool)), this, SLOT(slot_pressed(const bool)) );

--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -141,7 +141,7 @@ static int qPointerGC ( lua_State * L ) {
 
 
 int TForkedProcess::startProcess( TLuaInterpreter * interpreter, lua_State * L ) {
-    TForkedProcess * process = new TForkedProcess(interpreter, L);
+    auto process = new TForkedProcess(interpreter, L);
 
     // The userdata for the closures.
     QPointer<TForkedProcess> ** luaMemory = (QPointer<TForkedProcess> **)lua_newuserdata (L, sizeof(QPointer<TForkedProcess> *));

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1451,7 +1451,7 @@ bool TMap::restore( QString location )
             ifs >> areaSize;
             // restore area table
             for( int i=0; i<areaSize; i++ ) {
-                TArea * pA = new TArea( this, mpRoomDB );
+                auto pA = new TArea( this, mpRoomDB );
                 int areaID;
                 ifs >> areaID;
                 if( mVersion >= 18 ) {
@@ -1503,7 +1503,7 @@ bool TMap::restore( QString location )
         }
 
         if( ! mpRoomDB->getAreaMap().keys().contains( -1 ) ) {
-            TArea * pDefaultA = new TArea( this, mpRoomDB );
+            auto pDefaultA = new TArea( this, mpRoomDB );
             mpRoomDB->restoreSingleArea( -1, pDefaultA );
             QString defaultAreaInsertionMsg = tr( "[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
                                                               "area) not found, adding reserved -1 id." );
@@ -1569,7 +1569,7 @@ bool TMap::restore( QString location )
         while( ! ifs.atEnd() ) {
             int i;
             ifs >> i;
-            TRoom * pT = new TRoom(mpRoomDB);
+            auto pT = new TRoom(mpRoomDB);
             pT->restore( ifs, i, mVersion );
             mpRoomDB->restoreSingleRoom( i, pT );
         }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1301,7 +1301,7 @@ void TTextEdit::mousePressEvent( QMouseEvent * event )
                     QStringList hint = mpBuffer->mHintStore[mpBuffer->buffer[y][x].link];
                     if( command.size() > 1 )
                     {
-                        QMenu * popup = new QMenu( this );
+                        auto popup = new QMenu( this );
                         for( int i=0; i<command.size(); i++ )
                         {
                             QAction * pA;
@@ -1332,7 +1332,7 @@ void TTextEdit::mousePressEvent( QMouseEvent * event )
         QAction * action2 = new QAction("copy HTML", this );
         action2->setStatusTip(tr("copy selected text with colors as HTML (for web browsers)"));
         connect( action2, SIGNAL(triggered()), this, SLOT(slot_copySelectionToClipboardHTML()));
-        QMenu * popup = new QMenu( this );
+        auto popup = new QMenu( this );
         popup->addAction( action );
         popup->addAction( action2 );
         popup->popup( mapToGlobal( event->pos() ), action );

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -56,7 +56,7 @@ TToolBar::TToolBar( TAction * pA, const QString& name, QWidget * pW )
         QSizePolicy sizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred);
         mpWidget->setSizePolicy( sizePolicy );
     }
-    QWidget * test = new QWidget;
+    auto test = new QWidget;
     setTitleBarWidget(test);
     setStyleSheet( mpTAction->css );
     mpWidget->setStyleSheet( mpTAction->css );
@@ -141,7 +141,7 @@ void TToolBar::finalize()
     {
         return;
     }
-    QWidget * fillerWidget = new QWidget;
+    auto fillerWidget = new QWidget;
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding );
     fillerWidget->setSizePolicy( sizePolicy );
     int columns = mpTAction->getButtonColumns();
@@ -191,7 +191,7 @@ void TToolBar::slot_pressed(const bool isChecked)
 
 void TToolBar::clear()
 {
-    QWidget * pW = new QWidget( this );
+    auto pW = new QWidget( this );
     setWidget( pW );
     mpWidget->deleteLater();
     mpWidget = pW;
@@ -206,7 +206,7 @@ void TToolBar::clear()
     }
     else
         mpLayout = 0;
-    QWidget * test = new QWidget;
+    auto test = new QWidget;
     setStyleSheet( mpTAction->css );
     mpWidget->setStyleSheet( mpTAction->css );
     setTitleBarWidget( test );

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -557,7 +557,7 @@ inline void TTrigger::updateMultistates( int regexNumber,
     if( regexNumber == 0 )
     {
         // wird automatisch auf #1 gesetzt
-        TMatchState * pCondition = new TMatchState( mRegexCodeList.size(), mConditionLineDelta );
+        auto pCondition = new TMatchState( mRegexCodeList.size(), mConditionLineDelta );
         mConditionMap[pCondition] = pCondition;
         pCondition->multiCaptureList.push_back( captureList );
         pCondition->multiCapturePosList.push_back( posList );
@@ -1043,7 +1043,7 @@ bool TTrigger::match( char * subject, const QString & toMatch, int line, int pos
                     removeList.push_back( (*it).first );
                 }
             }
-            for( list<TMatchState*>::iterator it=removeList.begin(); it!=removeList.end(); it++ )
+            for( auto it=removeList.begin(); it!=removeList.end(); it++ )
             {
                 if( mConditionMap.find( *it ) != mConditionMap.end() )
                 {
@@ -1246,7 +1246,7 @@ TColorTable * TTrigger::createColorPattern( int ansiFg, int ansiBg )
 
     if( invalidColorCode ) return 0;
 
-    TColorTable * pCT = new TColorTable;
+    auto pCT = new TColorTable;
     if( !pCT ) return 0;
 
     pCT->ansiBg = ansiBg;

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -116,7 +116,7 @@ Tree<T>::~Tree()
 {
     while( mpMyChildrenList->size() > 0 )
     {
-        typename std::list<T*>::iterator it = mpMyChildrenList->begin();
+        auto it = mpMyChildrenList->begin();
         T * pChild = *it;
         delete pChild;
     }

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -66,7 +66,7 @@ void VarUnit::buildVarTree( QTreeWidgetItem * p, TVar * var, bool showHidden ){
         if ( showHidden || !isHidden( child ) ){
             QStringList s1;
             s1 << child->getName();
-            QTreeWidgetItem * pItem = new QTreeWidgetItem(s1);
+            auto pItem = new QTreeWidgetItem(s1);
             pItem->setText( 0, child->getName() );
             pItem->setFlags(Qt::ItemIsEnabled|Qt::ItemIsSelectable|Qt::ItemIsDropEnabled|Qt::ItemIsDragEnabled|Qt::ItemIsTristate|Qt::ItemIsUserCheckable);
             pItem->setToolTip(0, "Checked variables will be saved and loaded with your profile.");

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -206,7 +206,7 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
 
 void XMLimport::readVariableGroup(TVar* pParent)
 {
-    TVar* var = new TVar(pParent);
+    auto var = new TVar(pParent);
 
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
@@ -395,7 +395,7 @@ void XMLimport::readRooms(QMultiHash<int, int>& areaRoomsHash)
 // TRoomDB::addRoom(...)
 void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int* roomCount)
 {
-    TRoom* pT = new TRoom(mpHost->mpMap->mpRoomDB);
+    auto pT = new TRoom(mpHost->mpMap->mpRoomDB);
 
     pT->id = attributes().value(QStringLiteral("id")).toString().toInt();
     pT->area = attributes().value(QStringLiteral("area")).toString().toInt();
@@ -919,7 +919,7 @@ void XMLimport::readTriggerPackage()
 
 void XMLimport::readTriggerGroup(TTrigger* pParent)
 {
-    TTrigger* pT = new TTrigger(pParent, mpHost);
+    auto pT = new TTrigger(pParent, mpHost);
 
     if (module) {
         pT->mModuleMember = true;
@@ -1021,7 +1021,7 @@ void XMLimport::readTimerPackage()
 
 void XMLimport::readTimerGroup(TTimer* pParent)
 {
-    TTimer* pT = new TTimer(pParent, mpHost);
+    auto pT = new TTimer(pParent, mpHost);
 
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     pT->mIsTempTimer = (attributes().value("isTempTimer") == "yes");
@@ -1086,7 +1086,7 @@ void XMLimport::readAliasPackage()
 
 void XMLimport::readAliasGroup(TAlias* pParent)
 {
-    TAlias* pT = new TAlias(pParent, mpHost);
+    auto pT = new TAlias(pParent, mpHost);
 
     mpHost->getAliasUnit()->registerAlias(pT);
     pT->setIsActive(attributes().value("isActive") == "yes");
@@ -1142,7 +1142,7 @@ void XMLimport::readActionPackage()
 
 void XMLimport::readActionGroup(TAction* pParent)
 {
-    TAction* pT = new TAction(pParent, mpHost);
+    auto pT = new TAction(pParent, mpHost);
 
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     pT->mIsPushDownButton = (attributes().value("isPushButton") == "yes");
@@ -1227,7 +1227,7 @@ void XMLimport::readScriptPackage()
 
 void XMLimport::readScriptGroup(TScript* pParent)
 {
-    TScript* pT = new TScript(pParent, mpHost);
+    auto pT = new TScript(pParent, mpHost);
 
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     mpHost->getScriptUnit()->registerScript(pT);
@@ -1282,7 +1282,7 @@ void XMLimport::readKeyPackage()
 
 void XMLimport::readKeyGroup(TKey* pParent)
 {
-    TKey* pT = new TKey(pParent, mpHost);
+    auto pT = new TKey(pParent, mpHost);
 
     pT->mIsFolder = (attributes().value("isFolder") == "yes");
     mpHost->getKeyUnit()->registerKey(pT);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -462,7 +462,7 @@ void dlgConnectionProfiles::slot_addProfile()
 
     QString newname = tr( "new profile name" );
 
-    QListWidgetItem * pItem = new QListWidgetItem( newname );
+    auto pItem = new QListWidgetItem( newname );
     if( ! pItem ) {
         return;
     }
@@ -1084,7 +1084,7 @@ void dlgConnectionProfiles::fillout_form()
             continue;
         }
 
-        QListWidgetItem * pItem = new QListWidgetItem( mProfileList.at(i) );
+        auto pItem = new QListWidgetItem( mProfileList.at(i) );
         pItem->setFont(font);
         pItem->setForeground(QColor(Qt::white));
         profiles_tree_widget->addItem( pItem );
@@ -1189,7 +1189,7 @@ void dlgConnectionProfiles::slot_copy_profile()
         profile_name = profile_name2;
     }
 
-    QListWidgetItem * pItem = new QListWidgetItem( profile_name );
+    auto pItem = new QListWidgetItem( profile_name );
     if( ! pItem )
     {
         return;

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -369,7 +369,7 @@ void dlgPackageExporter::recurseTriggers(TTrigger* trig, QTreeWidgetItem* qTrig)
             continue;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         triggerMap.insert(pItem, pChild);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
@@ -391,7 +391,7 @@ void dlgPackageExporter::listTriggers()
         if( pChild->isTempTrigger() ) continue;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         top->addChild(pItem);
@@ -411,7 +411,7 @@ void dlgPackageExporter::recurseAliases(TAlias* item, QTreeWidgetItem* qItem){
             continue;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         qItem->addChild(pItem);
@@ -434,7 +434,7 @@ void dlgPackageExporter::listAliases()
             continue;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         top->addChild(pItem);
@@ -452,7 +452,7 @@ void dlgPackageExporter::recurseScripts(TScript* item, QTreeWidgetItem* qItem){
         TScript * pChild = *it;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         scriptMap.insert(pItem, pChild);
@@ -473,7 +473,7 @@ void dlgPackageExporter::listScripts()
         TScript * pChild = *it;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         scriptMap.insert(pItem, pChild);
@@ -491,7 +491,7 @@ void dlgPackageExporter::recurseKeys(TKey* item, QTreeWidgetItem* qItem){
         TKey * pChild = *it;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         keyMap.insert(pItem, pChild);
@@ -512,7 +512,7 @@ void dlgPackageExporter::listKeys()
         TKey * pChild = *it;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         keyMap.insert(pItem, pChild);
@@ -530,7 +530,7 @@ void dlgPackageExporter::recurseActions(TAction* item, QTreeWidgetItem* qItem){
         TAction * pChild = *it;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         actionMap.insert(pItem, pChild);
@@ -551,7 +551,7 @@ void dlgPackageExporter::listActions()
         TAction * pChild = *it;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         actionMap.insert(pItem, pChild);
@@ -571,7 +571,7 @@ void dlgPackageExporter::recurseTimers(TTimer* item, QTreeWidgetItem* qItem){
             continue;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         timerMap.insert(pItem, pChild);
@@ -594,7 +594,7 @@ void dlgPackageExporter::listTimers()
             continue;
         QStringList sl;
         sl << pChild->getName();
-        QTreeWidgetItem * pItem = new QTreeWidgetItem(sl);
+        auto pItem = new QTreeWidgetItem(sl);
         pItem->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsTristate|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
         pItem->setCheckState(0, Qt::Unchecked);
         timerMap.insert(pItem, pChild);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -94,7 +94,7 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
     for( int i=0; i<entries.size(); i++ )
     {
         QString n = entries[i].replace( ".dic", "" );
-        QListWidgetItem * item = new QListWidgetItem( entries[i] );
+        auto item = new QListWidgetItem( entries[i] );
         dictList->addItem( item );
         if( entries[i] == mpHost->mSpellDic )
         {
@@ -310,7 +310,7 @@ dlgProfilePreferences::dlgProfilePreferences( QWidget * pF, Host * pH )
                 continue;
             }
 
-            QAction * pItem = new QAction( s, 0 );
+            auto pItem = new QAction( s, 0 );
             pItem->setCheckable( true );
             pItem->setChecked( false );
             pMenu->addAction( pItem );

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -211,7 +211,7 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem * pI, int column )
 
 void dlgRoomExits::slot_addSpecialExit()
 {
-    QTreeWidgetItem * pI = new QTreeWidgetItem(specialExits);
+    auto pI = new QTreeWidgetItem(specialExits);
     pI->setText(0, tr("<room ID>", "This string is used in 2 places, ensure they match!") ); //Exit RoomID
     pI->setForeground( 0, QColor(Qt::red) );
     pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p></body></html>" )
@@ -1871,7 +1871,7 @@ void dlgRoomExits::init( int id )
             dir = dir.mid(1);  // Not sure if this will be relevent here??
 
         originalSpecialExits[dir] = new TExit();
-        QTreeWidgetItem * pI = new QTreeWidgetItem(specialExits);
+        auto pI = new QTreeWidgetItem(specialExits);
         TRoom * pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom( id_to );
         //0 was locked, now exit roomID
         pI->setText( 0, QString::number(id_to) );
@@ -2038,7 +2038,7 @@ void dlgRoomExits::init( int id )
 }
 
 TExit * dlgRoomExits::makeExitFromControls( int direction ) {
-    TExit * exit = new TExit();
+    auto exit = new TExit();
     switch( direction ) {
         case DIR_NORTHWEST:
             exit->destination = nw->text().toInt();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -115,12 +115,12 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     setUnifiedTitleAndToolBarOnMac( true ); //MAC OSX: make window moveable
     setWindowTitle( mpHost->getName() );
     setWindowIcon( QIcon( QStringLiteral( ":/icons/mudlet_editor.png" ) ) );
-    QStatusBar * statusBar = new QStatusBar(this);
+    auto statusBar = new QStatusBar(this);
     statusBar->setSizeGripEnabled( true );
     setStatusBar( statusBar );
     statusBar->show();
     mIsGrabKey = false;
-    QVBoxLayout * pVB1 = new QVBoxLayout(mainArea);
+    auto pVB1 = new QVBoxLayout(mainArea);
 
     // system message area
     mpSystemMessageArea = new dlgSystemMessageArea( mainArea );
@@ -204,7 +204,7 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
 
     // option areas
 
-    QHBoxLayout * pHB2 = new QHBoxLayout(popupArea);
+    auto pHB2 = new QHBoxLayout(popupArea);
     QSizePolicy sizePolicy2(QSizePolicy::Expanding, QSizePolicy::Maximum);
     popupArea->setMinimumSize(200,60);
     pHB2->setSizeConstraint( QLayout::SetMaximumSize );
@@ -415,7 +415,7 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     addKeysMenuAction->setEnabled( true );
     connect( addKeysMenuAction, SIGNAL(triggered()), this, SLOT( slot_addKey()));
 
-    QMenu * addTriggerMenu = new QMenu( this );
+    auto addTriggerMenu = new QMenu( this );
     addTriggerMenu->addAction( addTriggerMenuAction );
     addTriggerMenu->addAction( addTimersMenuAction );
     addTriggerMenu->addAction( addScriptsMenuAction );
@@ -441,7 +441,7 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     addScriptsGroupMenuAction->setEnabled( true );
     connect( addScriptsGroupMenuAction, SIGNAL(triggered()), this, SLOT( slot_addScriptGroup()));
 
-    QMenu * addTriggerGroupMenu = new QMenu( this );
+    auto addTriggerGroupMenu = new QMenu( this );
     addTriggerGroupMenu->addAction( addTriggerGroupMenuAction );
     addTriggerGroupMenu->addAction( addTimersGroupMenuAction );
     addTriggerGroupMenu->addAction( addScriptsGroupMenuAction );
@@ -549,13 +549,13 @@ dlgTriggerEditor::dlgTriggerEditor( Host * pH )
     treeWidget_searchResults->setHeaderLabels( labelList );
     mpScrollArea = mpTriggersMainArea->scrollArea;
     HpatternList = new QWidget;
-    QVBoxLayout * lay1 = new QVBoxLayout( HpatternList );
+    auto lay1 = new QVBoxLayout( HpatternList );
     lay1->setContentsMargins(0,0,0,0);
     lay1->setSpacing(0);
     mpScrollArea->setWidget( HpatternList );
     for( int i=0; i<50; i++)
     {
-        dlgTriggerPatternEdit * pItem = new dlgTriggerPatternEdit(HpatternList);
+        auto pItem = new dlgTriggerPatternEdit(HpatternList);
         QStringList _patternList;
         _patternList << "substring"
                      << "perl regex"
@@ -2840,7 +2840,7 @@ void dlgTriggerEditor::addVar( bool isFolder )
         pParent = cItem;
     else
         pParent = cItem->parent();
-    TVar * newVar = new TVar();
+    auto newVar = new TVar();
     if (pParent)
     {
         //we're nested under something, or going to be.  This HAS to be a table
@@ -4919,7 +4919,7 @@ void dlgTriggerEditor::slot_scripts_selected(QTreeWidgetItem *pItem)
         QStringList eventHandlerList = pT->getEventHandlerList();
         for( int i=0; i<eventHandlerList.size(); i++ )
         {
-            QListWidgetItem * pItem = new QListWidgetItem( mpScriptsMainArea->listWidget_registered_event_handlers );
+            auto pItem = new QListWidgetItem( mpScriptsMainArea->listWidget_registered_event_handlers );
             pItem->setText( eventHandlerList[i] );
             mpScriptsMainArea->listWidget_registered_event_handlers->addItem( pItem );
         }
@@ -5017,7 +5017,7 @@ void dlgTriggerEditor::fillout_form()
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( mpTriggerBaseItem, sList);
+        auto pItem = new QTreeWidgetItem( mpTriggerBaseItem, sList);
         pItem->setData( 0, Qt::UserRole, QVariant(pT->getID()) );
         mpTriggerBaseItem->addChild( pItem );
         QIcon icon;
@@ -5137,14 +5137,14 @@ void dlgTriggerEditor::fillout_form()
     mpTriggerBaseItem->setExpanded( true );
     list<TTimer *> baseNodeList_timers = mpHost->getTimerUnit()->getTimerRootNodeList();
 
-    for( list<TTimer *>::iterator it = baseNodeList_timers.begin(); it!=baseNodeList_timers.end(); it++ )
+    for( auto it = baseNodeList_timers.begin(); it!=baseNodeList_timers.end(); it++ )
     {
         TTimer * pT = *it;
         if( pT->isTempTimer() ) continue;
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( mpTimerBaseItem, sList);
+        auto pItem = new QTreeWidgetItem( mpTimerBaseItem, sList);
         pItem->setData( 0, Qt::UserRole, QVariant(pT->getID()) );
         mpTimerBaseItem->addChild( pItem );
         QIcon icon;
@@ -5225,14 +5225,14 @@ void dlgTriggerEditor::fillout_form()
     mpScriptsBaseItem->setExpanded( true );
     list<TScript *> baseNodeList_scripts = mpHost->getScriptUnit()->getScriptRootNodeList();
 
-    for( list<TScript *>::iterator it = baseNodeList_scripts.begin(); it!=baseNodeList_scripts.end(); it++ )
+    for( auto it = baseNodeList_scripts.begin(); it!=baseNodeList_scripts.end(); it++ )
     {
         TScript * pT = *it;
         QString s = pT->getName();
 
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( mpScriptsBaseItem, sList);
+        auto pItem = new QTreeWidgetItem( mpScriptsBaseItem, sList);
         pItem->setData( 0, Qt::UserRole, QVariant(pT->getID()) );
         mpScriptsBaseItem->addChild( pItem );
         QIcon icon;
@@ -5298,13 +5298,13 @@ void dlgTriggerEditor::fillout_form()
     mpAliasBaseItem->setExpanded( true );
     list<TAlias *> baseNodeList_alias = mpHost->getAliasUnit()->getAliasRootNodeList();
 
-    for( list<TAlias *>::iterator it = baseNodeList_alias.begin(); it!=baseNodeList_alias.end(); it++ )
+    for( auto it = baseNodeList_alias.begin(); it!=baseNodeList_alias.end(); it++ )
     {
         TAlias * pT = *it;
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( mpAliasBaseItem, sList);
+        auto pItem = new QTreeWidgetItem( mpAliasBaseItem, sList);
         pItem->setData( 0, Qt::UserRole, QVariant(pT->getID()) );
         mpAliasBaseItem->addChild( pItem );
         QIcon icon;
@@ -5398,13 +5398,13 @@ void dlgTriggerEditor::fillout_form()
     mpActionBaseItem->setExpanded( true );
     list<TAction *> baseNodeList_action = mpHost->getActionUnit()->getActionRootNodeList();
 
-    for( list<TAction *>::iterator it = baseNodeList_action.begin(); it!=baseNodeList_action.end(); it++ )
+    for( auto it = baseNodeList_action.begin(); it!=baseNodeList_action.end(); it++ )
     {
         TAction * pT = *it;
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( mpActionBaseItem, sList);
+        auto pItem = new QTreeWidgetItem( mpActionBaseItem, sList);
         pItem->setData( 0, Qt::UserRole, QVariant(pT->getID()) );
         mpActionBaseItem->addChild( pItem );
         QIcon icon;
@@ -5485,13 +5485,13 @@ void dlgTriggerEditor::fillout_form()
     mpKeyBaseItem->setExpanded( true );
     list<TKey *> baseNodeList_key = mpHost->getKeyUnit()->getKeyRootNodeList();
 
-    for( list<TKey *>::iterator it = baseNodeList_key.begin(); it!=baseNodeList_key.end(); it++ )
+    for( auto it = baseNodeList_key.begin(); it!=baseNodeList_key.end(); it++ )
     {
         TKey * pT = *it;
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( mpKeyBaseItem, sList);
+        auto pItem = new QTreeWidgetItem( mpKeyBaseItem, sList);
         pItem->setData( 0, Qt::UserRole, QVariant(pT->getID()) );
         mpKeyBaseItem->addChild( pItem );
         QIcon icon;
@@ -5607,7 +5607,7 @@ void dlgTriggerEditor::expand_child_triggers( TTrigger * pTriggerParent, QTreeWi
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
+        auto pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
         pItem->setData( 0, Qt::UserRole, pT->getID() );
 
         pWidgetItemParent->insertChild( 0, pItem );
@@ -5717,7 +5717,7 @@ void dlgTriggerEditor::expand_child_key( TKey * pTriggerParent, QTreeWidgetItem 
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
+        auto pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
         pItem->setData( 0, Qt::UserRole, pT->getID() );
 
         pWidgetItemParent->insertChild( 0, pItem );
@@ -5784,7 +5784,7 @@ void dlgTriggerEditor::expand_child_scripts( TScript * pTriggerParent, QTreeWidg
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
+        auto pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
         pItem->setData( 0, Qt::UserRole, pT->getID() );
 
         pWidgetItemParent->insertChild( 0, pItem );
@@ -5838,7 +5838,7 @@ void dlgTriggerEditor::expand_child_alias( TAlias * pTriggerParent, QTreeWidgetI
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
+        auto pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
         pItem->setData( 0, Qt::UserRole, pT->getID() );
 
         pWidgetItemParent->insertChild( 0, pItem );
@@ -5904,7 +5904,7 @@ void dlgTriggerEditor::expand_child_action( TAction * pTriggerParent, QTreeWidge
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
+        auto pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
         pItem->setData( 0, Qt::UserRole, pT->getID() );
 
         pWidgetItemParent->insertChild( 0, pItem );
@@ -5974,7 +5974,7 @@ void dlgTriggerEditor::expand_child_timers( TTimer * pTimerParent, QTreeWidgetIt
         QString s = pT->getName();
         QStringList sList;
         sList << s;
-        QTreeWidgetItem * pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
+        auto pItem = new QTreeWidgetItem( pWidgetItemParent, sList);
         pItem->setData( 0, Qt::UserRole, pT->getID() );
 
         pWidgetItemParent->insertChild( 0, pItem );
@@ -6648,7 +6648,7 @@ void dlgTriggerEditor::slot_script_main_area_add_handler()
     else
     {
     LAZY:
-        QListWidgetItem * pItem = new QListWidgetItem;
+        auto pItem = new QListWidgetItem;
         pItem->setText( mpScriptsMainArea->lineEdit->text() );
         mpScriptsMainArea->listWidget_registered_event_handlers->addItem( pItem );
 
@@ -7318,7 +7318,7 @@ void dlgTriggerEditor::slot_color_trigger_fg()
     pT->mColorTriggerFgAnsi = ansiFg;
     pT->mColorTriggerBgAnsi = ansiBg;
 
-    dlgColorTrigger * pD = new dlgColorTrigger(this, pT, 0 );
+    auto pD = new dlgColorTrigger(this, pT, 0 );
     pD->setModal( true );
     pD->setWindowModality( Qt::ApplicationModal );
     pD->exec();
@@ -7371,7 +7371,7 @@ void dlgTriggerEditor::slot_color_trigger_bg()
     pT->mColorTriggerFgAnsi = ansiFg;
     pT->mColorTriggerBgAnsi = ansiBg;
 
-    dlgColorTrigger * pD = new dlgColorTrigger(this, pT, 1 );
+    auto pD = new dlgColorTrigger(this, pT, 1 );
     pD->setModal( true );
     pD->setWindowModality( Qt::ApplicationModal );
     pD->exec();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -131,7 +131,7 @@ mudlet::mudlet()
     addToolBar( mpMainToolBar );
     mpMainToolBar->setMovable( false );
     addToolBarBreak();
-    QWidget * frame = new QWidget( this );
+    auto frame = new QWidget( this );
     frame->setFocusPolicy( Qt::NoFocus );
     setCentralWidget( frame );
     mpTabBar = new QTabBar( frame );
@@ -143,7 +143,7 @@ mudlet::mudlet()
     mpTabBar->setMovable(true);
 #endif
     connect( mpTabBar, SIGNAL(currentChanged(int)), this, SLOT(slot_tab_changed(int)));
-    QVBoxLayout * layoutTopLevel = new QVBoxLayout(frame);
+    auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0,0,0,0);
     layoutTopLevel->addWidget( mpTabBar );
     mainPane = new QWidget( frame );
@@ -152,7 +152,7 @@ mudlet::mudlet()
     mainPane->setAutoFillBackground(true);
     mainPane->setFocusPolicy( Qt::NoFocus );
     layoutTopLevel->addWidget( mainPane );
-    QHBoxLayout * layout = new QHBoxLayout( mainPane );
+    auto layout = new QHBoxLayout( mainPane );
     layout->setContentsMargins(0,0,0,0);
 
     mainPane->setContentsMargins(0,0,0,0);
@@ -273,7 +273,7 @@ mudlet::mudlet()
     mpDebugArea->setWindowTitle( tr( "Central Debug Console" ) );
     mpDebugArea->setWindowIcon( QIcon( QStringLiteral( ":/icons/mudlet_debug.png" ) ) );
 
-    TConsoleMonitor * consoleCloser = new TConsoleMonitor(mpDebugArea);
+    auto consoleCloser = new TConsoleMonitor(mpDebugArea);
     mpDebugArea->installEventFilter(consoleCloser);
 
     QSize generalRule( qApp->desktop()->size() );
@@ -372,7 +372,7 @@ mudlet::mudlet()
 
     readSettings();
 
-    QTimer * timerAutologin = new QTimer( this );
+    auto timerAutologin = new QTimer( this );
     timerAutologin->setSingleShot( true );
     connect(timerAutologin, SIGNAL(timeout()), this, SLOT(startAutoLogin()));
     timerAutologin->start( 1000 );
@@ -438,10 +438,10 @@ void mudlet::layoutModules(){
         for(int i=0;i<pModules.size();i++){
             int row = moduleTable->rowCount();
             moduleTable->insertRow(row);
-            QTableWidgetItem *masterModule = new QTableWidgetItem ();
-            QTableWidgetItem *itemEntry = new QTableWidgetItem ();
-            QTableWidgetItem *itemLocation = new QTableWidgetItem ();
-            QTableWidgetItem *itemPriority = new QTableWidgetItem ();
+            auto masterModule = new QTableWidgetItem ();
+            auto itemEntry = new QTableWidgetItem ();
+            auto itemLocation = new QTableWidgetItem ();
+            auto itemPriority = new QTableWidgetItem ();
             masterModule->setFlags(Qt::ItemIsUserCheckable|Qt::ItemIsEnabled|Qt::ItemIsSelectable);
             QStringList moduleInfo = pH->mInstalledModules[pModules[i]];
             masterModule->setText("sync?");
@@ -668,7 +668,7 @@ void mudlet::slot_uninstall_package()
 void mudlet::slot_package_exporter(){
     Host * pH = getActiveHost();
     if( ! pH ) return;
-    dlgPackageExporter *d = new dlgPackageExporter(this, pH);
+    auto d = new dlgPackageExporter(this, pH);
     // don't show the dialog if the user cancelled the wizard
     if (d->filePath.isEmpty()) {
         return;
@@ -804,7 +804,7 @@ void mudlet::addConsoleForNewHost( Host * pH )
 {
     if( mConsoleMap.contains( pH ) ) return;
     pH->mLogStatus = mAutolog;
-    TConsole * pConsole = new TConsole( pH, false );
+    auto pConsole = new TConsole( pH, false );
     if( ! pConsole ) return;
     pH->mpConsole = pConsole;
     pConsole->setWindowTitle( pH->getName() );
@@ -830,7 +830,7 @@ void mudlet::addConsoleForNewHost( Host * pH )
     pConsole->show();
     connect( pConsole->emergencyStop, SIGNAL(pressed()), this , SLOT(slot_stopAllTriggers()));
 
-    dlgTriggerEditor * pEditor = new dlgTriggerEditor( pH );
+    auto pEditor = new dlgTriggerEditor( pH );
     pH->mpEditorDialog = pEditor;
     pEditor->fillout_form();
 
@@ -932,12 +932,12 @@ bool mudlet::openWindow( Host * pHost, const QString & name )
 {
     if( ! dockWindowMap.contains( name ) )
     {
-        QDockWidget * pD = new QDockWidget;
+        auto pD = new QDockWidget;
         pD->setContentsMargins(0,0,0,0);
         pD->setFeatures( QDockWidget::AllDockWidgetFeatures );
         pD->setWindowTitle( name );
         dockWindowMap[name] = pD;
-        TConsole * pC = new TConsole( pHost, false );
+        auto pC = new TConsole( pHost, false );
         pC->setContentsMargins(0,0,0,0);
         pD->setWidget( pC );
         pC->show();
@@ -1789,7 +1789,7 @@ void mudlet::writeSettings()
 
 void mudlet::connectToServer()
 {
-    dlgConnectionProfiles * pDlg = new dlgConnectionProfiles(this);
+    auto pDlg = new dlgConnectionProfiles(this);
     connect (pDlg, SIGNAL (signal_establish_connection( QString, int )), this, SLOT (slot_connection_dlg_finnished(QString, int)));
     pDlg->fillout_form();
     pDlg->exec();
@@ -1877,7 +1877,7 @@ void mudlet::show_options_dialog()
 {
     Host * pHost = getActiveHost();
     if( ! pHost ) return;
-    dlgProfilePreferences * pDlg = new dlgProfilePreferences( this, pHost );
+    auto pDlg = new dlgProfilePreferences( this, pHost );
     connect(actionReconnect, SIGNAL(triggered()), pDlg->need_reconnect_for_data_protocol, SLOT(hide()));
     connect(dactionReconnect, SIGNAL(triggered()), pDlg->need_reconnect_for_data_protocol, SLOT(hide()));
     connect(actionReconnect, SIGNAL(triggered()), pDlg->need_reconnect_for_specialoption, SLOT(hide()));
@@ -2000,7 +2000,7 @@ void mudlet::slot_show_help_dialog_download()
 
 void mudlet::slot_show_about_dialog()
 {
-    dlgAboutDialog * pDlg = new dlgAboutDialog( this );
+    auto pDlg = new dlgAboutDialog( this );
     pDlg->raise();
     pDlg->show();
 }


### PR DESCRIPTION
Improved readability of code, less text to look at while all of the information is still there

I had to skip the iterators in TTrigger because .first() and .second() are used and without seeing the point right there and then, you wouldn't know what kind of data structures would those functions be operating on. Unfortunately haven't found a way yet to tell clang-tidy to ignore applying ``modernize-use-auto`` on it so it'll keep coming up in the future.

Tagging @Mudlet/core-cpp for review.