### PR TITLE
Fix replacement of the BUILD qmake variable

### DIFF
--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -20,7 +20,7 @@ if [ "${Q_OR_C_MAKE}" = "cmake" ]; then
   perl -pi -e "s/SET\(APP_BUILD \"-dev\"\)/SET(APP_BUILD \"${BUILD}\")/" "${TRAVIS_BUILD_DIR}/CMakeLists.txt"
 elif [ "${Q_OR_C_MAKE}" = "qmake" ]; then
   VERSION=$(perl -lne 'print $1 if /^VERSION = (.+)/' < "${TRAVIS_BUILD_DIR}/src/src.pro")
-  perl -pi -e "s/BUILD = -dev/BUILD = ${BUILD}/" "${TRAVIS_BUILD_DIR}/src/src.pro"
+  perl -pi -e "s/BUILD = \"-dev\"/BUILD = \"${BUILD}\"/" "${TRAVIS_BUILD_DIR}/src/src.pro"
 fi
 
 export VERSION


### PR DESCRIPTION
The variable was set into quotes, which made the replacement of the original value fail. This is corrected now.