### PR TITLE
Skip gcc builds for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ env:
   - Q_OR_C_MAKE=qmake
   global:
   - secure: VFI3UCiDrp47WTcUhsatdQvvWg+3gk00eBMZgSOXXKY5+hk+NOX7bOFcIM5t9nlZDbpHDr10SFTuUOw+PeWmLpFO06Zrjg86M9jm9WS4i8Cs9hfxoT6H4isXlR1vubX2LmNlHyzg8WtdNanlsufgecyaGksJxr7tVhG/cWyD6yo=
+matrix:
+  exclude:
+  - os: osx
+    compiler: gcc
 before_install: ./CI/travis.before_install.sh
 install: ./CI/travis.install.sh
 before_script:


### PR DESCRIPTION
Since macOS `gcc` builds are actually just clang builds with it posing as `gcc`,
we can save a little time and computing power by skipping the duplicate builds.

Fixes Mudlet/Mudlet#867