### PR TITLE
(release3_0_1)Enhance: restore version check to Mudlet XMLimport code

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -1086,7 +1086,7 @@ bool Host::installPackage( QString fileName, int module )
             {
                 mInstalledPackages.append( packageName );
             }
-            reader.importPackage( & file2, packageName, module);
+            reader.importPackage( & file2, packageName, module ); // TODO: Missing false return value handler
             setName( profileName );
             setLogin( login );
             setPass( pass );
@@ -1112,7 +1112,7 @@ bool Host::installPackage( QString fileName, int module )
         }
         else
             mInstalledPackages.append( packageName );
-        reader.importPackage( & file2, packageName, module);
+        reader.importPackage( & file2, packageName, module ); // TODO: Missing false return value handler
         setName( profileName );
         setLogin( login );
         setPass( pass );

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -25,6 +25,7 @@
 
 #include "Host.h"
 #include "LuaInterface.h"
+#include "mudlet.h"
 #include "TAction.h"
 #include "TAlias.h"
 #include "TKey.h"
@@ -127,7 +128,7 @@ bool XMLexport::writeModuleXML( QIODevice * device, QString moduleName){
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "TriggerPackage" );
     Host * pT = mpHost;
@@ -249,7 +250,7 @@ bool XMLexport::exportHost( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "HostPackage" );
     writeHost( mpHost );
@@ -561,7 +562,7 @@ bool XMLexport::exportGenericPackage( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeGenericPackage( mpHost );
 
@@ -668,7 +669,7 @@ bool XMLexport::exportTrigger( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "TriggerPackage" );
     writeTrigger( mpTrigger );
@@ -769,7 +770,7 @@ bool XMLexport::exportAlias( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "AliasPackage" );
     writeAlias( mpAlias );
@@ -824,7 +825,7 @@ bool XMLexport::exportAction( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "ActionPackage" );
     writeAction( mpAction );
@@ -897,7 +898,7 @@ bool XMLexport::exportTimer( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "TimerPackage" );
     writeTimer( mpTimer );
@@ -955,7 +956,7 @@ bool XMLexport::exportScript( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "ScriptPackage" );
     writeScript( mpScript );
@@ -1016,7 +1017,7 @@ bool XMLexport::exportKey( QIODevice * device )
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement( "MudletPackage" );
-    writeAttribute("version", "1.0");
+    writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement( "KeyPackage" );
     writeKey( mpKey );

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -42,8 +42,11 @@
 // clang-format: on
 #include <QDebug>
 #include <QStringList>
+#if QT_VERSION > 0x050002
 #include <QtMath>
-// clang-format: off
+#else
+#include <QtCore/qmath.h>
+#endif
 #include "post_guard.h"
 // clang-format: on
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -74,10 +74,10 @@ XMLimport::XMLimport(Host* pH)
 {
 }
 
-bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFlag, QString* pVersionString)
+bool XMLimport::importPackage(QFile* pfile, QString packName, int moduleFlag, QString* pVersionString)
 {
     mPackageName = packName;
-    setDevice(device);
+    setDevice(pfile);
 
     module = moduleFlag;
 
@@ -176,11 +176,13 @@ bool XMLimport::importPackage(QIODevice* device, QString packName, int moduleFla
                     /*||(mVersionMajor==1&&mVersionMinor)*/) {
                     // Minor check is not currently relevant, just abort on 2.000f or more
 
-                    QString moanMsg = tr("[ ALERT ] - Sorry, the file being read is marked as being version %1 which is\n"
-                                         "a later version than this Mudlet can handle! To avoid disappointing\n"
-                                         "behaviour it is being rejected outright. The Creators of Mudlet\n"
-                                         "suggest that you seek help on-line using the links that are available\n"
-                                         "on the screen that the \"About Mudlet\" button brings up...!")
+                    QString moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
+                                         "\"%1\"\n"
+                                         "reports it has a version (%2) it must have come from a newer Mudlet version,\n"
+                                         "which this one cannot read it, you need to update! The creators of Mudlet\n"
+                                         "suggest that you seek help and an update on-line using the links in the panel\n"
+                                         "that the \"About\" Mudlet main toolbar button shows...!")
+                                          .arg(pfile->fileName())
                                           .arg(versionString);
                     mpHost->postMessage(moanMsg);
                     return false;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -178,10 +178,8 @@ bool XMLimport::importPackage(QFile* pfile, QString packName, int moduleFlag, QS
 
                     QString moanMsg = tr("[ ALERT ] - Sorry, the file being read:\n"
                                          "\"%1\"\n"
-                                         "reports it has a version (%2) it must have come from a newer Mudlet version,\n"
-                                         "which this one cannot read it, you need to update! The creators of Mudlet\n"
-                                         "suggest that you seek help and an update on-line using the links in the panel\n"
-                                         "that the \"About\" Mudlet main toolbar button shows...!")
+                                         "reports it has a version (%2) it must have come from a later Mudlet version,\n"
+                                         "and this one cannot read it, you need a newer Mudlet!")
                                           .arg(pfile->fileName())
                                           .arg(versionString);
                     mpHost->postMessage(moanMsg);

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -50,7 +50,7 @@ class XMLimport : public QXmlStreamReader
 public:
     XMLimport(Host*);
 
-    bool importPackage(QIODevice* device, QString packageName = QString(), int moduleFlag = 0);
+    bool importPackage(QIODevice*, QString packageName = QString(), int moduleFlag = 0, QString* pVersionString = Q_NULLPTR);
 
 private:
     void readPackage();
@@ -95,6 +95,8 @@ private:
     void readStringList(QStringList&);
     void readIntegerList(QList<int>&, const QString&);
     void readModulesDetailsMap(QMap<QString, QStringList>&);
+    void getVersionString(QString&);
+
 
     Host* mpHost;
     QString mPackageName;
@@ -114,6 +116,8 @@ private:
     int module;
     int mMaxRoomId;
     int mMaxAreaId; // Could be useful when iterating through map data
+    quint8 mVersionMajor;
+    quint16 mVersionMinor; // Cannot be a quint8 as that only allows x.255 for the decimal
 };
 
 #endif // MUDLET_XMLEXPORT_H

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -26,6 +26,7 @@
 #include "pre_guard.h"
 // clang-format: on
 #include <QApplication>
+#include <QFile>
 #include <QMap>
 #include <QMultiHash>
 #include <QXmlStreamReader>
@@ -50,7 +51,7 @@ class XMLimport : public QXmlStreamReader
 public:
     XMLimport(Host*);
 
-    bool importPackage(QIODevice*, QString packageName = QString(), int moduleFlag = 0, QString* pVersionString = Q_NULLPTR);
+    bool importPackage(QFile*, QString packageName = QString(), int moduleFlag = 0, QString* pVersionString = Q_NULLPTR);
 
 private:
     void readPackage();

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -1257,7 +1257,7 @@ void dlgConnectionProfiles::slot_connectToServer()
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer( pHost );
         qDebug()<<"[LOADING PROFILE]:"<<file.fileName();
-        importer.importPackage( & file, 0);
+        importer.importPackage( & file, 0 ); // TODO: Missing false return value handler
     }
     else
     {
@@ -1348,7 +1348,7 @@ void dlgConnectionProfiles::slot_chose_history()
     Host * pHost = HostManager::self()->getHost( profile_name );
     if( ! pHost ) return;
     XMLimport importer( pHost );
-    importer.importPackage( & file );
+    importer.importPackage( & file ); // TODO: Missing false return value handler
 
     emit signal_establish_connection( profile_name, -1 );
     QDialog::accept();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -7020,7 +7020,7 @@ void dlgTriggerEditor::slot_import()
     treeWidget_scripts->clear();
 
     XMLimport reader( mpHost );
-    reader.importPackage( & file2, packageName );
+    reader.importPackage( & file2, packageName ); // TODO: Missing false return value handler
 
     mpHost->setName( profileName );
     mpHost->setLogin( login );

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -74,6 +74,30 @@ bool TConsoleMonitor::eventFilter(QObject *obj, QEvent *event)
         return QObject::eventFilter(obj, event);
     }
 }
+
+// "mMudletXmlDefaultFormat" number represents a major (integer part) and minor
+// (1000ths, range 0 to 999) that is used as a "version" attribute number when
+// writing the <MudletPackage ...> element of all (but maps if I ever get around
+// to doing a Map Xml file exporter/writer) Xml files used to export/save Mudlet
+// button/menu/toolbars; aliases. keys, scripts, timers, triggers and variables
+// and collections of these as modules/packages and entire profiles as "game
+// saves".  Mudlet versions up to 3.0.1 never bothered checking the version
+// detail and it had been hard coded as "1.0" back as far as history can
+// determine.  From that version a check was coded to test that the version
+// was less than 2.000f with the intention to loudly and clearly fail if a
+// higher version was encountered. Values above 1.000f have not yet been
+// codified but should be accepted so it should be possible to raise the number
+// a little and to use that to extend the Xml data format in a manner that older
+// versions ignore (possibly with some noise) but which they can still get the
+// details they can handle yet allow a later upgraded version to get extra
+// information they want.
+//
+// Taking this number to 2.000f or more WILL prevent old versions from reading
+// Xml files and should be considered a step associated with a major version
+// number change in the Mudlet application itself and SHOULD NOT BE DONE WITHOUT
+// agreement and consideration from the Project management, even a minor part
+// increment should not be done without justification...!
+const QString mudlet::scmMudletXmlDefaultVersion = QString::number( 1.0f, 'f', 3 );
 
 TConsole *  mudlet::mpDebugConsole = 0;
 QMainWindow * mudlet::mpDebugArea = 0;
@@ -2151,7 +2175,7 @@ void mudlet::doAutoLogin( QString & profile_name )
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer( pHost );
         qDebug()<<"[LOADING PROFILE]:"<<file.fileName();
-        importer.importPackage( & file );
+        importer.importPackage( & file ); // TODO: Missing false return value handler
     }
 
     QString login = "login";

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -123,6 +123,8 @@ public:
    void                          showUnzipProgress( QString txt );
    bool                          openWebPage(QString path);
    void                          processEventLoopHack();
+
+   static const QString         scmMudletXmlDefaultVersion;
    static TConsole *             mpDebugConsole;
    static QMainWindow *          mpDebugArea;
    static bool                   debugMode;


### PR DESCRIPTION
I foresee the need to tweak the Xml format in the future, however though there once was some checks for this in the code in the past it was commented out.  This commit is a revised version of a pull request (#370) originally aimed at the release_30 branch but which has changed so much it was easier to restart from a more up to date point.

This version checks the "version" attribute of the `MudletPackage` element of most types of XML files read (not Maps) and will allow through without comment a string value that works out to a float less than `2.000f` (three decimal place resolution) but will cause `XMLimport::importPackage(...)` to return a FALSE value - {the return is largely ignored currently} - to not read the file further and to cause an "[ ALERT ]" message on the main console should the version value be 2.000 or greater.

This is to cover the CURRENT code against problems that might arise in the future if the XML format/structure gets changed too much which will otherwise go _undetected_ by the Mudlet application as it is currently. 

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>