### PR TITLE
(release_30) Fixed GUI saved variables crashing with autologin

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2141,6 +2141,9 @@ void mudlet::doAutoLogin( QString & profile_name )
 
     if( ! pHost ) return;
 
+    LuaInterface * lI = pHost->getLuaInterface();
+    lI->getVars( true );
+
     QString folder = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/current/";
     QDir dir( folder );
     dir.setSorting(QDir::Time);


### PR DESCRIPTION
Fixed variables crash issue reported in 3.0.0 in http://forums.mudlet.org/viewtopic.php?f=9&t=19488

Tagging @Mudlet/core-cpp for review