### PR TITLE
Fixed main window buttons getting enabled when you hit Cancel

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1814,8 +1814,9 @@ void mudlet::connectToServer()
     auto pDlg = new dlgConnectionProfiles(this);
     connect (pDlg, SIGNAL (signal_establish_connection( QString, int )), this, SLOT (slot_connection_dlg_finnished(QString, int)));
     pDlg->fillout_form();
-    pDlg->exec();
-    enableToolbarButtons();
+    if (pDlg->exec() == QDialog::Accepted) {
+         enableToolbarButtons();
+    }
 }
 
 void mudlet::show_trigger_dialog()


### PR DESCRIPTION
Credit to patch at https://launchpadlibrarian.net/147506428/profile_dialogue_patch.diff from SlySven.

Fixes https://github.com/Mudlet/Mudlet/issues/610.

Tagging @Mudlet/core-cpp for review.