### PR TITLE
Revise: clean up some TEvent related stuff

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -363,7 +363,7 @@ void Host::resetProfile()
     mTimerUnit.reenableAllTriggers();
 
     TEvent event;
-    event.mArgumentList.append( "sysLoadEvent" );
+    event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     raiseEvent( event );
     qDebug()<<"resetProfile() DONE";
@@ -659,11 +659,11 @@ void Host::raiseEvent( const TEvent & pE )
 
 void Host::postIrcMessage(const QString& a, const QString& b, const QString& c )
 {
-    TEvent pE;
-    pE.mArgumentList << "sysIrcMessage";
-    pE.mArgumentList << a << b << c;
-    pE.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING;
-    raiseEvent( pE );
+    TEvent event;
+    event.mArgumentList << QLatin1String("sysIrcMessage");
+    event.mArgumentList << a << b << c;
+    event.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING;
+    raiseEvent( event );
 }
 
 void Host::enableTimer(const QString & name )

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3257,7 +3257,7 @@ void T2DMap::slot_setPlayerLocation()
         mpMap->mRoomIdHash[ mpHost->getName() ] = _newRoomId;
         mpMap->mNewMove = true;
         TEvent manualSetEvent;
-        manualSetEvent.mArgumentList.append( QStringLiteral( "sysManualLocationSetEvent" ) );
+        manualSetEvent.mArgumentList.append( QLatin1String( "sysManualLocationSetEvent" ) );
         manualSetEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
         manualSetEvent.mArgumentList.append( QString::number( _newRoomId ) );
         manualSetEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -655,16 +655,16 @@ void TConsole::resizeEvent( QResizeEvent * event )
         QString n = "WindowResizeEvent";
         pLua->call( func, n );
 
-        TEvent me;
-        me.mArgumentList.append( "sysWindowResizeEvent" );
-        me.mArgumentList.append( QString::number(x - mMainFrameLeftWidth - mMainFrameRightWidth) );
-        me.mArgumentList.append( QString::number(y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height()) );
-        me.mArgumentList.append( mConsoleName );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        mpHost->raiseEvent( me );
+        TEvent mudletEvent;
+        mudletEvent.mArgumentList.append(QLatin1String("sysWindowResizeEvent"));
+        mudletEvent.mArgumentList.append( QString::number(x - mMainFrameLeftWidth - mMainFrameRightWidth) );
+        mudletEvent.mArgumentList.append( QString::number(y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height()) );
+        mudletEvent.mArgumentList.append( mConsoleName );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        mpHost->raiseEvent( mudletEvent );
     }
 }
 
@@ -739,7 +739,7 @@ void TConsole::closeEvent( QCloseEvent *event )
     if( profile_name != "default_host" )
     {
         TEvent conCloseEvent;
-        conCloseEvent.mArgumentList.append( "sysExitEvent" );
+        conCloseEvent.mArgumentList.append(QLatin1String("sysExitEvent"));
         conCloseEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent( conCloseEvent );
 
@@ -2438,7 +2438,7 @@ void TConsole::createMapper( int x, int y, int width, int height )
         mpHost->mpMap->pushErrorMessagesToFile( tr( "Loading map(2) at %1 report" ).arg( now.toString( Qt::ISODate ) ), true );
 
         TEvent mapOpenEvent;
-        mapOpenEvent.mArgumentList.append( "mapOpenEvent" );
+        mapOpenEvent.mArgumentList.append(QLatin1String("mapOpenEvent"));
         mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent( mapOpenEvent );
     }

--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -84,7 +84,7 @@ inline QDebug& operator<<(QDebug& debug, const TEvent& event)
                     break;
                 default:
                     result.append(QLatin1String("[") % QString::number(i) % QLatin1String("{string}") % event.mArgumentList.at(i) % QLatin1String("]"));
-==              }
+                }
             }
             ++i;
         }

--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -27,6 +27,7 @@
 #include <QDebug>
 #include <QDebugStateSaver>
 #include <QList>
+#include <QStringBuilder>
 #include <QStringList>
 #include "post_guard.h"
 
@@ -50,46 +51,46 @@ inline QDebug & operator<<( QDebug & debug, const TEvent & event )
     const int argCount = event.mArgumentList.count();
     const int typeCount = event.mArgumentTypeList.count();
     int i = 0;
-    QString result( "TEvent(" );
+    QString result = QLatin1String("TEvent(");
     while( i < argCount && i < typeCount ) {
         if( Q_UNLIKELY( i >= typeCount ) ) {
-            result.append( QStringLiteral( "[%1{missing}%2]" ).arg( i ).arg( event.mArgumentList.at( i ) ) );
+            result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{missing}") % event.mArgumentList.at( i ) % QLatin1String("]") );
         }
         else {
             if( Q_UNLIKELY( i >=argCount ) ) {
                 switch( event.mArgumentTypeList.at( i ) ) {
                 case ARGUMENT_TYPE_NUMBER:
-                    result.append( QStringLiteral( "[%1{number}missing]" ).arg( i ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{number}missing]") );
                     break;
                 case ARGUMENT_TYPE_BOOLEAN:
-                    result.append( QStringLiteral( "[%1{bool}missing]" ).arg( i ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{bool}missing]") );
                     break;
                 case ARGUMENT_TYPE_NIL:
-                    result.append( QStringLiteral( "[%1{nil}missing]" ).arg( i ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{nil}missing]") );
                     break;
                 default:
-                    result.append( QStringLiteral( "[%1{string}missing]" ).arg( i ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{string}missing]") );
                 }
             }
             else {
                 switch( event.mArgumentTypeList.at( i ) ) {
                 case ARGUMENT_TYPE_NUMBER:
-                    result.append( QStringLiteral( "[%1{number}%2]" ).arg( i ).arg( event.mArgumentList.at( i ).toDouble() ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{number}") % QString::number(event.mArgumentList.at( i ).toDouble()) % QLatin1String("]") );
                     break;
                 case ARGUMENT_TYPE_BOOLEAN:
-                    result.append( QStringLiteral( "[%1{bool}%2]" ).arg( i ).arg( event.mArgumentList.at( i ).toInt() ? "true" : "false" ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{bool}") % (event.mArgumentList.at( i ).toInt()?QLatin1String("true"):QLatin1String("false")) % QLatin1String("]") );
                     break;
                 case ARGUMENT_TYPE_NIL:
-                    result.append( QStringLiteral( "[%1{nil}nil]" ).arg( i ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{nil}nil]") );
                     break;
                 default:
-                    result.append( QStringLiteral( "[%1{string}%2]" ).arg( i ).arg( event.mArgumentList.at( i ) ) );
+                    result.append( QLatin1String("[") % QString::number(i) % QLatin1String("{string}") % event.mArgumentList.at( i ) % QLatin1String("]") );
                 }
             }
             ++i;
         }
     }
-    result.append( QStringLiteral( ")" ) );
+    result.append( QLatin1String( ")" ) );
     debug.nospace() << result;
     return debug;
 }

--- a/src/TEvent.h
+++ b/src/TEvent.h
@@ -55,8 +55,7 @@ inline QDebug& operator<<(QDebug& debug, const TEvent& event)
     while (i < argCount && i < typeCount) {
         if (Q_UNLIKELY(i >= typeCount)) {
             result.append(QLatin1String("[") % QString::number(i) % QLatin1String("{missing}") % event.mArgumentList.at(i) % QLatin1String("]"));
-        }
-        else {
+        } else {
             if (Q_UNLIKELY(i >=argCount)) {
                 switch (event.mArgumentTypeList.at(i)) {
                 case ARGUMENT_TYPE_NUMBER:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -184,7 +184,7 @@ void TLuaInterpreter::slot_replyFinished(QNetworkReply * reply )
     else { // reply IS ok...
         QFile localFile( localFileName );
         if( ! localFile.open( QFile::WriteOnly ) ) {
-            event.mArgumentList << QStringLiteral("sysDownloadError");
+            event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -201,7 +201,7 @@ void TLuaInterpreter::slot_replyFinished(QNetworkReply * reply )
 
         qint64 bytesWritten = localFile.write( reply->readAll() );
         if( bytesWritten == -1 ) {
-            event.mArgumentList << QStringLiteral("sysDownloadError");
+            event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -219,7 +219,7 @@ void TLuaInterpreter::slot_replyFinished(QNetworkReply * reply )
         localFile.flush();
 
         if( localFile.error() == QFile::NoError ) {
-            event.mArgumentList << QStringLiteral("sysDownloadDone");
+            event.mArgumentList << QLatin1String("sysDownloadDone");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << localFileName;
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -227,7 +227,7 @@ void TLuaInterpreter::slot_replyFinished(QNetworkReply * reply )
             event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
         }
         else {
-            event.mArgumentList << QStringLiteral("sysDownloadError");
+            event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -167,80 +167,80 @@ void TLuaInterpreter::slot_replyFinished(QNetworkReply * reply )
     }
 
     QString localFileName = downloadMap.value( reply );
-    TEvent e;
+    TEvent event;
     if( reply->error() != QNetworkReply::NoError ) {
-        e.mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
-        e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        e.mArgumentList << reply->errorString();
-        e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        e.mArgumentList << localFileName;
-        e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        event.mArgumentList << QLatin1String("sysDownloadError");
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        event.mArgumentList << reply->errorString();
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        event.mArgumentList << localFileName;
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
         reply->deleteLater();
         downloadMap.remove( reply );
-        pHost->raiseEvent( e );
+        pHost->raiseEvent( event );
         return;
     }
     else { // reply IS ok...
         QFile localFile( localFileName );
         if( ! localFile.open( QFile::WriteOnly ) ) {
-            e.mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << localFileName;
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << tr( "unableToOpenLocalFileForWriting", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << QStringLiteral("sysDownloadError");
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << localFileName;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << tr( "unableToOpenLocalFileForWriting", "This string might not need to be translated!" );
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
             reply->deleteLater();
             downloadMap.remove( reply );
-            pHost->raiseEvent( e );
+            pHost->raiseEvent( event );
             return;
         }
 
         qint64 bytesWritten = localFile.write( reply->readAll() );
         if( bytesWritten == -1 ) {
-            e.mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << localFileName;
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << tr( "unableToWriteLocalFile", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << QStringLiteral("sysDownloadError");
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << localFileName;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << tr( "unableToWriteLocalFile", "This string might not need to be translated!" );
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
             reply->deleteLater();
             downloadMap.remove( reply );
-            pHost->raiseEvent( e );
+            pHost->raiseEvent( event );
             return;
         }
 
         localFile.flush();
 
         if( localFile.error() == QFile::NoError ) {
-            e.mArgumentList << "sysDownloadDone";
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << localFileName;
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << QString::number( bytesWritten );
-            e.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
+            event.mArgumentList << QStringLiteral("sysDownloadDone");
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << localFileName;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << QString::number( bytesWritten );
+            event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
         }
         else {
-            e.mArgumentList << tr( "sysDownloadError", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << localFileName;
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            e.mArgumentList << localFile.errorString();
-            e.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << QStringLiteral("sysDownloadError");
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << tr( "failureToWriteLocalFile", "This string might not need to be translated!" );
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << localFileName;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << localFile.errorString();
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         }
 
         localFile.close();
         reply->deleteLater();
         downloadMap.remove( reply );
-        pHost->raiseEvent( e );
+        pHost->raiseEvent( event );
     }
 }
 
@@ -3265,202 +3265,322 @@ int TLuaInterpreter::setBackgroundImage( lua_State *L )
 
 int TLuaInterpreter::setLabelClickCallback( lua_State *L )
 {
-    string luaSendText="";
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "setLabelClickCallback: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaSendText = lua_tostring( L, 1 );
-    }
-    string luaName="";
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "setLabelClickCallback: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaName = lua_tostring( L, 2 );
-    }
-
-    TEvent pE;
-
-    int n = lua_gettop( L );
-    for( int i=3; i<=n; i++)
-    {
-        if( lua_isnumber( L, i ) )
-        {
-            pE.mArgumentList.append( QString::number(lua_tonumber( L, i ) ) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        }
-        else if( lua_isstring( L, i ) )
-        {
-            pE.mArgumentList.append( QString(lua_tostring( L, i )) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        }
-    }
-
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString text(luaSendText.c_str());
-    QString name(luaName.c_str());
-    mudlet::self()->setLabelClickCallback( pHost, text, name, pE );
+    if(! pHost) {
+        lua_pushstring( L, tr( "setLabelClickCallback: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
 
-    return 0;
+    QString labelName;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "setLabelClickCallback: bad argument #1 type (label name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        labelName = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( labelName.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setLabelClickCallback: bad argument #1 value (label name cannot be an empty string.)" )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString eventName;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setLabelClickCallback: bad argument #2 type (event name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 2 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        eventName = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    TEvent event;
+    int n = lua_gettop( L );
+    for( int i = 3; i <= n; ++i ) {
+        if( lua_isnumber( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_tonumber( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        }
+        else if( lua_isstring( L, i ) ) {
+            event.mArgumentList.append( QString::fromUtf8( lua_tostring( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        }
+        else if( lua_isboolean( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_toboolean( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+        }
+        else if( lua_isnil( L, i ) ) {
+            event.mArgumentList.append( QString() );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
+        }
+        else {
+            lua_pushstring( L, tr( "setLabelClickCallback: bad argument #%1 type (boolean, number, string or nil\n"
+                                   "expected, got a %2!)" )
+                            .arg( i )
+                            .arg( luaL_typename( L, i ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+    }
+
+    if( L, mudlet::self()->setLabelClickCallback( pHost, labelName, eventName, event ) ) {
+        lua_pushboolean( L, true );
+        return 1;
+    } else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setLabelClickCallback: bad argument #1 value (label name \"%1\" not found.)" )
+                        .arg( labelName )
+                        .toUtf8().constData() );
+        return 2;
+    }
 }
 
 int TLuaInterpreter::setLabelReleaseCallback( lua_State *L )
 {
-    string luaSendText="";
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "setLabelReleaseCallback: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaSendText = lua_tostring( L, 1 );
-    }
-    string luaName="";
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "setLabelReleaseCallback: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaName = lua_tostring( L, 2 );
-    }
-
-    TEvent pE;
-
-    int n = lua_gettop( L );
-    for( int i=3; i<=n; i++)
-    {
-        if( lua_isnumber( L, i ) )
-        {
-            pE.mArgumentList.append( QString::number(lua_tonumber( L, i ) ) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        }
-        else if( lua_isstring( L, i ) )
-        {
-            pE.mArgumentList.append( QString(lua_tostring( L, i )) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        }
-    }
-
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString text(luaSendText.c_str());
-    QString name(luaName.c_str());
-    mudlet::self()->setLabelReleaseCallback( pHost, text, name, pE );
+    if(! pHost) {
+        lua_pushstring( L, tr( "setLabelReleaseCallback: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
 
-    return 0;
+    QString labelName;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "setLabelReleaseCallback: bad argument #1 type (label name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        labelName = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( labelName.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setLabelReleaseCallback: bad argument #1 value (label name cannot be an empty string.)" )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString eventName;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setLabelReleaseCallback: bad argument #2 type (event name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 2 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        eventName = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    TEvent event;
+    int n = lua_gettop( L );
+    for( int i = 3; i <= n; ++i ) {
+        if( lua_isnumber( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_tonumber( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        }
+        else if( lua_isstring( L, i ) ) {
+            event.mArgumentList.append( QString::fromUtf8( lua_tostring( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        }
+        else if( lua_isboolean( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_toboolean( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+        }
+        else if( lua_isnil( L, i ) ) {
+            event.mArgumentList.append( QString() );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
+        }
+        else {
+            lua_pushstring( L, tr( "setLabelReleaseCallback: bad argument #%1 type (boolean, number, string or nil\n"
+                                   "expected, got a %2!)" )
+                            .arg( i )
+                            .arg( luaL_typename( L, i ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+    }
+
+    if( L, mudlet::self()->setLabelReleaseCallback( pHost, labelName, eventName, event ) ) {
+        lua_pushboolean( L, true );
+        return 1;
+    } else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setLabelReleaseCallback: bad argument #1 value (label name \"%1\" not found.)" )
+                        .arg( labelName )
+                        .toUtf8().constData() );
+        return 2;
+    }
 }
 
 int TLuaInterpreter::setLabelOnEnter( lua_State *L )
 {
-    string luaSendText="";
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "setLabelOnEnter: wrong first argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaSendText = lua_tostring( L, 1 );
-    }
-    string luaName="";
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "setLabelOnEnter: wrong second argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaName = lua_tostring( L, 2 );
-    }
-
-    TEvent pE;
-
-    int n = lua_gettop( L );
-    for( int i=3; i<=n; i++)
-    {
-        if( lua_isnumber( L, i ) )
-        {
-            pE.mArgumentList.append( QString::number(lua_tonumber( L, i ) ) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        }
-        else if( lua_isstring( L, i ) )
-        {
-            pE.mArgumentList.append( QString(lua_tostring( L, i )) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        }
-    }
-
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString text(luaSendText.c_str());
-    QString name(luaName.c_str());
-    mudlet::self()->setLabelOnEnter( pHost, text, name, pE );
+    if(! pHost) {
+        lua_pushstring( L, tr( "setLabelOnEnter: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
 
-    return 0;
+    QString labelName;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "setLabelOnEnter: bad argument #1 type (label name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        labelName = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( labelName.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setLabelOnEnter: bad argument #1 value (label name cannot be an empty string.)" )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString eventName;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setLabelOnEnter: bad argument #2 type (event name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 2 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        eventName = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    TEvent event;
+    int n = lua_gettop( L );
+    for( int i = 3; i <= n; ++i ) {
+        if( lua_isnumber( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_tonumber( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        }
+        else if( lua_isstring( L, i ) ) {
+            event.mArgumentList.append( QString::fromUtf8( lua_tostring( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        }
+        else if( lua_isboolean( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_toboolean( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+        }
+        else if( lua_isnil( L, i ) ) {
+            event.mArgumentList.append( QString() );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
+        }
+        else {
+            lua_pushstring( L, tr( "setLabelOnEnter: bad argument #%1 type (boolean, number, string or nil expected,"
+                                   "got a %2!)" )
+                            .arg( i )
+                            .arg( luaL_typename( L, i ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+    }
+
+    if( L, mudlet::self()->setLabelOnEnter( pHost, labelName, eventName, event ) ) {
+        lua_pushboolean( L, true );
+        return 1;
+    } else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setLabelOnEnter: bad argument #1 value (label name \"%1\" not found.)" )
+                        .arg( labelName )
+                        .toUtf8().constData() );
+        return 2;
+    }
 }
 
 int TLuaInterpreter::setLabelOnLeave( lua_State *L )
 {
-    string luaSendText="";
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushstring( L, "setLabelOnLeave: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaSendText = lua_tostring( L, 1 );
-    }
-    string luaName="";
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushstring( L, "setLabelOnLeave: wrong argument type" );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaName = lua_tostring( L, 2 );
-    }
-
-    TEvent pE;
-
-    int n = lua_gettop( L );
-    for( int i=3; i<=n; i++)
-    {
-        if( lua_isnumber( L, i ) )
-        {
-            pE.mArgumentList.append( QString::number(lua_tonumber( L, i ) ) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        }
-        else if( lua_isstring( L, i ) )
-        {
-            pE.mArgumentList.append( QString(lua_tostring( L, i )) );
-            pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        }
-    }
-
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
-    QString text(luaSendText.c_str());
-    QString name(luaName.c_str());
-    mudlet::self()->setLabelOnLeave( pHost, text, name, pE );
+    if(! pHost) {
+        lua_pushstring( L, tr( "setLabelOnLeave: NULL Host pointer - something is wrong!" )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    }
 
-    return 0;
+    QString labelName;
+    if( ! lua_isstring( L, 1 ) ) {
+        lua_pushstring( L, tr( "setLabelOnLeave: bad argument #1 type (label name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 1 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        labelName = QString::fromUtf8( lua_tostring( L, 1 ) );
+        if( labelName.isEmpty() ) {
+            lua_pushnil( L );
+            lua_pushstring( L, tr( "setLabelOnLeave: bad argument #1 value (label name cannot be an empty string.)" )
+                            .toUtf8().constData() );
+            return 2;
+        }
+    }
+
+    QString eventName;
+    if( ! lua_isstring( L, 2 ) ) {
+        lua_pushstring( L, tr( "setLabelOnLeave: bad argument #2 type (event name as string expected, got %1!)" )
+                        .arg( luaL_typename( L, 2 ) )
+                        .toUtf8().constData() );
+        lua_error( L );
+        return 1;
+    } else {
+        eventName = QString::fromUtf8( lua_tostring( L, 2 ) );
+    }
+
+    TEvent event;
+    int n = lua_gettop( L );
+    for( int i = 3; i <= n; ++i ) {
+        if( lua_isnumber( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_tonumber( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        }
+        else if( lua_isstring( L, i ) ) {
+            event.mArgumentList.append( QString::fromUtf8( lua_tostring( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        }
+        else if( lua_isboolean( L, i ) ) {
+            event.mArgumentList.append( QString::number( lua_toboolean( L, i ) ) );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_BOOLEAN );
+        }
+        else if( lua_isnil( L, i ) ) {
+            event.mArgumentList.append( QString() );
+            event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
+        }
+        else {
+            lua_pushstring( L, tr( "setLabelOnLeave: bad argument type #%1 (boolean, number, string or nil expected,"
+                                   "got a %2!)" )
+                            .arg( i )
+                            .arg( luaL_typename( L, i ) )
+                            .toUtf8().constData() );
+            lua_error( L );
+            return 1;
+        }
+    }
+
+    if( L, mudlet::self()->setLabelOnLeave( pHost, labelName, eventName, event ) ) {
+        lua_pushboolean( L, true );
+        return 1;
+    } else {
+        lua_pushnil( L );
+        lua_pushstring( L, tr( "setLabelOnLeave: bad argument #1 value (label name \"%1\" not found.)" )
+                        .arg( labelName )
+                        .toUtf8().constData() );
+        return 2;
+    }
 }
 
 int TLuaInterpreter::setTextFormat( lua_State * L )
@@ -12308,7 +12428,7 @@ void TLuaInterpreter::setAtcpTable(const QString & var, const QString & arg )
 {
     lua_State * L = pGlobalLua;
     lua_getglobal( L, "atcp" ); //defined in LuaGlobal.lua
-    lua_pushstring( L, var.toLatin1().data() );
+    lua_pushstring( L, var.toLatin1().data() ); // CHECK: Does ATCP use utf-8?
     lua_pushstring( L, arg.toLatin1().data() );
     lua_rawset( L, -3 );
     lua_pop( L, 1 );
@@ -12643,8 +12763,7 @@ void TLuaInterpreter::setChannel102Table( int & var, int & arg )
     lua_pop( L, 1 );
 
     TEvent event;
-    QString e = "channel102Message";
-    event.mArgumentList.append( e );
+    event.mArgumentList.append( QStringLiteral("channel102Message") );
     event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
     event.mArgumentList.append( QString::number(var) );
     event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2391,7 +2391,7 @@ void TMap::slot_replyFinished( QNetworkReply * reply )
 
                     if( readXmlMapFile( file ) ) {
                         TEvent mapDownloadEvent;
-                        mapDownloadEvent.mArgumentList.append( QStringLiteral( "sysMapDownloadEvent" ) );
+                        mapDownloadEvent.mArgumentList.append( QLatin1String( "sysMapDownloadEvent" ) );
                         mapDownloadEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
                         pHost->raiseEvent( mapDownloadEvent );
                     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1156,30 +1156,30 @@ void TTextEdit::mousePressEvent( QMouseEvent * event )
 {
     if( ! mpConsole->mIsSubConsole && ! mpConsole->mIsDebugConsole )
     {
-        TEvent me;
-        me.mArgumentList.append( "sysWindowMousePressEvent" );
+        TEvent mudletEvent;
+        mudletEvent.mArgumentList.append( QLatin1String("sysWindowMousePressEvent") );
         switch( event->button() )
         {
         case Qt::LeftButton:
-            me.mArgumentList.append( QString::number(1) );
+            mudletEvent.mArgumentList.append( QString::number(1) );
             break;
         case Qt::RightButton:
-            me.mArgumentList.append( QString::number(2) );
+            mudletEvent.mArgumentList.append( QString::number(2) );
             break;
         case Qt::MidButton:
-            me.mArgumentList.append( QString::number(3) );
+            mudletEvent.mArgumentList.append( QString::number(3) );
             break;
-        default:
-            me.mArgumentList.append( 0 );
+        default: // TODO: What about those of us with more than three mouse buttons?
+            mudletEvent.mArgumentList.append( 0 );
             break;
         }
-        me.mArgumentList.append( QString::number(event->x()) );
-        me.mArgumentList.append( QString::number(event->y()) );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        mpHost->raiseEvent( me );
+        mudletEvent.mArgumentList.append( QString::number(event->x()) );
+        mudletEvent.mArgumentList.append( QString::number(event->y()) );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mpHost->raiseEvent( mudletEvent );
     }
     if( event->button() == Qt::LeftButton )
     {
@@ -1536,30 +1536,30 @@ void TTextEdit::mouseReleaseEvent( QMouseEvent * event )
     }
     if( ! mpConsole->mIsSubConsole && ! mpConsole->mIsDebugConsole )
     {
-        TEvent me;
-        me.mArgumentList.append( "sysWindowMouseReleaseEvent" );
+        TEvent mudletEvent;
+        mudletEvent.mArgumentList.append( QLatin1String("sysWindowMouseReleaseEvent") );
         switch( event->button() )
         {
         case Qt::LeftButton:
-            me.mArgumentList.append( QString::number(1) );
+            mudletEvent.mArgumentList.append( QString::number(1) );
             break;
         case Qt::RightButton:
-            me.mArgumentList.append( QString::number(2) );
+            mudletEvent.mArgumentList.append( QString::number(2) );
             break;
         case Qt::MidButton:
-            me.mArgumentList.append( QString::number(3) );
+            mudletEvent.mArgumentList.append( QString::number(3) );
             break;
         default:
-            me.mArgumentList.append( QString::number(0) );
+            mudletEvent.mArgumentList.append( QString::number(0) );
             break;
         }
-        me.mArgumentList.append( QString::number(event->x()) );
-        me.mArgumentList.append( QString::number(event->y()) );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-        mpHost->raiseEvent( me );
+        mudletEvent.mArgumentList.append( QString::number(event->x()) );
+        mudletEvent.mArgumentList.append( QString::number(event->y()) );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mudletEvent.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+        mpHost->raiseEvent( mudletEvent );
     }
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -253,20 +253,20 @@ void cTelnet::handle_socket_signal_connected()
         mTimerPass->start(3000);
     }
     //sendTelnetOption(252,3);// try to force GA by telling the server that we are NOT willing to supress GA signals
-    TEvent me;
-    me.mArgumentList.append( "sysConnectionEvent" );
-    me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    mpHost->raiseEvent( me );
+    TEvent event;
+    event.mArgumentList.append( QLatin1String("sysConnectionEvent") );
+    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    mpHost->raiseEvent( event );
 
 }
 
 void cTelnet::handle_socket_signal_disconnected()
 {
     postData();
-    TEvent me;
-    me.mArgumentList.append( "sysDisconnectionEvent" );
-    me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    mpHost->raiseEvent( me );
+    TEvent event;
+    event.mArgumentList.append( QLatin1String("sysDisconnectionEvent") );
+    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    mpHost->raiseEvent( event );
     QString msg;
     QTime timeDiff(0,0,0,0);
     msg = QString("[ INFO ]  - Connection time: %1\n    ").arg(timeDiff.addMSecs(mConnectionTime.elapsed()).toString("hh:mm:ss.zzz"));
@@ -308,12 +308,12 @@ bool cTelnet::sendData( QString & data )
     {
         data.replace(QChar('\n'),"");
     }
-    TEvent pE;
-    pE.mArgumentList.append( "sysDataSendRequest" );
-    pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    pE.mArgumentList.append( data );
-    pE.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    mpHost->raiseEvent( pE );
+    TEvent event;
+    event.mArgumentList.append(QLatin1String("sysDataSendRequest"));
+    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    event.mArgumentList.append( data );
+    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    mpHost->raiseEvent(event);
     if( mpHost->mAllowToSendCommand )
     {
         string outdata = (outgoingDataCodec->fromUnicode(data)).data();
@@ -1062,17 +1062,19 @@ void cTelnet::processTelnetCommand( const string & command )
       unsigned char type = static_cast<unsigned char>(command[1]);
       unsigned char telnetOption = static_cast<unsigned char>(command[2]);
       QString msg = command.c_str();
-      if( command.size() >= 6 ) msg = msg.mid( 3, command.size()-5 );
-      TEvent me;
-      me.mArgumentList.append( "sysTelnetEvent" );
-      me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-      me.mArgumentList.append( QString::number(type) );
-      me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-      me.mArgumentList.append( QString::number(telnetOption) );
-      me.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
-      me.mArgumentList.append( msg );
-      me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-      mpHost->raiseEvent( me );
+      if( command.size() >= 6 ) {
+          msg = msg.mid( 3, command.size()-5 );
+      }
+      TEvent event;
+      event.mArgumentList.append(QLatin1String("sysTelnetEvent"));
+      event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+      event.mArgumentList.append( QString::number(type) );
+      event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+      event.mArgumentList.append( QString::number(telnetOption) );
+      event.mArgumentTypeList.append( ARGUMENT_TYPE_NUMBER );
+      event.mArgumentList.append( msg );
+      event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+      mpHost->raiseEvent( event );
   }
 }
 
@@ -2029,10 +2031,10 @@ MAIN_LOOP_END: ;
 
 void cTelnet::raiseProtocolEvent( const QString & name, const QString & protocol )
 {
-    TEvent me;
-    me.mArgumentList.append( name );
-    me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    me.mArgumentList.append( protocol );
-    me.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
-    mpHost->raiseEvent( me );
+    TEvent event;
+    event.mArgumentList.append( name );
+    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    event.mArgumentList.append( protocol );
+    event.mArgumentTypeList.append( ARGUMENT_TYPE_STRING );
+    mpHost->raiseEvent( event );
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1983,7 +1983,7 @@ void mudlet::createMapper( bool isToLoadDefaultMapFile )
 
     check_for_mappingscript();
     TEvent mapOpenEvent;
-    mapOpenEvent.mArgumentList.append( "mapOpenEvent" );
+    mapOpenEvent.mArgumentList.append(QLatin1String("mapOpenEvent"));
     mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     pHost->raiseEvent( mapOpenEvent );
 }
@@ -2267,7 +2267,7 @@ void mudlet::slot_connection_dlg_finnished( const QString& profile, int historyV
     packagesToInstallList.clear();
 
     TEvent event;
-    event.mArgumentList.append( "sysLoadEvent" );
+    event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     pHost->raiseEvent( event );
 


### PR DESCRIPTION
Ensure all system generated events have event names that are NOT subjected to translation.  However as I have recently learned that `QLatin1String` is a better choice in most circumstances as opposed to `QStringLiteral` I have changed to use them instead.

Rename some `TEvent` instances where our convention on naming suggested the data structure reference was a pointed to a `TEvent` rather than the `TEvent` itself (i.e. use of `pE` - at some stage in the past we were using pointers!)

Revamp `TLuaInterpreter::setLabelClickCallback`, `setLabelReleaseCallback`, `setLabelOnEnter` and `setLabelOnLeave` to handle event arguments of `boolean` and `nil` types - as we have expanded the range for `TEvents` everywhere else. Also now returns a boolean `true` on success to find the given label or `nil` and an "error message" on various run-time failures - including not finding the label.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>