### PR TITLE
BugFix: prevent clipping of Editor search term entry widget

### DIFF
--- a/src/ui/trigger_editor.ui
+++ b/src/ui/trigger_editor.ui
@@ -486,12 +486,6 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>30</height>
-              </size>
-             </property>
              <property name="palette">
               <palette>
                <active>


### PR DESCRIPTION
There was a constraint set on a parent widget that prevented the `QComboBox` that is used to enter search terms from re-sizing itself to accommodate larger text than the form was originally designed for.

This commit removes that constraint and should prevent the clipping that was reported to be occurring.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>