### PR TITLE
Added Lua closeMudlet() 

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2499,6 +2499,12 @@ int TLuaInterpreter::killTrigger( lua_State *L )
     return 1;
 }
 
+int TLuaInterpreter::closeMudlet(lua_State* L)
+{
+    mudlet::self()->shutDown();
+    return 0;
+}
+
 // openUserWindow( session, string window_name )
 int TLuaInterpreter::openUserWindow( lua_State *L )
 {
@@ -13142,6 +13148,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "tempTimer", TLuaInterpreter::tempTimer );
     lua_register( pGlobalLua, "tempTrigger", TLuaInterpreter::tempTrigger );
     lua_register( pGlobalLua, "tempRegexTrigger", TLuaInterpreter::tempRegexTrigger );
+    lua_register( pGlobalLua, "closeMudlet", TLuaInterpreter::closeMudlet);
     lua_register( pGlobalLua, "openUserWindow", TLuaInterpreter::openUserWindow );
     lua_register( pGlobalLua, "echoUserWindow", TLuaInterpreter::echoUserWindow );
     lua_register( pGlobalLua, "enableTimer", TLuaInterpreter::enableTimer );

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2501,7 +2501,7 @@ int TLuaInterpreter::killTrigger( lua_State *L )
 
 int TLuaInterpreter::closeMudlet(lua_State* L)
 {
-    mudlet::self()->shutDown();
+    mudlet::self()->forceClose();
     return 0;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -238,6 +238,7 @@ public:
     static int setFgColor( lua_State * L );
     static int setBgColor( lua_State * L );
     static int tempTimer( lua_State * L );
+    static int closeMudlet( lua_State* L );
     static int openUserWindow( lua_State * L );
     static int echoUserWindow( lua_State * L );
     static int clearUserWindow( lua_State * L );

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1726,7 +1726,7 @@ void mudlet::closeEvent(QCloseEvent *event)
     qApp->quit();
 }
 
-void mudlet::shutDown()
+void mudlet::forceClose()
 {
     for (auto console : mConsoleMap) {
         console->mUserAgreedToCloseConsole = true;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1726,6 +1726,15 @@ void mudlet::closeEvent(QCloseEvent *event)
     qApp->quit();
 }
 
+void mudlet::shutDown()
+{
+    for (auto console : mConsoleMap) {
+        console->mUserAgreedToCloseConsole = true;
+    }
+
+    //closeEvent();
+    close();
+}
 
 void mudlet::readSettings()
 {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1731,8 +1731,7 @@ void mudlet::shutDown()
     for (auto console : mConsoleMap) {
         console->mUserAgreedToCloseConsole = true;
     }
-
-    //closeEvent();
+    
     close();
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -82,7 +82,7 @@ public:
    Host *                        getActiveHost();
    void                          registerTimer( TTimer *, QTimer * );
    void                          unregisterTimer( QTimer * );
-   void                          shutDown();
+   void                          forceClose();
    bool                          openWindow( Host *, const QString & );
    bool                          createMiniConsole( Host *, const QString &, int, int, int, int );
    bool                          createLabel( Host *, const QString &, int, int, int, int, bool );

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -82,6 +82,7 @@ public:
    Host *                        getActiveHost();
    void                          registerTimer( TTimer *, QTimer * );
    void                          unregisterTimer( QTimer * );
+   void                          shutDown();
    bool                          openWindow( Host *, const QString & );
    bool                          createMiniConsole( Host *, const QString &, int, int, int, int );
    bool                          createLabel( Host *, const QString &, int, int, int, int, bool );


### PR DESCRIPTION
 Allows Mudlet Lua scripts to simply save and close open profiles and then closes the application.

Botman uses Mudlet like it is a service and sometimes the service needs to be restarted by admin users of the Botman service.  This function allows Botman to script the entire restart process so service admin users can instruct the service to restart via command input and don't need to use remote desktop to restart the application and botman services. 