### PR TITLE
Fix tag deployment

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -31,7 +31,7 @@ if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "clang" ]; then
 
     mv "${HOME}/Desktop/Mudlet.dmg" "${HOME}/Desktop/Mudlet-${VERSION}.dmg"
 
-    DEPLOY_URL=$(scp -i /tmp/mudlet-deploy-key "${HOME}/Desktop/Mudlet-${VERSION}.dmg" "keneanung@mudlet.org:${DEPLOY_PATH}")
+    DEPLOY_URL=$(scp -i /tmp/mudlet-deploy-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/Mudlet-${VERSION}.dmg" "keneanung@mudlet.org:${DEPLOY_PATH}")
   fi
   export DEPLOY_URL
 fi

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -31,7 +31,8 @@ if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "clang" ]; then
 
     mv "${HOME}/Desktop/Mudlet.dmg" "${HOME}/Desktop/Mudlet-${VERSION}.dmg"
 
-    DEPLOY_URL=$(scp -i /tmp/mudlet-deploy-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/Mudlet-${VERSION}.dmg" "keneanung@mudlet.org:${DEPLOY_PATH}")
+    scp -i /tmp/mudlet-deploy-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "${HOME}/Desktop/Mudlet-${VERSION}.dmg" "keneanung@mudlet.org:${DEPLOY_PATH}"
+    DEPLOY_URL="http://www.mudlet.org/wp-content/files/Mudlet-${VERSION}.dmg"
   fi
   export DEPLOY_URL
 fi


### PR DESCRIPTION
This fixes some issues with the deployment of tags for macOS:
- `mudlet.org` was not among the known hosts. We skip the check now, as the kkeys get added at startup time only anyways.
- `DEPLOY_URL` was never properly set

@Mudlet/infrastructure should review this