### PR TITLE
Cleanup comments so that they are always just before their referent.

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -63,12 +63,14 @@ public:
     void wheelEvent(QWheelEvent*) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* e) override;
-    bool getCenterSelection();
+
     // Was getTopLeft() which returned an index into mMultiSelectionList but that
     // has been been changed to mMultiSelectionSet which cannot be accessed via
     // an index in the same way - this function now sets
     // mMultiSelectionHighlightRoomId and returns a (bool) on success or failure
     // to do so.
+    bool getCenterSelection();
+
     void setRoomSize(double);
     void setExitSize(double);
     void createLabel(QRectF labelRect);

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -351,17 +351,20 @@ void TAction::expandToolbar( TEasyButtonBar * pT )
 
        if( action->mIsFolder )
        {
-           auto newMenu = new QMenu( button );
            // This applied the CSS for THIS TAction to a CHILD's own menu - is this right
-           newMenu->setStyleSheet( css );
+           auto newMenu = new QMenu( button );
+
            // CHECK: consider using the Child's CSS instead for a menu on it
            // - Slysven:
            // newMenu->setStyleSheet( action->css );
-           action->fillMenu( pT, newMenu );
+           newMenu->setStyleSheet( css );
+
            // This has been moved until AFTER the child's menu has been
            // populated, it was being done straight after newMenu was created,
            // but I think we ought to insert the items into the menu before
            // applying the menu to the button - Slysven
+           action->fillMenu( pT, newMenu );
+
            button->setMenu( newMenu );
        }
 
@@ -412,10 +415,12 @@ void TAction::fillMenu( TEasyButtonBar * pT, QMenu * menu )
             // find the item that it is attached to - ah ha, try the toolbar...
             auto newMenu = new QMenu( pT );
             newAction->setMenu( newMenu );
-            newMenu->setStyleSheet( css );
+
             // CHECK: consider using the Child's CSS instead for a menu on it
             // - Slysven:
             // newMenu->setStyleSheet( action->css );
+            newMenu->setStyleSheet( css );
+
             action->fillMenu( pT, newMenu );
         }
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -139,9 +139,10 @@ public:
     // both at the same time thanks to mXmlImportMutex
     bool readXmlMapFile(QFile&, QString* errMsg = Q_NULLPTR);
 
-    // Use progresss dialog for post-download operations:
+    // Use progress dialog for post-download operations.
     void reportStringToProgressDialog(const QString);
 
+    // Use progress dialog for post-download operations.
     void reportProgressToProgressDialog(const int, const int);
 
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -97,7 +97,10 @@ public:
     void tidyMap(int area);
     bool setExit(int from, int to, int dir);
     bool setRoomCoordinates(int id, int x, int y, int z);
-    void audit(); // Was init( Host * ) but host pointer was not used and it does not initialise a map!
+
+    // Was init( Host * ) but host pointer was not used and it does not initialise a map!
+    void audit();
+
     QList<int> detectRoomCollisions(int id);
     void solveRoomCollision(int id, int creationDirection, bool PCheck = true);
     void setRoom(int);
@@ -111,34 +114,41 @@ public:
     void initGraph();
     void connectExitStub(int roomId, int dirType);
     void postMessage(const QString text);
-    void set3DViewCenter(const int, const int, const int, const int);
+
     // Used by the 2D mapper to send view center coordinates to 3D one
+    void set3DViewCenter(const int, const int, const int, const int);
 
     void appendRoomErrorMsg(const int, const QString, const bool isToSetFileViewingRecommended = false);
     void appendAreaErrorMsg(const int, const QString, const bool isToSetFileViewingRecommended = false);
     void appendErrorMsg(const QString, const bool isToSetFileViewingRecommended = false);
     void appendErrorMsgWithNoLf(const QString, const bool isToSetFileViewingRecommended = false);
-    void pushErrorMessagesToFile(const QString, const bool isACleanup = false);
+
     // If the argument is true does not write out any thing if there is no data
     // to dump, intended to be used before an operation like a map load so that
     // any messages previously recorded are not associated with a "fresh" batch
     // from the operation.
+    void pushErrorMessagesToFile(const QString, const bool isACleanup = false);
 
     // Moved and revised from dlgMapper:
     void downloadMap(const QString* remoteUrl = Q_NULLPTR, const QString* localFileName = Q_NULLPTR);
+
     // Also uses readXmlMapFile(...) but for local files:
     bool importMap(QFile&, QString* errMsg = Q_NULLPTR);
+
     // Used at end of downloadMap(...) OR as part of importMap(...) but not by
     // both at the same time thanks to mXmlImportMutex
     bool readXmlMapFile(QFile&, QString* errMsg = Q_NULLPTR);
+
     // Use progresss dialog for post-download operations:
     void reportStringToProgressDialog(const QString);
+
     void reportProgressToProgressDialog(const int, const int);
 
 
     TRoomDB* mpRoomDB;
     QMap<int, int> envColors;
     QPointer<Host> mpHost;
+
     // Was a single int mRoomId but that breaks things when maps are
     // copied/shared between profiles - so now we track the profile name
     QHash<QString, int> mRoomIdHash;
@@ -153,7 +163,10 @@ public:
     QList<int> mWeightList;
     QMap<int, QColor> customEnvColors;
     QMap<int, QVector3D> unitVectors;
-    QMap<int, int> reverseDirections; // contains complementary directions of dirs on TRoom.h
+
+    // contains complementary directions of dirs on TRoom.h
+    QMap<int, int> reverseDirections;
+
     GLWidget* mpM;
     dlgMapper* mpMapper;
     QMap<int, int> roomidToIndex;
@@ -209,13 +222,21 @@ private:
 
     QStringList mStoredMessages;
 
-    QMap<int, QList<QString>> mMapAuditRoomErrors; // Key is room number (where renumbered is the original one), Value is the errors, appended as they are found
-    QMap<int, QList<QString>> mMapAuditAreaErrors; // As for the Room ones but with key as the area number
-    QList<QString> mMapAuditErrors;                // For the whole map
-    bool mIsFileViewingRecommended;                // Are things so bad the user needs to check the log (ignored if messages ARE already sent to screen)
+    // Key is room number (where renumbered is the original one), Value is the errors, appended as they are found
+    QMap<int, QList<QString>> mMapAuditRoomErrors;
+
+    // As for the Room ones but with key as the area number
+    QMap<int, QList<QString>> mMapAuditAreaErrors;
+
+    // For the whole map
+    QList<QString> mMapAuditErrors;
+
+    // Are things so bad the user needs to check the log (ignored if messages ARE already sent to screen)
+    bool mIsFileViewingRecommended;
 
     // Moved and revised from dlgMapper:
     QNetworkAccessManager* mpNetworkAccessManager;
+
     QProgressDialog* mpProgressDialog;
     QNetworkReply* mpNetworkReply;
     QString mLocalMapFileName;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1742,11 +1742,13 @@ void mudlet::readSettings()
     mShowMenuBar = settings.value("showMenuBar",QVariant(0)).toBool();
     mShowToolbar = settings.value("showToolbar",QVariant(0)).toBool();
     mEditorTextOptions = QTextOption::Flags( settings.value( "editorTextOptions",QVariant(0)).toInt() );
-    mStatusBarState = StatusBarOptions( settings.value( "statusBarOptions", statusBarHidden ).toInt() );
+
     // By default the status bar will not be shown for new/upgraded
     // installations - if the user wants the status bar shown either all the
     // time or when it has something to show, they will have to enable that
     // themselves, but that only has to be done once! - Slysven
+    mStatusBarState = StatusBarOptions( settings.value( "statusBarOptions", statusBarHidden ).toInt() );
+
     mIsToDisplayMapAuditErrorsToConsole = settings.value( "reportMapIssuesToConsole", QVariant(false)).toBool();
     resize( size );
     move( pos );


### PR DESCRIPTION
Also use whitespace to reenforce the association between them.