### PR TITLE
Added saveProfile()

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -369,6 +369,28 @@ void Host::resetProfile()
     qDebug()<<"resetProfile() DONE";
 }
 
+// Saves profile to disk - does not save items dirty in the editor, however.
+// returns true if successful or false+error message if not
+std::pair<bool, QString> Host::saveProfile()
+{
+    QString directory_xml = QDir::homePath() + "/.config/mudlet/profiles/" + getName() + "/current";
+    QString filename_xml = directory_xml + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + ".xml";
+    QDir dir_xml;
+    if (!dir_xml.exists(directory_xml)) {
+        dir_xml.mkpath(directory_xml);
+    }
+    QFile file_xml(filename_xml);
+    if (file_xml.open(QIODevice::WriteOnly)) {
+        XMLexport writer(this);
+        writer.exportHost(&file_xml);
+        file_xml.close();
+        saveModules(1);
+        return std::make_pair(true, QString());
+    } else {
+        return std::make_pair(false, tr("Couldn't save %1 to %2 because: %3").arg(getName(), filename_xml, file_xml.errorString()));
+    }
+}
+
 // Now returns the total weight of the path
 const unsigned int Host::assemblePath()
 {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1159,7 +1159,7 @@ bool Host::installPackage( const QString& fileName, int module )
        mpEditorDialog->doCleanReset();
     }
     if (!module) {
-        saveProfile(nullptr);
+        saveProfile();
     }
     // reorder permanent and temporary triggers: perm first, temp second
     mTriggerUnit.reorderTriggersAfterPackageImport();
@@ -1348,7 +1348,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     _home.append( getName() );
     QString _dest = QString( "%1/%2/").arg( _home ).arg( packageName );
     removeDir( _dest, _dest );
-    saveProfile(nullptr);
+    saveProfile();
     //NOW we reset if we're uninstalling a module
     if( mpEditorDialog && module == 3 )
     {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -371,7 +371,7 @@ void Host::resetProfile()
 
 // Saves profile to disk - does not save items dirty in the editor, however.
 // returns true if successful or false+error message if not
-std::pair<bool, QString> Host::saveProfile()
+std::tuple<bool, QString, QString> Host::saveProfile()
 {
     QString directory_xml = QDir::homePath() + "/.config/mudlet/profiles/" + getName() + "/current";
     QString filename_xml = directory_xml + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + ".xml";
@@ -385,9 +385,11 @@ std::pair<bool, QString> Host::saveProfile()
         writer.exportHost(&file_xml);
         file_xml.close();
         saveModules(1);
-        return std::make_pair(true, QString());
+        return std::make_tuple(true, QString(), QString());
     } else {
-        return std::make_pair(false, tr("Couldn't save %1 to %2 because: %3").arg(getName(), filename_xml, file_xml.errorString()));
+        return std::make_tuple(false,
+                               QLatin1String("Couldn't save ") % getName() % " to " % filename_xml % " because: " % file_xml.errorString(),
+                               tr("Couldn't save %1 to %2 because: %3").arg(getName(), filename_xml, file_xml.errorString()));
     }
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -371,7 +371,7 @@ void Host::resetProfile()
 
 // Saves profile to disk - does not save items dirty in the editor, however.
 // returns true if successful or false+error message if not
-std::tuple<bool, QString, QString> Host::saveProfile()
+std::tuple<bool, QString, QString, QString, QString> Host::saveProfile()
 {
     QString directory_xml = QDir::homePath() + "/.config/mudlet/profiles/" + getName() + "/current";
     QString filename_xml = directory_xml + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + ".xml";
@@ -385,11 +385,9 @@ std::tuple<bool, QString, QString> Host::saveProfile()
         writer.exportHost(&file_xml);
         file_xml.close();
         saveModules(1);
-        return std::make_tuple(true, QString(), QString());
+        return std::make_tuple(true, QString(), QString(), QString(), QString());
     } else {
-        return std::make_tuple(false,
-                               QLatin1String("Couldn't save ") % getName() % " to " % filename_xml % " because: " % file_xml.errorString(),
-                               tr("Couldn't save %1 to %2 because: %3").arg(getName(), filename_xml, file_xml.errorString()));
+        return std::make_tuple(false, QLatin1String("Couldn't save %1 to %2 because: %3"), getName(), filename_xml, file_xml.errorString());
     }
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -36,10 +36,11 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
-#include <QtUiTools>
 #include <QApplication>
 #include <QDir>
 #include <QMessageBox>
+#include <QStringBuilder>
+#include <QtUiTools>
 #include "post_guard.h"
 
 #include <zip.h>
@@ -377,12 +378,12 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveLocation
 {
     QString directory_xml;
     if (saveLocation.isEmpty()) {
-        directory_xml = QDir::homePath() + QLatin1String("/.config/mudlet/profiles/") + getName() + QLatin1String("/current");
+        directory_xml = QStringLiteral("%1/.config/mudlet/profiles/%2/current").arg(QDir::homePath(), getName());
     } else {
         directory_xml = saveLocation;
     }
 
-    QString filename_xml = directory_xml + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + ".xml";
+    QString filename_xml = QStringLiteral("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
     QDir dir_xml;
     if (!dir_xml.exists(directory_xml)) {
         dir_xml.mkpath(directory_xml);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -36,11 +36,11 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
+#include <QtUiTools>
 #include <QApplication>
 #include <QDir>
 #include <QMessageBox>
 #include <QStringBuilder>
-#include <QtUiTools>
 #include "post_guard.h"
 
 #include <zip.h>

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -373,13 +373,13 @@ void Host::resetProfile()
 // takes a directory to save in or an empty string for the default location
 // as well as a boolean whenever to sync the modules or not
 // returns true+filepath if successful or false+error message otherwise
-std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveToDir, bool syncModules)
+std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveLocation, bool syncModules)
 {
     QString directory_xml;
-    if (saveToDir.isEmpty()) {
+    if (saveLocation.isEmpty()) {
         directory_xml = QDir::homePath() + QLatin1String("/.config/mudlet/profiles/") + getName() + QLatin1String("/current");
     } else {
-        directory_xml = saveToDir;
+        directory_xml = saveLocation;
     }
 
     QString filename_xml = directory_xml + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + ".xml";

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -373,7 +373,7 @@ void Host::resetProfile()
 // takes a directory to save in or an empty string for the default location
 // as well as a boolean whenever to sync the modules or not
 // returns true+filepath if successful or false+error message otherwise
-std::tuple<bool, QString, QString, QString> Host::saveProfile(const QString& saveToDir, bool syncModules)
+std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveToDir, bool syncModules)
 {
     QString directory_xml;
     if (saveToDir.isEmpty()) {
@@ -393,9 +393,9 @@ std::tuple<bool, QString, QString, QString> Host::saveProfile(const QString& sav
         writer.exportHost(&file_xml);
         file_xml.close();
         saveModules(syncModules ? 1 : 0);
-        return std::make_tuple(true, filename_xml, QString(), QString());
+        return std::make_tuple(true, filename_xml, QString());
     } else {
-        return std::make_tuple(false, getName(), filename_xml, file_xml.errorString());
+        return std::make_tuple(false, filename_xml, file_xml.errorString());
     }
 }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,7 +125,7 @@ public:
     void               unregisterEventHandler(const QString&, TScript * );
     void               raiseEvent( const TEvent & event );
     void               resetProfile();
-    std::pair<bool, QString> saveProfile();
+    std::tuple<bool, QString, QString> saveProfile();
     void               callEventHandlers();
     void               stopAllTriggers();
     void               reenableAllTriggers();

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,7 +125,7 @@ public:
     void               unregisterEventHandler(const QString&, TScript * );
     void               raiseEvent( const TEvent & event );
     void               resetProfile();
-    std::tuple<bool, QString, QString> saveProfile();
+    std::tuple<bool, QString, QString, QString, QString> saveProfile();
     void               callEventHandlers();
     void               stopAllTriggers();
     void               reenableAllTriggers();

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,7 +125,7 @@ public:
     void               unregisterEventHandler(const QString&, TScript * );
     void               raiseEvent( const TEvent & event );
     void               resetProfile();
-    std::tuple<bool, QString, QString, QString> saveProfile(const QString &saveLocation, bool syncModules = false);
+    std::tuple<bool, QString, QString> saveProfile(const QString &saveLocation, bool syncModules = false);
     void               callEventHandlers();
     void               stopAllTriggers();
     void               reenableAllTriggers();

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,6 +125,7 @@ public:
     void               unregisterEventHandler(const QString&, TScript * );
     void               raiseEvent( const TEvent & event );
     void               resetProfile();
+    std::pair<bool, QString> saveProfile();
     void               callEventHandlers();
     void               stopAllTriggers();
     void               reenableAllTriggers();

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,7 +125,7 @@ public:
     void               unregisterEventHandler(const QString&, TScript * );
     void               raiseEvent( const TEvent & event );
     void               resetProfile();
-    std::tuple<bool, QString, QString, QString, QString> saveProfile();
+    std::tuple<bool, QString, QString, QString> saveProfile(const QString &saveLocation, bool syncModules = false);
     void               callEventHandlers();
     void               stopAllTriggers();
     void               reenableAllTriggers();

--- a/src/Host.h
+++ b/src/Host.h
@@ -125,7 +125,7 @@ public:
     void               unregisterEventHandler(const QString&, TScript * );
     void               raiseEvent( const TEvent & event );
     void               resetProfile();
-    std::tuple<bool, QString, QString> saveProfile(const QString &saveLocation, bool syncModules = false);
+    std::tuple<bool, QString, QString> saveProfile(const QString &saveLocation = QString(), bool syncModules = false);
     void               callEventHandlers();
     void               stopAllTriggers();
     void               reenableAllTriggers();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -784,7 +784,7 @@ void TConsole::closeEvent( QCloseEvent *event )
             auto result = mpHost->saveProfile(nullptr);
 
             if (std::get<0>(result) == false) {
-                QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<3>(result)));
+                QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<2>(result)));
                 goto ASK;
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -746,7 +746,7 @@ void TConsole::closeEvent( QCloseEvent *event )
         if( mpHost->mFORCE_SAVE_ON_EXIT )
         {
             mpHost->modulesToWrite.clear();
-            mpHost->saveProfile(nullptr);
+            mpHost->saveProfile();
 
             if( mpHost->mpMap->mpRoomDB->size() > 0 )
             {
@@ -781,7 +781,7 @@ void TConsole::closeEvent( QCloseEvent *event )
         }
         if (choice == QMessageBox::Yes) {
             mpHost->modulesToWrite.clear();
-            auto result = mpHost->saveProfile(nullptr);
+            auto result = mpHost->saveProfile();
 
             if (std::get<0>(result) == false) {
                 QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<2>(result)));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -781,7 +781,7 @@ void TConsole::closeEvent( QCloseEvent *event )
         }
         if (choice == QMessageBox::Yes) {
             mpHost->modulesToWrite.clear();
-            auto result = mpHost->saveProfile();
+            std::tuple<bool, QString, QString> result = mpHost->saveProfile();
 
             if (std::get<0>(result) == false) {
                 QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<2>(result)));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2486,14 +2486,20 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         return lua_error(L);
     }
 
-    auto result = pHost->saveProfile();
+    QString saveToDir;
+    if (lua_isstring(L, 1)) {
+        saveToDir = QString::fromUtf8(lua_tostring(L, 1));
+    }
+
+    auto result = pHost->saveProfile(saveToDir);
 
     if (std::get<0>(result) == true) {
         lua_pushboolean(L, true);
-        return 1;
+        lua_pushstring(L, (std::get<1>(result).toUtf8().constData()));
+        return 2;
     } else {
         lua_pushnil(L);
-        lua_pushstring(L, QString(std::get<1>(result)).arg(std::get<2>(result)).arg(std::get<3>(result)).arg(std::get<4>(result)).toUtf8().constData());
+        lua_pushstring(L, QString("Couldn't save %1 to %2 because: %3").arg(std::get<1>(result)).arg(std::get<2>(result)).arg(std::get<3>(result)).toUtf8().constData());
         return 2;
     }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2493,7 +2493,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         return 1;
     } else {
         lua_pushnil(L);
-        lua_pushstring(L, QString(QLatin1String("saveProfile: ") % std::get<1>(result)).toUtf8().constData());
+        lua_pushstring(L, QString(std::get<1>(result)).arg(std::get<2>(result)).arg(std::get<3>(result)).arg(std::get<4>(result)).toUtf8().constData());
         return 2;
     }
 }
@@ -13377,7 +13377,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem );
     lua_register( pGlobalLua, "setDefaultAreaVisible", TLuaInterpreter::setDefaultAreaVisible );
     lua_register( pGlobalLua, "getProfileName", TLuaInterpreter::getProfileName );
-    lua_register( pGlobalLua, "raiseGlobalEvent", TLuaInterpreter::raiseGlobalEvent );
+    lua_register( pGlobalLua, "raiseGlobalEvent", TLuaInterpreter::raiseGlobalEvent );    
+    lua_register( pGlobalLua, "saveProfile", TLuaInterpreter::saveProfile );
 
 
     luaopen_yajl(pGlobalLua);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13377,7 +13377,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem );
     lua_register( pGlobalLua, "setDefaultAreaVisible", TLuaInterpreter::setDefaultAreaVisible );
     lua_register( pGlobalLua, "getProfileName", TLuaInterpreter::getProfileName );
-    lua_register( pGlobalLua, "raiseGlobalEvent", TLuaInterpreter::raiseGlobalEvent );    
+    lua_register( pGlobalLua, "raiseGlobalEvent", TLuaInterpreter::raiseGlobalEvent );
     lua_register( pGlobalLua, "saveProfile", TLuaInterpreter::saveProfile );
 
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -57,6 +57,7 @@
 #include <QSound>
 #include <QSslConfiguration>
 #include <QString>
+#include <QStringBuilder>
 #include "post_guard.h"
 
 #include <list>
@@ -2487,13 +2488,12 @@ int TLuaInterpreter::saveProfile(lua_State* L)
 
     auto result = pHost->saveProfile();
 
-    if (result.first == true) {
+    if (std::get<0>(result) == true) {
         lua_pushboolean(L, true);
         return 1;
     } else {
         lua_pushnil(L);
-        QString msg = QLatin1String("saveProfile: ") + result.second;
-        lua_pushstring(L, msg.toUtf8().constData());
+        lua_pushstring(L, QString(QLatin1String("saveProfile: ") % std::get<1>(result)).toUtf8().constData());
         return 2;
     }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2482,8 +2482,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
     Host* pHost = TLuaInterpreter::luaInterpreterMap[L];
     if (!pHost) {
         lua_pushstring(L, QLatin1String("saveProfile: NULL Host pointer - something is wrong!").data());
-        lua_error(L);
-        return 2;
+        return lua_error(L);
     }
 
     auto result = pHost->saveProfile();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2499,7 +2499,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         return 2;
     } else {
         lua_pushnil(L);
-        lua_pushstring(L, QString("Couldn't save %1 to %2 because: %3").arg(std::get<1>(result)).arg(std::get<2>(result)).arg(std::get<3>(result)).toUtf8().constData());
+        lua_pushstring(L, QString("Couldn't save %1 to %2 because: %3").arg(pHost->getName()).arg(std::get<1>(result)).arg(std::get<2>(result)).toUtf8().constData());
         return 2;
     }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2491,7 +2491,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         saveToDir = QString::fromUtf8(lua_tostring(L, 1));
     }
 
-    auto result = pHost->saveProfile(saveToDir);
+    std::tuple<bool, QString, QString> result = pHost->saveProfile(saveToDir);
 
     if (std::get<0>(result) == true) {
         lua_pushboolean(L, true);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2477,6 +2477,28 @@ int TLuaInterpreter::closeMudlet(lua_State* L)
     return 0;
 }
 
+int TLuaInterpreter::saveProfile(lua_State* L)
+{
+    Host* pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if (!pHost) {
+        lua_pushstring(L, QLatin1String("saveProfile: NULL Host pointer - something is wrong!").data());
+        lua_error(L);
+        return 2;
+    }
+
+    auto result = pHost->saveProfile();
+
+    if (result.first == true) {
+        lua_pushboolean(L, true);
+        return 1;
+    } else {
+        lua_pushnil(L);
+        QString msg = QLatin1String("saveProfile: ") + result.second;
+        lua_pushstring(L, msg.toUtf8().constData());
+        return 2;
+    }
+}
+
 // openUserWindow( session, string window_name )
 int TLuaInterpreter::openUserWindow( lua_State *L )
 {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -239,6 +239,7 @@ public:
     static int setBgColor( lua_State * L );
     static int tempTimer( lua_State * L );
     static int closeMudlet( lua_State* L );
+    static int saveProfile(lua_State* L);
     static int openUserWindow( lua_State * L );
     static int echoUserWindow( lua_State * L );
     static int clearUserWindow( lua_State * L );

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7007,7 +7007,7 @@ void dlgTriggerEditor::slot_profileSaveAction()
     auto result = mpHost->saveProfile(nullptr, true);
 
     if (std::get<0>(result) == false) {
-        QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<3>(result)));
+        QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<2>(result)));
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7004,7 +7004,7 @@ void dlgTriggerEditor::doCleanReset()
 
 void dlgTriggerEditor::slot_profileSaveAction()
 {
-    auto result = mpHost->saveProfile(nullptr, true);
+    std::tuple<bool, QString, QString> result = mpHost->saveProfile(nullptr, true);
 
     if (std::get<0>(result) == false) {
         QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<2>(result)));

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7004,24 +7004,10 @@ void dlgTriggerEditor::doCleanReset()
 
 void dlgTriggerEditor::slot_profileSaveAction()
 {
-    QString directory_xml = QDir::homePath()+"/.config/mudlet/profiles/"+mpHost->getName()+"/current";
-    QString filename_xml = directory_xml + "/"+QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss")+".xml";
-    QDir dir_xml;
-    if( ! dir_xml.exists( directory_xml ) )
-    {
-        dir_xml.mkpath( directory_xml );
-    }
-    QFile file_xml( filename_xml );
-    if ( file_xml.open( QIODevice::WriteOnly ) )
-    {
-        XMLexport writer( mpHost );
-        writer.exportHost( & file_xml );
-        file_xml.close();
-        mpHost->saveModules(1);
-    }
-    else
-    {
-        QMessageBox::critical( this, "Profile Save Failed", "Failed to save "+mpHost->getName()+" to location "+filename_xml+" because of the following error: "+file_xml.errorString() );
+    auto result = mpHost->saveProfile(nullptr, true);
+
+    if (std::get<0>(result) == false) {
+        QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<3>(result)));
     }
 }
 


### PR DESCRIPTION
This introduces a new pattern we haven't used in Mudlet before - passing multiple return values to the Lua interface.

I haven't replaced all cases where we save the profile yet with the overarching ``Host::saveProfile()`` yet - will do that after people agree this style is a good one to go with.

Tagging @Mudlet/core-cpp for review.