### PR TITLE
I18n: clear out translatable Lua error messsages

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -372,7 +372,7 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushfstring(L, "raiseEvent: bad argument #%i type (string, number, boolean, or nil\n"
+            lua_pushfstring(L, "raiseEvent: bad argument #%d type (string, number, boolean, or nil\n"
                               "expected, got a %s!)", i, luaL_typename(L, i));
             lua_error( L );
             return 1;
@@ -446,7 +446,7 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushfstring(L, "raiseGlobalEvent: bad argument type #%i (boolean, number, string or nil\n"
+            lua_pushfstring(L, "raiseGlobalEvent: bad argument type #%d (boolean, number, string or nil\n"
                                "expected, got a %s!)",
                             i, luaL_typename(L, i));
             lua_error( L );
@@ -489,7 +489,7 @@ int TLuaInterpreter::selectString( lua_State * L )
     QString windowName; // only for 3 argument case, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 2 ) {
         if( ! lua_isstring( L, s ) ) {
-            lua_pushfstring(L, "selectString: bad argument #%i type (window name as string, is optional {defaults"
+            lua_pushfstring(L, "selectString: bad argument #%d type (window name as string, is optional {defaults"
                                "to \"main\" if omitted}, got %s!)",
                             s, luaL_typename(L, s));
             lua_error( L );
@@ -509,7 +509,7 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     QString searchText;
     if( ! lua_isstring( L, s ) ) {
-        lua_pushfstring(L, "selectString: bad argument #%i type (text to select as string expected, got %s!)",
+        lua_pushfstring(L, "selectString: bad argument #%d type (text to select as string expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
         return 1;
@@ -522,7 +522,7 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     qint64 numOfMatch = 0;
     if( ! lua_isnumber( L, s ) ) {
-        lua_pushfstring(L, "selectString: bad argument #%i type (match count as number {1 for first} expected, got %s!)",
+        lua_pushfstring(L, "selectString: bad argument #%d type (match count as number {1 for first} expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
         return 1;
@@ -1295,7 +1295,7 @@ int TLuaInterpreter::centerview( lua_State * L )
     }
     else {
         lua_pushnil( L );
-        lua_pushfstring(L, "centerview: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "centerview: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -2022,7 +2022,7 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getExitStubs: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "getExitStubs: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -2039,7 +2039,7 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushfstring(L, "getExitStubs: no stubs in this room with id %i.",
+            lua_pushfstring(L, "getExitStubs: no stubs in this room with id %d.",
                            roomId);
             return 2;
         }
@@ -2075,7 +2075,7 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getExitStubs1: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "getExitStubs1: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -2092,7 +2092,7 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushfstring(L, "getExitStubs1: no stubs in this room with id %i.",
+            lua_pushfstring(L, "getExitStubs1: no stubs in this room with id %d.",
                             roomId);
             return 2;
         }
@@ -3439,7 +3439,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     QString windowName;
     if( ! lua_isstring( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (window name as string {use \"main\" or\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (window name as string {use \"main\" or\n"
                            "empty string for main console} expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3453,7 +3453,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     QVector<int>colorComponents(6); // 0-2 RGB foreground, 3-5 RGB background
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (red foreground color component as number\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (red foreground color component as number\n"
                            "expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3466,7 +3466,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (green foreground color component as number\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (green foreground color component as number\n"
                            "expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3479,7 +3479,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (blue foreground color component as number\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (blue foreground color component as number\n"
                            "expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3492,7 +3492,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (red background color component as number\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (red background color component as number\n"
                            "expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3505,7 +3505,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (green background color component as number\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (green background color component as number\n"
                            "expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3518,7 +3518,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (blue background color component as number\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (blue background color component as number\n"
                            "expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3540,7 +3540,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (bold format as boolean {or number,\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (bold format as boolean {or number,\n"
                            "non-zero is true} expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3558,7 +3558,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (underline format as boolean {or number,\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (underline format as boolean {or number,\n"
                            "non-zero is true} expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
@@ -3576,7 +3576,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushfstring(L, "setTextFormat: bad argument #%i type (italic format as boolean {or number,\n"
+        lua_pushfstring(L, "setTextFormat: bad argument #%d type (italic format as boolean {or number,\n"
                           "non-zero is true} expected, got %s!)",
                        s, luaL_typename(L, s));
         lua_error( L );
@@ -3596,7 +3596,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
         }
         else
         {
-            lua_pushfstring(L, "setTextFormat: bad argument #%i type (strikeout format as boolean {or number,\n"
+            lua_pushfstring(L, "setTextFormat: bad argument #%d type (strikeout format as boolean {or number,\n"
                                "non-zero is true} optional, got %s!)",
                             s, luaL_typename(L, s));
             lua_error( L );
@@ -3816,7 +3816,7 @@ int TLuaInterpreter::setRoomName( lua_State *L )
     }
     else {
         lua_pushnil( L );
-        lua_pushfstring(L, "setRoomName: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "setRoomName: bad argument #1 value (number %d is not a valid room id).",
                         id);
         return 2;
     }
@@ -3854,7 +3854,7 @@ int TLuaInterpreter::getRoomName( lua_State *L )
     }
     else {
         lua_pushnil( L );
-        lua_pushfstring(L, "getRoomName: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "getRoomName: bad argument #1 value (number %d is not a valid room id).",
                         id);
         return 2;
     }
@@ -4369,7 +4369,7 @@ int TLuaInterpreter::getAllRoomEntrances( lua_State *L )
         TRoom * pR = pHost->mpMap->mpRoomDB->getRoom(roomId);
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "getAllRoomEntrances: bad argument #1 value (number %i is not a valid room id).",
+            lua_pushfstring(L, "getAllRoomEntrances: bad argument #1 value (number %d is not a valid room id).",
                             roomId);
             return 2;
         }
@@ -4461,7 +4461,7 @@ int TLuaInterpreter::searchRoom( lua_State *L )
             return 1;
         }
         else {
-            lua_pushfstring(L, "searchRoom: bad argument #1 value (room id %i does not exist!)",
+            lua_pushfstring(L, "searchRoom: bad argument #1 value (room id %d does not exist!)",
                             room_id);
             // Should've been a nil with this as an second returned string!
             return 1;
@@ -4886,7 +4886,7 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( area );
     if( !pA ) {
         lua_pushnil(L);
-        lua_pushfstring(L, "getAreaExits: bad argument #1 value (number %i is not a valid area id).",
+        lua_pushfstring(L, "getAreaExits: bad argument #1 value (number %d is not a valid area id).",
                         area);
         return 2;
     }
@@ -4992,7 +4992,7 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( targetRoomId ) ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "gotoRoom: bad argument #1 value (number %i is not a valid target room id).",
+        lua_pushfstring(L, "gotoRoom: bad argument #1 value (number %d is not a valid target room id).",
                         targetRoomId);
         return 2;
     }
@@ -5006,7 +5006,7 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
         int totalWeight = pHost->assemblePath(); // Needed if unsucessful to clear lua speedwalk tables
         Q_UNUSED(totalWeight);
         lua_pushboolean( L, false );
-        lua_pushfstring(L, "gotoRoom: no path found from current room to room with id %i!",
+        lua_pushfstring(L, "gotoRoom: no path found from current room to room with id %d!",
                         targetRoomId);
         return 2;
     }
@@ -5049,13 +5049,13 @@ int TLuaInterpreter::getPath( lua_State *L )
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( originRoomId ) ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getPath: bad argument #1 value (number %i is not a valid source room id).",
+        lua_pushfstring(L, "getPath: bad argument #1 value (number %d is not a valid source room id).",
                         originRoomId);
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( targetRoomId ) ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getPath: bad argument #2 value (number %i is not a valid target room id).",
+        lua_pushfstring(L, "getPath: bad argument #2 value (number %d is not a valid target room id).",
                         targetRoomId);
         return 2;
     }
@@ -5071,7 +5071,7 @@ int TLuaInterpreter::getPath( lua_State *L )
     else {
         lua_pushboolean( L, false );
         lua_pushnumber( L, -1 );
-        lua_pushfstring(L, "getPath: no path found from room, with Id %i to room %i!",
+        lua_pushfstring(L, "getPath: no path found from room, with Id %d to room %d!",
                         originRoomId, targetRoomId);
         return 3;
     }
@@ -5569,7 +5569,7 @@ int TLuaInterpreter::setBold( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushfstring(L, "setBold: bad argument #%i type (more than one argument supplied and first,\n"
+            lua_pushfstring(L, "setBold: bad argument #%d type (more than one argument supplied and first,\n"
                                "window name, as string expected {omission selects \"main\" console window}, got %s!",
                             s, luaL_typename(L, s));
             lua_error( L );
@@ -5584,7 +5584,7 @@ int TLuaInterpreter::setBold( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushfstring(L, "setBold: bad argument #%i type (enable bold attribute as boolean expected, got %s!)",
+        lua_pushfstring(L, "setBold: bad argument #%d type (enable bold attribute as boolean expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
         return 1;
@@ -5620,7 +5620,7 @@ int TLuaInterpreter::setItalics( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushfstring(L, "setItalics: bad argument #%i type (more than one argument supplied and first,\n"
+            lua_pushfstring(L, "setItalics: bad argument #%d type (more than one argument supplied and first,\n"
                                "window name, as string expected {omission selects \"main\" console window}, got %s!",
                             s, luaL_typename(L, s));
             lua_error( L );
@@ -5635,7 +5635,7 @@ int TLuaInterpreter::setItalics( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushfstring(L, "setItalics: bad argument #%i type (enable italic attribute as boolean expected, got %s!)",
+        lua_pushfstring(L, "setItalics: bad argument #%d type (enable italic attribute as boolean expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
         return 1;
@@ -5671,7 +5671,7 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushfstring(L, "setUnderline: bad argument #%i type (more than one argument supplied and first,\n"
+            lua_pushfstring(L, "setUnderline: bad argument #%d type (more than one argument supplied and first,\n"
                                "window name, as string expected {omission selects \"main\" console window}, got %s!",
                             s, luaL_typename(L, s));
             lua_error( L );
@@ -5686,7 +5686,7 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushfstring(L, "setUnderline: bad argument #%i type (enable underline attribute as boolean expected, got %s!)",
+        lua_pushfstring(L, "setUnderline: bad argument #%d type (enable underline attribute as boolean expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
         return 1;
@@ -5722,7 +5722,7 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushfstring(L, "setStrikeOut: bad argument #%i type (more than one argument supplied and first,\n"
+            lua_pushfstring(L, "setStrikeOut: bad argument #%d type (more than one argument supplied and first,\n"
                                "window name, as string expected {omission selects \"main\" console window}, got %s!)",
                             s, luaL_typename(L, s));
             lua_error( L );
@@ -5737,7 +5737,7 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushfstring(L, "setStrikeOut: bad argument #%i type (enable strikeout attribute as boolean expected, got %s!)",
+        lua_pushfstring(L, "setStrikeOut: bad argument #%d type (enable strikeout attribute as boolean expected, got %s!)",
                         s, luaL_typename(L, s));
         lua_error( L );
         return 1;
@@ -7450,7 +7450,7 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         id = lua_tonumber( L, 1 );
         if( id < 1 ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "setAreaName: bad argument #1 value (number %i is not a valid area id as it is\n"
+            lua_pushfstring(L, "setAreaName: bad argument #1 value (number %d is not a valid area id as it is\n"
                                "less than 1).",
                             id);
             return 2;
@@ -7461,7 +7461,7 @@ int TLuaInterpreter::setAreaName( lua_State *L )
 // need to continue to allow this - Slysven
 //        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
 //            lua_pushnil( L );
-//            lua_pushstring(L, "setAreaName: bad argument #1 value (number %i is not a valid area id)."
+//            lua_pushstring(L, "setAreaName: bad argument #1 value (number %d is not a valid area id)."
 //                           id);
 //            return 2;
 //        }
@@ -7522,7 +7522,7 @@ int TLuaInterpreter::setAreaName( lua_State *L )
             lua_pushnil( L );
             // And it isn't the trivial case, where the given areaID already IS that name
             lua_pushfstring(L, "setAreaName: bad argument #2 value (area names may not be duplicated and area\n"
-                               "id %i already has the name \"%s\").",
+                               "id %d already has the name \"%s\").",
                             pHost->mpMap->mpRoomDB->getAreaNamesMap().key(newName),
                             newName.toUtf8().constData());
             return 2;
@@ -7609,7 +7609,7 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
         }
         else {
             lua_pushnumber( L, -1 );
-            lua_pushfstring(L, "getRoomAreaName: bad argument #1 value (number %i is not a valid area id).",
+            lua_pushfstring(L, "getRoomAreaName: bad argument #1 value (number %d is not a valid area id).",
                             id);
             return 2;
         }
@@ -7653,7 +7653,7 @@ int TLuaInterpreter::addAreaName( lua_State *L )
         // That name is already IN the areaNamesMap
         lua_pushnil( L );
         lua_pushfstring(L, "addAreaName: bad argument #2 value (area names may not be duplicated and area\n"
-                           "id %i already has the name \"%s\").",
+                           "id %d already has the name \"%s\").",
                         pHost->mpMap->mpRoomDB->getAreaNamesMap().key(name),
                         name.toUtf8().constData());
         return 2;
@@ -7690,7 +7690,7 @@ int TLuaInterpreter::deleteArea( lua_State *L )
         id = lua_tonumber( L, 1 );
         if( id < 1 ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "deleteArea: bad argument #1 value (number %i is not a valid area id greater\n"
+            lua_pushfstring(L, "deleteArea: bad argument #1 value (number %d is not a valid area id greater\n"
                                "than zero).",
                             id);
             return 2;
@@ -7698,7 +7698,7 @@ int TLuaInterpreter::deleteArea( lua_State *L )
         else if(    ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id )
                  && ! pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( id ) ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "deleteArea: bad argument #1 value (number %i is not a valid area id).",
+            lua_pushfstring(L, "deleteArea: bad argument #1 value (number %d is not a valid area id).",
                             id);
             return 2;
         }
@@ -7938,7 +7938,7 @@ int TLuaInterpreter::createRoomID( lua_State * L )
             int minId = lua_tointeger( L, 1 );
             if( minId <  1 ) {
                 lua_pushnil( L );
-                lua_pushfstring(L, "createRoomID: bad argument #1 value (minimum room id %i is an optional value\n"
+                lua_pushfstring(L, "createRoomID: bad argument #1 value (minimum room id %d is an optional value\n"
                                    "but if provided it must be greater than zero.)",
                                 minId);
                 return 2;
@@ -8493,7 +8493,7 @@ int TLuaInterpreter::setDoor( lua_State * L )
         pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "setDoor: bad argument #1 value (number %i is not a valid room id.)",
+            lua_pushfstring(L, "setDoor: bad argument #1 value (number %d is not a valid room id.)",
                             roomId);
             return 2;
         }
@@ -8530,7 +8530,7 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
                         // And NOT a special one either
                         lua_pushnil( L );
-                        lua_pushfstring(L, "setDoor: bad argument #2 value (room with id %i does not have a special\n"
+                        lua_pushfstring(L, "setDoor: bad argument #2 value (room with id %d does not have a special\n"
                                            "exit in direction \"%s\".)",
                                         roomId, exitCmd.toUtf8().constData());
                         return 2;
@@ -8554,7 +8554,7 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
                 // No there IS NOT a stub or real exit in the exitCmd direction
                 lua_pushnil( L );
-                lua_pushfstring(L, "setDoor: bad argument #2 value (room with id %i does not have a normal exit\n"
+                lua_pushfstring(L, "setDoor: bad argument #2 value (room with id %d does not have a normal exit\n"
                                    "or a stub exit in direction \"%s\".)",
                                 roomId, exitCmd.toUtf8().constData());
                 return 2;
@@ -8575,7 +8575,7 @@ int TLuaInterpreter::setDoor( lua_State * L )
         doorStatus = lua_tointeger( L, 3 );
         if( doorStatus < 0 || doorStatus > 3 ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "setDoor: bad argument #3 value (door type %i is not one of 0=\"none\", 1=\"open\",\n"
+            lua_pushfstring(L, "setDoor: bad argument #3 value (door type %d is not one of 0=\"none\", 1=\"open\",\n"
                                "2=\"closed\" or 3=\"locked\".)",
                             doorStatus);
             return 2;
@@ -8620,7 +8620,7 @@ int TLuaInterpreter::getDoors( lua_State * L )
         pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "getDoors: bad argument #1 value (number %i is not a valid room id).",
+            lua_pushfstring(L, "getDoors: bad argument #1 value (number %d is not a valid room id).",
                             roomId);
             return 2;
         }
@@ -9205,7 +9205,7 @@ int TLuaInterpreter::clearRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "clearRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "clearRoomUserData: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -9265,7 +9265,7 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "clearRoomUserDataItem: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "clearRoomUserDataItem: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -9316,7 +9316,7 @@ int TLuaInterpreter::clearAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "clearAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+        lua_pushfstring(L, "clearAreaUserData: bad argument #1 value (number %d is not a valid area id).",
                         areaId);
         return 2;
     }
@@ -9372,7 +9372,7 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "clearAreaUserDataItem: bad argument #1 value (number %i is not a valid area id).",
+        lua_pushfstring(L, "clearAreaUserDataItem: bad argument #1 value (number %d is not a valid area id).",
                         areaId);
         return 2;
     }
@@ -9659,7 +9659,7 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushfstring(L, "getRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+            lua_pushfstring(L, "getRoomUserData: bad argument #1 value (number %d is not a valid room id).",
                             roomId);
             return 2;
         }
@@ -9676,7 +9676,7 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
             }
             else {
                 lua_pushnil( L );
-                lua_pushfstring(L, "getRoomUserData: bad argument #2 value (no user data with key:\"%s\" in room with id: %i).",
+                lua_pushfstring(L, "getRoomUserData: bad argument #2 value (no user data with key:\"%s\" in room with id: %d).",
                                 key.toUtf8().constData(), roomId);
                 return 2;
             }
@@ -9729,7 +9729,7 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+        lua_pushfstring(L, "getAreaUserData: bad argument #1 value (number %d is not a valid area id).",
                         areaId);
         return 2;
     }
@@ -9741,7 +9741,7 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
         else {
             lua_pushnil( L );
             lua_pushfstring(L, "getAreaUserData: bad argument #2 value (no user data with key:\"%s\"\n"
-                               "in area with id:%i).",
+                               "in area with id:%d).",
                             key.toUtf8().constData(), areaId);
             return 2;
         }
@@ -9838,7 +9838,7 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "setRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "setRoomUserData: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -9922,7 +9922,7 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "setAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+        lua_pushfstring(L, "setAreaUserData: bad argument #1 value (number %d is not a valid area id).",
                         areaId);
         return 2;
     }
@@ -10032,7 +10032,7 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getRoomUserDataKeys: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "getRoomUserDataKeys: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -10082,7 +10082,7 @@ int TLuaInterpreter::getAllRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getAllRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "getAllRoomUserData: bad argument #1 value (number %d is not a valid room id).",
                         roomId);
         return 2;
     }
@@ -10130,7 +10130,7 @@ int TLuaInterpreter::getAllAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "getAllAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+        lua_pushfstring(L, "getAllAreaUserData: bad argument #1 value (number %d is not a valid area id).",
                         areaId);
         return 2;
     }
@@ -10267,7 +10267,7 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         id = lua_tointeger( L, 1 );
         if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "setRoomArea: bad argument #1 value (number %i is not a valid room id).",
+            lua_pushfstring(L, "setRoomArea: bad argument #1 value (number %d is not a valid room id).",
                             id);
             return 2;
         }
@@ -10279,14 +10279,14 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         areaId = lua_tonumber( L, 2 );
         if( areaId < 1 ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "setRoomArea: bad argument #2 value (number %i is not a valid area id greater\n"
+            lua_pushfstring(L, "setRoomArea: bad argument #2 value (number %d is not a valid area id greater\n"
                                "than zero.  To remove a room's area, use resetRoomArea( roomId ) ).",
                             areaId);
             return 2;
         }
         else if( !pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( areaId ) ) {
             lua_pushnil( L );
-            lua_pushfstring(L, "setRoomArea: bad argument #2 value (number %i is not a valid area id as it does not exist).",
+            lua_pushfstring(L, "setRoomArea: bad argument #2 value (number %d is not a valid area id as it does not exist).",
                             areaId);
             return 2;
         }
@@ -10358,7 +10358,7 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
         lua_pushnil( L );
-        lua_pushfstring(L, "resetRoomArea: bad argument #1 value (number %i is not a valid room id).",
+        lua_pushfstring(L, "resetRoomArea: bad argument #1 value (number %d is not a valid room id).",
                         id);
         return 2;
     }
@@ -10964,7 +10964,7 @@ int TLuaInterpreter::Echo( lua_State *L )
     }
 
     if (! lua_isstring(L, n)) {
-        lua_pushfstring(L, "echo: bad argument #%i type (text to display as string expected, got %s!)",
+        lua_pushfstring(L, "echo: bad argument #%d type (text to display as string expected, got %s!)",
                         n, luaL_typename(L, n));
         return lua_error(L);
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -346,8 +346,8 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "raiseEvent: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("raiseEvent: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -373,11 +373,11 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushstring( L, tr( "raiseEvent: bad argument #%1 type (string, number, boolean, or nil\n"
-                                   "expected, got a %2!)" )
-                            .arg( i )
-                            .arg( luaL_typename( L, i ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("raiseEvent: bad argument #%1 type (string, number, boolean, or nil\n"
+                                             "expected, got a %2!)")
+                            .arg(i)
+                            .arg(luaL_typename(L, i))
+                            .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -393,7 +393,8 @@ int TLuaInterpreter::getProfileName( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getProfileName: ERROR: NULL Host pointer!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getProfileName:  NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -410,16 +411,16 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "raiseGlobalEvent: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("raiseGlobalEvent: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
 
     int n = lua_gettop( L );
     if( ! n ) {
-        lua_pushstring( L, tr( "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)")
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -451,11 +452,11 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushstring( L, tr( "raiseGlobalEvent: bad argument type #%1 (boolean, number, string or nil\n"
-                                   "expected, got a %2!)" )
-                            .arg( i )
-                            .arg( luaL_typename( L, i ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("raiseGlobalEvent: bad argument type #%1 (boolean, number, string or nil\n"
+                                             "expected, got a %2!)")
+                           .arg(i)
+                           .arg(luaL_typename(L, i))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -487,8 +488,8 @@ int TLuaInterpreter::selectString( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "selectString: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("selectString: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -497,21 +498,21 @@ int TLuaInterpreter::selectString( lua_State * L )
     QString windowName; // only for 3 argument case, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 2 ) {
         if( ! lua_isstring( L, s ) ) {
-            lua_pushstring( L, tr( "selectString: bad argument #%1 type (window name as string, is optional {defaults"
-                                   "to \"main\" if omitted}, got %2!)" )
-                            .arg( s )
-                            .arg( luaL_typename( L, s ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("selectString: bad argument #%1 type (window name as string, is optional {defaults"
+                                             "to \"main\" if omitted}, got %2!)")
+                           .arg(s)
+                           .arg(luaL_typename(L, s))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
         else {
             // We cannot yet properly handle non-ASCII windows names but we will eventually!
             windowName = QString::fromUtf8( lua_tostring( L, s ) );
-            if( ! windowName.compare( tr( "main" ), Qt::CaseSensitive ) ) {
+            if (windowName == QLatin1String("main")) {
                 // This matches the identifier for the main window - so make it
                 // appear so by emptying it...
-                windowName = QString();
+                windowName.clear();
             }
             s++;
         }
@@ -519,10 +520,10 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     QString searchText;
     if( ! lua_isstring( L, s ) ) {
-        lua_pushstring( L, tr( "selectString: bad argument #%1 type (text to select as string expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("selectString: bad argument #%1 type (text to select as string expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -534,10 +535,10 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     qint64 numOfMatch = 0;
     if( ! lua_isnumber( L, s ) ) {
-        lua_pushstring( L, tr( "selectString: bad argument #%1 type (match count as number {1 for first} expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("selectString: bad argument #%1 type (match count as number {1 for first} expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -1270,22 +1271,22 @@ int TLuaInterpreter::centerview( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "centerview: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("centerview: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "centerview: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("centerview: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "centerview: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("centerview: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -1312,9 +1313,9 @@ int TLuaInterpreter::centerview( lua_State * L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "centerview: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( roomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("centerview: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
 }
@@ -1367,17 +1368,17 @@ int TLuaInterpreter::feedTriggers( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if (! pHost) {
-        lua_pushstring(L, tr("feedTriggers: NULL Host pointer - something is wrong!")
-                       .toUtf8().constData());
+        lua_pushstring(L, QStringLiteral("feedTriggers: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return lua_error(L);
     }
 
     std::string text;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, tr("feedTriggers: bad argument #1 type (imitation MUD server text as string\n"
-                             "expected, got %1!)")
-                             .arg(luaL_typename(L, 1))
-                             .toUtf8().constData());
+        lua_pushstring(L, QStringLiteral("feedTriggers: bad argument #1 type (imitation MUD server text as string\n"
+                                         "expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         return lua_error(L);
     } else {
         text = lua_tostring( L, 1 );
@@ -2018,22 +2019,22 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getExitStubs: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getExitStubs: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( !lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getExitStubs: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -2045,9 +2046,9 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getExitStubs: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( roomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -2063,9 +2064,9 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getExitStubs: no stubs in this room with id %1." )
-                            .arg( roomId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getExitStubs: no stubs in this room with id %1.")
+                           .arg(roomId)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -2076,22 +2077,22 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getExitStubs1: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs1: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getExitStubs1: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs1: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( !lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getExitStubs1: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs1: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -2103,9 +2104,9 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getExitStubs1: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( roomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getExitStubs1: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -2121,9 +2122,9 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getExitStubs1: no stubs in this room with id %1." )
-                            .arg( roomId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getExitStubs1: no stubs in this room with id %1.")
+                           .arg(roomId)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -2207,18 +2208,18 @@ int TLuaInterpreter::loadMap( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "loadMap: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("loadMap: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
     QString location;
     if( lua_gettop( L ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "loadMap: bad argument #1 type (Map pathFile as string is optional {loads last\n"
-                                   "stored map if omitted}, got %1!)" )
-                            .arg( luaL_typename( L, 1 ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("loadMap: bad argument #1 type (Map pathFile as string is optional {loads last\n"
+                                             "stored map if omitted}, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -3159,17 +3160,17 @@ int TLuaInterpreter::startLogging( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "startLogging: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("startLogging: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         lua_error(L);
         return 2;
     }
 
     bool logOn = true;
     if( ! lua_isboolean( L, 1 ) ) {
-        lua_pushfstring( L, tr( "startLogging: bad argument #1 type (turn logging on/off, as boolean expected, got %1!)")
-                         .arg(luaL_typename(L, 1))
-                         .toUtf8().constData());
+        lua_pushfstring(L, QStringLiteral( "startLogging: bad argument #1 type (turn logging on/off, as boolean expected, got %1!)")
+                        .arg(luaL_typename(L, 1))
+                        .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3193,29 +3194,36 @@ int TLuaInterpreter::startLogging( lua_State *L )
         if( pHost->mpConsole->mLogToLogFile ) {
             pHost->mpConsole->logButton->setChecked(true);
             // Sets the button as checked but clicked() & pressed() signals are NOT generated
-            lua_pushstring( L, tr( "Main console output has started to be logged to file: %1" ).arg( pHost->mpConsole->mLogFileName ).toUtf8().constData() );
-            lua_pushstring( L, pHost->mpConsole->mLogFileName.toUtf8().constData() );
-            lua_pushnumber( L, 1 );
+            lua_pushstring(L, QStringLiteral("Main console output has started to be logged to file: %1")
+                           .arg(pHost->mpConsole->mLogFileName)
+                           .toUtf8().constData());
+            lua_pushstring(L, pHost->mpConsole->mLogFileName.toUtf8().constData());
+            lua_pushnumber(L, 1);
         }
         else {
             pHost->mpConsole->logButton->setChecked(false);
-            lua_pushstring( L, tr( "Main console output has stopped being logged to file: %1" ).arg( savedLogFileName ).toUtf8().constData() );
-            lua_pushstring( L, pHost->mpConsole->mLogFileName.toUtf8().constData() );
-            lua_pushnumber( L, 0 );
+            lua_pushstring(L, QStringLiteral("Main console output has stopped being logged to file: %1")
+                           .arg(savedLogFileName)
+                           .toUtf8().constData());
+            lua_pushstring(L, pHost->mpConsole->mLogFileName.toUtf8().constData());
+            lua_pushnumber(L, 0);
         }
 
     }
     else {
         lua_pushnil( L );
         if( pHost->mpConsole->mLogToLogFile ) {
-            lua_pushstring( L, tr( "Main console output is already being logged to file: %1" ).arg( pHost->mpConsole->mLogFileName ).toUtf8().constData() );
-            lua_pushstring( L, pHost->mpConsole->mLogFileName.toUtf8().constData() );
-            lua_pushnumber( L, -1 );
+            lua_pushstring(L, QStringLiteral("Main console output is already being logged to file: %1")
+                           .arg(pHost->mpConsole->mLogFileName)
+                           .toUtf8().constData());
+            lua_pushstring(L, pHost->mpConsole->mLogFileName.toUtf8().constData());
+            lua_pushnumber(L, -1);
         }
         else {
-            lua_pushstring( L, tr( "Main console output was already not being logged to a file." ).toUtf8().constData() );
-            lua_pushnil( L );
-            lua_pushnumber( L, -2 );
+            lua_pushstring(L, QStringLiteral("Main console output was already not being logged to a file.")
+                           .toLatin1().constData());
+            lua_pushnil(L);
+            lua_pushnumber(L, -2);
         }
 
     }
@@ -3460,8 +3468,8 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setTextFormat: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -3471,10 +3479,11 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     QString windowName;
     if( ! lua_isstring( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (window name as string {use \"main\" or empty string for main console} expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (window name as string {use \"main\" or\n"
+                                         "empty string for main console} expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3486,10 +3495,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     QVector<int>colorComponents(6); // 0-2 RGB foreground, 3-5 RGB background
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (red foreground color component as number expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (red foreground color component as number expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3500,10 +3509,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (green foreground color component as number expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (green foreground color component as number expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3514,10 +3523,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (blue foreground color component as number expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (blue foreground color component as number expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3528,10 +3537,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (red background color component as number expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (red background color component as number expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3542,10 +3551,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (green background color component as number expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (green background color component as number expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3556,10 +3565,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (blue background color component as number expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (blue background color component as number expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3579,10 +3588,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (bold format as boolean {or number, non-zero is true} expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (bold format as boolean {or number, non-zero is true} expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3598,10 +3607,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (underline format as boolean {or number, non-zero is true} expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (underline format as boolean {or number, non-zero is true} expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3617,10 +3626,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (italic format as boolean {or number, non-zero is true} expected, got %2!)" )
-                        .arg( s )
-                        .arg( luaL_typename( L, s ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (italic format as boolean {or number, non-zero is true} expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3638,10 +3647,10 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
         }
         else
         {
-            lua_pushstring( L, tr( "setTextFormat: bad argument #%1 type (strikeout format as boolean {or number, non-zero is true} optional, got %2!)" )
-                            .arg( s )
-                            .arg( luaL_typename( L, s ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (strikeout format as boolean {or number, non-zero is true} optional, got %2!)")
+                           .arg(s)
+                           .arg(luaL_typename(L, s))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -3820,22 +3829,22 @@ int TLuaInterpreter::setRoomName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomName: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomName: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomName: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomName: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setRoomName: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomName: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3845,9 +3854,9 @@ int TLuaInterpreter::setRoomName( lua_State *L )
 
     QString name;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setRoomName: bad argument #2 type (room name as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 2 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomName: bad argument #2 type (room name as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3863,9 +3872,9 @@ int TLuaInterpreter::setRoomName( lua_State *L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomName: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( id )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomName: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(id)
+                       .toLatin1().constData());
         return 2;
     }
 }
@@ -3875,20 +3884,22 @@ int TLuaInterpreter::getRoomName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomName: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomName: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomName: no map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomName: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getRoomName: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomName: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -3898,14 +3909,14 @@ int TLuaInterpreter::getRoomName( lua_State *L )
 
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom(id);
     if( pR ) {
-        lua_pushstring(L, pR->name.toUtf8().constData() );
+        lua_pushstring(L, pR->name.toUtf8().constData());
         return 1;
     }
     else {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomName: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( id )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomName: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(id)
+                       .toLatin1().constData());
         return 2;
     }
 }
@@ -4396,9 +4407,9 @@ int TLuaInterpreter::getAllRoomEntrances( lua_State *L )
 {
     int roomId = 0;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getAllRoomEntrances: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData());
+        lua_pushstring(L, QStringLiteral("getAllRoomEntrances: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         return lua_error( L );
     }
     else {
@@ -4408,23 +4419,23 @@ int TLuaInterpreter::getAllRoomEntrances( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllRoomEntrances: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllRoomEntrances: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllRoomEntrances: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllRoomEntrances: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
     else {
         TRoom * pR = pHost->mpMap->mpRoomDB->getRoom(roomId);
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getAllRoomEntrances: bad argument #1 value (number %1 is not a valid room id)." )
-                            .arg( roomId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getAllRoomEntrances: bad argument #1 value (number %1 is not a valid room id).")
+                           .arg(roomId)
+                           .toLatin1().constData());
             return 2;
         }
         lua_newtable(L);
@@ -4457,12 +4468,14 @@ int TLuaInterpreter::searchRoom( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "searchRoom: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchRoom: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "searchRoom: no map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchRoom: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -4483,20 +4496,20 @@ int TLuaInterpreter::searchRoom( lua_State *L )
                 caseSensitive = lua_toboolean( L, 2 );
                 if( n > 2 ) {
                     if( lua_isboolean( L, 3) )
-                        exactMatch = lua_toboolean( L, 3);
+                        exactMatch = lua_toboolean( L, 3 );
                     else {
-                        lua_pushstring( L, tr( "searchRoom: bad argument #3 type (\"exact match\" as boolean is optional, got %1!)" )
-                                        .arg( luaL_typename( L, 3 ) )
-                                        .toUtf8().constData() );
+                        lua_pushstring(L, QStringLiteral("searchRoom: bad argument #3 type (\"exact match\" as boolean is optional, got %1!)")
+                                       .arg(luaL_typename(L, 3))
+                                       .toLatin1().constData());
                         lua_error( L );
                         return 1;
                     }
                 }
             }
             else {
-                lua_pushstring( L, tr( "searchRoom: bad argument #2 type (\"case sensitive\" as boolean is optional, got %1!)" )
-                                .arg( luaL_typename( L, 2 ) )
-                                .toUtf8().constData() );
+                lua_pushstring(L, QStringLiteral("searchRoom: bad argument #2 type (\"case sensitive\" as boolean is optional, got %1!)")
+                               .arg(luaL_typename(L, 2))
+                               .toLatin1().constData());
                 lua_error( L );
                 return 1;
             }
@@ -4504,9 +4517,9 @@ int TLuaInterpreter::searchRoom( lua_State *L )
         room = QString::fromUtf8( lua_tostring( L, 1 ) );
     }
     else {
-        lua_pushstring( L, tr( "searchRoom: bad argument #1 (\"room name\" as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchRoom: bad argument #1 (\"room name\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -4514,13 +4527,14 @@ int TLuaInterpreter::searchRoom( lua_State *L )
     if( gotRoomID ) {
         TRoom * pR = pHost->mpMap->mpRoomDB->getRoom(room_id);
         if( pR ) {
-            lua_pushstring( L, pR->name.toUtf8().constData() );
+            lua_pushstring(L, pR->name.toUtf8().constData());
             return 1;
         }
         else {
-            lua_pushstring( L, tr( "searchRoom ERROR: no such room!" )
-                            .toUtf8().constData() );
-            // Should've been a nil with this as an second returned string !
+            lua_pushstring(L, QStringLiteral("searchRoom: bad argument #1 value (room id %1 does not exist!)")
+                           .arg(room_id)
+                           .toLatin1().constData());
+            // Should've been a nil with this as an second returned string!
             return 1;
         }
     }
@@ -4569,14 +4583,14 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "searchRoomUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchRoomUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "searchRoomUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchRoomUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -4585,8 +4599,9 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
 
     if( lua_gettop( L ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "searchRoomUserData: bad argument #1 (\"key\" as string is optional, got %1!)" )
-                            .arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("searchRoomUserData: bad argument #1 (\"key\" as string is optional, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -4596,8 +4611,9 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
 
         if( lua_gettop( L ) > 1 ) {
             if( ! lua_isstring( L, 2 ) ) {
-                lua_pushstring( L, tr( "searchRoomUserData: bad argument #2 (\"value\" as string is optional, got %1!)" )
-                                .arg( luaL_typename( L, 2 ) ).toUtf8().constData() );
+                lua_pushstring(L, QStringLiteral("searchRoomUserData: bad argument #2 (\"value\" as string is optional, got %1!)")
+                               .arg(luaL_typename(L, 2))
+                               .toLatin1().constData());
                 lua_error( L );
                 return 1;
             }
@@ -4690,14 +4706,14 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "searchAreaUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchAreaUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "searchAreaUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("searchAreaUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -4706,8 +4722,9 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
 
     if( lua_gettop( L ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "searchAreaUserData: bad argument #1 (\"key\" as string is optional, got %1!)" )
-                            .arg( luaL_typename(L, 1) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("searchAreaUserData: bad argument #1 (\"key\" as string is optional, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -4717,8 +4734,9 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
 
         if( lua_gettop( L ) > 1 ) {
             if( ! lua_isstring( L, 2 ) ) {
-                lua_pushstring( L, tr( "searchAreaUserData: bad argument #2 (\"value\" as string is optional, got %1!)" )
-                                .arg( luaL_typename(L, 2) ).toUtf8().constData() );
+                lua_pushstring(L, QStringLiteral("searchAreaUserData: bad argument #2 (\"value\" as string is optional, got %1!)")
+                               .arg(luaL_typename(L, 2))
+                               .toLatin1().constData());
                 lua_error( L );
                 return 1;
             }
@@ -4810,12 +4828,14 @@ int TLuaInterpreter::getAreaTable( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaTable: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaTable: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaTable: no map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaTable: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -4837,12 +4857,14 @@ int TLuaInterpreter::getAreaTableSwap( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaTableSwap: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaTableSwap: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaTableSwap: no map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaTableSwap: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -4923,9 +4945,9 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     int n = lua_gettop( L );
     bool isFullDataRequired = false;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getAreaExits: bad argument #1 type (area id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaExits: bad argument #1 type (area id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         return lua_error( L );
     }
     else {
@@ -4934,9 +4956,9 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
 
     if( n > 1 ) {
         if( ! lua_isboolean( L, 2 ) ) {
-            lua_pushstring( L, tr("getAreaExits: bad argument #2 type (full data wanted as boolean is optional, got %1!)")
-                            .arg( luaL_typename(L, 2) )
-                            .toUtf8().constData() );
+            lua_pushstring( L, QStringLiteral("getAreaExits: bad argument #2 type (full data wanted as boolean is optional, got %1!)")
+                            .arg(luaL_typename(L, 2))
+                            .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -4949,9 +4971,9 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( area );
     if( !pA ) {
         lua_pushnil(L);
-        lua_pushstring( L, tr( "getAreaExits: bad argument #1 value (number %1 is not a valid area id).")
-                        .arg( area )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaExits: bad argument #1 value (number %1 is not a valid area id).")
+                       .arg( area )
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5034,9 +5056,9 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
 {
     int targetRoomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "gotoRoom: bad argument #1 type (target room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("gotoRoom: bad argument #1 type (target room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5047,21 +5069,21 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "gotoRoom: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("gotoRoom: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "gotoRoom: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("gotoRoom: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( targetRoomId ) ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "gotoRoom: bad argument #1 value (number %1 is not a valid target room id)." )
-                        .arg( targetRoomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("gotoRoom: bad argument #1 value (number %1 is not a valid target room id).")
+                       .arg(targetRoomId)
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5074,9 +5096,9 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
         int totalWeight = pHost->assemblePath(); // Needed if unsucessful to clear lua speedwalk tables
         Q_UNUSED(totalWeight);
         lua_pushboolean( L, false );
-        lua_pushstring( L, tr( "gotoRoom: no path found from current room to room with id %1!" )
-                        .arg( targetRoomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("gotoRoom: no path found from current room to room with id %1!")
+                       .arg(targetRoomId)
+                       .toLatin1().constData());
         return 2;
     }
 }
@@ -5085,9 +5107,9 @@ int TLuaInterpreter::getPath( lua_State *L )
 {
     int originRoomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getPath: bad argument #1 type (starting room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: bad argument #1 type (starting room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5097,9 +5119,9 @@ int TLuaInterpreter::getPath( lua_State *L )
 
     int targetRoomId;
     if( ! lua_isnumber( L, 2 ) ) {
-        lua_pushstring( L, tr( "getPath: bad argument #2 type (target room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 2 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: bad argument #2 type (target room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5110,28 +5132,28 @@ int TLuaInterpreter::getPath( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getPath: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getPath: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( originRoomId ) ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getPath: bad argument #1 value (number %1 is not a valid source room id)." )
-                        .arg( originRoomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: bad argument #1 value (number %1 is not a valid source room id).")
+                       .arg(originRoomId)
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( targetRoomId ) ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getPath: bad argument #2 value (number %1 is not a valid target room id)." )
-                        .arg( targetRoomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: bad argument #2 value (number %1 is not a valid target room id).")
+                       .arg(targetRoomId)
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5146,7 +5168,10 @@ int TLuaInterpreter::getPath( lua_State *L )
     else {
         lua_pushboolean( L, false );
         lua_pushnumber( L, -1 );
-        lua_pushstring( L, tr( "getPath: no path found from room, with Id %1 to room %2!" ).arg(originRoomId).arg(targetRoomId).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getPath: no path found from room, with Id %1 to room %2!")
+                       .arg(originRoomId)
+                       .arg(targetRoomId)
+                       .toLatin1().constData());
         return 3;
     }
 }
@@ -5155,7 +5180,8 @@ int TLuaInterpreter::deselect( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "deselect: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("deselect: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5163,20 +5189,20 @@ int TLuaInterpreter::deselect( lua_State *L )
     QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "deselect: bad argument #1 type (window name as string, is optional {defaults"
-                                   "to \"main\" if omitted}, got %1!)" )
-                            .arg( luaL_typename( L, 1 ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("deselect: bad argument #1 type (window name as string, is optional {defaults"
+                                             "to \"main\" if omitted}, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
         else {
             // We cannot yet properly handle non-ASCII windows names but we will eventually!
             windowName = QString::fromUtf8( lua_tostring( L, 1 ) );
-            if( ! windowName.compare( tr( "main" ), Qt::CaseSensitive ) ) {
+            if (windowName == QLatin1String("main")) {
                 // This matches the identifier for the main window - so make it
                 // appear so by emptying it...
-                windowName = QString();
+                windowName.clear();
             }
         }
     }
@@ -5196,7 +5222,8 @@ int TLuaInterpreter::resetFormat( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring( L, tr( "resetFormat: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("resetFormat: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5204,20 +5231,20 @@ int TLuaInterpreter::resetFormat( lua_State *L )
     QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "resetFormat: bad argument #1 type (window name as string, is optional {defaults"
-                                   "to \"main\" if omitted}, got %1!)" )
-                            .arg( luaL_typename( L, 1 ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("resetFormat: bad argument #1 type (window name as string, is optional {defaults"
+                                             "to \"main\" if omitted}, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toUtf8().constData());
             lua_error( L );
             return 1;
         }
         else {
             // We cannot yet properly handle non-ASCII windows names but we will eventually!
             windowName = QString::fromUtf8( lua_tostring( L, 1 ) );
-            if( ! windowName.compare( tr( "main" ), Qt::CaseSensitive ) ) {
+            if (windowName == QLatin1String("main")) {
                 // This matches the identifier for the main window - so make it
                 // appear so by emptying it...
-                windowName = QString();
+                windowName.clear();
             }
         }
     }
@@ -5288,8 +5315,8 @@ int TLuaInterpreter::setAppStyleSheet( lua_State *L )
 int TLuaInterpreter::showUnzipProgress( lua_State * L )
 {
     lua_pushnil( L );
-    lua_pushstring( L, tr( "showUnzipProgress: removed command, this function is now inactive and does nothing!" )
-                    .toUtf8().constData() );
+    lua_pushstring(L, QStringLiteral("showUnzipProgress: removed command, this function is now inactive and does nothing!")
+                   .toLatin1().constData());
     return 2;
 }
 
@@ -5636,7 +5663,8 @@ int TLuaInterpreter::setBold( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setBold: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setBold: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5646,8 +5674,11 @@ int TLuaInterpreter::setBold( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring( L, tr( "setBold: bad argument #%1 type (more than one argument supplied and first, window name, as string expected {ommision selects \"main\" console window}, got %2!" )
-                            .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setBold: bad argument #%1 type (more than one argument supplied and first,\n"
+                                             "window name, as string expected {omission selects \"main\" console window}, got %2!")
+                           .arg(s)
+                           .arg(luaL_typename(L, s))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -5660,8 +5691,10 @@ int TLuaInterpreter::setBold( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setBold: bad argument #%1 type (enable bold attribute as boolean expected, got %2!) " )
-                        .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() ) ;
+        lua_pushstring(L, QStringLiteral("setBold: bad argument #%1 type (enable bold attribute as boolean expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData()) ;
         lua_error( L );
         return 1;
     }
@@ -5686,7 +5719,8 @@ int TLuaInterpreter::setItalics( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setItalics: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setItalics: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5696,8 +5730,11 @@ int TLuaInterpreter::setItalics( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring( L, tr( "setItalics: bad argument #%1 type (more than one argument supplied and first, window name, as string expected {ommision selects \"main\" console window}, got %2!" )
-                            .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setItalics: bad argument #%1 type (more than one argument supplied and first,\n"
+                                             "window name, as string expected {omission selects \"main\" console window}, got %2!")
+                           .arg(s)
+                           .arg(luaL_typename(L, s))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -5710,8 +5747,10 @@ int TLuaInterpreter::setItalics( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setItalics: bad argument #%1 type (enable italic attribute as boolean expected, got %2!) " )
-                        .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() ) ;
+        lua_pushstring(L, QStringLiteral("setItalics: bad argument #%1 type (enable italic attribute as boolean expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5736,7 +5775,8 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setUnderline: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setUnderline: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5746,8 +5786,11 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring( L, tr( "setUnderline: bad argument #%1 type (more than one argument supplied and first, window name, as string expected {ommision selects \"main\" console window}, got %2!" )
-                            .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setUnderline: bad argument #%1 type (more than one argument supplied and first,\n"
+                                             "window name, as string expected {ommision selects \"main\" console window}, got %2!")
+                           .arg(s)
+                           .arg(luaL_typename(L, s))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -5760,8 +5803,10 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setUnderline: bad argument #%1 type (enable underline attribute as boolean expected, got %2!) " )
-                        .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() ) ;
+        lua_pushstring(L, QStringLiteral("setUnderline: bad argument #%1 type (enable underline attribute as boolean expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -5786,7 +5831,8 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setStrikeOut: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setStrikeOut: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -5796,8 +5842,11 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring( L, tr( "setStrikeOut: bad argument #%1 type (more than one argument supplied and first, window name, as string expected {ommision selects \"main\" console window}, got %2!" )
-                            .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setStrikeOut: bad argument #%1 type (more than one argument supplied and first,\n"
+                                             "window name, as string expected {omission selects \"main\" console window}, got %2!)")
+                           .arg(s)
+                           .arg(luaL_typename(L, s))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -5810,8 +5859,10 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring( L, tr( "setStrikeOut: bad argument #%1 type (enable strikeout attribute as boolean expected, got %2!) " )
-                        .arg( s ).arg( luaL_typename( L, s ) ).toUtf8().constData() ) ;
+        lua_pushstring(L, QStringLiteral("setStrikeOut: bad argument #%1 type (enable strikeout attribute as boolean expected, got %2!)")
+                       .arg(s)
+                       .arg(luaL_typename(L, s))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -6086,7 +6137,8 @@ int TLuaInterpreter::getMousePosition( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getMousePosition: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getMousePosition: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -7510,14 +7562,14 @@ int TLuaInterpreter::setAreaName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setAreaName: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaName: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setAreaName: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaName: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -7525,8 +7577,10 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         id = lua_tonumber( L, 1 );
         if( id < 1 ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (number %1 is not a valid area id as it is less than 1)." )
-                            .arg( id ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (number %1 is not a valid area id as it is\n"
+                                             "less than 1).")
+                           .arg(id)
+                           .toLatin1().constData());
             return 2;
         }
 // Strangely, previous code allowed this command to create a NEW area's name
@@ -7535,8 +7589,9 @@ int TLuaInterpreter::setAreaName( lua_State *L )
 // need to continue to allow this - Slysven
 //        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
 //            lua_pushnil( L );
-//            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (number %1 is not a valid area id)." )
-//                            .arg( id ).toUtf8().constData() );
+//            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (number %1 is not a valid area id).")
+//                           .arg(id)
+//                           .toLatin1().constData());
 //            return 2;
 //        }
     }
@@ -7545,35 +7600,39 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         id = pHost->mpMap->mpRoomDB->getAreaNamesMap().key( existingName, 0 );
         if( existingName.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area name cannot be empty)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (area name cannot be empty).")
+                           .toLatin1().constData());
             return 2;
         }
         else if( ! pHost->mpMap->mpRoomDB->getAreaNamesMap().values().contains( existingName ) ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area name \"%1\" does not exist)." )
-                            .arg( existingName ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (area name \"%1\" does not exist).")
+                           .arg(existingName)
+                           .toUtf8().constData());
             return 2;
         }
         else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( -1 ).contains( existingName ) ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaName: bad argument #1 value (area name \"%1\" is reserved and protected - it cannot be changed)." )
-                            .arg( existingName ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (area name \"%1\" is reserved and\n"
+                                             "protected - it cannot be changed).")
+                           .arg(existingName)
+                           .toUtf8().constData());
             return 2;
         }
     }
     else {
-        lua_pushstring( L, tr( "setAreaName: bad argument #1 type (area id as number or area name as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 1) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 type (area id as number or area name as string\n"
+                                         "expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
 
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setAreaName: bad argument #2 type (area name as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaName: bad argument #2 type (area name as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -7585,8 +7644,9 @@ int TLuaInterpreter::setAreaName( lua_State *L )
     if( newName.isEmpty() ) {
         // Empty name not allowed (any more)
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setAreaName: bad argument #2 value (area names may not be empty strings {and spaces are trimmed from the ends})!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaName: bad argument #2 value (area names may not be empty strings\n"
+                                         "{and spaces are trimmed from the ends})!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().values().count( newName ) > 0 ) {
@@ -7596,9 +7656,11 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) != newName ) {
             lua_pushnil( L );
             // And it isn't the trivial case, where the given areaID already IS that name
-            lua_pushstring( L, tr( "setAreaName: bad argument #2 value (area names may not be duplicated and area id %1 already has the name \"%2\")." )
-                            .arg( pHost->mpMap->mpRoomDB->getAreaNamesMap().key( newName ) )
-                            .arg( newName ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #2 value (area names may not be duplicated and area\n"
+                                             "id %1 already has the name \"%2\").")
+                           .arg(pHost->mpMap->mpRoomDB->getAreaNamesMap().key(newName))
+                           .arg(newName)
+                           .toUtf8().constData());
             return 2;
         }
         else {
@@ -7636,12 +7698,14 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomAreaName: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomAreaName: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomAreaName: no map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomAreaName: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -7649,9 +7713,10 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
     QString name;
     if( ! lua_isnumber( L, 1 ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring( L, tr( "getRoomAreaName: bad argument #1 type (area id as number or area name as string expected, got %1!)" )
-                            .arg( luaL_typename( L, 1 ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getRoomAreaName: bad argument #1 type (area id as number or area name as string\n"
+                                             "expected, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -7670,7 +7735,10 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
             return 1;
         }
         else {
-            lua_pushstring( L, tr( "getRoomAreaName: bad argument #1 value (string \"%1\" is not a valid area name)." ).arg( name ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getRoomAreaName: bad argument #1 value (string \"%1\" is\n"
+                                             "not a valid area name).")
+                           .arg(name)
+                           .toUtf8().constData());
             return 2;
         }
     }
@@ -7681,7 +7749,9 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
         }
         else {
             lua_pushnumber( L, -1 );
-            lua_pushstring( L, tr( "getRoomAreaName: bad argument #1 value (number %1 is not a valid area id)." ).arg( id ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getRoomAreaName: bad argument #1 value (number %1 is not a valid area id).")
+                           .arg(id)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -7693,9 +7763,9 @@ int TLuaInterpreter::addAreaName( lua_State *L )
     QString name;
 
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring( L, tr( "addAreaName: bad argument #1 type (area name as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("addAreaName: bad argument #1 type (area name as string expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -7706,29 +7776,32 @@ int TLuaInterpreter::addAreaName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "addAreaName: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("addAreaName: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ( ! pHost->mpMap ) || ( ! pHost->mpMap->mpRoomDB ) ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "addAreaName: error, no map seems to be loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("addAreaName: error, no map seems to be loaded!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( name.isEmpty() ) {
         // Empty names now not allowed
         lua_pushnil( L );
-        lua_pushstring( L, tr( "addAreaName: bad argument #1 value (area names may not be empty strings {and spaces are trimmed from the ends})!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("addAreaName: bad argument #1 value (area names may not be empty strings {and\n"
+                                         "spaces are trimmed from the ends})!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().values().count( name ) > 0 ) {
         // That name is already IN the areaNamesMap
         lua_pushnil( L );
-        lua_pushstring( L, tr( "addAreaName: bad argument #2 value (area names may not be duplicated and area id %1 already has the name \"%2\")." )
-                        .arg( pHost->mpMap->mpRoomDB->getAreaNamesMap().key( name ) )
-                        .arg( name ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("addAreaName: bad argument #2 value (area names may not be duplicated and area\n"
+                                         "id %1 already has the name \"%2\")." )
+                       .arg(pHost->mpMap->mpRoomDB->getAreaNamesMap().key(name))
+                       .arg(name)
+                       .toUtf8().constData());
         return 2;
     }
 
@@ -7750,14 +7823,14 @@ int TLuaInterpreter::deleteArea( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "deleteArea: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("deleteArea: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "deleteArea: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("deleteArea: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -7765,15 +7838,18 @@ int TLuaInterpreter::deleteArea( lua_State *L )
         id = lua_tonumber( L, 1 );
         if( id < 1 ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (number %1 is not a valid area id greater than zero)." )
-                            .arg( id ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (number %1 is not a valid area id greater\n"
+                                             "than zero).")
+                           .arg(id)
+                           .toLatin1().constData());
             return 2;
         }
         else if(    ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id )
                  && ! pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( id ) ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (number %1 is not a valid area id)." )
-                            .arg( id ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (number %1 is not a valid area id).")
+                           .arg(id)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -7781,21 +7857,24 @@ int TLuaInterpreter::deleteArea( lua_State *L )
         name = QString::fromUtf8( lua_tostring( L, 1 ) );
         if( name.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (an empty string is not a valid area name)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (an empty string is not a valid area name).")
+                           .toLatin1().constData());
             return 2;
         }
         else if( ! pHost->mpMap->mpRoomDB->getAreaNamesMap().values().contains( name ) ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "deleteArea: bad argument #1 value (string \"%1\" is not a valid area name)." )
-                            .arg( name ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (string \"%1\" is not a valid\n"
+                                             "area name).")
+                           .arg(name)
+                           .toUtf8().constData());
             return 2;
         }
     }
     else {
-        lua_pushstring( L, tr( "deleteArea: bad argument #1 type (area Id as number or area name as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 type (area Id as number or area name as string\n"
+                                         "expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -7967,9 +8046,9 @@ int TLuaInterpreter::addRoom( lua_State * L )
 {
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "addRoom: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("addRoom: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -7993,29 +8072,33 @@ int TLuaInterpreter::createRoomID( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "createRoomID: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("createRoomID: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "createRoomID: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("createRoomID: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isnumber( L, 1 ) ) {
-            lua_pushstring( L, tr( "createRoomID: bad argument #1 type (minimum room Id as number is optional, got %1!)" )
-                            .arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("createRoomID: bad argument #1 type (minimum room Id as number is optional,\n"
+                                             "got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
         }
         else {
             int minId = lua_tointeger( L, 1 );
             if( minId <  1 ) {
                 lua_pushnil( L );
-                lua_pushstring( L, tr( "createRoomID: bad argument #1 value (minimum room id %1 is an optional value but if provided it must be greater than zero.)" )
-                                .arg( minId ).toUtf8().constData() );
+                lua_pushstring(L, QStringLiteral("createRoomID: bad argument #1 value (minimum room id %1 is an optional value\n"
+                                                 "but if provided it must be greater than zero.)")
+                               .arg(minId)
+                               .toLatin1().constData());
                 return 2;
             }
         }
@@ -8546,23 +8629,23 @@ int TLuaInterpreter::setDoor( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setDoor: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDoor: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setDoor: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDoor: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     TRoom * pR;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setDoor: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDoor: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -8571,18 +8654,18 @@ int TLuaInterpreter::setDoor( lua_State * L )
         pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setDoor: bad argument #1 value (number %1 is not a valid room id.)" )
-                            .arg( roomId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setDoor: bad argument #1 value (number %1 is not a valid room id.)")
+                           .arg(roomId)
+                           .toLatin1().constData());
             return 2;
         }
     }
 
     QString exitCmd;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setDoor: bad argument #2 type (door command as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 2 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDoor: bad argument #2 type (door command as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -8610,9 +8693,11 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
                         // And NOT a special one either
                         lua_pushnil( L );
-                        lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with id %1 does not have a special exit in direction \"%2\".)" )
-                                        .arg( roomId ).arg( exitCmd )
-                                        .toUtf8().constData() );
+                        lua_pushstring(L, QStringLiteral("setDoor: bad argument #2 value (room with id %1 does not have a special\n"
+                                                         "exit in direction \"%2\".)")
+                                       .arg(roomId)
+                                       .arg(exitCmd)
+                                       .toUtf8().constData());
                         return 2;
             }
             // else IS a valid special exit - so fall out of if and continue
@@ -8634,9 +8719,11 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
                 // No there IS NOT a stub or real exit in the exitCmd direction
                 lua_pushnil( L );
-                lua_pushstring( L, tr( "setDoor: bad argument #2 value (room with id %1 does not have a normal exit or a stub exit in direction \"%2\".)" )
-                                .arg( roomId ).arg( exitCmd )
-                                .toUtf8().constData() );
+                lua_pushstring(L, QStringLiteral("setDoor: bad argument #2 value (room with id %1 does not have a normal exit\n"
+                                                 "or a stub exit in direction \"%2\".)")
+                               .arg(roomId)
+                               .arg(exitCmd)
+                               .toUtf8().constData());
                 return 2;
             }
             // else IS a valid stub or real normal exit -fall through to continue
@@ -8645,9 +8732,10 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
     int doorStatus;
     if( ! lua_isnumber( L, 3 ) ) {
-        lua_pushstring( L, tr( "setDoor: bad argument #3 type (door type as number expected {0=\"none\", 1=\"open\", 2=\"closed\", 3=\"locked\"}, got %1!)" )
-                        .arg( luaL_typename( L, 3 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDoor: bad argument #3 type (door type as number expected {0=\"none\",\n"
+                                         "1=\"open\", 2=\"closed\", 3=\"locked\"}, got %1!)")
+                       .arg(luaL_typename(L, 3))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -8655,9 +8743,10 @@ int TLuaInterpreter::setDoor( lua_State * L )
         doorStatus = lua_tointeger( L, 3 );
         if( doorStatus < 0 || doorStatus > 3 ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setDoor: bad argument #3 value (door type %1 is not one of 0=\"none\", 1=\"open\", 2=\"closed\" or 3=\"locked\".)" )
-                            .arg( luaL_typename( L, 3 ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setDoor: bad argument #3 value (door type %1 is not one of 0=\"none\", 1=\"open\",\n"
+                                             "2=\"closed\" or 3=\"locked\".)")
+                           .arg(doorStatus)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -8678,23 +8767,23 @@ int TLuaInterpreter::getDoors( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getDoors: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getDoors: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getDoors: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getDoors: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     TRoom * pR;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getDoors: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getDoors: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -8703,9 +8792,9 @@ int TLuaInterpreter::getDoors( lua_State * L )
         pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getDoors: bad argument #1 value (number %1 is not a valid room id)." )
-                            .arg( roomId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getDoors: bad argument #1 value (number %1 is not a valid room id).")
+                           .arg(roomId)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -9266,22 +9355,22 @@ int TLuaInterpreter::clearRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearRoomUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearRoomUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if(! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearRoomUserData: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserData: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9292,9 +9381,9 @@ int TLuaInterpreter::clearRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearRoomUserData: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( roomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -9318,22 +9407,23 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearRoomUserDataItem: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearRoomUserDataItem: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: bad argument #1 type (room id as number expected,\n"
+                                         "got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9343,9 +9433,9 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
 
     QString key = QString(); // This assigns the null value which is different from an empty one
     if ( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9356,9 +9446,9 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearRoomUserDataItem: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg(roomId)
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -9385,22 +9475,22 @@ int TLuaInterpreter::clearAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearAreaUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearAreaUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int areaId;
     if(! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearAreaUserData: bad argument #1 type (area id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserData: bad argument #1 type (area id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9411,15 +9501,15 @@ int TLuaInterpreter::clearAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearAreaUserData: bad argument #1 value (number %1 is not a valid area id)." )
-                        .arg(areaId)
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
+                       .arg(areaId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
         if( ! pA->mUserData.isEmpty() ) {
             pA->mUserData.clear();
-            lua_pushboolean( L , true );
+            lua_pushboolean( L, true );
         }
         else {
             lua_pushboolean( L, false );
@@ -9434,22 +9524,22 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearAreaUserDataItem: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearAreaUserDataItem: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #1 type (area id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #1 type (area id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9459,9 +9549,9 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
 
     QString key = QString(); // This assigns the null value which is different from an empty one
     if ( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9472,16 +9562,16 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #1 value (number %1 is not a valid area id)." )
-                        .arg( areaId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #1 value (number %1 is not a valid area id).")
+                       .arg(areaId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "clearAreaUserDataItem: bad argument #2 value (\"key\" can not be an empty string)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #2 value (\"key\" can not be an empty string).")
+                           .toLatin1().constData());
             return 2;
         }
         else {
@@ -9498,20 +9588,20 @@ int TLuaInterpreter::clearMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearMapUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearMapUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearMapUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearMapUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     if( ! pHost->mpMap->mUserData.isEmpty() ) {
         pHost->mpMap->mUserData.clear();
-        lua_pushboolean( L , true );
+        lua_pushboolean( L, true );
     }
     else {
         lua_pushboolean( L, false );
@@ -9526,22 +9616,22 @@ int TLuaInterpreter::clearMapUserDataItem( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearMapUserDataItem: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearMapUserDataItem: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "clearMapUserDataItem: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearMapUserDataItem: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     QString key = QString(); // This assigns the null value which is different from an empty one
     if ( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring( L, tr( "clearMapUserDataItem: bad argument #1 type (\"key\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 1) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("clearMapUserDataItem: bad argument #1 type (\"key\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9549,8 +9639,8 @@ int TLuaInterpreter::clearMapUserDataItem( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 1 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "clearMapUserDataItem: bad argument #1 value (\"key\" can not be an empty string)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("clearMapUserDataItem: bad argument #1 value (\"key\" can not be an empty string).")
+                           .toLatin1().constData());
             return 2;
         }
         else {
@@ -9714,22 +9804,22 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getRoomUserData: bad argument #1 (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #1 (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9739,9 +9829,9 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "getRoomUserData: bad argument #2 (key as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #2 (key as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9752,10 +9842,10 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
     bool isBackwardCompatibilityRequired = true;
     if( lua_gettop( L ) > 2 ) {
         if( ! lua_isboolean( L, 3 ) ) {
-            lua_pushstring( L, tr( "getRoomUserData: bad argument #3 (enableFullErrorReporting as boolean {default\n"
-                                   "= false} is optional, got %1!)" )
-                            .arg( luaL_typename( L, 3 ) )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #3 (enableFullErrorReporting as boolean {default\n"
+                                             "= false} is optional, got %1!)")
+                           .arg(luaL_typename(L, 1))
+                           .toLatin1().constData());
             lua_error( L );
             return 1;
         }
@@ -9772,9 +9862,9 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getRoomUserData: bad argument #1 value (number %1 is not a valid room id)." )
-                            .arg( roomId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
+                           .arg(roomId)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -9790,10 +9880,10 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
             }
             else {
                 lua_pushnil( L );
-                lua_pushstring( L, tr( "getRoomUserData: bad argument #2 value (no user data with key:\"%1\" in room with id: %2)." )
-                                .arg( key )
-                                .arg( roomId )
-                                .toUtf8().constData() );
+                lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #2 value (no user data with key:\"%1\" in room with id: %2).")
+                               .arg( key )
+                               .arg(roomId)
+                               .toUtf8().constData());
                 return 2;
             }
         }
@@ -9805,9 +9895,9 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
 {
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getAreaUserData: bad argument #1 (area id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #1 (area id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9817,9 +9907,9 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "getAreaUserData: bad argument #2 (key as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #2 (key as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9827,9 +9917,10 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getAreaUserData: bad argument #2 value (\"key\" is not allowed to be an empty string)." )
-                            .arg(areaId)
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #2 value (\"key\" is not allowed to be an\n"
+            "empty string).")
+                           .arg(areaId)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -9837,22 +9928,22 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAreaUserData: bad argument #1 value (number %1 is not a valid area id)." )
-                        .arg( areaId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
+                       .arg(areaId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -9862,10 +9953,11 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "getAreaUserData: bad argument #2 value (no user data with key:\"%1\" in area with id:%2 )." )
-                            .arg( key )
-                            .arg( areaId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #2 value (no user data with key:\"%1\"\n"
+                                             "in area with id:%2 ).")
+                           .arg(key)
+                           .arg(areaId)
+                           .toUtf8().constData());
             return 2;
         }
     }
@@ -9878,22 +9970,22 @@ int TLuaInterpreter::getMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getMapUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getMapUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getMapUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getMapUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     QString key;
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring( L, tr( "getMapUserData: bad argument #1 (key as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 1) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getMapUserData: bad argument #1 (key as string expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9907,9 +9999,9 @@ int TLuaInterpreter::getMapUserData( lua_State * L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getMapUserData: bad argument #1 value (no user data with key:\"%1\" in map)." )
-                        .arg( key )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getMapUserData: bad argument #1 value (no user data with key:\"%1\" in map).")
+                       .arg(key)
+                       .toUtf8().constData());
         return 2;
     }
 }
@@ -9919,22 +10011,22 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9944,9 +10036,9 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #2 type (\"key\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #2 type (\"key\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9957,9 +10049,9 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
 
     QString value;
     if( ! lua_isstring( L, 3 ) ) {
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #3 type (\"value\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 3) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #3 type (\"value\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 3))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9970,9 +10062,9 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomUserData: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg(roomId)
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -9987,9 +10079,9 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
 {
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setAreaUserData: bad argument #1 type (area id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #1 type (area id as number expected, got %1!)")
+                        .arg(luaL_typename(L, 1))
+                        .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -9999,9 +10091,9 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setAreaUserData: bad argument #2 type (\"key\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #2 type (\"key\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10009,17 +10101,18 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setAreaUserData: bad argument #2 value (\"key\" is not allowed to be an empty string)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #2 value (\"key\" is not allowed to be an\n"
+                                             "empty string).")
+                           .toLatin1().constData());
             return 2;
         }
     }
 
     QString value;
     if( ! lua_isstring( L, 3 ) ) {
-        lua_pushstring( L, tr( "setAreaUserData: bad argument #3 type (\"value\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 3) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #3 type (\"value\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 3))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10030,16 +10123,14 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setAreaUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8()
-                        .constData() );
+        lua_pushstring(L, QStringLiteral("setAreaUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setAreaUserData: no map present or loaded!" )
-                        .toUtf8()
-                        .constData() );
+        lua_pushstring(L, QStringLiteral("setAreaUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -10062,9 +10153,9 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setAreaUserData: bad argument #1 value (number %1 is not a valid area id)." )
-                        .arg( areaId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
+                       .arg(areaId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -10081,22 +10172,22 @@ int TLuaInterpreter::setMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setMapUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setMapUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setMapUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setMapUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     QString key;
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring( L, tr( "setMapUserData: bad argument #1 type (\"key\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 1) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setMapUserData: bad argument #1 type (\"key\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10104,17 +10195,17 @@ int TLuaInterpreter::setMapUserData( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 1 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setMapUserData: bad argument #1 value (\"key\" is not allowed to be an empty string)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setMapUserData: bad argument #1 value (\"key\" is not allowed to be an empty string)." )
+                           .toLatin1().constData());
             return 2;
         }
     }
 
     QString value;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "setMapUserData: bad argument #2 type (\"value\" as string expected, got %1!)" )
-                        .arg( luaL_typename(L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setMapUserData: bad argument #2 type (\"value\" as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10154,22 +10245,22 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomUserDataKeys: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomUserDataKeys: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getRoomUserDataKeys: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10181,9 +10272,9 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getRoomUserDataKeys: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( roomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -10207,22 +10298,22 @@ int TLuaInterpreter::getAllRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllRoomUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllRoomUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllRoomUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllRoomUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getAllRoomUserData: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllRoomUserData: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10235,9 +10326,9 @@ int TLuaInterpreter::getAllRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllRoomUserData: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( roomId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg(roomId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -10259,22 +10350,22 @@ int TLuaInterpreter::getAllAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllAreaUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllAreaUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllAreaUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllAreaUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "getAllAreaUserData: bad argument #1 type (area id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllAreaUserData: bad argument #1 type (area id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10287,9 +10378,9 @@ int TLuaInterpreter::getAllAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllAreaUserData: bad argument #1 value (number %1 is not a valid area id)." )
-                        .arg( areaId )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
+                       .arg(areaId)
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -10312,14 +10403,14 @@ int TLuaInterpreter::getAllMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllMapUserData: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllMapUserData: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "getAllMapUserData: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("getAllMapUserData: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
@@ -10341,16 +10432,16 @@ int TLuaInterpreter::downloadFile( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "downloadFile: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("downloadFile: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
 
     QString localFile;
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring( L, tr( "downloadFile: bad argument #1 type (local filename as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("downloadFile: bad argument #1 type (local filename as string expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10360,9 +10451,9 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
     QString urlString;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring( L, tr( "downloadFile: bad argument #1 type (remote url as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 2 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("downloadFile: bad argument #2 type (remote url as string expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toUtf8().constData());
         lua_error( L );
         return 1;
     }
@@ -10374,10 +10465,10 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
     if( ! url.isValid() ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "downloadFile: bad argument #2 value (url is not deemed valid), validation\n"
-                               "produced the following error message:\n%1." )
-                        .arg( url.errorString() )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("downloadFile: bad argument #2 value (url is not deemed valid), validation\n"
+                                         "produced the following error message:\n%1.")
+                       .arg(url.errorString())
+                       .toUtf8().constData());
         return 2;
     }
 
@@ -10411,23 +10502,23 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomArea: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setRoomArea: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomArea: no map present or loaded!")
+                       .toLatin1().constData());
 
         return 2;
     }
 
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "setRoomArea: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10435,9 +10526,9 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         id = lua_tointeger( L, 1 );
         if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setRoomArea: bad argument #1 value (number %1 is not a valid room id)." )
-                            .arg( id )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #1 value (number %1 is not a valid room id).")
+                           .arg(id)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -10448,16 +10539,17 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         areaId = lua_tonumber( L, 2 );
         if( areaId < 1 ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (number %1 is not a valid area id greater than zero.  To remove a room's area, use resetRoomArea( roomId ) )." )
-                            .arg( areaId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (number %1 is not a valid area id greater\n"
+                                             "than zero.  To remove a room's area, use resetRoomArea( roomId ) ).")
+                           .arg(areaId)
+                           .toLatin1().constData());
             return 2;
         }
         else if( !pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( areaId ) ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (number %1 is not a valid area id as it does not exist)." )
-                            .arg( areaId )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (number %1 is not a valid area id as it does not exist).")
+                           .arg(areaId)
+                           .toLatin1().constData());
             return 2;
         }
     }
@@ -10466,23 +10558,24 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         // areaId will be zero if not found!
         if( areaName.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area name cannot be empty)." )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (area name cannot be empty).")
+                           .toLatin1().constData());
             return 2;
         }
         areaId = pHost->mpMap->mpRoomDB->getAreaNamesMap().key( areaName, 0 );
         if( ! areaId ) {
             lua_pushnil( L );
-            lua_pushstring( L, tr( "setRoomArea: bad argument #2 value (area name \"%1\" does not exist)." )
-                            .arg( areaName )
-                            .toUtf8().constData() );
+            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (area name \"%1\" does not exist)." )
+                           .arg(areaName)
+                           .toUtf8().constData());
             return 2;
         }
     }
     else {
-        lua_pushstring( L, tr( "setRoomArea: bad argument #2 type (area Id as number or area name as string expected, got %1!)" )
-                        .arg( luaL_typename( L, 2) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 type (area Id as number or area name as string\n"
+                                         "expected, got %1!)")
+                       .arg(luaL_typename(L, 2))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10508,9 +10601,9 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     //will reset the room area to our void area
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring( L, tr( "resetRoomArea: bad argument #1 type (room id as number expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("resetRoomArea: bad argument #1 type (room id as number expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
         return 1;
     }
@@ -10521,21 +10614,21 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "resetRoomArea: NULL Host pointer - something is wrong!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("resetRoomArea: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "resetRoomArea: no map present or loaded!" )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("resetRoomArea: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "resetRoomArea: bad argument #1 value (number %1 is not a valid room id)." )
-                        .arg( id )
-                        .toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("resetRoomArea: bad argument #1 value (number %1 is not a valid room id).")
+                       .arg( id )
+                       .toLatin1().constData());
         return 2;
     }
     else {
@@ -11109,8 +11202,8 @@ int TLuaInterpreter::Echo( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if (! pHost) {
-        lua_pushstring(L, tr("echo: NULL Host pointer - something is wrong!")
-                       .toUtf8().constData());
+        lua_pushstring(L, QStringLiteral("echo: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return lua_error(L);
     }
 
@@ -11120,16 +11213,14 @@ int TLuaInterpreter::Echo( lua_State *L )
 
     if (n > 1) {
         if (! lua_isstring(L, 1)) {
-            lua_pushstring(L, tr("echo: bad argument #1 type (console name as string, is optional, got %1!)")
+            lua_pushstring(L, QStringLiteral("echo: bad argument #1 type (console name as string, is optional, got %1!)")
                            .arg(luaL_typename(L, 1))
-                           .toUtf8().constData());
+                           .toLatin1().constData());
             return lua_error(L);
         } else {
             consoleName = QString::fromUtf8(lua_tostring(L, 1));
             if (!consoleName.isEmpty()) {
-                if (!consoleName.compare(tr("main","This text is used programmatically, ensure all translations are the same."),
-                                         Qt::CaseSensitive)) {
-
+                if (consoleName == QLatin1String("main")) {
                     // QString::compare is zero for a match on the "default"
                     // case so clear the variable - to flag this as the main
                     // window case - as is the case for an empty string
@@ -11139,16 +11230,16 @@ int TLuaInterpreter::Echo( lua_State *L )
         }
     } else if (!n) {
         // Handle case with NO arguments
-        lua_pushstring(L, tr("echo: bad argument #1 type (text to display as string expected, got nil!)")
-                       .toUtf8().constData());
+        lua_pushstring(L, QStringLiteral("echo: bad argument #1 type (text to display as string expected, got nil!)")
+                       .toLatin1().constData());
         return lua_error(L);
     }
 
     if (! lua_isstring(L, n)) {
-        lua_pushstring(L, tr("echo: bad argument #%1 type (text to display as string expected, got %2!)")
+        lua_pushstring(L, QStringLiteral("echo: bad argument #%1 type (text to display as string expected, got %2!)")
                        .arg(n)
                        .arg(luaL_typename(L, n))
-                       .toUtf8().constData()); // Cannot combine the 2 args, is ambiguous
+                       .toLatin1().constData());
         return lua_error(L);
     } else {
         displayText = QString::fromUtf8(lua_tostring(L, n));
@@ -11168,8 +11259,8 @@ int TLuaInterpreter::Echo( lua_State *L )
             return 1;
         } else {
             lua_pushnil(L);
-            lua_pushstring(L, tr("echo: bad argument #1 value (console name \"%1\" does not exist, omit this"
-                                 "{or use the default \"main\"} to send text to main console!)")
+            lua_pushstring(L, QStringLiteral("echo: bad argument #1 value (console name \"%1\" does not exist, omit this"
+                                             "{or use the default \"main\"} to send text to main console!)")
                            .arg(consoleName)
                            .toUtf8().constData());
             return 2;
@@ -11921,18 +12012,22 @@ int TLuaInterpreter::setDefaultAreaVisible( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setDefaultAreaVisible: NULL Host pointer - something is wrong!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDefaultAreaVisible: NULL Host pointer - something is wrong!")
+                       .toLatin1().constData());
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring( L, tr( "setDefaultAreaVisible: no map present or loaded!" ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDefaultAreaVisible: no map present or loaded!")
+                       .toLatin1().constData());
         return 2;
     }
 
     if( ! lua_isboolean( L, 1 ) ) {
-        lua_pushstring( L, tr( "setDefaultAreaVisible: bad argument #1 type (isToShowDefaultArea as boolean expected, got %1!)" )
-                        .arg( luaL_typename( L, 1 ) ).toUtf8().constData() );
+        lua_pushstring(L, QStringLiteral("setDefaultAreaVisible: bad argument #1 type (isToShowDefaultArea as boolean\n"
+                                         "expected, got %1!)")
+                       .arg(luaL_typename(L, 1))
+                       .toLatin1().constData());
         lua_error( L );
     }
     else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -346,8 +346,7 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring(L, QStringLiteral("raiseEvent: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "raiseEvent: NULL Host pointer - something is wrong!");
         lua_error( L );
         return 1;
     }
@@ -373,11 +372,8 @@ int TLuaInterpreter::raiseEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushstring(L, QStringLiteral("raiseEvent: bad argument #%1 type (string, number, boolean, or nil\n"
-                                             "expected, got a %2!)")
-                            .arg(i)
-                            .arg(luaL_typename(L, i))
-                            .toLatin1().constData());
+            lua_pushfstring(L, "raiseEvent: bad argument #%i type (string, number, boolean, or nil\n"
+                              "expected, got a %s!)", i, luaL_typename(L, i));
             lua_error( L );
             return 1;
         }
@@ -393,8 +389,8 @@ int TLuaInterpreter::getProfileName( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getProfileName:  NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getProfileName:  NULL Host pointer - something is wrong!");
+
         return 2;
     }
 
@@ -411,16 +407,14 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring(L, QStringLiteral("raiseGlobalEvent: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "raiseGlobalEvent: NULL Host pointer - something is wrong!");
         lua_error( L );
         return 1;
     }
 
     int n = lua_gettop( L );
     if( ! n ) {
-        lua_pushstring(L, QStringLiteral("raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)")
-                       .toLatin1().constData());
+        lua_pushstring(L, "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)");
         lua_error( L );
         return 1;
     }
@@ -452,11 +446,9 @@ int TLuaInterpreter::raiseGlobalEvent( lua_State * L )
             event.mArgumentTypeList.append( ARGUMENT_TYPE_NIL );
         }
         else {
-            lua_pushstring(L, QStringLiteral("raiseGlobalEvent: bad argument type #%1 (boolean, number, string or nil\n"
-                                             "expected, got a %2!)")
-                           .arg(i)
-                           .arg(luaL_typename(L, i))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "raiseGlobalEvent: bad argument type #%i (boolean, number, string or nil\n"
+                               "expected, got a %s!)",
+                            i, luaL_typename(L, i));
             lua_error( L );
             return 1;
         }
@@ -488,8 +480,7 @@ int TLuaInterpreter::selectString( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring(L, QStringLiteral("selectString: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "selectString: NULL Host pointer - something is wrong!");
         lua_error( L );
         return 1;
     }
@@ -498,11 +489,9 @@ int TLuaInterpreter::selectString( lua_State * L )
     QString windowName; // only for 3 argument case, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 2 ) {
         if( ! lua_isstring( L, s ) ) {
-            lua_pushstring(L, QStringLiteral("selectString: bad argument #%1 type (window name as string, is optional {defaults"
-                                             "to \"main\" if omitted}, got %2!)")
-                           .arg(s)
-                           .arg(luaL_typename(L, s))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "selectString: bad argument #%i type (window name as string, is optional {defaults"
+                               "to \"main\" if omitted}, got %s!)",
+                            s, luaL_typename(L, s));
             lua_error( L );
             return 1;
         }
@@ -520,10 +509,8 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     QString searchText;
     if( ! lua_isstring( L, s ) ) {
-        lua_pushstring(L, QStringLiteral("selectString: bad argument #%1 type (text to select as string expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "selectString: bad argument #%i type (text to select as string expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -535,10 +522,8 @@ int TLuaInterpreter::selectString( lua_State * L )
 
     qint64 numOfMatch = 0;
     if( ! lua_isnumber( L, s ) ) {
-        lua_pushstring(L, QStringLiteral("selectString: bad argument #%1 type (match count as number {1 for first} expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "selectString: bad argument #%i type (match count as number {1 for first} expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -1271,22 +1256,19 @@ int TLuaInterpreter::centerview( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("centerview: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "centerview: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("centerview: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "centerview: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("centerview: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "centerview: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -1313,9 +1295,8 @@ int TLuaInterpreter::centerview( lua_State * L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("centerview: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "centerview: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
 }
@@ -1368,17 +1349,15 @@ int TLuaInterpreter::feedTriggers( lua_State * L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if (! pHost) {
-        lua_pushstring(L, QStringLiteral("feedTriggers: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "feedTriggers: NULL Host pointer - something is wrong!");
         return lua_error(L);
     }
 
     std::string text;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, QStringLiteral("feedTriggers: bad argument #1 type (imitation MUD server text as string\n"
-                                         "expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "feedTriggers: bad argument #1 type (imitation MUD server text as string\n"
+                           "expected, got %s!)",
+                        luaL_typename(L, 1));
         return lua_error(L);
     } else {
         text = lua_tostring( L, 1 );
@@ -2019,22 +1998,19 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getExitStubs: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getExitStubs: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getExitStubs: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getExitStubs: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( !lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getExitStubs: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getExitStubs: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -2046,9 +2022,8 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getExitStubs: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getExitStubs: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -2064,9 +2039,8 @@ int TLuaInterpreter::getExitStubs( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getExitStubs: no stubs in this room with id %1.")
-                           .arg(roomId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getExitStubs: no stubs in this room with id %i.",
+                           roomId);
             return 2;
         }
     }
@@ -2077,22 +2051,19 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getExitStubs1: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getExitStubs1: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getExitStubs1: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getExitStubs1: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( !lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getExitStubs1: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getExitStubs1: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -2104,9 +2075,8 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getExitStubs1: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getExitStubs1: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -2122,9 +2092,8 @@ int TLuaInterpreter::getExitStubs1( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getExitStubs1: no stubs in this room with id %1.")
-                           .arg(roomId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getExitStubs1: no stubs in this room with id %i.",
+                            roomId);
             return 2;
         }
     }
@@ -2208,18 +2177,16 @@ int TLuaInterpreter::loadMap( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("loadMap: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "loadMap: NULL Host pointer - something is wrong!");
         return 2;
     }
 
     QString location;
     if( lua_gettop( L ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("loadMap: bad argument #1 type (Map pathFile as string is optional {loads last\n"
-                                             "stored map if omitted}, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "loadMap: bad argument #1 type (Map pathFile as string is optional {loads last\n"
+                               "stored map if omitted}, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -3160,17 +3127,15 @@ int TLuaInterpreter::startLogging( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring(L, QStringLiteral("startLogging: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "startLogging: NULL Host pointer - something is wrong!");
         lua_error(L);
         return 2;
     }
 
     bool logOn = true;
     if( ! lua_isboolean( L, 1 ) ) {
-        lua_pushfstring(L, QStringLiteral( "startLogging: bad argument #1 type (turn logging on/off, as boolean expected, got %1!)")
-                        .arg(luaL_typename(L, 1))
-                        .toLatin1().constData());
+        lua_pushfstring(L, "startLogging: bad argument #1 type (turn logging on/off, as boolean expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -3194,17 +3159,15 @@ int TLuaInterpreter::startLogging( lua_State *L )
         if( pHost->mpConsole->mLogToLogFile ) {
             pHost->mpConsole->logButton->setChecked(true);
             // Sets the button as checked but clicked() & pressed() signals are NOT generated
-            lua_pushstring(L, QStringLiteral("Main console output has started to be logged to file: %1")
-                           .arg(pHost->mpConsole->mLogFileName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "Main console output has started to be logged to file: %s.",
+                            pHost->mpConsole->mLogFileName.toUtf8().constData());
             lua_pushstring(L, pHost->mpConsole->mLogFileName.toUtf8().constData());
             lua_pushnumber(L, 1);
         }
         else {
             pHost->mpConsole->logButton->setChecked(false);
-            lua_pushstring(L, QStringLiteral("Main console output has stopped being logged to file: %1")
-                           .arg(savedLogFileName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "Main console output has stopped being logged to file: %s.",
+                            savedLogFileName.toUtf8().constData());
             lua_pushstring(L, pHost->mpConsole->mLogFileName.toUtf8().constData());
             lua_pushnumber(L, 0);
         }
@@ -3213,15 +3176,13 @@ int TLuaInterpreter::startLogging( lua_State *L )
     else {
         lua_pushnil( L );
         if( pHost->mpConsole->mLogToLogFile ) {
-            lua_pushstring(L, QStringLiteral("Main console output is already being logged to file: %1")
-                           .arg(pHost->mpConsole->mLogFileName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "Main console output is already being logged to file: %s.",
+                            pHost->mpConsole->mLogFileName.toUtf8().constData());
             lua_pushstring(L, pHost->mpConsole->mLogFileName.toUtf8().constData());
             lua_pushnumber(L, -1);
         }
         else {
-            lua_pushstring(L, QStringLiteral("Main console output was already not being logged to a file.")
-                           .toLatin1().constData());
+            lua_pushstring(L, "Main console output was already not being logged to a file.");
             lua_pushnil(L);
             lua_pushnumber(L, -2);
         }
@@ -3468,8 +3429,7 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setTextFormat: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setTextFormat: NULL Host pointer - something is wrong!");
         return 2;
     }
 
@@ -3479,11 +3439,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     QString windowName;
     if( ! lua_isstring( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (window name as string {use \"main\" or\n"
-                                         "empty string for main console} expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (window name as string {use \"main\" or\n"
+                           "empty string for main console} expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3495,10 +3453,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     QVector<int>colorComponents(6); // 0-2 RGB foreground, 3-5 RGB background
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (red foreground color component as number expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (red foreground color component as number\n"
+                           "expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3509,10 +3466,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (green foreground color component as number expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (green foreground color component as number\n"
+                           "expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3523,10 +3479,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (blue foreground color component as number expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (blue foreground color component as number\n"
+                           "expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3537,10 +3492,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (red background color component as number expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (red background color component as number\n"
+                           "expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3551,10 +3505,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (green background color component as number expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (green background color component as number\n"
+                           "expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3565,10 +3518,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
 
     if( ! lua_isnumber( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (blue background color component as number expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (blue background color component as number\n"
+                           "expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3588,10 +3540,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (bold format as boolean {or number, non-zero is true} expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (bold format as boolean {or number,\n"
+                           "non-zero is true} expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3607,10 +3558,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (underline format as boolean {or number, non-zero is true} expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (underline format as boolean {or number,\n"
+                           "non-zero is true} expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3626,10 +3576,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
     }
     else
     {
-        lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (italic format as boolean {or number, non-zero is true} expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setTextFormat: bad argument #%i type (italic format as boolean {or number,\n"
+                          "non-zero is true} expected, got %s!)",
+                       s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -3647,10 +3596,9 @@ int TLuaInterpreter::setTextFormat( lua_State * L )
         }
         else
         {
-            lua_pushstring(L, QStringLiteral("setTextFormat: bad argument #%1 type (strikeout format as boolean {or number, non-zero is true} optional, got %2!)")
-                           .arg(s)
-                           .arg(luaL_typename(L, s))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setTextFormat: bad argument #%i type (strikeout format as boolean {or number,\n"
+                               "non-zero is true} optional, got %s!)",
+                            s, luaL_typename(L, s));
             lua_error( L );
             return 1;
         }
@@ -3829,22 +3777,19 @@ int TLuaInterpreter::setRoomName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomName: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setRoomName: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomName: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setRoomName: no map present or loaded!");
         return 2;
     }
 
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setRoomName: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomName: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -3854,9 +3799,8 @@ int TLuaInterpreter::setRoomName( lua_State *L )
 
     QString name;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("setRoomName: bad argument #2 type (room name as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomName: bad argument #2 type (room name as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -3872,9 +3816,8 @@ int TLuaInterpreter::setRoomName( lua_State *L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomName: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(id)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomName: bad argument #1 value (number %i is not a valid room id).",
+                        id);
         return 2;
     }
 }
@@ -3884,22 +3827,19 @@ int TLuaInterpreter::getRoomName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomName: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomName: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomName: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomName: no map present or loaded!");
         return 2;
     }
 
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getRoomName: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getRoomName: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -3914,9 +3854,8 @@ int TLuaInterpreter::getRoomName( lua_State *L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomName: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(id)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getRoomName: bad argument #1 value (number %i is not a valid room id).",
+                        id);
         return 2;
     }
 }
@@ -4407,9 +4346,8 @@ int TLuaInterpreter::getAllRoomEntrances( lua_State *L )
 {
     int roomId = 0;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getAllRoomEntrances: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAllRoomEntrances: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         return lua_error( L );
     }
     else {
@@ -4419,23 +4357,20 @@ int TLuaInterpreter::getAllRoomEntrances( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllRoomEntrances: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllRoomEntrances: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllRoomEntrances: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllRoomEntrances: no map present or loaded!");
         return 2;
     }
     else {
         TRoom * pR = pHost->mpMap->mpRoomDB->getRoom(roomId);
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getAllRoomEntrances: bad argument #1 value (number %1 is not a valid room id).")
-                           .arg(roomId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getAllRoomEntrances: bad argument #1 value (number %i is not a valid room id).",
+                            roomId);
             return 2;
         }
         lua_newtable(L);
@@ -4468,14 +4403,12 @@ int TLuaInterpreter::searchRoom( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("searchRoom: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "searchRoom: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("searchRoom: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "searchRoom: no map present or loaded!");
         return 2;
     }
 
@@ -4498,18 +4431,16 @@ int TLuaInterpreter::searchRoom( lua_State *L )
                     if( lua_isboolean( L, 3) )
                         exactMatch = lua_toboolean( L, 3 );
                     else {
-                        lua_pushstring(L, QStringLiteral("searchRoom: bad argument #3 type (\"exact match\" as boolean is optional, got %1!)")
-                                       .arg(luaL_typename(L, 3))
-                                       .toLatin1().constData());
+                        lua_pushfstring(L, "searchRoom: bad argument #3 type (\"exact match\" as boolean is optional, got %s!)",
+                                        luaL_typename(L, 3));
                         lua_error( L );
                         return 1;
                     }
                 }
             }
             else {
-                lua_pushstring(L, QStringLiteral("searchRoom: bad argument #2 type (\"case sensitive\" as boolean is optional, got %1!)")
-                               .arg(luaL_typename(L, 2))
-                               .toLatin1().constData());
+                lua_pushfstring(L, "searchRoom: bad argument #2 type (\"case sensitive\" as boolean is optional, got %s!)",
+                                luaL_typename(L, 2));
                 lua_error( L );
                 return 1;
             }
@@ -4517,9 +4448,8 @@ int TLuaInterpreter::searchRoom( lua_State *L )
         room = QString::fromUtf8( lua_tostring( L, 1 ) );
     }
     else {
-        lua_pushstring(L, QStringLiteral("searchRoom: bad argument #1 (\"room name\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "searchRoom: bad argument #1 (\"room name\" as string expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -4531,9 +4461,8 @@ int TLuaInterpreter::searchRoom( lua_State *L )
             return 1;
         }
         else {
-            lua_pushstring(L, QStringLiteral("searchRoom: bad argument #1 value (room id %1 does not exist!)")
-                           .arg(room_id)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "searchRoom: bad argument #1 value (room id %i does not exist!)",
+                            room_id);
             // Should've been a nil with this as an second returned string!
             return 1;
         }
@@ -4583,14 +4512,12 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("searchRoomUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "searchRoomUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("searchRoomUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "searchRoomUserData: no map present or loaded!");
         return 2;
     }
 
@@ -4599,9 +4526,8 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
 
     if( lua_gettop( L ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("searchRoomUserData: bad argument #1 (\"key\" as string is optional, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "searchRoomUserData: bad argument #1 (\"key\" as string is optional, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -4611,9 +4537,8 @@ int TLuaInterpreter::searchRoomUserData( lua_State *L )
 
         if( lua_gettop( L ) > 1 ) {
             if( ! lua_isstring( L, 2 ) ) {
-                lua_pushstring(L, QStringLiteral("searchRoomUserData: bad argument #2 (\"value\" as string is optional, got %1!)")
-                               .arg(luaL_typename(L, 2))
-                               .toLatin1().constData());
+                lua_pushfstring(L, "searchRoomUserData: bad argument #2 (\"value\" as string is optional, got %s!)",
+                                luaL_typename(L, 2));
                 lua_error( L );
                 return 1;
             }
@@ -4706,14 +4631,12 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("searchAreaUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "searchAreaUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("searchAreaUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "searchAreaUserData: no map present or loaded!");
         return 2;
     }
 
@@ -4722,9 +4645,8 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
 
     if( lua_gettop( L ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("searchAreaUserData: bad argument #1 (\"key\" as string is optional, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "searchAreaUserData: bad argument #1 (\"key\" as string is optional, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -4734,9 +4656,8 @@ int TLuaInterpreter::searchAreaUserData( lua_State *L )
 
         if( lua_gettop( L ) > 1 ) {
             if( ! lua_isstring( L, 2 ) ) {
-                lua_pushstring(L, QStringLiteral("searchAreaUserData: bad argument #2 (\"value\" as string is optional, got %1!)")
-                               .arg(luaL_typename(L, 2))
-                               .toLatin1().constData());
+                lua_pushfstring(L, "searchAreaUserData: bad argument #2 (\"value\" as string is optional, got %s!)",
+                                luaL_typename(L, 2));
                 lua_error( L );
                 return 1;
             }
@@ -4828,14 +4749,12 @@ int TLuaInterpreter::getAreaTable( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaTable: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAreaTable: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaTable: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAreaTable: no map present or loaded!");
         return 2;
     }
 
@@ -4857,14 +4776,12 @@ int TLuaInterpreter::getAreaTableSwap( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaTableSwap: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAreaTableSwap: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaTableSwap: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAreaTableSwap: no map present or loaded!");
         return 2;
     }
 
@@ -4945,9 +4862,8 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     int n = lua_gettop( L );
     bool isFullDataRequired = false;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getAreaExits: bad argument #1 type (area id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAreaExits: bad argument #1 type (area id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         return lua_error( L );
     }
     else {
@@ -4956,9 +4872,8 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
 
     if( n > 1 ) {
         if( ! lua_isboolean( L, 2 ) ) {
-            lua_pushstring( L, QStringLiteral("getAreaExits: bad argument #2 type (full data wanted as boolean is optional, got %1!)")
-                            .arg(luaL_typename(L, 2))
-                            .toLatin1().constData());
+            lua_pushfstring( L, "getAreaExits: bad argument #2 type (full data wanted as boolean is optional, got %s!)",
+                             luaL_typename(L, 2));
             lua_error( L );
             return 1;
         }
@@ -4971,9 +4886,8 @@ int TLuaInterpreter::getAreaExits( lua_State *L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( area );
     if( !pA ) {
         lua_pushnil(L);
-        lua_pushstring(L, QStringLiteral("getAreaExits: bad argument #1 value (number %1 is not a valid area id).")
-                       .arg( area )
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAreaExits: bad argument #1 value (number %i is not a valid area id).",
+                        area);
         return 2;
     }
 
@@ -5056,9 +4970,8 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
 {
     int targetRoomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("gotoRoom: bad argument #1 type (target room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "gotoRoom: bad argument #1 type (target room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -5069,21 +4982,18 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("gotoRoom: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "gotoRoom: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("gotoRoom: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "gotoRoom: no map present or loaded!");
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( targetRoomId ) ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("gotoRoom: bad argument #1 value (number %1 is not a valid target room id).")
-                       .arg(targetRoomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "gotoRoom: bad argument #1 value (number %i is not a valid target room id).",
+                        targetRoomId);
         return 2;
     }
 
@@ -5096,9 +5006,8 @@ int TLuaInterpreter::gotoRoom( lua_State *L )
         int totalWeight = pHost->assemblePath(); // Needed if unsucessful to clear lua speedwalk tables
         Q_UNUSED(totalWeight);
         lua_pushboolean( L, false );
-        lua_pushstring(L, QStringLiteral("gotoRoom: no path found from current room to room with id %1!")
-                       .arg(targetRoomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "gotoRoom: no path found from current room to room with id %i!",
+                        targetRoomId);
         return 2;
     }
 }
@@ -5107,9 +5016,8 @@ int TLuaInterpreter::getPath( lua_State *L )
 {
     int originRoomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getPath: bad argument #1 type (starting room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getPath: bad argument #1 type (starting room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -5119,9 +5027,8 @@ int TLuaInterpreter::getPath( lua_State *L )
 
     int targetRoomId;
     if( ! lua_isnumber( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("getPath: bad argument #2 type (target room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getPath: bad argument #2 type (target room id as number expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -5132,28 +5039,24 @@ int TLuaInterpreter::getPath( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getPath: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getPath: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getPath: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getPath: no map present or loaded!");
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( originRoomId ) ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getPath: bad argument #1 value (number %1 is not a valid source room id).")
-                       .arg(originRoomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getPath: bad argument #1 value (number %i is not a valid source room id).",
+                        originRoomId);
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoom( targetRoomId ) ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getPath: bad argument #2 value (number %1 is not a valid target room id).")
-                       .arg(targetRoomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getPath: bad argument #2 value (number %i is not a valid target room id).",
+                        targetRoomId);
         return 2;
     }
 
@@ -5168,10 +5071,8 @@ int TLuaInterpreter::getPath( lua_State *L )
     else {
         lua_pushboolean( L, false );
         lua_pushnumber( L, -1 );
-        lua_pushstring(L, QStringLiteral("getPath: no path found from room, with Id %1 to room %2!")
-                       .arg(originRoomId)
-                       .arg(targetRoomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getPath: no path found from room, with Id %i to room %i!",
+                        originRoomId, targetRoomId);
         return 3;
     }
 }
@@ -5180,8 +5081,7 @@ int TLuaInterpreter::deselect( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring(L, QStringLiteral("deselect: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "deselect: NULL Host pointer - something is wrong!");
         lua_error( L );
         return 1;
     }
@@ -5189,10 +5089,9 @@ int TLuaInterpreter::deselect( lua_State *L )
     QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("deselect: bad argument #1 type (window name as string, is optional {defaults"
-                                             "to \"main\" if omitted}, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "deselect: bad argument #1 type (window name as string, is optional {defaults"
+                               "to \"main\" if omitted}, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -5222,8 +5121,7 @@ int TLuaInterpreter::resetFormat( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
-        lua_pushstring(L, QStringLiteral("resetFormat: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "resetFormat: NULL Host pointer - something is wrong!");
         lua_error( L );
         return 1;
     }
@@ -5231,10 +5129,9 @@ int TLuaInterpreter::resetFormat( lua_State *L )
     QString windowName; // only for case with an argument, will be null if not assigned to which is different from being empty
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("resetFormat: bad argument #1 type (window name as string, is optional {defaults"
-                                             "to \"main\" if omitted}, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toUtf8().constData());
+            lua_pushfstring(L, "resetFormat: bad argument #1 type (window name as string, is optional {defaults"
+                               "to \"main\" if omitted}, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -5315,8 +5212,7 @@ int TLuaInterpreter::setAppStyleSheet( lua_State *L )
 int TLuaInterpreter::showUnzipProgress( lua_State * L )
 {
     lua_pushnil( L );
-    lua_pushstring(L, QStringLiteral("showUnzipProgress: removed command, this function is now inactive and does nothing!")
-                   .toLatin1().constData());
+    lua_pushstring(L, "showUnzipProgress: removed command, this function is now inactive and does nothing!");
     return 2;
 }
 
@@ -5663,8 +5559,7 @@ int TLuaInterpreter::setBold( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setBold: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setBold: NULL Host pointer - something is wrong!");
         return 2;
     }
 
@@ -5674,11 +5569,9 @@ int TLuaInterpreter::setBold( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring(L, QStringLiteral("setBold: bad argument #%1 type (more than one argument supplied and first,\n"
-                                             "window name, as string expected {omission selects \"main\" console window}, got %2!")
-                           .arg(s)
-                           .arg(luaL_typename(L, s))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setBold: bad argument #%i type (more than one argument supplied and first,\n"
+                               "window name, as string expected {omission selects \"main\" console window}, got %s!",
+                            s, luaL_typename(L, s));
             lua_error( L );
             return 1;
         }
@@ -5691,10 +5584,8 @@ int TLuaInterpreter::setBold( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setBold: bad argument #%1 type (enable bold attribute as boolean expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData()) ;
+        lua_pushfstring(L, "setBold: bad argument #%i type (enable bold attribute as boolean expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -5719,8 +5610,7 @@ int TLuaInterpreter::setItalics( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setItalics: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setItalics: NULL Host pointer - something is wrong!");
         return 2;
     }
 
@@ -5730,11 +5620,9 @@ int TLuaInterpreter::setItalics( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring(L, QStringLiteral("setItalics: bad argument #%1 type (more than one argument supplied and first,\n"
-                                             "window name, as string expected {omission selects \"main\" console window}, got %2!")
-                           .arg(s)
-                           .arg(luaL_typename(L, s))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setItalics: bad argument #%i type (more than one argument supplied and first,\n"
+                               "window name, as string expected {omission selects \"main\" console window}, got %s!",
+                            s, luaL_typename(L, s));
             lua_error( L );
             return 1;
         }
@@ -5747,10 +5635,8 @@ int TLuaInterpreter::setItalics( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setItalics: bad argument #%1 type (enable italic attribute as boolean expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setItalics: bad argument #%i type (enable italic attribute as boolean expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -5775,8 +5661,7 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setUnderline: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setUnderline: NULL Host pointer - something is wrong!");
         return 2;
     }
 
@@ -5786,11 +5671,9 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring(L, QStringLiteral("setUnderline: bad argument #%1 type (more than one argument supplied and first,\n"
-                                             "window name, as string expected {ommision selects \"main\" console window}, got %2!")
-                           .arg(s)
-                           .arg(luaL_typename(L, s))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setUnderline: bad argument #%i type (more than one argument supplied and first,\n"
+                               "window name, as string expected {omission selects \"main\" console window}, got %s!",
+                            s, luaL_typename(L, s));
             lua_error( L );
             return 1;
         }
@@ -5803,10 +5686,8 @@ int TLuaInterpreter::setUnderline( lua_State *L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setUnderline: bad argument #%1 type (enable underline attribute as boolean expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setUnderline: bad argument #%i type (enable underline attribute as boolean expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -5831,8 +5712,7 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setStrikeOut: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setStrikeOut: NULL Host pointer - something is wrong!");
         return 2;
     }
 
@@ -5842,11 +5722,9 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     { // Have more than one argument so first must be a console name
         if( ! lua_isstring( L, ++s ) )
         {
-            lua_pushstring(L, QStringLiteral("setStrikeOut: bad argument #%1 type (more than one argument supplied and first,\n"
-                                             "window name, as string expected {omission selects \"main\" console window}, got %2!)")
-                           .arg(s)
-                           .arg(luaL_typename(L, s))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setStrikeOut: bad argument #%i type (more than one argument supplied and first,\n"
+                               "window name, as string expected {omission selects \"main\" console window}, got %s!)",
+                            s, luaL_typename(L, s));
             lua_error( L );
             return 1;
         }
@@ -5859,10 +5737,8 @@ int TLuaInterpreter::setStrikeOut( lua_State * L )
     bool isAtttributeEnabled;
     if( ! lua_isboolean( L, ++s ) )
     {
-        lua_pushstring(L, QStringLiteral("setStrikeOut: bad argument #%1 type (enable strikeout attribute as boolean expected, got %2!)")
-                       .arg(s)
-                       .arg(luaL_typename(L, s))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setStrikeOut: bad argument #%i type (enable strikeout attribute as boolean expected, got %s!)",
+                        s, luaL_typename(L, s));
         lua_error( L );
         return 1;
     }
@@ -6137,8 +6013,7 @@ int TLuaInterpreter::getMousePosition( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getMousePosition: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getMousePosition: NULL Host pointer - something is wrong!");
         return 2;
     }
 
@@ -7562,14 +7437,12 @@ int TLuaInterpreter::setAreaName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setAreaName: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setAreaName: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setAreaName: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setAreaName: no map present or loaded!");
         return 2;
     }
 
@@ -7577,10 +7450,9 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         id = lua_tonumber( L, 1 );
         if( id < 1 ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (number %1 is not a valid area id as it is\n"
-                                             "less than 1).")
-                           .arg(id)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setAreaName: bad argument #1 value (number %i is not a valid area id as it is\n"
+                               "less than 1).",
+                            id);
             return 2;
         }
 // Strangely, previous code allowed this command to create a NEW area's name
@@ -7589,9 +7461,8 @@ int TLuaInterpreter::setAreaName( lua_State *L )
 // need to continue to allow this - Slysven
 //        else if( ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id ) ) {
 //            lua_pushnil( L );
-//            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (number %1 is not a valid area id).")
-//                           .arg(id)
-//                           .toLatin1().constData());
+//            lua_pushstring(L, "setAreaName: bad argument #1 value (number %i is not a valid area id)."
+//                           id);
 //            return 2;
 //        }
     }
@@ -7600,39 +7471,34 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         id = pHost->mpMap->mpRoomDB->getAreaNamesMap().key( existingName, 0 );
         if( existingName.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (area name cannot be empty).")
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setAreaName: bad argument #1 value (area name cannot be empty).");
             return 2;
         }
         else if( ! pHost->mpMap->mpRoomDB->getAreaNamesMap().values().contains( existingName ) ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (area name \"%1\" does not exist).")
-                           .arg(existingName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "setAreaName: bad argument #1 value (area name \"%s\" does not exist).",
+                            existingName.toUtf8().constData());
             return 2;
         }
         else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( -1 ).contains( existingName ) ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 value (area name \"%1\" is reserved and\n"
-                                             "protected - it cannot be changed).")
-                           .arg(existingName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "setAreaName: bad argument #1 value (area name \"%s\" is reserved and\n"
+                               "protected - it cannot be changed).",
+                            existingName.toUtf8().constData());
             return 2;
         }
     }
     else {
-        lua_pushstring(L, QStringLiteral("setAreaName: bad argument #1 type (area id as number or area name as string\n"
-                                         "expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setAreaName: bad argument #1 type (area id as number or area name as string\n"
+                           "expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
 
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("setAreaName: bad argument #2 type (area name as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setAreaName: bad argument #2 type (area name as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -7644,9 +7510,8 @@ int TLuaInterpreter::setAreaName( lua_State *L )
     if( newName.isEmpty() ) {
         // Empty name not allowed (any more)
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setAreaName: bad argument #2 value (area names may not be empty strings\n"
-                                         "{and spaces are trimmed from the ends})!")
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setAreaName: bad argument #2 value (area names may not be empty strings\n"
+                           "{and spaces are trimmed from the ends})!");
         return 2;
     }
     else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().values().count( newName ) > 0 ) {
@@ -7656,11 +7521,10 @@ int TLuaInterpreter::setAreaName( lua_State *L )
         if( pHost->mpMap->mpRoomDB->getAreaNamesMap().value( id ) != newName ) {
             lua_pushnil( L );
             // And it isn't the trivial case, where the given areaID already IS that name
-            lua_pushstring(L, QStringLiteral("setAreaName: bad argument #2 value (area names may not be duplicated and area\n"
-                                             "id %1 already has the name \"%2\").")
-                           .arg(pHost->mpMap->mpRoomDB->getAreaNamesMap().key(newName))
-                           .arg(newName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "setAreaName: bad argument #2 value (area names may not be duplicated and area\n"
+                               "id %i already has the name \"%s\").",
+                            pHost->mpMap->mpRoomDB->getAreaNamesMap().key(newName),
+                            newName.toUtf8().constData());
             return 2;
         }
         else {
@@ -7698,14 +7562,12 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomAreaName: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomAreaName: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomAreaName: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomAreaName: no map present or loaded!");
         return 2;
     }
 
@@ -7713,10 +7575,9 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
     QString name;
     if( ! lua_isnumber( L, 1 ) ) {
         if( ! lua_isstring( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("getRoomAreaName: bad argument #1 type (area id as number or area name as string\n"
-                                             "expected, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getRoomAreaName: bad argument #1 type (area id as number or area name as string\n"
+                               "expected, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -7735,10 +7596,9 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
             return 1;
         }
         else {
-            lua_pushstring(L, QStringLiteral("getRoomAreaName: bad argument #1 value (string \"%1\" is\n"
-                                             "not a valid area name).")
-                           .arg(name)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "getRoomAreaName: bad argument #1 value (string \"%s\" is\n"
+                               "not a valid area name).",
+                            name.toUtf8().constData());
             return 2;
         }
     }
@@ -7749,9 +7609,8 @@ int TLuaInterpreter::getRoomAreaName( lua_State *L )
         }
         else {
             lua_pushnumber( L, -1 );
-            lua_pushstring(L, QStringLiteral("getRoomAreaName: bad argument #1 value (number %1 is not a valid area id).")
-                           .arg(id)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getRoomAreaName: bad argument #1 value (number %i is not a valid area id).",
+                            id);
             return 2;
         }
     }
@@ -7763,9 +7622,8 @@ int TLuaInterpreter::addAreaName( lua_State *L )
     QString name;
 
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("addAreaName: bad argument #1 type (area name as string expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "addAreaName: bad argument #1 type (area name as string expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -7776,32 +7634,28 @@ int TLuaInterpreter::addAreaName( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("addAreaName: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "addAreaName: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ( ! pHost->mpMap ) || ( ! pHost->mpMap->mpRoomDB ) ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("addAreaName: error, no map seems to be loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "addAreaName: error, no map seems to be loaded!");
         return 2;
     }
     else if( name.isEmpty() ) {
         // Empty names now not allowed
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("addAreaName: bad argument #1 value (area names may not be empty strings {and\n"
-                                         "spaces are trimmed from the ends})!")
-                       .toLatin1().constData());
+        lua_pushfstring(L, "addAreaName: bad argument #1 value (area names may not be empty strings {and\n"
+                           "spaces are trimmed from the ends})!");
         return 2;
     }
     else if( pHost->mpMap->mpRoomDB->getAreaNamesMap().values().count( name ) > 0 ) {
         // That name is already IN the areaNamesMap
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("addAreaName: bad argument #2 value (area names may not be duplicated and area\n"
-                                         "id %1 already has the name \"%2\")." )
-                       .arg(pHost->mpMap->mpRoomDB->getAreaNamesMap().key(name))
-                       .arg(name)
-                       .toUtf8().constData());
+        lua_pushfstring(L, "addAreaName: bad argument #2 value (area names may not be duplicated and area\n"
+                           "id %i already has the name \"%s\").",
+                        pHost->mpMap->mpRoomDB->getAreaNamesMap().key(name),
+                        name.toUtf8().constData());
         return 2;
     }
 
@@ -7823,14 +7677,12 @@ int TLuaInterpreter::deleteArea( lua_State *L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("deleteArea: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "deleteArea: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("deleteArea: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "deleteArea: no map present or loaded!");
         return 2;
     }
 
@@ -7838,18 +7690,16 @@ int TLuaInterpreter::deleteArea( lua_State *L )
         id = lua_tonumber( L, 1 );
         if( id < 1 ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (number %1 is not a valid area id greater\n"
-                                             "than zero).")
-                           .arg(id)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "deleteArea: bad argument #1 value (number %i is not a valid area id greater\n"
+                               "than zero).",
+                            id);
             return 2;
         }
         else if(    ! pHost->mpMap->mpRoomDB->getAreaIDList().contains( id )
                  && ! pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( id ) ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (number %1 is not a valid area id).")
-                           .arg(id)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "deleteArea: bad argument #1 value (number %i is not a valid area id).",
+                            id);
             return 2;
         }
     }
@@ -7857,24 +7707,21 @@ int TLuaInterpreter::deleteArea( lua_State *L )
         name = QString::fromUtf8( lua_tostring( L, 1 ) );
         if( name.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (an empty string is not a valid area name).")
-                           .toLatin1().constData());
+            lua_pushstring(L, "deleteArea: bad argument #1 value (an empty string is not a valid area name).");
             return 2;
         }
         else if( ! pHost->mpMap->mpRoomDB->getAreaNamesMap().values().contains( name ) ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 value (string \"%1\" is not a valid\n"
-                                             "area name).")
-                           .arg(name)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "deleteArea: bad argument #1 value (string \"%s\" is not a valid\n"
+                               "area name).",
+                            name.toUtf8().constData());
             return 2;
         }
     }
     else {
-        lua_pushstring(L, QStringLiteral("deleteArea: bad argument #1 type (area Id as number or area name as string\n"
-                                         "expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "deleteArea: bad argument #1 type (area Id as number or area name as string\n"
+                           "expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -8046,9 +7893,8 @@ int TLuaInterpreter::addRoom( lua_State * L )
 {
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("addRoom: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "addRoom: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -8072,33 +7918,29 @@ int TLuaInterpreter::createRoomID( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("createRoomID: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "createRoomID: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("createRoomID: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "createRoomID: no map present or loaded!");
         return 2;
     }
 
     if( lua_gettop( L ) > 0 ) {
         if( ! lua_isnumber( L, 1 ) ) {
-            lua_pushstring(L, QStringLiteral("createRoomID: bad argument #1 type (minimum room Id as number is optional,\n"
-                                             "got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "createRoomID: bad argument #1 type (minimum room Id as number is optional,\n"
+                               "got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
         }
         else {
             int minId = lua_tointeger( L, 1 );
             if( minId <  1 ) {
                 lua_pushnil( L );
-                lua_pushstring(L, QStringLiteral("createRoomID: bad argument #1 value (minimum room id %1 is an optional value\n"
-                                                 "but if provided it must be greater than zero.)")
-                               .arg(minId)
-                               .toLatin1().constData());
+                lua_pushfstring(L, "createRoomID: bad argument #1 value (minimum room id %i is an optional value\n"
+                                   "but if provided it must be greater than zero.)",
+                                minId);
                 return 2;
             }
         }
@@ -8629,23 +8471,20 @@ int TLuaInterpreter::setDoor( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setDoor: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setDoor: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setDoor: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setDoor: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     TRoom * pR;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setDoor: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setDoor: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -8654,18 +8493,16 @@ int TLuaInterpreter::setDoor( lua_State * L )
         pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setDoor: bad argument #1 value (number %1 is not a valid room id.)")
-                           .arg(roomId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setDoor: bad argument #1 value (number %i is not a valid room id.)",
+                            roomId);
             return 2;
         }
     }
 
     QString exitCmd;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("setDoor: bad argument #2 type (door command as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setDoor: bad argument #2 type (door command as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -8693,11 +8530,9 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
                         // And NOT a special one either
                         lua_pushnil( L );
-                        lua_pushstring(L, QStringLiteral("setDoor: bad argument #2 value (room with id %1 does not have a special\n"
-                                                         "exit in direction \"%2\".)")
-                                       .arg(roomId)
-                                       .arg(exitCmd)
-                                       .toUtf8().constData());
+                        lua_pushfstring(L, "setDoor: bad argument #2 value (room with id %i does not have a special\n"
+                                           "exit in direction \"%s\".)",
+                                        roomId, exitCmd.toUtf8().constData());
                         return 2;
             }
             // else IS a valid special exit - so fall out of if and continue
@@ -8719,11 +8554,9 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
                 // No there IS NOT a stub or real exit in the exitCmd direction
                 lua_pushnil( L );
-                lua_pushstring(L, QStringLiteral("setDoor: bad argument #2 value (room with id %1 does not have a normal exit\n"
-                                                 "or a stub exit in direction \"%2\".)")
-                               .arg(roomId)
-                               .arg(exitCmd)
-                               .toUtf8().constData());
+                lua_pushfstring(L, "setDoor: bad argument #2 value (room with id %i does not have a normal exit\n"
+                                   "or a stub exit in direction \"%s\".)",
+                                roomId, exitCmd.toUtf8().constData());
                 return 2;
             }
             // else IS a valid stub or real normal exit -fall through to continue
@@ -8732,10 +8565,9 @@ int TLuaInterpreter::setDoor( lua_State * L )
 
     int doorStatus;
     if( ! lua_isnumber( L, 3 ) ) {
-        lua_pushstring(L, QStringLiteral("setDoor: bad argument #3 type (door type as number expected {0=\"none\",\n"
-                                         "1=\"open\", 2=\"closed\", 3=\"locked\"}, got %1!)")
-                       .arg(luaL_typename(L, 3))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setDoor: bad argument #3 type (door type as number expected {0=\"none\",\n"
+                           "1=\"open\", 2=\"closed\", 3=\"locked\"}, got %s!)",
+                        luaL_typename(L, 3));
         lua_error( L );
         return 1;
     }
@@ -8743,10 +8575,9 @@ int TLuaInterpreter::setDoor( lua_State * L )
         doorStatus = lua_tointeger( L, 3 );
         if( doorStatus < 0 || doorStatus > 3 ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setDoor: bad argument #3 value (door type %1 is not one of 0=\"none\", 1=\"open\",\n"
-                                             "2=\"closed\" or 3=\"locked\".)")
-                           .arg(doorStatus)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setDoor: bad argument #3 value (door type %i is not one of 0=\"none\", 1=\"open\",\n"
+                               "2=\"closed\" or 3=\"locked\".)",
+                            doorStatus);
             return 2;
         }
     }
@@ -8767,23 +8598,20 @@ int TLuaInterpreter::getDoors( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getDoors: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getDoors: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getDoors: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getDoors: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     TRoom * pR;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getDoors: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getDoors: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -8792,9 +8620,8 @@ int TLuaInterpreter::getDoors( lua_State * L )
         pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
         if( ! pR ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getDoors: bad argument #1 value (number %1 is not a valid room id).")
-                           .arg(roomId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getDoors: bad argument #1 value (number %i is not a valid room id).",
+                            roomId);
             return 2;
         }
     }
@@ -9355,22 +9182,19 @@ int TLuaInterpreter::clearRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearRoomUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearRoomUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearRoomUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearRoomUserData: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if(! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("clearRoomUserData: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearRoomUserData: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9381,9 +9205,8 @@ int TLuaInterpreter::clearRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -9407,23 +9230,20 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearRoomUserDataItem: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearRoomUserDataItem: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: bad argument #1 type (room id as number expected,\n"
-                                         "got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearRoomUserDataItem: bad argument #1 type (room id as number expected,\n"
+                           "got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9433,9 +9253,8 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
 
     QString key = QString(); // This assigns the null value which is different from an empty one
     if ( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearRoomUserDataItem: bad argument #2 type (\"key\" as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -9446,9 +9265,8 @@ int TLuaInterpreter::clearRoomUserDataItem( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearRoomUserDataItem: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearRoomUserDataItem: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -9475,22 +9293,19 @@ int TLuaInterpreter::clearAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearAreaUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearAreaUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearAreaUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearAreaUserData: no map present or loaded!");
         return 2;
     }
 
     int areaId;
     if(! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("clearAreaUserData: bad argument #1 type (area id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearAreaUserData: bad argument #1 type (area id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9501,9 +9316,8 @@ int TLuaInterpreter::clearAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
-                       .arg(areaId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+                        areaId);
         return 2;
     }
     else {
@@ -9524,22 +9338,19 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearAreaUserDataItem: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearAreaUserDataItem: no map present or loaded!");
         return 2;
     }
 
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #1 type (area id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearAreaUserDataItem: bad argument #1 type (area id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9549,9 +9360,8 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
 
     QString key = QString(); // This assigns the null value which is different from an empty one
     if ( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #2 type (\"key\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearAreaUserDataItem: bad argument #2 type (\"key\" as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -9562,16 +9372,14 @@ int TLuaInterpreter::clearAreaUserDataItem( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #1 value (number %1 is not a valid area id).")
-                       .arg(areaId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearAreaUserDataItem: bad argument #1 value (number %i is not a valid area id).",
+                        areaId);
         return 2;
     }
     else {
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("clearAreaUserDataItem: bad argument #2 value (\"key\" can not be an empty string).")
-                           .toLatin1().constData());
+            lua_pushfstring(L, "clearAreaUserDataItem: bad argument #2 value (\"key\" can not be an empty string).");
             return 2;
         }
         else {
@@ -9588,14 +9396,12 @@ int TLuaInterpreter::clearMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearMapUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearMapUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearMapUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearMapUserData: no map present or loaded!");
         return 2;
     }
 
@@ -9616,22 +9422,19 @@ int TLuaInterpreter::clearMapUserDataItem( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearMapUserDataItem: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearMapUserDataItem: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("clearMapUserDataItem: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "clearMapUserDataItem: no map present or loaded!");
         return 2;
     }
 
     QString key = QString(); // This assigns the null value which is different from an empty one
     if ( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("clearMapUserDataItem: bad argument #1 type (\"key\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "clearMapUserDataItem: bad argument #1 type (\"key\" as string expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9639,8 +9442,7 @@ int TLuaInterpreter::clearMapUserDataItem( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 1 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("clearMapUserDataItem: bad argument #1 value (\"key\" can not be an empty string).")
-                           .toLatin1().constData());
+            lua_pushfstring(L, "clearMapUserDataItem: bad argument #1 value (\"key\" can not be an empty string).");
             return 2;
         }
         else {
@@ -9804,22 +9606,19 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomUserData: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #1 (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getRoomUserData: bad argument #1 (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9829,9 +9628,8 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #2 (key as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getRoomUserData: bad argument #2 (key as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -9842,10 +9640,9 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
     bool isBackwardCompatibilityRequired = true;
     if( lua_gettop( L ) > 2 ) {
         if( ! lua_isboolean( L, 3 ) ) {
-            lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #3 (enableFullErrorReporting as boolean {default\n"
-                                             "= false} is optional, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getRoomUserData: bad argument #3 (enableFullErrorReporting as boolean {default\n"
+                               "= false} is optional, got %s!)",
+                            luaL_typename(L, 1));
             lua_error( L );
             return 1;
         }
@@ -9862,9 +9659,8 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
-                           .arg(roomId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "getRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+                            roomId);
             return 2;
         }
     }
@@ -9880,10 +9676,8 @@ int TLuaInterpreter::getRoomUserData( lua_State * L )
             }
             else {
                 lua_pushnil( L );
-                lua_pushstring(L, QStringLiteral("getRoomUserData: bad argument #2 value (no user data with key:\"%1\" in room with id: %2).")
-                               .arg( key )
-                               .arg(roomId)
-                               .toUtf8().constData());
+                lua_pushfstring(L, "getRoomUserData: bad argument #2 value (no user data with key:\"%s\" in room with id: %i).",
+                                key.toUtf8().constData(), roomId);
                 return 2;
             }
         }
@@ -9895,9 +9689,8 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
 {
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #1 (area id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAreaUserData: bad argument #1 (area id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9907,9 +9700,8 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #2 (key as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAreaUserData: bad argument #2 (key as string expected, got %s!)",
+                       luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -9917,10 +9709,8 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #2 value (\"key\" is not allowed to be an\n"
-            "empty string).")
-                           .arg(areaId)
-                           .toLatin1().constData());
+            lua_pushstring(L, "getAreaUserData: bad argument #2 value (\"key\" is not allowed to be an\n"
+                              "empty string).");
             return 2;
         }
     }
@@ -9928,22 +9718,19 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAreaUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAreaUserData: no map present or loaded!");
         return 2;
     }
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
-                       .arg(areaId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+                        areaId);
         return 2;
     }
     else {
@@ -9953,11 +9740,9 @@ int TLuaInterpreter::getAreaUserData( lua_State * L )
         }
         else {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("getAreaUserData: bad argument #2 value (no user data with key:\"%1\"\n"
-                                             "in area with id:%2 ).")
-                           .arg(key)
-                           .arg(areaId)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "getAreaUserData: bad argument #2 value (no user data with key:\"%s\"\n"
+                               "in area with id:%i).",
+                            key.toUtf8().constData(), areaId);
             return 2;
         }
     }
@@ -9970,22 +9755,19 @@ int TLuaInterpreter::getMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getMapUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getMapUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getMapUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getMapUserData: no map present or loaded!");
         return 2;
     }
 
     QString key;
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getMapUserData: bad argument #1 (key as string expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getMapUserData: bad argument #1 (key as string expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -9999,9 +9781,8 @@ int TLuaInterpreter::getMapUserData( lua_State * L )
     }
     else {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getMapUserData: bad argument #1 value (no user data with key:\"%1\" in map).")
-                       .arg(key)
-                       .toUtf8().constData());
+        lua_pushfstring(L, "getMapUserData: bad argument #1 value (no user data with key:\"%s\" in map).",
+                        key.toUtf8().constData());
         return 2;
     }
 }
@@ -10011,22 +9792,19 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setRoomUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setRoomUserData: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomUserData: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10036,9 +9814,8 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #2 type (\"key\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomUserData: bad argument #2 type (\"key\" as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -10049,9 +9826,8 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
 
     QString value;
     if( ! lua_isstring( L, 3 ) ) {
-        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #3 type (\"value\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 3))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomUserData: bad argument #3 type (\"value\" as string expected, got %s!)",
+                        luaL_typename(L, 3));
         lua_error( L );
         return 1;
     }
@@ -10062,9 +9838,8 @@ int TLuaInterpreter::setRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -10079,9 +9854,8 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
 {
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #1 type (area id as number expected, got %1!)")
-                        .arg(luaL_typename(L, 1))
-                        .toLatin1().constData());
+        lua_pushfstring(L, "setAreaUserData: bad argument #1 type (area id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10091,9 +9865,8 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
 
     QString key;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #2 type (\"key\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setAreaUserData: bad argument #2 type (\"key\" as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -10101,18 +9874,16 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 2 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #2 value (\"key\" is not allowed to be an\n"
-                                             "empty string).")
-                           .toLatin1().constData());
+            lua_pushstring(L, "setAreaUserData: bad argument #2 value (\"key\" is not allowed to be an\n"
+                                             "empty string).");
             return 2;
         }
     }
 
     QString value;
     if( ! lua_isstring( L, 3 ) ) {
-        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #3 type (\"value\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 3))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setAreaUserData: bad argument #3 type (\"value\" as string expected, got %s!)",
+                        luaL_typename(L, 3));
         lua_error( L );
         return 1;
     }
@@ -10123,14 +9894,12 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setAreaUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setAreaUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setAreaUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setAreaUserData: no map present or loaded!");
         return 2;
     }
 
@@ -10153,9 +9922,8 @@ int TLuaInterpreter::setAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
-                       .arg(areaId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+                        areaId);
         return 2;
     }
     else {
@@ -10172,22 +9940,19 @@ int TLuaInterpreter::setMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setMapUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setMapUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setMapUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setMapUserData: no map present or loaded!");
         return 2;
     }
 
     QString key;
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setMapUserData: bad argument #1 type (\"key\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setMapUserData: bad argument #1 type (\"key\" as string expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10195,17 +9960,15 @@ int TLuaInterpreter::setMapUserData( lua_State * L )
         key = QString::fromUtf8( lua_tostring( L, 1 ) );
         if( key.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setMapUserData: bad argument #1 value (\"key\" is not allowed to be an empty string)." )
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setMapUserData: bad argument #1 value (\"key\" is not allowed to be an empty string)." );
             return 2;
         }
     }
 
     QString value;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("setMapUserData: bad argument #2 type (\"value\" as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setMapUserData: bad argument #2 type (\"value\" as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -10245,22 +10008,19 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomUserDataKeys: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getRoomUserDataKeys: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getRoomUserDataKeys: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10272,9 +10032,8 @@ int TLuaInterpreter::getRoomUserDataKeys( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getRoomUserDataKeys: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getRoomUserDataKeys: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -10298,22 +10057,19 @@ int TLuaInterpreter::getAllRoomUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllRoomUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllRoomUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllRoomUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllRoomUserData: no map present or loaded!");
         return 2;
     }
 
     int roomId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getAllRoomUserData: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAllRoomUserData: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10326,9 +10082,8 @@ int TLuaInterpreter::getAllRoomUserData( lua_State * L )
     TRoom * pR = pHost->mpMap->mpRoomDB->getRoom( roomId );
     if( ! pR ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllRoomUserData: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg(roomId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAllRoomUserData: bad argument #1 value (number %i is not a valid room id).",
+                        roomId);
         return 2;
     }
     else {
@@ -10350,22 +10105,19 @@ int TLuaInterpreter::getAllAreaUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllAreaUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllAreaUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllAreaUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllAreaUserData: no map present or loaded!");
         return 2;
     }
 
     int areaId;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("getAllAreaUserData: bad argument #1 type (area id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAllAreaUserData: bad argument #1 type (area id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10378,9 +10130,8 @@ int TLuaInterpreter::getAllAreaUserData( lua_State * L )
     TArea * pA = pHost->mpMap->mpRoomDB->getArea( areaId );
     if( ! pA ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllAreaUserData: bad argument #1 value (number %1 is not a valid area id).")
-                       .arg(areaId)
-                       .toLatin1().constData());
+        lua_pushfstring(L, "getAllAreaUserData: bad argument #1 value (number %i is not a valid area id).",
+                        areaId);
         return 2;
     }
     else {
@@ -10403,14 +10154,12 @@ int TLuaInterpreter::getAllMapUserData( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllMapUserData: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllMapUserData: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("getAllMapUserData: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "getAllMapUserData: no map present or loaded!");
         return 2;
     }
 
@@ -10432,16 +10181,14 @@ int TLuaInterpreter::downloadFile( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("downloadFile: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "downloadFile: NULL Host pointer - something is wrong!");
         return 2;
     }
 
     QString localFile;
     if( ! lua_isstring( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("downloadFile: bad argument #1 type (local filename as string expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "downloadFile: bad argument #1 type (local filename as string expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10451,9 +10198,8 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
     QString urlString;
     if( ! lua_isstring( L, 2 ) ) {
-        lua_pushstring(L, QStringLiteral("downloadFile: bad argument #2 type (remote url as string expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toUtf8().constData());
+        lua_pushfstring(L, "downloadFile: bad argument #2 type (remote url as string expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -10465,10 +10211,9 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
     if( ! url.isValid() ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("downloadFile: bad argument #2 value (url is not deemed valid), validation\n"
-                                         "produced the following error message:\n%1.")
-                       .arg(url.errorString())
-                       .toUtf8().constData());
+        lua_pushfstring(L, "downloadFile: bad argument #2 value (url is not deemed valid), validation\n"
+                           "produced the following error message:\n%s.",
+                        url.errorString().toUtf8().constData());
         return 2;
     }
 
@@ -10502,23 +10247,19 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomArea: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setRoomArea: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setRoomArea: no map present or loaded!")
-                       .toLatin1().constData());
-
+        lua_pushstring(L, "setRoomArea: no map present or loaded!");
         return 2;
     }
 
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomArea: bad argument #1 type (room id as number expected, got %s!)",
+                        luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10526,9 +10267,8 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         id = lua_tointeger( L, 1 );
         if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #1 value (number %1 is not a valid room id).")
-                           .arg(id)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setRoomArea: bad argument #1 value (number %i is not a valid room id).",
+                            id);
             return 2;
         }
     }
@@ -10539,17 +10279,15 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         areaId = lua_tonumber( L, 2 );
         if( areaId < 1 ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (number %1 is not a valid area id greater\n"
-                                             "than zero.  To remove a room's area, use resetRoomArea( roomId ) ).")
-                           .arg(areaId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setRoomArea: bad argument #2 value (number %i is not a valid area id greater\n"
+                               "than zero.  To remove a room's area, use resetRoomArea( roomId ) ).",
+                            areaId);
             return 2;
         }
         else if( !pHost->mpMap->mpRoomDB->getAreaNamesMap().contains( areaId ) ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (number %1 is not a valid area id as it does not exist).")
-                           .arg(areaId)
-                           .toLatin1().constData());
+            lua_pushfstring(L, "setRoomArea: bad argument #2 value (number %i is not a valid area id as it does not exist).",
+                            areaId);
             return 2;
         }
     }
@@ -10558,24 +10296,21 @@ int TLuaInterpreter::setRoomArea( lua_State * L )
         // areaId will be zero if not found!
         if( areaName.isEmpty() ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (area name cannot be empty).")
-                           .toLatin1().constData());
+            lua_pushstring(L, "setRoomArea: bad argument #2 value (area name cannot be empty).");
             return 2;
         }
         areaId = pHost->mpMap->mpRoomDB->getAreaNamesMap().key( areaName, 0 );
         if( ! areaId ) {
             lua_pushnil( L );
-            lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 value (area name \"%1\" does not exist)." )
-                           .arg(areaName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "setRoomArea: bad argument #2 value (area name \"%s\" does not exist).",
+                            areaName.toUtf8().constData());
             return 2;
         }
     }
     else {
-        lua_pushstring(L, QStringLiteral("setRoomArea: bad argument #2 type (area Id as number or area name as string\n"
-                                         "expected, got %1!)")
-                       .arg(luaL_typename(L, 2))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setRoomArea: bad argument #2 type (area Id as number or area name as string\n"
+                           "expected, got %s!)",
+                        luaL_typename(L, 2));
         lua_error( L );
         return 1;
     }
@@ -10601,9 +10336,8 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     //will reset the room area to our void area
     int id;
     if( ! lua_isnumber( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("resetRoomArea: bad argument #1 type (room id as number expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "resetRoomArea: bad argument #1 type (room id as number expected, got %s!)",
+                       luaL_typename(L, 1));
         lua_error( L );
         return 1;
     }
@@ -10614,21 +10348,18 @@ int TLuaInterpreter::resetRoomArea( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("resetRoomArea: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "resetRoomArea: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("resetRoomArea: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "resetRoomArea: no map present or loaded!");
         return 2;
     }
     else if( ! pHost->mpMap->mpRoomDB->getRoomIDList().contains( id ) ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("resetRoomArea: bad argument #1 value (number %1 is not a valid room id).")
-                       .arg( id )
-                       .toLatin1().constData());
+        lua_pushfstring(L, "resetRoomArea: bad argument #1 value (number %i is not a valid room id).",
+                        id);
         return 2;
     }
     else {
@@ -11202,8 +10933,7 @@ int TLuaInterpreter::Echo( lua_State *L )
 {
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if (! pHost) {
-        lua_pushstring(L, QStringLiteral("echo: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "echo: NULL Host pointer - something is wrong!");
         return lua_error(L);
     }
 
@@ -11213,9 +10943,8 @@ int TLuaInterpreter::Echo( lua_State *L )
 
     if (n > 1) {
         if (! lua_isstring(L, 1)) {
-            lua_pushstring(L, QStringLiteral("echo: bad argument #1 type (console name as string, is optional, got %1!)")
-                           .arg(luaL_typename(L, 1))
-                           .toLatin1().constData());
+            lua_pushfstring(L, "echo: bad argument #1 type (console name as string, is optional, got %s!)",
+                            luaL_typename(L, 1));
             return lua_error(L);
         } else {
             consoleName = QString::fromUtf8(lua_tostring(L, 1));
@@ -11230,16 +10959,13 @@ int TLuaInterpreter::Echo( lua_State *L )
         }
     } else if (!n) {
         // Handle case with NO arguments
-        lua_pushstring(L, QStringLiteral("echo: bad argument #1 type (text to display as string expected, got nil!)")
-                       .toLatin1().constData());
+        lua_pushstring(L, "echo: bad argument #1 type (text to display as string expected, got nil!)");
         return lua_error(L);
     }
 
     if (! lua_isstring(L, n)) {
-        lua_pushstring(L, QStringLiteral("echo: bad argument #%1 type (text to display as string expected, got %2!)")
-                       .arg(n)
-                       .arg(luaL_typename(L, n))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "echo: bad argument #%i type (text to display as string expected, got %s!)",
+                        n, luaL_typename(L, n));
         return lua_error(L);
     } else {
         displayText = QString::fromUtf8(lua_tostring(L, n));
@@ -11259,10 +10985,9 @@ int TLuaInterpreter::Echo( lua_State *L )
             return 1;
         } else {
             lua_pushnil(L);
-            lua_pushstring(L, QStringLiteral("echo: bad argument #1 value (console name \"%1\" does not exist, omit this"
-                                             "{or use the default \"main\"} to send text to main console!)")
-                           .arg(consoleName)
-                           .toUtf8().constData());
+            lua_pushfstring(L, "echo: bad argument #1 value (console name \"%s\" does not exist, omit this"
+                               "{or use the default \"main\"} to send text to main console!)",
+                            consoleName.toUtf8().constData());
             return 2;
         }
     }
@@ -12012,22 +11737,18 @@ int TLuaInterpreter::setDefaultAreaVisible( lua_State * L )
     Host * pHost = TLuaInterpreter::luaInterpreterMap[L];
     if( ! pHost ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setDefaultAreaVisible: NULL Host pointer - something is wrong!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setDefaultAreaVisible: NULL Host pointer - something is wrong!");
         return 2;
     }
     else if( ! pHost->mpMap || ! pHost->mpMap->mpRoomDB ) {
         lua_pushnil( L );
-        lua_pushstring(L, QStringLiteral("setDefaultAreaVisible: no map present or loaded!")
-                       .toLatin1().constData());
+        lua_pushstring(L, "setDefaultAreaVisible: no map present or loaded!");
         return 2;
     }
 
     if( ! lua_isboolean( L, 1 ) ) {
-        lua_pushstring(L, QStringLiteral("setDefaultAreaVisible: bad argument #1 type (isToShowDefaultArea as boolean\n"
-                                         "expected, got %1!)")
-                       .arg(luaL_typename(L, 1))
-                       .toLatin1().constData());
+        lua_pushfstring(L, "setDefaultAreaVisible: bad argument #1 type (isToShowDefaultArea as boolean\n"
+                           "expected, got %s!)", luaL_typename(L, 1));
         lua_error( L );
     }
     else {


### PR DESCRIPTION
Since it has been decided that the Mudlet Lua API should not have the capability to report errors in using the API in a translated form the use of the Qt `tr(...)` function to mark such `QStrings` is not wanted.  This commit switches those usages to use the `QStringLiteral(...)` wrapper instead. As the strings concerned are each unique the known downsides of using this "non"-translatable `QString` wrapper should not be significant and the code "template" for the two things are very similar {if there are no second or second & third arguments in the `tr(...)` case} - the editing to switch to `QLatin1Strings` in the same location would be much more intensive.

Where the (formerly) translated `QString` is then passed to the Lua system there are some instances where `QString::toUtf8()` must be used instead of `QString::toLatin1()` - these are generally the cases where a variable included in the resulting `QString` can contain non-ASCII characters which is any user defined/named item or {mainly on Windows platform} involving file-system objects as that can also have non-ASCII characters.

There may be a few long text lines that I have manually inserted new-lines into to try and prevent the resulting text from exceeding around 80 characters when shown on the main profile console.

There was a typo in one error message for `TLuaInterpreter::downloadFile` as it described an issue for argument 1 when it should have said 2.  Also in three functions a `QString "windowName"` is set to the null `QString` when the `QString::clear()`is a little more descriptive of what is happening.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>