### PR TITLE
Allow usage of env variables to set lua search path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -391,8 +391,15 @@ ADD_DEFINITIONS(-DAPP_VERSION="${APP_VERSION}" -DAPP_BUILD="${APP_BUILD}" -DAPP_
 IF(UNIX)
     SET(DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/share" CACHE STRING "The platform-specific directory in which read-only data is generally installed")
     SET(DATADIR "${DATAROOTDIR}/mudlet" CACHE STRING "Directory in which mudlet installs its read-only data")
-    SET(LUA_DEFAULT_DIR "${DATADIR}/lua" CACHE STRING "Directory in which mudlet installs its read-only lua scripts")
 ENDIF(UNIX)
+
+# Allow to define a different path to look for Mudlet's lua files by using
+# the MUDLET_LUA_DEFAULT_DIR environment variable
+IF(DEFINED ENV{MUDLET_LUA_DEFAULT_DIR} AND NOT $ENV{MUDLET_LUA_DEFAULT_DIR} STREQUAL "")
+  SET(LUA_DEFAULT_DIR $ENV{MUDLET_LUA_DEFAULT_DIR})
+ELSEIF(UNIX)
+  SET(LUA_DEFAULT_DIR "${DATADIR}/lua")
+ENDIF()
 
 # Define a preprocessor symbol with the default fallback location from which
 # to load installed mudlet lua files. Set LUA_DEFAULT_DIR to a

--- a/src/src.pro
+++ b/src/src.pro
@@ -128,6 +128,14 @@ unix:!macx {
 # hard-coded executable's /mudlet-lua/lua/ subdirectory
 #    LUA_DEFAULT_DIR = $$clean_path($$system(echo %ProgramFiles%)/lua)
 }
+
+# Override LUA_DEFAULT_DIR, if the environement variable MUDLET_LUA_DEFAULT_DIR
+# was set
+LUA_DEFAULT_DIR_ENV = $$(MUDLET_LUA_DEFAULT_DIR)
+!isEmpty( LUA_DEFAULT_DIR_ENV ){
+  LUA_DEFAULT_DIR = $$LUA_DEFAULT_DIR_ENV
+}
+
 unix:!macx {
 #   the "target" install set is handled automagically, just not very well...
     target.path = $${BINDIR}


### PR DESCRIPTION
By defining the environment variable `MUDLET_LUA_DEFAULT_DIR`, it's now possible
to define a fallback location where Mudlet's lua files are searched.