### PR TITLE
Re-added braces to TCommandLine.cpp

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -122,10 +122,11 @@ bool TCommandLine::event(QEvent* event)
             mAutoCompletionCount = -1;
             mTabCompletionTyped = "";
             mAutoCompletionTyped = "";
-            if (mpHost->mAutoClearCommandLineAfterSend)
+            if (mpHost->mAutoClearCommandLineAfterSend) {
                 mHistoryBuffer = -1;
-            else
+            } else {
                 mHistoryBuffer = 0;
+            }
             mLastCompletion = "";
             break;
 
@@ -133,10 +134,11 @@ bool TCommandLine::event(QEvent* event)
             if (ke->modifiers() & Qt::ControlModifier) {
                 int currentIndex = mudlet::self()->mpTabBar->currentIndex();
                 int count = mudlet::self()->mpTabBar->count();
-                if (currentIndex - 1 < 0)
+                if (currentIndex - 1 < 0) {
                     mudlet::self()->mpTabBar->setCurrentIndex(count - 1);
-                else
+                } else {
                     mudlet::self()->mpTabBar->setCurrentIndex(currentIndex - 1);
+                }
             } else {
                 handleTabCompletion(false);
                 adjustHeight();
@@ -148,12 +150,14 @@ bool TCommandLine::event(QEvent* event)
             if (ke->modifiers() & Qt::ControlModifier) {
                 int currentIndex = mudlet::self()->mpTabBar->currentIndex();
                 int count = mudlet::self()->mpTabBar->count();
-                if (currentIndex + 1 < count)
+                if (currentIndex + 1 < count) {
                     mudlet::self()->mpTabBar->setCurrentIndex(currentIndex + 1);
-                else
+                } else {
                     mudlet::self()->mpTabBar->setCurrentIndex(0);
-            } else
+                }
+            } else {
                 handleTabCompletion(true);
+            }
             ke->accept();
             return true;
 
@@ -162,10 +166,11 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Backspace:
-            if (mpHost->mAutoClearCommandLineAfterSend)
+            if (mpHost->mAutoClearCommandLineAfterSend) {
                 mHistoryBuffer = -1;
-            else
+            } else {
                 mHistoryBuffer = 0;
+            }
             if (mTabCompletionTyped.size() >= 1) {
                 mTabCompletionTyped.chop(1);
                 mAutoCompletionTyped.chop(1);
@@ -184,10 +189,11 @@ bool TCommandLine::event(QEvent* event)
             return true;
 
         case Qt::Key_Delete:
-            if (mpHost->mAutoClearCommandLineAfterSend)
+            if (mpHost->mAutoClearCommandLineAfterSend) {
                 mHistoryBuffer = -1;
-            else
+            } else {
                 mHistoryBuffer = 0;
+            }
             if (mTabCompletionTyped.size() >= 1) {
                 mTabCompletionTyped.chop(1);
                 mAutoCompletionTyped.chop(1);
@@ -236,8 +242,9 @@ bool TCommandLine::event(QEvent* event)
                 if (mpHost->mAutoClearCommandLineAfterSend) {
                     clear();
                     mHistoryBuffer = -1;
-                } else
+                } else {
                     mHistoryBuffer = 0;
+                }
                 adjustHeight();
                 ke->accept();
                 return true;
@@ -256,8 +263,9 @@ bool TCommandLine::event(QEvent* event)
             if (mpHost->mAutoClearCommandLineAfterSend) {
                 clear();
                 mHistoryBuffer = -1;
-            } else
+            } else {
                 mHistoryBuffer = 0;
+            }
             adjustHeight();
             ke->accept();
             return true;
@@ -291,10 +299,11 @@ bool TCommandLine::event(QEvent* event)
             mTabCompletionCount = -1;
             mAutoCompletionCount = -1;
             setPalette(mRegularPalette);
-            if (mpHost->mAutoClearCommandLineAfterSend)
+            if (mpHost->mAutoClearCommandLineAfterSend) {
                 mHistoryBuffer = -1;
-            else
+            } else {
                 mHistoryBuffer = 0;
+            }
             ke->accept();
             return true;
 
@@ -327,12 +336,12 @@ bool TCommandLine::event(QEvent* event)
                 QPlainTextEdit::event(event);
                 adjustHeight();
 
-                if (mpHost->mAutoClearCommandLineAfterSend)
+                if (mpHost->mAutoClearCommandLineAfterSend) {
                     mHistoryBuffer = -1;
-                else
+                } else {
                     mHistoryBuffer = 0;
-                if (mTabCompletionOld != toPlainText()) //text() )
-                {
+                }
+                if (mTabCompletionOld != toPlainText()) { //text() )
                     mUserKeptOnTyping = true;
                     mAutoCompletionCount = -1;
                 } else {
@@ -481,9 +490,9 @@ void TCommandLine::enterCommand(QKeyEvent* event)
         mHistoryList.removeAll(toPlainText());
         mHistoryList.push_front(toPlainText());
     }
-    if (mpHost->mAutoClearCommandLineAfterSend)
+    if (mpHost->mAutoClearCommandLineAfterSend) {
         clear();
-    else {
+    } else {
         selectAll();
     }
     adjustHeight();
@@ -505,8 +514,9 @@ void TCommandLine::handleTabCompletion(bool direction)
 {
     if ((mTabCompletionCount < 0) || (mUserKeptOnTyping)) {
         mTabCompletionTyped = toPlainText();
-        if (mTabCompletionTyped.size() == 0)
+        if (mTabCompletionTyped.size() == 0) {
             return;
+        }
         mUserKeptOnTyping = false;
         mTabCompletionCount = -1;
     }
@@ -603,14 +613,17 @@ void TCommandLine::handleAutoCompletion()
 
 void TCommandLine::historyDown(QKeyEvent* event)
 {
-    if (mHistoryList.size() < 1)
+    if (mHistoryList.size() < 1) {
         return;
+    }
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0)) {
         mHistoryBuffer--;
-        if (mHistoryBuffer >= mHistoryList.size())
+        if (mHistoryBuffer >= mHistoryList.size()) {
             mHistoryBuffer = mHistoryList.size() - 1;
-        if (mHistoryBuffer < 0)
+        }
+        if (mHistoryBuffer < 0) {
             mHistoryBuffer = 0;
+        }
         setPlainText(mHistoryList[mHistoryBuffer]);
         selectAll();
         adjustHeight();
@@ -626,15 +639,19 @@ void TCommandLine::historyDown(QKeyEvent* event)
 
 void TCommandLine::historyUp(QKeyEvent* event)
 {
-    if (mHistoryList.size() < 1)
+    if (mHistoryList.size() < 1) {
         return;
+    }
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0)) {
-        if (toPlainText().size() != 0)
+        if (toPlainText().size() != 0) {
             mHistoryBuffer++;
-        if (mHistoryBuffer >= mHistoryList.size())
+        }
+        if (mHistoryBuffer >= mHistoryList.size()) {
             mHistoryBuffer = mHistoryList.size() - 1;
-        if (mHistoryBuffer < 0)
+        }
+        if (mHistoryBuffer < 0) {
             mHistoryBuffer = 0;
+        }
         setPlainText(mHistoryList[mHistoryBuffer]);
         selectAll();
         adjustHeight();


### PR DESCRIPTION
They got lost in the merge conflicts that occured in #972.

You can use uncrustify (thanks Stephen) with just this config to add them, then run `clang-format` on top:

```cpp
nl_if_brace                     = remove
mod_full_brace_if               = force
```

At one point you do start wondering though what are you exactly spending your time on, coding or formatting...

Tagging @Mudlet/core-cpp for review.