### PR TITLE
BugFix: getting crashing at start of session

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -307,11 +307,13 @@ QPoint TBuffer::getEndPos()
 {
     int x = 0;
     int y = 0;
-    if( buffer.size() > 0 )
+    if (!buffer.empty()) {
         y = buffer.size()-1;
-    if( buffer[y].size() > 0 )
-        x = buffer[y].size()-1;
-    QPoint P_end( x, y );
+        if (!buffer.at(y).empty()) {
+            x = buffer.at(y).size() - 1;
+        }
+    }
+    QPoint P_end(x, y);
     return P_end;
 }
 


### PR DESCRIPTION
Found missing braces was allowing some code to execute when the item it
was trying to reference did not exist.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>