### PR TITLE
Use MUDLET_VERSION_BUILD env var instead of BUILD

### DIFF
--- a/CI/travis.after_success.sh
+++ b/CI/travis.after_success.sh
@@ -19,14 +19,14 @@ fi
 
 if [ ! -z "${DEPLOY_URL}" ]; then
   curl \
-    --data-urlencode "message=Deployed Mudlet \`${VERSION}${BUILD}\` (${TRAVIS_OS_NAME}${prId}) to [${DEPLOY_URL}](${DEPLOY_URL})" \
+    --data-urlencode "message=Deployed Mudlet \`${VERSION}${MUDLET_VERSION_BUILD}\` (${TRAVIS_OS_NAME}${prId}) to [${DEPLOY_URL}](${DEPLOY_URL})" \
     https://webhooks.gitter.im/e/cc99072d43b642c4673a
 fi
 
 echo ""
 echo "******************************************************"
 echo ""
-echo "Finished building Mudlet ${VERSION}${BUILD}"
+echo "Finished building Mudlet ${VERSION}${MUDLET_VERSION_BUILD}"
 if [ ! -z "${DEPLOY_URL}" ]; then
   echo "Deployed the output to ${DEPLOY_URL}"
 fi

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -11,7 +11,7 @@ if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "clang" ]; then
   ln -s "${TRAVIS_BUILD_DIR}" source
 
   if [ -z "${TRAVIS_TAG}" ]; then
-    appBaseName="Mudlet-${VERSION}${BUILD}"
+    appBaseName="Mudlet-${VERSION}${MUDLET_VERSION_BUILD}"
     mv "source/build/Mudlet.app" "source/build/${appBaseName}.app"
 
     bash make-installer.sh "${appBaseName}.app"


### PR DESCRIPTION
When changing the way the BUILD part of the version is specified, I forgot
to change the variable used in the after_success travis hook. This should be
fixed now.