### PR TITLE
BugFix: insert new TArea instances for wanted but absent ones on map load

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -712,7 +712,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Sort the ids so that the reporting is ordered, which could be
             // helpful if there is a large number of faults
             std::sort(missingAreasNeeded.begin(), missingAreasNeeded.end());
-            foreach (int newAreaId, missingAreasNeeded) {
+            for (int newAreaId : missingAreasNeeded) {
 
                 // This will create a new "Default" area name if there is not one
                 // already for this id - and we do not anticipate that it could ever


### PR DESCRIPTION
A user reported that they were constantly getting:
"--------------------------- Area id: ### --------------------------------
[ ALERT ] - Area with this id expected but not found, will be created."

error messages on loading in a map.  It turned out that although there was code to detect when there was an Area Name for an area or one or more rooms that claimed to be in an area but no such area existed;  there was NOT code to actually create that area should it have a positive id number (and thus be a valid one) but not actually be present in the map. If the area had an invalid id (0 or <-1) it would have been handled!

This commit addresses that issue; should there be an existing area name for the missing id than it will persist and be used, but the now established non-blank and unique requirements will be applied if not, so that the newly created area will have some identifying string which will be reported or logged as required - and the newly created area will gain any room that claims to belong in it.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>