### PR TITLE
BugFix: remove typo made in previous work

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3277,7 +3277,7 @@ int TLuaInterpreter::setLabelClickCallback( lua_State *L )
         }
     }
 
-    if (L, mudlet::self()->setLabelClickCallback(pHost, labelName, eventName, event)) {
+    if (mudlet::self()->setLabelClickCallback(pHost, labelName, eventName, event)) {
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -3342,7 +3342,7 @@ int TLuaInterpreter::setLabelReleaseCallback( lua_State *L )
         }
     }
 
-    if (L, mudlet::self()->setLabelReleaseCallback(pHost, labelName, eventName, event)) {
+    if (mudlet::self()->setLabelReleaseCallback(pHost, labelName, eventName, event)) {
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -3407,7 +3407,7 @@ int TLuaInterpreter::setLabelOnEnter( lua_State *L )
         }
     }
 
-    if (L, mudlet::self()->setLabelOnEnter(pHost, labelName, eventName, event)) {
+    if (mudlet::self()->setLabelOnEnter(pHost, labelName, eventName, event)) {
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -3472,7 +3472,7 @@ int TLuaInterpreter::setLabelOnLeave( lua_State *L )
         }
     }
 
-    if (L, mudlet::self()->setLabelOnLeave(pHost, labelName, eventName, event)) {
+    if (mudlet::self()->setLabelOnLeave(pHost, labelName, eventName, event)) {
         lua_pushboolean(L, true);
         return 1;
     } else {


### PR DESCRIPTION
The error (4 instances) is not harmful and it is ineffective code; however code analysers are moaning about this error and there is no reason not to correct by removing the `L, ` that has been inserted into the condition code for some "if"s in the Lua commands that set up events for `TLabels`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>