### PR TITLE
BugFix: allows most ASCII control characters to be used/saved in Lua Code

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -764,7 +764,7 @@ bool XMLexport::writeTrigger(TTrigger* pT)
 
         { // Blocked so that indentation reflects that of the XML file
             writeTextElement("name", pT->mName);
-            writeTextElement("script", pT->mScript);
+            writeScriptElement(pT->mScript);
             writeTextElement("triggerType", QString::number(pT->mTriggerType));
             writeTextElement("conditonLineDelta", QString::number(pT->mConditionLineDelta));
             writeTextElement("mStayOpen", QString::number(pT->mStayOpen));
@@ -852,7 +852,7 @@ bool XMLexport::writeAlias(TAlias* pT)
 
         { // Blocked so that indentation reflects that of the XML file
             writeTextElement("name", pT->mName);
-            writeTextElement("script", pT->mScript);
+            writeScriptElement(pT->mScript);
             writeTextElement("command", pT->mCommand);
             writeTextElement("packageName", pT->mPackageName);
             writeTextElement("regex", pT->mRegexCode);
@@ -913,7 +913,7 @@ bool XMLexport::writeAction(TAction* pT)
         { // Blocked so that indentation reflects that of the XML file
             writeTextElement("name", pT->mName);
             writeTextElement("packageName", pT->mPackageName);
-            writeTextElement("script", pT->mScript);
+            writeScriptElement(pT->mScript);
             writeTextElement("css", pT->css);
             writeTextElement("commandButtonUp", pT->mCommandButtonUp);
             writeTextElement("commandButtonDown", pT->mCommandButtonDown);
@@ -985,7 +985,7 @@ bool XMLexport::writeTimer(TTimer* pT)
 
         { // Blocked so that indentation reflects that of the XML file
             writeTextElement("name", pT->mName);
-            writeTextElement("script", pT->mScript);
+            writeScriptElement(pT->mScript);
             writeTextElement("command", pT->mCommand);
             writeTextElement("packageName", pT->mPackageName);
             writeTextElement("time", pT->mTime.toString("hh:mm:ss.zzz"));
@@ -1044,7 +1044,7 @@ bool XMLexport::writeScript(TScript* pT)
         { // Blocked so that indentation reflects that of the XML file
             writeTextElement("name", pT->mName);
             writeTextElement("packageName", pT->mPackageName);
-            writeTextElement("script", pT->mScript);
+            writeScriptElement(pT->mScript);
 
             writeStartElement("eventHandlerList");
             for (int i = 0; i < pT->mEventHandlerList.size(); ++i) {
@@ -1106,7 +1106,7 @@ bool XMLexport::writeKey(TKey* pT)
         { // Blocked so that indentation reflects that of the XML file
             writeTextElement("name", pT->mName);
             writeTextElement("packageName", pT->mPackageName);
-            writeTextElement("script", pT->mScript);
+            writeScriptElement(pT->mScript);
             writeTextElement("command", pT->mCommand);
             writeTextElement("keyCode", QString::number(pT->mKeyCode));
             writeTextElement("keyModifier", QString::number(pT->mKeyModifier));
@@ -1126,4 +1126,39 @@ bool XMLexport::writeKey(TKey* pT)
     }
 
     return (isOk && (!hasError()));
+}
+
+bool XMLexport::writeScriptElement(const QString & script)
+{
+    QString localScript = script;
+    localScript.replace(QChar('\x01'), QStringLiteral("\xFFFC\x2401")); // SOH
+    localScript.replace(QChar('\x02'), QStringLiteral("\xFFFC\x2402")); // STX
+    localScript.replace(QChar('\x03'), QStringLiteral("\xFFFC\x2403")); // ETX
+    localScript.replace(QChar('\x04'), QStringLiteral("\xFFFC\x2404")); // EOT
+    localScript.replace(QChar('\x05'), QStringLiteral("\xFFFC\x2405")); // ENQ
+    localScript.replace(QChar('\x06'), QStringLiteral("\xFFFC\x2406")); // ACK
+    localScript.replace(QChar('\x07'), QStringLiteral("\xFFFC\x2407")); // BEL
+    localScript.replace(QChar('\x08'), QStringLiteral("\xFFFC\x2408")); // BS
+    localScript.replace(QChar('\x0B'), QStringLiteral("\xFFFC\x240B")); // VT
+    localScript.replace(QChar('\x0C'), QStringLiteral("\xFFFC\x240C")); // FF
+    localScript.replace(QChar('\x0E'), QStringLiteral("\xFFFC\x240E")); // SS
+    localScript.replace(QChar('\x0F'), QStringLiteral("\xFFFC\x240F")); // SI
+    localScript.replace(QChar('\x10'), QStringLiteral("\xFFFC\x2410")); // DLE
+    localScript.replace(QChar('\x11'), QStringLiteral("\xFFFC\x2411")); // DC1
+    localScript.replace(QChar('\x12'), QStringLiteral("\xFFFC\x2412")); // DC2
+    localScript.replace(QChar('\x13'), QStringLiteral("\xFFFC\x2413")); // DC3
+    localScript.replace(QChar('\x14'), QStringLiteral("\xFFFC\x2414")); // DC4
+    localScript.replace(QChar('\x15'), QStringLiteral("\xFFFC\x2415")); // NAK
+    localScript.replace(QChar('\x16'), QStringLiteral("\xFFFC\x2416")); // SYN
+    localScript.replace(QChar('\x17'), QStringLiteral("\xFFFC\x2417")); // ETB
+    localScript.replace(QChar('\x18'), QStringLiteral("\xFFFC\x2418")); // CAN
+    localScript.replace(QChar('\x19'), QStringLiteral("\xFFFC\x2419")); // EM
+    localScript.replace(QChar('\x1A'), QStringLiteral("\xFFFC\x241A")); // SUB
+    localScript.replace(QChar('\x1B'), QStringLiteral("\xFFFC\x241B")); // ESC
+    localScript.replace(QChar('\x1C'), QStringLiteral("\xFFFC\x241C")); // FS
+    localScript.replace(QChar('\x1D'), QStringLiteral("\xFFFC\x241D")); // GS
+    localScript.replace(QChar('\x1E'), QStringLiteral("\xFFFC\x241E")); // RS
+    localScript.replace(QChar('\x1F'), QStringLiteral("\xFFFC\x241F")); // US
+    localScript.replace(QChar('\x7F'), QStringLiteral("\xFFFC\x2471")); // DEL
+    writeTextElement(QLatin1String("script"), localScript);
 }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -1159,6 +1159,6 @@ bool XMLexport::writeScriptElement(const QString & script)
     localScript.replace(QChar('\x1D'), QStringLiteral("\xFFFC\x241D")); // GS
     localScript.replace(QChar('\x1E'), QStringLiteral("\xFFFC\x241E")); // RS
     localScript.replace(QChar('\x1F'), QStringLiteral("\xFFFC\x241F")); // US
-    localScript.replace(QChar('\x7F'), QStringLiteral("\xFFFC\x2471")); // DEL
+    localScript.replace(QChar('\x7F'), QStringLiteral("\xFFFC\x2421")); // DEL
     writeTextElement(QLatin1String("script"), localScript);
 }

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -80,6 +80,8 @@ public:
     bool exportScript(TScript*);
     bool exportKey(TKey*);
 
+    bool writeScriptElement(const QString &);
+
 private:
     QPointer<Host> mpHost;
     TTrigger* mpTrigger;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -978,7 +978,7 @@ void XMLimport::readTriggerGroup(TTrigger* pParent)
             if (name() == "name") {
                 pT->setName(readElementText());
             } else if (name() == "script") {
-                QString tempScript = readElementText();
+                QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readTriggerGroup(...): ERROR: can not compile trigger's lua code for: " << pT->getName();
                 }
@@ -1073,7 +1073,7 @@ void XMLimport::readTimerGroup(TTimer* pParent)
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
             } else if (name() == "script") {
-                QString tempScript = readElementText();
+                QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readTimerGroup(...): ERROR: can not compile timer's lua code for: " << pT->getName();
                 }
@@ -1136,7 +1136,7 @@ void XMLimport::readAliasGroup(TAlias* pParent)
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
             } else if (name() == "script") {
-                QString tempScript = readElementText();
+                QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readAliasGroup(...): ERROR: can not compile alias's lua code for: " << pT->getName();
                 }
@@ -1195,7 +1195,7 @@ void XMLimport::readActionGroup(TAction* pParent)
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
             } else if (name() == "script") {
-                QString tempScript = readElementText();
+                QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readActionGroup(...): ERROR: can not compile action's lua code for: " << pT->getName();
                 }
@@ -1277,7 +1277,7 @@ void XMLimport::readScriptGroup(TScript* pParent)
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
             } else if (name() == "script") {
-                QString tempScript = readElementText();
+                QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readScriptGroup(...): ERROR: can not compile script's lua code for: " << pT->getName();
                 }
@@ -1332,7 +1332,7 @@ void XMLimport::readKeyGroup(TKey* pParent)
             } else if (name() == "packageName") {
                 pT->mPackageName = readElementText();
             } else if (name() == "script") {
-                QString tempScript = readElementText();
+                QString tempScript = readScriptElement();
                 if (!pT->setScript(tempScript)) {
                     qDebug().nospace() << "XMLimport::readKeyGroup(...): ERROR: can not compile key's lua code for: " << pT->getName();
                 }
@@ -1435,4 +1435,50 @@ void XMLimport::readIntegerList(QList<int>& list, const QString& parentName)
 void XMLimport::getVersionString(QString& versionString)
 {
     versionString = QString::number((mVersionMajor * 1000 + mVersionMinor) / 1000.0, 'f', 3);
+}
+
+QString XMLimport::readScriptElement()
+{
+
+    QString localScript = readElementText();
+    if (Error() != NoError) {
+        qDebug() << "XMLimport::readScriptElement() ERROR:"
+                 << errorString();
+    }
+
+    if (mVersionMajor > 1 || mVersionMajor == 1 && mVersionMinor > 0 ) {
+        // This is NOT the original version, so it will have control characters
+        // encoded up using Object Replacement and Control Symbol (for relevant ASCII control code) code-points
+        localScript.replace(QStringLiteral("\xFFFC\x2401"), QChar('\x01')); // SOH
+        localScript.replace(QStringLiteral("\xFFFC\x2402"), QChar('\x02')); // STX
+        localScript.replace(QStringLiteral("\xFFFC\x2403"), QChar('\x03')); // ETX
+        localScript.replace(QStringLiteral("\xFFFC\x2404"), QChar('\x04')); // EOT
+        localScript.replace(QStringLiteral("\xFFFC\x2405"), QChar('\x05')); // ENQ
+        localScript.replace(QStringLiteral("\xFFFC\x2406"), QChar('\x06')); // ACK
+        localScript.replace(QStringLiteral("\xFFFC\x2407"), QChar('\x07')); // BEL
+        localScript.replace(QStringLiteral("\xFFFC\x2408"), QChar('\x08')); // BS
+        localScript.replace(QStringLiteral("\xFFFC\x240B"), QChar('\x0B')); // VT
+        localScript.replace(QStringLiteral("\xFFFC\x240C"), QChar('\x0C')); // FF
+        localScript.replace(QStringLiteral("\xFFFC\x240E"), QChar('\x0E')); // SS
+        localScript.replace(QStringLiteral("\xFFFC\x240F"), QChar('\x0F')); // SI
+        localScript.replace(QStringLiteral("\xFFFC\x2410"), QChar('\x10')); // DLE
+        localScript.replace(QStringLiteral("\xFFFC\x2411"), QChar('\x11')); // DC1
+        localScript.replace(QStringLiteral("\xFFFC\x2412"), QChar('\x12')); // DC2
+        localScript.replace(QStringLiteral("\xFFFC\x2413"), QChar('\x13')); // DC3
+        localScript.replace(QStringLiteral("\xFFFC\x2414"), QChar('\x14')); // DC4
+        localScript.replace(QStringLiteral("\xFFFC\x2415"), QChar('\x15')); // NAK
+        localScript.replace(QStringLiteral("\xFFFC\x2416"), QChar('\x16')); // SYN
+        localScript.replace(QStringLiteral("\xFFFC\x2417"), QChar('\x17')); // ETB
+        localScript.replace(QStringLiteral("\xFFFC\x2418"), QChar('\x18')); // CAN
+        localScript.replace(QStringLiteral("\xFFFC\x2419"), QChar('\x19')); // EM
+        localScript.replace(QStringLiteral("\xFFFC\x241A"), QChar('\x1A')); // SUB
+        localScript.replace(QStringLiteral("\xFFFC\x241B"), QChar('\x1B')); // ESC
+        localScript.replace(QStringLiteral("\xFFFC\x241C"), QChar('\x1C')); // FS
+        localScript.replace(QStringLiteral("\xFFFC\x241D"), QChar('\x1D')); // GS
+        localScript.replace(QStringLiteral("\xFFFC\x241E"), QChar('\x1E')); // RS
+        localScript.replace(QStringLiteral("\xFFFC\x241F"), QChar('\x1F')); // US
+        localScript.replace(QStringLiteral("\xFFFC\x2471"), QChar('\x7F')); // DEL
+    }
+
+    return localScript;
 }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1477,7 +1477,7 @@ QString XMLimport::readScriptElement()
         localScript.replace(QStringLiteral("\xFFFC\x241D"), QChar('\x1D')); // GS
         localScript.replace(QStringLiteral("\xFFFC\x241E"), QChar('\x1E')); // RS
         localScript.replace(QStringLiteral("\xFFFC\x241F"), QChar('\x1F')); // US
-        localScript.replace(QStringLiteral("\xFFFC\x2471"), QChar('\x7F')); // DEL
+        localScript.replace(QStringLiteral("\xFFFC\x2421"), QChar('\x7F')); // DEL
     }
 
     return localScript;

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -95,6 +95,7 @@ private:
     void readIntegerList(QList<int>&, const QString&);
     void readModulesDetailsMap(QMap<QString, QStringList>&);
     void getVersionString(QString&);
+    QString readScriptElement();
 
 
     QPointer<Host> mpHost;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -100,7 +100,15 @@ bool TConsoleMonitor::eventFilter(QObject *obj, QEvent *event)
 // number change in the Mudlet application itself and SHOULD NOT BE DONE WITHOUT
 // agreement and consideration from the Project management, even a minor part
 // increment should not be done without justification...!
-const QString mudlet::scmMudletXmlDefaultVersion = QString::number( 1.0f, 'f', 3 );
+// XML version Change history (what and why):
+// 1.001    Added method to allow XML format to permit ASCII control codes
+//          0x01-0x08, 0x0b, 0x0c, 0x0e-0x1f, 0x7f to be stored as part of the
+//          "script" element for a Mudlet "item" (0x09, 0x0a, 0x0d are the only
+//          ones that ARE permitted) - this is wanted so that, for instance
+//          ANSI ESC codes can be included in a Lua script without breaking
+//          the XML format used to store it - prior to this embedding such
+//          codes would break or destroy the script that used it.
+const QString mudlet::scmMudletXmlDefaultVersion = QString::number( 1.001f, 'f', 3 );
 
 QPointer<TConsole> mudlet::mpDebugConsole = 0;
 QMainWindow* mudlet::mpDebugArea = 0;


### PR DESCRIPTION
We use XML to save Mudlet game data including the scripts that contain Lua code for all of the Mudlet item {Alias|Button|Key|Timer|Script|Trigger} but because the former (at version 1.0 which is all that the Qt library code handles) prohibits all but Horizontal Tab, Carriage Return and Line Feed out of the range of ASCII control codes it means that a user trying to embed a raw string containing, say, the ESC code (0x1b) will either lose their code for just the item containing that code OR everything that follows it in the file that it is being loaded from.  As that could be the game save data this may will cause data loss.

This commit allows all but the ASCII NULL (`\0`) character code to be stored as it replaces the remaining control codes with a pair of other Unicode code-points that can be safely stored, that is (U+FFFC) the Unicode Object Replacement Character code-point followed by one of the code-points from the Control Picture Symbol range. The former is not a visible character in normal circumstances but the latter (if present in a font) is typically a two or three letters in a diagonal line in a single grapheme that has the same two or three letters used to abbreviate an ASCII Control code in, say, visible table representations.  The chances of the Object Replacement Character occurring in ANY document is virtually zero so the use for this purpose should be "safe" in this context and using the Control Picture Character does have the nice feature in that viewing a saved file with them in does suggest which character is being used - and the chances of them being used in, even a Mudlet script, otherwise is vanishingly small in my opinion.

Note that NO attempt is made to handle the ASCII NUL character as that is also, symbolically the end of a C/C++ string normally and it would be confusing to the Lua interpreter even though the Qt `QString` text handling system could tolerate having such characters in positions other than at the end of a `QString`.

During the development of this system to "Escape" these codes I did experiment with the use of "XML Entities" to represent them - such as "&ESC;" to stand in for the ASCII 0x1B character.  However the Qt process to insert such elements into the required a costly splitting the script
text up into fragments without any of the codes to be escaped so that each code could then be injected into the `QXmlStreamWriter` stream interleaved with the text fragments that surrounds them and whilst this proved to be possible I then found that the process that then took the entities and substituted in the original ASCII control codes when the script data was
read with the `QXmlStreamReader` failed to work because the `QXmlStreamEntityResolver` applied the same character code restrictions onto the replacement text - which is exactly not what was wanted!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>