### PR TITLE
BugFix: ensure there is always a "Default" map area

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -42,6 +42,9 @@ TRoomDB::TRoomDB( TMap * pMap )
 , mUnnamedAreaName( tr( "Unnamed Area" ) )
 , mDefaultAreaName( tr( "Default Area" ) )
 {
+    // Ensure the default area is created, the area/areaName items that get
+    // created here will get blown away when a map is loaded but that is expected...
+    addArea(-1, mDefaultAreaName);
 }
 
 TRoom* TRoomDB::getRoom(int id)


### PR DESCRIPTION
While there was already code that ensures a map has the Default (reserved) -1 area when a file is loaded in and when the existing one is cleared by `TRoomDB::clearMap()` there was nothing to ensure this state for a new profile with no pre-existing map data.

This seems to be the cause of both Issues:
* https://github.com/Mudlet/Mudlet/issues/1001
* https://github.com/Mudlet/Mudlet/issues/1002
IMHO and the commit here should address both.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>