### PR TITLE
BugFix: prevent long-playing sound crashing Mudlet if starting Host gone

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2489,9 +2489,7 @@ void mudlet::playSound(QString s, int soundVolume)
 
         if (!pPlayer) {
             /* It (should) be impossible to ever reach this */
-            if (pHost) {
-                pHost->postMessage("\n[  ERROR  ]  - Unable to create new QMediaPlayer object\n");
-            }
+            pHost->postMessage("\n[  ERROR  ]  - Unable to create new QMediaPlayer object\n");
             return;
         }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2481,7 +2481,7 @@ void mudlet::playSound(QString s, int soundVolume)
     if (!pPlayer) {
         pPlayer = new QMediaPlayer(this);
 
-        auto pHost = getActiveHost();
+        QPointer<Host> pHost = getActiveHost();
 
         if (!pPlayer) {
             /* It (should) be impossible to ever reach this */
@@ -2500,7 +2500,17 @@ void mudlet::playSound(QString s, int soundVolume)
                 soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
                 soundFinished.mArgumentList.append(pPlayer->media().canonicalUrl().path());
                 soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-                pHost->raiseEvent(soundFinished);
+                if (pHost) {
+                    // The host may have gone away if the sound was a long one
+                    // and we are multi-playing so we ought to test it...
+                    pHost->raiseEvent(soundFinished);
+                } else {
+                    qDebug() << "mudlet::playSound(...) INFO: Sound playback"
+                                " finished but Host that started it has already"
+                                " gone away so NOT going to try sending it a"
+                                " \"sysSoundFinished\" event as that would have"
+                                " crashed Mudlet 8-)...";
+                }
             }
         });
 


### PR DESCRIPTION
Found issue https://github.com/Mudlet/Mudlet/issues/1003 when debugging something else, the code that causes a `sysSoundFinished` event to be sent to the `Host`(profile) that started the sound playing was storing a pointer to that `Host` and attempting to use it even when it had been destroyed, specifically when multi-playing...

This solves the issue by ensuring the code used a `QPointer` to retain the address of the `Host` instance which will automatically be zeroed when the `Host` is destroyed and by now testing the pointer value before using it.
 
Signed-off-by: Stephen Lyons <slysven@virginmedia.com>