### PR TITLE
Reduced autologin delay by nearly a second

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -413,7 +413,7 @@ mudlet::mudlet()
     auto timerAutologin = new QTimer( this );
     timerAutologin->setSingleShot( true );
     connect(timerAutologin, SIGNAL(timeout()), this, SLOT(startAutoLogin()));
-    timerAutologin->start( 1000 );
+    timerAutologin->start( 50 );
 
     connect(mpMainStatusBar, SIGNAL(messageChanged(QString)), this, SLOT(slot_statusBarMessageChanged(QString)));
     // Do something with the QStatusBar just so we "use" it (for 15 seconds)...


### PR DESCRIPTION
This makes Mudlet feel a lot more snappier when it's launching. Can't go below 50ms because X11 is async and the window doesn't get painted before that.

Should double-check this still looks ok on macOS and Windows.