### PR TITLE
Replace chained .args with multi-arg

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -731,11 +731,9 @@ bool Host::installPackage(const QString& fileName, int module)
       || fileName.endsWith( QStringLiteral( ".mpackage"), Qt::CaseInsensitive ) )
     {
         QString _home = QStringLiteral( "%1/.config/mudlet/profiles/%2" )
-                        .arg( QDir::homePath() )
-                        .arg( getName() );
+                        .arg( QDir::homePath(), getName() );
         QString _dest = QStringLiteral( "%1/%2/" )
-                        .arg( _home )
-                        .arg( packageName );
+                        .arg( _home, packageName );
         QDir _tmpDir( _home ); // home directory for the PROFILE
         _tmpDir.mkpath( _dest );
 
@@ -801,7 +799,7 @@ bool Host::installPackage(const QString& fileName, int module)
                 if (entryInArchive.endsWith(QLatin1Char('/'))) {
 //                    qDebug() << "Host::installPackage() Scanning archive (for directories) found item:" << i << "called:" << entryInArchive << "this is a DIRECTORY...!";
                     if (!directoriesNeededMap.contains(pathInArchive)) {
-                        QString pathInProfile(QStringLiteral("%1/%2").arg(packageName).arg(pathInArchive));
+                        QString pathInProfile(QStringLiteral("%1/%2").arg(packageName, pathInArchive));
                         directoriesNeededMap.insert(pathInArchive, pathInProfile);
 //                        qDebug() << "Added:" << pathInArchive << "to list of sub-directories to be made.";
                     }
@@ -814,7 +812,7 @@ bool Host::installPackage(const QString& fileName, int module)
                     // Extract needed path from name for archives that do NOT
                     // explicitly list directories
                     if (!pathInArchive.isEmpty() && !directoriesNeededMap.contains(pathInArchive)) {
-                        QString pathInProfile(QStringLiteral("%1/%2").arg(packageName).arg(pathInArchive));
+                        QString pathInProfile(QStringLiteral("%1/%2").arg(packageName, pathInArchive));
                         directoriesNeededMap.insert(pathInArchive, pathInProfile);
 //                        qDebug() << "Added:" << pathInArchive << "to list of sub-directories to be made.";
                     }
@@ -875,7 +873,7 @@ bool Host::installPackage(const QString& fileName, int module)
                     return false;
                 }
 
-                QFile fd(QStringLiteral("%1%2").arg(_dest).arg(entryInArchive));
+                QFile fd(QStringLiteral("%1%2").arg(_dest, entryInArchive));
 
                 if (!fd.open(QIODevice::ReadWrite | QIODevice::Truncate)) {
                     //FIXME: report error to user
@@ -884,7 +882,7 @@ bool Host::installPackage(const QString& fileName, int module)
                              << ","
                              << module
                              << ")\n    ERROR opening:"
-                             << QStringLiteral( "%1%2" ).arg( _dest ).arg( entryInArchive )
+                             << QStringLiteral( "%1%2" ).arg(_dest, entryInArchive)
                              << "!\n    Reported error was:"
                              << fd.errorString();
                     zip_fclose(zf);
@@ -971,7 +969,7 @@ bool Host::installPackage(const QString& fileName, int module)
                 }
             }
             // continuing, so update the folder name on disk
-            QString newpath(QStringLiteral("%1/%2/").arg(_home).arg(packageName));
+            QString newpath(QStringLiteral("%1/%2/").arg(_home, packageName));
             _dir.rename(_dir.absolutePath(), newpath);
             _dir = QDir(newpath);
         }
@@ -1193,7 +1191,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     QString _home = QDir::homePath();
     _home.append("/.config/mudlet/profiles/");
     _home.append(getName());
-    QString _dest = QString("%1/%2/").arg(_home).arg(packageName);
+    QString _dest = QString("%1/%2/").arg(_home, packageName);
     removeDir(_dest, _dest);
     saveProfile();
     //NOW we reset if we're uninstalling a module
@@ -1260,7 +1258,7 @@ void Host::readPackageConfig(const QString& luaConfig, QString& packageName)
             qDebug() << reason.c_str() << " in config.lua:" << e.c_str();
         }
         // should print error to main display
-        QString msg = QString("%1 in config.lua: %2\n").arg(reason.c_str()).arg(e.c_str());
+        QString msg = QString("%1 in config.lua: %2\n").arg(reason.c_str(), e.c_str());
         mpConsole->printSystemMessage(msg);
 
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2034,7 +2034,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             QString _paid_name = mpMap->mpRoomDB->getAreaNamesMap().value( _iaid );
             if( _paid )
             {
-                infoText = tr( "Area: %1 ID:%2 x:%3 <-> %4 y:%5 <-> %6 z:%7 <-> %8\n").arg(_paid_name).arg(_iaid).arg(_paid->min_x).arg(_paid->max_x).arg(_paid->min_y).arg(_paid->max_y).arg(_paid->min_z).arg(_paid->max_z);
+                infoText = tr( "Area: %1 ID:%2 x:%3 <-> %4 y:%5 <-> %6 z:%7 <-> %8\n").arg(_paid_name, QString::number(_iaid), QString::number(_paid->min_x), QString::number(_paid->max_x), QString::number(_paid->min_y), QString::number(_paid->max_y), QString::number(_paid->min_z), QString::number((_paid->max_z)));
             }
             else
             {
@@ -2058,7 +2058,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             switch( selectionSize )
             {
             case 0:
-                infoText.append( tr("Room ID: %1 (Current) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)) );
+                infoText.append( tr("Room ID: %1 (Current) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid), QString::number(_prid->x), QString::number(_prid->y), QString::number(_prid->z)) );
                 if( playerArea != mAID ) {
                     f.setItalic( true );
                 }
@@ -2067,7 +2067,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 }
                 break;
             case 1:
-                infoText.append( tr("Room ID: %1 (Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)) );
+                infoText.append( tr("Room ID: %1 (Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid), QString::number(_prid->x), QString::number(_prid->y), QString::number(_prid->z)) );
                 f.setBold( true );
                 if( infoColor.lightness() > 127 ) {
                     infoColor = QColor( 255, 223, 191 ); // Slightly orange white
@@ -2077,7 +2077,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
                 }
                 break;
             default:
-                infoText.append( tr("Room ID: %1 (%5 Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid)).arg(QString::number(_prid->x)).arg(QString::number(_prid->y)).arg(QString::number(_prid->z)).arg(QString::number(selectionSize)) );
+                infoText.append( tr("Room ID: %1 (%5 Selected) Position on Map: (%2,%3,%4)\n").arg(QString::number(__rid), QString::number(_prid->x), QString::number(_prid->y), QString::number(_prid->z), QString::number(selectionSize)) );
                 f.setBold( true );
                 if( infoColor.lightness() > 127 ) {
                     infoColor = QColor( 255, 223, 191 ); // Slightly orange white
@@ -2089,7 +2089,7 @@ void T2DMap::paintEvent( QPaintEvent * e )
             }
         }
 
-        infoText.append( tr("render time: %1S mO: (%2,%3,%4)").arg( __time.nsecsElapsed() * 1.0e-9,0,'f',3).arg(QString::number(mOx)).arg(QString::number(mOy)).arg(QString::number(mOz)) );
+        infoText.append( tr("render time: %1S mO: (%2,%3,%4)").arg( __time.nsecsElapsed() * 1.0e-9,0,'f',3).arg(QString::number(mOx), QString::number(mOy), QString::number(mOz)) );
 
         uint infoLeftSideAvoid = 10; // Left margin for info widget
         if( mMultiSelectionListWidget.isVisible() ) { // Room Selection Widget showing, so increase margin to avoid
@@ -3515,7 +3515,7 @@ void T2DMap::slot_setCharacter()
                     itSymbolUsed.next();
                     if( itSymbolUsed.value() == symbolCountsList.at(i) )
                     {
-                        displayStrings.append( tr("%1 {count:%2}").arg(itSymbolUsed.key()).arg(itSymbolUsed.value()));
+                        displayStrings.append( tr("%1 {count:%2}").arg(itSymbolUsed.key(), itSymbolUsed.value()));
                     }
                 }
             }
@@ -3993,11 +3993,11 @@ void T2DMap::slot_setRoomWeight()
                     {
                         if( itWeightsUsed.key() == 1 )
                         { // Indicate the "default" value which is unity weight
-                            displayStrings.append( tr("%1 {count:%2, default}").arg(itWeightsUsed.key()).arg(itWeightsUsed.value()));
+                            displayStrings.append( tr("%1 {count:%2, default}").arg(itWeightsUsed.key(), itWeightsUsed.value()));
                         }
                         else
                         {
-                            displayStrings.append( tr("%1 {count:%2}").arg(itWeightsUsed.key()).arg(itWeightsUsed.value()));
+                            displayStrings.append( tr("%1 {count:%2}").arg(itWeightsUsed.key(), itWeightsUsed.value()));
                         }
                     }
                 }
@@ -4075,7 +4075,7 @@ void T2DMap::slot_setArea()
         it.next();
         int areaID = it.key();
         if( areaID > 0 ) {
-            arealist_combobox->addItem( QStringLiteral( "%1 (%2)" ).arg( it.value() ).arg( areaID ), QVariant(areaID) );
+            arealist_combobox->addItem( QStringLiteral( "%1 (%2)" ).arg( it.value(), areaID ), QVariant(areaID) );
         }
     }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4075,7 +4075,7 @@ void T2DMap::slot_setArea()
         it.next();
         int areaID = it.key();
         if( areaID > 0 ) {
-            arealist_combobox->addItem( QStringLiteral( "%1 (%2)" ).arg( it.value(), areaID ), QVariant(areaID) );
+            arealist_combobox->addItem( QStringLiteral( "%1 (%2)" ).arg( it.value(), QString::number(areaID) ), QVariant(areaID) );
         }
     }
 

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -265,7 +265,7 @@ void TAlias::compileRegex()
             TDebug(QColor(Qt::white), QColor(Qt::red)) << "REGEX ERROR: failed to compile, reason:\n" << error << "\n" >> 0;
             TDebug(QColor(Qt::red), QColor(Qt::gray)) << "in: \"" << mRegexCode << "\"\n" >> 0;
         }
-        setError(QStringLiteral("<b><font color='blue'>%1</font></b>").arg(tr("Error: in \"Pattern:\", faulty regular expression, reason: \"%1\".").arg(error)));
+        setError(QStringLiteral("<b><font color='blue'>%1</font></b>").arg(tr("Error: in \"Pattern:\", faulty regular expression, reason: \"%1\".", error)));
     } else {
         mOK_init = true;
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -853,8 +853,8 @@ void TConsole::toggleLogging( bool isMessageEnabled )
         QTextStream out(&file);
         file.close();
 
-        QString directoryLogFile = QStringLiteral( "%1/.config/mudlet/profiles/%2/log" ).arg( QDir::homePath() ).arg( profile_name );
-        mLogFileName = QStringLiteral( "%1/%2" ).arg( directoryLogFile ).arg( QDateTime::currentDateTime().toString( QStringLiteral( "yyyy-MM-dd#hh-mm-ss" ) ) );
+        QString directoryLogFile = QStringLiteral( "%1/.config/mudlet/profiles/%2/log" ).arg(QDir::homePath(), profile_name);
+        mLogFileName = QStringLiteral( "%1/%2" ).arg(directoryLogFile, QDateTime::currentDateTime().toString( QStringLiteral( "yyyy-MM-dd#hh-mm-ss" ) ) );
         // Revised file name derived from time so that alphabetical filename and
         // date sort order are the same...
         QDir dirLogFile;
@@ -1628,7 +1628,7 @@ bool TConsole::loadMap(const QString& location)
         pHost->mpMap->pushErrorMessagesToFile( tr( "Loading map(1) at %1 report" ).arg( now.toString( Qt::ISODate ) ), true );
     }
     else {
-        pHost->mpMap->pushErrorMessagesToFile( tr( "Loading map(1) \"%1\" at %2 report" ).arg( location ).arg( now.toString( Qt::ISODate ) ), true );
+        pHost->mpMap->pushErrorMessagesToFile( tr( "Loading map(1) \"%1\" at %2 report" ).arg(location, now.toString( Qt::ISODate) ), true );
     }
 
     return result;
@@ -1681,9 +1681,7 @@ bool TConsole::importMap( const QString & location, QString * errMsg )
         if( fileInfo.isRelative() ) {
             // Resolve the name relative to the profile home directory:
             filePathNameString = QDir::cleanPath( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" )
-                                                  .arg( QDir::homePath() )
-                                                  .arg( pHost->getName() )
-                                                  .arg( fileInfo.filePath() ) );
+                                                  .arg( QDir::homePath(), pHost->getName(), fileInfo.filePath() ) );
         }
         else {
             if( fileInfo.exists() ) {
@@ -1722,7 +1720,7 @@ bool TConsole::importMap( const QString & location, QString * errMsg )
         result = pHost->mpMap->importMap( file, errMsg );
 
         file.close();
-        pHost->mpMap->pushErrorMessagesToFile( tr( "Importing map(1) \"%1\" at %2 report" ).arg( location ).arg( now.toString( Qt::ISODate ) ) );
+        pHost->mpMap->pushErrorMessagesToFile( tr( "Importing map(1) \"%1\" at %2 report" ).arg(location, now.toString( Qt::ISODate) ) );
     }
     else {
         if( ! errMsg ) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2454,7 +2454,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         return 2;
     } else {
         lua_pushnil(L);
-        lua_pushstring(L, QString("Couldn't save %1 to %2 because: %3").arg(pHost->getName()).arg(std::get<1>(result)).arg(std::get<2>(result)).toUtf8().constData());
+        lua_pushstring(L, QString("Couldn't save %1 to %2 because: %3").arg(pHost->getName(), std::get<1>(result), std::get<2>(result)).toUtf8().constData());
         return 2;
     }
 }
@@ -10296,11 +10296,7 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
     QNetworkRequest request = QNetworkRequest( url );
     // This should fix: https://bugs.launchpad.net/mudlet/+bug/1366781
-    request.setRawHeader( QByteArray( "User-Agent" ),
-                          QByteArray( QStringLiteral( "Mozilla/5.0 (Mudlet/%1%2)" )
-                                      .arg( APP_VERSION )
-                                      .arg( APP_BUILD )
-                                      .toUtf8().constData() ) );
+    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
 #ifndef QT_NO_OPENSSL
     if( url.scheme() == QStringLiteral( "https" ) ) {
         QSslConfiguration config( QSslConfiguration::defaultConfiguration() );
@@ -12661,16 +12657,16 @@ bool TLuaInterpreter::call(const QString & function, const QString & mName )
 void TLuaInterpreter::logError( std::string & e, const QString & name, const QString & function )
 {
     //QDateTime time = QDateTime::currentDateTime();
-    // QString entry = QString("[%1]object:<%2> function:<%3> error:<%4>").arg(time.toString("MMM:dd:yyyy hh-mm-ss")).arg(name).arg(function).arg(e.c_str());
+    // QString entry = QString("[%1]object:<%2> function:<%3> error:<%4>").arg(time.toString("MMM:dd:yyyy hh-mm-ss"), name, function, e.c_str());
     //mpHost->mErrorLogStream << entry << endl;
     auto blue = QColor(Qt::blue);
     auto green = QColor(Qt::green);
     auto red = QColor(Qt::red);
     auto black = QColor(Qt::black);
     QString s1 = QString("[ERROR:]");
-    QString s2 = QString(" object:<%1> function:<%2>\n").arg(name).arg(function);
+    QString s2 = QString(" object:<%1> function:<%2>\n").arg(name, function);
     QString s3 = QString("         <%1>\n").arg(e.c_str());
-    QString msg = QString("[  LUA  ] - Object<%1> Function<%2>\n<%3>").arg(name).arg(function).arg(e.c_str());
+    QString msg = QString("[  LUA  ] - Object<%1> Function<%2>\n<%3>").arg(name, function, e.c_str());
 
     if( mpHost->mpEditorDialog )
     {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10296,6 +10296,7 @@ int TLuaInterpreter::downloadFile( lua_State * L )
 
     QNetworkRequest request = QNetworkRequest( url );
     // This should fix: https://bugs.launchpad.net/mudlet/+bug/1366781
+    qDebug() << QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData());
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
 #ifndef QT_NO_OPENSSL
     if( url.scheme() == QStringLiteral( "https" ) ) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1297,9 +1297,7 @@ bool TMap::restore( QString location )
     QStringList entries;
 
     if( location.isEmpty() ) {
-        folder = QStringLiteral( "%1/.config/mudlet/profiles/%2/map/" )
-                 .arg( QDir::homePath() )
-                 .arg( mpHost->getName() );
+        folder = QStringLiteral("%1/.config/mudlet/profiles/%2/map/").arg(QDir::homePath(), mpHost->getName());
         QDir dir( folder );
         dir.setSorting( QDir::Time );
         entries = dir.entryList( QDir::Files, QDir::Time );
@@ -1308,7 +1306,7 @@ bool TMap::restore( QString location )
     bool canRestore = true;
     if( entries.size() || ! location.isEmpty() ) {
         QFile file(   location.isEmpty()
-                    ? QStringLiteral( "%1%2" ).arg( folder ).arg( entries.at(0) )
+                    ? QStringLiteral( "%1%2" ).arg(folder, entries.at(0) )
                     : location );
 
         if( ! file.open( QFile::ReadOnly ) ) {
@@ -1574,9 +1572,7 @@ bool TMap::retrieveMapFileStats( QString profile, QString * latestFileName = 0, 
 
     QString folder;
     QStringList entries;
-    folder = QStringLiteral( "%1/.config/mudlet/profiles/%2/map/" )
-             .arg( QDir::homePath() )
-             .arg( profile );
+    folder = QStringLiteral("%1/.config/mudlet/profiles/%2/map/").arg(QDir::homePath(), profile);
     QDir dir( folder );
     dir.setSorting( QDir::Time );
     entries = dir.entryList( QDir::Files|QDir::NoDotAndDotDot, QDir::Time );
@@ -1586,7 +1582,7 @@ bool TMap::retrieveMapFileStats( QString profile, QString * latestFileName = 0, 
     }
 
     // As the files are sorted by time this gets the latest one
-    QFile file( QStringLiteral( "%1%2" ).arg( folder ).arg( entries.at( 0 ) ) );
+    QFile file( QStringLiteral( "%1%2" ).arg(folder, entries.at( 0) ) );
 
     if( ! file.open( QFile::ReadOnly ) ) {
         QString errMsg = tr( "[ ERROR ] - Unable to open (for reading) map file: \"%1\"!" )
@@ -1977,9 +1973,7 @@ const QString TMap::createFileHeaderLine( const QString title, const QChar fillC
 {
     QString text;
     if( title.length() <= 76 ) {
-        text = QStringLiteral( "%1 %2 %1\n" )
-                               .arg( QString( fillChar ).repeated( (78 - title.length()) / 2 ) )
-                               .arg( title );
+        text = QStringLiteral("%1 %2 %1\n").arg(QString(fillChar).repeated((78 - title.length()) / 2), title);
     }
     else {
         text = title;
@@ -2076,9 +2070,7 @@ void TMap::pushErrorMessagesToFile( const QString title, const bool isACleanup )
                          "- look for the (last) report with the title:\n"
                          "\"%2\"." )
                          .arg( QStringLiteral( "%1/.config/mudlet/profiles/%2/log/errors.txt" )
-                                               .arg( QDir::homePath() )
-                                               .arg( mpHost->getName() ) )
-                         .arg( title ) );
+                                               .arg( QDir::homePath(), mpHost->getName() ), title ) );
     }
     else if( mIsFileViewingRecommended && mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
         postMessage( tr( "[ INFO ]  - The equivalent to the above information about that last map\n"
@@ -2087,9 +2079,7 @@ void TMap::pushErrorMessagesToFile( const QString title, const bool isACleanup )
                          "- look for the (last) report with the title:\n"
                          "\"%2\"." )
                          .arg( QStringLiteral( "%1/.config/mudlet/profiles/%2/log/errors.txt" )
-                                               .arg( QDir::homePath() )
-                                               .arg( mpHost->getName() ) )
-                         .arg( title ) );
+                                               .arg( QDir::homePath(), mpHost->getName() ), title ) );
     }
 
     mIsFileViewingRecommended = false;
@@ -2127,8 +2117,7 @@ void TMap::downloadMap( const QString * remoteUrl, const QString * localFileName
                                                      "%1\n"
                                                      "and the error message (may contain technical details) was:"
                                                      "\"%2\"." )
-                         .arg( url.toString() )
-                         .arg( url.errorString() );
+                         .arg( url.toString(), url.errorString() );
         postMessage( errMsg );
         mXmlImportMutex.unlock();
         return;
@@ -2136,8 +2125,7 @@ void TMap::downloadMap( const QString * remoteUrl, const QString * localFileName
 
     if( ! localFileName || localFileName->isEmpty() ) {
         mLocalMapFileName = QStringLiteral( "%1/.config/mudlet/profiles/%2/map.xml" )
-                            .arg( QDir::homePath() )
-                            .arg( pHost->getName() );
+                            .arg( QDir::homePath(), pHost->getName() );
     }
     else {
         mLocalMapFileName = *localFileName;
@@ -2150,8 +2138,7 @@ void TMap::downloadMap( const QString * remoteUrl, const QString * localFileName
     // placed this code here:
     request.setRawHeader( QByteArray( "User-Agent" ),
                           QByteArray( QStringLiteral( "Mozilla/5.0 (Mudlet/%1%2)" )
-                                      .arg( APP_VERSION )
-                                      .arg( APP_BUILD )
+                                      .arg( APP_VERSION, APP_BUILD )
                                       .toUtf8().constData() ) );
 
 #ifndef QT_NO_OPENSSL

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -944,14 +944,12 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
                                          "%2, was: \"%3\" now: \"%4\".")
                                               .arg(id, 6, QLatin1Char('0'))
                                               .arg(_nk, 6, QLatin1Char('0'))
-                                              .arg(_cmd)
-                                              .arg(_nc);
+                                              .arg(_cmd, _nc);
                     mpRoomDB->mpMap->postMessage(warnMsg);
                 }
                 mpRoomDB->mpMap->appendRoomErrorMsg( id, tr( "[ INFO ]  - Room needed patching {internal fixup} of (special) exit to %1, was: \"%2\" now: \"%3\"." )
                                                              .arg( _nk, 6, QLatin1Char( '0' ) )
-                                                             .arg( _cmd )
-                                                             .arg( _nc ) );
+                                                             .arg( _cmd, _nc ) );
             }
         }
         // Now finished with (mutable) iterator, can re-insert changed things

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -769,7 +769,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Insert replacement value into hash
             itRemappedArea.setValue(replacementAreaId);
             if (mudlet::self()->getAuditErrorsToConsoleEnabled()) {
-                infoMsg.append(QStringLiteral("\n%1 ==> %2").arg(faultyAreaId, replacementAreaId));
+                infoMsg.append(QStringLiteral("\n%1 ==> %2").arg(QString::number(faultyAreaId), QString::number(replacementAreaId)));
             }
 
             mpMap->appendAreaErrorMsg(faultyAreaId, tr("[ INFO ]  - The area with this bad id was renumbered to: %1.").arg(replacementAreaId), true);
@@ -852,7 +852,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             itRenumberedRoomId.setValue(newRoomId); // Update the QHash
             validUsedRoomIds.insert(newRoomId);
             if (mudlet::self()->getAuditErrorsToConsoleEnabled()) {
-                infoMsg.append(QStringLiteral("%1 ==> %2").arg(itRenumberedRoomId.key(), itRenumberedRoomId.value()));
+                infoMsg.append(QStringLiteral("%1 ==> %2").arg(QString::number(itRenumberedRoomId.key()), QString::number(itRenumberedRoomId.value())));
             }
 
             mpMap->appendRoomErrorMsg(itRenumberedRoomId.key(), tr("[ INFO ]  - This room with the bad id was renumbered to: %1.").arg(itRenumberedRoomId.value()), true);

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -769,7 +769,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Insert replacement value into hash
             itRemappedArea.setValue(replacementAreaId);
             if (mudlet::self()->getAuditErrorsToConsoleEnabled()) {
-                infoMsg.append(QStringLiteral("\n%1 ==> %2").arg(faultyAreaId).arg(replacementAreaId));
+                infoMsg.append(QStringLiteral("\n%1 ==> %2").arg(faultyAreaId, replacementAreaId));
             }
 
             mpMap->appendAreaErrorMsg(faultyAreaId, tr("[ INFO ]  - The area with this bad id was renumbered to: %1.").arg(replacementAreaId), true);
@@ -852,7 +852,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             itRenumberedRoomId.setValue(newRoomId); // Update the QHash
             validUsedRoomIds.insert(newRoomId);
             if (mudlet::self()->getAuditErrorsToConsoleEnabled()) {
-                infoMsg.append(QStringLiteral("%1 ==> %2").arg(itRenumberedRoomId.key()).arg(itRenumberedRoomId.value()));
+                infoMsg.append(QStringLiteral("%1 ==> %2").arg(itRenumberedRoomId.key(), itRenumberedRoomId.value()));
             }
 
             mpMap->appendRoomErrorMsg(itRenumberedRoomId.key(), tr("[ INFO ]  - This room with the bad id was renumbered to: %1.").arg(itRenumberedRoomId.value()), true);
@@ -1164,9 +1164,9 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
             while (itRemappedNames.hasPrevious()) {
                 itRemappedNames.previous();
                 QString oldName = itRemappedNames.key().isEmpty() ? tr("<nothing>") : itRemappedNames.key();
-                detailText.append(QStringLiteral("(%1) \"%2\" ==> \"%3\"\n").arg(areaNamesMap.key(itRemappedNames.value())).arg(oldName).arg(itRemappedNames.value()));
+                detailText.append(QStringLiteral("(%1) \"%2\" ==> \"%3\"\n").arg(areaNamesMap.key(itRemappedNames.value())).arg(oldName, itRemappedNames.value()));
                 mpMap->appendAreaErrorMsg(areaNamesMap.key(itRemappedNames.value()),
-                                          tr("[ INFO ]  - Area name changed to prevent duplicates or unnamed ones; old name: \"%1\", new name: \"%2\".").arg(oldName).arg(itRemappedNames.value()),
+                                          tr("[ INFO ]  - Area name changed to prevent duplicates or unnamed ones; old name: \"%1\", new name: \"%2\".").arg(oldName, itRemappedNames.value()),
                                           true);
                 ;
             }
@@ -1190,8 +1190,7 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
                                  "  If there were more than one area without a name then all but the\n"
                                  "first will also gain a suffix in this manner.\n"
                                  "%2")
-                                      .arg(mUnnamedAreaName)
-                                      .arg(extraTextForMatchingSuffixAlreadyUsed);
+                                      .arg(mUnnamedAreaName, extraTextForMatchingSuffixAlreadyUsed);
         } else if (renamedMap.size()) {
             // Duplicates but no unnnamed area
             alertText = tr("[ ALERT ] - Duplicate area names detected in the Map file!");

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1435,14 +1435,14 @@ void TTextEdit::copySelectionToClipboardHTML()
                  ++it ) {
 
                 if( (*it).second == this->mpConsole ) {
-                    title = tr( "Mudlet, %1 mini-console extract from %2 profile" ).arg( (*it).first.data() ).arg( this->mpHost->getName() );
+                    title = tr( "Mudlet, %1 mini-console extract from %2 profile" ).arg((*it).first.data(), this->mpHost->getName() );
                     break;
                 }
             }
         }
     }
     else {
-        title = tr( "Mudlet, %1 console extract from %2 profile" ).arg( this->mpConsole->mConsoleName ).arg(  this->mpHost->getName() );
+        title = tr( "Mudlet, %1 console extract from %2 profile" ).arg(this->mpConsole->mConsoleName, this->mpHost->getName() );
     }
 
     QStringList fontsList; // List of fonts to become the font-family entry for

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1272,7 +1272,7 @@ bool TTrigger::setupTmpColorTrigger( int ansiFg, int ansiBg )
     TColorTable * pCT = createColorPattern( ansiFg, ansiBg );
     if( ! pCT ) return false;
     QString code;
-    code = QString("FG%1BG%2").arg(ansiFg, ansiBg);
+    code = QString("FG%1BG%2").arg(QString::number(ansiFg), QString::number(ansiBg));
     mRegexCodeList << code;
     mRegexCodePropertyList << REGEX_COLOR_PATTERN;
     mColorPatternList.push_back( pCT );

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -193,11 +193,8 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
                                                                 << "\"\n"
                                                                 >>0;
                 }
-                setError( QStringLiteral( "<b><font color='blue'>%1</font></b>" )
-                          .arg( tr( "Error: in item %1, perl regex: \"%2\", it failed to compile, reason: \"%3\"." )
-                                .arg( i )
-                                .arg( local8Bit.constData() )
-                                .arg( error ) ) );
+                setError(QStringLiteral("<b><font color='blue'>%1</font></b>")
+                                 .arg(tr("Error: in item %1, perl regex: \"%2\", it failed to compile, reason: \"%3\".").arg(QString::number(i), local8Bit.constData(), error)));
                 state = false;
             }
             else
@@ -217,15 +214,12 @@ bool TTrigger::setRegexCodeList( QStringList regexList, QList<int> propertyList 
              std::stringstream func;
              func << "trigger" << mID << "condition" << i;
              funcName = func.str();
-             QString code = QStringLiteral("function %1()\n%2\nend\n").arg( funcName.c_str() ).arg( regexList[i] );
+             QString code = QStringLiteral("function %1()\n%2\nend\n").arg(funcName.c_str(), regexList[i]);
              QString error;
              if( ! mpLua->compile( code, error, QString::fromStdString(funcName) ) )
              {
-                 setError( QStringLiteral( "<b><font color='blue'>%1</font></b>" )
-                           .arg( tr("Error: in item %1, lua condition function \"%2\" failed to compile, reason:%3.")
-                                 .arg( i )
-                                 .arg( regexList.at( i ) )
-                                 .arg( error ) ) );
+                 setError(QStringLiteral("<b><font color='blue'>%1</font></b>")
+                                  .arg(tr("Error: in item %1, lua condition function \"%2\" failed to compile, reason:%3.").arg(QString::number(i), regexList.at(i), error)));
                  state = false;
                  if( mudlet::debugMode )
                  {
@@ -1278,7 +1272,7 @@ bool TTrigger::setupTmpColorTrigger( int ansiFg, int ansiBg )
     TColorTable * pCT = createColorPattern( ansiFg, ansiBg );
     if( ! pCT ) return false;
     QString code;
-    code = QString("FG%1BG%2").arg(ansiFg).arg(ansiBg);
+    code = QString("FG%1BG%2").arg(ansiFg, ansiBg);
     mRegexCodeList << code;
     mRegexCodePropertyList << REGEX_COLOR_PATTERN;
     mColorPatternList.push_back( pCT );

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -173,8 +173,7 @@ bool XMLimport::importPackage(QFile* pfile, QString packName, int moduleFlag, QS
                                          "\"%1\"\n"
                                          "reports it has a version (%2) it must have come from a later Mudlet version,\n"
                                          "and this one cannot read it, you need a newer Mudlet!")
-                                          .arg(pfile->fileName())
-                                          .arg(versionString);
+                                          .arg(pfile->fileName(), versionString);
                     mpHost->postMessage(moanMsg);
                     return false;
                 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -899,7 +899,7 @@ void cTelnet::processTelnetCommand( const string & command )
                   int newVersion = version.toInt();
                   if( mpHost->mServerGUI_Package_version != newVersion )
                   {
-                      QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(mpHost->mServerGUI_Package_version).arg(newVersion);
+                      QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(mpHost->mServerGUI_Package_version, newVersion);
                       mpHost->mpConsole->print(_smsg.toLatin1().data());
                       mpHost->uninstallPackage( mpHost->mServerGUI_Package_name, 0);
                       mpHost->mServerGUI_Package_version = newVersion;
@@ -927,7 +927,7 @@ void cTelnet::processTelnetCommand( const string & command )
                   QString _home = QDir::homePath();
                   _home.append( "/.config/mudlet/profiles/" );
                   _home.append( mpHost->getName() );
-                  mServerPackage = QString( "%1/%2").arg( _home ).arg( fileName );
+                  mServerPackage = QString( "%1/%2").arg(_home, fileName);
 
                   QNetworkReply * reply = mpDownloader->get( QNetworkRequest( QUrl( url ) ) );
                   mpProgressDialog = new QProgressDialog("downloading game GUI from server", "Abort", 0, 4000000, mpHost->mpConsole );
@@ -1146,7 +1146,7 @@ void cTelnet::setGMCPVariables(const QString & msg )
         int newVersion = version.toInt();
         if( mpHost->mServerGUI_Package_version != newVersion )
         {
-            QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(mpHost->mServerGUI_Package_version).arg(newVersion);
+            QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(mpHost->mServerGUI_Package_version, newVersion);
             mpHost->mpConsole->print(_smsg.toLatin1().data());
             mpHost->uninstallPackage( mpHost->mServerGUI_Package_name, 0);
             mpHost->mServerGUI_Package_version = newVersion;
@@ -1174,7 +1174,7 @@ void cTelnet::setGMCPVariables(const QString & msg )
         QString _home = QDir::homePath();
         _home.append( "/.config/mudlet/profiles/" );
         _home.append( mpHost->getName() );
-        mServerPackage = QString( "%1/%2").arg( _home ).arg( fileName );
+        mServerPackage = QString( "%1/%2").arg(_home, fileName);
 
         QNetworkReply * reply = mpDownloader->get( QNetworkRequest( QUrl( url ) ) );
         mpProgressDialog = new QProgressDialog("downloading game GUI from server", "Abort", 0, 4000000, mpHost->mpConsole );

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -899,7 +899,7 @@ void cTelnet::processTelnetCommand( const string & command )
                   int newVersion = version.toInt();
                   if( mpHost->mServerGUI_Package_version != newVersion )
                   {
-                      QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(mpHost->mServerGUI_Package_version, newVersion);
+                      QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(QString::number(mpHost->mServerGUI_Package_version), QString::number(newVersion));
                       mpHost->mpConsole->print(_smsg.toLatin1().data());
                       mpHost->uninstallPackage( mpHost->mServerGUI_Package_name, 0);
                       mpHost->mServerGUI_Package_version = newVersion;
@@ -1146,7 +1146,7 @@ void cTelnet::setGMCPVariables(const QString & msg )
         int newVersion = version.toInt();
         if( mpHost->mServerGUI_Package_version != newVersion )
         {
-            QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(mpHost->mServerGUI_Package_version, newVersion);
+            QString _smsg = QString("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>").arg(QString::number(mpHost->mServerGUI_Package_version), QString::number(newVersion));
             mpHost->mpConsole->print(_smsg.toLatin1().data());
             mpHost->uninstallPackage( mpHost->mServerGUI_Package_name, 0);
             mpHost->mServerGUI_Package_version = newVersion;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -356,7 +356,7 @@ void dlgConnectionProfiles::slot_save_name()
 
         pItem->setText( newProfileName );
 
-        QDir currentPath( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg( QDir::homePath() ).arg( currentProfileEditName ) );
+        QDir currentPath( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg(QDir::homePath(), currentProfileEditName) );
         QDir dir;
 
         if (currentPath.exists())
@@ -372,7 +372,7 @@ void dlgConnectionProfiles::slot_save_name()
                 notificationAreaMessageBox->setText( tr( "Could not rename your profile data on the computer." ));
             }
         }
-        else if (! dir.mkpath( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg( QDir::homePath() ).arg( newProfileName ) ) )
+        else if (! dir.mkpath( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg(QDir::homePath(), newProfileName) ) )
         {
             notificationArea->show();
             notificationAreaIconLabelWarning->show();
@@ -511,7 +511,7 @@ void dlgConnectionProfiles::slot_deleteprofile_check( const QString text )
 void dlgConnectionProfiles::slot_reallyDeleteProfile()
 {
     QString profile = profiles_tree_widget->currentItem()->text();
-    QDir dir( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg( QDir::homePath() ).arg( profile ) );
+    QDir dir( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg(QDir::homePath(), profile) );
     dir.removeRecursively(); // note: we should replace this with a function that pops up a progress dialog should the deletion be taking longer than a second
     fillout_form();
     profiles_tree_widget->setFocus();
@@ -556,7 +556,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
 
 QString dlgConnectionProfiles::readProfileData( QString profile, QString item )
 {
-    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" ).arg( QDir::homePath() ).arg( profile ).arg( item ) );
+    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" ).arg( QDir::homePath(), profile, item ) );
     bool success = file.open( QIODevice::ReadOnly );
     QString ret;
     if ( success ) {
@@ -570,7 +570,7 @@ QString dlgConnectionProfiles::readProfileData( QString profile, QString item )
 
 QStringList dlgConnectionProfiles::readProfileHistory( QString profile, QString item )
 {
-    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" ).arg( QDir::homePath() ).arg( profile ).arg( item ) );
+    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" ).arg( QDir::homePath(), profile, item ) );
     file.open( QIODevice::ReadOnly );
     QDataStream ifs( & file );
     QString ret;
@@ -586,7 +586,7 @@ QStringList dlgConnectionProfiles::readProfileHistory( QString profile, QString 
 
 void dlgConnectionProfiles::writeProfileData( QString profile, QString item, QString what )
 {
-    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" ).arg( QDir::homePath() ).arg( profile ).arg( item ) );
+    QFile file( QStringLiteral( "%1/.config/mudlet/profiles/%2/%3" ).arg( QDir::homePath(), profile, item ) );
     file.open( QIODevice::WriteOnly | QIODevice::Unbuffered );
     QDataStream ofs( & file );
     ofs << what;
@@ -769,7 +769,7 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem *pItem)
 
     profile_history->clear();
 
-    QDir dir( QStringLiteral( "%1/.config/mudlet/profiles/%2/current/" ).arg( QDir::homePath() ).arg( profile_name ) );
+    QDir dir( QStringLiteral( "%1/.config/mudlet/profiles/%2/current/" ).arg(QDir::homePath(), profile_name) );
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList( QDir::Files|QDir::NoDotAndDotDot, QDir::Time );
 
@@ -1147,7 +1147,7 @@ void dlgConnectionProfiles::fillout_form()
         // Previously was using Host.dat file but that is (not now) used or
         // present; now use the "current" directory as that is updated when a
         // profile is used AND saved...
-        QDateTime profile_lastRead = QFileInfo( QStringLiteral( "%1/.config/mudlet/profiles/%2/current/" ).arg( QDir::homePath() ).arg( mProfileList.at(i) ) ).lastRead();
+        QDateTime profile_lastRead = QFileInfo( QStringLiteral( "%1/.config/mudlet/profiles/%2/current/" ).arg(QDir::homePath(), mProfileList.at(i) ) ).lastRead();
         // Since Qt 5.x null QTimes and QDateTimes are invalid - and might not
         // work as expected - so test for validity of the test_date value as well
         if( ( ! test_date.isValid() ) || profile_lastRead > test_date )
@@ -1213,12 +1213,12 @@ void dlgConnectionProfiles::slot_copy_profile()
     port_entry->setReadOnly( false );
 
     // copy the folder on-disk
-    QDir dir( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg( QDir::homePath() ).arg( oldname ) );
+    QDir dir( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg(QDir::homePath(), oldname) );
     if (!dir.exists())
         return;
 
-    copyFolder( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg( QDir::homePath() ).arg( oldname ),
-                QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg( QDir::homePath() ).arg( profile_name ) );
+    copyFolder( QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg(QDir::homePath(), oldname),
+                QStringLiteral( "%1/.config/mudlet/profiles/%2" ).arg(QDir::homePath(), profile_name) );
     mProfileList << profile_name;
     slot_item_clicked(pItem);
 }
@@ -1243,9 +1243,7 @@ void dlgConnectionProfiles::slot_connectToServer()
 
     if( ! pHost ) return;
 
-    QString folder = QStringLiteral( "%1/.config/mudlet/profiles/%2/current/" )
-                     .arg( QDir::homePath() )
-                     .arg( profile_name );
+    QString folder = QStringLiteral("%1/.config/mudlet/profiles/%2/current/").arg(QDir::homePath(), profile_name);
     QDir dir( folder );
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList( QDir::Files, QDir::Time );
@@ -1254,9 +1252,7 @@ void dlgConnectionProfiles::slot_connectToServer()
     lI->getVars( true );
     if( ! entries.isEmpty() )
     {
-        QFile file( QStringLiteral( "%1%2" )
-                    .arg(  folder )
-                    .arg( profile_history->itemData( profile_history->currentIndex() ).toString() ) );
+        QFile file(QStringLiteral("%1%2").arg(folder, profile_history->itemData(profile_history->currentIndex()).toString()));
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer( pHost );
         qDebug()<<"[LOADING PROFILE]:"<<file.fileName();

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -186,11 +186,11 @@ void dlgIRC::irc_gotMsg(QString a, QString b, QString c)
     const QString n = a;
     QString t;
     if (b == mNick)
-        t = tr("<font color=#a5a5a5>[%1] </font>msg from <font color=#ff0000>%2</font><font color=#ff0000>: %3</font>").arg(_t).arg(n).arg(msg);
+        t = tr("<font color=#a5a5a5>[%1] </font>msg from <font color=#ff0000>%2</font><font color=#ff0000>: %3</font>").arg(_t, n, msg);
     else if (a == mNick)
-        t = tr("<font color=#a5a5a5>[%1] </font><font color=#00aaaa>%2</font><font color=#004400>: %3</font>").arg(_t).arg(n).arg(msg);
+        t = tr("<font color=#a5a5a5>[%1] </font><font color=#00aaaa>%2</font><font color=#004400>: %3</font>").arg(_t, n, msg);
     else
-        t = tr("<font color=#a5a5a5>[%1] </font><font color=#0000ff>%2</font><font color=#000000>: %3</font>").arg(_t).arg(n).arg(msg);
+        t = tr("<font color=#a5a5a5>[%1] </font><font color=#0000ff>%2</font><font color=#000000>: %3</font>").arg(_t, n, msg);
 
 
     QString hi = QString("<font color=#aa00aa>%1</font>").arg(mNick);
@@ -228,11 +228,11 @@ void dlgIRC::irc_gotMsg2(QString a, QStringList c)
     const QString n = a;
     QString t;
     if (msg.contains(mNick))
-        t = tr("<font color=#a5a5a5>[%1] </font><font color=#ff0000>%2</font><font color=#000000>: %3</font>").arg(_t).arg(n).arg(msg);
+        t = tr("<font color=#a5a5a5>[%1] </font><font color=#ff0000>%2</font><font color=#000000>: %3</font>").arg(_t, n, msg);
     else
-        t = tr("<font color=#a5a5a5>[%1] </font><font color=#0000ff>%2</font><font color=#000000>: %3</font>").arg(_t).arg(n).arg(msg);
+        t = tr("<font color=#a5a5a5>[%1] </font><font color=#0000ff>%2</font><font color=#000000>: %3</font>").arg(_t, n, msg);
 
-    //QString t = tr("<font color=#aaaaaa>[%1] </font><font color=#ff0000>%2</font><font color=#000000>: %3</font>").arg(_t).arg(n).arg(msg);
+    //QString t = tr("<font color=#aaaaaa>[%1] </font><font color=#ff0000>%2</font><font color=#000000>: %3</font>").arg(_t, n, msg);
     QTextCursor cur = irc->textCursor();
     cur.movePosition(QTextCursor::End);
     cur.insertBlock();
@@ -296,7 +296,7 @@ void dlgIRC::irc_gotMsg3(QString a, uint code, QStringList c)
 void dlgIRC::slot_joined(QString nick, QString chan)
 {
     const QString _t = QTime::currentTime().toString();
-    QString t = tr("<font color=#008800>[%1] %2 has joined the channel.</font>").arg(_t).arg(nick);
+    QString t = tr("<font color=#008800>[%1] %2 has joined the channel.</font>").arg(_t, nick);
     QTextCursor cur = irc->textCursor();
     cur.movePosition(QTextCursor::End);
     cur.insertBlock();
@@ -308,7 +308,7 @@ void dlgIRC::slot_joined(QString nick, QString chan)
 void dlgIRC::slot_parted(QString nick, QString chan, QString msg)
 {
     const QString _t = QTime::currentTime().toString();
-    QString t = tr("<font color=#888800>[%1] %2 has left the channel.</font>").arg(_t).arg(nick);
+    QString t = tr("<font color=#888800>[%1] %2 has left the channel.</font>").arg(_t, nick);
     QTextCursor cur = irc->textCursor();
     cur.movePosition(QTextCursor::End);
     cur.insertBlock();

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -160,7 +160,7 @@ void dlgMapper::updateAreaComboBox()
         uint deduplicate = 0;
         QString _name;
         do {
-            _name = QStringLiteral("%1+%2").arg(itAreaNamesA.value().toLower(), ++deduplicate);
+            _name = QStringLiteral("%1+%2").arg(itAreaNamesA.value().toLower(), QString::number(++deduplicate));
             // Use a different suffix separator to one that area names
             // deduplication uses ('_') - makes debugging easier?
         } while (_areaNames.contains(_name));

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -160,7 +160,7 @@ void dlgMapper::updateAreaComboBox()
         uint deduplicate = 0;
         QString _name;
         do {
-            _name = QStringLiteral("%1+%2").arg(itAreaNamesA.value().toLower()).arg(++deduplicate);
+            _name = QStringLiteral("%1+%2").arg(itAreaNamesA.value().toLower(), ++deduplicate);
             // Use a different suffix separator to one that area names
             // deduplication uses ('_') - makes debugging easier?
         } while (_areaNames.contains(_name));

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -964,15 +964,14 @@ void dlgProfilePreferences::copyMap()
 
             // Check for the destination directory for the other profiles
             QDir toProfileDir;
-            QString toProfileDirPathString = QStringLiteral("%1/.config/mudlet/profiles/%2/map").arg(QDir::homePath()).arg(toProfileName);
+            QString toProfileDirPathString = QStringLiteral("%1/.config/mudlet/profiles/%2/map").arg(QDir::homePath(), toProfileName);
             if (!toProfileDir.exists(toProfileDirPathString)) {
                 if (!toProfileDir.mkpath(toProfileDirPathString)) {
                     QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map for other profile \"%1\".\n"
                                         "Please check that you have permissions/access to:\n"
                                         "\"%2\"\n"
                                         "and there is enough space. The copying operation has failed.")
-                                             .arg(toProfileName)
-                                             .arg(toProfileDirPathString);
+                                             .arg(toProfileName, toProfileDirPathString);
                     pHost->postMessage(errMsg);
                     label_mapFileActionResult->show();
                     label_mapFileActionResult->setText(tr("Creating a destination directory failed..."));
@@ -1088,8 +1087,7 @@ void dlgProfilePreferences::copyMap()
     QString thisProfileLatestMapPathFileName;
     QFile thisProfileLatestMapFile;
     QString sourceMapFolder( QStringLiteral( "%1/.config/mudlet/profiles/%2/map" )
-                                 .arg( QDir::homePath() )
-                                 .arg( pHost->getName() ) );
+                                 .arg( QDir::homePath(), pHost->getName() ) );
     QStringList mProfileList = QDir( sourceMapFolder )
                                    .entryList( QDir::Files | QDir::NoDotAndDotDot, QDir::Time );
     for (unsigned int i = 0, total = mProfileList.size(); i < total; ++i) {
@@ -1099,8 +1097,7 @@ void dlgProfilePreferences::copyMap()
         }
 
         thisProfileLatestMapFile.setFileName( QStringLiteral( "%1/%2" )
-                                                  .arg( sourceMapFolder )
-                                                  .arg( thisProfileLatestMapPathFileName ) );
+                                                  .arg( sourceMapFolder, thisProfileLatestMapPathFileName ) );
         break;
     }
 
@@ -1123,9 +1120,7 @@ void dlgProfilePreferences::copyMap()
                                // show up when saving big maps
 
         if( ! thisProfileLatestMapFile.copy( QStringLiteral( "%1/.config/mudlet/profiles/%2/map/%3" )
-                                                 .arg( QDir::homePath() )
-                                                 .arg( otherHostName )
-                                                 .arg( thisProfileLatestMapPathFileName ) ) ) {
+                                                 .arg( QDir::homePath(), otherHostName, thisProfileLatestMapPathFileName ) ) ) {
             label_mapFileActionResult->setText( tr( "Could not copy the map to %1 - unable to copy the new map file over." )
                                                         .arg( otherHostName ));
             QTimer::singleShot(10 * 1000, this, SLOT(hideActionLabel()));

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -138,15 +138,15 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem * pI, int column )
         if ( pExitToRoom ) {
             mpEditItem->setForeground( 0, QColor(Qt::blue) );
             if( ! pExitToRoom->name.isEmpty() ) {
-                mpEditItem->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                                        .arg( tr( "Exit to \"%1\"." )
-                                              .arg( pExitToRoom->name ) )
-                                        .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
-                                              .arg( pExitToRoom->getWeight() ) ));
+                mpEditItem->setToolTip(0,
+                                       QStringLiteral("<html><head/><body><p>%1</p><p>%2</p></body></html>")
+                                               .arg(tr("Exit to \"%1\".").arg(pExitToRoom->name),
+                                                    tr("<b>Room</b> Weight of destination: %1.",
+                                                       "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not.")
+                                                            .arg(pExitToRoom->getWeight())));
             } else {
                 mpEditItem->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                                        .arg( tr( "Exit to unnamed room is valid" ) )
-                                        .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                        .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                               .arg( pExitToRoom->getWeight() ) ));
             }
         } else {
@@ -659,14 +659,12 @@ void dlgRoomExits::slot_nw_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                             .arg( tr( "Exit to \"%1\"." )
-                                  .arg( exitToRoom->name ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
         else {
             nw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                            .arg( tr( "Exit to unnamed room is valid" ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                            .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0 ) {
@@ -715,14 +713,12 @@ void dlgRoomExits::slot_n_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                            .arg( tr( "Exit to \"%1\"." )
-                                 .arg( exitToRoom->name ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
         else {
             n->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                           .arg( tr( "Exit to unnamed room is valid" ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                           .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -768,14 +764,12 @@ void dlgRoomExits::slot_ne_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                             .arg( tr( "Exit to \"%1\"." )
-                                  .arg( exitToRoom->name ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
         else {
             ne->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                            .arg( tr( "Exit to unnamed room is valid" ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                            .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -821,14 +815,12 @@ void dlgRoomExits::slot_up_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                            .arg( tr( "Exit to \"%1\"." )
-                                 .arg( exitToRoom->name ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
         else {
             up->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                           .arg( tr( "Exit to unnamed room is valid" ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                           .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -874,14 +866,12 @@ void dlgRoomExits::slot_w_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                            .arg( tr( "Exit to \"%1\"." )
-                                 .arg( exitToRoom->name ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
         else {
             w->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                           .arg( tr( "Exit to unnamed room is valid" ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                           .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -927,14 +917,12 @@ void dlgRoomExits::slot_e_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                            .arg( tr( "Exit to \"%1\"." )
-                                 .arg( exitToRoom->name ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
         else {
             e->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                           .arg( tr( "Exit to unnamed room is valid" ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                           .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -980,14 +968,12 @@ void dlgRoomExits::slot_down_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                               .arg( tr( "Exit to \"%1\"." )
-                                    .arg( exitToRoom->name ) )
-                              .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                    .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                     .arg( exitToRoom->getWeight() ) ));
         }
         else {
             down->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                              .arg( tr( "Exit to unnamed room is valid" ) )
-                              .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                              .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                     .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -1033,14 +1019,12 @@ void dlgRoomExits::slot_sw_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                             .arg( tr( "Exit to \"%1\"." )
-                                  .arg( exitToRoom->name ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
         else {
             sw->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                            .arg( tr( "Exit to unnamed room is valid" ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                            .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -1086,14 +1070,12 @@ void dlgRoomExits::slot_s_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                            .arg( tr( "Exit to \"%1\"." )
-                                 .arg( exitToRoom->name ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                 .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
         else {
             s->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                           .arg( tr( "Exit to unnamed room is valid" ) )
-                           .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                           .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                  .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -1139,14 +1121,12 @@ void dlgRoomExits::slot_se_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                             .arg( tr( "Exit to \"%1\"." )
-                                  .arg( exitToRoom->name ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
         else {
             se->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                            .arg( tr( "Exit to unnamed room is valid" ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                            .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -1192,14 +1172,12 @@ void dlgRoomExits::slot_in_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                             .arg( tr( "Exit to \"%1\"." )
-                                  .arg( exitToRoom->name ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                  .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
         else {
             in->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                            .arg( tr( "Exit to unnamed room is valid" ) )
-                            .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                            .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                   .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -1245,14 +1223,12 @@ void dlgRoomExits::slot_out_textEdited(const QString &text)
         if( exitToRoom->name.trimmed().length() ) {
             out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                              .arg( tr( "Exit to \"%1\"." )
-                                   .arg( exitToRoom->name ) )
-                             .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                   .arg( exitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                    .arg( exitToRoom->getWeight() ) ));
         }
         else {
             out->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                             .arg( tr( "Exit to unnamed room is valid" ) )
-                             .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                             .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                    .arg( exitToRoom->getWeight() ) ));
         }
     } else if ( text.size() > 0) {
@@ -1743,13 +1719,11 @@ void dlgRoomExits::initExit( int roomId, int direction, int exitId, QLineEdit * 
         if( pExitR->name.trimmed().length() ) {
             exitLineEdit->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                                       .arg( tr( "Exit to \"%1\"." )
-                                            .arg( pExitR->name ) )
-                                      .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                            .arg( pExitR->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                             .arg( pExitR->getWeight() ) ));
         } else {
             exitLineEdit->setToolTip( QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                                      .arg( tr( "Exit to unnamed room is valid" ) )
-                                      .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                      .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                             .arg( pExitR->getWeight() ) ));
         }
         noRoute->setEnabled(true);    //Enable speedwalk lock control
@@ -1882,13 +1856,11 @@ void dlgRoomExits::init( int id )
             if( ! pExitToRoom->name.isEmpty() ) {
                 pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
                                 .arg( tr( "Exit to \"%1\"." )
-                                      .arg( pExitToRoom->name ) )
-                                .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                      .arg( pExitToRoom->name ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                       .arg( pExitToRoom->getWeight() ) ));
             } else {
                 pI->setToolTip( 0, QStringLiteral( "<html><head/><body><p>%1</p><p>%2</p></body></html>" )
-                                .arg( tr( "Exit to unnamed room is valid" ) )
-                                .arg( tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
+                                .arg( tr( "Exit to unnamed room is valid" ), tr( "<b>Room</b> Weight of destination: %1.", "Bold HTML tags are used to emphasis that the value is destination room's weight whether overriden by a non-zero exit weight here or not." )
                                       .arg( pExitToRoom->getWeight() ) ));
             }
         } else {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1830,10 +1830,8 @@ void dlgTriggerEditor::slot_trigger_toggle_active()
         iconError.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
         pItem->setIcon( 0, iconError );
     }
-    showInfo( QString( "Trying to %2 trigger <em>%1</em> %3." )
-              .arg(pT->getName())
-              .arg( pT->shouldBeActive() ? "activate" : "deactivate" )
-              .arg( pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
+    showInfo(QString("Trying to %2 trigger <em>%1</em> %3.")
+                     .arg(pT->getName(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError()));
     if( pItem->childCount() > 0 )
     {
         children_icon_triggers( pItem );
@@ -2025,9 +2023,7 @@ void dlgTriggerEditor::slot_timer_toggle_active()
 
 
     showInfo( QString( "Trying to %2 timer <em>%1</em> %3." )
-              .arg(pT->getName())
-              .arg( pT->shouldBeActive() ? "activate" : "deactivate" )
-              .arg( pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
+              .arg(pT->getName(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
 }
 
 void dlgTriggerEditor::slot_alias_toggle_active()
@@ -2075,9 +2071,7 @@ void dlgTriggerEditor::slot_alias_toggle_active()
         pItem->setIcon( 0, iconError );
     }
     showInfo( QString( "Trying to %2 alias <em>%1</em> %3." )
-              .arg(pT->getName())
-              .arg( pT->shouldBeActive() ? "activate" : "deactivate" )
-              .arg( pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
+              .arg(pT->getName(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
 
     if( pItem->childCount() > 0 )
     {
@@ -2212,9 +2206,7 @@ void dlgTriggerEditor::slot_script_toggle_active()
         pItem->setIcon( 0, iconError );
     }
     showInfo( QString( "Trying to %2 script <em>%1</em> %3." )
-              .arg(pT->getName())
-              .arg( pT->shouldBeActive() ? "activate" : "deactivate" )
-              .arg( pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
+              .arg(pT->getName(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
 }
 
 void dlgTriggerEditor::slot_action_toggle_active()
@@ -2297,8 +2289,7 @@ void dlgTriggerEditor::slot_action_toggle_active()
     {
         pT->setIsActive( false );
         showError( tr( "Unable to activate (and automatically deactivating) a button/menu/toolbar or the part of a module \"%1\" that contains them; reason: %2." )
-                   .arg( pT->getName() )
-                   .arg( pT->getError() ) );
+                   .arg( pT->getName(), pT->getError() ) );
         icon.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
     }
     pItem->setIcon( 0, icon);
@@ -2353,9 +2344,7 @@ void dlgTriggerEditor::slot_key_toggle_active()
         pItem->setIcon( 0, iconError );
     }
     showInfo( QString( "Trying to %2 key <em>%1</em> %3." )
-              .arg(pT->getName())
-              .arg( pT->shouldBeActive() ? "activate" : "deactivate" )
-              .arg( pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
+              .arg(pT->getName(), pT->shouldBeActive() ? "activate" : "deactivate", pT->state() ? "succeeded" : QString("failed; reason: ") + pT->getError() ) );
     if( pItem->childCount() > 0 )
     {
         children_icon_key( pItem );
@@ -6731,8 +6720,7 @@ void dlgTriggerEditor::slot_export()
     {
         QMessageBox::warning(this, tr("export package:"),
                              tr("Cannot write file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
+                             .arg(fileName, file.errorString()));
         return;
     }
 
@@ -6795,8 +6783,7 @@ void dlgTriggerEditor::slot_import()
     {
         QMessageBox::warning(this, tr("Import Mudlet Package:"),
                              tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
+                             .arg(fileName, file.errorString()));
         return;
     }
 
@@ -6820,10 +6807,10 @@ void dlgTriggerEditor::slot_import()
         QString _home = QDir::homePath();
         _home.append( "/.config/mudlet/profiles/" );
         _home.append( mpHost->getName() );
-        QString _dest = QString( "%1/%2/").arg( _home ).arg( packageName );
+        QString _dest = QString( "%1/%2/").arg(_home, packageName);
         QDir _tmpDir;
         _tmpDir.mkpath(_dest);
-        QString _script = QString( "unzip([[%1]], [[%2]])" ).arg( fileName ).arg( _dest );
+        QString _script = QString( "unzip([[%1]], [[%2]])" ).arg(fileName, _dest);
         mpHost->mLuaInterpreter.compileAndExecuteScript( _script );
 
         // requirements for zip packages:
@@ -6955,8 +6942,7 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
     {
        QMessageBox::warning(this, tr("Backup Profile:"),
                             tr("Cannot write file %1:\n%2.")
-                            .arg(fileName)
-                            .arg(file.errorString()));
+                            .arg(fileName, file.errorString()));
        return;
     }
     XMLexport writer( mpHost ); //just export a generic package without host element
@@ -7157,7 +7143,7 @@ void dlgTriggerEditor::slot_color_trigger_fg()
 
     row = ((dlgTriggerPatternEdit*)pB->parent())->mRow;
     pI = mTriggerPatternEdit[row];
-    pI->lineEdit->setText(QString("FG%1BG%2").arg(pT->mColorTriggerFgAnsi).arg(pT->mColorTriggerBgAnsi) );
+    pI->lineEdit->setText(QString("FG%1BG%2").arg(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi) );
     pB->setStyleSheet( styleSheet );
 }
 
@@ -7210,7 +7196,7 @@ void dlgTriggerEditor::slot_color_trigger_bg()
     row = ((dlgTriggerPatternEdit*)pB->parent())->mRow;
     pI = mTriggerPatternEdit[row];
     if( ! pI ) return;
-    pI->lineEdit->setText(QString("FG%1BG%2").arg(pT->mColorTriggerFgAnsi).arg(pT->mColorTriggerBgAnsi) );
+    pI->lineEdit->setText(QString("FG%1BG%2").arg(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi) );
     pB->setStyleSheet( styleSheet );
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7143,7 +7143,7 @@ void dlgTriggerEditor::slot_color_trigger_fg()
 
     row = ((dlgTriggerPatternEdit*)pB->parent())->mRow;
     pI = mTriggerPatternEdit[row];
-    pI->lineEdit->setText(QString("FG%1BG%2").arg(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi) );
+    pI->lineEdit->setText(QString("FG%1BG%2").arg(QString::number(pT->mColorTriggerFgAnsi), QString::number(pT->mColorTriggerBgAnsi)) );
     pB->setStyleSheet( styleSheet );
 }
 
@@ -7196,7 +7196,7 @@ void dlgTriggerEditor::slot_color_trigger_bg()
     row = ((dlgTriggerPatternEdit*)pB->parent())->mRow;
     pI = mTriggerPatternEdit[row];
     if( ! pI ) return;
-    pI->lineEdit->setText(QString("FG%1BG%2").arg(pT->mColorTriggerFgAnsi, pT->mColorTriggerBgAnsi) );
+    pI->lineEdit->setText(QString("FG%1BG%2").arg(QString::number(pT->mColorTriggerFgAnsi), QString::number(pT->mColorTriggerBgAnsi)) );
     pB->setStyleSheet( styleSheet );
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -625,8 +625,7 @@ void mudlet::slot_install_module()
     {
         QMessageBox::warning(this, tr("Load Mudlet Module:"),
                              tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
+                             .arg(fileName, file.errorString()));
         return;
     }
 
@@ -700,8 +699,7 @@ void mudlet::slot_install_package()
     {
         QMessageBox::warning(this, tr("Import Mudlet Package:"),
                              tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
+                             .arg(fileName, file.errorString()));
         return;
     }
 
@@ -2342,8 +2340,7 @@ void mudlet::slot_replay()
     {
         QMessageBox::warning(this, tr("Select Replay"),
                              tr("Cannot read file %1:\n%2.")
-                             .arg(fileName)
-                             .arg(file.errorString()));
+                             .arg(fileName, file.errorString()));
         return;
     }
     //QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";


### PR DESCRIPTION
Saves on memory allocations and it's especially useful in some performance-critical functions like the mapper paint event.

This would need a thorough review to avoid issues like https://github.com/Mudlet/Mudlet/issues/999 again.

Fixes https://github.com/Mudlet/Mudlet/issues/903.