### PR TITLE
Proposed fix for sysDisconnectionEvent related crash

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -593,7 +593,7 @@ void Host::unregisterEventHandler(const QString& name, TScript* pScript)
 
 void Host::raiseEvent(const TEvent& pE)
 {
-    if (pE.mArgumentList.isEmpty()) {
+    if (pE.mArgumentList.isEmpty() || isClosingDown()) {
         return;
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -593,7 +593,7 @@ void Host::unregisterEventHandler(const QString& name, TScript* pScript)
 
 void Host::raiseEvent(const TEvent& pE)
 {
-    if (pE.mArgumentList.isEmpty() || isClosingDown()) {
+    if (pE.mArgumentList.isEmpty()) {
         return;
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -752,7 +752,7 @@ void mudlet::slot_close_profile_requested( int tab )
         pH->mpConsole->mUserAgreedToCloseConsole = true;
     pH->closingDown();
 
-    // disconnect telnet early.
+    // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
     pH->mTelnet.disconnect();
 
     pH->stopAllTriggers();
@@ -805,7 +805,7 @@ void mudlet::slot_close_profile()
 
                 pH->closingDown();
 
-                // disconnect telnet early.
+                // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
                 pH->mTelnet.disconnect();
 
                 mpCurrentActiveHost->mpEditorDialog->close();
@@ -1933,7 +1933,7 @@ void mudlet::closeEvent(QCloseEvent *event)
     {
         if( pC->mpHost->getName() != "default_host" )
         {
-            // disconnect telnet early.
+            // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
             pC->mpHost->mTelnet.disconnect();
 
             // close script-editor

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1925,6 +1925,9 @@ void mudlet::closeEvent(QCloseEvent *event)
     {
         if( pC->mpHost->getName() != "default_host" )
         {
+            // mark host as closing.
+            pC->mpHost->closingDown();
+
             // close script-editor
             if( pC->mpHost->mpEditorDialog )
             {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -751,6 +751,10 @@ void mudlet::slot_close_profile_requested( int tab )
     else
         pH->mpConsole->mUserAgreedToCloseConsole = true;
     pH->closingDown();
+
+    // disconnect telnet early.
+    pH->mTelnet.disconnect();
+
     pH->stopAllTriggers();
     pH->mpEditorDialog->close();
     for( auto consoleName : hostConsoleMap.keys() ) {
@@ -800,6 +804,10 @@ void mudlet::slot_close_profile()
                 QString name = pH->getName();
 
                 pH->closingDown();
+
+                // disconnect telnet early.
+                pH->mTelnet.disconnect();
+
                 mpCurrentActiveHost->mpEditorDialog->close();
                 for( auto consoleName : hostConsoleMap.keys() ) {
                     hostConsoleMap[consoleName]->close();
@@ -1925,8 +1933,8 @@ void mudlet::closeEvent(QCloseEvent *event)
     {
         if( pC->mpHost->getName() != "default_host" )
         {
-            // mark host as closing.
-            pC->mpHost->closingDown();
+            // disconnect telnet early.
+            pC->mpHost->mTelnet.disconnect();
 
             // close script-editor
             if( pC->mpHost->mpEditorDialog )
@@ -1940,7 +1948,6 @@ void mudlet::closeEvent(QCloseEvent *event)
                 pC->mpHost->mpNotePad->setAttribute( Qt::WA_DeleteOnClose );
                 pC->mpHost->mpNotePad->close();
             }
-
 
             // close console
             pC->close();


### PR DESCRIPTION
I've tested this with the tempTimer and with the profile provided for MidnightSun2 and this seems to do the trick, in those cases at least. I'm hopeful this will resolve Issue #512 

All this really does is attempt to raise the disconnection event earlier by disconnecting the telnet client earlier in the closing processes rather than disconnecting it in the destructor for the host itself.  

**Edit:**  to clarify, this causes the `sysDisconnectionEvent` to be raised a bit earlier when closing a host profile or Mudlet itself, which should mean all our host windows, labels, etc., etc. are still in-memory for use by Lua.