### PR TITLE
Fix some TToolBar bugs.

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -273,7 +273,7 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
         if (action->mPackageName.size() > 0) {
             for (auto& childAction : *action->mpMyChildrenList) {
                 bool found = false;
-                TToolBar* pTB = 0;
+                QPointer<TToolBar> pTB = 0;
                 for (auto& toolBar : mToolBarList) {
                     if (toolBar == childAction->mpToolBar) {
                         found = true;
@@ -296,7 +296,7 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
             continue; //action package
         }
         bool found = false;
-        TToolBar* pTB = 0;
+        QPointer<TToolBar> pTB = 0;
         for (auto& toolBar : mToolBarList) {
             if (toolBar == action->mpToolBar) {
                 found = true;

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -411,6 +411,10 @@ void ActionUnit::hideToolBar(const QString& name)
 
 void ActionUnit::constructToolbar(TAction* pA, TToolBar* pTB)
 {
+    if( ! pA->isDataChanged() ) {
+        return;
+    }
+
     pTB->clear();
     if ((pA->mLocation != 4) || (!pA->isActive())) {
         pTB->setFloating(false);
@@ -450,6 +454,7 @@ void ActionUnit::constructToolbar(TAction* pA, TToolBar* pTB)
         pTB->show();
 
     pTB->setStyleSheet(pTB->mpTAction->css);
+    pA->setDataSaved();
 }
 
 TAction* ActionUnit::getHeadAction(TEasyButtonBar* pT)

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -116,20 +116,32 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
     if (!pChild) {
         return;
     }
+
     if (pOldParent) {
+        pChild->setDataChanged();
         pOldParent->popChild(pChild);
         pOldParent->setDataChanged();
+
+        // clear references to old parent toolbars and buttonbars.
+        if( pOldParent->mpToolBar == pChild->mpToolBar ) {
+            pChild->mpToolBar = 0;
+        }
+        if( pOldParent->mpEasyButtonBar == pChild->mpEasyButtonBar ) {
+            pChild->mpEasyButtonBar = 0;
+        }
     }
     if (!pOldParent) {
         removeActionRootNode(pChild);
+        pChild->setDataChanged();
     }
 
     if (pNewParent) {
         pNewParent->Tree<TAction>::addChild(pChild, parentPosition, childPosition);
-        pNewParent->setDataChanged();
         if (pChild) {
             pChild->Tree<TAction>::setParent(pNewParent);
         }
+        pChild->setDataChanged();
+        pNewParent->setDataChanged();
         //cout << "dumping family of newParent:"<<endl;
         //pNewParent->Dump();
     } else {
@@ -270,6 +282,9 @@ int ActionUnit::getNewID()
 std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
 {
     for (auto& action : mActionRootNodeList) {
+        if( action->mLocation != 4 ) {
+            continue;  // skip over any root action node that is NOT going to be a TToolBar.
+        }
         if (action->mPackageName.size() > 0) {
             for (auto& childAction : *action->mpMyChildrenList) {
                 bool found = false;
@@ -323,6 +338,9 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
 std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
 {
     for (auto& rootAction : mActionRootNodeList) {
+        if( rootAction->mLocation == 4 ) {
+            continue; // skip over any root action node that IS going to be a TToolBar.
+        }
         if (rootAction->mPackageName.size() > 0) {
             for (auto childActionIterator = rootAction->mpMyChildrenList->begin(); childActionIterator != rootAction->mpMyChildrenList->end(); childActionIterator++) {
                 bool found = false;

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -446,11 +446,16 @@ void ActionUnit::constructToolbar(TAction* pA, TToolBar* pTB)
     pTB->setTitleBarWidget(0);
     pTB->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     if (pA->mLocation == 4) {
-        mudlet::self()->addDockWidget(Qt::LeftDockWidgetArea, pTB); //float toolbar
-        pTB->setFloating(true);
-        QPoint pos = QPoint(pA->mPosX, pA->mPosY);
-        pTB->show();
-        pTB->move(pos);
+        mudlet::self()->addDockWidget(pA->mToolbarLastDockArea, pTB);
+        if (pA->mToolbarLastFloatingState) {
+            pTB->setFloating(true);
+            QPoint pos = QPoint(pA->mPosX, pA->mPosY);
+            pTB->show();
+            pTB->move(pos);
+        } else {
+            pTB->setFloating(false);
+            pTB->show();
+        }
         pTB->mpTAction = pA;
         pTB->recordMove();
     } else

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -267,7 +267,7 @@ int ActionUnit::getNewID()
     return ++mMaxID;
 }
 
-std::list<TToolBar*> ActionUnit::getToolBarList()
+std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
 {
     for (auto& action : mActionRootNodeList) {
         if (action->mPackageName.size() > 0) {
@@ -320,7 +320,7 @@ std::list<TToolBar*> ActionUnit::getToolBarList()
     return mToolBarList;
 }
 
-std::list<TEasyButtonBar*> ActionUnit::getEasyButtonBarList()
+std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
 {
     for (auto& rootAction : mActionRootNodeList) {
         if (rootAction->mPackageName.size() > 0) {

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -118,6 +118,7 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
     }
     if (pOldParent) {
         pOldParent->popChild(pChild);
+        pOldParent->setDataChanged();
     }
     if (!pOldParent) {
         removeActionRootNode(pChild);
@@ -125,6 +126,7 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
 
     if (pNewParent) {
         pNewParent->Tree<TAction>::addChild(pChild, parentPosition, childPosition);
+        pNewParent->setDataChanged();
         if (pChild) {
             pChild->Tree<TAction>::setParent(pNewParent);
         }
@@ -135,6 +137,7 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
         addActionRootNode(pChild, parentPosition, childPosition);
     }
 
+    pChild->setDataChanged();
 
     if ((!pOldParent) && (pNewParent)) {
         if (pChild->mpEasyButtonBar) {

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -63,8 +63,8 @@ public:
     void uninstall(const QString&);
     void _uninstall(TAction* pChild, const QString& packageName);
     void updateToolbar();
-    std::list<TToolBar*> getToolBarList();
-    std::list<TEasyButtonBar*> getEasyButtonBarList();
+    std::list<QPointer<TToolBar>> getToolBarList();
+    std::list<QPointer<TEasyButtonBar>> getEasyButtonBarList();
     TAction* getHeadAction(TToolBar*);
     TAction* getHeadAction(TEasyButtonBar*);
     void constructToolbar(TAction*, TToolBar* pTB);
@@ -86,11 +86,11 @@ private:
     QMap<int, TAction*> mActionMap;
     std::list<TAction*> mActionRootNodeList;
     int mMaxID;
-    TToolBar* mpToolBar;
-    TEasyButtonBar* mpEasyButtonBar;
+    QPointer<TToolBar> mpToolBar;
+    QPointer<TEasyButtonBar> mpEasyButtonBar;
     bool mModuleMember;
-    std::list<TToolBar*> mToolBarList;
-    std::list<TEasyButtonBar*> mEasyButtonBarList;
+    std::list<QPointer<TToolBar>> mToolBarList;
+    std::list<QPointer<TEasyButtonBar>> mEasyButtonBarList;
 };
 
 #endif // MUDLET_ACTIONUNIT_H

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -60,6 +60,8 @@ TAction::TAction(TAction* parent, Host* pHost)
 , mSizeX()
 , mSizeY()
 , mDataChanged(true)
+, mToolbarLastDockArea(Qt::LeftDockWidgetArea)
+, mToolbarLastFloatingState(true)
 {
 }
 
@@ -89,6 +91,8 @@ TAction::TAction(const QString& name, Host* pHost)
 , mSizeX()
 , mSizeY()
 , mDataChanged(true)
+, mToolbarLastDockArea(Qt::LeftDockWidgetArea)
+, mToolbarLastFloatingState(true)
 {
 }
 

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -59,6 +59,7 @@ TAction::TAction(TAction* parent, Host* pHost)
 , mButtonFlat()
 , mSizeX()
 , mSizeY()
+, mDataChanged(true)
 {
 }
 
@@ -87,6 +88,7 @@ TAction::TAction(const QString& name, Host* pHost)
 , mButtonFlat()
 , mSizeX()
 , mSizeY()
+, mDataChanged(true)
 {
 }
 
@@ -136,6 +138,9 @@ void TAction::compile()
 
 bool TAction::setScript(const QString& script)
 {
+    if(script != mScript) {
+        setDataChanged();
+    }
     mScript = script;
     mNeedsToBeCompiled = true;
     mOK_code = compileScript();

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -130,12 +130,12 @@ public:
     QPointer<Host> mpHost;
     bool exportItem;
     bool mModuleMasterFolder;
-    bool mDataChanged;
 
 private:
     TAction() {}
     QString mFuncName;
     bool mModuleMember;
+    bool mDataChanged;
 };
 
 #endif // MUDLET_TACTION_H

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -88,8 +88,8 @@ public:
     void expandToolbar(TToolBar* pT);
     void insertActions(TEasyButtonBar* pT, QMenu* menu);
     void expandToolbar(TEasyButtonBar* pT);
-    TToolBar* mpToolBar;
-    TEasyButtonBar* mpEasyButtonBar;
+    QPointer<TToolBar> mpToolBar;
+    QPointer<TEasyButtonBar> mpEasyButtonBar;
     // The following was an int but there was confusion over:
     // EITHER: "1" = released/unclicked/up & "2" = pressed/clicked/down
     // OR:     "1" = pressed/clicked/down  & "0" = released/unclicked/up

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -130,6 +130,8 @@ public:
     QPointer<Host> mpHost;
     bool exportItem;
     bool mModuleMasterFolder;
+    Qt::DockWidgetArea mToolbarLastDockArea;
+    bool mToolbarLastFloatingState;
 
 private:
     TAction() {}

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -52,19 +52,19 @@ public:
     TAction(const QString& name, Host* pHost);
     void compileAll();
     QString getName() { return mName; }
-    void setName(const QString& name) { if(name != mName) { setDataChanged(); } mName = name; }
-    void setButtonColor(QColor c) { if(c != mButtonColor) { setDataChanged(); } mButtonColor = c; }
+    void setName(const QString& name) { if(name != mName) { setDataChanged(); mName = name; } }
+    void setButtonColor(QColor c) { if(c != mButtonColor) { setDataChanged(); mButtonColor = c; } }
     QColor getButtonColor() { return mButtonColor; }
-    void setButtonRotation(int r) { if(r != mButtonRotation) { setDataChanged(); } mButtonRotation = r; }
+    void setButtonRotation(int r) { if(r != mButtonRotation) { setDataChanged(); mButtonRotation = r; } }
     int getButtonRotation() { return mButtonRotation; }
-    void setButtonColumns(int c) { if(c != mButtonColumns) { setDataChanged(); } mButtonColumns = c; }
+    void setButtonColumns(int c) { if(c != mButtonColumns) { setDataChanged(); mButtonColumns = c; } }
     int getButtonColumns() { return mButtonColumns; }
     bool getButtonFlat() { return mButtonFlat; }
-    void setButtonFlat(bool flat) { if(flat != mButtonFlat) { setDataChanged(); } mButtonFlat = flat; }
+    void setButtonFlat(bool flat) { if(flat != mButtonFlat) { setDataChanged(); mButtonFlat = flat; } }
 
-    void setSizeX(int s) { if(s != mSizeX) { setDataChanged(); } mSizeX = s; }
+    void setSizeX(int s) { if(s != mSizeX) { setDataChanged(); mSizeX = s; } }
     int getSizeX() { return mSizeX; }
-    void setSizeY(int s) { if(s != mSizeY) { setDataChanged(); } mSizeY = s; }
+    void setSizeY(int s) { if(s != mSizeY) { setDataChanged(); mSizeY = s; } }
     int getSizeY() { return mSizeY; }
 
     void fillMenu(TEasyButtonBar* pT, QMenu* menu);
@@ -72,17 +72,17 @@ public:
     bool compileScript();
     void execute();
     QString getIcon() { return mIcon; }
-    void setIcon(const QString& icon) { if(icon != mIcon) { setDataChanged(); } mIcon = icon; }
+    void setIcon(const QString& icon) { if(icon != mIcon) { mIcon = icon; } }
     QString getScript() { return mScript; }
     bool setScript(const QString& script);
     QString getCommandButtonUp() { return mCommandButtonUp; }
-    void setCommandButtonUp(const QString& cmd) { if(cmd != mCommandButtonUp) { setDataChanged(); } mCommandButtonUp = cmd; }
-    void setCommandButtonDown(const QString& cmd) { if(cmd != mCommandButtonDown) { setDataChanged(); } mCommandButtonDown = cmd; }
+    void setCommandButtonUp(const QString& cmd) { if(cmd != mCommandButtonUp) { setDataChanged(); mCommandButtonUp = cmd; } }
+    void setCommandButtonDown(const QString& cmd) { if(cmd != mCommandButtonDown) { setDataChanged(); mCommandButtonDown = cmd; } }
     QString getCommandButtonDown() { return mCommandButtonDown; }
     bool isFolder() { return mIsFolder; }
     bool isPushDownButton() { return mIsPushDownButton; }
-    void setIsPushDownButton(bool b) { if(b != mIsPushDownButton) { setDataChanged(); } mIsPushDownButton = b; }
-    void setIsFolder(bool b) { if(b != mIsFolder) { setDataChanged(); } mIsFolder = b; }
+    void setIsPushDownButton(bool b) { if(b != mIsPushDownButton) { setDataChanged(); mIsPushDownButton = b; } }
+    void setIsFolder(bool b) { if(b != mIsFolder) { setDataChanged(); mIsFolder = b;} }
     bool registerAction();
     void insertActions(TToolBar* pT, QMenu* menu);
     void expandToolbar(TToolBar* pT);

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -52,19 +52,19 @@ public:
     TAction(const QString& name, Host* pHost);
     void compileAll();
     QString getName() { return mName; }
-    void setName(const QString& name) { mName = name; }
-    void setButtonColor(QColor c) { mButtonColor = c; }
+    void setName(const QString& name) { if(name != mName) { setDataChanged(); } mName = name; }
+    void setButtonColor(QColor c) { if(c != mButtonColor) { setDataChanged(); } mButtonColor = c; }
     QColor getButtonColor() { return mButtonColor; }
-    void setButtonRotation(int r) { mButtonRotation = r; }
+    void setButtonRotation(int r) { if(r != mButtonRotation) { setDataChanged(); } mButtonRotation = r; }
     int getButtonRotation() { return mButtonRotation; }
-    void setButtonColumns(int c) { mButtonColumns = c; }
+    void setButtonColumns(int c) { if(c != mButtonColumns) { setDataChanged(); } mButtonColumns = c; }
     int getButtonColumns() { return mButtonColumns; }
     bool getButtonFlat() { return mButtonFlat; }
-    void setButtonFlat(bool flat) { mButtonFlat = flat; }
+    void setButtonFlat(bool flat) { if(flat != mButtonFlat) { setDataChanged(); } mButtonFlat = flat; }
 
-    void setSizeX(int s) { mSizeX = s; }
+    void setSizeX(int s) { if(s != mSizeX) { setDataChanged(); } mSizeX = s; }
     int getSizeX() { return mSizeX; }
-    void setSizeY(int s) { mSizeY = s; }
+    void setSizeY(int s) { if(s != mSizeY) { setDataChanged(); } mSizeY = s; }
     int getSizeY() { return mSizeY; }
 
     void fillMenu(TEasyButtonBar* pT, QMenu* menu);
@@ -72,22 +72,26 @@ public:
     bool compileScript();
     void execute();
     QString getIcon() { return mIcon; }
-    void setIcon(const QString& icon) { mIcon = icon; }
+    void setIcon(const QString& icon) { if(icon != mIcon) { setDataChanged(); } mIcon = icon; }
     QString getScript() { return mScript; }
     bool setScript(const QString& script);
     QString getCommandButtonUp() { return mCommandButtonUp; }
-    void setCommandButtonUp(const QString& cmd) { mCommandButtonUp = cmd; }
-    void setCommandButtonDown(const QString& command) { mCommandButtonDown = command; }
+    void setCommandButtonUp(const QString& cmd) { if(cmd != mCommandButtonUp) { setDataChanged(); } mCommandButtonUp = cmd; }
+    void setCommandButtonDown(const QString& cmd) { if(cmd != mCommandButtonDown) { setDataChanged(); } mCommandButtonDown = cmd; }
     QString getCommandButtonDown() { return mCommandButtonDown; }
     bool isFolder() { return mIsFolder; }
     bool isPushDownButton() { return mIsPushDownButton; }
-    void setIsPushDownButton(bool b) { mIsPushDownButton = b; }
-    void setIsFolder(bool b) { mIsFolder = b; }
+    void setIsPushDownButton(bool b) { if(b != mIsPushDownButton) { setDataChanged(); } mIsPushDownButton = b; }
+    void setIsFolder(bool b) { if(b != mIsFolder) { setDataChanged(); } mIsFolder = b; }
     bool registerAction();
     void insertActions(TToolBar* pT, QMenu* menu);
     void expandToolbar(TToolBar* pT);
     void insertActions(TEasyButtonBar* pT, QMenu* menu);
     void expandToolbar(TEasyButtonBar* pT);
+    void setDataSaved() { if(mpParent) { mpParent->setDataSaved(); } mDataChanged = false; }
+    void setDataChanged() { if(mpParent) { mpParent->setDataChanged(); } mDataChanged = true; }
+    bool isDataChanged() { return mDataChanged; }
+
     QPointer<TToolBar> mpToolBar;
     QPointer<TEasyButtonBar> mpEasyButtonBar;
     // The following was an int but there was confusion over:
@@ -126,6 +130,7 @@ public:
     QPointer<Host> mpHost;
     bool exportItem;
     bool mModuleMasterFolder;
+    bool mDataChanged;
 
 private:
     TAction() {}

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -48,6 +48,9 @@ TToolBar::TToolBar( TAction * pA, const QString& name, QWidget * pW )
     setWidget(mpWidget);
     setObjectName(QString("dockToolBar_%1").arg(name));
 
+    connect(this, SIGNAL(dockLocationChanged(Qt::DockWidgetArea)), this, SLOT(slot_dockLocationChanged(Qt::DockWidgetArea)));
+    connect(this, SIGNAL(topLevelChanged(bool)), this, SLOT(slot_topLevelChanged(bool)));
+
     if (!mpTAction->mUseCustomLayout) {
         mpLayout = new QGridLayout(mpWidget);
         setContentsMargins(0, 0, 0, 0);
@@ -82,6 +85,18 @@ void TToolBar::moveEvent(QMoveEvent* e)
         mpTAction->mPosY = e->pos().y();
     }
     e->ignore();
+}
+
+void TToolBar::slot_dockLocationChanged(Qt::DockWidgetArea dwArea) {
+    if (mpTAction) {
+        mpTAction->mToolbarLastDockArea = dwArea;
+    }
+}
+
+void TToolBar::slot_topLevelChanged(bool topLevel) {
+    if (mpTAction) {
+        mpTAction->mToolbarLastFloatingState = topLevel;
+    }
 }
 
 void TToolBar::addButton(TFlipButton* pB)

--- a/src/TToolBar.h
+++ b/src/TToolBar.h
@@ -61,6 +61,8 @@ private:
 
 public slots:
     void slot_pressed(const bool);
+    void slot_topLevelChanged(bool);
+    void slot_dockLocationChanged(Qt::DockWidgetArea);
 };
 
 #endif // MUDLET_TTOOLBAR_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3528,34 +3528,34 @@ void dlgTriggerEditor::saveAction()
     // reduce the noise in a git commit/diff caused by the removal of a
     // redundent "if( pITem )" - can be removed next time the file is modified
         int actionID = pItem->data(0, Qt::UserRole).toInt();
-        TAction * pT = mpHost->getActionUnit()->getAction( actionID );
-        if( pT )
+        TAction * pA = mpHost->getActionUnit()->getAction( actionID );
+        if( pA )
         {
             // Do not change anything for a module master folder - it won't "take"
-            if( pT->mPackageName.isEmpty() )
+            if( pA->mPackageName.isEmpty() )
             {
-                pT->setName( name );
-                pT->setIcon( icon );
-                pT->setScript( script );
-                pT->setCommandButtonDown( commandDown );
-                pT->setCommandButtonUp( commandUp );
-                pT->setIsPushDownButton( isChecked );
-                pT->mLocation = location;
-                pT->mOrientation = orientation;
-                pT->setIsActive( pT->shouldBeActive() );
-                pT->setButtonRotation( rotation );
-                pT->setButtonColumns( columns );
-                pT->mUseCustomLayout = false;
-                pT->css = mpActionsMainArea->css->toPlainText();
+                pA->setName( name );
+                pA->setIcon( icon );
+                pA->setScript( script );
+                pA->setCommandButtonDown( commandDown );
+                pA->setCommandButtonUp( commandUp );
+                pA->setIsPushDownButton( isChecked );
+                pA->mLocation = location;
+                pA->mOrientation = orientation;
+                pA->setIsActive( pA->shouldBeActive() );
+                pA->setButtonRotation( rotation );
+                pA->setButtonColumns( columns );
+                pA->mUseCustomLayout = false;
+                pA->css = mpActionsMainArea->css->toPlainText();
             }
 
             QIcon icon;
-            if( pT->isFolder() )
+            if( pA->isFolder() )
             {
-                if( ! pT->mPackageName.isEmpty() )
+                if( ! pA->mPackageName.isEmpty() )
                 {
                     // Has a package name so is a module master folder
-                    if( pT->isActive() )
+                    if( pA->isActive() )
                     {
                         icon.addPixmap( QPixmap( QStringLiteral( ":/icons/folder-brown.png" ) ), QIcon::Normal, QIcon::Off );
                     }
@@ -3564,11 +3564,11 @@ void dlgTriggerEditor::saveAction()
                         icon.addPixmap( QPixmap( QStringLiteral( ":/icons/folder-brown-locked.png" ) ), QIcon::Normal, QIcon::Off );
                     }
                 }
-                else if( ! pT->getParent()
-                      || ! pT->getParent()->mPackageName.isEmpty() )
+                else if( ! pA->getParent()
+                      || ! pA->getParent()->mPackageName.isEmpty() )
                 {
                     // No parent or it has a parent with a package name so is a toolbar
-                    if( pT->isActive() )
+                    if( pA->isActive() )
                     {
                         icon.addPixmap( QPixmap( QStringLiteral( ":/icons/folder-yellow.png" ) ), QIcon::Normal, QIcon::Off );
                     }
@@ -3580,7 +3580,7 @@ void dlgTriggerEditor::saveAction()
                 else
                 {
                     // Else must be a menu
-                    if( pT->isActive() )
+                    if( pA->isActive() )
                     {
                         icon.addPixmap( QPixmap( QStringLiteral( ":/icons/folder-cyan.png" ) ), QIcon::Normal, QIcon::Off );
                     }
@@ -3593,7 +3593,7 @@ void dlgTriggerEditor::saveAction()
             else
             {
                 // Is a button
-                if( pT->isActive() )
+                if( pA->isActive() )
                 {
                     icon.addPixmap( QPixmap( QStringLiteral( ":/icons/tag_checkbox_checked.png" ) ), QIcon::Normal, QIcon::Off );
                 }
@@ -3603,7 +3603,7 @@ void dlgTriggerEditor::saveAction()
                 }
             }
 
-            if( pT->state() )
+            if( pA->state() )
             {
                 pItem->setIcon( 0, icon);
                 pItem->setText( 0, name );
@@ -3618,13 +3618,13 @@ void dlgTriggerEditor::saveAction()
             }
 
             // If not active, don't bother raising the TToolBar for this save.
-            if( !pT->shouldBeActive() ) {
-                pT->setDataSaved();
+            if( !pA->shouldBeActive() ) {
+                pA->setDataSaved();
             }
 
             // if the action has a toolbar with a script error, hide the toolbar.
-            if( pT->mpToolBar && !pT->state() ) {
-                pT->mpToolBar->hide();
+            if( pA->mpToolBar && !pA->state() ) {
+                pA->mpToolBar->hide();
             }
         }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -32,6 +32,7 @@
 #include "TConsole.h"
 #include "THighlighter.h"
 #include "TTextEdit.h"
+#include "TToolBar.h"
 #include "TTreeWidget.h"
 #include "TTrigger.h"
 #include "TriggerUnit.h"
@@ -2236,6 +2237,14 @@ void dlgTriggerEditor::slot_action_toggle_active()
 
     pT->setIsActive( ! pT->shouldBeActive() );
     pT->setDataChanged();
+
+    if( pT->mpToolBar ) {
+        if( !pT->isActive() ) {
+            pT->mpToolBar->hide();
+        } else {
+            pT->mpToolBar->show();
+        }
+    }
 
     if( pT->isFolder() )
     {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3534,6 +3534,14 @@ void dlgTriggerEditor::saveAction()
             // Do not change anything for a module master folder - it won't "take"
             if( pA->mPackageName.isEmpty() )
             {
+                // Check if data has been changed before it gets updated.
+                if( pA->mLocation != location ||
+                    pA->mOrientation != orientation ||
+                    pA->css != mpActionsMainArea->css->toPlainText() )
+                {
+                    pA->setDataChanged();
+                }
+
                 pA->setName( name );
                 pA->setIcon( icon );
                 pA->setScript( script );

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1619,10 +1619,12 @@ void dlgTriggerEditor::slot_deleteAction()
     TAction * pT = mpHost->getActionUnit()->getAction(pItem->data(0, Qt::UserRole).toInt());
     if( ! pT ) return;
 
+    // if active, deactivate.
+    if( pT->isActive() ) {
+        pT->deactivate();
+    }
+
     // set this and the parent TActions as changed so the toolbar is updated.
-    int parentID = pParent->data(0, Qt::UserRole).toInt();
-    TAction * pParentAction = mpHost->getActionUnit()->getAction( parentID );
-    pParentAction->setDataChanged();
     pT->setDataChanged();
 
     if( pParent )
@@ -3604,6 +3606,11 @@ void dlgTriggerEditor::saveAction()
                 iconError.addPixmap( QPixmap( QStringLiteral( ":/icons/tools-report-bug.png" ) ), QIcon::Normal, QIcon::Off );
                 pItem->setIcon( 0, iconError );
                 pItem->setText( 0, name );
+            }
+
+            // If not active, don't bother raising the TToolBar for this save.
+            if( !pT->isActive() ) {
+                pT->setDataSaved();
             }
         }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -2931,14 +2931,14 @@ void dlgTriggerEditor::addAction( bool isFolder )
     {
         int parentID = pParent->data(0, Qt::UserRole).toInt();
 
-        TAction * pParentTrigger = mpHost->getActionUnit()->getAction( parentID );
-        if( pParentTrigger )
+        TAction * pParentAction = mpHost->getActionUnit()->getAction( parentID );
+        if( pParentAction )
         {
             // insert new items as siblings unless the parent is a folder
-            if( ! pParentTrigger->isFolder() )
+            if( ! pParentAction->isFolder() )
             {
                 // handle root items
-                if( ! pParentTrigger->getParent() )
+                if( ! pParentAction->getParent() )
                 {
                     goto ROOT_ACTION;
                 }
@@ -2947,7 +2947,7 @@ void dlgTriggerEditor::addAction( bool isFolder )
                     // insert new item as sibling of the clicked item
                     if( pParent->parent() )
                     {
-                        pT = new TAction( pParentTrigger->getParent(), mpHost );
+                        pT = new TAction( pParentAction->getParent(), mpHost );
                         pNewItem = new QTreeWidgetItem( pParent->parent(), nameL );
                         pParent->parent()->insertChild( 0, pNewItem );
                     }
@@ -2955,7 +2955,7 @@ void dlgTriggerEditor::addAction( bool isFolder )
             }
             else
             {
-                pT = new TAction( pParentTrigger, mpHost );
+                pT = new TAction( pParentAction, mpHost );
                 pNewItem = new QTreeWidgetItem( pParent, nameL );
                 pParent->insertChild( 0, pNewItem );
             }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3527,8 +3527,8 @@ void dlgTriggerEditor::saveAction()
     // This is an unnecessary level of indentation but has been retained to
     // reduce the noise in a git commit/diff caused by the removal of a
     // redundent "if( pITem )" - can be removed next time the file is modified
-        int triggerID = pItem->data(0, Qt::UserRole).toInt();
-        TAction * pT = mpHost->getActionUnit()->getAction( triggerID );
+        int actionID = pItem->data(0, Qt::UserRole).toInt();
+        TAction * pT = mpHost->getActionUnit()->getAction( actionID );
         if( pT )
         {
             // Do not change anything for a module master folder - it won't "take"
@@ -3618,8 +3618,13 @@ void dlgTriggerEditor::saveAction()
             }
 
             // If not active, don't bother raising the TToolBar for this save.
-            if( !pT->isActive() ) {
+            if( !pT->shouldBeActive() ) {
                 pT->setDataSaved();
+            }
+
+            // if the action has a toolbar with a script error, hide the toolbar.
+            if( pT->mpToolBar && !pT->state() ) {
+                pT->mpToolBar->hide();
             }
         }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1619,6 +1619,12 @@ void dlgTriggerEditor::slot_deleteAction()
     TAction * pT = mpHost->getActionUnit()->getAction(pItem->data(0, Qt::UserRole).toInt());
     if( ! pT ) return;
 
+    // set this and the parent TActions as changed so the toolbar is updated.
+    int parentID = pParent->data(0, Qt::UserRole).toInt();
+    TAction * pParentAction = mpHost->getActionUnit()->getAction( parentID );
+    pParentAction->setDataChanged();
+    pT->setDataChanged();
+
     if( pParent )
     {
         pParent->removeChild( pItem );
@@ -2227,6 +2233,7 @@ void dlgTriggerEditor::slot_action_toggle_active()
     if( ! pT ) return;
 
     pT->setIsActive( ! pT->shouldBeActive() );
+    pT->setDataChanged();
 
     if( pT->isFolder() )
     {
@@ -2998,6 +3005,10 @@ void dlgTriggerEditor::addAction( bool isFolder )
     mpActionsMainArea->lineEdit_action_icon->clear();
     mpActionsMainArea->checkBox_pushdownbutton->setChecked(false);
     mpSourceEditor->clear();
+
+    // This prevents reloading a Floating toolbar when an empty action is added.
+    // After the action is saved it may trigger the rebuild.
+    pT->setDataSaved();
 
     mpHost->getActionUnit()->updateToolbar();
     mpCurrentActionItem = pNewItem;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -743,7 +743,7 @@ void mudlet::slot_close_profile_requested( int tab )
     Host* pH = getHostManager().getHost(name);
     if( ! pH ) return;
 
-    list<TToolBar*> hostToolBarMap = pH->getActionUnit()->getToolBarList();
+    list<QPointer<TToolBar>> hostToolBarMap = pH->getActionUnit()->getToolBarList();
     QMap<QString, TDockWidget *> & dockWindowMap = mHostDockConsoleMap[pH];
     QMap<QString, TConsole*> & hostConsoleMap = mHostConsoleMap[pH];
 
@@ -801,7 +801,7 @@ void mudlet::slot_close_profile()
             Host * pH = mpCurrentActiveHost;
             if( pH )
             {
-                list<TToolBar*> hostTToolBarMap = pH->getActionUnit()->getToolBarList();
+                list<QPointer<TToolBar>> hostTToolBarMap = pH->getActionUnit()->getToolBarList();
                 QMap<QString, TDockWidget *> & dockWindowMap = mHostDockConsoleMap[pH];
                 QMap<QString, TConsole*> & hostConsoleMap = mHostConsoleMap[pH];
                 QString name = pH->getName();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -769,8 +769,10 @@ void mudlet::slot_close_profile_requested( int tab )
     mHostConsoleMap.remove(pH);
 
     for( TToolBar* pTB : hostToolBarMap ) {
-        pTB->setAttribute( Qt::WA_DeleteOnClose );
-        pTB->close();
+        if (pTB) {
+            pTB->setAttribute( Qt::WA_DeleteOnClose );
+            pTB->deleteLater();
+        }
     }
 
     mConsoleMap[pH]->close();
@@ -823,8 +825,10 @@ void mudlet::slot_close_profile()
                 mHostConsoleMap.remove(pH);
 
                 for( TToolBar* pTB : hostTToolBarMap ) {
-                    pTB->setAttribute( Qt::WA_DeleteOnClose );
-                    pTB->close();
+                    if (pTB) {
+                        pTB->setAttribute( Qt::WA_DeleteOnClose );
+                        pTB->deleteLater();
+                    }
                 }
 
                 mConsoleMap[ pH ]->close();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -743,6 +743,7 @@ void mudlet::slot_close_profile_requested( int tab )
     Host* pH = getHostManager().getHost(name);
     if( ! pH ) return;
 
+    list<TToolBar*> hostToolBarMap = pH->getActionUnit()->getToolBarList();
     QMap<QString, TDockWidget *> & dockWindowMap = mHostDockConsoleMap[pH];
     QMap<QString, TConsole*> & hostConsoleMap = mHostConsoleMap[pH];
 
@@ -766,6 +767,11 @@ void mudlet::slot_close_profile_requested( int tab )
     }
     mHostDockConsoleMap.remove(pH);
     mHostConsoleMap.remove(pH);
+
+    for( TToolBar* pTB : hostToolBarMap ) {
+        pTB->setAttribute( Qt::WA_DeleteOnClose );
+        pTB->close();
+    }
 
     mConsoleMap[pH]->close();
     if( mTabMap.contains( pH->getName() ) )
@@ -795,6 +801,7 @@ void mudlet::slot_close_profile()
             Host * pH = mpCurrentActiveHost;
             if( pH )
             {
+                list<TToolBar*> hostTToolBarMap = pH->getActionUnit()->getToolBarList();
                 QMap<QString, TDockWidget *> & dockWindowMap = mHostDockConsoleMap[pH];
                 QMap<QString, TConsole*> & hostConsoleMap = mHostConsoleMap[pH];
                 QString name = pH->getName();
@@ -814,6 +821,11 @@ void mudlet::slot_close_profile()
                 }
                 mHostDockConsoleMap.remove(pH);
                 mHostConsoleMap.remove(pH);
+
+                for( TToolBar* pTB : hostTToolBarMap ) {
+                    pTB->setAttribute( Qt::WA_DeleteOnClose );
+                    pTB->close();
+                }
 
                 mConsoleMap[ pH ]->close();
                 if( mTabMap.contains( name ) )


### PR DESCRIPTION
This PR focuses on making Floating Toolbars more usable and addressing bugs with the `TToolBar` object and its related parts.   In short this PR has made the following changes:  

1.  Fixes bug where Floating Toolbars were not closed with their Host Profile.
2.  Changes how Floating Toolbars are constructed, to avoid pulling the Editor Dialog away from the user abruptly.
3.  When Floating Toolbars are docked they get rebuilt in the same place you left them last, unless you delete them or restart the host profile.

Before this set of changes Floating Toolbars would create frustrating usability conditions.  
While a Floating Toolbar is active, clicking any of the Toolbars, Menus, or Buttons (`TAction`) items in the Editor Dialog window would result in the main window being raised and shown.  Thus any save, activation, or navigation event that resulted in a save of the items in the editor would result in the Editor Dialog effectively being pulled away from the user in the middle of them using it.
The larger portion of this PR focuses on that usability issue and makes changes to enforce building the Floating Toolbars only when the user has changed them in some way.
