### PR TITLE
Added clearExitStub

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1875,6 +1875,41 @@ int TLuaInterpreter::setExitStub( lua_State * L  ){
     return 0;
 }
 
+int TLuaInterpreter::clearExitStub(lua_State* L)
+{
+    int roomId, dirType;
+    if (!lua_isnumber(L, 1)) {
+        lua_pushfstring(L, "clearExitStub: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
+        lua_error(L);
+        return 1;
+    } else {
+        roomId = lua_tonumber(L, 1);
+    }
+    dirType = dirToNumber(L, 2);
+    if (!dirType) {
+        lua_pushfstring(L, "clearExitStub: bad argument #2 type (direction as string or number expected, got %s!)", luaL_typename(L, 2));
+        lua_error(L);
+        return 1;
+    }
+
+    Host* pHost = TLuaInterpreter::luaInterpreterMap[L];
+    if (!pHost->mpMap)
+        return 0;
+    TRoom* pR = pHost->mpMap->mpRoomDB->getRoom(roomId);
+    if (!pR) {
+        lua_pushfstring(L, "clearExitStub: room %s doesn't exist", roomId);
+        lua_error(L);
+        return 1;
+    }
+    if (dirType > 12 || dirType < 1) {
+        lua_pushstring(L, "clearExitStub: direction as a number must be between 1 and 12");
+        lua_error(L);
+        return 1;
+    }
+    pR->setExitStub(dirType, false);
+    return 0;
+}
+
 int TLuaInterpreter::connectExitStub( lua_State * L  ){
     //takes exit stubs from the selected room, finds the room in that direction and if
     //that room has a stub, a two way exit is formed
@@ -13212,6 +13247,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register( pGlobalLua, "lockSpecialExit", TLuaInterpreter::lockSpecialExit );
     lua_register( pGlobalLua, "hasSpecialExitLock", TLuaInterpreter::hasSpecialExitLock );
     lua_register( pGlobalLua, "setExitStub", TLuaInterpreter::setExitStub );
+    lua_register( pGlobalLua, "clearExitStub", TLuaInterpreter::clearExitStub );
     lua_register( pGlobalLua, "connectExitStub", TLuaInterpreter::connectExitStub );
     lua_register( pGlobalLua, "getExitStubs", TLuaInterpreter::getExitStubs );
     lua_register( pGlobalLua, "getExitStubs1", TLuaInterpreter::getExitStubs1 );

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -358,6 +358,7 @@ public:
     static int saveMap(lua_State* L);
     static int loadMap(lua_State* L);
     static int setExitStub(lua_State* L);
+    static int clearExitStub(lua_State* L);
     static int connectExitStub(lua_State* L);
     static int getExitStubs(lua_State* L);
     static int getExitStubs1(lua_State* L);


### PR DESCRIPTION
Fixing the issue that caused https://github.com/Mudlet/Mudlet/issues/1027 to be filed.

I think it would be nice to have clear* functions for mapper things - it would make it intuitive that when you see a set* function, you can expect to see a corresponding clear*.

Tagging @Mudlet/lua-interface for review.