### PR TITLE
BugFix: create missing area when there is only one missing

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2065,7 +2065,8 @@ void TMap::pushErrorMessagesToFile( const QString title, const bool isACleanup )
     mapAuditRoomErrors.clear();
     if( mIsFileViewingRecommended && (! mudlet::self()->getAuditErrorsToConsoleEnabled() ) ) {
         postMessage( tr( "[ ALERT ] - At least one thing was detected during that last map operation\n"
-                         "that it is recommended that you review the most recent report in the file:\n"
+                         "that it is recommended that you review the most recent report in\n"
+                         "the file:\n"
                          "\"%1\"\n"
                          "- look for the (last) report with the title:\n"
                          "\"%2\"." )
@@ -2074,7 +2075,8 @@ void TMap::pushErrorMessagesToFile( const QString title, const bool isACleanup )
     }
     else if( mIsFileViewingRecommended && mudlet::self()->getAuditErrorsToConsoleEnabled() ) {
         postMessage( tr( "[ INFO ]  - The equivalent to the above information about that last map\n"
-                         "operation has been saved for review as the most recent report in the file:\n"
+                         "operation has been saved for review as the most recent report in\n"
+                         "the file:\n"
                          "\"%1\"\n"
                          "- look for the (last) report with the title:\n"
                          "\"%2\"." )

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -690,8 +690,8 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     if (!missingAreasNeeded.isEmpty()) {
         if (mudlet::self()->getAuditErrorsToConsoleEnabled()) {
             QString alertMsg = tr( "[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.\n"
-                                   " Look for further messsages related to the rooms that are supposed to\n"
-                                   " be in this/these area(s)...",
+                                   " Look for further messsages related to the rooms that are supposed\n"
+                                   " to be in this/these area(s)...",
                                    "Making use of %n to allow quantity dependent message form 8-) !",
                                    missingAreasNeeded.count() );
             mpMap->postMessage(alertMsg);
@@ -715,22 +715,20 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Sort the ids so that the reporting is ordered, which could be
             // helpful if there is a large number of faults
             std::sort(missingAreasNeeded.begin(), missingAreasNeeded.end());
-            for (int newAreaId : missingAreasNeeded) {
-
-                // This will create a new "Default" area name if there is not one
-                // already for this id - and we do not anticipate that it could ever
-                // fail and return false...
-                addArea(newAreaId);
-                infoMsg.append(QStringLiteral("\n%1 ==> \"%2\"")
-                               .arg(newAreaId)
-                               .arg(areaNamesMap.value(newAreaId)));
-            }
-
-            // Didn't really needed to be done, but as we have finished with it
-            // now, clearing it may make tracking the overall processes going on
-            // in the debugger a little clearer...
-            missingAreasNeeded.clear();
         }
+
+        for (int newAreaId : missingAreasNeeded) {
+            // This will create a new "Default" area name if there is not one
+            // already for this id - and we do not anticipate that it could ever
+            // fail and return false...
+            addArea(newAreaId);
+            infoMsg.append(QStringLiteral("\n%1 ==> \"%2\"").arg(QString::number(newAreaId), areaNamesMap.value(newAreaId)));
+        }
+
+        // Didn't really needed to be done, but as we have finished with it
+        // now, clearing it may make tracking the overall processes going on
+        // in the debugger a little clearer...
+        missingAreasNeeded.clear();
 
         if (mudlet::self()->getAuditErrorsToConsoleEnabled()) {
             mpMap->postMessage(infoMsg);


### PR DESCRIPTION
A code structure error in a prior fix meant that instead of sorting the missing areas if there was more than one such area BEFORE creating them ALL, the corner case of a single missing area was not being created as required.

Also move two chained `QString::arg()` usages into a single instance as per new coding guidelines - as the first is a number it is necessary to force it to a `QString` to avoid a compile failure (in later Qt versions ?) that have a twin argument overload that expects a first number argument to be followed by a second numeric value being a width specifier.

Also re-layout a few related console messages to avoid hitting a default re-wrapping width at 80 characters.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>