### PR TITLE
Added mudletOlderThan()

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -646,7 +646,7 @@ function mudletOlderThan(inputmajor, inputminor, inputpatch)
 
   assert(type(inputmajor) == "number", sformat("bad argument #1 type (major version as number expected, got %s!)", type(inputmajor)))
   assert(inputminor == nil or type(inputminor) == "number", sformat("bad argument #2 type (optional minor version as number expected, got %s!)", type(inputminor)))
-  assert(inputpatch == nil or type(inputpatch) == "number", sformat("bad argument #2 type (optional patch version as number expected, got %s!)", type(inputpatch)))
+  assert(inputpatch == nil or type(inputpatch) == "number", sformat("bad argument #3 type (optional patch version as number expected, got %s!)", type(inputpatch)))
 
 
   if mudletmajor < inputmajor then return true end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -636,3 +636,29 @@ function shms(seconds, bool)
 		return hh, mm, ss
 	end
 end
+
+-- returns true if your Mudlet is older than the given version
+-- for example, it'll return true if you're on 2.1 and you do mudletOlderThan("3.1")
+-- it'll return false if you're on 4.0 and you do mudletOlderThan("4.0.0")
+-- credit to https://stackoverflow.com/a/16187766/72944 for the algorithm
+function mudletOlderThan(version)
+  local tonumber = tonumber
+	
+	-- strip trailing zeros from input version
+  local input = rex.gsub(version, [[(\.0+)+$]], ''):split('%.')
+	local mudlets = {getMudletVersion("table")}
+	
+	-- strip any build suffixes from Mudlets version so we only
+	-- have to deal with numbers in the comparison
+	if tonumber(mudlets[#mudlets]) == nil then mudlets[#mudlets] = nil end
+	
+	local minlength = math.min(#input, #mudlets)
+
+    local diff
+	for i = 1, minlength do
+	  diff = tonumber(input[i]) - mudlets[i]
+		if diff ~= 0 then break end
+	end
+	
+	if diff > 0 then return true else return false end
+end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -638,27 +638,20 @@ function shms(seconds, bool)
 end
 
 -- returns true if your Mudlet is older than the given version
--- for example, it'll return true if you're on 2.1 and you do mudletOlderThan("3.1")
--- it'll return false if you're on 4.0 and you do mudletOlderThan("4.0.0")
--- credit to https://stackoverflow.com/a/16187766/72944 for the algorithm
-function mudletOlderThan(version)
-  local tonumber = tonumber
-	
-	-- strip trailing zeros from input version
-  local input = rex.gsub(version, [[(\.0+)+$]], ''):split('%.')
-	local mudlets = {getMudletVersion("table")}
-	
-	-- strip any build suffixes from Mudlets version so we only
-	-- have to deal with numbers in the comparison
-	if tonumber(mudlets[#mudlets]) == nil then mudlets[#mudlets] = nil end
-	
-	local minlength = math.min(#input, #mudlets)
+-- for example, it'll return true if you're on 2.1 and you do mudletOlderThan(3,1)
+-- it'll return false if you're on 4.0 and you do mudletOlderThan(4,0,0)
+function mudletOlderThan(inputmajor, inputminor, inputpatch)
+  local mudletmajor, mudletminor, mudletpatch = getMudletVersion("table")
+  local type, sformat = type, string.format
 
-    local diff
-	for i = 1, minlength do
-	  diff = tonumber(input[i]) - mudlets[i]
-		if diff ~= 0 then break end
-	end
-	
-	if diff > 0 then return true else return false end
+  assert(type(inputmajor) == "number", sformat("bad argument #1 type (major version as number expected, got %s!)", type(inputmajor)))
+  assert(inputminor == nil or type(inputminor) == "number", sformat("bad argument #2 type (optional minor version as number expected, got %s!)", type(inputminor)))
+  assert(inputpatch == nil or type(inputpatch) == "number", sformat("bad argument #2 type (optional patch version as number expected, got %s!)", type(inputpatch)))
+
+
+  if mudletmajor < inputmajor then return true end
+  if inputminor and (mudletminor < inputminor) then return true end
+  if inputpatch and (mudletpatch < inputpatch) then return true end
+
+  return false
 end

--- a/src/mudlet-lua/tests/Other.lua
+++ b/src/mudlet-lua/tests/Other.lua
@@ -70,4 +70,37 @@ describe("Tests Other.lua functions", function()
       assert.spy(tempTimer).was.called(6)
     end)
   end)
+
+  describe("Tests mudletOlderThan()", function()
+    setup(function()
+      -- fake getMudletversion here
+      --[[
+      local function getMudletVersion()
+        return 2,0,1,"-dev"
+      end
+      ]]
+    end)
+
+    it("tests the comparisons", function()
+      -- should be true
+      display(mudletOlderThan("2.5.10.4159"))
+      -- should be true
+      display(mudletOlderThan("3.5.10.4159"))
+      -- should be false
+      display(mudletOlderThan("1.0.0"))
+      --[[mudletOlderThan("0.5")
+      mudletOlderThan("0.4.1")
+      mudletOlderThan("1")
+      mudletOlderThan("1.1")
+      mudletOlderThan("0.0.0")
+      mudletOlderThan("2.5.0")
+      mudletOlderThan("2")
+      mudletOlderThan("0.0")
+      mudletOlderThan("2.5.10")
+      mudletOlderThan("10.5")
+      mudletOlderThan("1.25.4")
+      mudletOlderThan("1.2.15")]]
+
+    end)
+  end)
 end)


### PR DESCRIPTION
We all know [the pain](https://github.com/Mudlet/Mudlet/blob/development/src/src.pro#L21) of not having a proper function to do version comparison, so we shouldn't inflict it on Mudlet users.

Makes it easy to write `if mudletOlderThan("3.2") then return end` in case some features cannot be checked in the preferred way of `if desiredMudletFunction then` such as coroutine support - coroutines were always present and would instantly crash the application if you tried to use them. There's no way to check for that sans checking the major+minor version.

I've also dumped some tests but as busted doesn't work, they're incomplete. Somehow busted's [tests are passing](https://travis-ci.org/Olivine-Labs/busted) so we'll have to see how do they make it work.

Tagging @Mudlet/lua-interface for review.