### PR TITLE
Add mudlet supports coroutines

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -2,6 +2,10 @@
 --- Mudlet Unsorted Stuff
 ----------------------------------------------------------------------------------
 
+mudlet = mudlet or {}
+mudlet.supports = {
+  coroutines = true
+}
 
 -- Extending default libraries makes Babelfish happy.
 setmetatable( _G, {


### PR DESCRIPTION
If you want to check if Mudlet has a certain function, you can do something like `if echo then`. If you want to check if Mudlet has a certain feature, you can't. I started on #1064 as a misguided attempt to solve this, but making people sprinkle random version numbers in their code is a terrible idea, starting with poor readability.

Instead, we could have a `mudlet.supports*` values where we could put such Lua-unarticulatable feature flags in - so in case of coroutines for example, you could do `if mudlet.supportscoroutines then`. Nice and readable! 

As coroutines are a new feature in 3.2 and using them in 3.1 or below completely crashes the application, I'd like to have this toggle in so people can start writing code the right way from the start.

(it would be nice if it could be `mudlet.supports.coroutines`, but `mudlet.supports` doesn't exist as a table yet so older Mudlets will error. Bummer)