### PR TITLE
BugFix: multiple issues with TKey creation from lua script commands

### DIFF
--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -60,12 +60,14 @@ void KeyUnit::uninstall(const QString& packageName)
 
 bool KeyUnit::processDataStream(int key, int modifier)
 {
+    bool isAtLeastOneMatch = false;
     for (auto keyObject : mKeyRootNodeList) {
-        if (keyObject->match(key, modifier))
-            return true;
+        if (keyObject->match(key, modifier)) {
+            isAtLeastOneMatch = true;
+        }
     }
 
-    return false;
+    return isAtLeastOneMatch;
 }
 
 void KeyUnit::compileAll()

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -60,14 +60,13 @@ void KeyUnit::uninstall(const QString& packageName)
 
 bool KeyUnit::processDataStream(int key, int modifier)
 {
-    bool isAtLeastOneMatch = false;
     for (auto keyObject : mKeyRootNodeList) {
         if (keyObject->match(key, modifier)) {
-            isAtLeastOneMatch = true;
+            return true;
         }
     }
 
-    return isAtLeastOneMatch;
+    return false;
 }
 
 void KeyUnit::compileAll()

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6974,7 +6974,7 @@ int TLuaInterpreter::permSubstringTrigger( lua_State * L )
 
 int TLuaInterpreter::permKey( lua_State *L )
 {
-    quint8 argIndex = 0;
+    uint_fast8_t argIndex = 0;
     QString keyName;
     if (!lua_isstring(L, ++argIndex)) {
         lua_pushfstring(L, "permKey: bad argument #1 type (key name as string expected, got %s!)", luaL_typename(L, argIndex));
@@ -7027,7 +7027,7 @@ int TLuaInterpreter::permKey( lua_State *L )
 
 int TLuaInterpreter::tempKey( lua_State *L )
 {
-    quint8 argIndex = 0;
+    uint_fast8_t argIndex = 0;
     int keyModifier = Qt::NoModifier;
     if (lua_gettop(L) > 2) {
         if (!lua_isnumber(L, ++argIndex)) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6974,138 +6974,90 @@ int TLuaInterpreter::permSubstringTrigger( lua_State * L )
 
 int TLuaInterpreter::permKey( lua_State *L )
 {
-    int n = lua_gettop( L );
-    int i = 3;
-
+    quint8 argIndex = 0;
     QString keyName;
-    if( ! lua_isstring( L, 1 ) )
-    {
-        lua_pushfstring(L, "permKey: bad argument #1 type (key name as string expected, got %s!)",
-                        luaL_typename(L, 1));
+    if (!lua_isstring(L, ++argIndex)) {
+        lua_pushfstring(L, "permKey: bad argument #1 type (key name as string expected, got %s!)", luaL_typename(L, argIndex));
         return lua_error(L);
-    }
-    else
-    {
-        keyName = QString::fromUtf8(lua_tostring(L, 1));
+    } else {
+        keyName = QString::fromUtf8(lua_tostring(L, argIndex));
     }
 
-    QString parentGroup = "";
-    if( ! lua_isstring( L, 2 ) )
-    {
-        lua_pushfstring(L, "permKey: bad argument #2 type (key parent group as string expected, got %s!)",
-                        luaL_typename(L, 1));
+    QString parentGroup;
+    if (!lua_isstring(L, ++argIndex)) {
+        lua_pushfstring(L, "permKey: bad argument #2 type (key parent group as string expected, got %s!)", luaL_typename(L, argIndex));
         return lua_error(L);
-    }
-    else
-    {
-        parentGroup = QString::fromUtf8(lua_tostring(L, 2));
+    } else {
+        parentGroup = QString::fromUtf8(lua_tostring(L, argIndex));
     }
 
-    int luaModifier = 0x00000000;
-    if (n > 4) {
-        if( ! lua_isstring( L, i ) )
-        {
-            lua_pushfstring(L, "permKey: bad argument type (key modifier as string expected, got %s!)",
-                            luaL_typename(L, 1));
+    int keyModifier = Qt::NoModifier;
+    if (lua_gettop(L) > 4) {
+        if (!lua_isnumber(L, ++argIndex)) {
+            lua_pushfstring(L, "permKey: bad argument #%d type (key modifier as number is optional, got %s!)", argIndex, luaL_typename(L, argIndex));
             return lua_error(L);
+        } else {
+            keyModifier = lua_tointeger(L, argIndex);
         }
-        else
-        {
-            luaModifier = lua_tointeger( L, i );
-        }
-        i++;
     }
 
-    int luaKeyCode;
-    if( ! lua_isstring( L, i ) )
-    {
-        lua_pushfstring(L, "permKey: bad argument type (key code as string expected, got %s!)",
-                        luaL_typename(L, 1));
+    int KeyCode = 0;
+    if (!lua_isnumber(L, ++argIndex)) {
+        lua_pushfstring(L, "permKey: bad argument #%d type (key code as number expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
+    } else {
+        KeyCode = lua_tointeger(L, argIndex);
     }
-    else
-    {
-        luaKeyCode = lua_tointeger( L, i );
-    }
-    i++;
 
     QString luaFunction;
-    if( ! lua_isstring( L, i ) )
-    {
-        lua_pushfstring(L, "permKey: bad argument type (lua code as string expected, got %s!)",
-                        luaL_typename(L, 1));
+    if (!lua_isstring(L, ++argIndex)) {
+        lua_pushfstring(L, "permKey: bad argument #%d type (lua script as string expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
-    }
-    else
-    {
-        luaFunction = lua_tostring( L, i );
+    } else {
+        luaFunction = QString::fromUtf8(lua_tostring(L, argIndex));
     }
 
     Host& host = getHostFromLua(L);
-    TLuaInterpreter * pLuaInterpreter = host.getLuaInterpreter();
-    int keyID = pLuaInterpreter->startPermKey( keyName, parentGroup, luaModifier, luaKeyCode, luaFunction );
-    lua_pushnumber( L, keyID );
+    TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+    // FIXME: The script in the luaFunction could fail to compile - although this will still create a key (which will error each time it is encountered)
+    int keyID = pLuaInterpreter->startPermKey(keyName, parentGroup, KeyCode, keyModifier, luaFunction);
+    lua_pushnumber(L, keyID);
     return 1;
 }
 
 int TLuaInterpreter::tempKey( lua_State *L )
 {
-    int n = lua_gettop( L );    //Number of values being passed in lua_State *L
-    int i = 1;                  //Index of current value being acted upon
-
-    int luaModifier = 0x00000000;
-    if (n > 2) {
-        if( ! lua_isstring( L, i ) )
-        {
-            lua_pushstring( L, tr( "tempKey: bad argument type (key modifier as string expected, got %1!)" )
-                .arg( luaL_typename( L, i ) )
-                .toUtf8().constData() );
-            lua_error( L );
-            return 1;
+    quint8 argIndex = 0;
+    int keyModifier = Qt::NoModifier;
+    if (lua_gettop(L) > 2) {
+        if (!lua_isnumber(L, ++argIndex)) {
+            lua_pushfstring(L, "tempKey: bad argument #%d type (key modifier as number is optional, got %s!)", argIndex, luaL_typename(L, argIndex));
+            return lua_error(L);
+        } else {
+            keyModifier = lua_tointeger(L, argIndex);
         }
-        else
-        {
-            luaModifier = lua_tointeger( L, i );
-        }
-        i++;
     }
 
-    int luaKeyCode;
-    if( ! lua_isstring( L, i ) )
-    {
-        lua_pushstring( L, tr( "tempKey: bad argument type (key code as string expected, got %1!)" )
-            .arg( luaL_typename( L, i ) )
-            .toUtf8().constData() );
-        lua_error( L );
-        return 1;
+    int keyCode = 0;
+    if (!lua_isnumber(L, ++argIndex)) {
+        lua_pushfstring(L, "tempKey: bad argument #%d type (key code as number expected, got %s!)", argIndex, luaL_typename(L, argIndex));
+        return lua_error(L);
+    } else {
+        keyCode = lua_tointeger(L, argIndex);
     }
-    else
-    {
-        luaKeyCode = lua_tointeger( L, i );
-    }
-    i++;
 
-    string luaFunction = "";
-    if( ! lua_isstring( L, i ) )
-    {
-        lua_pushstring( L, tr( "permKey: bad argument type (lua code as string expected, got %1!)" )
-            .arg( luaL_typename( L, i ) )
-            .toUtf8().constData() );
-        lua_error( L );
-        return 1;
-    }
-    else
-    {
-        luaFunction = lua_tostring( L, i );
+    QString luaFunction;
+    if (!lua_isstring(L, ++argIndex)) {
+        lua_pushfstring(L, "tempKey: bad argument #%d type (lua script as string expected, got %s!)", argIndex, luaL_typename(L, argIndex));
+        return lua_error(L);
+    } else {
+        luaFunction = QString::fromUtf8(lua_tostring(L, argIndex));
     }
 
     Host& host = getHostFromLua(L);
-    TLuaInterpreter * pLuaInterpreter = host.getLuaInterpreter();
-    QString _luaFunction = luaFunction.c_str();
-    int _luaModifier = luaModifier;
-    int _luaKeyCode = luaKeyCode;
-    int timerID = pLuaInterpreter->startTempKey( _luaModifier, _luaKeyCode, _luaFunction );
-    lua_pushnumber( L, timerID );
+    TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+    int timerID = pLuaInterpreter->startTempKey(keyModifier, keyCode, luaFunction);
+    lua_pushnumber(L, timerID);
     return 1;
 }
 
@@ -13505,47 +13457,44 @@ int TLuaInterpreter::startTempAlias(const QString & regex, const QString & funct
 
 int TLuaInterpreter::startPermKey( QString & name, QString & parent, int & keycode, int & modifier, QString & function )
 {
-    TKey * pT;
+    TKey* pT;
 
-    if( parent.isEmpty() )
-    {
-        pT = new TKey("a", mpHost );
-    }
-    else
-    {
-        TKey * pP = mpHost->getKeyUnit()->findKey( parent );
-        if( !pP )
-        {
-            return -1;//parent not found
+    if (parent.isEmpty()) {
+        pT = new TKey("a", mpHost); // The use of "a" seems a bit arbitary...!
+    } else {
+        TKey* pP = mpHost->getKeyUnit()->findKey(parent);
+        if (!pP) {
+            return -1; //parent not found
         }
-        pT = new TKey( pP, mpHost );
+        pT = new TKey(pP, mpHost);
     }
-    pT->setKeyCode( keycode );
-    pT->setKeyModifiers( modifier );
-    pT->setIsFolder( false );
-    pT->setIsActive( true );
-    pT->setIsTempKey( false );
+    pT->setKeyCode(keycode);
+    pT->setKeyModifiers(modifier);
+    pT->setIsFolder(false);
+    pT->setIsActive(true);
+    pT->setIsTempKey(false);
     pT->registerKey();
-    pT->setScript( function );
+    // CHECK: The lua code in function could fail to compile - but there is no feedback here to the caller.
+    pT->setScript(function);
     int id = pT->getID();
-    pT->setName( name );
+    pT->setName(name);
     mpHost->mpEditorDialog->mNeedUpdateData = true;
     return id;
 }
 
 int TLuaInterpreter::startTempKey( int & modifier, int & keycode, QString & function )
 {
-    TKey * pT;
-    pT = new TKey( "a", mpHost );
-    pT->setKeyCode( keycode );
-    pT->setKeyModifiers( modifier );
-    pT->setIsFolder( false );
-    pT->setIsActive( true );
-    pT->setIsTempKey( true );
+    TKey* pT;
+    pT = new TKey("a", mpHost);
+    pT->setKeyCode(keycode);
+    pT->setKeyModifiers(modifier);
+    pT->setIsFolder(false);
+    pT->setIsActive(true);
+    pT->setIsTempKey(true);
     pT->registerKey();
-    pT->setScript( function );
+    pT->setScript(function);
     int id = pT->getID();
-    pT->setName( QString::number( id ) );
+    pT->setName(QString::number(id));
     return id;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7001,12 +7001,12 @@ int TLuaInterpreter::permKey( lua_State *L )
         }
     }
 
-    int KeyCode = 0;
+    int keyCode = 0;
     if (!lua_isnumber(L, ++argIndex)) {
         lua_pushfstring(L, "permKey: bad argument #%d type (key code as number expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
     } else {
-        KeyCode = lua_tointeger(L, argIndex);
+        keyCode = lua_tointeger(L, argIndex);
     }
 
     QString luaFunction;
@@ -7020,7 +7020,7 @@ int TLuaInterpreter::permKey( lua_State *L )
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     // FIXME: The script in the luaFunction could fail to compile - although this will still create a key (which will error each time it is encountered)
-    int keyID = pLuaInterpreter->startPermKey(keyName, parentGroup, KeyCode, keyModifier, luaFunction);
+    int keyID = pLuaInterpreter->startPermKey(keyName, parentGroup, keyCode, keyModifier, luaFunction);
     lua_pushnumber(L, keyID);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7028,7 +7028,7 @@ int TLuaInterpreter::permKey( lua_State *L )
 int TLuaInterpreter::tempKey( lua_State *L )
 {
     uint_fast8_t argIndex = 0;
-    int l = Qt::NoModifier;
+    int keyModifier = Qt::NoModifier;
     if (lua_gettop(L) > 2) {
         if (!lua_isnumber(L, ++argIndex) && !lua_isnil(L, argIndex)) {
             lua_pushfstring(L, "tempKey: bad argument #%d type (key modifier as number is optional, got %s!)", argIndex, luaL_typename(L, argIndex));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6993,7 +6993,7 @@ int TLuaInterpreter::permKey( lua_State *L )
 
     int keyModifier = Qt::NoModifier;
     if (lua_gettop(L) > 4) {
-        if (!lua_isnumber(L, ++argIndex)) {
+        if (!lua_isnumber(L, ++argIndex) && !lua_isnil(L, argIndex)) {
             lua_pushfstring(L, "permKey: bad argument #%d type (key modifier as number is optional, got %s!)", argIndex, luaL_typename(L, argIndex));
             return lua_error(L);
         } else {
@@ -7028,9 +7028,9 @@ int TLuaInterpreter::permKey( lua_State *L )
 int TLuaInterpreter::tempKey( lua_State *L )
 {
     uint_fast8_t argIndex = 0;
-    int keyModifier = Qt::NoModifier;
+    int l = Qt::NoModifier;
     if (lua_gettop(L) > 2) {
-        if (!lua_isnumber(L, ++argIndex)) {
+        if (!lua_isnumber(L, ++argIndex) && !lua_isnil(L, argIndex)) {
             lua_pushfstring(L, "tempKey: bad argument #%d type (key modifier as number is optional, got %s!)", argIndex, luaL_typename(L, argIndex));
             return lua_error(L);
         } else {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -101,7 +101,7 @@ public:
 
     int startTempTimer(double, const QString&);
     int startTempAlias(const QString&, const QString&);
-    int startTempKey(int& keycode, int& modifier, QString& function);
+    int startTempKey(int&, int&, QString&);
     int startTempTrigger(const QString&, const QString&);
     int startTempBeginOfLineTrigger(const QString&, const QString&);
     int startTempExactMatchTrigger(const QString&, const QString&);
@@ -113,7 +113,7 @@ public:
     int startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
     int startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
     int startPermAlias(const QString& name, const QString& parent, const QString& regex, const QString& function);
-    int startPermKey(QString& name, QString& parent, int& keycode, int& modifier, QString& function);
+    int startPermKey(QString&, QString&, int &, int &, QString&);
 
     static int getCustomLines(lua_State*);
     static int addCustomLine(lua_State*);


### PR DESCRIPTION
Bug fixes for issue(s) raised in: https://github.com/Mudlet/Mudlet/issues/1068

* in `TLuaInterpreter::permKey(...)` corrected `luaL_typename(...)` calls to refer to correct argument instead of hard-coded `1`.
* in `TLuaInterpreter::permKey(...)` and `tempKey(...)` corrected tests for strings for optional third and required fourth to be the number ones as that is what we want them to be interpreted as; edited the type error message to match; revised the error message to the `keyModifier` argument to refer to it as optional as it is!
* in `TLuaInterpreter::tempKey(...)` forced the error message generation to no longer be subject to potential translation efforts following the decision already implemented elsewhere in the class NOT to I18n these texts.
* in `TLuaInterpreter::permKey(...)` and `tempKey(...)` added missing argument number from error messages for cases where the number is a run-time variable rather than a compile time constant.
* in `TLuaInterpreter::permKey(...)` corrected the swap of `keyModifier` and `keyCode` in the call to `TLuaIntepreter::startPermKey(...)`
* in `TLuaInterpreter::tempKey(...)` refactored the `luaScript` variable to be a `QString` all the way through and to explicitly retrieve it from the Lua sub-system as UTF-8 text with a `QString::fromUtf8(...)` call whereas the previous `std::string::c_str()` as an argument to a plain `QString()` constructor will fail in the future if/when the `QT_NO_CAST_FROM_ASCII` macro is `#define`-d.

* As a separate issue I found that the code that checks for `TKeys` being  matched on user text input was defective as it only ran the first match that was found instead of running all - this needed a revision to `(bool) KeyUnit::processDataStream(int, int)` ...

* I have run clang-format over the code that I have touched.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>