### PR TITLE
IRC client update of UI and logic

### DIFF
--- a/3rdparty/communi/CMakeLists.txt
+++ b/3rdparty/communi/CMakeLists.txt
@@ -42,6 +42,20 @@ SET(SRCS
   src/core/ircnetwork.cpp
   src/core/ircprotocol.cpp
   src/3rdparty/mozilla/rdf_utils.c
+  src/model/ircbuffer.cpp
+  src/model/ircbuffermodel.cpp
+  src/model/ircchannel.cpp
+  src/model/ircmodel.cpp
+  src/model/ircuser.cpp
+  src/model/ircusermodel.cpp
+  src/util/irccommandparser.cpp
+  src/util/irccommandqueue.cpp
+  src/util/irccompleter.cpp
+  src/util/irclagtimer.cpp
+  src/util/ircpalette.cpp
+  src/util/irctextformat.cpp
+  src/util/irctoken.cpp
+  src/util/ircutil.cpp
 )
 SET(HDRS
   include/IrcCore/irccommand_p.h
@@ -51,6 +65,15 @@ SET(HDRS
   include/IrcCore/ircmessagecomposer_p.h
   include/IrcCore/ircmessagedecoder_p.h
   include/IrcCore/ircnetwork_p.h
+  include/IrcModel/ircuser_p.h
+  include/IrcModel/ircbuffer_p.h
+  include/IrcModel/ircchannel_p.h
+  include/IrcModel/ircusermodel_p.h
+  include/IrcModel/ircbuffermodel_p.h
+  include/IrcUtil/irctoken_p.h
+  include/IrcUtil/irclagtimer_p.h
+  include/IrcUtil/irccommandqueue_p.h
+  include/IrcUtil/irccommandparser_p.h
 )
 SET(MOC_HDRS
   include/IrcCore/irc.h
@@ -59,6 +82,19 @@ SET(MOC_HDRS
   include/IrcCore/ircmessage.h
   include/IrcCore/ircnetwork.h
   include/IrcCore/ircprotocol.h
+  include/IrcModel/ircbuffer.h
+  include/IrcModel/ircbuffermodel.h
+  include/IrcModel/ircchannel.h
+  include/IrcModel/ircmodel.h
+  include/IrcModel/ircuser.h
+  include/IrcModel/ircusermodel.h
+  include/IrcUtil/irccommandparser.h
+  include/IrcUtil/irccommandqueue.h
+  include/IrcUtil/irccompleter.h
+  include/IrcUtil/irclagtimer.h
+  include/IrcUtil/ircpalette.h
+  include/IrcUtil/irctextformat.h
+  include/IrcUtil/ircutil.h
 )
 SET(PUB_HDRS
   ${MOC_HDRS}
@@ -75,6 +111,19 @@ SET(PUB_HDRS
   include/IrcCore/IrcMessageFilter
   include/IrcCore/IrcNetwork
   include/IrcCore/IrcProtocol
+  include/IrcModel/IrcBuffer
+  include/IrcModel/IrcBufferModel
+  include/IrcModel/IrcChannel
+  include/IrcModel/IrcModel
+  include/IrcModel/IrcUser
+  include/IrcModel/IrcUserModel
+  include/IrcUtil/IrcCommandParser
+  include/IrcUtil/IrcCommandQueue
+  include/IrcUtil/IrcCompleter
+  include/IrcUtil/IrcLagTimer
+  include/IrcUtil/IrcPalette
+  include/IrcUtil/IrcTextFormat
+  include/IrcUtil/IrcUtil
 )
 
 QT5_GENERATE_MOC(include/IrcCore/irc.h ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_irc.cpp)
@@ -84,6 +133,17 @@ QT5_GENERATE_MOC(include/IrcCore/ircmessage.h ${CMAKE_CURRENT_BINARY_DIR}/IrcCor
 QT5_GENERATE_MOC(include/IrcCore/ircmessagecomposer_p.h ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_ircmessagecomposer_p.cpp)
 QT5_GENERATE_MOC(include/IrcCore/ircnetwork.h ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_ircnetwork.cpp)
 QT5_GENERATE_MOC(include/IrcCore/ircprotocol.h ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_ircprotocol.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircusermodel.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircusermodel.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircchannel.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircchannel.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircbuffer.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffer.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircbuffermodel_p.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffermodel_p.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircbuffermodel.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffermodel.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircuser.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircuser.cpp)
+QT5_GENERATE_MOC(include/IrcModel/ircusermodel.h ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircusermodel.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irccompleter.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccompleter.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irccommandparser.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandparser.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irccommandqueue.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandqueue.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irclagtimer.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irclagtimer.cpp)
 
 SET_PROPERTY(SOURCE src/core/irc.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_irc.cpp)
@@ -99,6 +159,28 @@ SET_PROPERTY(SOURCE src/core/ircnetwork.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_ircnetwork.cpp)
 SET_PROPERTY(SOURCE src/core/ircprotocol.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_ircprotocol.cpp)
+SET_PROPERTY(SOURCE src/model/ircusermodel.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircusermodel.cpp)
+SET_PROPERTY(SOURCE src/model/ircchannel.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircchannel.cpp)
+SET_PROPERTY(SOURCE src/model/ircbuffer.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffer.cpp)
+SET_PROPERTY(SOURCE src/model/ircbuffermodel.cpp 
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffermodel.cpp)
+SET_PROPERTY(SOURCE src/model/ircuser.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircuser.cpp)
+SET_PROPERTY(SOURCE src/model/ircusermodel.cpp 
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircusermodel.cpp)
+SET_PROPERTY(SOURCE src/util/irccompleter.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccompleter.cpp)
+SET_PROPERTY(SOURCE src/util/irccommandparser.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandparser.cpp)
+SET_PROPERTY(SOURCE src/util/irccommandqueue.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandqueue.cpp)
+SET_PROPERTY(SOURCE src/util/irclagtimer.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irclagtimer.cpp)
+SET_PROPERTY(SOURCE src/util/irctextformat.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irctextformat.cpp)
 
 ADD_LIBRARY(communi STATIC ${SRCS} ${HDRS} ${PUB_HDRS})
 
@@ -106,9 +188,13 @@ TARGET_LINK_LIBRARIES(communi ${Qt5Core_LIBRARIES} ${Qt5Network_LIBRARIES})
 
 TARGET_INCLUDE_DIRECTORIES(communi PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/IrcCore
+  ${CMAKE_CURRENT_BINARY_DIR}/IrcModel
+  ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil
 )
 TARGET_INCLUDE_DIRECTORIES(communi PUBLIC
   ${Qt5Core_INCLUDE_DIRS}
   ${Qt5Network_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcCore
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcModel
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcUtil
 )

--- a/3rdparty/communi/CMakeLists.txt
+++ b/3rdparty/communi/CMakeLists.txt
@@ -28,6 +28,12 @@ PROJECT(communi)
 FIND_PACKAGE(Qt5Core REQUIRED)
 FIND_PACKAGE(Qt5Network REQUIRED)
 
+INCLUDE_DIRECTORIES(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcCore
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcModel
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/IrcUtil
+)
+
 SET(SRCS
   src/core/irc.cpp
   src/core/irccommand.cpp
@@ -143,7 +149,11 @@ QT5_GENERATE_MOC(include/IrcModel/ircusermodel.h ${CMAKE_CURRENT_BINARY_DIR}/Irc
 QT5_GENERATE_MOC(include/IrcUtil/irccompleter.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccompleter.cpp)
 QT5_GENERATE_MOC(include/IrcUtil/irccommandparser.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandparser.cpp)
 QT5_GENERATE_MOC(include/IrcUtil/irccommandqueue.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandqueue.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irccommandqueue_p.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandqueue_p.cpp)
 QT5_GENERATE_MOC(include/IrcUtil/irclagtimer.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irclagtimer.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irclagtimer_p.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irclagtimer_p.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/irctextformat.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irctextformat.cpp)
+QT5_GENERATE_MOC(include/IrcUtil/ircpalette.h ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_ircpalette.cpp)
 
 SET_PROPERTY(SOURCE src/core/irc.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcCore/moc_irc.cpp)
@@ -167,6 +177,8 @@ SET_PROPERTY(SOURCE src/model/ircbuffer.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffer.cpp)
 SET_PROPERTY(SOURCE src/model/ircbuffermodel.cpp 
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffermodel.cpp)
+SET_PROPERTY(SOURCE src/model/ircbuffermodel.cpp 
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircbuffermodel_p.cpp)
 SET_PROPERTY(SOURCE src/model/ircuser.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcModel/moc_ircuser.cpp)
 SET_PROPERTY(SOURCE src/model/ircusermodel.cpp 
@@ -177,10 +189,16 @@ SET_PROPERTY(SOURCE src/util/irccommandparser.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandparser.cpp)
 SET_PROPERTY(SOURCE src/util/irccommandqueue.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandqueue.cpp)
+SET_PROPERTY(SOURCE src/util/irccommandqueue.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irccommandqueue_p.cpp)
 SET_PROPERTY(SOURCE src/util/irclagtimer.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irclagtimer.cpp)
+SET_PROPERTY(SOURCE src/util/irclagtimer.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irclagtimer_p.cpp)
 SET_PROPERTY(SOURCE src/util/irctextformat.cpp
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_irctextformat.cpp)
+SET_PROPERTY(SOURCE src/util/ircpalette.cpp
+  APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/IrcUtil/moc_ircpalette.cpp)
 
 ADD_LIBRARY(communi STATIC ${SRCS} ${HDRS} ${PUB_HDRS})
 

--- a/3rdparty/communi/include/IrcModel/IrcBuffer
+++ b/3rdparty/communi/include/IrcModel/IrcBuffer
@@ -1,0 +1,1 @@
+#include <ircbuffer.h>

--- a/3rdparty/communi/include/IrcModel/IrcBufferModel
+++ b/3rdparty/communi/include/IrcModel/IrcBufferModel
@@ -1,0 +1,1 @@
+#include <ircbuffermodel.h>

--- a/3rdparty/communi/include/IrcModel/IrcChannel
+++ b/3rdparty/communi/include/IrcModel/IrcChannel
@@ -1,0 +1,1 @@
+#include <ircchannel.h>

--- a/3rdparty/communi/include/IrcModel/IrcModel
+++ b/3rdparty/communi/include/IrcModel/IrcModel
@@ -1,0 +1,1 @@
+#include <ircmodel.h>

--- a/3rdparty/communi/include/IrcModel/IrcUser
+++ b/3rdparty/communi/include/IrcModel/IrcUser
@@ -1,0 +1,1 @@
+#include <ircuser.h>

--- a/3rdparty/communi/include/IrcModel/IrcUserModel
+++ b/3rdparty/communi/include/IrcModel/IrcUserModel
@@ -1,0 +1,1 @@
+#include <ircusermodel.h>

--- a/3rdparty/communi/include/IrcModel/ircbuffer.h
+++ b/3rdparty/communi/include/IrcModel/ircbuffer.h
@@ -1,0 +1,126 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCBUFFER_H
+#define IRCBUFFER_H
+
+#include <Irc>
+#include <IrcGlobal>
+#include <QtCore/qobject.h>
+#include <QtCore/qvariant.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qscopedpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcChannel;
+class IrcCommand;
+class IrcMessage;
+class IrcNetwork;
+class IrcConnection;
+class IrcBufferModel;
+class IrcBufferPrivate;
+
+class IRC_MODEL_EXPORT IrcBuffer : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString title READ title NOTIFY titleChanged)
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(QString prefix READ prefix WRITE setPrefix NOTIFY prefixChanged)
+    Q_PROPERTY(IrcConnection* connection READ connection CONSTANT)
+    Q_PROPERTY(IrcNetwork* network READ network CONSTANT)
+    Q_PROPERTY(IrcBufferModel* model READ model CONSTANT)
+    Q_PROPERTY(bool active READ isActive NOTIFY activeChanged)
+    Q_PROPERTY(bool channel READ isChannel CONSTANT)
+    Q_PROPERTY(bool sticky READ isSticky WRITE setSticky NOTIFY stickyChanged)
+    Q_PROPERTY(bool persistent READ isPersistent WRITE setPersistent NOTIFY persistentChanged)
+    Q_PROPERTY(QVariantMap userData READ userData WRITE setUserData NOTIFY userDataChanged)
+
+public:
+    Q_INVOKABLE explicit IrcBuffer(QObject* parent = 0);
+    virtual ~IrcBuffer();
+
+    QString title() const;
+    QString name() const;
+    QString prefix() const;
+
+    bool isChannel() const;
+    Q_INVOKABLE IrcChannel* toChannel();
+
+    IrcConnection* connection() const;
+    IrcNetwork* network() const;
+    IrcBufferModel* model() const;
+
+    virtual bool isActive() const;
+
+    bool isSticky() const;
+    void setSticky(bool sticky);
+
+    bool isPersistent() const;
+    void setPersistent(bool persistent);
+
+    QVariantMap userData() const;
+    void setUserData(const QVariantMap& data);
+
+    Q_INVOKABLE bool sendCommand(IrcCommand* command);
+
+public Q_SLOTS:
+    void setName(const QString& name);
+    void setPrefix(const QString& prefix);
+    void receiveMessage(IrcMessage* message);
+    virtual void close(const QString& reason = QString());
+
+Q_SIGNALS:
+    void titleChanged(const QString& title);
+    void nameChanged(const QString& name);
+    void prefixChanged(const QString& name);
+    void messageReceived(IrcMessage* message);
+    void destroyed(IrcBuffer* buffer);
+    void activeChanged(bool active);
+    void stickyChanged(bool sticky);
+    void persistentChanged(bool persistent);
+    void userDataChanged(const QVariantMap& data);
+
+protected:
+    IrcBuffer(IrcBufferPrivate& dd, QObject* parent);
+
+    QScopedPointer<IrcBufferPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcBuffer)
+    Q_DISABLE_COPY(IrcBuffer)
+};
+
+#ifndef QT_NO_DEBUG_STREAM
+IRC_MODEL_EXPORT QDebug operator<<(QDebug debug, const IrcBuffer* buffer);
+#endif // QT_NO_DEBUG_STREAM
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcBuffer*))
+Q_DECLARE_METATYPE(QList<IRC_PREPEND_NAMESPACE(IrcBuffer*)>)
+
+#endif // IRCBUFFER_H

--- a/3rdparty/communi/include/IrcModel/ircbuffer_p.h
+++ b/3rdparty/communi/include/IrcModel/ircbuffer_p.h
@@ -1,0 +1,98 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCBUFFER_P_H
+#define IRCBUFFER_P_H
+
+#include "ircbuffer.h"
+#include "ircmessage.h"
+#include <qstringlist.h>
+#include <qdatetime.h>
+#include <qlist.h>
+#include <qmap.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcUser;
+class IrcUserModel;
+
+class IrcBufferPrivate
+{
+    Q_DECLARE_PUBLIC(IrcBuffer)
+
+public:
+    IrcBufferPrivate();
+    virtual ~IrcBufferPrivate();
+
+    virtual void init(const QString& title, IrcBufferModel* model);
+    virtual void connected();
+    virtual void disconnected();
+
+    void setName(const QString& name);
+    void setPrefix(const QString& prefix);
+    void setModel(IrcBufferModel* model);
+
+    enum MonitorStatus { MonitorUnknown, MonitorOffline, MonitorOnline };
+    void setMonitorStatus(MonitorStatus status);
+    bool isMonitorable() const;
+
+    bool processMessage(IrcMessage* message);
+
+    virtual bool processAwayMessage(IrcAwayMessage* message);
+    virtual bool processJoinMessage(IrcJoinMessage* message);
+    virtual bool processKickMessage(IrcKickMessage* message);
+    virtual bool processModeMessage(IrcModeMessage* message);
+    virtual bool processNamesMessage(IrcNamesMessage* message);
+    virtual bool processNickMessage(IrcNickMessage* message);
+    virtual bool processNoticeMessage(IrcNoticeMessage* message);
+    virtual bool processNumericMessage(IrcNumericMessage* message);
+    virtual bool processPartMessage(IrcPartMessage* message);
+    virtual bool processPrivateMessage(IrcPrivateMessage* message);
+    virtual bool processQuitMessage(IrcQuitMessage* message);
+    virtual bool processTopicMessage(IrcTopicMessage* message);
+    virtual bool processWhoReplyMessage(IrcWhoReplyMessage* message);
+
+    static IrcBufferPrivate* get(IrcBuffer* buffer)
+    {
+        return buffer->d_func();
+    }
+
+    IrcBuffer* q_ptr;
+    IrcBufferModel* model;
+    QString name;
+    QString prefix;
+    bool persistent;
+    bool sticky;
+    QVariantMap userData;
+    QDateTime activity;
+    MonitorStatus monitorStatus;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCBUFFER_P_H

--- a/3rdparty/communi/include/IrcModel/ircbuffermodel.h
+++ b/3rdparty/communi/include/IrcModel/ircbuffermodel.h
@@ -1,0 +1,174 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCBUFFERMODEL_H
+#define IRCBUFFERMODEL_H
+
+#include <Irc>
+#include <IrcGlobal>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qstringlist.h>
+#include <QtCore/qabstractitemmodel.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcBuffer;
+class IrcChannel;
+class IrcMessage;
+class IrcNetwork;
+class IrcConnection;
+class IrcBufferModelPrivate;
+
+class IRC_MODEL_EXPORT IrcBufferModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(bool empty READ isEmpty NOTIFY emptyChanged)
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder)
+    Q_PROPERTY(Irc::SortMethod sortMethod READ sortMethod WRITE setSortMethod)
+    Q_PROPERTY(QStringList channels READ channels NOTIFY channelsChanged)
+    Q_PROPERTY(Irc::DataRole displayRole READ displayRole WRITE setDisplayRole)
+    Q_PROPERTY(bool persistent READ isPersistent WRITE setPersistent NOTIFY persistentChanged)
+    Q_PROPERTY(QList<IrcBuffer*> buffers READ buffers NOTIFY buffersChanged)
+    Q_PROPERTY(IrcConnection* connection READ connection WRITE setConnection NOTIFY connectionChanged)
+    Q_PROPERTY(IrcNetwork* network READ network NOTIFY networkChanged)
+    Q_PROPERTY(IrcBuffer* bufferPrototype READ bufferPrototype WRITE setBufferPrototype NOTIFY bufferPrototypeChanged)
+    Q_PROPERTY(IrcChannel* channelPrototype READ channelPrototype WRITE setChannelPrototype NOTIFY channelPrototypeChanged)
+    Q_PROPERTY(int joinDelay READ joinDelay WRITE setJoinDelay NOTIFY joinDelayChanged)
+    Q_PROPERTY(bool monitorEnabled READ isMonitorEnabled WRITE setMonitorEnabled NOTIFY monitorEnabledChanged)
+
+public:
+    explicit IrcBufferModel(QObject* parent = 0);
+    virtual ~IrcBufferModel();
+
+    IrcConnection* connection() const;
+    void setConnection(IrcConnection* connection);
+
+    IrcNetwork* network() const;
+
+    int count() const;
+    bool isEmpty() const;
+    QStringList channels() const;
+    QList<IrcBuffer*> buffers() const;
+    Q_INVOKABLE IrcBuffer* get(int index) const;
+    Q_INVOKABLE IrcBuffer* find(const QString& title) const;
+    Q_INVOKABLE bool contains(const QString& title) const;
+    Q_INVOKABLE int indexOf(IrcBuffer* buffer) const;
+
+    Q_INVOKABLE IrcBuffer* add(const QString& title);
+    Q_INVOKABLE void add(IrcBuffer* buffer);
+    Q_INVOKABLE void remove(const QString& title);
+    Q_INVOKABLE void remove(IrcBuffer* buffer);
+
+    Qt::SortOrder sortOrder() const;
+    void setSortOrder(Qt::SortOrder order);
+
+    Irc::SortMethod sortMethod() const;
+    void setSortMethod(Irc::SortMethod method);
+
+    Irc::DataRole displayRole() const;
+    void setDisplayRole(Irc::DataRole role);
+
+    bool isPersistent() const;
+    void setPersistent(bool persistent);
+
+    QModelIndex index(IrcBuffer* buffer) const;
+    IrcBuffer* buffer(const QModelIndex& index) const;
+
+    QHash<int, QByteArray> roleNames() const;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+    QModelIndex index(int row, int column = 0, const QModelIndex& parent = QModelIndex()) const;
+
+    IrcBuffer* bufferPrototype() const;
+    void setBufferPrototype(IrcBuffer* prototype);
+
+    IrcChannel* channelPrototype() const;
+    void setChannelPrototype(IrcChannel* prototype);
+
+    int joinDelay() const;
+    void setJoinDelay(int delay);
+
+    bool isMonitorEnabled() const;
+    void setMonitorEnabled(bool enabled);
+
+    Q_INVOKABLE QByteArray saveState(int version = 0) const;
+    Q_INVOKABLE bool restoreState(const QByteArray& state, int version = 0);
+
+public Q_SLOTS:
+    void clear();
+    void receiveMessage(IrcMessage* message);
+    void sort(int column = 0, Qt::SortOrder order = Qt::AscendingOrder);
+    void sort(Irc::SortMethod method, Qt::SortOrder order = Qt::AscendingOrder);
+
+Q_SIGNALS:
+    void countChanged(int count);
+    void emptyChanged(bool empty);
+    void added(IrcBuffer* buffer);
+    void removed(IrcBuffer* buffer);
+    void aboutToBeAdded(IrcBuffer* buffer);
+    void aboutToBeRemoved(IrcBuffer* buffer);
+    void persistentChanged(bool persistent);
+    void buffersChanged(const QList<IrcBuffer*>& buffers);
+    void channelsChanged(const QStringList& channels);
+    void connectionChanged(IrcConnection* connection);
+    void networkChanged(IrcNetwork* network);
+    void messageIgnored(IrcMessage* message);
+    void bufferPrototypeChanged(IrcBuffer* prototype);
+    void channelPrototypeChanged(IrcChannel* prototype);
+    void destroyed(IrcBufferModel* model);
+    void joinDelayChanged(int delay);
+    void monitorEnabledChanged(bool enabled);
+
+protected Q_SLOTS:
+    virtual IrcBuffer* createBuffer(const QString& title);
+    virtual IrcChannel* createChannel(const QString& title);
+
+protected:
+    virtual bool lessThan(IrcBuffer* one, IrcBuffer* another, Irc::SortMethod method) const;
+
+private:
+    friend class IrcBufferLessThan;
+    friend class IrcBufferGreaterThan;
+    QScopedPointer<IrcBufferModelPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcBufferModel)
+    Q_DISABLE_COPY(IrcBufferModel)
+
+    Q_PRIVATE_SLOT(d_func(), void _irc_connected())
+    Q_PRIVATE_SLOT(d_func(), void _irc_initialized())
+    Q_PRIVATE_SLOT(d_func(), void _irc_disconnected())
+    Q_PRIVATE_SLOT(d_func(), void _irc_bufferDestroyed(IrcBuffer*))
+    Q_PRIVATE_SLOT(d_func(), void _irc_restoreBuffers())
+    Q_PRIVATE_SLOT(d_func(), void _irc_monitorStatus())
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcBufferModel*))
+
+#endif // IRCBUFFERMODEL_H

--- a/3rdparty/communi/include/IrcModel/ircbuffermodel_p.h
+++ b/3rdparty/communi/include/IrcModel/ircbuffermodel_p.h
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCBUFFERMODEL_P_H
+#define IRCBUFFERMODEL_P_H
+
+#include "ircbuffer.h"
+#include "ircfilter.h"
+#include "ircbuffermodel.h"
+#include <qpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcBufferModelPrivate : public QObject, public IrcMessageFilter, public IrcCommandFilter
+{
+    Q_OBJECT
+    Q_DECLARE_PUBLIC(IrcBufferModel)
+    Q_INTERFACES(IrcMessageFilter IrcCommandFilter)
+
+public:
+    IrcBufferModelPrivate();
+
+    bool messageFilter(IrcMessage* message);
+    bool commandFilter(IrcCommand* command);
+
+    IrcBuffer* createBufferHelper(const QString& title);
+    IrcChannel* createChannelHelper(const QString& title);
+
+    IrcBuffer* createBuffer(const QString& title);
+    void destroyBuffer(const QString& title, bool force = false);
+
+    void addBuffer(IrcBuffer* buffer, bool notify = true);
+    void insertBuffer(int index, IrcBuffer* buffer, bool notify = true);
+    void removeBuffer(IrcBuffer* buffer, bool notify = true);
+    bool renameBuffer(const QString& from, const QString& to);
+    void promoteBuffer(IrcBuffer* buffer);
+
+    void restoreBuffer(IrcBuffer* buffer);
+    QVariantMap saveBuffer(IrcBuffer* buffer) const;
+
+    bool processMessage(const QString& title, IrcMessage* message, bool create = false);
+
+    void _irc_connected();
+    void _irc_initialized();
+    void _irc_disconnected();
+    void _irc_bufferDestroyed(IrcBuffer* buffer);
+
+    void _irc_restoreBuffers();
+    void _irc_monitorStatus();
+
+    static IrcBufferModelPrivate* get(IrcBufferModel* model)
+    {
+        return model->d_func();
+    }
+
+    IrcBufferModel* q_ptr;
+    Irc::DataRole role;
+    QPointer<IrcConnection> connection;
+    QList<IrcBuffer*> bufferList;
+    QMap<QString, IrcBuffer*> bufferMap;
+    QHash<QString, QString> keys;
+    QVariantMap bufferStates;
+    QStringList channels;
+    Irc::SortMethod sortMethod;
+    Qt::SortOrder sortOrder;
+    IrcBuffer* bufferProto;
+    IrcChannel* channelProto;
+    bool persistent;
+    int joinDelay;
+    bool monitorEnabled;
+    bool monitorPending;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCBUFFERMODEL_P_H

--- a/3rdparty/communi/include/IrcModel/ircchannel.h
+++ b/3rdparty/communi/include/IrcModel/ircchannel.h
@@ -1,0 +1,82 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCHANNEL_H
+#define IRCCHANNEL_H
+
+#include <IrcGlobal>
+#include <IrcBuffer>
+#include <QtCore/qmetatype.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcChannelPrivate;
+
+class IRC_MODEL_EXPORT IrcChannel : public IrcBuffer
+{
+    Q_OBJECT
+    Q_PROPERTY(QString key READ key NOTIFY keyChanged)
+    Q_PROPERTY(QString mode READ mode NOTIFY modeChanged)
+    Q_PROPERTY(QString topic READ topic NOTIFY topicChanged)
+
+public:
+    Q_INVOKABLE explicit IrcChannel(QObject* parent = 0);
+    virtual ~IrcChannel();
+
+    QString key() const;
+    QString mode() const;
+    QString topic() const;
+
+    virtual bool isActive() const;
+
+public Q_SLOTS:
+    void who();
+    void join(const QString& key = QString());
+    void part(const QString& reason = QString());
+    void close(const QString& reason = QString());
+
+Q_SIGNALS:
+    void keyChanged(const QString& key);
+    void modeChanged(const QString& mode);
+    void topicChanged(const QString& topic);
+    void destroyed(IrcChannel* channel);
+private:
+    Q_DECLARE_PRIVATE(IrcChannel)
+    Q_DISABLE_COPY(IrcChannel)
+};
+
+#ifndef QT_NO_DEBUG_STREAM
+IRC_MODEL_EXPORT QDebug operator<<(QDebug debug, const IrcChannel* channel);
+#endif // QT_NO_DEBUG_STREAM
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcChannel*))
+Q_DECLARE_METATYPE(QList<IRC_PREPEND_NAMESPACE(IrcChannel*)>)
+
+#endif // IRCCHANNEL

--- a/3rdparty/communi/include/IrcModel/ircchannel_p.h
+++ b/3rdparty/communi/include/IrcModel/ircchannel_p.h
@@ -1,0 +1,101 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCHANNEL_P_H
+#define IRCCHANNEL_P_H
+
+#include "ircchannel.h"
+#include "ircnetwork.h"
+#include "ircbuffer_p.h"
+#include <qstringlist.h>
+#include <qlist.h>
+#include <qmap.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcChannelPrivate : public IrcBufferPrivate
+{
+    Q_DECLARE_PUBLIC(IrcChannel)
+
+public:
+    IrcChannelPrivate();
+    virtual ~IrcChannelPrivate();
+
+    virtual void init(const QString& title, IrcBufferModel* model);
+    virtual void connected();
+    virtual void disconnected();
+
+    void setActive(bool active);
+
+    void changeModes(const QString& value, const QStringList& arguments);
+    void setModes(const QString& value, const QStringList& arguments);
+    void setTopic(const QString& value);
+    void setKey(const QString& value);
+
+    void addUser(const QString& user);
+    bool removeUser(const QString& user);
+    void setUsers(const QStringList& users);
+    bool renameUser(const QString& from, const QString& to);
+    void setUserMode(const QString& user, const QString& mode);
+    void promoteUser(const QString& user);
+    bool setUserAway(const QString &name, bool away);
+    void setUserServOp(const QString &name, bool servOp);
+
+    virtual bool processAwayMessage(IrcAwayMessage* message);
+    virtual bool processJoinMessage(IrcJoinMessage* message);
+    virtual bool processKickMessage(IrcKickMessage* message);
+    virtual bool processModeMessage(IrcModeMessage* message);
+    virtual bool processNamesMessage(IrcNamesMessage* message);
+    virtual bool processNickMessage(IrcNickMessage* message);
+    virtual bool processNoticeMessage(IrcNoticeMessage* message);
+    virtual bool processNumericMessage(IrcNumericMessage* message);
+    virtual bool processPartMessage(IrcPartMessage* message);
+    virtual bool processPrivateMessage(IrcPrivateMessage* message);
+    virtual bool processQuitMessage(IrcQuitMessage* message);
+    virtual bool processTopicMessage(IrcTopicMessage* message);
+    virtual bool processWhoReplyMessage(IrcWhoReplyMessage* message);
+
+    static IrcChannelPrivate* get(IrcChannel* channel)
+    {
+        return channel->d_func();
+    }
+
+    QMap<QString, QString> modes;
+    QString topic;
+    bool active;
+    bool enabled;
+    QStringList names;
+    QList<IrcUser*> userList;
+    QList<IrcUser*> activeUsers;
+    QMap<QString, IrcUser*> userMap;
+    QList<IrcUserModel*> userModels;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCCHANNEL_P_H

--- a/3rdparty/communi/include/IrcModel/ircmodel.h
+++ b/3rdparty/communi/include/IrcModel/ircmodel.h
@@ -1,0 +1,46 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCMODEL_H
+#define IRCMODEL_H
+
+#include "ircbuffer.h"
+#include "ircbuffermodel.h"
+#include "ircchannel.h"
+#include "ircuser.h"
+#include "ircusermodel.h"
+
+IRC_BEGIN_NAMESPACE
+
+namespace IrcModel {
+    IRC_MODEL_EXPORT void registerMetaTypes();
+}
+
+IRC_END_NAMESPACE
+
+#endif // IRCMODEL_H

--- a/3rdparty/communi/include/IrcModel/ircuser.h
+++ b/3rdparty/communi/include/IrcModel/ircuser.h
@@ -1,0 +1,89 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCUSER_H
+#define IRCUSER_H
+
+#include <IrcGlobal>
+#include <QtCore/qobject.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qscopedpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcChannel;
+class IrcUserPrivate;
+
+class IRC_MODEL_EXPORT IrcUser : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString title READ title NOTIFY titleChanged)
+    Q_PROPERTY(QString name READ name NOTIFY nameChanged)
+    Q_PROPERTY(QString prefix READ prefix NOTIFY prefixChanged)
+    Q_PROPERTY(QString mode READ mode NOTIFY modeChanged)
+    Q_PROPERTY(bool servOp READ isServOp NOTIFY servOpChanged)
+    Q_PROPERTY(bool away READ isAway NOTIFY awayChanged)
+    Q_PROPERTY(IrcChannel* channel READ channel CONSTANT)
+
+public:
+    explicit IrcUser(QObject* parent = 0);
+    virtual ~IrcUser();
+
+    QString title() const;
+    QString name() const;
+    QString prefix() const;
+    QString mode() const;
+    bool isServOp() const;
+    bool isAway() const;
+
+    IrcChannel* channel() const;
+
+Q_SIGNALS:
+    void titleChanged(const QString& title);
+    void nameChanged(const QString& name);
+    void prefixChanged(const QString& prefix);
+    void modeChanged(const QString& mode);
+    void servOpChanged(bool servOp);
+    void awayChanged(bool away);
+
+private:
+    QScopedPointer<IrcUserPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcUser)
+    Q_DISABLE_COPY(IrcUser)
+};
+
+#ifndef QT_NO_DEBUG_STREAM
+IRC_MODEL_EXPORT QDebug operator<<(QDebug debug, const IrcUser* user);
+#endif // QT_NO_DEBUG_STREAM
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcUser*))
+Q_DECLARE_METATYPE(QList<IRC_PREPEND_NAMESPACE(IrcUser*)>)
+
+#endif // IRCUSER_H

--- a/3rdparty/communi/include/IrcModel/ircuser_p.h
+++ b/3rdparty/communi/include/IrcModel/ircuser_p.h
@@ -1,0 +1,63 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCUSER_P_H
+#define IRCUSER_P_H
+
+#include "ircuser.h"
+
+IRC_BEGIN_NAMESPACE
+
+class IrcUserPrivate
+{
+    Q_DECLARE_PUBLIC(IrcUser)
+
+public:
+    void setName(const QString& n);
+    void setPrefix(const QString& p);
+    void setMode(const QString& m);
+    void setServOp(const bool& o);
+    void setAway(const bool& a);
+
+    static IrcUserPrivate* get(IrcUser* user)
+    {
+        return user->d_func();
+    }
+
+    IrcUser* q_ptr;
+    IrcChannel* channel;
+    QString name;
+    QString prefix;
+    QString mode;
+    bool servOp;
+    bool away;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCUSER_P_H

--- a/3rdparty/communi/include/IrcModel/ircusermodel.h
+++ b/3rdparty/communi/include/IrcModel/ircusermodel.h
@@ -1,0 +1,125 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCUSERMODEL_H
+#define IRCUSERMODEL_H
+
+#include <Irc>
+#include <IrcGlobal>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qstringlist.h>
+#include <QtCore/qabstractitemmodel.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcUser;
+class IrcChannel;
+class IrcMessage;
+class IrcUserModelPrivate;
+
+class IRC_MODEL_EXPORT IrcUserModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(bool empty READ isEmpty NOTIFY emptyChanged)
+    Q_PROPERTY(QStringList names READ names NOTIFY namesChanged)
+    Q_PROPERTY(QStringList titles READ titles NOTIFY titlesChanged)
+    Q_PROPERTY(QList<IrcUser*> users READ users NOTIFY usersChanged)
+    Q_PROPERTY(Irc::DataRole displayRole READ displayRole WRITE setDisplayRole)
+    Q_PROPERTY(IrcChannel* channel READ channel WRITE setChannel NOTIFY channelChanged)
+    Q_PROPERTY(Irc::SortMethod sortMethod READ sortMethod WRITE setSortMethod)
+    Q_PROPERTY(Qt::SortOrder sortOrder READ sortOrder WRITE setSortOrder)
+
+public:
+    explicit IrcUserModel(QObject* parent = 0);
+    virtual ~IrcUserModel();
+
+    IrcChannel* channel() const;
+    void setChannel(IrcChannel* channel);
+
+    int count() const;
+    bool isEmpty() const;
+    QStringList names() const;
+    QStringList titles() const;
+    QList<IrcUser*> users() const;
+    Q_INVOKABLE IrcUser* get(int index) const;
+    Q_INVOKABLE IrcUser* find(const QString& name) const;
+    Q_INVOKABLE bool contains(const QString& name) const;
+    Q_INVOKABLE int indexOf(IrcUser* user) const;
+
+    Irc::DataRole displayRole() const;
+    void setDisplayRole(Irc::DataRole role);
+
+    Irc::SortMethod sortMethod() const;
+    void setSortMethod(Irc::SortMethod method);
+
+    Qt::SortOrder sortOrder() const;
+    void setSortOrder(Qt::SortOrder order);
+
+    QModelIndex index(IrcUser* user) const;
+    IrcUser* user(const QModelIndex& index) const;
+
+    QHash<int, QByteArray> roleNames() const;
+    int rowCount(const QModelIndex& parent = QModelIndex()) const;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+    QModelIndex index(int row, int column = 0, const QModelIndex& parent = QModelIndex()) const;
+
+public Q_SLOTS:
+    void clear();
+    void sort(int column = 0, Qt::SortOrder order = Qt::AscendingOrder);
+    void sort(Irc::SortMethod method, Qt::SortOrder order = Qt::AscendingOrder);
+
+Q_SIGNALS:
+    void added(IrcUser* user);
+    void removed(IrcUser* user);
+    void aboutToBeAdded(IrcUser* user);
+    void aboutToBeRemoved(IrcUser* user);
+    void countChanged(int count);
+    void emptyChanged(bool empty);
+    void namesChanged(const QStringList& names);
+    void titlesChanged(const QStringList& titles);
+    void usersChanged(const QList<IrcUser*>& users);
+    void channelChanged(IrcChannel* channel);
+
+protected:
+    virtual bool lessThan(IrcUser* one, IrcUser* another, Irc::SortMethod method) const;
+
+private:
+    friend class IrcUserLessThan;
+    friend class IrcChannelPrivate;
+    friend class IrcUserGreaterThan;
+    QScopedPointer<IrcUserModelPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcUserModel)
+    Q_DISABLE_COPY(IrcUserModel)
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcUserModel*))
+
+#endif // IRCUSERMODEL_H

--- a/3rdparty/communi/include/IrcModel/ircusermodel_p.h
+++ b/3rdparty/communi/include/IrcModel/ircusermodel_p.h
@@ -1,0 +1,72 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCUSERMODEL_P_H
+#define IRCUSERMODEL_P_H
+
+#include "ircuser.h"
+#include "ircchannel_p.h"
+#include "ircusermodel.h"
+#include <qpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcUserModelPrivate
+{
+    Q_DECLARE_PUBLIC(IrcUserModel)
+
+public:
+    IrcUserModelPrivate();
+
+    void addUser(IrcUser* user, bool notify = true);
+    void insertUser(int index, IrcUser* user, bool notify = true);
+    void removeUser(IrcUser* user, bool notify = true);
+    void setUsers(const QList<IrcUser*>& users, bool reset = true);
+    void renameUser(IrcUser* user);
+    void setUserMode(IrcUser* user);
+    void promoteUser(IrcUser* user);
+    bool updateUser(IrcUser* user);
+    bool updateTitles();
+
+    static IrcUserModelPrivate* get(IrcUserModel* model)
+    {
+        return model->d_func();
+    }
+
+    IrcUserModel* q_ptr;
+    Irc::DataRole role;
+    QStringList titles;
+    QList<IrcUser*> userList;
+    QPointer<IrcChannel> channel;
+    Irc::SortMethod sortMethod;
+    Qt::SortOrder sortOrder;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCUSERMODEL_P_H

--- a/3rdparty/communi/include/IrcUtil/IrcCommandParser
+++ b/3rdparty/communi/include/IrcUtil/IrcCommandParser
@@ -1,0 +1,1 @@
+#include <irccommandparser.h>

--- a/3rdparty/communi/include/IrcUtil/IrcCommandQueue
+++ b/3rdparty/communi/include/IrcUtil/IrcCommandQueue
@@ -1,0 +1,1 @@
+#include <irccommandqueue.h>

--- a/3rdparty/communi/include/IrcUtil/IrcCompleter
+++ b/3rdparty/communi/include/IrcUtil/IrcCompleter
@@ -1,0 +1,1 @@
+#include <irccompleter.h>

--- a/3rdparty/communi/include/IrcUtil/IrcLagTimer
+++ b/3rdparty/communi/include/IrcUtil/IrcLagTimer
@@ -1,0 +1,1 @@
+#include <irclagtimer.h>

--- a/3rdparty/communi/include/IrcUtil/IrcPalette
+++ b/3rdparty/communi/include/IrcUtil/IrcPalette
@@ -1,0 +1,1 @@
+#include <ircpalette.h>

--- a/3rdparty/communi/include/IrcUtil/IrcTextFormat
+++ b/3rdparty/communi/include/IrcUtil/IrcTextFormat
@@ -1,0 +1,1 @@
+#include <irctextformat.h>

--- a/3rdparty/communi/include/IrcUtil/IrcUtil
+++ b/3rdparty/communi/include/IrcUtil/IrcUtil
@@ -1,0 +1,1 @@
+#include <ircutil.h>

--- a/3rdparty/communi/include/IrcUtil/irccommandparser.h
+++ b/3rdparty/communi/include/IrcUtil/irccommandparser.h
@@ -1,0 +1,112 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCOMMANDPARSER_H
+#define IRCCOMMANDPARSER_H
+
+#include <IrcGlobal>
+#include <IrcCommand>
+#include <QtCore/qobject.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qstringlist.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcCommandParserPrivate;
+
+class IRC_UTIL_EXPORT IrcCommandParser : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QStringList commands READ commands NOTIFY commandsChanged)
+    Q_PROPERTY(QStringList triggers READ triggers WRITE setTriggers NOTIFY triggersChanged)
+    Q_PROPERTY(QStringList channels READ channels WRITE setChannels NOTIFY channelsChanged)
+    Q_PROPERTY(QString target READ target WRITE setTarget NOTIFY targetChanged)
+    Q_PROPERTY(bool tolerant READ isTolerant WRITE setTolerant NOTIFY tolerancyChanged)
+    Q_FLAGS(Details)
+
+public:
+    explicit IrcCommandParser(QObject* parent = 0);
+    virtual ~IrcCommandParser();
+
+    QStringList commands() const;
+
+    enum Detail {
+        Full = 0x0,
+        NoTarget = 0x1,
+        NoPrefix = 0x2,
+        NoEllipsis = 0x4,
+        NoParentheses = 0x8,
+        NoBrackets = 0x10,
+        NoAngles = 0x20,
+        Visual = NoTarget | NoPrefix | NoEllipsis
+    };
+    Q_DECLARE_FLAGS(Details, Detail)
+
+    Q_INVOKABLE QString syntax(const QString& command, Details details = Visual) const;
+
+    Q_INVOKABLE void addCommand(IrcCommand::Type type, const QString& syntax);
+    Q_INVOKABLE void removeCommand(IrcCommand::Type type, const QString& syntax = QString());
+
+    QStringList triggers() const;
+
+    QString target() const;
+    QStringList channels() const;
+
+    bool isTolerant() const;
+    void setTolerant(bool tolerant);
+
+    Q_INVOKABLE IrcCommand* parse(const QString& input) const;
+
+public Q_SLOTS:
+    void clear();
+    void reset();
+
+    void setTriggers(const QStringList& triggers);
+    void setChannels(const QStringList& channels);
+    void setTarget(const QString& target);
+
+Q_SIGNALS:
+    void commandsChanged(const QStringList& commands);
+    void triggersChanged(const QStringList& triggers);
+    void channelsChanged(const QStringList& channels);
+    void targetChanged(const QString& target);
+    void tolerancyChanged(bool tolerant);
+
+private:
+    QScopedPointer<IrcCommandParserPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcCommandParser)
+    Q_DISABLE_COPY(IrcCommandParser)
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(IrcCommandParser::Details)
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcCommandParser*))
+
+#endif // IRCCOMMANDPARSER_H

--- a/3rdparty/communi/include/IrcUtil/irccommandparser_p.h
+++ b/3rdparty/communi/include/IrcUtil/irccommandparser_p.h
@@ -1,0 +1,96 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCOMMANDPARSER_P_H
+#define IRCCOMMANDPARSER_P_H
+
+#include "irccommandparser.h"
+#include "irccommand.h"
+
+#include <QList>
+#include <QString>
+#include <QMultiMap>
+#include <QStringList>
+
+IRC_BEGIN_NAMESPACE
+
+struct IrcParameterInfo
+{
+    IrcParameterInfo() : optional(false), channel(false), current(false), multi(false) { }
+    bool optional;
+    bool channel;
+    bool current;
+    bool multi;
+    QString value;
+    QString syntax;
+};
+
+struct IrcCommandInfo
+{
+    IrcCommandInfo() : type(IrcCommand::Custom), min(0), max(0) { }
+
+    QString fullSyntax()
+    {
+        return command + QLatin1Char(' ') + syntax;
+    }
+
+    IrcCommand::Type type;
+    QString command;
+    QString syntax;
+    int min, max;
+    QList<IrcParameterInfo> params;
+};
+
+class IrcCommandParserPrivate
+{
+public:
+    IrcCommandParserPrivate();
+
+    QList<IrcCommandInfo> find(const QString& command) const;
+    static IrcCommandInfo parseSyntax(IrcCommand::Type type, const QString& syntax);
+    IrcCommand* parseCommand(const IrcCommandInfo& command, const QString& input) const;
+    bool processParameters(const IrcCommandInfo& command, const QString& input, QStringList* params) const;
+    bool processCommand(QString* input, int* removed = 0) const;
+    bool processMessage(QString* input, int* removed = 0) const;
+    bool onChannel() const;
+
+    static IrcCommandParserPrivate* get(IrcCommandParser* parser)
+    {
+        return parser->d_func();
+    }
+
+    bool tolerant;
+    QString target;
+    QStringList triggers;
+    QStringList channels;
+    QMultiMap<QString, IrcCommandInfo> commands;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCCOMMANDPARSER_P_H

--- a/3rdparty/communi/include/IrcUtil/irccommandqueue.h
+++ b/3rdparty/communi/include/IrcUtil/irccommandqueue.h
@@ -1,0 +1,85 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCOMMANDQUEUE_H
+#define IRCCOMMANDQUEUE_H
+
+#include <IrcGlobal>
+#include <QtCore/qobject.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qscopedpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcConnection;
+class IrcCommandQueuePrivate;
+
+class IRC_UTIL_EXPORT IrcCommandQueue : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int batch READ batch WRITE setBatch)
+    Q_PROPERTY(int interval READ interval WRITE setInterval)
+    Q_PROPERTY(int size READ size NOTIFY sizeChanged)
+    Q_PROPERTY(IrcConnection* connection READ connection WRITE setConnection)
+
+public:
+    explicit IrcCommandQueue(QObject* parent = 0);
+    virtual ~IrcCommandQueue();
+
+    int batch() const;
+    void setBatch(int batch);
+
+    int interval() const;
+    void setInterval(int seconds);
+
+    int size() const;
+
+    IrcConnection* connection() const;
+    void setConnection(IrcConnection* connection);
+
+public Q_SLOTS:
+    void clear();
+    void flush();
+
+Q_SIGNALS:
+    void sizeChanged(int size);
+
+private:
+    QScopedPointer<IrcCommandQueuePrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcCommandQueue)
+    Q_DISABLE_COPY(IrcCommandQueue)
+
+    Q_PRIVATE_SLOT(d_func(), void _irc_updateTimer())
+    Q_PRIVATE_SLOT(d_func(), void _irc_sendBatch())
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcCommandQueue*))
+
+#endif // IRCCOMMANDQUEUE_H

--- a/3rdparty/communi/include/IrcUtil/irccommandqueue_p.h
+++ b/3rdparty/communi/include/IrcUtil/irccommandqueue_p.h
@@ -1,0 +1,64 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCOMMANDQUEUE_P_H
+#define IRCCOMMANDQUEUE_P_H
+
+#include "irccommandqueue.h"
+#include "ircfilter.h"
+#include <QPointer>
+#include <QQueue>
+#include <QTimer>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcCommandQueuePrivate : public QObject,  public IrcCommandFilter
+{
+    Q_OBJECT
+    Q_INTERFACES(IrcCommandFilter)
+    Q_DECLARE_PUBLIC(IrcCommandQueue)
+
+public:
+    IrcCommandQueuePrivate();
+
+    bool commandFilter(IrcCommand* cmd);
+
+    void _irc_updateTimer();
+    void _irc_sendBatch(bool force = false);
+
+    IrcCommandQueue* q_ptr;
+    IrcConnection* connection;
+    QTimer timer;
+    int batch;
+    int interval;
+    QQueue<QPointer<IrcCommand> > commands;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCCOMMANDQUEUE_P_H

--- a/3rdparty/communi/include/IrcUtil/irccompleter.h
+++ b/3rdparty/communi/include/IrcUtil/irccompleter.h
@@ -1,0 +1,90 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCCOMPLETER_H
+#define IRCCOMPLETER_H
+
+#include <IrcGlobal>
+#include <QtCore/qobject.h>
+#include <QtCore/qstring.h>
+#include <QtCore/qmetatype.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcBuffer;
+class IrcCommandParser;
+class IrcCompleterPrivate;
+
+class IRC_UTIL_EXPORT IrcCompleter : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString suffix READ suffix WRITE setSuffix NOTIFY suffixChanged)
+    Q_PROPERTY(IrcBuffer* buffer READ buffer WRITE setBuffer NOTIFY bufferChanged)
+    Q_PROPERTY(IrcCommandParser* parser READ parser WRITE setParser NOTIFY parserChanged)
+    Q_ENUMS(Direction)
+
+public:
+    explicit IrcCompleter(QObject* parent = 0);
+    virtual ~IrcCompleter();
+
+    enum Direction {
+        Forward,
+        Backward
+    };
+
+    QString suffix() const;
+    IrcBuffer* buffer() const;
+    IrcCommandParser* parser() const;
+
+public Q_SLOTS:
+    void setSuffix(const QString& suffix);
+    void setBuffer(IrcBuffer* buffer);
+    void setParser(IrcCommandParser* parser);
+
+    void complete(const QString& text, int cursor, Direction direction = Forward);
+    void reset();
+
+Q_SIGNALS:
+    void suffixChanged(const QString& suffix);
+    void bufferChanged(IrcBuffer* buffer);
+    void parserChanged(IrcCommandParser* parser);
+
+    void completed(const QString& text, int cursor);
+
+private:
+    QScopedPointer<IrcCompleterPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcCompleter)
+    Q_DISABLE_COPY(IrcCompleter)
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcCompleter*))
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcCompleter::Direction))
+
+#endif // IRCCOMPLETER_H

--- a/3rdparty/communi/include/IrcUtil/irclagtimer.h
+++ b/3rdparty/communi/include/IrcUtil/irclagtimer.h
@@ -1,0 +1,78 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCLAGTIMER_H
+#define IRCLAGTIMER_H
+
+#include <IrcGlobal>
+#include <QtCore/qobject.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qscopedpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcConnection;
+class IrcLagTimerPrivate;
+
+class IRC_UTIL_EXPORT IrcLagTimer : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(qint64 lag READ lag NOTIFY lagChanged)
+    Q_PROPERTY(int interval READ interval WRITE setInterval)
+    Q_PROPERTY(IrcConnection* connection READ connection WRITE setConnection)
+
+public:
+    explicit IrcLagTimer(QObject* parent = 0);
+    virtual ~IrcLagTimer();
+
+    IrcConnection* connection() const;
+    void setConnection(IrcConnection* connection);
+
+    qint64 lag() const;
+
+    int interval() const;
+    void setInterval(int seconds);
+
+Q_SIGNALS:
+    void lagChanged(qint64 lag);
+
+private:
+    QScopedPointer<IrcLagTimerPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcLagTimer)
+    Q_DISABLE_COPY(IrcLagTimer)
+
+    Q_PRIVATE_SLOT(d_func(), void _irc_connected())
+    Q_PRIVATE_SLOT(d_func(), void _irc_pingServer())
+    Q_PRIVATE_SLOT(d_func(), void _irc_disconnected())
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcLagTimer*))
+
+#endif // IRCLAGTIMER_H

--- a/3rdparty/communi/include/IrcUtil/irclagtimer_p.h
+++ b/3rdparty/communi/include/IrcUtil/irclagtimer_p.h
@@ -1,0 +1,68 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCLAGTIMER_P_H
+#define IRCLAGTIMER_P_H
+
+#include "irclagtimer.h"
+#include "ircfilter.h"
+#include <QTimer>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcPongMessage;
+
+class IrcLagTimerPrivate : public QObject,  public IrcMessageFilter
+{
+    Q_OBJECT
+    Q_INTERFACES(IrcMessageFilter)
+    Q_DECLARE_PUBLIC(IrcLagTimer)
+
+public:
+    IrcLagTimerPrivate();
+
+    bool messageFilter(IrcMessage* msg);
+    bool processPongReply(IrcPongMessage* msg);
+
+    void _irc_connected();
+    void _irc_pingServer();
+    void _irc_disconnected();
+
+    void updateTimer();
+    void updateLag(qint64 value);
+
+    IrcLagTimer* q_ptr;
+    IrcConnection* connection;
+    QTimer timer;
+    int interval;
+    qint64 lag;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCLAGTIMER_P_H

--- a/3rdparty/communi/include/IrcUtil/ircpalette.h
+++ b/3rdparty/communi/include/IrcUtil/ircpalette.h
@@ -1,0 +1,133 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCPALETTE_H
+#define IRCPALETTE_H
+
+#include <IrcGlobal>
+#include <QtCore/qmap.h>
+#include <QtCore/qobject.h>
+#include <QtCore/qstring.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qscopedpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcPalettePrivate;
+
+class IRC_UTIL_EXPORT IrcPalette : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString white READ white WRITE setWhite)
+    Q_PROPERTY(QString black READ black WRITE setBlack)
+    Q_PROPERTY(QString blue READ blue WRITE setBlue)
+    Q_PROPERTY(QString green READ green WRITE setGreen)
+    Q_PROPERTY(QString red READ red WRITE setRed)
+    Q_PROPERTY(QString brown READ brown WRITE setBrown)
+    Q_PROPERTY(QString purple READ purple WRITE setPurple)
+    Q_PROPERTY(QString orange READ orange WRITE setOrange)
+    Q_PROPERTY(QString yellow READ yellow WRITE setYellow)
+    Q_PROPERTY(QString lightGreen READ lightGreen WRITE setLightGreen)
+    Q_PROPERTY(QString cyan READ cyan WRITE setCyan)
+    Q_PROPERTY(QString lightCyan READ lightCyan WRITE setLightCyan)
+    Q_PROPERTY(QString lightBlue READ lightBlue WRITE setLightBlue)
+    Q_PROPERTY(QString pink READ pink WRITE setPink)
+    Q_PROPERTY(QString gray READ gray WRITE setGray)
+    Q_PROPERTY(QString lightGray READ lightGray WRITE setLightGray)
+
+public:
+    ~IrcPalette();
+
+    QMap<int, QString> colorNames() const;
+    void setColorNames(const QMap<int, QString>& names);
+
+    QString colorName(int color, const QString& fallback = QLatin1String("black")) const;
+    void setColorName(int color, const QString& name);
+
+    QString white() const;
+    void setWhite(const QString& color);
+
+    QString black() const;
+    void setBlack(const QString& color);
+
+    QString blue() const;
+    void setBlue(const QString& color);
+
+    QString green() const;
+    void setGreen(const QString& color);
+
+    QString red() const;
+    void setRed(const QString& color);
+
+    QString brown() const;
+    void setBrown(const QString& color);
+
+    QString purple() const;
+    void setPurple(const QString& color);
+
+    QString orange() const;
+    void setOrange(const QString& color);
+
+    QString yellow() const;
+    void setYellow(const QString& color);
+
+    QString lightGreen() const;
+    void setLightGreen(const QString& color);
+
+    QString cyan() const;
+    void setCyan(const QString& color);
+
+    QString lightCyan() const;
+    void setLightCyan(const QString& color);
+
+    QString lightBlue() const;
+    void setLightBlue(const QString& color);
+
+    QString pink() const;
+    void setPink(const QString& color);
+
+    QString gray() const;
+    void setGray(const QString& color);
+
+    QString lightGray() const;
+    void setLightGray(const QString& color);
+
+private:
+    friend class IrcTextFormat;
+    explicit IrcPalette(QObject* parent);
+
+    QScopedPointer<IrcPalettePrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcPalette)
+    Q_DISABLE_COPY(IrcPalette)
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcPalette*))
+
+#endif // IRCPALETTE_H

--- a/3rdparty/communi/include/IrcUtil/irctextformat.h
+++ b/3rdparty/communi/include/IrcUtil/irctextformat.h
@@ -1,0 +1,90 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCTEXTFORMAT_H
+#define IRCTEXTFORMAT_H
+
+#include <IrcGlobal>
+#include <QtCore/qurl.h>
+#include <QtCore/qlist.h>
+#include <QtCore/qobject.h>
+#include <QtCore/qstring.h>
+#include <QtCore/qmetatype.h>
+#include <QtCore/qscopedpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcPalette;
+class IrcTextFormatPrivate;
+
+class IRC_UTIL_EXPORT IrcTextFormat : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(IrcPalette* palette READ palette CONSTANT)
+    Q_PROPERTY(QString urlPattern READ urlPattern WRITE setUrlPattern)
+    Q_PROPERTY(QString plainText READ plainText)
+    Q_PROPERTY(QString html READ html)
+    Q_PROPERTY(QList<QUrl> urls READ urls)
+    Q_ENUMS(SpanFormat)
+
+public:
+    explicit IrcTextFormat(QObject* parent = 0);
+    virtual ~IrcTextFormat();
+
+    IrcPalette* palette() const;
+
+    QString urlPattern() const;
+    void setUrlPattern(const QString& pattern);
+
+    enum SpanFormat { SpanStyle, SpanClass };
+
+    SpanFormat spanFormat() const;
+    void setSpanFormat(SpanFormat format);
+
+    Q_INVOKABLE QString toHtml(const QString& text) const;
+    Q_INVOKABLE QString toPlainText(const QString& text) const;
+
+    QString plainText() const;
+    QString html() const;
+    QList<QUrl> urls() const;
+
+public Q_SLOTS:
+    void parse(const QString& text);
+
+private:
+    QScopedPointer<IrcTextFormatPrivate> d_ptr;
+    Q_DECLARE_PRIVATE(IrcTextFormat)
+    Q_DISABLE_COPY(IrcTextFormat)
+};
+
+IRC_END_NAMESPACE
+
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcTextFormat*))
+Q_DECLARE_METATYPE(IRC_PREPEND_NAMESPACE(IrcTextFormat::SpanFormat))
+
+#endif // IRCTEXTFORMAT_H

--- a/3rdparty/communi/include/IrcUtil/irctoken_p.h
+++ b/3rdparty/communi/include/IrcUtil/irctoken_p.h
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCTOKEN_P_H
+#define IRCTOKEN_P_H
+
+#include "ircglobal.h"
+#include <QtCore/qlist.h>
+#include <QtCore/qstring.h>
+
+IRC_BEGIN_NAMESPACE
+
+class IrcToken
+{
+public:
+    IrcToken() : idx(-1), pos(-1) { }
+    IrcToken(int index, int position, const QString& text)
+        : idx(index), pos(position), str(text) { }
+
+    bool isValid() const { return idx != -1; }
+    int index() const { return idx; }
+    int position() const { return pos; }
+    int length() const { return str.length(); }
+    QString text() const { return str; }
+
+private:
+    int idx;
+    int pos;
+    QString str;
+    friend class IrcTokenizer;
+};
+
+class IrcTokenizer
+{
+public:
+    IrcTokenizer(const QString& str = QString());
+
+    int count() const;
+    bool isEmpty() const;
+    QList<IrcToken> tokens() const;
+    IrcToken at(int index) const;
+    IrcTokenizer mid(int index) const;
+
+    void clear();
+    void replace(int index, const QString& text);
+    IrcToken find(int pos) const;
+    QString toString() const;
+
+private:
+    int len;
+    QList<IrcToken> t;
+};
+
+IRC_END_NAMESPACE
+
+#endif // IRCTOKEN_P_H

--- a/3rdparty/communi/include/IrcUtil/ircutil.h
+++ b/3rdparty/communi/include/IrcUtil/ircutil.h
@@ -1,0 +1,47 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef IRCUTIL_H
+#define IRCUTIL_H
+
+#include "irccommandparser.h"
+#include "irccommandqueue.h"
+#include "irccompleter.h"
+#include "irclagtimer.h"
+#include "ircpalette.h"
+#include "irctextformat.h"
+
+IRC_BEGIN_NAMESPACE
+
+namespace IrcUtil {
+    IRC_UTIL_EXPORT void registerMetaTypes();
+}
+
+IRC_END_NAMESPACE
+
+#endif // IRCUTIL_H

--- a/3rdparty/communi/src/model/ircbuffer.cpp
+++ b/3rdparty/communi/src/model/ircbuffer.cpp
@@ -1,0 +1,637 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircbuffer.h"
+#include "ircbuffer_p.h"
+#include "ircbuffermodel.h"
+#include "ircbuffermodel_p.h"
+#include "ircconnection.h"
+#include "ircnetwork.h"
+#include "ircchannel.h"
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircbuffer.h
+    \brief \#include &lt;IrcBuffer&gt;
+ */
+
+/*!
+    \class IrcBuffer ircbuffer.h <IrcBuffer>
+    \ingroup models
+    \brief Keeps track of buffer status.
+
+    \sa IrcBufferModel
+*/
+
+/*!
+    \fn void IrcBuffer::messageReceived(IrcMessage* message)
+
+    This signal is emitted when a buffer specific message is received.
+
+    The message may one of the following types:
+    - IrcMessage::Away
+    - IrcMessage::Join
+    - IrcMessage::Kick
+    - IrcMessage::Mode
+    - IrcMessage::Names
+    - IrcMessage::Nick
+    - IrcMessage::Notice
+    - IrcMessage::Numeric
+    - IrcMessage::Part
+    - IrcMessage::Private
+    - IrcMessage::Quit
+    - IrcMessage::Topic
+
+    \sa IrcConnection::messageReceived(), IrcBufferModel::messageIgnored()
+ */
+
+#ifndef IRC_DOXYGEN
+IrcBufferPrivate::IrcBufferPrivate()
+    : q_ptr(0), model(0), persistent(false), sticky(false), monitorStatus(MonitorUnknown)
+{
+    qRegisterMetaType<IrcBuffer*>();
+    qRegisterMetaType<QList<IrcBuffer*> >();
+}
+
+IrcBufferPrivate::~IrcBufferPrivate()
+{
+}
+
+void IrcBufferPrivate::init(const QString& title, IrcBufferModel* m)
+{
+    name = title;
+    setModel(m);
+}
+
+void IrcBufferPrivate::connected()
+{
+    Q_Q(IrcBuffer);
+    emit q->activeChanged(q->isActive());
+}
+
+void IrcBufferPrivate::disconnected()
+{
+    Q_Q(IrcBuffer);
+    emit q->activeChanged(q->isActive());
+}
+
+void IrcBufferPrivate::setName(const QString& value)
+{
+    Q_Q(IrcBuffer);
+    if (name != value) {
+        const QString oldTitle = q->title();
+        name = value;
+        emit q->nameChanged(name);
+        emit q->titleChanged(q->title());
+        if (model)
+            IrcBufferModelPrivate::get(model)->renameBuffer(oldTitle, q->title());
+    }
+}
+
+void IrcBufferPrivate::setPrefix(const QString& value)
+{
+    Q_Q(IrcBuffer);
+    if (prefix != value) {
+        const QString oldTitle = q->title();
+        prefix = value;
+        emit q->prefixChanged(prefix);
+        emit q->titleChanged(q->title());
+        if (model)
+            IrcBufferModelPrivate::get(model)->renameBuffer(oldTitle, q->title());
+    }
+}
+
+void IrcBufferPrivate::setModel(IrcBufferModel* value)
+{
+    model = value;
+}
+
+void IrcBufferPrivate::setMonitorStatus(MonitorStatus status)
+{
+    Q_Q(IrcBuffer);
+    if (monitorStatus != status) {
+        bool wasActive = q->isActive();
+        monitorStatus = status;
+        bool isActive = q->isActive();
+        if (wasActive != isActive)
+            emit q->activeChanged(isActive);
+    }
+}
+
+bool IrcBufferPrivate::isMonitorable() const
+{
+    Q_Q(const IrcBuffer);
+    IrcNetwork* n = q->network();
+    IrcConnection* c = q->connection();
+    if (!sticky && !name.startsWith(QLatin1String("*")) && c && c->isConnected() && n && n->numericLimit(IrcNetwork::MonitorCount) >= 0 && !n->isChannel(q->title()))
+        return true;
+    return false;
+}
+
+bool IrcBufferPrivate::processMessage(IrcMessage* message)
+{
+    Q_Q(IrcBuffer);
+    bool processed = false;
+    switch (message->type()) {
+    case IrcMessage::Away:
+        processed = processAwayMessage(static_cast<IrcAwayMessage*>(message));
+        break;
+    case IrcMessage::Join:
+        processed = processJoinMessage(static_cast<IrcJoinMessage*>(message));
+        break;
+    case IrcMessage::Kick:
+        processed = processKickMessage(static_cast<IrcKickMessage*>(message));
+        break;
+    case IrcMessage::Mode:
+        processed = processModeMessage(static_cast<IrcModeMessage*>(message));
+        break;
+    case IrcMessage::Names:
+        processed = processNamesMessage(static_cast<IrcNamesMessage*>(message));
+        break;
+    case IrcMessage::Nick:
+        processed = processNickMessage(static_cast<IrcNickMessage*>(message));
+        break;
+    case IrcMessage::Notice:
+        processed = processNoticeMessage(static_cast<IrcNoticeMessage*>(message));
+        break;
+    case IrcMessage::Numeric:
+        processed = processNumericMessage(static_cast<IrcNumericMessage*>(message));
+        break;
+    case IrcMessage::Part:
+        processed = processPartMessage(static_cast<IrcPartMessage*>(message));
+        break;
+    case IrcMessage::Private:
+        processed = processPrivateMessage(static_cast<IrcPrivateMessage*>(message));
+        if (processed) {
+            activity = message->timeStamp();
+            IrcBufferModelPrivate::get(model)->promoteBuffer(q);
+        }
+        break;
+    case IrcMessage::Quit:
+        processed = processQuitMessage(static_cast<IrcQuitMessage*>(message));
+        break;
+    case IrcMessage::Topic:
+        processed = processTopicMessage(static_cast<IrcTopicMessage*>(message));
+        break;
+    case IrcMessage::WhoReply:
+        processed = processWhoReplyMessage(static_cast<IrcWhoReplyMessage*>(message));
+        break;
+    default:
+        break;
+    }
+    if (processed)
+        emit q->messageReceived(message);
+    return processed;
+}
+
+bool IrcBufferPrivate::processAwayMessage(IrcAwayMessage* message)
+{
+    return !message->nick().compare(name, Qt::CaseInsensitive);
+}
+
+bool IrcBufferPrivate::processJoinMessage(IrcJoinMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processKickMessage(IrcKickMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processModeMessage(IrcModeMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processNamesMessage(IrcNamesMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processNickMessage(IrcNickMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback) && !message->nick().compare(name, Qt::CaseInsensitive)) {
+        setName(message->newNick());
+        return true;
+    }
+    return !message->newNick().compare(name, Qt::CaseInsensitive);
+}
+
+bool IrcBufferPrivate::processNoticeMessage(IrcNoticeMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processNumericMessage(IrcNumericMessage* message)
+{
+    if (message->code() == Irc::RPL_MONONLINE)
+        setMonitorStatus(MonitorOnline);
+    else if (message->code() == Irc::RPL_MONOFFLINE)
+        setMonitorStatus(MonitorOffline);
+    return message->isImplicit();
+}
+
+bool IrcBufferPrivate::processPartMessage(IrcPartMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processPrivateMessage(IrcPrivateMessage* message)
+{
+    Q_UNUSED(message);
+    return true;
+}
+
+bool IrcBufferPrivate::processQuitMessage(IrcQuitMessage* message)
+{
+    return !message->nick().compare(name, Qt::CaseInsensitive);
+}
+
+bool IrcBufferPrivate::processTopicMessage(IrcTopicMessage* message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+
+bool IrcBufferPrivate::processWhoReplyMessage(IrcWhoReplyMessage *message)
+{
+    Q_UNUSED(message);
+    return false;
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new buffer object with \a parent.
+ */
+IrcBuffer::IrcBuffer(QObject* parent)
+    : QObject(parent), d_ptr(new IrcBufferPrivate)
+{
+    Q_D(IrcBuffer);
+    d->q_ptr = this;
+}
+
+/*!
+    \internal
+ */
+IrcBuffer::IrcBuffer(IrcBufferPrivate& dd, QObject* parent)
+    : QObject(parent), d_ptr(&dd)
+{
+    Q_D(IrcBuffer);
+    d->q_ptr = this;
+}
+
+/*!
+    Destructs the buffer object.
+ */
+IrcBuffer::~IrcBuffer()
+{
+    emit destroyed(this);
+}
+
+/*!
+    This property holds the whole buffer title.
+
+    The title consists of \ref prefix and \ref name.
+
+    \par Access function:
+    \li QString <b>title</b>() const
+
+    \par Notifier signal:
+    \li void <b>titleChanged</b>(const QString& title)
+ */
+QString IrcBuffer::title() const
+{
+    Q_D(const IrcBuffer);
+    return d->prefix + d->name;
+}
+
+/*!
+    This property holds the name part of the buffer \ref title.
+
+    \par Access functions:
+    \li QString <b>name</b>() const
+    \li void <b>setName</b>(const QString& name) [slot]
+
+    \par Notifier signal:
+    \li void <b>nameChanged</b>(const QString& name)
+ */
+QString IrcBuffer::name() const
+{
+    Q_D(const IrcBuffer);
+    return d->name;
+}
+
+void IrcBuffer::setName(const QString& name)
+{
+    Q_D(IrcBuffer);
+    d->setName(name);
+}
+
+/*!
+    This property holds the prefix part of the buffer \ref title.
+
+    \par Access functions:
+    \li QString <b>prefix</b>() const
+    \li void <b>setPrefix</b>(const QString& prefix) [slot]
+
+    \par Notifier signal:
+    \li void <b>prefixChanged</b>(const QString& prefix)
+ */
+QString IrcBuffer::prefix() const
+{
+    Q_D(const IrcBuffer);
+    return d->prefix;
+}
+
+void IrcBuffer::setPrefix(const QString& prefix)
+{
+    Q_D(IrcBuffer);
+    return d->setPrefix(prefix);
+}
+
+/*!
+    \property bool IrcBuffer::channel
+    This property holds whether the buffer is a channel.
+
+    \par Access function:
+    \li bool <b>isChannel</b>() const
+
+    \sa toChannel()
+ */
+bool IrcBuffer::isChannel() const
+{
+    return qobject_cast<const IrcChannel*>(this);
+}
+
+/*!
+    Returns the buffer cast to a IrcChannel,
+    if the class is actually a channel, \c 0 otherwise.
+
+    \sa \ref channel "isChannel()"
+*/
+IrcChannel* IrcBuffer::toChannel()
+{
+    return qobject_cast<IrcChannel*>(this);
+}
+
+/*!
+    This property holds the connection of the buffer.
+
+    \par Access function:
+    \li \ref IrcConnection* <b>connection</b>() const
+ */
+IrcConnection* IrcBuffer::connection() const
+{
+    Q_D(const IrcBuffer);
+    return d->model ? d->model->connection() : 0;
+}
+
+/*!
+    This property holds the network of the buffer.
+
+    \par Access function:
+    \li \ref IrcNetwork* <b>network</b>() const
+ */
+IrcNetwork* IrcBuffer::network() const
+{
+    Q_D(const IrcBuffer);
+    return d->model ? d->model->network() : 0;
+}
+
+/*!
+    This property holds the model of the buffer.
+
+    \par Access function:
+    \li \ref IrcBufferModel* <b>model</b>() const
+ */
+IrcBufferModel* IrcBuffer::model() const
+{
+    Q_D(const IrcBuffer);
+    return d->model;
+}
+
+/*!
+    \property bool IrcBuffer::active
+    This property holds whether the buffer is active.
+
+    A buffer is considered active when a %connection is established. Furthermore,
+    channel buffers are only considered active when the user is on the channel.
+
+    \par Access function:
+    \li bool <b>isActive</b>() const
+
+    \par Notifier signal:
+    \li void <b>activeChanged</b>(bool active)
+
+    \sa IrcConnection::connected
+ */
+bool IrcBuffer::isActive() const
+{
+    Q_D(const IrcBuffer);
+    bool connected = false;
+    if (IrcConnection* c = connection())
+        connected = c->isConnected();
+    bool monitor = false;
+    if (d->model)
+        monitor = d->model->isMonitorEnabled();
+    return connected && (!monitor || !d->isMonitorable() || d->monitorStatus == IrcBufferPrivate::MonitorOnline);
+}
+
+/*!
+    \property bool IrcBuffer::sticky
+    This property holds whether the buffer is sticky.
+
+    A sticky buffer stays in the beginning (Qt::AscendingOrder) or
+    end (Qt::DescendingOrder) of the list of buffers in IrcBufferModel.
+
+    The default value is \c false.
+
+    \par Access functions:
+    \li bool <b>isSticky</b>() const
+    \li void <b>setSticky</b>(bool sticky)
+
+    \par Notifier signal:
+    \li void <b>stickyChanged</b>(bool sticky)
+ */
+
+bool IrcBuffer::isSticky() const
+{
+    Q_D(const IrcBuffer);
+    return d->sticky;
+}
+
+void IrcBuffer::setSticky(bool sticky)
+{
+    Q_D(IrcBuffer);
+    if (d->sticky != sticky) {
+        d->sticky = sticky;
+        emit stickyChanged(sticky);
+    }
+}
+
+/*!
+    \property bool IrcBuffer::persistent
+    This property holds whether the buffer is persistent.
+
+    The default value is \c false.
+
+    A persistent buffer does not get removed and destructed
+    when calling IrcBufferModel::clear(), or when when leaving
+    the corresponding channel. In order to remove a persistent
+    buffer, either explicitly call IrcBufferModel::remove() or
+    delete the buffer.
+
+    \par Access functions:
+    \li bool <b>isPersistent</b>() const
+    \li void <b>setPersistent</b>(bool persistent)
+
+    \par Notifier signal:
+    \li void <b>persistentChanged</b>(bool persistent)
+ */
+
+bool IrcBuffer::isPersistent() const
+{
+    Q_D(const IrcBuffer);
+    return d->persistent;
+}
+
+void IrcBuffer::setPersistent(bool persistent)
+{
+    Q_D(IrcBuffer);
+    if (d->persistent != persistent) {
+        d->persistent = persistent;
+        emit persistentChanged(persistent);
+    }
+}
+
+/*!
+    \since 3.1
+
+    This property holds arbitrary user data.
+
+    \par Access functions:
+    \li QVariantMap <b>userData</b>() const
+    \li void <b>setUserData</b>(const QVariantMap& data)
+
+    \par Notifier signal:
+    \li void <b>userDataChanged</b>(const QVariantMap& data)
+ */
+QVariantMap IrcBuffer::userData() const
+{
+    Q_D(const IrcBuffer);
+    return d->userData;
+}
+
+void IrcBuffer::setUserData(const QVariantMap& data)
+{
+    Q_D(IrcBuffer);
+    if (d->userData != data) {
+        d->userData = data;
+        emit userDataChanged(data);
+    }
+}
+
+/*!
+    Sends a \a command to the server.
+
+    This method is provided for convenience. It is equal to:
+    \code
+    IrcConnection* connection = buffer->connection();
+    connection->sendCommand(command);
+    \endcode
+
+    \sa IrcConnection::sendCommand()
+ */
+bool IrcBuffer::sendCommand(IrcCommand* command)
+{
+    if (IrcConnection* c = connection())
+        return c->sendCommand(command);
+    return false;
+}
+
+/*!
+    Emits messageReceived() with \a message.
+
+    IrcBufferModel handles only buffer specific messages and delivers them
+    to the appropriate IrcBuffer instances. When applications decide to handle
+    IrcBuffer::messageReceived(), IrcBufferModel::messageIgnored() makes it
+    easy to implement handling for the rest, non-buffer specific messages.
+    This method can be used to forward such ignored messages to the desired
+    buffers (for instance the one that is currently active in the GUI).
+ */
+void IrcBuffer::receiveMessage(IrcMessage* message)
+{
+    if (message)
+        emit messageReceived(message);
+}
+
+/*!
+    \since 3.1
+
+    Closes the buffer with an optional \a reason.
+
+    The default implementation removes the buffer from its \ref model.
+    Furthermore, IrcChannel parts the channel with \a reason and custom
+    IrcBuffer subclasses might do some additional tasks.
+
+    \sa IrcChannel::close()
+ */
+void IrcBuffer::close(const QString& reason)
+{
+    Q_UNUSED(reason);
+    Q_D(const IrcBuffer);
+    if (d->model)
+        d->model->remove(this);
+}
+
+#ifndef QT_NO_DEBUG_STREAM
+QDebug operator<<(QDebug debug, const IrcBuffer* buffer)
+{
+    if (!buffer)
+        return debug << "IrcBuffer(0x0) ";
+    debug.nospace() << buffer->metaObject()->className() << '(' << (void*) buffer;
+    if (!buffer->objectName().isEmpty())
+        debug.nospace() << ", name=" << qPrintable(buffer->objectName());
+    if (!buffer->title().isEmpty())
+        debug.nospace() << ", title=" << qPrintable(buffer->title());
+    debug.nospace() << ')';
+    return debug.space();
+}
+#endif // QT_NO_DEBUG_STREAM
+
+#include "moc_ircbuffer.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/model/ircbuffermodel.cpp
+++ b/3rdparty/communi/src/model/ircbuffermodel.cpp
@@ -1,0 +1,1358 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircbuffermodel.h"
+#include "ircbuffermodel_p.h"
+#include "ircchannel_p.h"
+#include "ircbuffer_p.h"
+#include "ircnetwork.h"
+#include "ircchannel.h"
+#include "ircmessage.h"
+#include "irccommand.h"
+#include "ircconnection.h"
+#include <qmetatype.h>
+#include <qmetaobject.h>
+#include <qdatastream.h>
+#include <qvariant.h>
+#include <qtimer.h>
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircbuffermodel.h
+    \brief \#include &lt;IrcBufferModel&gt;
+ */
+
+/*!
+    \class IrcBufferModel ircbuffermodel.h <IrcBufferModel>
+    \ingroup models
+    \brief Keeps track of buffers.
+
+    IrcBufferModel automatically keeps track of channel and query buffers
+    and manages IrcBuffer instances for them. It will notify via signals
+    when channel and query buffers are added and/or removed. IrcBufferModel
+    can be used directly as a data model for Qt's item views - both in C++
+    and QML.
+
+    \code
+    IrcConnection* connection = new IrcConnection(this);
+    IrcBufferModel* model = new IrcBufferModel(connection);
+    connect(model, SIGNAL(added(IrcBuffer*)), this, SLOT(onBufferAdded(IrcBuffer*)));
+    connect(model, SIGNAL(removed(IrcBuffer*)), this, SLOT(onBufferRemoved(IrcBuffer*)));
+    listView->setModel(model);
+    \endcode
+ */
+
+/*!
+    \fn void IrcBufferModel::added(IrcBuffer* buffer)
+
+    This signal is emitted when a \a buffer is added to the list of buffers.
+ */
+
+/*!
+    \fn void IrcBufferModel::removed(IrcBuffer* buffer)
+
+    This signal is emitted when a \a buffer is removed from the list of buffers.
+ */
+
+/*!
+    \fn void IrcBufferModel::aboutToBeAdded(IrcBuffer* buffer)
+
+    This signal is emitted just before a \a buffer is added to the list of buffers.
+ */
+
+/*!
+    \fn void IrcBufferModel::aboutToBeRemoved(IrcBuffer* buffer)
+
+    This signal is emitted just before a \a buffer is removed from the list of buffers.
+ */
+
+/*!
+    \fn void IrcBufferModel::messageIgnored(IrcMessage* message)
+
+    This signal is emitted when a message was ignored.
+
+    IrcBufferModel handles only buffer specific messages and delivers
+    them to the appropriate IrcBuffer instances. When applications decide
+    to handle IrcBuffer::messageReceived(), this signal makes it easy to
+    implement handling for the rest, non-buffer specific messages.
+
+    \sa IrcConnection::messageReceived(), IrcBuffer::messageReceived()
+ */
+
+#ifndef IRC_DOXYGEN
+class IrcBufferLessThan
+{
+public:
+    IrcBufferLessThan(IrcBufferModel* model, Irc::SortMethod method) : model(model), method(method) { }
+    bool operator()(IrcBuffer* b1, IrcBuffer* b2) const { return model->lessThan(b1, b2, method); }
+private:
+    IrcBufferModel* model;
+    Irc::SortMethod method;
+};
+
+class IrcBufferGreaterThan
+{
+public:
+    IrcBufferGreaterThan(IrcBufferModel* model, Irc::SortMethod method) : model(model), method(method) { }
+    bool operator()(IrcBuffer* b1, IrcBuffer* b2) const { return model->lessThan(b2, b1, method); }
+private:
+    IrcBufferModel* model;
+    Irc::SortMethod method;
+};
+
+IrcBufferModelPrivate::IrcBufferModelPrivate() : q_ptr(0), role(Irc::TitleRole),
+    sortMethod(Irc::SortByHand), sortOrder(Qt::AscendingOrder),
+    bufferProto(0), channelProto(0), persistent(false), joinDelay(0),
+    monitorEnabled(false), monitorPending(false)
+{
+}
+
+bool IrcBufferModelPrivate::messageFilter(IrcMessage* msg)
+{
+    Q_Q(IrcBufferModel);
+    if (msg->type() == IrcMessage::Join && msg->isOwn())
+        createBuffer(static_cast<IrcJoinMessage*>(msg)->channel());
+
+    bool processed = false;
+    switch (msg->type()) {
+        case IrcMessage::Away:
+        case IrcMessage::Nick:
+        case IrcMessage::Quit:
+            foreach (IrcBuffer* buffer, bufferList) {
+                if (buffer->isActive())
+                    IrcBufferPrivate::get(buffer)->processMessage(msg);
+            }
+            if (msg->type() != IrcMessage::Away || !msg->isOwn())
+                processed = true;
+            break;
+
+        case IrcMessage::Join:
+        case IrcMessage::Part:
+        case IrcMessage::Kick:
+        case IrcMessage::Names:
+        case IrcMessage::Topic:
+            processed = processMessage(msg->property("channel").toString(), msg);
+            break;
+
+        case IrcMessage::WhoReply:
+            processed = processMessage(static_cast<IrcWhoReplyMessage*>(msg)->mask(), msg);
+            break;
+
+        case IrcMessage::Private:
+            if (IrcPrivateMessage* pm = static_cast<IrcPrivateMessage*>(msg))
+                processed = !pm->isRequest() && processMessage(pm->isPrivate() ? pm->nick() : pm->target(), pm, true);
+            break;
+
+        case IrcMessage::Notice:
+            if (IrcNoticeMessage* no = static_cast<IrcNoticeMessage*>(msg))
+                processed = !no->isReply() && processMessage(no->isPrivate() ? no->nick() : no->target(), no);
+            break;
+
+        case IrcMessage::Mode:
+            processed = processMessage(static_cast<IrcModeMessage*>(msg)->target(), msg);
+            break;
+
+        case IrcMessage::Numeric:
+            // TODO: any other special cases besides RPL_NAMREPLY?
+            if (static_cast<IrcNumericMessage*>(msg)->code() == Irc::RPL_NAMREPLY) {
+                const int count = msg->parameters().count();
+                const QString channel = msg->parameters().value(count - 2);
+                processed = processMessage(channel, msg);
+            } else if (static_cast<IrcNumericMessage*>(msg)->code() == Irc::RPL_MONONLINE ||
+                       static_cast<IrcNumericMessage*>(msg)->code() == Irc::RPL_MONOFFLINE) {
+                msg->setFlag(IrcMessage::Implicit);
+                foreach (const QString& target, msg->parameters().value(1).split(QLatin1String(",")))
+                    processed |= processMessage(Irc::nickFromPrefix(target), msg);
+            } else {
+                processed = processMessage(msg->parameters().value(1), msg);
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    if (!processed)
+        emit q->messageIgnored(msg);
+
+    if (!msg->testFlag(IrcMessage::Playback)) {
+        if (msg->type() == IrcMessage::Part && msg->isOwn()) {
+            destroyBuffer(static_cast<IrcPartMessage*>(msg)->channel());
+        } else if (msg->type() == IrcMessage::Kick) {
+            const IrcKickMessage* kickMsg = static_cast<IrcKickMessage*>(msg);
+            if (!kickMsg->user().compare(msg->connection()->nickName(), Qt::CaseInsensitive))
+                destroyBuffer(kickMsg->channel());
+        }
+    }
+    return false;
+}
+
+bool IrcBufferModelPrivate::commandFilter(IrcCommand* cmd)
+{
+    if (cmd->type() == IrcCommand::Join) {
+        const QString channel = cmd->parameters().value(0).toLower();
+        const QString key = cmd->parameters().value(1);
+        if (!key.isEmpty())
+            keys.insert(channel, key);
+        else
+            keys.remove(channel);
+    }
+    return false;
+}
+
+IrcBuffer* IrcBufferModelPrivate::createBufferHelper(const QString& title)
+{
+    Q_Q(IrcBufferModel);
+    IrcBuffer* buffer = 0;
+    const QMetaObject* metaObject = q->metaObject();
+    int idx = metaObject->indexOfMethod("createBuffer(QVariant)");
+    if (idx != -1) {
+        // QML: QVariant createBuffer(QVariant)
+        QVariant ret;
+        QMetaMethod method = metaObject->method(idx);
+        method.invoke(q, Q_RETURN_ARG(QVariant, ret), Q_ARG(QVariant, title));
+        buffer = ret.value<IrcBuffer*>();
+    } else {
+        // C++: IrcBuffer* createBuffer(QString)
+        idx = metaObject->indexOfMethod("createBuffer(QString)");
+        QMetaMethod method = metaObject->method(idx);
+        method.invoke(q, Q_RETURN_ARG(IrcBuffer*, buffer), Q_ARG(QString, title));
+    }
+    return buffer;
+}
+
+IrcChannel* IrcBufferModelPrivate::createChannelHelper(const QString& title)
+{
+    Q_Q(IrcBufferModel);
+    IrcChannel* channel = 0;
+    const QMetaObject* metaObject = q->metaObject();
+    int idx = metaObject->indexOfMethod("createChannel(QVariant)");
+    if (idx != -1) {
+        // QML: QVariant createChannel(QVariant)
+        QVariant ret;
+        QMetaMethod method = metaObject->method(idx);
+        method.invoke(q, Q_RETURN_ARG(QVariant, ret), Q_ARG(QVariant, title));
+        channel = ret.value<IrcChannel*>();
+    } else {
+        // C++: IrcChannel* createChannel(QString)
+        idx = metaObject->indexOfMethod("createChannel(QString)");
+        QMetaMethod method = metaObject->method(idx);
+        method.invoke(q, Q_RETURN_ARG(IrcChannel*, channel), Q_ARG(QString, title));
+    }
+    return channel;
+}
+
+IrcBuffer* IrcBufferModelPrivate::createBuffer(const QString& title)
+{
+    Q_Q(IrcBufferModel);
+    IrcBuffer* buffer = bufferMap.value(title.toLower());
+    if (!buffer) {
+        if (connection && connection->network()->isChannel(title))
+            buffer = createChannelHelper(title);
+        else
+            buffer = createBufferHelper(title);
+        if (buffer) {
+            IrcBufferPrivate::get(buffer)->init(title, q);
+            addBuffer(buffer);
+        }
+    }
+    return buffer;
+}
+
+void IrcBufferModelPrivate::destroyBuffer(const QString& title, bool force)
+{
+    IrcBuffer* buffer = bufferMap.value(title.toLower());
+    if (buffer && (force || (!persistent && !buffer->isPersistent()))) {
+        removeBuffer(buffer);
+        buffer->deleteLater();
+    }
+}
+
+void IrcBufferModelPrivate::addBuffer(IrcBuffer* buffer, bool notify)
+{
+    insertBuffer(-1, buffer, notify);
+}
+
+void IrcBufferModelPrivate::insertBuffer(int index, IrcBuffer* buffer, bool notify)
+{
+    Q_Q(IrcBufferModel);
+    if (buffer && !bufferList.contains(buffer)) {
+        restoreBuffer(buffer);
+        const QString title = buffer->title();
+        const QString lower = title.toLower();
+        if (bufferMap.contains(lower)) {
+            qWarning() << "IrcBufferModel: ignored duplicate buffer" << title;
+            return;
+        }
+        IrcBufferPrivate::get(buffer)->setModel(q);
+        const bool isChannel = buffer->isChannel();
+        if (sortMethod != Irc::SortByHand) {
+            QList<IrcBuffer*>::iterator it;
+            if (sortOrder == Qt::AscendingOrder)
+                it = qUpperBound(bufferList.begin(), bufferList.end(), buffer, IrcBufferLessThan(q, sortMethod));
+            else
+                it = qUpperBound(bufferList.begin(), bufferList.end(), buffer, IrcBufferGreaterThan(q, sortMethod));
+            index = it - bufferList.begin();
+        } else if (index == -1) {
+            index = bufferList.count();
+        }
+        if (notify)
+            emit q->aboutToBeAdded(buffer);
+        q->beginInsertRows(QModelIndex(), index, index);
+        bufferList.insert(index, buffer);
+        bufferMap.insert(lower, buffer);
+        if (isChannel) {
+            channels += title;
+            IrcChannel* channel = buffer->toChannel();
+            if (keys.contains(lower) && channel->key().isEmpty())
+                IrcChannelPrivate::get(channel)->setKey(keys.take(lower));
+        }
+        q->connect(buffer, SIGNAL(destroyed(IrcBuffer*)), SLOT(_irc_bufferDestroyed(IrcBuffer*)));
+        q->endInsertRows();
+        if (notify) {
+            emit q->added(buffer);
+            if (isChannel)
+                emit q->channelsChanged(channels);
+            emit q->buffersChanged(bufferList);
+            emit q->countChanged(bufferList.count());
+            if (bufferList.count() == 1)
+                emit q->emptyChanged(false);
+        }
+        if (monitorEnabled && IrcBufferPrivate::get(buffer)->isMonitorable()) {
+            connection->sendCommand(IrcCommand::createMonitor("+", buffer->title()));
+            if (!monitorPending) {
+                monitorPending = true;
+                QTimer::singleShot(1000, q, SLOT(_irc_monitorStatus()));
+            }
+        }
+    }
+}
+
+void IrcBufferModelPrivate::removeBuffer(IrcBuffer* buffer, bool notify)
+{
+    Q_Q(IrcBufferModel);
+    int idx = bufferList.indexOf(buffer);
+    if (idx != -1) {
+        const QString title = buffer->title();
+        const QString lower = title.toLower();
+        const bool isChannel = buffer->isChannel();
+        if (notify)
+            emit q->aboutToBeRemoved(buffer);
+        q->beginRemoveRows(QModelIndex(), idx, idx);
+        bufferList.removeAt(idx);
+        bufferMap.remove(lower);
+        bufferStates.remove(lower);
+        if (isChannel)
+            channels.removeOne(title);
+        q->endRemoveRows();
+        if (notify) {
+            emit q->removed(buffer);
+            if (isChannel)
+                emit q->channelsChanged(channels);
+            emit q->buffersChanged(bufferList);
+            emit q->countChanged(bufferList.count());
+            if (bufferList.isEmpty())
+                emit q->emptyChanged(true);
+        }
+        if (monitorEnabled && IrcBufferPrivate::get(buffer)->isMonitorable())
+            connection->sendCommand(IrcCommand::createMonitor("-", title));
+    }
+}
+
+bool IrcBufferModelPrivate::renameBuffer(const QString& from, const QString& to)
+{
+    Q_Q(IrcBufferModel);
+    const QString fromLower = from.toLower();
+    const QString toLower = to.toLower();
+    if (bufferMap.contains(toLower))
+        destroyBuffer(toLower, true);
+    if (bufferMap.contains(fromLower)) {
+        IrcBuffer* buffer = bufferMap.take(fromLower);
+        bufferMap.insert(toLower, buffer);
+
+        const int idx = bufferList.indexOf(buffer);
+        QModelIndex index = q->index(idx);
+        emit q->dataChanged(index, index);
+
+        if (sortMethod != Irc::SortByHand) {
+            QList<IrcBuffer*> buffers = bufferList;
+            const bool notify = false;
+            removeBuffer(buffer, notify);
+            insertBuffer(-1, buffer, notify);
+            if (buffers != bufferList)
+                emit q->buffersChanged(bufferList);
+        }
+        return true;
+    }
+    return false;
+}
+
+void IrcBufferModelPrivate::promoteBuffer(IrcBuffer* buffer)
+{
+    Q_Q(IrcBufferModel);
+    if (sortMethod == Irc::SortByActivity) {
+        const bool notify = false;
+        removeBuffer(buffer, notify);
+        insertBuffer(0, buffer, notify);
+        emit q->buffersChanged(bufferList);
+    }
+}
+
+void IrcBufferModelPrivate::restoreBuffer(IrcBuffer* buffer)
+{
+    const QVariantMap& b = bufferStates.value(buffer->title().toLower()).toMap();
+    if (!b.isEmpty()) {
+        buffer->setSticky(b.value("sticky").toBool());
+        buffer->setPersistent(b.value("persistent").toBool());
+        buffer->setUserData(b.value("userData").toMap());
+        IrcChannel* channel = buffer->toChannel();
+        if (channel && !channel->isActive()) {
+            IrcChannelPrivate* p = IrcChannelPrivate::get(channel);
+            const QStringList modes = b.value("modes").toStringList();
+            const QStringList args = b.value("args").toStringList();
+            for (int i = 0; i < modes.count(); ++i)
+                p->modes.insert(modes.at(i), args.value(i));
+            p->enabled = b.value("enabled", true).toBool();
+        }
+    }
+}
+
+QVariantMap IrcBufferModelPrivate::saveBuffer(IrcBuffer* buffer) const
+{
+    QVariantMap b;
+    b.insert("title", buffer->title());
+    b.insert("name", buffer->name());
+    b.insert("prefix", buffer->prefix());
+    if (IrcChannel* channel = buffer->toChannel()) {
+        IrcChannelPrivate* p = IrcChannelPrivate::get(channel);
+        b.insert("modes", QStringList(p->modes.keys()));
+        b.insert("args", QStringList(p->modes.values()));
+        b.insert("topic", channel->topic());
+        b.insert("enabled", p->enabled);
+    }
+    b.insert("channel", buffer->isChannel());
+    b.insert("sticky", buffer->isSticky());
+    b.insert("persistent", buffer->isPersistent());
+    b.insert("userData", buffer->userData());
+    return b;
+}
+
+bool IrcBufferModelPrivate::processMessage(const QString& title, IrcMessage* message, bool create)
+{
+    IrcBuffer* buffer = bufferMap.value(title.toLower());
+    if (!buffer && create && title != QLatin1String("*"))
+        buffer = createBuffer(title);
+    if (buffer)
+        return IrcBufferPrivate::get(buffer)->processMessage(message);
+    return false;
+}
+
+void IrcBufferModelPrivate::_irc_connected()
+{
+    foreach (IrcBuffer* buffer, bufferList)
+        IrcBufferPrivate::get(buffer)->connected();
+}
+
+void IrcBufferModelPrivate::_irc_initialized()
+{
+    Q_Q(IrcBufferModel);
+    if (joinDelay >= 0)
+        QTimer::singleShot(joinDelay * 1000, q, SLOT(_irc_restoreBuffers()));
+
+    bool monitored = false;
+    foreach (IrcBuffer* buffer, bufferList) {
+        if (monitorEnabled && IrcBufferPrivate::get(buffer)->isMonitorable()) {
+            connection->sendCommand(IrcCommand::createMonitor("+", buffer->title()));
+            monitored = true;
+        }
+    }
+
+    if (monitored && !monitorPending) {
+        monitorPending = true;
+        QTimer::singleShot(1000, q, SLOT(_irc_monitorStatus()));
+    }
+}
+
+void IrcBufferModelPrivate::_irc_disconnected()
+{
+    foreach (IrcBuffer* buffer, bufferList)
+        IrcBufferPrivate::get(buffer)->disconnected();
+}
+
+void IrcBufferModelPrivate::_irc_bufferDestroyed(IrcBuffer* buffer)
+{
+    removeBuffer(buffer);
+}
+
+void IrcBufferModelPrivate::_irc_restoreBuffers()
+{
+    Q_Q(IrcBufferModel);
+    if (!connection || !connection->isConnected())
+        return;
+
+    bool hasActiveChannels = false;
+    foreach (IrcBuffer* buffer, bufferList) {
+        if (buffer->isChannel() && buffer->isActive()) {
+            // this is probably a bouncer connection if there are already
+            // active channels. don't restore and re-join channels that were
+            // left in another client meanwhile this client was disconnected.
+            hasActiveChannels = true;
+        }
+    }
+
+    if (!hasActiveChannels) {
+        foreach (const QVariant& v, bufferStates) {
+            QVariantMap b = v.toMap();
+            IrcBuffer* buffer = q->find(b.value("title").toString());
+            if (!buffer) {
+                if (b.value("channel").toBool())
+                    buffer = createChannelHelper(b.value("title").toString());
+                else
+                    buffer = createBufferHelper(b.value("title").toString());
+                buffer->setName(b.value("name").toString());
+                buffer->setPrefix(b.value("prefix").toString());
+                q->add(buffer);
+            }
+        }
+
+        QStringList chans, keys;
+        foreach (IrcBuffer* buffer, bufferList) {
+            IrcChannel* channel = buffer->toChannel();
+            if (channel && !channel->isActive()) {
+                IrcChannelPrivate* p = IrcChannelPrivate::get(channel);
+                if (p->enabled) {
+                    chans += channel->title();
+                    keys += channel->key();
+                    p->enabled = true;
+                }
+            }
+            if (chans.length() == 3) {
+                connection->sendCommand(IrcCommand::createJoin(chans, keys));
+                chans.clear();
+                keys.clear();
+            }
+        }
+        if (!chans.isEmpty())
+            connection->sendCommand(IrcCommand::createJoin(chans, keys));
+    }
+}
+
+void IrcBufferModelPrivate::_irc_monitorStatus()
+{
+    if (monitorEnabled && connection)
+        connection->sendCommand(IrcCommand::createMonitor("S"));
+    monitorPending = false;
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new model with \a parent.
+
+    \note If \a parent is an instance of IrcConnection, it will be
+    automatically assigned to \ref IrcBufferModel::connection "connection".
+ */
+IrcBufferModel::IrcBufferModel(QObject* parent)
+    : QAbstractListModel(parent), d_ptr(new IrcBufferModelPrivate)
+{
+    Q_D(IrcBufferModel);
+    d->q_ptr = this;
+    setBufferPrototype(new IrcBuffer(this));
+    setChannelPrototype(new IrcChannel(this));
+    setConnection(qobject_cast<IrcConnection*>(parent));
+}
+
+/*!
+    Destructs the model.
+ */
+IrcBufferModel::~IrcBufferModel()
+{
+    Q_D(IrcBufferModel);
+    foreach (IrcBuffer* buffer, d->bufferList) {
+        buffer->disconnect(this);
+        delete buffer;
+    }
+    d->bufferList.clear();
+    d->bufferMap.clear();
+    d->channels.clear();
+    emit destroyed(this);
+}
+
+/*!
+    This property holds the connection.
+
+    \par Access functions:
+    \li \ref IrcConnection* <b>connection</b>() const
+    \li void <b>setConnection</b>(\ref IrcConnection* connection)
+
+    \warning Changing the connection on the fly is not supported.
+ */
+IrcConnection* IrcBufferModel::connection() const
+{
+    Q_D(const IrcBufferModel);
+    return d->connection;
+}
+
+void IrcBufferModel::setConnection(IrcConnection* connection)
+{
+    Q_D(IrcBufferModel);
+    if (d->connection != connection) {
+        if (d->connection) {
+            qCritical("IrcBufferModel::setConnection(): changing the connection on the fly is not supported.");
+            return;
+        }
+        d->connection = connection;
+        d->connection->installMessageFilter(d);
+        d->connection->installCommandFilter(d);
+        connect(d->connection, SIGNAL(connected()), this, SLOT(_irc_connected()));
+        connect(d->connection, SIGNAL(disconnected()), this, SLOT(_irc_disconnected()));
+        connect(d->connection->network(), SIGNAL(initialized()), this, SLOT(_irc_initialized()));
+        emit connectionChanged(connection);
+        emit networkChanged(network());
+    }
+}
+
+/*!
+    This property holds the network.
+
+    \par Access functions:
+    \li \ref IrcNetwork* <b>network</b>() const
+ */
+IrcNetwork* IrcBufferModel::network() const
+{
+    Q_D(const IrcBufferModel);
+    return d->connection ? d->connection->network() : 0;
+}
+
+/*!
+    This property holds the number of buffers.
+
+    \par Access function:
+    \li int <b>count</b>() const
+
+    \par Notifier signal:
+    \li void <b>countChanged</b>(int count)
+ */
+int IrcBufferModel::count() const
+{
+    return rowCount();
+}
+
+/*!
+    \since 3.1
+    \property bool IrcBufferModel::empty
+
+    This property holds the whether the model is empty.
+
+    \par Access function:
+    \li bool <b>isEmpty</b>() const
+
+    \par Notifier signal:
+    \li void <b>emptyChanged</b>(bool empty)
+ */
+bool IrcBufferModel::isEmpty() const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferList.isEmpty();
+}
+
+/*!
+    This property holds the list of channel names.
+
+    \par Access function:
+    \li QStringList <b>channels</b>() const
+
+    \par Notifier signal:
+    \li void <b>channelsChanged</b>(const QStringList& channels)
+ */
+QStringList IrcBufferModel::channels() const
+{
+    Q_D(const IrcBufferModel);
+    return d->channels;
+}
+
+/*!
+    This property holds the list of buffers.
+
+    \par Access function:
+    \li QList<\ref IrcBuffer*> <b>buffers</b>() const
+
+    \par Notifier signal:
+    \li void <b>buffersChanged</b>(const QList<\ref IrcBuffer*>& buffers)
+ */
+QList<IrcBuffer*> IrcBufferModel::buffers() const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferList;
+}
+
+/*!
+    Returns the buffer object at \a index.
+ */
+IrcBuffer* IrcBufferModel::get(int index) const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferList.value(index);
+}
+
+/*!
+    Returns the buffer object for \a title or \c 0 if not found.
+ */
+IrcBuffer* IrcBufferModel::find(const QString& title) const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferMap.value(title.toLower());
+}
+
+/*!
+    Returns \c true if the model contains \a title.
+ */
+bool IrcBufferModel::contains(const QString& title) const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferMap.contains(title.toLower());
+}
+
+/*!
+    Returns the index of the specified \a buffer,
+    or \c -1 if the model does not contain the \a buffer.
+ */
+int IrcBufferModel::indexOf(IrcBuffer* buffer) const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferList.indexOf(buffer);
+}
+
+/*!
+    Adds a buffer with \a title to the model and returns it.
+ */
+IrcBuffer* IrcBufferModel::add(const QString& title)
+{
+    Q_D(IrcBufferModel);
+    return d->createBuffer(title);
+}
+
+/*!
+    Adds the \a buffer to the model.
+ */
+void IrcBufferModel::add(IrcBuffer* buffer)
+{
+    Q_D(IrcBufferModel);
+    d->addBuffer(buffer);
+}
+
+/*!
+    Removes and destroys a buffer with \a title from the model.
+ */
+void IrcBufferModel::remove(const QString& title)
+{
+    Q_D(IrcBufferModel);
+    d->destroyBuffer(title, true);
+}
+
+/*!
+    Removes and destroys a \a buffer from the model.
+ */
+void IrcBufferModel::remove(IrcBuffer* buffer)
+{
+    delete buffer;
+}
+
+/*!
+    This property holds the display role.
+
+    The specified data role is returned for Qt::DisplayRole.
+
+    The default value is \ref Irc::TitleRole.
+
+    \par Access functions:
+    \li \ref Irc::DataRole <b>displayRole</b>() const
+    \li void <b>setDisplayRole</b>(\ref Irc::DataRole role)
+ */
+Irc::DataRole IrcBufferModel::displayRole() const
+{
+    Q_D(const IrcBufferModel);
+    return d->role;
+}
+
+void IrcBufferModel::setDisplayRole(Irc::DataRole role)
+{
+    Q_D(IrcBufferModel);
+    d->role = role;
+}
+
+/*!
+    \since 3.1
+
+    \property bool IrcBufferModel::persistent
+    This property holds whether the model is persistent.
+
+    The default value is \c false.
+
+    A persistent model does not remove and destruct channel buffers
+    automatically when leaving the corresponding channels. In order
+    to remove buffers from a persistent model, either call
+    IrcBufferModel::remove() or delete the buffer.
+
+    \par Access functions:
+    \li bool <b>isPersistent</b>() const
+    \li void <b>setPersistent</b>(bool persistent)
+
+    \par Notifier signal:
+    \li void <b>persistentChanged</b>(bool persistent)
+ */
+bool IrcBufferModel::isPersistent() const
+{
+    Q_D(const IrcBufferModel);
+    return d->persistent;
+}
+
+void IrcBufferModel::setPersistent(bool persistent)
+{
+    Q_D(IrcBufferModel);
+    if (d->persistent != persistent) {
+        d->persistent = persistent;
+        emit persistentChanged(persistent);
+    }
+}
+
+/*!
+    Returns the model index for \a buffer.
+ */
+QModelIndex IrcBufferModel::index(IrcBuffer* buffer) const
+{
+    Q_D(const IrcBufferModel);
+    return index(d->bufferList.indexOf(buffer));
+}
+
+/*!
+    Returns the buffer for model \a index.
+ */
+IrcBuffer* IrcBufferModel::buffer(const QModelIndex& index) const
+{
+    if (!hasIndex(index.row(), index.column()))
+        return 0;
+
+    return static_cast<IrcBuffer*>(index.internalPointer());
+}
+
+/*!
+    This property holds the model sort order.
+
+    The default value is \c Qt::AscendingOrder.
+
+    \par Access functions:
+    \li Qt::SortOrder <b>sortOrder</b>() const
+    \li void <b>setSortOrder</b>(Qt::SortOrder order)
+
+    \sa sort(), lessThan()
+ */
+Qt::SortOrder IrcBufferModel::sortOrder() const
+{
+    Q_D(const IrcBufferModel);
+    return d->sortOrder;
+}
+
+void IrcBufferModel::setSortOrder(Qt::SortOrder order)
+{
+    Q_D(IrcBufferModel);
+    if (d->sortOrder != order) {
+        d->sortOrder = order;
+        if (d->sortMethod != Irc::SortByHand && !d->bufferList.isEmpty())
+            sort(d->sortMethod, d->sortOrder);
+    }
+}
+
+/*!
+    This property holds the model sort method.
+
+    The default value is \c Irc::SortByHand.
+
+    Method              | Description                                                                      | Example
+    --------------------|----------------------------------------------------------------------------------|-------------------------------------------------
+    Irc::SortByHand     | Buffers are not sorted automatically, but only by calling sort().                | -
+    Irc::SortByName     | Buffers are sorted alphabetically, ignoring any channel prefix.                  | "bot", "#communi", "#freenode", "jpnurmi", "#qt"
+    Irc::SortByTitle    | Buffers are sorted alphabetically, and channels before queries.                  | "#communi", "#freenode", "#qt", "bot", "jpnurmi"
+    Irc::SortByActivity | Buffers are sorted based on their messaging activity, last active buffers first. | -
+
+    \note Irc::SortByActivity support was added in version \b 3.4.
+
+    \par Access functions:
+    \li Irc::SortMethod <b>sortMethod</b>() const
+    \li void <b>setSortMethod</b>(Irc::SortMethod method)
+
+    \sa sort(), lessThan()
+ */
+Irc::SortMethod IrcBufferModel::sortMethod() const
+{
+    Q_D(const IrcBufferModel);
+    return d->sortMethod;
+}
+
+void IrcBufferModel::setSortMethod(Irc::SortMethod method)
+{
+    Q_D(IrcBufferModel);
+    if (d->sortMethod != method) {
+        d->sortMethod = method;
+        if (d->sortMethod != Irc::SortByHand && !d->bufferList.isEmpty())
+            sort(d->sortMethod, d->sortOrder);
+    }
+}
+
+/*!
+    Clears the model.
+
+    All buffers except \ref IrcBuffer::persistent "persistent" buffers are removed and destroyed.
+
+    In order to remove a persistent buffer, either explicitly call remove() or delete the buffer.
+ */
+void IrcBufferModel::clear()
+{
+    Q_D(IrcBufferModel);
+    if (!d->bufferList.isEmpty()) {
+        bool bufferRemoved = false;
+        bool channelRemoved = false;
+        foreach (IrcBuffer* buffer, d->bufferList) {
+            if (!buffer->isPersistent()) {
+                if (!bufferRemoved) {
+                    beginResetModel();
+                    bufferRemoved = true;
+                }
+                channelRemoved |= buffer->isChannel();
+                buffer->disconnect(this);
+                d->bufferList.removeOne(buffer);
+                d->channels.removeOne(buffer->title());
+                d->bufferMap.remove(buffer->title().toLower());
+                delete buffer;
+            }
+        }
+        if (bufferRemoved) {
+            endResetModel();
+            if (channelRemoved)
+                emit channelsChanged(d->channels);
+            emit buffersChanged(d->bufferList);
+            emit countChanged(d->bufferList.count());
+            if (d->bufferList.isEmpty())
+                emit emptyChanged(true);
+        }
+    }
+}
+
+/*!
+    Makes the model receive and handle \a message.
+ */
+void IrcBufferModel::receiveMessage(IrcMessage* message)
+{
+    Q_D(IrcBufferModel);
+    d->messageFilter(message);
+}
+
+/*!
+    Sorts the model using the given \a order.
+ */
+void IrcBufferModel::sort(int column, Qt::SortOrder order)
+{
+    Q_D(IrcBufferModel);
+    if (column == 0)
+        sort(d->sortMethod, order);
+}
+
+/*!
+    Sorts the model using the given \a method and \a order.
+
+    \sa lessThan()
+ */
+void IrcBufferModel::sort(Irc::SortMethod method, Qt::SortOrder order)
+{
+    Q_D(IrcBufferModel);
+    if (method == Irc::SortByHand)
+        return;
+
+    emit layoutAboutToBeChanged();
+
+    QList<IrcBuffer*> persistentBuffers;
+    QModelIndexList oldPersistentIndexes = persistentIndexList();
+    foreach (const QModelIndex& index, oldPersistentIndexes)
+        persistentBuffers += static_cast<IrcBuffer*>(index.internalPointer());
+
+    if (order == Qt::AscendingOrder)
+        qSort(d->bufferList.begin(), d->bufferList.end(), IrcBufferLessThan(this, method));
+    else
+        qSort(d->bufferList.begin(), d->bufferList.end(), IrcBufferGreaterThan(this, method));
+
+    QModelIndexList newPersistentIndexes;
+    foreach (IrcBuffer* buffer, persistentBuffers)
+        newPersistentIndexes += index(d->bufferList.indexOf(buffer));
+    changePersistentIndexList(oldPersistentIndexes, newPersistentIndexes);
+
+    emit layoutChanged();
+}
+
+/*!
+    Creates a buffer object with \a title.
+
+    IrcBufferModel will automatically call this factory method when a
+    need for the buffer object occurs ie. a private message is received.
+
+    The default implementation creates an instance of the buffer prototype.
+    Reimplement this function in order to alter the default behavior.
+
+    \sa bufferPrototype
+ */
+IrcBuffer* IrcBufferModel::createBuffer(const QString& title)
+{
+    Q_D(IrcBufferModel);
+    Q_UNUSED(title);
+    QObject* instance = d->bufferProto->metaObject()->newInstance(Q_ARG(QObject*, this));
+    return qobject_cast<IrcBuffer*>(instance);
+}
+
+/*!
+    Creates a channel object with \a title.
+
+    IrcBufferModel will automatically call this factory method when a
+    need for the channel object occurs ie. a channel is being joined.
+
+    The default implementation creates an instance of the channel prototype.
+    Reimplement this function in order to alter the default behavior.
+
+    \sa channelPrototype
+ */
+IrcChannel* IrcBufferModel::createChannel(const QString& title)
+{
+    Q_D(IrcBufferModel);
+    Q_UNUSED(title);
+    QObject* instance = d->channelProto->metaObject()->newInstance(Q_ARG(QObject*, this));
+    return qobject_cast<IrcChannel*>(instance);
+}
+
+/*!
+    Returns \c true if \a one buffer is "less than" \a another,
+    otherwise returns \c false.
+
+    The default implementation sorts according to the specified sort method.
+    Reimplement this function in order to customize the sort order.
+
+    \sa sort(), sortMethod
+ */
+bool IrcBufferModel::lessThan(IrcBuffer* one, IrcBuffer* another, Irc::SortMethod method) const
+{
+    if (one->isSticky() != another->isSticky())
+        return one->isSticky();
+
+    if (method == Irc::SortByActivity) {
+        QDateTime ts1 = IrcBufferPrivate::get(one)->activity;
+        QDateTime ts2 = IrcBufferPrivate::get(another)->activity;
+        if (ts1.isValid() || ts2.isValid())
+            return ts1.isValid() && ts1 > ts2;
+    }
+
+    if (method == Irc::SortByTitle) {
+        const QStringList prefixes = one->network()->channelTypes();
+
+        const QString p1 = one->prefix();
+        const QString p2 = another->prefix();
+
+        const int i1 = !p1.isEmpty() ? prefixes.indexOf(p1.at(0)) : -1;
+        const int i2 = !p2.isEmpty() ? prefixes.indexOf(p2.at(0)) : -1;
+
+        if (i1 >= 0 && i2 < 0)
+            return true;
+        if (i1 < 0 && i2 >= 0)
+            return false;
+        if (i1 >= 0 && i2 >= 0 && i1 != i2)
+            return i1 < i2;
+    }
+
+    // Irc::SortByName
+    const QString n1 = one->name();
+    const QString n2 = another->name();
+    return n1.compare(n2, Qt::CaseInsensitive) < 0;
+}
+
+/*!
+    The following role names are provided by default:
+
+    Role             | Name       | Type        | Example
+    -----------------|------------|-------------|--------
+    Qt::DisplayRole  | "display"  | 1)          | -
+    Irc::BufferRole  | "buffer"   | IrcBuffer*  | &lt;object&gt;
+    Irc::ChannelRole | "channel"  | IrcChannel* | &lt;object&gt;
+    Irc::NameRole    | "name"     | QString     | "communi"
+    Irc::PrefixRole  | "prefix"   | QString     | "#"
+    Irc::TitleRole   | "title"    | QString     | "#communi"
+
+    1) The type depends on \ref displayRole.
+ */
+QHash<int, QByteArray> IrcBufferModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[Qt::DisplayRole] = "display";
+    roles[Irc::BufferRole] = "buffer";
+    roles[Irc::ChannelRole] = "channel";
+    roles[Irc::NameRole] = "name";
+    roles[Irc::PrefixRole] = "prefix";
+    roles[Irc::TitleRole] = "title";
+    return roles;
+}
+
+/*!
+    Returns the number of buffers.
+ */
+int IrcBufferModel::rowCount(const QModelIndex& parent) const
+{
+    if (parent.isValid())
+        return 0;
+
+    Q_D(const IrcBufferModel);
+    return d->bufferList.count();
+}
+
+/*!
+    Returns the data for specified \a role and user referred to by by the \a index.
+ */
+QVariant IrcBufferModel::data(const QModelIndex& index, int role) const
+{
+    Q_D(const IrcBufferModel);
+    if (!hasIndex(index.row(), index.column(), index.parent()))
+        return QVariant();
+
+    IrcBuffer* buffer = static_cast<IrcBuffer*>(index.internalPointer());
+    Q_ASSERT(buffer);
+
+    switch (role) {
+    case Qt::DisplayRole:
+        return data(index, d->role);
+    case Irc::BufferRole:
+        return QVariant::fromValue(buffer);
+    case Irc::ChannelRole:
+        return QVariant::fromValue(buffer->toChannel());
+    case Irc::NameRole:
+        return buffer->name();
+    case Irc::PrefixRole:
+        return buffer->prefix();
+    case Irc::TitleRole:
+        return buffer->title();
+    }
+
+    return QVariant();
+}
+
+/*!
+    Returns the index of the item in the model specified by the given \a row, \a column and \a parent index.
+ */
+QModelIndex IrcBufferModel::index(int row, int column, const QModelIndex& parent) const
+{
+    Q_D(const IrcBufferModel);
+    if (!hasIndex(row, column, parent))
+        return QModelIndex();
+
+    return createIndex(row, column, d->bufferList.at(row));
+}
+
+/*!
+    This property holds the buffer prototype.
+
+    The prototype is used by the default implementation of createBuffer().
+
+    \note The prototype must have an invokable constructor.
+
+    \par Access functions:
+    \li \ref IrcBuffer* <b>bufferPrototype</b>() const
+    \li void <b>setBufferPrototype</b>(\ref IrcBuffer* prototype)
+ */
+IrcBuffer* IrcBufferModel::bufferPrototype() const
+{
+    Q_D(const IrcBufferModel);
+    return d->bufferProto;
+}
+
+void IrcBufferModel::setBufferPrototype(IrcBuffer* prototype)
+{
+    Q_D(IrcBufferModel);
+    if (d->bufferProto != prototype) {
+        if (d->bufferProto && d->bufferProto->parent() == this)
+            delete d->bufferProto;
+        d->bufferProto = prototype ? prototype : new IrcBuffer(this);
+        emit bufferPrototypeChanged(d->bufferProto);
+    }
+}
+
+/*!
+    This property holds the channel prototype.
+
+    The prototype is used by the default implementation of createChannel().
+
+    \note The prototype must have an invokable constructor.
+
+    \par Access functions:
+    \li \ref IrcChannel* <b>channelPrototype</b>() const
+    \li void <b>setChannelPrototype</b>(\ref IrcChannel* prototype)
+ */
+IrcChannel* IrcBufferModel::channelPrototype() const
+{
+    Q_D(const IrcBufferModel);
+    return d->channelProto;
+}
+
+void IrcBufferModel::setChannelPrototype(IrcChannel* prototype)
+{
+    Q_D(IrcBufferModel);
+    if (d->channelProto != prototype) {
+        if (d->channelProto && d->channelProto->parent() == this)
+            delete d->channelProto;
+        d->channelProto = prototype ? prototype : new IrcChannel(this);
+        emit channelPrototypeChanged(d->channelProto);
+    }
+}
+
+/*!
+    \since 3.3
+
+    This property holds the join delay in seconds.
+
+    The default value is \c 0 - channels are joined immediately
+    after getting connected. A negative value disables automatic
+    joining of channels.
+
+    \par Access function:
+    \li int <b>joinDelay</b>() const
+    \li void <b>setJoinDelay</b>(int delay)
+
+    \par Notifier signal:
+    \li void <b>joinDelayChanged</b>(int delay)
+ */
+int IrcBufferModel::joinDelay() const
+{
+    Q_D(const IrcBufferModel);
+    return d->joinDelay;
+}
+
+void IrcBufferModel::setJoinDelay(int delay)
+{
+    Q_D(IrcBufferModel);
+    if (d->joinDelay != delay) {
+        d->joinDelay = delay;
+        emit joinDelayChanged(delay);
+    }
+}
+
+/*!
+    \since 3.4
+    \property bool IrcBufferModel::monitorEnabled
+
+    This property holds whether automatic monitor is enabled.
+
+    The default value is \c false.
+
+    \par Access function:
+    \li bool <b>isMonitorEnabled</b>() const
+    \li void <b>setMonitorEnabled</b>(bool enabled)
+
+    \par Notifier signal:
+    \li void <b>monitorEnabledChanged</b>(bool enabled)
+
+    \sa \ref ircv3
+ */
+bool IrcBufferModel::isMonitorEnabled() const
+{
+    Q_D(const IrcBufferModel);
+    return d->monitorEnabled;
+}
+
+void IrcBufferModel::setMonitorEnabled(bool enabled)
+{
+    Q_D(IrcBufferModel);
+    if (d->monitorEnabled != enabled) {
+        d->monitorEnabled = enabled;
+        emit monitorEnabledChanged(enabled);
+    }
+}
+
+/*!
+    \since 3.1
+
+    Saves the state of the model. The \a version number is stored as part of the state data.
+
+    To restore the saved state, pass the return value and \a version number to restoreState().
+ */
+QByteArray IrcBufferModel::saveState(int version) const
+{
+    Q_D(const IrcBufferModel);
+    QVariantMap args;
+    args.insert("version", version);
+
+    QVariantMap states = d->bufferStates;
+    foreach (IrcBuffer* buffer, d->bufferList)
+        states.insert(buffer->title(), d->saveBuffer(buffer));
+
+    QVariantList buffers;
+    foreach (const QVariant& b, states)
+        buffers += b;
+    args.insert("buffers", buffers);
+
+    QByteArray state;
+    QDataStream out(&state, QIODevice::WriteOnly);
+    out << args;
+    return state;
+}
+
+/*!
+    \since 3.1
+
+    Restores the \a state of the model. The \a version number is compared with that stored in \a state.
+    If they do not match, the model state is left unchanged, and this function returns \c false; otherwise,
+    the state is restored, and \c true is returned.
+
+    \sa saveState()
+ */
+bool IrcBufferModel::restoreState(const QByteArray& state, int version)
+{
+    Q_D(IrcBufferModel);
+    QVariantMap args;
+    QDataStream in(state);
+    in >> args;
+    if (in.status() != QDataStream::Ok || args.value("version", -1).toInt() != version)
+        return false;
+
+    const QVariantList buffers = args.value("buffers").toList();
+    foreach (const QVariant& v, buffers) {
+        const QVariantMap b = v.toMap();
+        d->bufferStates.insert(b.value("title").toString(), b);
+    }
+
+    if (d->joinDelay >= 0 && d->connection && d->connection->isConnected())
+        QTimer::singleShot(d->joinDelay * 1000, this, SLOT(_irc_restoreBuffers()));
+
+    return true;
+}
+
+#include "moc_ircbuffermodel.cpp"
+#include "moc_ircbuffermodel_p.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/model/ircchannel.cpp
+++ b/3rdparty/communi/src/model/ircchannel.cpp
@@ -1,0 +1,667 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircchannel.h"
+#include "ircchannel_p.h"
+#include "ircusermodel.h"
+#include "ircusermodel_p.h"
+#include "ircbuffermodel.h"
+#include "ircbuffermodel_p.h"
+#include "ircconnection.h"
+#include "ircnetwork.h"
+#include "irccommand.h"
+#include "ircuser_p.h"
+#include "irc.h"
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircchannel.h
+    \brief \#include &lt;IrcChannel&gt;
+ */
+
+/*!
+    \class IrcChannel ircchannel.h <IrcChannel>
+    \ingroup models
+    \brief Keeps track of channel status.
+
+    \sa IrcBufferModel
+*/
+
+#ifndef IRC_DOXYGEN
+static QString getPrefix(const QString& name, const QStringList& prefixes)
+{
+    int i = 0;
+    while (i < name.length() && prefixes.contains(name.at(i)))
+        ++i;
+    return name.left(i);
+}
+
+static QString getMode(IrcNetwork *network, const QString& prefix)
+{
+    QString mode;
+    foreach (const QString& p, prefix)
+        mode += network->prefixToMode(p);
+    return mode;
+}
+
+static QString channelName(const QString& title, const QStringList& prefixes)
+{
+    int i = 0;
+    while (i < title.length() && prefixes.contains(title.at(i)))
+        ++i;
+    return title.mid(i);
+}
+
+static QString userName(const QString& name, const QStringList& prefixes)
+{
+    QString copy = name;
+    while (!copy.isEmpty() && prefixes.contains(copy.at(0)))
+        copy.remove(0, 1);
+    return Irc::nickFromPrefix(copy);
+}
+
+IrcChannelPrivate::IrcChannelPrivate() : active(false), enabled(true)
+{
+    qRegisterMetaType<IrcChannel*>();
+    qRegisterMetaType<QList<IrcChannel*> >();
+}
+
+IrcChannelPrivate::~IrcChannelPrivate()
+{
+}
+
+void IrcChannelPrivate::init(const QString& title, IrcBufferModel* m)
+{
+    IrcBufferPrivate::init(title, m);
+
+    const QStringList chanTypes = m->network()->channelTypes();
+    prefix = getPrefix(title, chanTypes);
+    name = channelName(title, chanTypes);
+}
+
+void IrcChannelPrivate::connected()
+{
+    // not active until joined
+    setActive(false);
+}
+
+void IrcChannelPrivate::disconnected()
+{
+    setActive(false);
+}
+
+void IrcChannelPrivate::setActive(bool value)
+{
+    Q_Q(IrcChannel);
+    if (active != value) {
+        active = value;
+        emit q->activeChanged(active);
+    }
+}
+
+void IrcChannelPrivate::changeModes(const QString& value, const QStringList& arguments)
+{
+    Q_Q(IrcChannel);
+    const IrcNetwork* network = q->network();
+
+    QMap<QString, QString> ms = modes;
+    QStringList args = arguments;
+
+    bool add = true;
+    for (int i = 0; i < value.size(); ++i) {
+        const QString m = value.at(i);
+        if (m == QLatin1String("+")) {
+            add = true;
+        } else if (m == QLatin1String("-")) {
+            add = false;
+        } else {
+            if (add) {
+                QString a;
+                if (!args.isEmpty() && network && network->channelModes(IrcNetwork::TypeB | IrcNetwork::TypeC).contains(m))
+                    a = args.takeFirst();
+                ms.insert(m, a);
+            } else {
+                ms.remove(m);
+            }
+        }
+    }
+
+    if (modes != ms) {
+        setKey(ms.value(QLatin1String("k")));
+        modes = ms;
+        emit q->modeChanged(q->mode());
+    }
+}
+
+void IrcChannelPrivate::setModes(const QString& value, const QStringList& arguments)
+{
+    Q_Q(IrcChannel);
+    const IrcNetwork* network = q->network();
+
+    QMap<QString, QString> ms;
+    QStringList args = arguments;
+
+    for (int i = 0; i < value.size(); ++i) {
+        const QString m = value.at(i);
+        if (m != QLatin1String("+") && m != QLatin1String("-")) {
+            QString a;
+            if (!args.isEmpty() && network && network->channelModes(IrcNetwork::TypeB | IrcNetwork::TypeC).contains(m))
+                a = args.takeFirst();
+            ms.insert(m, a);
+        }
+    }
+
+    if (modes != ms) {
+        setKey(ms.value(QLatin1String("k")));
+        modes = ms;
+        emit q->modeChanged(q->mode());
+    }
+}
+
+void IrcChannelPrivate::setTopic(const QString& value)
+{
+    Q_Q(IrcChannel);
+    if (topic != value) {
+        topic = value;
+        emit q->topicChanged(topic);
+    }
+}
+
+void IrcChannelPrivate::setKey(const QString& value)
+{
+    Q_Q(IrcChannel);
+    if (modes.value(QLatin1String("k")) != value) {
+        modes.insert(QLatin1String("k"), value);
+        emit q->keyChanged(value);
+    }
+}
+
+void IrcChannelPrivate::addUser(const QString& name)
+{
+    Q_Q(IrcChannel);
+    const QStringList prefixes = q->network()->prefixes();
+
+    IrcUser* user = new IrcUser(q);
+    IrcUserPrivate* priv = IrcUserPrivate::get(user);
+    priv->channel = q;
+    priv->setName(userName(name, prefixes));
+    priv->setPrefix(getPrefix(name, prefixes));
+    priv->setMode(getMode(q->network(), user->prefix()));
+    activeUsers.prepend(user);
+    userList.append(user);
+    userMap.insert(user->name(), user);
+    names = userMap.keys();
+
+    foreach (IrcUserModel* model, userModels)
+        IrcUserModelPrivate::get(model)->addUser(user);
+}
+
+bool IrcChannelPrivate::removeUser(const QString& name)
+{
+    if (IrcUser* user = userMap.value(name)) {
+        userMap.remove(name);
+        names = userMap.keys();
+        userList.removeOne(user);
+        activeUsers.removeOne(user);
+        foreach (IrcUserModel* model, userModels)
+            IrcUserModelPrivate::get(model)->removeUser(user);
+        user->deleteLater();
+        return true;
+    }
+    return false;
+}
+
+void IrcChannelPrivate::setUsers(const QStringList& users)
+{
+    Q_Q(IrcChannel);
+    const QStringList prefixes = q->network()->prefixes();
+
+    qDeleteAll(userList);
+    userMap.clear();
+    userList.clear();
+    activeUsers.clear();
+
+    foreach (const QString& name, users) {
+        IrcUser* user = new IrcUser(q);
+        IrcUserPrivate* priv = IrcUserPrivate::get(user);
+        priv->channel = q;
+        priv->setName(userName(name, prefixes));
+        priv->setPrefix(getPrefix(name, prefixes));
+        priv->setMode(getMode(q->network(), user->prefix()));
+        activeUsers.append(user);
+        userList.append(user);
+        userMap.insert(user->name(), user);
+    }
+    names = userMap.keys();
+
+    foreach (IrcUserModel* model, userModels)
+        IrcUserModelPrivate::get(model)->setUsers(userList);
+}
+
+bool IrcChannelPrivate::renameUser(const QString& from, const QString& to)
+{
+    if (IrcUser* user = userMap.take(from)) {
+        IrcUserPrivate::get(user)->setName(to);
+        userMap.insert(to, user);
+        names = userMap.keys();
+
+        foreach (IrcUserModel* model, userModels) {
+            IrcUserModelPrivate::get(model)->renameUser(user);
+            emit model->namesChanged(names);
+        }
+        return true;
+    }
+    return false;
+}
+
+void IrcChannelPrivate::setUserMode(const QString& name, const QString& command)
+{
+    if (IrcUser* user = userMap.value(name)) {
+        bool add = true;
+        QString mode = user->mode();
+        QString prefix = user->prefix();
+        const IrcNetwork* network = model->network();
+        for (int i = 0; i < command.size(); ++i) {
+            QChar c = command.at(i);
+            if (c == QLatin1Char('+')) {
+                add = true;
+            } else if (c == QLatin1Char('-')) {
+                add = false;
+            } else {
+                QString p = network->modeToPrefix(c);
+                if (add) {
+                    if (!mode.contains(c))
+                        mode += c;
+                    if (!prefix.contains(p))
+                        prefix += p;
+                } else {
+                    mode.remove(c);
+                    prefix.remove(p);
+                }
+            }
+        }
+
+        QString sortedMode;
+        foreach (const QString& m, network->modes())
+            if (mode.contains(m))
+                sortedMode += m;
+
+        QString sortedPrefix;
+        foreach (const QString& p, network->prefixes())
+            if (prefix.contains(p))
+                sortedPrefix += p;
+
+        IrcUserPrivate* priv = IrcUserPrivate::get(user);
+        priv->setPrefix(sortedPrefix);
+        priv->setMode(sortedMode);
+
+        foreach (IrcUserModel* model, userModels)
+            IrcUserModelPrivate::get(model)->setUserMode(user);
+    }
+}
+
+void IrcChannelPrivate::promoteUser(const QString& name)
+{
+    if (IrcUser* user = userMap.value(name)) {
+        const int idx = activeUsers.indexOf(user);
+        Q_ASSERT(idx != -1);
+        activeUsers.move(idx, 0);
+        foreach (IrcUserModel* model, userModels)
+            IrcUserModelPrivate::get(model)->promoteUser(user);
+    }
+}
+
+bool IrcChannelPrivate::setUserAway(const QString& name, bool away)
+{
+    if (IrcUser* user = userMap.value(name)) {
+        IrcUserPrivate* priv = IrcUserPrivate::get(user);
+        priv->setAway(away);
+        foreach (IrcUserModel* model, userModels)
+            IrcUserModelPrivate::get(model)->updateUser(user);
+        return true;
+    }
+    return false;
+}
+
+void IrcChannelPrivate::setUserServOp(const QString& name, bool servOp)
+{
+    if (IrcUser* user = userMap.value(name)) {
+        IrcUserPrivate* priv = IrcUserPrivate::get(user);
+        priv->setServOp(servOp);
+        foreach (IrcUserModel* model, userModels)
+            IrcUserModelPrivate::get(model)->updateUser(user);
+    }
+}
+
+bool IrcChannelPrivate::processAwayMessage(IrcAwayMessage* message)
+{
+    setUserAway(message->nick(), message->isAway());
+    return false;
+}
+
+bool IrcChannelPrivate::processJoinMessage(IrcJoinMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback)) {
+        if (message->isOwn()) {
+            setActive(true);
+            enabled = true;
+        } else {
+            addUser(message->nick());
+        }
+    }
+    return true;
+}
+
+bool IrcChannelPrivate::processKickMessage(IrcKickMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback)) {
+        if (!message->user().compare(message->connection()->nickName(), Qt::CaseInsensitive)) {
+            setActive(false);
+            enabled = false;
+            return true;
+        }
+        return removeUser(message->user());
+    }
+    return userMap.contains(message->user());
+}
+
+bool IrcChannelPrivate::processModeMessage(IrcModeMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback)) {
+        if (message->kind() == IrcModeMessage::Channel) {
+            if (message->isReply())
+                setModes(message->mode(), message->arguments());
+            else
+                changeModes(message->mode(), message->arguments());
+            return true;
+        } else if (!message->argument().isEmpty()) {
+            setUserMode(message->argument(), message->mode());
+        }
+    }
+    return true;
+}
+
+bool IrcChannelPrivate::processNamesMessage(IrcNamesMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback))
+        setUsers(message->names());
+    return true;
+}
+
+bool IrcChannelPrivate::processNickMessage(IrcNickMessage* message)
+{
+    const bool renamed = renameUser(message->oldNick(), message->newNick());
+    if (renamed)
+        promoteUser(message->newNick());
+    return renamed;
+}
+
+bool IrcChannelPrivate::processNoticeMessage(IrcNoticeMessage* message)
+{
+    promoteUser(message->nick());
+    return false;
+}
+
+bool IrcChannelPrivate::processNumericMessage(IrcNumericMessage* message)
+{
+    promoteUser(message->nick());
+    return message->isImplicit();
+}
+
+bool IrcChannelPrivate::processPartMessage(IrcPartMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback)) {
+        if (message->isOwn()) {
+            setActive(false);
+            enabled = false;
+            return true;
+        }
+        return removeUser(message->nick());
+    }
+    return true;
+}
+
+bool IrcChannelPrivate::processPrivateMessage(IrcPrivateMessage* message)
+{
+    const QString content = message->content();
+    const bool prefixed = !content.isEmpty() && message->network()->prefixes().contains(content.at(0));
+    foreach (IrcUser* user, activeUsers) {
+        const QString str = prefixed ? user->title() : user->name();
+        if (content.startsWith(str)) {
+            promoteUser(user->name());
+            break;
+        }
+    }
+    promoteUser(message->nick());
+    return true;
+}
+
+bool IrcChannelPrivate::processQuitMessage(IrcQuitMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback)) {
+        if (message->isOwn()) {
+            setActive(false);
+            return true;
+        }
+        return removeUser(message->nick()) || IrcBufferPrivate::processQuitMessage(message);
+    }
+    return userMap.contains(message->nick()) || IrcBufferPrivate::processQuitMessage(message);
+}
+
+bool IrcChannelPrivate::processTopicMessage(IrcTopicMessage* message)
+{
+    if (!message->testFlag(IrcMessage::Playback))
+        setTopic(message->topic());
+    return true;
+}
+
+bool IrcChannelPrivate::processWhoReplyMessage(IrcWhoReplyMessage *message)
+{
+    if (message->isValid()) {
+        setUserAway(message->nick(), message->isAway());
+        setUserServOp(message->nick(), message->isServOp());
+    }
+    return message->isImplicit();
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new channel object with \a parent.
+ */
+IrcChannel::IrcChannel(QObject* parent)
+    : IrcBuffer(*new IrcChannelPrivate, parent)
+{
+}
+
+/*!
+    Destructs the channel object.
+ */
+IrcChannel::~IrcChannel()
+{
+    Q_D(IrcChannel);
+    qDeleteAll(d->userList);
+    d->userList.clear();
+    d->userMap.clear();
+    d->names.clear();
+    d->userModels.clear();
+    emit destroyed(this);
+}
+
+/*!
+    \since 3.1
+
+    This property holds the channel key.
+
+    \par Access function:
+    \li QString <b>key</b>() const
+
+    \par Notifier signal:
+    \li void <b>keyChanged</b>(const QString& key)
+ */
+QString IrcChannel::key() const
+{
+    Q_D(const IrcChannel);
+    return d->modes.value(QLatin1String("k"));
+}
+
+/*!
+    This property holds the complete channel mode including possible arguments.
+
+    \par Access function:
+    \li QString <b>mode</b>() const
+
+    \par Notifier signal:
+    \li void <b>modeChanged</b>(const QString& mode)
+ */
+QString IrcChannel::mode() const
+{
+    Q_D(const IrcChannel);
+    QString m = QStringList(d->modes.keys()).join(QString());
+    QStringList a = d->modes.values();
+    a.removeAll(QString());
+    if (!a.isEmpty())
+        m += QLatin1String(" ") + a.join(QLatin1String(" "));
+    if (!m.isEmpty())
+        m.prepend(QLatin1String("+"));
+    return m;
+}
+
+/*!
+    This property holds the channel topic.
+
+    \par Access function:
+    \li QString <b>topic</b>() const
+
+    \par Notifier signal:
+    \li void <b>topicChanged</b>(const QString& topic)
+ */
+QString IrcChannel::topic() const
+{
+    Q_D(const IrcChannel);
+    return d->topic;
+}
+
+bool IrcChannel::isActive() const
+{
+    Q_D(const IrcChannel);
+    return IrcBuffer::isActive() && d->active;
+}
+
+/*!
+    \since 3.3
+
+    Sends a who command to the channel.
+
+    This method is provided for convenience. It is equal to:
+    \code
+    IrcCommand* command = IrcCommand::createWho(channel->title());
+    channel->sendCommand(command);
+    \endcode
+
+    \sa IrcBuffer::sendCommand(), IrcCommand::createWho()
+ */
+void IrcChannel::who()
+{
+    sendCommand(IrcCommand::createWho(title()));
+}
+
+/*!
+    \since 3.1
+
+    Joins the channel with an optional \a key.
+
+    This method is provided for convenience. It is equal to:
+    \code
+    IrcCommand* command = IrcCommand::createJoin(channel->title(), key);
+    channel->sendCommand(command);
+    \endcode
+
+    \sa IrcBuffer::sendCommand(), IrcCommand::createJoin()
+ */
+void IrcChannel::join(const QString& key)
+{
+    Q_D(IrcChannel);
+    if (!key.isEmpty())
+        d->setKey(key);
+    d->enabled = true;
+    sendCommand(IrcCommand::createJoin(title(), IrcChannel::key()));
+}
+
+/*!
+    Parts the channel with an optional \a reason.
+
+    This method is provided for convenience. It is equal to:
+    \code
+    IrcCommand* command = IrcCommand::createPart(channel->title(), reason);
+    channel->sendCommand(command);
+    \endcode
+
+    \sa IrcBuffer::sendCommand(), IrcCommand::createPart()
+ */
+void IrcChannel::part(const QString& reason)
+{
+    Q_D(IrcChannel);
+    d->enabled = false;
+    sendCommand(IrcCommand::createPart(title(), reason));
+}
+
+/*!
+    \since 3.1
+
+    Closes the channel with an optional \a reason.
+
+    \sa IrcBuffer::close(), IrcChannel::part()
+ */
+void IrcChannel::close(const QString& reason)
+{
+    Q_D(IrcChannel);
+    d->enabled = false;
+    if (isActive())
+        part(reason);
+    IrcBuffer::close(reason);
+}
+
+#ifndef QT_NO_DEBUG_STREAM
+QDebug operator<<(QDebug debug, const IrcChannel* channel)
+{
+    if (!channel)
+        return debug << "IrcChannel(0x0) ";
+    debug.nospace() << channel->metaObject()->className() << '(' << (void*) channel;
+    if (!channel->objectName().isEmpty())
+        debug.nospace() << ", name=" << qPrintable(channel->objectName());
+    if (!channel->title().isEmpty())
+        debug.nospace() << ", title=" << qPrintable(channel->title());
+    debug.nospace() << ')';
+    return debug.space();
+}
+#endif // QT_NO_DEBUG_STREAM
+
+#include "moc_ircchannel.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/model/ircmodel.cpp
+++ b/3rdparty/communi/src/model/ircmodel.cpp
@@ -1,0 +1,61 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircmodel.h"
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircmodel.h
+    \brief \#include &lt;IrcModel&gt;
+ */
+
+/*!
+    \namespace IrcModel
+    \ingroup models
+    \brief Module meta-type registration.
+ */
+
+namespace IrcModel {
+
+    /*!
+        Registers IrcModel types to the %Qt meta-system.
+
+        \sa IrcCore::registerMetaTypes(), IrcUtil::registerMetaTypes(), qRegisterMetaType()
+     */
+    void registerMetaTypes()
+    {
+        qRegisterMetaType<IrcBuffer*>("IrcBuffer*");
+        qRegisterMetaType<IrcBufferModel*>("IrcBufferModel*");
+        qRegisterMetaType<IrcChannel*>("IrcChannel*");
+        qRegisterMetaType<IrcUser*>("IrcUser*");
+        qRegisterMetaType<IrcUserModel*>("IrcUserModel*");
+    }
+}
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/model/ircuser.cpp
+++ b/3rdparty/communi/src/model/ircuser.cpp
@@ -1,0 +1,276 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircuser.h"
+#include "ircuser_p.h"
+#include <qdebug.h>
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircuser.h
+    \brief \#include &lt;IrcUser&gt;
+ */
+
+/*!
+    \class IrcUser ircuser.h <IrcUser>
+    \ingroup models
+    \brief Keeps track of user status on a channel.
+
+    \sa IrcUserModel
+*/
+
+#ifndef IRC_DOXYGEN
+void IrcUserPrivate::setName(const QString& n)
+{
+    Q_Q(IrcUser);
+    if (name != n) {
+        name = n;
+        emit q->nameChanged(name);
+        emit q->titleChanged(q->title());
+    }
+}
+
+void IrcUserPrivate::setPrefix(const QString& p)
+{
+    Q_Q(IrcUser);
+    if (prefix != p) {
+        prefix = p;
+        emit q->prefixChanged(prefix);
+        emit q->titleChanged(q->title());
+    }
+}
+
+void IrcUserPrivate::setMode(const QString& m)
+{
+    Q_Q(IrcUser);
+    if (mode != m) {
+        mode = m;
+        emit q->modeChanged(mode);
+    }
+}
+
+void IrcUserPrivate::setServOp(const bool& o)
+{
+    Q_Q(IrcUser);
+    if (servOp != o) {
+        servOp = o;
+        emit q->servOpChanged(servOp);
+    }
+}
+
+void IrcUserPrivate::setAway(const bool& a)
+{
+    Q_Q(IrcUser);
+    if (away != a) {
+        away = a;
+        emit q->awayChanged(away);
+    }
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new user with \a parent.
+ */
+IrcUser::IrcUser(QObject* parent)
+    : QObject(parent), d_ptr(new IrcUserPrivate)
+{
+    Q_D(IrcUser);
+    d->q_ptr = this;
+    d->channel = 0;
+    d->away = false;
+    d->servOp = false;
+}
+
+/*!
+    Destructs the user object.
+ */
+IrcUser::~IrcUser()
+{
+}
+
+/*!
+    This property holds the title.
+
+    The title consists of \ref prefix and \ref name.
+
+    \par Access function:
+    \li QString <b>title</b>() const
+
+    \par Notifier signal:
+    \li void <b>titleChanged</b>(const QString& title)
+ */
+QString IrcUser::title() const
+{
+    Q_D(const IrcUser);
+    return d->prefix.left(1) + d->name;
+}
+
+/*!
+    This property holds the name.
+
+    \par Access function:
+    \li QString <b>name</b>() const
+
+    \par Notifier signal:
+    \li void <b>nameChanged</b>(const QString& name)
+ */
+QString IrcUser::name() const
+{
+    Q_D(const IrcUser);
+    return d->name;
+}
+
+/*!
+    This property holds the prefix character.
+
+    Typical prefix characters are \c @ (op) and \c + (voice).
+
+    \note The prefix may be multiple characters if the \c multi-prefix
+          capability is enabled.
+
+    \par Access function:
+    \li QString <b>prefix</b>() const
+
+    \par Notifier signal:
+    \li void <b>prefixChanged</b>(const QString& prefix)
+
+    \sa mode, \ref ircv3
+ */
+QString IrcUser::prefix() const
+{
+    Q_D(const IrcUser);
+    return d->prefix;
+}
+
+/*!
+    This property holds the mode letter.
+
+    Typical mode letters are \c o (op) and \c v (voice).
+
+    \note The mode may be multiple characters if the \c multi-prefix
+          capability is enabled.
+
+    \par Access function:
+    \li QString <b>mode</b>() const
+
+    \par Notifier signal:
+    \li void <b>modeChanged</b>(const QString& mode)
+
+    \sa prefix, \ref ircv3
+ */
+QString IrcUser::mode() const
+{
+    Q_D(const IrcUser);
+    return d->mode;
+}
+
+/*!
+    \since 3.1
+
+    \property bool IrcUser::servOp
+    This property holds whether the user is a server operator.
+
+    \note IRC servers do not send this information by default.
+    In order to fetch the information for all users on a channel,
+    issue a WHO command on the channel:
+    \code
+    IrcChannel* channel = user->channel();
+    IrcCommand* command = IrcCommand::createWho(channel->title());
+    channel->sendCommand(command);
+    \endcode
+
+    \par Access function:
+    \li bool <b>isServOp</b>() const
+
+    \par Notifier signal:
+    \li void <b>servOpChanged</b>(bool servOp)
+ */
+bool IrcUser::isServOp() const
+{
+    Q_D(const IrcUser);
+    return d->servOp;
+}
+
+/*!
+    \since 3.1
+
+    \property bool IrcUser::away
+    This property holds whether the user is marked as being away.
+
+    \note IRC servers do not send this information by default.
+    In order to fetch the information for all users on a channel,
+    issue a WHO command on the channel:
+    \code
+    IrcChannel* channel = user->channel();
+    IrcCommand* command = IrcCommand::createWho(channel->title());
+    channel->sendCommand(command);
+    \endcode
+
+    \par Access function:
+    \li bool <b>isAway</b>() const
+
+    \par Notifier signal:
+    \li void <b>awayChanged</b>(bool away)
+ */
+bool IrcUser::isAway() const
+{
+    Q_D(const IrcUser);
+    return d->away;
+}
+
+/*!
+    This property holds the channel of the user.
+
+    \par Access function:
+    \li \ref IrcChannel* <b>channel</b>() const
+ */
+IrcChannel* IrcUser::channel() const
+{
+    Q_D(const IrcUser);
+    return d->channel;
+}
+
+#ifndef QT_NO_DEBUG_STREAM
+QDebug operator<<(QDebug debug, const IrcUser* user)
+{
+    if (!user)
+        return debug << "IrcUser(0x0) ";
+    debug.nospace() << user->metaObject()->className() << '(' << (void*) user;
+    if (!user->objectName().isEmpty())
+        debug.nospace() << ", name=" << qPrintable(user->objectName());
+    if (!user->name().isEmpty())
+        debug.nospace() << ", user=" << qPrintable(user->name());
+    debug.nospace() << ')';
+    return debug.space();
+}
+#endif // QT_NO_DEBUG_STREAM
+
+#include "moc_ircuser.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/model/ircusermodel.cpp
+++ b/3rdparty/communi/src/model/ircusermodel.cpp
@@ -1,0 +1,755 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircusermodel.h"
+#include "ircusermodel_p.h"
+#include "ircbuffermodel.h"
+#include "ircconnection.h"
+#include "ircchannel_p.h"
+#include "ircuser.h"
+#include <qpointer.h>
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircusermodel.h
+    \brief \#include &lt;IrcUserModel&gt;
+ */
+
+/*!
+    \class IrcUserModel ircusermodel.h <IrcUserModel>
+    \ingroup models
+    \brief Keeps track of channel users.
+
+    In order to keep track of channel users, create an instance of IrcUserModel.
+    It will notify via signals when users are added and/or removed. IrcUserModel
+    can be used directly as a data model for Qt's item views - both in C++ and QML.
+
+    \code
+    void ChatView::setChannel(IrcChannel* channel)
+    {
+        IrcUserModel* model = new IrcUserModel(channel);
+        connect(model, SIGNAL(added(IrcUser*)), this, SLOT(onUserAdded(IrcUser*)));
+        connect(model, SIGNAL(removed(IrcUser*)), this, SLOT(onUserRemoved(IrcUser*)));
+        nickCompleter->setModel(model);
+        userListView->setModel(model);
+    }
+    \endcode
+*/
+
+/*!
+    \fn void IrcUserModel::added(IrcUser* user)
+
+    This signal is emitted when a \a user is added to the list of users.
+ */
+
+/*!
+    \fn void IrcUserModel::removed(IrcUser* user)
+
+    This signal is emitted when a \a user is removed from the list of users.
+ */
+
+/*!
+    \fn void IrcUserModel::aboutToBeAdded(IrcUser* user)
+
+    This signal is emitted just before a \a user is added to the list of users.
+ */
+
+/*!
+    \fn void IrcUserModel::aboutToBeRemoved(IrcUser* user)
+
+    This signal is emitted just before a \a user is removed from the list of users.
+ */
+
+#ifndef IRC_DOXYGEN
+class IrcUserLessThan
+{
+public:
+    IrcUserLessThan(IrcUserModel* model, Irc::SortMethod method) : model(model), method(method) { }
+    bool operator()(IrcUser* u1, IrcUser* u2) const { return model->lessThan(u1, u2, method); }
+private:
+    IrcUserModel* model;
+    Irc::SortMethod method;
+};
+
+class IrcUserGreaterThan
+{
+public:
+    IrcUserGreaterThan(IrcUserModel* model, Irc::SortMethod method) : model(model), method(method) { }
+    bool operator()(IrcUser* u1, IrcUser* u2) const { return model->lessThan(u2, u1, method); }
+private:
+    IrcUserModel* model;
+    Irc::SortMethod method;
+};
+
+IrcUserModelPrivate::IrcUserModelPrivate() : q_ptr(0), role(Irc::TitleRole),
+    sortMethod(Irc::SortByHand), sortOrder(Qt::AscendingOrder)
+{
+}
+
+void IrcUserModelPrivate::addUser(IrcUser* user, bool notify)
+{
+    insertUser(-1, user, notify);
+}
+
+void IrcUserModelPrivate::insertUser(int index, IrcUser* user, bool notify)
+{
+    Q_Q(IrcUserModel);
+    if (index == -1)
+        index = userList.count();
+    if (sortMethod != Irc::SortByHand) {
+        QList<IrcUser*>::iterator it;
+        if (sortOrder == Qt::AscendingOrder)
+            it = qUpperBound(userList.begin(), userList.end(), user, IrcUserLessThan(q, sortMethod));
+        else
+            it = qUpperBound(userList.begin(), userList.end(), user, IrcUserGreaterThan(q, sortMethod));
+        index = it - userList.begin();
+    }
+    if (notify)
+        emit q->aboutToBeAdded(user);
+    q->beginInsertRows(QModelIndex(), index, index);
+    userList.insert(index, user);
+    updateTitles();
+    q->endInsertRows();
+    if (notify) {
+        emit q->added(user);
+        emit q->namesChanged(IrcChannelPrivate::get(channel)->names);
+        emit q->titlesChanged(titles);
+        emit q->usersChanged(userList);
+        emit q->countChanged(userList.count());
+        if (userList.count() == 1)
+            emit q->emptyChanged(false);
+    }
+}
+
+void IrcUserModelPrivate::removeUser(IrcUser* user, bool notify)
+{
+    Q_Q(IrcUserModel);
+    int idx = userList.indexOf(user);
+    if (idx != -1) {
+        if (notify)
+            emit q->aboutToBeRemoved(user);
+        q->beginRemoveRows(QModelIndex(), idx, idx);
+        userList.removeAt(idx);
+        updateTitles();
+        q->endRemoveRows();
+        if (notify) {
+            emit q->removed(user);
+            emit q->namesChanged(IrcChannelPrivate::get(channel)->names);
+            emit q->titlesChanged(titles);
+            emit q->usersChanged(userList);
+            emit q->countChanged(userList.count());
+            if (userList.isEmpty())
+                emit q->emptyChanged(true);
+        }
+    }
+}
+
+void IrcUserModelPrivate::setUsers(const QList<IrcUser*>& users, bool reset)
+{
+    Q_Q(IrcUserModel);
+    bool wasEmpty = userList.isEmpty();
+    if (reset)
+        q->beginResetModel();
+    userList = users;
+    if (sortMethod != Irc::SortByHand) {
+        if (sortOrder == Qt::AscendingOrder)
+            qSort(userList.begin(), userList.end(), IrcUserLessThan(q, sortMethod));
+        else
+            qSort(userList.begin(), userList.end(), IrcUserGreaterThan(q, sortMethod));
+    }
+    updateTitles();
+    if (reset)
+        q->endResetModel();
+    QStringList names;
+    if (channel)
+        names = IrcChannelPrivate::get(channel)->names;
+    emit q->namesChanged(names);
+    emit q->titlesChanged(titles);
+    emit q->usersChanged(userList);
+    emit q->countChanged(userList.count());
+    if (wasEmpty != userList.isEmpty())
+        emit q->emptyChanged(userList.isEmpty());
+}
+
+void IrcUserModelPrivate::renameUser(IrcUser* user)
+{
+    Q_Q(IrcUserModel);
+    if (updateUser(user) && sortMethod != Irc::SortByHand) {
+        QList<IrcUser*> users = userList;
+        const bool notify = false;
+        removeUser(user, notify);
+        insertUser(-1, user, notify);
+        if (updateTitles())
+            emit q->titlesChanged(titles);
+        if (users != userList)
+            emit q->usersChanged(userList);
+    }
+}
+
+void IrcUserModelPrivate::setUserMode(IrcUser* user)
+{
+    Q_Q(IrcUserModel);
+    if (updateUser(user) && sortMethod == Irc::SortByTitle) {
+        const bool notify = false;
+        removeUser(user, notify);
+        insertUser(0, user, notify);
+        if (updateTitles())
+            emit q->titlesChanged(titles);
+        emit q->usersChanged(userList);
+    }
+}
+
+void IrcUserModelPrivate::promoteUser(IrcUser* user)
+{
+    Q_Q(IrcUserModel);
+    if (sortMethod == Irc::SortByActivity) {
+        const bool notify = false;
+        removeUser(user, notify);
+        insertUser(0, user, notify);
+        if (updateTitles())
+            emit q->titlesChanged(titles);
+        emit q->usersChanged(userList);
+    }
+}
+
+bool IrcUserModelPrivate::updateUser(IrcUser* user)
+{
+    Q_Q(IrcUserModel);
+    const int idx = userList.indexOf(user);
+    if (idx != -1) {
+        QModelIndex index = q->index(idx, 0);
+        emit q->dataChanged(index, index);
+        return true;
+    }
+    return false;
+}
+
+bool IrcUserModelPrivate::updateTitles()
+{
+    QStringList prev = titles;
+    titles.clear();
+    foreach (IrcUser* user, userList)
+        titles += user->title();
+    return titles != prev;
+}
+
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new model with \a parent.
+
+    \note If \a parent is an instance of IrcChannel, it will be
+    automatically assigned to \ref IrcUserModel::channel "channel".
+ */
+IrcUserModel::IrcUserModel(QObject* parent) : QAbstractListModel(parent), d_ptr(new IrcUserModelPrivate)
+{
+    Q_D(IrcUserModel);
+    d->q_ptr = this;
+    setChannel(qobject_cast<IrcChannel*>(parent));
+
+    qRegisterMetaType<IrcUser*>();
+    qRegisterMetaType<QList<IrcUser*> >();
+}
+
+/*!
+    Destructs the model.
+ */
+IrcUserModel::~IrcUserModel()
+{
+    Q_D(IrcUserModel);
+    if (d->channel)
+        IrcChannelPrivate::get(d->channel)->userModels.removeOne(this);
+}
+
+/*!
+    This property holds the channel.
+
+    \par Access functions:
+    \li \ref IrcChannel* <b>channel</b>() const
+    \li void <b>setChannel</b>(\ref IrcChannel* channel)
+
+    \par Notifier signal:
+    \li void <b>channelChanged</b>(\ref IrcChannel* channel)
+ */
+IrcChannel* IrcUserModel::channel() const
+{
+    Q_D(const IrcUserModel);
+    return d->channel;
+}
+
+void IrcUserModel::setChannel(IrcChannel* channel)
+{
+    Q_D(IrcUserModel);
+    if (d->channel != channel) {
+        beginResetModel();
+        if (d->channel)
+            IrcChannelPrivate::get(d->channel)->userModels.removeOne(this);
+
+        d->channel = channel;
+
+        QList<IrcUser*> users;
+        if (d->channel) {
+            IrcChannelPrivate::get(d->channel)->userModels.append(this);
+            if (d->sortMethod == Irc::SortByActivity)
+                users = IrcChannelPrivate::get(d->channel)->activeUsers;
+            else
+                users = IrcChannelPrivate::get(d->channel)->userList;
+        }
+        const bool reset = false;
+        d->setUsers(users, reset);
+        endResetModel();
+
+        emit channelChanged(channel);
+    }
+}
+
+/*!
+    This property holds the number of users on the channel.
+
+    \par Access function:
+    \li int <b>count</b>() const
+
+    \par Notifier signal:
+    \li void <b>countChanged</b>(int count)
+ */
+int IrcUserModel::count() const
+{
+    return rowCount();
+}
+
+/*!
+    \since 3.1
+    \property bool IrcUserModel::empty
+
+    This property holds the whether the model is empty.
+
+    \par Access function:
+    \li bool <b>isEmpty</b>() const
+
+    \par Notifier signal:
+    \li void <b>emptyChanged</b>(bool empty)
+ */
+bool IrcUserModel::isEmpty() const
+{
+    Q_D(const IrcUserModel);
+    return d->userList.isEmpty();
+}
+
+/*!
+    This property holds the list of names in alphabetical order.
+
+    \par Access function:
+    \li QStringList <b>names</b>() const
+
+    \par Notifier signal:
+    \li void <b>namesChanged</b>(const QStringList& names)
+ */
+QStringList IrcUserModel::names() const
+{
+    Q_D(const IrcUserModel);
+    if (d->channel && !d->userList.isEmpty())
+        return IrcChannelPrivate::get(d->channel)->names;
+    return QStringList();
+}
+
+/*!
+    \since 3.3
+
+    This property holds the list of titles.
+
+    \par Access function:
+    \li QStringList <b>titles</b>() const
+
+    \par Notifier signal:
+    \li void <b>titlesChanged</b>(const QStringList& titles)
+ */
+QStringList IrcUserModel::titles() const
+{
+    Q_D(const IrcUserModel);
+    return d->titles;
+}
+
+/*!
+    This property holds the list of users.
+
+    The order of users is kept as sent from the server.
+
+    \par Access function:
+    \li QList<\ref IrcUser*> <b>users</b>() const
+
+    \par Notifier signal:
+    \li void <b>usersChanged</b>(const QList<\ref IrcUser*>& users)
+ */
+QList<IrcUser*> IrcUserModel::users() const
+{
+    Q_D(const IrcUserModel);
+    return d->userList;
+}
+
+/*!
+    Returns the user object at \a index.
+ */
+IrcUser* IrcUserModel::get(int index) const
+{
+    Q_D(const IrcUserModel);
+    return d->userList.value(index);
+}
+
+/*!
+    Returns the user object for \a name or \c 0 if not found.
+ */
+IrcUser* IrcUserModel::find(const QString& name) const
+{
+    Q_D(const IrcUserModel);
+    if (d->channel && !d->userList.isEmpty())
+        return IrcChannelPrivate::get(d->channel)->userMap.value(name);
+    return 0;
+}
+
+/*!
+    Returns \c true if the model contains \a name.
+ */
+bool IrcUserModel::contains(const QString& name) const
+{
+    Q_D(const IrcUserModel);
+    if (d->channel && !d->userList.isEmpty())
+        return IrcChannelPrivate::get(d->channel)->userMap.contains(name);
+    return false;
+}
+
+/*!
+    Returns the index of the specified \a user,
+    or \c -1 if the model does not contain the \a user.
+ */
+int IrcUserModel::indexOf(IrcUser* user) const
+{
+    Q_D(const IrcUserModel);
+    return d->userList.indexOf(user);
+}
+
+/*!
+    This property holds the model sort method.
+
+    The default value is \c Irc::SortByHand.
+
+    Method              | Description                                                                                       | Example
+    --------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------
+    Irc::SortByHand     | Users are not sorted automatically, but only by calling sort().                                   | -
+    Irc::SortByName     | Users are sorted alphabetically, ignoring any mode prefix.                                        | "bot", "@ChanServ", "jpnurmi", "+qtassistant"
+    Irc::SortByTitle    | Users are sorted alphabetically, and special users (operators, voiced users) before normal users. | "@ChanServ", "+qtassistant", "bot", "jpnurmi"
+    Irc::SortByActivity | Users are sorted based on their activity, last active and mentioned (1) users first.              | -
+
+    1) For performance reasons, IrcUserModel does \b not scan the whole channel
+       messages to find out if a channel user was mentioned. IrcUserModel merely
+       checks if channel messages \b begin with the name of a user in the model.
+
+    \par Access functions:
+    \li Irc::SortMethod <b>sortMethod</b>() const
+    \li void <b>setSortMethod</b>(Irc::SortMethod method)
+
+    \sa sort(), lessThan()
+ */
+Irc::SortMethod IrcUserModel::sortMethod() const
+{
+    Q_D(const IrcUserModel);
+    return d->sortMethod;
+}
+
+void IrcUserModel::setSortMethod(Irc::SortMethod method)
+{
+    Q_D(IrcUserModel);
+    if (d->sortMethod != method) {
+        d->sortMethod = method;
+        if (method == Irc::SortByActivity && d->channel) {
+            d->userList = IrcChannelPrivate::get(d->channel)->activeUsers;
+            if (d->updateTitles())
+                emit titlesChanged(d->titles);
+        }
+        if (d->sortMethod != Irc::SortByHand && !d->userList.isEmpty())
+            sort(d->sortMethod, d->sortOrder);
+    }
+}
+
+/*!
+    This property holds the model sort order.
+
+    The default value is \c Qt::AscendingOrder.
+
+    \par Access functions:
+    \li Qt::SortOrder <b>sortOrder</b>() const
+    \li void <b>setSortOrder</b>(Qt::SortOrder order)
+
+    \sa sort(), lessThan()
+ */
+Qt::SortOrder IrcUserModel::sortOrder() const
+{
+    Q_D(const IrcUserModel);
+    return d->sortOrder;
+}
+
+void IrcUserModel::setSortOrder(Qt::SortOrder order)
+{
+    Q_D(IrcUserModel);
+    if (d->sortOrder != order) {
+        d->sortOrder = order;
+        if (d->sortMethod != Irc::SortByHand && !d->userList.isEmpty())
+            sort(d->sortMethod, d->sortOrder);
+    }
+}
+
+/*!
+    This property holds the display role.
+
+    The specified data role is returned for Qt::DisplayRole.
+
+    The default value is \ref Irc::TitleRole.
+
+    \par Access functions:
+    \li \ref Irc::DataRole <b>displayRole</b>() const
+    \li void <b>setDisplayRole</b>(\ref Irc::DataRole role)
+ */
+Irc::DataRole IrcUserModel::displayRole() const
+{
+    Q_D(const IrcUserModel);
+    return d->role;
+}
+
+void IrcUserModel::setDisplayRole(Irc::DataRole role)
+{
+    Q_D(IrcUserModel);
+    d->role = role;
+}
+
+/*!
+    Returns the model index for \a user.
+ */
+QModelIndex IrcUserModel::index(IrcUser* user) const
+{
+    Q_D(const IrcUserModel);
+    return index(d->userList.indexOf(user));
+}
+
+/*!
+    Returns the user for model \a index.
+ */
+IrcUser* IrcUserModel::user(const QModelIndex& index) const
+{
+    if (!hasIndex(index.row(), index.column()))
+        return 0;
+
+    return static_cast<IrcUser*>(index.internalPointer());
+}
+
+/*!
+    The following role names are provided by default:
+
+    Role            | Name      | Type     | Example
+    --------------- | ----------|----------|--------
+    Qt::DisplayRole | "display" | 1)       | -
+    Irc::UserRole   | "user"    | IrcUser* | &lt;object&gt;
+    Irc::NameRole   | "name"    | QString  | "jpnurmi"
+    Irc::PrefixRole | "prefix"  | QString  | "@"
+    Irc::ModeRole   | "mode"    | QString  | "o"
+    Irc::TitleRole  | "title"   | QString  | "@jpnurmi"
+
+    1) The type depends on \ref displayRole.
+ */
+QHash<int, QByteArray> IrcUserModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[Qt::DisplayRole] = "display";
+    roles[Irc::UserRole] = "user";
+    roles[Irc::NameRole] = "name";
+    roles[Irc::PrefixRole] = "prefix";
+    roles[Irc::ModeRole] = "mode";
+    roles[Irc::TitleRole] = "title";
+    return roles;
+}
+
+/*!
+    Returns the number of users on the channel.
+ */
+int IrcUserModel::rowCount(const QModelIndex& parent) const
+{
+    Q_D(const IrcUserModel);
+    if (parent.isValid() || !d->channel)
+        return 0;
+
+    return d->userList.count();
+}
+
+/*!
+    Returns the data for specified \a role referred to by the \a index.
+
+    \sa Irc::DataRole, roleNames()
+ */
+QVariant IrcUserModel::data(const QModelIndex& index, int role) const
+{
+    Q_D(const IrcUserModel);
+    if (!d->channel || !hasIndex(index.row(), index.column(), index.parent()))
+        return QVariant();
+
+    IrcUser* user = static_cast<IrcUser*>(index.internalPointer());
+    Q_ASSERT(user);
+
+    switch (role) {
+    case Qt::DisplayRole:
+        return data(index, d->role);
+    case Irc::UserRole:
+        return QVariant::fromValue(user);
+    case Irc::NameRole:
+        return user->name();
+    case Irc::PrefixRole:
+        return user->prefix().left(1);
+    case Irc::ModeRole:
+        return user->mode().left(1);
+    case Irc::TitleRole:
+        return user->title();
+    }
+
+    return QVariant();
+}
+
+/*!
+    Returns the index of the item in the model specified by the given \a row, \a column and \a parent index.
+ */
+QModelIndex IrcUserModel::index(int row, int column, const QModelIndex& parent) const
+{
+    Q_D(const IrcUserModel);
+    if (!d->channel || !hasIndex(row, column, parent))
+        return QModelIndex();
+
+    return createIndex(row, column, d->userList.value(row));
+}
+
+/*!
+    Clears the model.
+ */
+void IrcUserModel::clear()
+{
+    Q_D(IrcUserModel);
+    if (!d->userList.isEmpty()) {
+        beginResetModel();
+        d->userList.clear();
+        endResetModel();
+        emit namesChanged(QStringList());
+        emit titlesChanged(QStringList());
+        emit usersChanged(QList<IrcUser*>());
+        emit countChanged(0);
+        emit emptyChanged(true);
+    }
+}
+
+/*!
+    Sorts the model using the given \a order.
+ */
+void IrcUserModel::sort(int column, Qt::SortOrder order)
+{
+    Q_D(IrcUserModel);
+    if (column == 0)
+        sort(d->sortMethod, order);
+}
+
+/*!
+    Sorts the model using the given \a method and \a order.
+
+    \sa lessThan()
+ */
+void IrcUserModel::sort(Irc::SortMethod method, Qt::SortOrder order)
+{
+    Q_D(IrcUserModel);
+    if (method == Irc::SortByHand)
+        return;
+
+    emit layoutAboutToBeChanged();
+
+    QList<IrcUser*> persistentUsers;
+    QModelIndexList oldPersistentIndexes = persistentIndexList();
+    foreach (const QModelIndex& index, oldPersistentIndexes)
+        persistentUsers += static_cast<IrcUser*>(index.internalPointer());
+
+    if (order == Qt::AscendingOrder)
+        qSort(d->userList.begin(), d->userList.end(), IrcUserLessThan(this, method));
+    else
+        qSort(d->userList.begin(), d->userList.end(), IrcUserGreaterThan(this, method));
+
+    if (d->updateTitles())
+        emit titlesChanged(d->titles);
+
+    QModelIndexList newPersistentIndexes;
+    foreach (IrcUser* user, persistentUsers)
+        newPersistentIndexes += index(d->userList.indexOf(user));
+    changePersistentIndexList(oldPersistentIndexes, newPersistentIndexes);
+
+    emit layoutChanged();
+}
+
+/*!
+    Returns \c true if \a one buffer is "less than" \a another,
+    otherwise returns \c false.
+
+    The default implementation sorts according to the specified sort method.
+    Reimplement this function in order to customize the sort order.
+
+    \sa sort(), sortMethod
+ */
+bool IrcUserModel::lessThan(IrcUser* one, IrcUser* another, Irc::SortMethod method) const
+{
+    if (method == Irc::SortByActivity) {
+        QList<IrcUser*> activeUsers = IrcChannelPrivate::get(one->channel())->activeUsers;
+        const int i1 = activeUsers.indexOf(one);
+        const int i2 = activeUsers.indexOf(another);
+        return i1 < i2;
+    } else if (method == Irc::SortByTitle) {
+        const IrcNetwork* network = one->channel()->network();
+        const QStringList prefixes = network->prefixes();
+
+        const QString p1 = one->prefix();
+        const QString p2 = another->prefix();
+
+        const int i1 = !p1.isEmpty() ? prefixes.indexOf(p1.at(0)) : -1;
+        const int i2 = !p2.isEmpty() ? prefixes.indexOf(p2.at(0)) : -1;
+
+        if (i1 >= 0 && i2 < 0)
+            return true;
+        if (i1 < 0 && i2 >= 0)
+            return false;
+        if (i1 >= 0 && i2 >= 0 && i1 != i2)
+            return i1 < i2;
+    }
+
+    // Irc::SortByName
+    const QString n1 = one->name();
+    const QString n2 = another->name();
+    return n1.compare(n2, Qt::CaseInsensitive) < 0;
+}
+
+#include "moc_ircusermodel.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/model/model.pri
+++ b/3rdparty/communi/src/model/model.pri
@@ -1,0 +1,40 @@
+######################################################################
+# Communi
+######################################################################
+
+DEFINES += BUILD_IRC_MODEL
+
+INCDIR = $$PWD/../../include/IrcModel
+
+DEPENDPATH += $$PWD $$INCDIR
+INCLUDEPATH += $$PWD $$INCDIR
+
+CONV_HEADERS  = $$INCDIR/IrcBuffer
+CONV_HEADERS += $$INCDIR/IrcBufferModel
+CONV_HEADERS += $$INCDIR/IrcChannel
+CONV_HEADERS += $$INCDIR/IrcModel
+CONV_HEADERS += $$INCDIR/IrcUser
+CONV_HEADERS += $$INCDIR/IrcUserModel
+
+PUB_HEADERS  = $$INCDIR/ircbuffer.h
+PUB_HEADERS += $$INCDIR/ircbuffermodel.h
+PUB_HEADERS += $$INCDIR/ircchannel.h
+PUB_HEADERS += $$INCDIR/ircmodel.h
+PUB_HEADERS += $$INCDIR/ircuser.h
+PUB_HEADERS += $$INCDIR/ircusermodel.h
+
+PRIV_HEADERS  = $$INCDIR/ircbuffer_p.h
+PRIV_HEADERS += $$INCDIR/ircbuffermodel_p.h
+PRIV_HEADERS += $$INCDIR/ircchannel_p.h
+PRIV_HEADERS += $$INCDIR/ircuser_p.h
+PRIV_HEADERS += $$INCDIR/ircusermodel_p.h
+
+HEADERS += $$PUB_HEADERS
+HEADERS += $$PRIV_HEADERS
+
+SOURCES += $$PWD/ircbuffer.cpp
+SOURCES += $$PWD/ircbuffermodel.cpp
+SOURCES += $$PWD/ircchannel.cpp
+SOURCES += $$PWD/ircmodel.cpp
+SOURCES += $$PWD/ircuser.cpp
+SOURCES += $$PWD/ircusermodel.cpp

--- a/3rdparty/communi/src/util/irccommandparser.cpp
+++ b/3rdparty/communi/src/util/irccommandparser.cpp
@@ -1,0 +1,597 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "irccommandparser.h"
+#include "irccommandparser_p.h"
+#include "irctoken_p.h"
+#include <climits>
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file irccommandparser.h
+    \brief \#include &lt;IrcCommandParser&gt;
+ */
+
+/*!
+    \class IrcCommandParser irccommandparser.h <IrcCommandParser>
+    \ingroup util
+    \brief Parses commands from user input.
+
+    \section syntax Syntax
+
+    Since the list of supported commands and the exact syntax for each
+    command is application specific, IrcCommandParser does not provide
+    any built-in command syntaxes. It is left up to the applications
+    to introduce the supported commands and syntaxes.
+    IrcCommandParser supports the following command syntax markup:
+
+    Syntax             | Example              | Description
+    -------------------|----------------------|------------
+    &lt;param&gt;      | &lt;target&gt;       | A required parameter.
+    (&lt;param&gt;)    | (&lt;key&gt;)        | An optional parameter.
+    &lt;param...&gt;   | &lt;message...&gt;   | A required parameter, multiple words accepted. (1)
+    (&lt;param...&gt;) | (&lt;message...&gt;) | An optional parameter, multiple words accepted. (1)
+    (&lt;\#param&gt;)  | (&lt;\#channel&gt;)  | An optional channel parameter. (2)
+    [param]            | [target]             | Inject the current target.
+
+    -# Multi-word parameters are only supported in the last parameter position.
+    -# An optional channel parameter is filled up with the current channel when absent.
+
+    The following example presents introducing some typical commands.
+    \code
+    IrcCommandParser* parser = new IrcCommandParser(this);
+    parser->addCommand(IrcCommand::Join, "JOIN <#channel> (<key>)");
+    parser->addCommand(IrcCommand::Part, "PART (<#channel>) (<message...>)");
+    parser->addCommand(IrcCommand::Kick, "KICK (<#channel>) <nick> (<reason...>)");
+    parser->addCommand(IrcCommand::CtcpAction, "ME [target] <message...>");
+    parser->addCommand(IrcCommand::CtcpAction, "ACTION <target> <message...>");
+    \endcode
+
+    \note The parameter names are insignificant, but descriptive
+    parameter names are recommended for the sake of readability.
+
+    \section context Context
+
+    Notice that commands are often context sensitive. While some command
+    may accept an optional parameter that is filled up with the current
+    target (channel/query) name when absent, another command may always
+    inject the current target name as a certain parameter. Therefore
+    IrcCommandParser must be kept up-to-date with the \ref target
+    "current target" and the \ref channels "list of channels".
+
+    \code
+    // currently in a query, and also present on some channels
+    parser->setTarget("jpnurmi");
+    parser->setChannels(QStringList() << "#communi" << "#freenode");
+    \endcode
+
+    \section command-triggers Command triggers
+
+    IrcCommandParser serves as a generic parser for typical IRC commands.
+    It can be utilized for parsing commands from user input in GUI clients,
+    and from messages from other clients when implementing IRC bots.
+
+    The command parsing behavior is controlled by setting up command
+    \ref triggers. Whilst a typical GUI client might use \c "/" as a command
+    trigger, an IRC bot might use \c "!" and the nick name of the bot. The
+    following snippet illustrates a typical GUI client usage.
+
+    \code
+    parser->setTarget("#communi");
+    parser->setTriggers(QStringList() << "/");
+    parser->parse(input);
+    \endcode
+
+    \p
+    Input             | Result              | Description
+    ------------------|---------------------|------------
+    "hello"           | IrcCommand::Message | No matching command trigger => a message "hello" to \#communi
+    "/join #channel"  | IrcCommand::Join    | Matching command trigger => a command to join "#channel"
+
+    See the \ref bot "bot example" to see how the parser can be effectively utilized for IRC bots.
+
+    \section parse-custom-commands Custom commands
+
+    The parser also supports such custom client specific commands that
+    are not sent to the server. Since IrcCommand does not know how to
+    handle custom commands, the parser treats them as a special case
+    injecting the command as a first parameter.
+
+    \code
+    IrcParser parser;
+    parser.addCommand(IrcCommand::Custom, "QUERY <user>");
+    IrcCommand* command = parser.parse("/query jpnurmi");
+    Q_ASSERT(command->type() == IrcCommand::Custom);
+    qDebug() << command->parameters(); // ("QUERY", "jpnurmi")
+    \endcode
+ */
+
+/*!
+    \enum IrcCommandParser::Detail
+    This enum describes the available syntax details.
+ */
+
+/*!
+    \var IrcCommandParser::Full
+    \brief The syntax in full details
+ */
+
+/*!
+    \var IrcCommandParser::NoTarget
+    \brief The syntax has injected [target] removed
+ */
+
+/*!
+    \var IrcCommandParser::NoPrefix
+    \brief The syntax has \#channel prefixes removed
+ */
+
+/*!
+    \var IrcCommandParser::NoEllipsis
+    \brief The syntax has ellipsis... removed
+ */
+
+/*!
+    \var IrcCommandParser::NoParentheses
+    \brief The syntax has parentheses () removed
+ */
+
+/*!
+    \var IrcCommandParser::NoBrackets
+    \brief The syntax has brackets [] removed
+ */
+
+/*!
+    \var IrcCommandParser::NoAngles
+    \brief The syntax has angle brackets <> removed
+ */
+
+/*!
+    \var IrcCommandParser::Visual
+    \brief The syntax suitable for visual representation
+ */
+
+#ifndef IRC_DOXYGEN
+IrcCommandParserPrivate::IrcCommandParserPrivate() : tolerant(false)
+{
+}
+
+QList<IrcCommandInfo> IrcCommandParserPrivate::find(const QString& command) const
+{
+    QList<IrcCommandInfo> result;
+    foreach (const IrcCommandInfo& cmd, commands) {
+        if (cmd.command == command)
+            result += cmd;
+    }
+    return result;
+}
+
+static inline bool isOptional(const QString& token)
+{
+    return token.startsWith(QLatin1Char('(')) && token.endsWith(QLatin1Char(')'));
+}
+
+static inline bool isMultiWord(const QString& token)
+{
+    return token.contains(QLatin1String("..."));
+}
+
+static inline bool isChannel(const QString& token)
+{
+    return token.contains(QLatin1Char('#'));
+}
+
+static inline bool isCurrent(const QString& token)
+{
+    return token.startsWith(QLatin1Char('[')) && token.endsWith(QLatin1Char(']'));
+}
+
+IrcCommandInfo IrcCommandParserPrivate::parseSyntax(IrcCommand::Type type, const QString& syntax)
+{
+    IrcCommandInfo cmd;
+    QStringList tokens = syntax.split(QLatin1Char(' '), QString::SkipEmptyParts);
+    if (!tokens.isEmpty()) {
+        cmd.type = type;
+        cmd.command = tokens.takeFirst().toUpper();
+        cmd.syntax = tokens.join(QLatin1String(" "));
+        cmd.max = tokens.count();
+
+        IrcParameterInfo param;
+        for (int i = 0; i < tokens.count(); ++i) {
+            const QString& token = tokens.at(i);
+            param.optional = isOptional(token);
+            param.channel = isChannel(token);
+            param.current = isCurrent(token);
+            param.multi = isMultiWord(token);
+            if (!param.optional)
+                ++cmd.min;
+            if (param.optional && param.channel)
+                ++cmd.min;
+            const bool last = (i == tokens.count() - 1);
+            if (last && param.multi)
+                cmd.max = INT_MAX;
+            cmd.params += param;
+        }
+    }
+    return cmd;
+}
+
+IrcCommand* IrcCommandParserPrivate::parseCommand(const IrcCommandInfo& command, const QString& input) const
+{
+    IrcCommand* cmd = 0;
+    QStringList params;
+    if (processParameters(command, input, &params)) {
+        const int count = params.count();
+        if (count >= command.min && count <= command.max) {
+            cmd = new IrcCommand;
+            cmd->setType(command.type);
+            if (command.type == IrcCommand::Custom)
+                params.prepend(command.command);
+            cmd->setParameters(params);
+        }
+    }
+    return cmd;
+}
+
+bool IrcCommandParserPrivate::processParameters(const IrcCommandInfo& command, const QString& input, QStringList* params) const
+{
+    IrcTokenizer tokenizer(input);
+    for (int i = 0; i < command.params.count(); ++i) {
+        const IrcParameterInfo& info = command.params.at(i);
+        const IrcToken token = tokenizer.at(0);
+        if (info.optional && info.channel) {
+            if (onChannel()) {
+                if (!token.isValid() || !channels.contains(token.text(), Qt::CaseInsensitive)) {
+                    params->append(target);
+                } else if (token.isValid()) {
+                    tokenizer = tokenizer.mid(1);
+                    params->append(token.text());
+                }
+            } else if (!channels.contains(token.text())) {
+                return false;
+            }
+        } else if (info.current) {
+            params->append(target);
+        } else if (info.multi) {
+            const QString multi = tokenizer.toString();
+            if (!multi.isEmpty()) {
+                params->append(multi);
+                tokenizer.clear();
+            }
+        } else {
+            tokenizer = tokenizer.mid(1);
+            if (token.isValid())
+                params->append(token.text());
+        }
+    }
+    return tokenizer.isEmpty();
+}
+
+bool IrcCommandParserPrivate::processCommand(QString* input, int* removed) const
+{
+    foreach (const QString& trigger, triggers) {
+        if (tolerant && trigger.length() == 1 && (input->startsWith(trigger.repeated(2)) || input->startsWith(trigger + QLatin1Char(' ')))) {
+            // treat "//cmd" and "/ /cmd" as message (-> "/cmd")
+            input->remove(0, 1);
+            if (removed)
+                *removed = 1;
+            return false;
+        } else if (input->startsWith(trigger)) {
+            input->remove(0, trigger.length());
+            if (removed)
+                *removed = trigger.length();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IrcCommandParserPrivate::processMessage(QString* input, int* removed) const
+{
+    if (input->isEmpty())
+        return false;
+    if (triggers.isEmpty())
+        return tolerant;
+    if (processCommand(input, removed))
+        return false;
+    return tolerant;
+}
+
+bool IrcCommandParserPrivate::onChannel() const
+{
+    return channels.contains(target, Qt::CaseInsensitive);
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a command parser with \a parent.
+ */
+IrcCommandParser::IrcCommandParser(QObject* parent) : QObject(parent), d_ptr(new IrcCommandParserPrivate)
+{
+}
+
+/*!
+    Destructs the command parser.
+ */
+IrcCommandParser::~IrcCommandParser()
+{
+}
+
+/*!
+    This property holds the known commands.
+
+    The commands are uppercased and in alphabetical order.
+
+    \par Access function:
+    \li QStringList <b>commands</b>() const
+
+    \par Notifier signal:
+    \li void <b>commandsChanged</b>(const QStringList& commands)
+
+    \sa addCommand(), removeCommand()
+ */
+QStringList IrcCommandParser::commands() const
+{
+    Q_D(const IrcCommandParser);
+    return d->commands.uniqueKeys();
+}
+
+/*!
+    Returns syntax for the given \a command in given \a details level.
+ */
+QString IrcCommandParser::syntax(const QString& command, Details details) const
+{
+    Q_D(const IrcCommandParser);
+    IrcCommandInfo info = d->find(command.toUpper()).value(0);
+    if (!info.command.isEmpty()) {
+        QString str = info.fullSyntax();
+        if (details != Full) {
+            if (details & NoTarget)
+                str.remove(QRegExp("\\[[^\\]]+\\]"));
+            if (details & NoPrefix)
+                str.remove("#");
+            if (details & NoEllipsis)
+                str.remove("...");
+            if (details & NoParentheses)
+                str.remove("(").remove(")");
+            if (details & NoBrackets)
+                str.remove("[").remove("]");
+            if (details & NoAngles)
+                str.remove("<").remove(">");
+        }
+        return str.simplified();
+    }
+    return QString();
+}
+
+/*!
+    Adds a command with \a type and \a syntax.
+ */
+void IrcCommandParser::addCommand(IrcCommand::Type type, const QString& syntax)
+{
+    Q_D(IrcCommandParser);
+    IrcCommandInfo cmd = d->parseSyntax(type, syntax);
+    if (!cmd.command.isEmpty()) {
+        const bool contains = d->commands.contains(cmd.command);
+        d->commands.insert(cmd.command, cmd);
+        if (!contains)
+            emit commandsChanged(commands());
+    }
+}
+
+/*!
+    Removes the command with \a type and \a syntax.
+ */
+void IrcCommandParser::removeCommand(IrcCommand::Type type, const QString& syntax)
+{
+    Q_D(IrcCommandParser);
+    bool changed = false;
+    QMutableMapIterator<QString, IrcCommandInfo> it(d->commands);
+    while (it.hasNext()) {
+        IrcCommandInfo cmd = it.next().value();
+        if (cmd.type == type && (syntax.isEmpty() || !syntax.compare(cmd.fullSyntax(), Qt::CaseInsensitive))) {
+            it.remove();
+            if (!d->commands.contains(cmd.command))
+                changed = true;
+        }
+    }
+    if (changed)
+        emit commandsChanged(commands());
+}
+
+/*!
+    This property holds the available channels.
+
+    \par Access functions:
+    \li QStringList <b>channels</b>() const
+    \li void <b>setChannels</b>(const QStringList& channels) [slot]
+
+    \par Notifier signal:
+    \li void <b>channelsChanged</b>(const QStringList& channels)
+
+    \sa IrcBufferModel::channels()
+ */
+QStringList IrcCommandParser::channels() const
+{
+    Q_D(const IrcCommandParser);
+    return d->channels;
+}
+
+void IrcCommandParser::setChannels(const QStringList& channels)
+{
+    Q_D(IrcCommandParser);
+    if (d->channels != channels) {
+        d->channels = channels;
+        emit channelsChanged(channels);
+    }
+}
+
+/*!
+    This property holds the current target.
+
+    \par Access functions:
+    \li QString <b>target</b>() const
+    \li void <b>setTarget</b>(const QString& target) [slot]
+
+    \par Notifier signal:
+    \li void <b>targetChanged</b>(const QString& target)
+ */
+QString IrcCommandParser::target() const
+{
+    Q_D(const IrcCommandParser);
+    return d->target;
+}
+
+void IrcCommandParser::setTarget(const QString& target)
+{
+    Q_D(IrcCommandParser);
+    if (d->target != target) {
+        d->target = target;
+        emit targetChanged(target);
+    }
+}
+
+/*!
+    This property holds the command triggers.
+
+    \par Access functions:
+    \li QStringList <b>triggers</b>() const
+    \li void <b>setTriggers</b>(const QStringList& triggers) [slot]
+
+    \par Notifier signal:
+    \li void <b>triggersChanged</b>(const QStringList& triggers)
+ */
+QStringList IrcCommandParser::triggers() const
+{
+    Q_D(const IrcCommandParser);
+    return d->triggers;
+}
+
+void IrcCommandParser::setTriggers(const QStringList& triggers)
+{
+    Q_D(IrcCommandParser);
+    if (d->triggers != triggers) {
+        d->triggers = triggers;
+        emit triggersChanged(triggers);
+    }
+}
+
+/*!
+    \property bool IrcCommandParser::tolerant
+
+    This property holds whether the parser is tolerant.
+
+    A tolerant parser creates message commands out of input that does not
+    start with a command trigger, and raw server commands when the input
+    starts with a command trigger but the command is unrecognized. Known
+    commands with invalid arguments are still considered invalid.
+
+    The default value is \c false.
+
+    \par Access functions:
+    \li bool <b>isTolerant</b>() const
+    \li void <b>setTolerant</b>(bool tolerant)
+
+    \par Notifier signal:
+    \li void <b>tolerancyChanged</b>(bool tolerant)
+
+    \sa IrcCommand::Quote
+ */
+bool IrcCommandParser::isTolerant() const
+{
+    Q_D(const IrcCommandParser);
+    return d->tolerant;
+}
+
+void IrcCommandParser::setTolerant(bool tolerant)
+{
+    Q_D(IrcCommandParser);
+    if (d->tolerant != tolerant) {
+        d->tolerant = tolerant;
+        emit tolerancyChanged(tolerant);
+    }
+}
+
+/*!
+    Parses and returns the command for \a input, or \c 0 if the input is not valid.
+ */
+IrcCommand* IrcCommandParser::parse(const QString& input) const
+{
+    Q_D(const IrcCommandParser);
+    QString message = input;
+    if (d->processMessage(&message)) {
+        return IrcCommand::createMessage(d->target, message.trimmed());
+    } else if (!message.isEmpty()) {
+        IrcTokenizer tokenizer(message);
+        const QString command = tokenizer.at(0).text().toUpper();
+        QString params = tokenizer.mid(1).toString();
+        const QList<IrcCommandInfo> commands = d->find(command);
+        if (!commands.isEmpty()) {
+            foreach (const IrcCommandInfo& c, commands) {
+                IrcCommand* cmd = d->parseCommand(c, params);
+                if (cmd)
+                    return cmd;
+            }
+        } else if (d->tolerant) {
+            IrcCommandInfo custom = d->parseSyntax(IrcCommand::Quote, QString(QLatin1String("%1 (<parameters...>)")).arg(command));
+            params.prepend(custom.command + QLatin1Char(' '));
+            return d->parseCommand(custom, params);
+        }
+    }
+    return 0;
+}
+
+/*!
+    Clears the list of commands.
+
+    \sa reset()
+ */
+void IrcCommandParser::clear()
+{
+    Q_D(IrcCommandParser);
+    if (!d->commands.isEmpty()) {
+        d->commands.clear();
+        emit commandsChanged(QStringList());
+    }
+}
+
+/*!
+    Resets the channels and the current target.
+
+    \sa clear()
+ */
+void IrcCommandParser::reset()
+{
+    setChannels(QStringList());
+    setTarget(QString());
+}
+
+#include "moc_irccommandparser.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/irccommandqueue.cpp
+++ b/3rdparty/communi/src/util/irccommandqueue.cpp
@@ -1,0 +1,251 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "irccommandqueue.h"
+#include "irccommandqueue_p.h"
+#include "ircconnection.h"
+#include "irccommand.h"
+
+IRC_BEGIN_NAMESPACE
+
+static const int DEFAULT_BATCH = 3;
+static const int DEFAULT_INTERVAL = 2;
+
+/*!
+    \file irccommandqueue.h
+    \brief \#include &lt;IrcCommandQueue&gt;
+ */
+
+/*!
+    \since 3.4
+    \class IrcCommandQueue irccommandqueue.h <IrcCommandQueue>
+    \ingroup util
+    \brief Provides a flood protection queue for commands.
+ */
+
+/*!
+    \fn void IrcCommandQueue::sizeChanged(int size)
+
+    This signal is emitted when the queue \a size has changed.
+ */
+
+#ifndef IRC_DOXYGEN
+IrcCommandQueuePrivate::IrcCommandQueuePrivate() : q_ptr(0),
+    connection(0), batch(DEFAULT_BATCH), interval(DEFAULT_INTERVAL)
+{
+}
+
+bool IrcCommandQueuePrivate::commandFilter(IrcCommand* cmd)
+{
+    Q_Q(IrcCommandQueue);
+    if (cmd->type() == IrcCommand::Quit) {
+        _irc_sendBatch(true);
+    } else if (interval > 0 && !cmd->parent() && connection->isConnected()) {
+        cmd->setParent(q);
+        commands.enqueue(cmd);
+        emit q->sizeChanged(commands.size());
+        _irc_updateTimer();
+        return true;
+    }
+    return false;
+}
+
+void IrcCommandQueuePrivate::_irc_updateTimer()
+{
+    if (connection && interval > 0 && !commands.isEmpty() && connection->isConnected()) {
+        timer.setInterval(interval * 1000);
+        if (!timer.isActive())
+            timer.start();
+    } else {
+        if (timer.isActive())
+            timer.stop();
+    }
+}
+
+void IrcCommandQueuePrivate::_irc_sendBatch(bool force)
+{
+    Q_Q(IrcCommandQueue);
+    if (!commands.isEmpty()) {
+        int i = batch;
+        while ((force || --i >= 0) && !commands.isEmpty()) {
+            IrcCommand* cmd = commands.dequeue();
+            if (cmd) {
+                connection->sendCommand(cmd);
+                cmd->deleteLater();
+            }
+        }
+        emit q->sizeChanged(commands.size());
+    }
+    _irc_updateTimer();
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new command queue with \a parent.
+
+    \note If \a parent is an instance of IrcConnection, it will be
+    automatically assigned to \ref IrcCommandQueue::connection "connection".
+ */
+IrcCommandQueue::IrcCommandQueue(QObject* parent) : QObject(parent), d_ptr(new IrcCommandQueuePrivate)
+{
+    Q_D(IrcCommandQueue);
+    d->q_ptr = this;
+    connect(&d->timer, SIGNAL(timeout()), this, SLOT(_irc_sendBatch()));
+    setConnection(qobject_cast<IrcConnection*>(parent));
+}
+
+/*!
+    Destructs the command queue.
+ */
+IrcCommandQueue::~IrcCommandQueue()
+{
+    clear();
+}
+
+/*!
+    This property holds the batch size.
+
+    This is the amount of commands sent at once.
+    The default value is \c 3.
+
+    \par Access functions:
+    \li int <b>batch</b>() const
+    \li void <b>setBatch</b>(int batch)
+ */
+int IrcCommandQueue::batch() const
+{
+    Q_D(const IrcCommandQueue);
+    return d->batch;
+}
+
+void IrcCommandQueue::setBatch(int batch)
+{
+    Q_D(IrcCommandQueue);
+    d->batch = batch;
+}
+
+/*!
+    This property holds the queue processing interval in seconds.
+
+    The default value is \c 2 seconds. A value equal to or
+    less than \c 0 seconds disables command queueing.
+
+    \par Access functions:
+    \li int <b>interval</b>() const
+    \li void <b>setInterval</b>(int seconds)
+ */
+int IrcCommandQueue::interval() const
+{
+    Q_D(const IrcCommandQueue);
+    return d->interval;
+}
+
+void IrcCommandQueue::setInterval(int seconds)
+{
+    Q_D(IrcCommandQueue);
+    if (d->interval != seconds) {
+        d->interval = seconds;
+        d->_irc_updateTimer();
+    }
+}
+
+/*!
+    This property holds the current size of the queue.
+
+    \par Access function:
+    \li int <b>size</b>() const
+
+    \par Notifier signal:
+    \li void <b>sizeChanged</b>(int size)
+ */
+int IrcCommandQueue::size() const
+{
+    Q_D(const IrcCommandQueue);
+    return d->commands.size();
+}
+
+/*!
+    This property holds the associated connection.
+
+    \par Access functions:
+    \li IrcConnection* <b>connection</b>() const
+    \li void <b>setConnection</b>(IrcConnection* connection)
+ */
+IrcConnection* IrcCommandQueue::connection() const
+{
+    Q_D(const IrcCommandQueue);
+    return d->connection;
+}
+
+void IrcCommandQueue::setConnection(IrcConnection* connection)
+{
+    Q_D(IrcCommandQueue);
+    if (d->connection != connection) {
+        if (d->connection) {
+            d->connection->removeCommandFilter(d);
+            disconnect(d->connection, SIGNAL(connected()), this, SLOT(_irc_sendBatch()));
+            disconnect(d->connection, SIGNAL(disconnected()), this, SLOT(_irc_updateTimer()));
+        }
+        d->connection = connection;
+        if (connection) {
+            connection->installCommandFilter(d);
+            connect(connection, SIGNAL(connected()), this, SLOT(_irc_sendBatch()));
+            connect(connection, SIGNAL(disconnected()), this, SLOT(_irc_updateTimer()));
+        }
+        d->_irc_updateTimer();
+    }
+}
+
+/*!
+    This methods clears the command queue.
+
+    \note Any queued commands are not sent.
+
+    \sa flush()
+ */
+void IrcCommandQueue::clear()
+{
+    Q_D(IrcCommandQueue);
+    qDeleteAll(d->commands);
+    d->commands.clear();
+    d->_irc_updateTimer();
+}
+
+/*!
+    This methods flushes the whole command queue without batching.
+ */
+void IrcCommandQueue::flush()
+{
+    Q_D(IrcCommandQueue);
+    d->_irc_sendBatch(true);
+}
+
+#include "moc_irccommandqueue.cpp"
+#include "moc_irccommandqueue_p.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/irccompleter.cpp
+++ b/3rdparty/communi/src/util/irccompleter.cpp
@@ -1,0 +1,411 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "irccompleter.h"
+#include "irccommandparser.h"
+#include "irccommandparser_p.h"
+#include "ircbuffermodel.h"
+#include "ircusermodel.h"
+#include "ircnetwork.h"
+#include "ircchannel.h"
+#include "irctoken_p.h"
+#include "ircuser.h"
+
+#include <QTextBoundaryFinder>
+#include <QPointer>
+#include <QList>
+#include <QPair>
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file irccompleter.h
+    \brief \#include &lt;IrcCompleter&gt;
+ */
+
+/*!
+    \since 3.1
+    \class IrcCompleter irccompleter.h <IrcCompleter>
+    \ingroup util
+    \brief Provides command and name completion.
+
+    IrcCompleter provides command and name completion for a text input field. The completer
+    is made context aware by assigning a command \ref IrcCompleter::parser "parser" and a
+    \ref buffer that is currently active in the GUI. The parser is used for completing
+    commands, and the buffer is used for completing buffer and user names.
+
+    In order to perform a completion, call complete() with the current text input field
+    content and the cursor position. If a suitable completion is found, the completed()
+    signal is emitted with a suggestion for a new content and cursor position for the
+    text input field.
+
+    \code
+    TextField {
+        id: textField
+
+        Keys.onTabPressed: completer.complete(text, cursorPosition)
+
+        IrcCompleter {
+            id: completer
+
+            buffer: ...
+            parser: ...
+
+            onCompleted: {
+                textField.text = text
+                textField.cursorPosition = cursor
+            }
+        }
+    }
+    \endcode
+
+    \sa IrcCommandParser, IrcBuffer
+ */
+
+/*!
+    \fn void IrcCompleter::completed(const QString& text, int cursor)
+
+    This signal is emitted when a suitable completion with \a text and \a cursor position is found.
+ */
+
+#ifndef IRC_DOXYGEN
+
+static bool isPrefixed(const QString& text, int pos, const QStringList& prefixes, int* len)
+{
+    foreach (const QString& prefix, prefixes) {
+        const int ll = prefix.length();
+        if (text.mid(pos, ll) == prefix) {
+            if (len)
+                *len = 0;
+            return true;
+        } else if (text.mid(pos - ll, ll) == prefix) {
+            if (len)
+                *len = ll;
+            return true;
+        }
+    }
+    return false;
+}
+
+struct IrcCompletion
+{
+    IrcCompletion() : text(), cursor(-1) { }
+    IrcCompletion(const QString& txt, int pos) : text(txt), cursor(pos) { }
+    bool isValid() const { return !text.isNull() && cursor != -1; }
+    bool operator ==(const IrcCompletion& other) const { return text == other.text && cursor == other.cursor; }
+    bool operator !=(const IrcCompletion& other) const { return text != other.text || cursor != other.cursor; }
+    QString text;
+    int cursor;
+};
+
+class IrcCompleterPrivate
+{
+    Q_DECLARE_PUBLIC(IrcCompleter)
+
+public:
+    IrcCompleterPrivate();
+
+    void completeNext(IrcCompleter::Direction direction);
+    QList<IrcCompletion> completeCommands(const QString& text, int pos) const;
+    QList<IrcCompletion> completeWords(const QString& text, int pos) const;
+
+    IrcCompleter* q_ptr;
+
+    int index;
+    int cursor;
+    QString text;
+    QList<IrcCompletion> completions;
+
+    QString suffix;
+    QPointer<IrcBuffer> buffer;
+    QPointer<IrcCommandParser> parser;
+};
+
+IrcCompleterPrivate::IrcCompleterPrivate() : q_ptr(0), index(-1), cursor(-1), suffix(":"), buffer(0), parser(0)
+{
+}
+
+void IrcCompleterPrivate::completeNext(IrcCompleter::Direction direction)
+{
+    Q_Q(IrcCompleter);
+    Q_ASSERT(!completions.isEmpty());
+    if (direction == IrcCompleter::Forward) {
+        index = (index + 1) % completions.length();
+    } else {
+        if (--index < 0)
+            index = completions.length() - 1;
+    }
+    if (index >= 0 && index < completions.length()) {
+        const IrcCompletion completion = completions.at(index);
+        text = completion.text;
+        cursor = completion.cursor;
+        emit q->completed(text, cursor);
+    }
+}
+
+static IrcCompletion completeCommand(const QString& text, const QString& command)
+{
+    IrcTokenizer tokenizer(text);
+    tokenizer.replace(0, command);
+    QString completion = tokenizer.toString();
+    int next = command.length();
+    if (next >= completion.length() || completion.at(next) != QLatin1Char(' '))
+        completion.insert(next, QLatin1Char(' '));
+    return IrcCompletion(completion, ++next);
+}
+
+QList<IrcCompletion> IrcCompleterPrivate::completeCommands(const QString& text, int pos) const
+{
+    if (!parser)
+        return QList<IrcCompletion>();
+
+    QList<IrcCompletion> completions;
+
+    int removed = 0;
+    QString input = text;
+    IrcCommandParserPrivate* pp = IrcCommandParserPrivate::get(parser);
+    if (pp->processCommand(&input, &removed)) {
+        const QString command = input.split(QLatin1Char(' '), QString::SkipEmptyParts).value(0).toUpper();
+        if (!command.isEmpty()) {
+            foreach (const IrcCommandInfo& cmd, pp->commands) {
+                if (cmd.command == command)
+                    return QList<IrcCompletion>() << completeCommand(text, text.left(removed) + cmd.command);
+                if (cmd.command.startsWith(command))
+                    completions += completeCommand(text, text.left(removed) + cmd.command);
+            }
+        }
+        // TODO: context sensitive command parameter completion
+        Q_UNUSED(pos);
+    }
+    return completions;
+}
+
+static IrcCompletion completeWord(const QString& text, int from, int len, const QString& word)
+{
+    QString completion = QString(text).replace(from, len, word);
+    int next = from + word.length();
+    if (next >= completion.length() || completion.at(next) != QLatin1Char(' '))
+        completion.insert(next, QLatin1Char(' '));
+    return IrcCompletion(completion, ++next);
+}
+
+QList<IrcCompletion> IrcCompleterPrivate::completeWords(const QString& text, int pos) const
+{
+    if (!buffer || !buffer->network())
+        return QList<IrcCompletion>();
+
+    QList<IrcCompletion> completions;
+
+    const IrcToken token = IrcTokenizer(text).find(pos);
+    const QPair<int, int> bounds = qMakePair(token.position(), token.length());
+    if (bounds.first != -1 && bounds.second != -1) {
+        const QString word = text.mid(bounds.first, bounds.second);
+
+        int pfx = 0;
+        QString prefix;
+        bool isChannel = isPrefixed(text, bounds.first, buffer->network()->channelTypes(), &pfx);
+        if (isChannel && pfx > 0)
+            prefix = text.mid(bounds.first - pfx, pfx);
+
+        if (!isChannel) {
+            IrcUserModel userModel;
+            userModel.setSortMethod(Irc::SortByActivity);
+            userModel.setChannel(qobject_cast<IrcChannel*>(buffer));
+            foreach (IrcUser* user, userModel.users()) {
+                if (user->name().startsWith(word, Qt::CaseInsensitive)) {
+                    QString name = user->name();
+                    if (token.index() == 0)
+                        name += suffix;
+                    IrcCompletion completion = completeWord(text, bounds.first, bounds.second, name);
+                    if (completion.isValid() && !completions.contains(completion))
+                        completions += completion;
+                }
+            }
+        }
+
+        QList<IrcBuffer*> buffers = buffer->model()->buffers();
+        buffers.move(buffers.indexOf(buffer), 0); // promote the current buffer
+        foreach (IrcBuffer* buffer, buffers) {
+            if (!buffer->isChannel()) {
+                // it would be very confusing to auto-complete the titles of other
+                // open query (or server) buffers, because it makes it look like such
+                // user would be on the channel
+                continue;
+            }
+            QString title = buffer->title();
+            if (!isChannel && token.index() == 0)
+                title += suffix;
+            IrcCompletion completion;
+            if (title.startsWith(word, Qt::CaseInsensitive))
+                completion = completeWord(text, bounds.first, bounds.second, title);
+            else if (isChannel && !prefix.isEmpty() && title.startsWith(prefix + word, Qt::CaseInsensitive))
+                completion = completeWord(text, bounds.first - prefix.length(), bounds.second + prefix.length(), title);
+            if (completion.isValid() && !completions.contains(completion))
+                completions += completion;
+        }
+    }
+    return completions;
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a completer with \a parent.
+ */
+IrcCompleter::IrcCompleter(QObject* parent) : QObject(parent), d_ptr(new IrcCompleterPrivate)
+{
+    Q_D(IrcCompleter);
+    d->q_ptr = this;
+}
+
+/*!
+    Destructs the completer.
+ */
+IrcCompleter::~IrcCompleter()
+{
+}
+
+/*!
+    This property holds the completion suffix.
+
+    The suffix is appended to the end of a completed nick name, but
+    only when the nick name is in the beginning of completed text.
+
+    The default value is \c ":".
+
+    \par Access functions:
+    \li QString <b>suffix</b>() const
+    \li void <b>setSuffix</b>(const QString& suffix) [slot]
+
+    \par Notifier signal:
+    \li void <b>suffixChanged</b>(const QString& suffix)
+ */
+QString IrcCompleter::suffix() const
+{
+    Q_D(const IrcCompleter);
+    return d->suffix;
+}
+
+void IrcCompleter::setSuffix(const QString& suffix)
+{
+    Q_D(IrcCompleter);
+    if (d->suffix != suffix) {
+        d->suffix = suffix;
+        emit suffixChanged(suffix);
+    }
+}
+
+/*!
+    This property holds the buffer used for name completion.
+
+    \par Access functions:
+    \li \ref IrcBuffer* <b>buffer</b>() const
+    \li void <b>setBuffer</b>(\ref IrcBuffer* buffer) [slot]
+
+    \par Notifier signal:
+    \li void <b>bufferChanged</b>(\ref IrcBuffer* buffer)
+ */
+IrcBuffer* IrcCompleter::buffer() const
+{
+    Q_D(const IrcCompleter);
+    return d->buffer;
+}
+
+void IrcCompleter::setBuffer(IrcBuffer* buffer)
+{
+    Q_D(IrcCompleter);
+    if (d->buffer != buffer) {
+        d->buffer = buffer;
+        emit bufferChanged(buffer);
+    }
+}
+
+/*!
+    This property holds the parser used for command completion.
+
+    \par Access functions:
+    \li \ref IrcCommandParser* <b>parser</b>() const
+    \li void <b>setParser</b>(\ref IrcCommandParser* parser) [slot]
+
+    \par Notifier signal:
+    \li void <b>parserChanged</b>(\ref IrcCommandParser* parser)
+ */
+IrcCommandParser* IrcCompleter::parser() const
+{
+    Q_D(const IrcCompleter);
+    return d->parser;
+}
+
+void IrcCompleter::setParser(IrcCommandParser* parser)
+{
+    Q_D(IrcCompleter);
+    if (d->parser != parser) {
+        d->parser = parser;
+        emit parserChanged(parser);
+    }
+}
+
+/*!
+    Completes \a text at \a cursor position, iterating multiple
+    matches to the specified \a direction, and emits completed()
+    if a suitable completion is found.
+ */
+void IrcCompleter::complete(const QString& text, int cursor, Direction direction)
+{
+    Q_D(IrcCompleter);
+    if (!d->completions.isEmpty() && d->cursor == cursor && d->text == text) {
+        d->completeNext(direction);
+        return;
+    }
+
+    QList<IrcCompletion> completions = d->completeCommands(text, cursor);
+    if (completions.isEmpty() || IrcTokenizer(text).find(cursor).index() > 0)
+        completions = d->completeWords(text, cursor);
+
+    if (d->completions != completions) {
+        d->index = -1;
+        d->completions = completions;
+    }
+    if (!d->completions.isEmpty())
+        d->completeNext(direction);
+}
+
+/*!
+    Resets the completer state.
+ */
+void IrcCompleter::reset()
+{
+    Q_D(IrcCompleter);
+    d->index = -1;
+    d->cursor = -1;
+    d->text.clear();
+    d->completions.clear();
+}
+
+#include "moc_irccompleter.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/irclagtimer.cpp
+++ b/3rdparty/communi/src/util/irclagtimer.cpp
@@ -1,0 +1,242 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "irclagtimer.h"
+#include "irclagtimer_p.h"
+#include "ircconnection.h"
+#include "ircmessage.h"
+#include "irccommand.h"
+#include <QDateTime>
+
+IRC_BEGIN_NAMESPACE
+
+static const int DEFAULT_INTERVAL = 60;
+
+/*!
+    \file irclagtimer.h
+    \brief \#include &lt;IrcLagTimer&gt;
+ */
+
+/*!
+    \class IrcLagTimer irclagtimer.h <IrcLagTimer>
+    \ingroup util
+    \brief Provides a timer for measuring lag.
+
+    \note IrcLagTimer relies on functionality introduced in Qt 4.7.0, and is
+          therefore not functional when built against earlier versions of Qt.
+ */
+
+/*!
+    \fn void IrcLagTimer::lagChanged(qint64 lag)
+
+    This signal is emitted when the \a lag has changed.
+ */
+
+#ifndef IRC_DOXYGEN
+IrcLagTimerPrivate::IrcLagTimerPrivate() : q_ptr(0), connection(0), interval(DEFAULT_INTERVAL), lag(-1)
+{
+}
+
+bool IrcLagTimerPrivate::messageFilter(IrcMessage* msg)
+{
+    if (msg->type() == IrcMessage::Pong)
+        return processPongReply(static_cast<IrcPongMessage*>(msg));
+    return false;
+}
+
+bool IrcLagTimerPrivate::processPongReply(IrcPongMessage* msg)
+{
+#if QT_VERSION >= 0x040700
+    // TODO: configurable format?
+    if (msg->argument().startsWith("communi/")) {
+        bool ok = false;
+        qint64 timestamp = msg->argument().mid(8).toLongLong(&ok);
+        if (ok) {
+            updateLag(QDateTime::currentMSecsSinceEpoch() - timestamp);
+            return true;
+        }
+    }
+#endif // QT_VERSION
+    return false;
+}
+
+void IrcLagTimerPrivate::_irc_connected()
+{
+#if QT_VERSION >= 0x040700
+    if (interval > 0)
+        timer.start();
+#endif // QT_VERSION
+}
+
+void IrcLagTimerPrivate::_irc_pingServer()
+{
+#if QT_VERSION >= 0x040700
+    // TODO: configurable format?
+    QString cmd = QString("PING communi/%1").arg(QDateTime::currentMSecsSinceEpoch());
+    connection->sendData(cmd.toUtf8());
+#endif // QT_VERSION
+}
+
+void IrcLagTimerPrivate::_irc_disconnected()
+{
+#if QT_VERSION >= 0x040700
+    updateLag(-1);
+    if (timer.isActive())
+        timer.stop();
+#endif // QT_VERSION
+}
+
+void IrcLagTimerPrivate::updateTimer()
+{
+#if QT_VERSION >= 0x040700
+    if (connection && interval > 0) {
+        timer.setInterval(interval * 1000);
+        if (!timer.isActive() && connection->isConnected())
+            timer.start();
+    } else {
+        if (timer.isActive())
+            timer.stop();
+        updateLag(-1);
+    }
+#endif // QT_VERSION
+}
+
+void IrcLagTimerPrivate::updateLag(qint64 value)
+{
+    Q_Q(IrcLagTimer);
+    if (lag != value) {
+        lag = qMax(-1ll, value);
+        emit q->lagChanged(lag);
+    }
+}
+#endif // IRC_DOXYGEN
+
+/*!
+    Constructs a new lag timer with \a parent.
+
+    \note If \a parent is an instance of IrcConnection, it will be
+    automatically assigned to \ref IrcLagTimer::connection "connection".
+ */
+IrcLagTimer::IrcLagTimer(QObject* parent) : QObject(parent), d_ptr(new IrcLagTimerPrivate)
+{
+    Q_D(IrcLagTimer);
+    d->q_ptr = this;
+    connect(&d->timer, SIGNAL(timeout()), this, SLOT(_irc_pingServer()));
+    setConnection(qobject_cast<IrcConnection*>(parent));
+}
+
+/*!
+    Destructs the lag timer.
+ */
+IrcLagTimer::~IrcLagTimer()
+{
+}
+
+/*!
+    This property holds the associated connection.
+
+    \par Access functions:
+    \li IrcConnection* <b>connection</b>() const
+    \li void <b>setConnection</b>(IrcConnection* connection)
+ */
+IrcConnection* IrcLagTimer::connection() const
+{
+    Q_D(const IrcLagTimer);
+    return d->connection;
+}
+
+void IrcLagTimer::setConnection(IrcConnection* connection)
+{
+    Q_D(IrcLagTimer);
+    if (d->connection != connection) {
+        if (d->connection) {
+            d->connection->removeMessageFilter(d);
+            disconnect(d->connection, SIGNAL(connected()), this, SLOT(_irc_connected()));
+            disconnect(d->connection, SIGNAL(disconnected()), this, SLOT(_irc_disconnected()));
+        }
+        d->connection = connection;
+        if (connection) {
+            connection->installMessageFilter(d);
+            connect(connection, SIGNAL(connected()), this, SLOT(_irc_connected()));
+            connect(connection, SIGNAL(disconnected()), this, SLOT(_irc_disconnected()));
+        }
+        d->updateLag(-1);
+        d->updateTimer();
+    }
+}
+
+/*!
+    This property holds the current lag in milliseconds.
+
+    The value is \c -1 when
+    \li the connection is not connected,
+    \li the lag has not yet been measured,
+    \li the lag timer is disabled (interval <= 0s), or
+    \li the Qt version is too old (4.7.0 or later is required).
+
+    \par Access function:
+    \li qint64 <b>lag</b>() const
+
+    \par Notifier signal:
+    \li void <b>lagChanged</b>(qint64 lag)
+ */
+qint64 IrcLagTimer::lag() const
+{
+    Q_D(const IrcLagTimer);
+    return d->lag;
+}
+
+/*!
+    This property holds the lag measurement interval in seconds.
+
+    The default value is \c 60 seconds. A value equal to or
+    less than \c 0 seconds disables the lag measurement.
+
+    \par Access functions:
+    \li int <b>interval</b>() const
+    \li void <b>setInterval</b>(int seconds)
+ */
+int IrcLagTimer::interval() const
+{
+    Q_D(const IrcLagTimer);
+    return d->interval;
+}
+
+void IrcLagTimer::setInterval(int seconds)
+{
+    Q_D(IrcLagTimer);
+    if (d->interval != seconds) {
+        d->interval = seconds;
+        d->updateTimer();
+    }
+}
+
+#include "moc_irclagtimer.cpp"
+#include "moc_irclagtimer_p.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/ircpalette.cpp
+++ b/3rdparty/communi/src/util/ircpalette.cpp
@@ -1,0 +1,527 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircpalette.h"
+#include "irc.h"
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircpalette.h
+    \brief \#include &lt;IrcPalette&gt;
+ */
+
+/*!
+    \class IrcPalette ircpalette.h <IrcPalette>
+    \ingroup util
+    \brief Specifies a palette of IRC colors.
+
+    IrcPalette is used to specify the desired IRC color palette when
+    converting IRC-style formatted messages to HTML using IrcTextFormat.
+
+    \code
+    IrcTextFormat format;
+    IrcPalette* palette = format.palette();
+    palette->setColorName(Irc::Red, "#ff3333");
+    palette->setColorName(Irc::Green, "#33ff33");
+    palette->setColorName(Irc::Blue, "#3333ff");
+    // ...
+
+    QString html = format.toHtml(message);
+    \endcode
+
+    \sa Irc::Color, <a href="http://www.mirc.com/colors.html">mIRC colors</a>, <a href="http://www.w3.org/TR/SVG/types.html#ColorKeywords">SVG color keyword names</a>
+ */
+
+class IrcPalettePrivate
+{
+public:
+    QMap<int, QString> colors;
+};
+
+static QMap<int, QString>& irc_default_colors()
+{
+    static QMap<int, QString> x;
+    if (x.isEmpty()) {
+        x.insert(Irc::White, QLatin1String("white"));
+        x.insert(Irc::Black, QLatin1String("black"));
+        x.insert(Irc::Blue, QLatin1String("blue"));
+        x.insert(Irc::Green, QLatin1String("green"));
+        x.insert(Irc::Red, QLatin1String("red"));
+        x.insert(Irc::Brown, QLatin1String("brown"));
+        x.insert(Irc::Purple, QLatin1String("purple"));
+        x.insert(Irc::Orange, QLatin1String("orange"));
+        x.insert(Irc::Yellow, QLatin1String("yellow"));
+        x.insert(Irc::LightGreen, QLatin1String("lightgreen"));
+        x.insert(Irc::Cyan, QLatin1String("cyan"));
+        x.insert(Irc::LightCyan, QLatin1String("lightcyan"));
+        x.insert(Irc::LightBlue, QLatin1String("lightblue"));
+        x.insert(Irc::Pink, QLatin1String("pink"));
+        x.insert(Irc::Gray, QLatin1String("gray"));
+        x.insert(Irc::LightGray, QLatin1String("lightgray"));
+    }
+    return x;
+}
+
+/*!
+    \internal
+    Constructs a new palette with \a parent.
+ */
+IrcPalette::IrcPalette(QObject* parent) : QObject(parent), d_ptr(new IrcPalettePrivate)
+{
+    Q_D(IrcPalette);
+    d->colors = irc_default_colors();
+}
+
+/*!
+    \internal
+    Destructs the palette.
+ */
+IrcPalette::~IrcPalette()
+{
+}
+
+/*!
+    This property holds the white color name.
+
+    The default value is \c "white".
+
+    \par Access functions:
+    \li QString <b>white</b>() const
+    \li void <b>setWhite</b>(const QString& color)
+
+    \sa Irc::White
+ */
+QString IrcPalette::white() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::White);
+}
+
+void IrcPalette::setWhite(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::White, color);
+}
+
+/*!
+    This property holds the black color name.
+
+    The default value is \c "black".
+
+    \par Access functions:
+    \li QString <b>black</b>() const
+    \li void <b>setBlack</b>(const QString& color)
+
+    \sa Irc::Black
+ */
+QString IrcPalette::black() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Black);
+}
+
+void IrcPalette::setBlack(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Black, color);
+}
+
+/*!
+    This property holds the blue color name.
+
+    The default value is \c "blue".
+
+    \par Access functions:
+    \li QString <b>blue</b>() const
+    \li void <b>setBlue</b>(const QString& color)
+
+    \sa Irc::Blue
+ */
+QString IrcPalette::blue() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Blue);
+}
+
+void IrcPalette::setBlue(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Blue, color);
+}
+
+/*!
+    This property holds the green color name.
+
+    The default value is \c "green".
+
+    \par Access functions:
+    \li QString <b>green</b>() const
+    \li void <b>setGreen</b>(const QString& color)
+
+    \sa Irc::Green
+ */
+QString IrcPalette::green() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Green);
+}
+
+void IrcPalette::setGreen(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Green, color);
+}
+
+/*!
+    This property holds the red color name.
+
+    The default value is \c "red".
+
+    \par Access functions:
+    \li QString <b>red</b>() const
+    \li void <b>setRed</b>(const QString& color)
+
+    \sa Irc::Red
+ */
+QString IrcPalette::red() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Red);
+}
+
+void IrcPalette::setRed(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Red, color);
+}
+
+/*!
+    This property holds the brown color name.
+
+    The default value is \c "brown".
+
+    \par Access functions:
+    \li QString <b>brown</b>() const
+    \li void <b>setBrown</b>(const QString& color)
+
+    \sa Irc::Brown
+ */
+QString IrcPalette::brown() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Brown);
+}
+
+void IrcPalette::setBrown(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Brown, color);
+}
+
+/*!
+    This property holds the purple color name.
+
+    The default value is \c "purple".
+
+    \par Access functions:
+    \li QString <b>purple</b>() const
+    \li void <b>setPurple</b>(const QString& color)
+
+    \sa Irc::Purple
+ */
+QString IrcPalette::purple() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Purple);
+}
+
+void IrcPalette::setPurple(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Purple, color);
+}
+
+/*!
+    This property holds the orange color name.
+
+    The default value is \c "orange".
+
+    \par Access functions:
+    \li QString <b>orange</b>() const
+    \li void <b>setOrange</b>(const QString& color)
+
+    \sa Irc::Orange
+ */
+QString IrcPalette::orange() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Orange);
+}
+
+void IrcPalette::setOrange(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Orange, color);
+}
+
+/*!
+    This property holds the yellow color name.
+
+    The default value is \c "yellow".
+
+    \par Access functions:
+    \li QString <b>yellow</b>() const
+    \li void <b>setYellow</b>(const QString& color)
+
+    \sa Irc::Yellow
+ */
+QString IrcPalette::yellow() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Yellow);
+}
+
+void IrcPalette::setYellow(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Yellow, color);
+}
+
+/*!
+    This property holds the light green color name.
+
+    The default value is \c "lightgreen".
+
+    \par Access functions:
+    \li QString <b>lightGreen</b>() const
+    \li void <b>setLightGreen</b>(const QString& color)
+
+    \sa Irc::LightGreen
+ */
+QString IrcPalette::lightGreen() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::LightGreen);
+}
+
+void IrcPalette::setLightGreen(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::LightGreen, color);
+}
+
+/*!
+    This property holds the cyan color name.
+
+    The default value is \c "cyan".
+
+    \par Access functions:
+    \li QString <b>cyan</b>() const
+    \li void <b>setCyan</b>(const QString& color)
+
+    \sa Irc::Cyan
+ */
+QString IrcPalette::cyan() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Cyan);
+}
+
+void IrcPalette::setCyan(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Cyan, color);
+}
+
+/*!
+    This property holds the light cyan color name.
+
+    The default value is \c "lightcyan".
+
+    \par Access functions:
+    \li QString <b>lightCyan</b>() const
+    \li void <b>setLightCyan</b>(const QString& color)
+
+    \sa Irc::LightCyan
+ */
+QString IrcPalette::lightCyan() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::LightCyan);
+}
+
+void IrcPalette::setLightCyan(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::LightCyan, color);
+}
+
+/*!
+    This property holds the light blue color name.
+
+    The default value is \c "lightblue".
+
+    \par Access functions:
+    \li QString <b>lightBlue</b>() const
+    \li void <b>setLightBlue</b>(const QString& color)
+
+    \sa Irc::LightBlue
+ */
+QString IrcPalette::lightBlue() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::LightBlue);
+}
+
+void IrcPalette::setLightBlue(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::LightBlue, color);
+}
+
+/*!
+    This property holds the pink color name.
+
+    The default value is \c "pink".
+
+    \par Access functions:
+    \li QString <b>pink</b>() const
+    \li void <b>setPink</b>(const QString& color)
+
+    \sa Irc::Pink
+ */
+QString IrcPalette::pink() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Pink);
+}
+
+void IrcPalette::setPink(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Pink, color);
+}
+
+/*!
+    This property holds the gray color name.
+
+    The default value is \c "gray".
+
+    \par Access functions:
+    \li QString <b>gray</b>() const
+    \li void <b>setGray</b>(const QString& color)
+
+    \sa Irc::Gray
+ */
+QString IrcPalette::gray() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::Gray);
+}
+
+void IrcPalette::setGray(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::Gray, color);
+}
+
+/*!
+    This property holds the light gray color name.
+
+    The default value is \c "lightgray".
+
+    \par Access functions:
+    \li QString <b>lightGray</b>() const
+    \li void <b>setLightGray</b>(const QString& color)
+
+    \sa Irc::LightGray
+ */
+QString IrcPalette::lightGray() const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(Irc::LightGray);
+}
+
+void IrcPalette::setLightGray(const QString& color)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(Irc::LightGray, color);
+}
+
+/*!
+    Returns the map of color names.
+ */
+QMap<int, QString> IrcPalette::colorNames() const
+{
+    Q_D(const IrcPalette);
+    return d->colors;
+}
+
+/*!
+    Sets the map of color \a names.
+ */
+void IrcPalette::setColorNames(const QMap<int, QString>& names)
+{
+    Q_D(IrcPalette);
+    d->colors = names;
+}
+
+/*!
+    Converts a \a color code to a color name. If the \a color code
+    is unknown, the function returns the \a fallback color name.
+*/
+QString IrcPalette::colorName(int color, const QString& fallback) const
+{
+    Q_D(const IrcPalette);
+    return d->colors.value(color, fallback);
+}
+
+/*!
+    Assigns a \a name for \a color code.
+
+    The color \a name may be in one of these formats:
+
+    \li \#RGB (each of R, G, and B is a single hex digit)
+    \li \#RRGGBB
+    \li \#RRRGGGBBB
+    \li \#RRRRGGGGBBBB
+    \li A name from the list of colors defined in the list of <a href="http://www.w3.org/TR/SVG/types.html#ColorKeywords">SVG color keyword names</a>
+        provided by the World Wide Web Consortium; for example, "steelblue" or "gainsboro". These color names work on all platforms. Note that these
+        color names are not the same as defined by the Qt::GlobalColor enums, e.g. "green" and Qt::green does not refer to the same color.
+    \li transparent - representing the absence of a color.
+*/
+void IrcPalette::setColorName(int color, const QString& name)
+{
+    Q_D(IrcPalette);
+    d->colors.insert(color, name);
+}
+
+#include "moc_ircpalette.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/irctextformat.cpp
+++ b/3rdparty/communi/src/util/irctextformat.cpp
@@ -1,0 +1,550 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+  Parts of this code come from Konversation and are copyrighted to:
+  Copyright (C) 2002 Dario Abatianni <eisfuchs@tigress.com>
+  Copyright (C) 2004 Peter Simonsson <psn@linux.se>
+  Copyright (C) 2006-2008 Eike Hein <hein@kde.org>
+  Copyright (C) 2004-2009 Eli Mackenzie <argonel@gmail.com>
+*/
+
+#include "irctextformat.h"
+#include "ircpalette.h"
+#if QT_VERSION >= 0x050000
+#include <QRegularExpression>
+#endif
+#include <QStringList>
+#include <QRegExp>
+#include <QUrl>
+#include "irc.h"
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file irctextformat.h
+    \brief \#include &lt;IrcTextFormat&gt;
+ */
+
+/*!
+    \class IrcTextFormat irctextformat.h <IrcTextFormat>
+    \ingroup util
+    \brief Provides methods for text formatting.
+
+    IrcTextFormat is used to convert IRC-style formatted messages to either
+    plain text or HTML. When converting to plain text, the IRC-style formatting
+    (colors, bold, underline etc.) are simply stripped away. When converting
+    to HTML, the IRC-style formatting is converted to the corresponding HTML
+    formatting.
+
+    \code
+    IrcTextFormat format;
+    QString text = format.toPlainText(message);
+
+    format.palette()->setColorName(Irc::Red, "#ff3333");
+    format.palette()->setColorName(Irc::Green, "#33ff33");
+    format.palette()->setColorName(Irc::Blue, "#3333ff");
+    // ...
+    QString html = format.toHtml(message);
+    \endcode
+
+    \sa IrcPalette
+ */
+
+/*!
+    \enum IrcTextFormat::SpanFormat
+    This enum describes the supported formats for HTML span-elements.
+ */
+
+/*!
+    \var IrcTextFormat::SpanStyle
+    \brief HTML span-elements with style-attributes.
+ */
+
+/*!
+    \var IrcTextFormat::SpanClass
+    \brief HTML span-elements with class-attributes.
+ */
+
+class IrcTextFormatPrivate
+{
+public:
+    void parse(const QString& str, QString* text, QString* html, QList<QUrl>* urls) const;
+
+    QString plainText;
+    QString html;
+    QList<QUrl> urls;
+    QString urlPattern;
+    IrcPalette* palette;
+    IrcTextFormat::SpanFormat spanFormat;
+};
+
+static bool parseColors(const QString& message, int pos, int* len, int* fg = 0, int* bg = 0)
+{
+    // fg(,bg)
+    *len = 0;
+    if (fg)
+        *fg = -1;
+    if (bg)
+        *bg = -1;
+    QRegExp rx(QLatin1String("(\\d{1,2})(?:,(\\d{1,2}))?"));
+    int idx = rx.indexIn(message, pos);
+    if (idx == pos) {
+        *len = rx.matchedLength();
+        if (fg)
+            *fg = rx.cap(1).toInt();
+        if (bg) {
+            bool ok = false;
+            int tmp = rx.cap(2).toInt(&ok);
+            if (ok)
+                *bg = tmp;
+        }
+    }
+    return *len > 0;
+}
+
+static QString generateLink(const QString& protocol, const QString& href)
+{
+    const char* exclude = ":/?@%#=+&,";
+    const QByteArray url = QUrl::toPercentEncoding(href, exclude);
+    return QString(QLatin1String("<a href='%1%2'>%3</a>")).arg(protocol, url, href);
+}
+
+static QString parseLinks(const QString& message, const QString& pattern, QList<QUrl>* urls)
+{
+    QString processed = message;
+#if QT_VERSION >= 0x050000
+    int offset = 0;
+    QRegularExpression rx(pattern);
+    QRegularExpressionMatchIterator it = rx.globalMatch(message);
+    while (it.hasNext()) {
+        QRegularExpressionMatch match = it.next();
+        QString protocol;
+        if (match.capturedRef(2).isEmpty()) {
+            QStringRef link = match.capturedRef(1);
+            if (link.startsWith(QStringLiteral("ftp."), Qt::CaseInsensitive))
+                protocol = QStringLiteral("ftp://");
+            else if (link.contains(QStringLiteral("@")))
+                protocol = QStringLiteral("mailto:");
+            else
+                protocol = QStringLiteral("http://");
+        }
+
+        const int start = match.capturedStart();
+        const int len = match.capturedEnd() - start;
+        const QString href = match.captured();
+        const QString link = generateLink(protocol, href);
+        processed.replace(start + offset, len, link);
+        offset += link.length() - len;
+        if (urls)
+            urls->append(QUrl(protocol + href));
+    }
+#else
+    int pos = 0;
+    QRegExp rx(pattern);
+    while ((pos = rx.indexIn(processed, pos)) >= 0) {
+        int len = rx.matchedLength();
+        QString href = processed.mid(pos, len);
+
+        QString protocol;
+        if (rx.cap(2).isEmpty()) {
+            if (rx.cap(1).contains(QLatin1Char('@')))
+                protocol = QLatin1String("mailto:");
+            else if (rx.cap(1).startsWith(QLatin1String("ftp."), Qt::CaseInsensitive))
+                protocol = QLatin1String("ftp://");
+            else
+                protocol = QLatin1String("http://");
+        }
+
+        QString link = generateLink(protocol, href);
+        processed.replace(pos, len, link);
+        pos += link.length();
+        if (urls)
+            urls->append(QUrl(protocol + href));
+    }
+#endif
+    return processed;
+}
+
+void IrcTextFormatPrivate::parse(const QString& str, QString* text, QString* html, QList<QUrl>* urls) const
+{
+    QString processed = str;
+
+    // TODO:
+    //processed.replace(QLatin1Char('&'), QLatin1String("&amp;"));
+    processed.replace(QLatin1Char('<'), QLatin1String("&lt;"));
+    //processed.replace(QLatin1Char('>'), QLatin1String("&gt;"));
+    //processed.replace(QLatin1Char('"'), QLatin1String("&quot;"));
+    //processed.replace(QLatin1Char('\''), QLatin1String("&apos;"));
+    //processed.replace(QLatin1Char('\t'), QLatin1String("&nbsp;"));
+
+    enum {
+        None            = 0x0,
+        Bold            = 0x1,
+        Italic          = 0x4,
+        LineThrough     = 0x8,
+        Underline       = 0x10,
+        Inverse         = 0x20
+    };
+    int state = None;
+
+    int pos = 0;
+    int len = 0;
+    int fg = -1;
+    int bg = -1;
+    int depth = 0;
+    bool potentialUrl = false;
+    while (pos < processed.size()) {
+        QString replacement;
+        switch (processed.at(pos).unicode()) {
+            case '\x02': // bold
+                if (state & Bold) {
+                    depth--;
+                    replacement = QLatin1String("</span>");
+                } else {
+                    depth++;
+                    if (spanFormat == IrcTextFormat::SpanStyle)
+                        replacement = QLatin1String("<span style='font-weight: bold'>");
+                    else
+                        replacement = QLatin1String("<span class='bold'>");
+                }
+                state ^= Bold;
+                break;
+
+            case '\x03': // color
+                if (parseColors(processed, pos + 1, &len, &fg, &bg)) {
+                    depth++;
+                    if (spanFormat == IrcTextFormat::SpanStyle) {
+                        QStringList styles;
+                        styles += QString(QLatin1String("color: %1")).arg(palette->colorName(fg, QLatin1String("black")));
+                        if (bg != -1)
+                            styles += QString(QLatin1String("background-color: %1")).arg(palette->colorName(bg, QLatin1String("transparent")));
+                        replacement = QString(QLatin1String("<span style='%1'>")).arg(styles.join(QLatin1String("; ")));
+                    } else {
+                        QStringList classes;
+                        classes += palette->colorName(fg, QLatin1String("black"));
+                        if (bg != -1)
+                            classes += palette->colorName(bg, QLatin1String("transparent")) + QLatin1String("-background");
+                        replacement = QString(QLatin1String("<span class='%1'>")).arg(classes.join(QLatin1String(" ")));
+                    }
+                    // \x03FF(,BB)
+                    processed.replace(pos, len + 1, replacement);
+                    pos += replacement.length();
+                    continue;
+                } else {
+                    depth--;
+                    replacement = QLatin1String("</span>");
+                }
+                break;
+
+                //case '\x09': // italic
+            case '\x1d': // italic
+                if (state & Italic) {
+                    depth--;
+                    replacement = QLatin1String("</span>");
+                } else {
+                    depth++;
+                    if (spanFormat == IrcTextFormat::SpanStyle)
+                        replacement = QLatin1String("<span style='font-style: italic'>");
+                    else
+                        replacement = QLatin1String("<span class='italic'>");
+                }
+                state ^= Italic;
+                break;
+
+            case '\x13': // line-through
+                if (state & LineThrough) {
+                    depth--;
+                    replacement = QLatin1String("</span>");
+                } else {
+                    depth++;
+                    if (spanFormat == IrcTextFormat::SpanStyle)
+                        replacement = QLatin1String("<span style='text-decoration: line-through'>");
+                    else
+                        replacement = QLatin1String("<span class='line-through'>");
+                }
+                state ^= LineThrough;
+                break;
+
+            case '\x15': // underline
+            case '\x1f': // underline
+                if (state & Underline) {
+                    depth--;
+                    replacement = QLatin1String("</span>");
+                } else {
+                    depth++;
+                    if (spanFormat == IrcTextFormat::SpanStyle)
+                        replacement = QLatin1String("<span style='text-decoration: underline'>");
+                    else
+                        replacement = QLatin1String("<span class='underline'>");
+                }
+                state ^= Underline;
+                break;
+
+            case '\x16': // inverse
+                if (state & Inverse) {
+                    depth--;
+                    replacement = QLatin1String("</span>");
+                } else {
+                    depth++;
+                    if (spanFormat == IrcTextFormat::SpanStyle)
+                        replacement = QLatin1String("<span style='text-decoration: inverse'>");
+                    else
+                        replacement = QLatin1String("<span class='inverse'>");
+                }
+                state ^= Inverse;
+                break;
+
+            case '\x0f': // none
+                if (depth > 0)
+                    replacement = QString(QLatin1String("</span>")).repeated(depth);
+                else
+                    processed.remove(pos--, 1); // must rewind back for ++pos below...
+                state = None;
+                depth = 0;
+                break;
+
+            case '.':
+            case '/':
+            case ':':
+                // a dot, slash or colon NOT surrounded by a space indicates a potential URL
+                if (!potentialUrl && pos > 0 && !processed.at(pos - 1).isSpace()
+                        && pos < processed.length() - 1 && !processed.at(pos + 1).isSpace())
+                    potentialUrl = true;
+                // flow through
+            default:
+                if (text)
+                    *text += processed.at(pos);
+                break;
+        }
+
+        if (!replacement.isEmpty()) {
+            processed.replace(pos, 1, replacement);
+            pos += replacement.length();
+        } else {
+            ++pos;
+        }
+    }
+
+    if ((html || urls) && potentialUrl && !urlPattern.isEmpty())
+        processed = parseLinks(processed, urlPattern, urls);
+    if (html)
+        *html = processed;
+}
+
+/*!
+    Constructs a new text format with \a parent.
+ */
+IrcTextFormat::IrcTextFormat(QObject* parent) : QObject(parent), d_ptr(new IrcTextFormatPrivate)
+{
+    Q_D(IrcTextFormat);
+    d->palette = new IrcPalette(this);
+    d->urlPattern = QString("\\b((?:(?:([a-z][\\w\\.-]+:/{1,3})|www|ftp\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|\\}\\]|[^\\s`!()\\[\\]{};:'\".,<>?%1%2%3%4%5%6])|[a-z0-9.\\-+_]+@[a-z0-9.\\-]+[.][a-z]{1,5}[^\\s/`!()\\[\\]{};:'\".,<>?%1%2%3%4%5%6]))").arg(QChar(0x00AB)).arg(QChar(0x00BB)).arg(QChar(0x201C)).arg(QChar(0x201D)).arg(QChar(0x2018)).arg(QChar(0x2019));
+    d->spanFormat = SpanStyle;
+}
+
+/*!
+    Destructs the text format.
+ */
+IrcTextFormat::~IrcTextFormat()
+{
+}
+
+/*!
+    This property holds the palette used for color formatting.
+
+    \par Access function:
+    \li \ref IrcPalette* <b>palette</b>() const
+ */
+IrcPalette* IrcTextFormat::palette() const
+{
+    Q_D(const IrcTextFormat);
+    return d->palette;
+}
+
+/*!
+    This property holds the regular expression pattern used for matching URLs.
+
+    \par Access functions:
+    \li QString <b>urlPattern</b>() const
+    \li void <b>setUrlPattern</b>(const QString& pattern)
+ */
+QString IrcTextFormat::urlPattern() const
+{
+    Q_D(const IrcTextFormat);
+    return d->urlPattern;
+}
+
+void IrcTextFormat::setUrlPattern(const QString& pattern)
+{
+    Q_D(IrcTextFormat);
+    d->urlPattern = pattern;
+}
+
+/*!
+    \since 3.1
+
+    This property holds the format used for HTML span-elements.
+
+    IrcTextFormat uses HTML span-elements for converting the IRC-style text
+    formatting to the corresponding HTML formatting. The \ref SpanStyle format
+    generates self contained span-elements with style-attributes, resulting to
+    HTML that is ready to be used with Qt's rich text classes without additional
+    styling. For more flexible styling, the \ref SpanClass generates span-elements
+    with class-attributes that can be styled with additional style sheets.
+
+    The default value is \ref SpanStyle. The following table illustrates the
+    difference between \ref SpanStyle and \ref SpanClass HTML formatting:
+
+    IRC format                              | SpanStyle                                                             | SpanClass
+    --------------------------------------- | ----------------------------------------------------------------------|----------
+    Bold ("\02...\0F")                      | &lt;span style='font-weight: bold'&gt;...&lt;/span&gt;                | &lt;span class='bold'&gt;...&lt;/span&gt;
+    Color ("\03fg...\0F")                   | &lt;span style='color: fg;'&gt;...&lt;/span&gt;                       | &lt;span class='fg'&gt;...&lt;/span&gt;
+    Background ("\03fgbg...\0F")            | &lt;span style='color: fg; background-color: bg'&gt;...&lt;/span&gt;  | &lt;span class='fg bg-background'&gt;...&lt;/span&gt;
+    Italic ("\09...\0F")                    | &lt;span style='font-style: italic'&gt;...&lt;/span&gt;               | &lt;span class='italic'&gt;...&lt;/span&gt;
+    Line-through ("\13...\0F")              | &lt;span style='text-decoration: line-through'&gt;...&lt;/span&gt;    | &lt;span class='line-through'&gt;...&lt;/span&gt;
+    Underline ("\15...\0F" or "\1F...\0F")  | &lt;span style='text-decoration: underline'&gt;...&lt;/span&gt;       | &lt;span class='underline'&gt;...&lt;/span&gt;
+    Inverse ("\16...\0F")                   | &lt;span style='text-decoration: inverse'&gt;...&lt;/span&gt;         | &lt;span class='inverse'&gt;...&lt;/span&gt;
+
+    \par Access functions:
+    \li \ref SpanFormat <b>spanFormat</b>() const
+    \li void <b>setSpanFormat</b>(\ref SpanFormat format)
+ */
+IrcTextFormat::SpanFormat IrcTextFormat::spanFormat() const
+{
+    Q_D(const IrcTextFormat);
+    return d->spanFormat;
+}
+
+void IrcTextFormat::setSpanFormat(IrcTextFormat::SpanFormat format)
+{
+    Q_D(IrcTextFormat);
+    d->spanFormat = format;
+}
+
+
+/*!
+    Converts \a text to HTML. This function parses the text and replaces
+    IRC-style formatting (colors, bold, underline etc.) to the corresponding
+    HTML formatting. Furthermore, this function detects URLs and replaces
+    them with appropriate HTML hyperlinks.
+
+    \note URL detection can be disabled by setting an empty
+          regular expression pattern used for matching URLs.
+
+    \sa toPlainText(), parse(), palette, urlPattern, spanFormat
+*/
+QString IrcTextFormat::toHtml(const QString& text) const
+{
+    Q_D(const IrcTextFormat);
+    QString html;
+    d->parse(text, 0, &html, 0);
+    return html;
+}
+
+/*!
+    Converts \a text to plain text. This function parses the text and
+    strips away IRC-style formatting (colors, bold, underline etc.)
+
+    \sa toHtml(), parse()
+*/
+QString IrcTextFormat::toPlainText(const QString& text) const
+{
+    Q_D(const IrcTextFormat);
+    QString plain;
+    d->parse(text, &plain, 0, 0);
+    return plain;
+}
+
+/*!
+    \since 3.2
+
+    This property holds the current plain text content.
+
+    \par Access function:
+    \li QString <b>plainText</b>() const
+
+    \sa parse(), html, urls
+ */
+QString IrcTextFormat::plainText() const
+{
+    Q_D(const IrcTextFormat);
+    return d->plainText;
+}
+
+/*!
+    \since 3.2
+
+    This property holds the current HTML content.
+
+    \par Access function:
+    \li QString <b>html</b>() const
+
+    \sa parse(), plainText, urls
+ */
+QString IrcTextFormat::html() const
+{
+    Q_D(const IrcTextFormat);
+    return d->html;
+}
+
+/*!
+    \since 3.2
+
+    This property holds the current list of URLs.
+
+    \par Access function:
+    \li QList<QUrl> <b>urls</b>() const
+
+    \sa parse(), plainText, html
+ */
+QList<QUrl> IrcTextFormat::urls() const
+{
+    Q_D(const IrcTextFormat);
+    return d->urls;
+}
+
+/*!
+    \since 3.2
+
+    Parses \a text converting it to plain text and HTML and detects URLs.
+
+    \sa plainText, html, urls
+ */
+void IrcTextFormat::parse(const QString& text)
+{
+    Q_D(IrcTextFormat);
+    d->plainText.clear();
+    d->html.clear();
+    d->urls.clear();
+    d->parse(text, &d->plainText, &d->html, &d->urls);
+}
+
+#include "moc_irctextformat.cpp"
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/irctoken.cpp
+++ b/3rdparty/communi/src/util/irctoken.cpp
@@ -1,0 +1,125 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "irctoken_p.h"
+#include <QStringList>
+
+IRC_BEGIN_NAMESPACE
+
+#ifndef IRC_DOXYGEN
+static QList<IrcToken> tokenize(const QString& str)
+{
+    int idx = -1;
+    int pos = 0;
+    QList<IrcToken> tokens;
+    foreach (const QString& txt, str.split(QLatin1String(" "))) {
+        if (!txt.isEmpty())
+            tokens += IrcToken(++idx, pos, txt);
+        pos += txt.length() + 1;
+    }
+    return tokens;
+}
+
+IrcTokenizer::IrcTokenizer(const QString& str) : len(str.length()), t(tokenize(str))
+{
+}
+
+int IrcTokenizer::count() const
+{
+    return t.count();
+}
+
+bool IrcTokenizer::isEmpty() const
+{
+    return t.isEmpty();
+}
+
+QList<IrcToken> IrcTokenizer::tokens() const
+{
+    return t;
+}
+
+IrcToken IrcTokenizer::at(int index) const
+{
+    return t.value(index);
+}
+
+IrcTokenizer IrcTokenizer::mid(int index) const
+{
+    IrcTokenizer tt;
+    tt.t = t.mid(index);
+    if (!tt.isEmpty()) {
+        int d = tt.t.first().position();
+        tt.len = len - d;
+        for (int i = 0; i < tt.t.length(); ++i) {
+            tt.t[i].idx = i;
+            tt.t[i].pos -= d;
+        }
+    }
+    return tt;
+}
+
+void IrcTokenizer::clear()
+{
+    t.clear();
+}
+
+void IrcTokenizer::replace(int index, const QString& text)
+{
+    IrcToken token = t.value(index);
+    if (token.isValid()) {
+        int d = text.length() - token.length();
+        token = IrcToken(index, token.position(), text);
+        t.replace(index, token);
+        len += d;
+        for (int i = index + 1; i < t.length(); ++i)
+            t[i].pos += d;
+    }
+}
+
+IrcToken IrcTokenizer::find(int pos) const
+{
+    IrcToken token;
+    foreach (const IrcToken& tk, t) {
+        if (tk.position() > pos)
+            break;
+        token = tk;
+    }
+    return token;
+}
+
+QString IrcTokenizer::toString() const
+{
+    QString str(len, QLatin1Char(' '));
+    foreach (const IrcToken& token, t)
+        str.replace(token.position(), token.length(), token.text());
+    return str;
+}
+#endif // IRC_DOXYGEN
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/ircutil.cpp
+++ b/3rdparty/communi/src/util/ircutil.cpp
@@ -1,0 +1,61 @@
+/*
+  Copyright (C) 2008-2016 The Communi Project
+
+  You may use this file under the terms of BSD license as follows:
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR
+  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "ircutil.h"
+
+IRC_BEGIN_NAMESPACE
+
+/*!
+    \file ircutil.h
+    \brief \#include &lt;IrcUtil&gt;
+ */
+
+/*!
+    \namespace IrcUtil
+    \ingroup util
+    \brief Module meta-type registration.
+ */
+
+namespace IrcUtil {
+
+    /*!
+        Registers IrcUtil types to the %Qt meta-system.
+
+        \sa IrcCore::registerMetaTypes(), IrcModel::registerMetaTypes(), qRegisterMetaType()
+     */
+    void registerMetaTypes()
+    {
+        qRegisterMetaType<IrcCommandParser*>("IrcCommandParser*");
+        qRegisterMetaType<IrcCompleter*>("IrcCompleter*");
+        qRegisterMetaType<IrcLagTimer*>("IrcLagTimer*");
+        qRegisterMetaType<IrcPalette*>("IrcPalette*");
+        qRegisterMetaType<IrcTextFormat*>("IrcTextFormat*");
+    }
+}
+
+IRC_END_NAMESPACE

--- a/3rdparty/communi/src/util/util.pri
+++ b/3rdparty/communi/src/util/util.pri
@@ -1,0 +1,43 @@
+######################################################################
+# Communi
+######################################################################
+
+DEFINES += BUILD_IRC_UTIL
+
+INCDIR = $$PWD/../../include/IrcUtil
+
+DEPENDPATH += $$PWD $$INCDIR
+INCLUDEPATH += $$PWD $$INCDIR
+
+CONV_HEADERS += $$INCDIR/IrcCommandParser
+CONV_HEADERS += $$INCDIR/IrcCommandQueue
+CONV_HEADERS += $$INCDIR/IrcCompleter
+CONV_HEADERS += $$INCDIR/IrcLagTimer
+CONV_HEADERS += $$INCDIR/IrcPalette
+CONV_HEADERS += $$INCDIR/IrcTextFormat
+CONV_HEADERS += $$INCDIR/IrcUtil
+
+PUB_HEADERS += $$INCDIR/irccommandparser.h
+PUB_HEADERS += $$INCDIR/irccommandqueue.h
+PUB_HEADERS += $$INCDIR/irccompleter.h
+PUB_HEADERS += $$INCDIR/irclagtimer.h
+PUB_HEADERS += $$INCDIR/ircpalette.h
+PUB_HEADERS += $$INCDIR/irctextformat.h
+PUB_HEADERS += $$INCDIR/ircutil.h
+
+PRIV_HEADERS  = $$INCDIR/irccommandparser_p.h
+PRIV_HEADERS  = $$INCDIR/irccommandqueue_p.h
+PRIV_HEADERS += $$INCDIR/irclagtimer_p.h
+PRIV_HEADERS += $$INCDIR/irctoken_p.h
+
+HEADERS += $$PUB_HEADERS
+HEADERS += $$PRIV_HEADERS
+
+SOURCES += $$PWD/irccommandparser.cpp
+SOURCES += $$PWD/irccommandqueue.cpp
+SOURCES += $$PWD/irccompleter.cpp
+SOURCES += $$PWD/irclagtimer.cpp
+SOURCES += $$PWD/ircpalette.cpp
+SOURCES += $$PWD/irctextformat.cpp
+SOURCES += $$PWD/irctoken.cpp
+SOURCES += $$PWD/ircutil.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ SET(mudlet_SRCS
     VarUnit.cpp
     XMLexport.cpp
     XMLimport.cpp
+    ircmessageformatter.cpp
 )
 
 # This is for compiled UI files, not those used at runtime though the resource file.
@@ -196,6 +197,7 @@ SET(mudlet_HDRS
     VarUnit.h
     XMLexport.h
     XMLimport.h
+    ircmessageformatter.h
 )
 
 IF(MSVC)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11755,8 +11755,10 @@ int TLuaInterpreter::sendIrc( lua_State * L )
     QString chan = who.c_str();
     QString txt = text.c_str();
     if( ! mudlet::self()->mpIRC ) return 0;
-    mudlet::self()->mpIRC->connection->sendCommand( IrcCommand::createMessage( chan, txt ) );
-    return 0;
+
+    lua_pushboolean(L, mudlet::self()->mpIRC->sendMsg(chan, txt));
+
+    return 1;
 }
 
 int TLuaInterpreter::setServerEncoding(lua_State * L)

--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -66,6 +66,7 @@ private slots:
     void slot_nickNameRequired(const QString& reserved, QString* alt);
     void slot_nickNameChanged(const QString& nick);
     void slot_joinedChannel(IrcJoinMessage* message);
+    void slot_partedChannel(IrcPartMessage* message);
     void slot_receiveMessage(IrcMessage* message);
     void slot_onAnchorClicked(const QUrl& link);
     void slot_onHistoryCompletion();
@@ -92,7 +93,7 @@ private:
     QString mNickName;
     QString mUserName;
     QString mRealName;
-    QString mChannel;
+    QStringList mChannels;
 };
 
 #endif // MUDLET_DLGIRC_H

--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -65,8 +65,10 @@ private slots:
     void slot_onUserActivated(const QModelIndex& index);
     void slot_nickNameRequired(const QString& reserved, QString* alt);
     void slot_nickNameChanged(const QString& nick);
+    void slot_joinedChannel(IrcJoinMessage* message);
     void slot_receiveMessage(IrcMessage* message);
     void slot_onAnchorClicked(const QUrl& link);
+    void slot_onHistoryCompletion();
 
 private:
     void setupCommandParser();
@@ -80,6 +82,10 @@ private:
     IrcBufferModel* bufferModel;
     QHash<IrcBuffer*, IrcUserModel*> userModels;
     QHash<IrcBuffer*, QTextDocument*> bufferTexts;
+    QStringList mInputHistory;
+    int mInputHistoryMax;
+    int mInputHistoryIdxNext;
+    int mInputHistoryIdxCurrent;
     quint64 mPingStarted;
     QString mHostName;
     int mHostPort;

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -1,0 +1,351 @@
+/***************************************************************************
+ *   Copyright (C) 2008-2017 The Communi Project                           *
+ *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "ircmessageformatter.h"
+
+#include "pre_guard.h"
+#include <IrcTextFormat>
+#include "post_guard.h"
+
+QString IrcMessageFormatter::formatMessage(IrcMessage* message)
+{
+    QString formatted;
+    switch (message->type()) {
+        case IrcMessage::Away:
+            formatted = formatAwayMessage(static_cast<IrcAwayMessage*>(message));
+            break;
+        case IrcMessage::Invite:
+            formatted = formatInviteMessage(static_cast<IrcInviteMessage*>(message));
+            break;
+        case IrcMessage::Join:
+            formatted = formatJoinMessage(static_cast<IrcJoinMessage*>(message));
+            break;
+        case IrcMessage::Mode:
+            formatted = formatModeMessage(static_cast<IrcModeMessage*>(message));
+            break;
+        case IrcMessage::Motd:
+            formatted = formatMotdMessage(static_cast<IrcMotdMessage*>(message));
+            break;
+        case IrcMessage::Names:
+            formatted = formatNamesMessage(static_cast<IrcNamesMessage*>(message));
+            break;
+        case IrcMessage::Nick:
+            formatted = formatNickMessage(static_cast<IrcNickMessage*>(message));
+            break;
+        case IrcMessage::Notice:
+            formatted = formatNoticeMessage(static_cast<IrcNoticeMessage*>(message));
+            break;
+        case IrcMessage::Part:
+            formatted = formatPartMessage(static_cast<IrcPartMessage*>(message));
+            break;
+        case IrcMessage::Pong:
+            formatted = formatPongMessage(static_cast<IrcPongMessage*>(message));
+            break;
+        case IrcMessage::Private:
+            formatted = formatPrivateMessage(static_cast<IrcPrivateMessage*>(message));
+            break;
+        case IrcMessage::Quit:
+            formatted = formatQuitMessage(static_cast<IrcQuitMessage*>(message));
+            break;
+        case IrcMessage::Topic:
+            formatted = formatTopicMessage(static_cast<IrcTopicMessage*>(message));
+            break;
+        case IrcMessage::Whois:
+            formatted = formatWhoisMessage(static_cast<IrcWhoisMessage*>(message));
+            break;
+        case IrcMessage::Whowas:
+            formatted = formatWhowasMessage(static_cast<IrcWhowasMessage*>(message));
+            break;
+        case IrcMessage::WhoReply:
+            formatted = formatWhoReplyMessage(static_cast<IrcWhoReplyMessage*>(message));
+            break;
+        case IrcMessage::Error:
+            formatted = formatErrorMessage(static_cast<IrcErrorMessage*>(message));
+            break;
+        case IrcMessage::Unknown:
+            formatted = formatUnknownMessage(message);
+            break;
+        case IrcMessage::Numeric:
+            formatted = formatNumericMessage(static_cast<IrcNumericMessage*>(message));
+            break;
+        default:
+            break;
+    }
+    return formatMessage(formatted);
+}
+
+QString IrcMessageFormatter::formatMessage(const QString& message)
+{
+    if (!message.isEmpty()) {
+        QString formatted = QObject::tr("[%1] %2").arg(QTime::currentTime().toString(), message);
+        if (message.startsWith("!"))
+            formatted = QObject::tr("<font color='gray'>%1</font>").arg(formatted);
+        else if (message.startsWith("*"))
+            formatted = QObject::tr("<font color='maroon'>%1</font>").arg(formatted);
+        else if (message.startsWith("["))
+            formatted = QObject::tr("<font color='indianred'>%1</font>").arg(formatted);
+        return formatted;
+    }
+    return QString();
+}
+
+QString IrcMessageFormatter::formatAwayMessage(IrcAwayMessage* message)
+{
+    if (message->flags() & IrcMessage::Own)
+        return QObject::tr("! %1").arg(IrcTextFormat().toHtml(message->content()));
+    else if (!message->content().isEmpty())
+        return QObject::tr("! %1 is away (%2)").arg(message->nick(), IrcTextFormat().toHtml(message->content()));
+    return QObject::tr("! %1 is back").arg(message->nick());
+}
+
+QString IrcMessageFormatter::formatInviteMessage(IrcInviteMessage* message)
+{
+    if (message->isReply())
+        return QObject::tr("! invited %1 to %2").arg(message->user(), message->channel());
+
+    return QObject::tr("! %2 invited to %3").arg(message->nick(), message->channel());
+}
+
+QString IrcMessageFormatter::formatJoinMessage(IrcJoinMessage* message)
+{
+    if (message->flags() & IrcMessage::Own)
+        return QObject::tr("! You have joined %1 as %2").arg(message->channel(), message->nick());
+    else
+        return QObject::tr("! %1 has joined %2").arg(message->nick(), message->channel());
+}
+
+QString IrcMessageFormatter::formatKickMessage(IrcKickMessage* message)
+{
+    return QObject::tr("! %1 kicked %2").arg(message->nick(), message->user());
+}
+
+QString IrcMessageFormatter::formatModeMessage(IrcModeMessage* message)
+{
+    QString args = message->arguments().join(" ");
+    if (message->isReply())
+        return QObject::tr("! %1 mode is %2 %3").arg(message->target(), message->mode(), args);
+    else
+        return QObject::tr("! %1 sets mode %2 %3 %4").arg(message->nick(), message->target(), message->mode(), args);
+}
+
+QString IrcMessageFormatter::formatMotdMessage(IrcMotdMessage* message)
+{
+    QString motdData;
+    foreach (const QString& line, message->lines()) {
+        motdData += QObject::tr("[MOTD] %1").arg(IrcTextFormat().toHtml(line));
+        motdData += "<br />\n";
+    }
+    return motdData;
+}
+
+QString IrcMessageFormatter::formatNamesMessage(IrcNamesMessage* message)
+{
+    return QObject::tr("! %1 has %2 users").arg(message->channel()).arg(message->names().count());
+}
+
+QString IrcMessageFormatter::formatNickMessage(IrcNickMessage* message)
+{
+    return QObject::tr("! %1 has changed nick to %2").arg(message->oldNick(), message->newNick());
+}
+
+QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message)
+{
+    if (message->isReply()) {
+       const QStringList params = message->content().split(" ", QString::SkipEmptyParts);
+       const QString cmd = params.value(0);
+       if (cmd.toUpper() == "PING") {
+           const QString secs = formatSeconds(params.value(1).toInt());
+           return QObject::tr("! %1 replied in %2").arg(message->nick(), secs);
+       } else if (cmd.toUpper() == "TIME") {
+           const QString rest = QStringList(params.mid(1)).join(" ");
+           return QObject::tr("! %1 time is %2").arg(message->nick(), rest);
+       } else if (cmd.toUpper() == "VERSION") {
+            const QString rest = QStringList(params.mid(1)).join(" ");
+            return QObject::tr("! %1 version is %2").arg(message->nick(), rest);
+       }
+    }
+
+    QString pfx = message->statusPrefix();
+    if (!pfx.isEmpty())
+        pfx = ":" + pfx;
+
+    if (message->isPrivate()) {
+        const QString content = IrcTextFormat().toHtml(message->content());
+        return QObject::tr("[%1%2] %3").arg(message->nick(), pfx, content);
+    }
+
+    const QString content = IrcTextFormat().toHtml(message->content());
+    return QObject::tr("&lt;%1%2&gt; [%3] %4").arg(message->nick(), pfx, message->target(), content);
+}
+
+QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message)
+{
+    if (message->code() < 300) {
+        const QString info = QStringList(message->parameters().mid(1)).join(" ");
+        return QObject::tr("[INFO] %1").arg(IrcTextFormat().toHtml(info));
+    }
+
+    switch (message->code()) {
+        case Irc::RPL_VERSION:
+            return QObject::tr("! %1 version is %2").arg(message->nick(), message->parameters().value(1));
+
+        case Irc::RPL_TIME:
+            return QObject::tr("! %1 time is %2").arg(message->parameters().value(1), message->parameters().value(2));
+
+        default:
+            break;
+    }
+
+    if (message->isComposed() || message->flags() & IrcMessage::Implicit)
+        return QString();
+
+    // if you change this, change formatErrorMessage too
+    if (Irc::codeToString(message->code()).startsWith("ERR_")) {
+        const QString info = QStringList(message->parameters().mid(1)).join(" ");
+        return QObject::tr("[ERROR] %1").arg(IrcTextFormat().toHtml(info));
+    }
+    if (message->code() == Irc::RPL_CHANNEL_URL) {
+        const QString info = QStringList(message->parameters().mid(1)).join(" ");
+        return QObject::tr("[Channel URL] %1").arg(IrcTextFormat().toHtml(info));
+    }
+    const QString info = QStringList(message->parameters().mid(1)).join(" ");
+    return QObject::tr("[%1] %2").arg(QString::number(message->code()), IrcTextFormat().toHtml(info));
+}
+
+QString IrcMessageFormatter::formatErrorMessage(IrcErrorMessage* message)
+{
+    // if you change this, change ERR_ in formatNumericMessage too
+    return QObject::tr("[ERROR] %1").arg(message->error());
+}
+
+QString IrcMessageFormatter::formatPartMessage(IrcPartMessage* message)
+{
+    if (message->reason().isEmpty())
+        return QObject::tr("! %1 has left %2").arg(message->nick(), message->channel());
+    else
+        return QObject::tr("! %1 has left %2 (%3)").arg(message->nick(), message->channel(), message->reason());
+}
+
+QString IrcMessageFormatter::formatPongMessage(IrcPongMessage* message)
+{
+    quint64 msec = message->timeStamp().toMSecsSinceEpoch();
+    quint64 dms = (QDateTime::currentMSecsSinceEpoch() - msec);
+    const QString secs = QString().sprintf("%04.3f", (float)((float)dms/(float)1000));
+    return QObject::tr("! %1 replied in %2 seconds").arg(message->nick(), secs);
+}
+
+QString IrcMessageFormatter::formatPrivateMessage(IrcPrivateMessage* message)
+{
+    const QString content = IrcTextFormat().toHtml(message->content());
+    if (message->isAction())
+        return QObject::tr("* %1 %2").arg(message->nick(), content);
+    else
+        return QObject::tr("&lt;%1&gt; %2").arg(message->nick(),content);
+}
+
+QString IrcMessageFormatter::formatQuitMessage(IrcQuitMessage* message)
+{
+    if (message->reason().isEmpty())
+        return QObject::tr("! %1 has quit").arg(message->nick());
+    else
+        return QObject::tr("! %1 has quit (%2)").arg(message->nick(), message->reason());
+}
+
+QString IrcMessageFormatter::formatTopicMessage(IrcTopicMessage* message)
+{
+    if (message->flags() & IrcMessage::Implicit)
+        return QString();
+
+    if (message->isReply()) {
+        if (message->topic().isEmpty())
+            return QObject::tr("! no topic");
+        return QObject::tr("[TOPIC] %1").arg(IrcTextFormat().toHtml(message->topic()));
+    }
+
+    if (message->topic().isEmpty())
+        return QObject::tr("! %2 cleared topic").arg(message->nick());
+
+    return QObject::tr("! %2 changed topic").arg(message->nick());
+}
+
+QString IrcMessageFormatter::formatUnknownMessage(IrcMessage* message)
+{
+    return QObject::tr("? %2 %3 %4").arg(message->nick(), message->command(), message->parameters().join(" ") );
+}
+
+QString IrcMessageFormatter::formatWhoisMessage(IrcWhoisMessage* message)
+{
+    QString wData;
+    wData = QObject::tr("[WHOIS] %1 is %2@%3 (%4)").arg(message->nick(), message->ident(), message->host(), message->realName());
+    wData += QObject::tr("[WHOIS] %1 is connected via %2 (%3)").arg(message->nick(), message->server(), message->info());
+    wData += QObject::tr("[WHOIS] %1 is connected since %2 (idle %3)").arg(message->nick(), message->since().toString(), formatDuration(message->idle()));
+    if (!message->awayReason().isEmpty())
+        wData += QObject::tr("[WHOIS] %1 is away: %2").arg(message->nick(), message->awayReason());
+    if (!message->account().isEmpty())
+        wData += QObject::tr("[WHOIS] %1 is logged in as %2").arg(message->nick(), message->account());
+    if (!message->address().isEmpty())
+        wData += QObject::tr("[WHOIS] %1 is connected from %2").arg(message->nick(), message->address());
+    if (message->isSecure())
+        wData += QObject::tr("[WHOIS] %1 is using a secure connection").arg(message->nick());
+    if (!message->channels().isEmpty())
+        wData += QObject::tr("[WHOIS] %1 is on %2").arg(message->nick(), message->channels().join(" "));
+    return wData;
+}
+
+QString IrcMessageFormatter::formatWhowasMessage(IrcWhowasMessage* message)
+{
+    QString wData;
+    wData = QObject::tr("[WHOWAS] %1 was %2@%3 (%4)").arg(message->nick(), message->ident(), message->host(), message->realName());
+    wData += QObject::tr("[WHOWAS] %1 was connected via %2 (%3)").arg(message->nick(), message->server(), message->info());
+    if (!message->account().isEmpty())
+        wData += QObject::tr("[WHOWAS] %1 was logged in as %2").arg(message->nick(), message->account());
+    return wData;
+}
+
+QString IrcMessageFormatter::formatWhoReplyMessage(IrcWhoReplyMessage* message)
+{
+    QString format = QObject::tr("[WHO] %1 (%2)").arg(message->nick(), message->realName());
+    if (message->isAway())
+        format += QObject::tr(" - away");
+    if (message->isServOp())
+        format += QObject::tr(" - server operator");
+    return format;
+}
+
+QString IrcMessageFormatter::formatSeconds(int secs)
+{
+    const QDateTime time = QDateTime::fromTime_t(secs);
+    return QObject::tr("%1s").arg(time.secsTo(QDateTime::currentDateTime()));
+}
+
+QString IrcMessageFormatter::formatDuration(int secs)
+{
+    QStringList idle;
+    if (int days = secs / 86400)
+        idle += QObject::tr("%1 days").arg(days);
+    secs %= 86400;
+    if (int hours = secs / 3600)
+        idle += QObject::tr("%1 hours").arg(hours);
+    secs %= 3600;
+    if (int mins = secs / 60)
+        idle += QObject::tr("%1 mins").arg(mins);
+    idle += QObject::tr("%1 secs").arg(secs % 60);
+    return idle.join(" ");
+}

--- a/src/ircmessageformatter.h
+++ b/src/ircmessageformatter.h
@@ -30,7 +30,7 @@ class IrcMessageFormatter
 {
 public:
     static QString formatMessage(IrcMessage* message);
-    static QString formatMessage(const QString& message);
+    static QString formatMessage(const QString& message, QString color = "#f29010");
     static QString formatSeconds(int secs);
     static QString formatDuration(int secs);
 private:

--- a/src/ircmessageformatter.h
+++ b/src/ircmessageformatter.h
@@ -1,0 +1,59 @@
+#ifndef IRCMESSAGEFORMATTER_H
+#define IRCMESSAGEFORMATTER_H
+
+/***************************************************************************
+ *   Copyright (C) 2008-2017 The Communi Project                           *
+ *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "pre_guard.h"
+#include <IrcMessage>
+#include <QString>
+#include "post_guard.h"
+
+class IrcMessageFormatter
+{
+public:
+    static QString formatMessage(IrcMessage* message);
+    static QString formatMessage(const QString& message);
+    static QString formatSeconds(int secs);
+    static QString formatDuration(int secs);
+private:
+    static QString formatAwayMessage(IrcAwayMessage* message);
+    static QString formatInviteMessage(IrcInviteMessage* message);
+    static QString formatJoinMessage(IrcJoinMessage* message);
+    static QString formatKickMessage(IrcKickMessage* message);
+    static QString formatModeMessage(IrcModeMessage* message);
+    static QString formatMotdMessage(IrcMotdMessage* message);
+    static QString formatNamesMessage(IrcNamesMessage* message);
+    static QString formatNickMessage(IrcNickMessage* message);
+    static QString formatNoticeMessage(IrcNoticeMessage* message);
+    static QString formatNumericMessage(IrcNumericMessage* message);
+    static QString formatErrorMessage(IrcErrorMessage* message);
+    static QString formatPartMessage(IrcPartMessage* message);
+    static QString formatPongMessage(IrcPongMessage* message);
+    static QString formatPrivateMessage(IrcPrivateMessage* message);
+    static QString formatQuitMessage(IrcQuitMessage* message);
+    static QString formatTopicMessage(IrcTopicMessage* message);
+    static QString formatUnknownMessage(IrcMessage* message);
+    static QString formatWhoisMessage(IrcWhoisMessage* message);
+    static QString formatWhowasMessage(IrcWhowasMessage* message);
+    static QString formatWhoReplyMessage(IrcWhoReplyMessage* message);
+};
+
+#endif // IRCMESSAGEFORMATTER_H

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -171,7 +171,7 @@ public:
     int mReplaySpeed;
     QToolBar* mpMainToolBar;
     QMap<QTimer*, TTimer*> mTimerMap;
-    dlgIRC* mpIRC;
+    QPointer<dlgIRC> mpIRC;
     QString version;
     QPointer<Host> mpCurrentActiveHost;
     bool mAutolog;

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,6 +24,8 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
 
 # Including IRC Library
 include(../3rdparty/communi/src/core/core.pri)
+include(../3rdparty/communi/src/util/util.pri)
+include(../3rdparty/communi/src/model/model.pri)
 
 include(../3rdparty/lua_yajl/src.pri)
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -244,7 +244,8 @@ SOURCES += \
     TVar.cpp \
     VarUnit.cpp \
     XMLexport.cpp \
-    XMLimport.cpp
+    XMLimport.cpp \
+    ircmessageformatter.cpp
 
 
 HEADERS += \
@@ -320,7 +321,8 @@ HEADERS += \
     TVar.h \
     VarUnit.h \
     XMLexport.h \
-    XMLimport.h
+    XMLimport.h \
+    ircmessageformatter.h
 
 # This is for compiled UI files, not those used at runtime through the resource file.
 FORMS += \

--- a/src/ui/irc.ui
+++ b/src/ui/irc.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>621</width>
-    <height>443</height>
+    <width>693</width>
+    <height>415</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,7 +22,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Script editor</string>
+   <string>Mudlet IRC Client</string>
   </property>
   <property name="unifiedTitleAndToolBarOnMac">
    <bool>true</bool>
@@ -34,212 +34,117 @@
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <layout class="QHBoxLayout" name="horizontalLayout_3">
     <property name="spacing">
      <number>0</number>
     </property>
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item>
-     <widget class="QWidget" name="i1" native="true">
+     <widget class="QWidget" name="widget" native="true">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <property name="margin">
-        <number>0</number>
-       </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
        <property name="spacing">
-        <number>0</number>
+        <number>1</number>
        </property>
-       <item row="0" column="0">
-        <widget class="QWidget" name="i2" native="true">
+       <property name="leftMargin">
+        <number>1</number>
+       </property>
+       <property name="topMargin">
+        <number>1</number>
+       </property>
+       <property name="rightMargin">
+        <number>1</number>
+       </property>
+       <property name="bottomMargin">
+        <number>1</number>
+       </property>
+       <item>
+        <widget class="QSplitter" name="splitter">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="spacing">
-           <number>0</number>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="handleWidth">
+          <number>3</number>
+         </property>
+         <widget class="QListView" name="bufferList">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="leftMargin">
-           <number>3</number>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
-          <property name="topMargin">
-           <number>0</number>
+         </widget>
+         <widget class="QWidget" name="viewportWidget" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>3</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="rightMargin">
-           <number>3</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="i3" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_8">
-             <property name="spacing">
-              <number>0</number>
+          <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
+           <property name="spacing">
+            <number>3</number>
+           </property>
+           <property name="leftMargin">
+            <number>1</number>
+           </property>
+           <property name="topMargin">
+            <number>1</number>
+           </property>
+           <property name="rightMargin">
+            <number>1</number>
+           </property>
+           <property name="bottomMargin">
+            <number>1</number>
+           </property>
+           <item>
+            <widget class="QTextBrowser" name="ircBrowser">
+             <property name="openExternalLinks">
+              <bool>true</bool>
              </property>
-             <property name="margin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QSplitter" name="splitter">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="lineWidth">
-                <number>0</number>
-               </property>
-               <property name="midLineWidth">
-                <number>5</number>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="opaqueResize">
-                <bool>true</bool>
-               </property>
-               <property name="handleWidth">
-                <number>5</number>
-               </property>
-               <widget class="QFrame" name="left_frame">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                  <horstretch>3</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="baseSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Plain</enum>
-                </property>
-                <property name="lineWidth">
-                 <number>1</number>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout_3">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <property name="margin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QWidget" name="irctext" native="true">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_6">
-                    <property name="spacing">
-                     <number>5</number>
-                    </property>
-                    <property name="margin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <widget class="QTextBrowser" name="irc"/>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="lineEdit"/>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-               <widget class="QFrame" name="right_frame">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                  <horstretch>1</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>16777215</width>
-                  <height>16777215</height>
-                 </size>
-                </property>
-                <property name="baseSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="font">
-                 <font>
-                  <stylestrategy>PreferAntialias</stylestrategy>
-                 </font>
-                </property>
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="frameShadow">
-                 <enum>QFrame::Plain</enum>
-                </property>
-                <property name="lineWidth">
-                 <number>1</number>
-                </property>
-                <layout class="QHBoxLayout" name="horizontalLayout_2">
-                 <property name="spacing">
-                  <number>0</number>
-                 </property>
-                 <property name="margin">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <widget class="QListWidget" name="nickList">
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="lineEdit"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QListView" name="userList">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -337,3 +242,4 @@
  <resources/>
  <connections/>
 </ui>
+


### PR DESCRIPTION
This PR provides a complete rewrite of the IRC Client UI and logic, as well as the addition of `IrcModel` and `IrcUtil` component libraries of Communi.   
These changes attempt to closely replicate the functionality of the old client so as to avoid breaking expected functionality, however this PR is also a precursor to the changes made in this branch:  https://github.com/itsTheFae/Mudlet/tree/feature-Irc3-WithMoreLua  

That being the case, my primary focus with this PR is getting cmake to play nice with the extra libraries needed, since I couldn't manage to do it on my own.   Anything outside of that can probably wait and be addressed in the second PR with the functional changes and lua additions for the IRC client. 