### PR TITLE
Added utf8 Lua module

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13128,7 +13128,7 @@ void TLuaInterpreter::initLuaGlobals()
     }
     else
     {
-        QString msg = "[  OK  ]  - Lua module lfs loaded";
+        QString msg = "[  OK  ]  - Lua module lfs loaded.";
         mpHost->postMessage( msg );
     }
 
@@ -13148,7 +13148,28 @@ void TLuaInterpreter::initLuaGlobals()
     }
     else
     {
-        QString msg = "[  OK  ]  - Lua module sqlite3 loaded";
+        QString msg = "[  OK  ]  - Lua module sqlite3 loaded.";
+        mpHost->postMessage( msg );
+    }
+
+
+    error = luaL_dostring( pGlobalLua, R"(utf8 = require "lua-utf8")" );
+    if( error != 0 )
+    {
+        string e = "no error message available from Lua";
+        if( lua_isstring( pGlobalLua, -1 ) )
+        {
+            e = "Lua error:";
+            e+=lua_tostring( pGlobalLua, -1 );
+        }
+        QString msg = "[ ERROR ] - Cannot find Lua module utf8.\n"
+                                  "utf8.* Lua functions won't be available.\n";
+        msg.append( e.c_str() );
+        mpHost->postMessage( msg );
+    }
+    else
+    {
+        QString msg = "[  OK  ]  - Lua module utf8 loaded.";
         mpHost->postMessage( msg );
     }
 


### PR DESCRIPTION
This allows you to do things right like:

```
lua string.len("привет")
12

lua utf8.len("привет")
6

lua string.upper("привет")
"привет"

lua utf8.upper("привет")
"ПРИВЕТ"
```

The Lua library we'll be using [starwing/luautf8](https://github.com/starwing/luautf8), it is very popular and has been confirmed by an independent third party that it works fine in production (http://notecasepro.com has used it for years).

Most of the work will not be in this PR but documenting all of the utf8 functions on our wiki and updating all installers to include it. I hope this won't take long to merge so I can get started on the documentation and installers efforts.

Fixes https://github.com/Mudlet/Mudlet/issues/854.