### PR TITLE
Adds saveWindowLayout() call to ForceSaveOnExit processing.

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -750,6 +750,7 @@ void TConsole::closeEvent( QCloseEvent *event )
 
         if( mpHost->mFORCE_SAVE_ON_EXIT )
         {
+            mudlet::self()->saveWindowLayout();
             mpHost->modulesToWrite.clear();
             mpHost->saveProfile();
 


### PR DESCRIPTION
This adds a call to save the window layout of Mudlet when closing a profile which is marked for auto-saving on exit.    Hopefully this will address Issue #1075 and if not it should at least prevent similar issues on platforms we know are able to use the window layout methods. 