### PR TITLE
BugFix: import some fixes by "Zolder" from Mudlet Realms of Legend Fork

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1184,10 +1184,10 @@ void TBuffer::translateToPlainText( std::string & incoming, const bool isFromSer
             {
                 QChar ch2 = localBuffer[localBufferPosition];
 
-                if( ch2 == 'z' )
-                {
+                if (ch2 == 'z' && !mpHost->mFORCE_MXP_NEGOTIATION_OFF) {
                     gotHeader = false;
                     gotESC = false;
+
                     // MXP line modes
 
                     // locked mode
@@ -3117,21 +3117,14 @@ inline int TBuffer::wrap( int startLine )
             if( length-i2 > mWrapAt-indent )
             {
                 wrapPos = calcWrapPos( i, i2, i2+mWrapAt-indent );
-                if( wrapPos > 0 )
-                {
-                    lastSpace = wrapPos;
-                }
-                else
-                {
-                    lastSpace = 0;
-                }
+                lastSpace = qMax(0, wrapPos);
             }
             else
             {
                 lastSpace = 0;
             }
-            int __wrapPos = lastSpace == 0 ? mWrapAt-indent : lastSpace;
-            for( int i3=0; i3<=__wrapPos; i3++ )
+            int wrapPosition = (lastSpace) ? lastSpace : (mWrapAt - indent);
+            for( int i3=0; i3<wrapPosition; i3++ )
             {
                 if( lastSpace > 0 )
                 {
@@ -3295,14 +3288,7 @@ int TBuffer::wrapLine( int startLine, int screenWidth, int indentSize, TChar & f
             if( length-i2 > screenWidth-indent )
             {
                 wrapPos = calcWrapPos( i, i2, i2+screenWidth-indent );
-                if( wrapPos > -1 )
-                {
-                    lastSpace = wrapPos;
-                }
-                else
-                {
-                    lastSpace = -1;
-                }
+                lastSpace = qMax(-1, wrapPos);
             }
             else
             {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -301,24 +301,11 @@ void TTextEdit::updateScreenView()
     int currentScreenWidth = visibleRegion().boundingRect().width() / mFontWidth;
     if( ! mIsDebugConsole && ! mIsMiniConsole )
     {
-        if( mpHost->mScreenWidth > currentScreenWidth )
-        {
-            if( currentScreenWidth < 100 )
-            {
-                mScreenWidth = 100;
-            }
-            else
-            {
-                mScreenWidth = currentScreenWidth;
-                mpHost->mScreenWidth = mScreenWidth;
-            }
-        }
-        else
-        {
-            mpHost->mScreenWidth = currentScreenWidth;
-            mScreenWidth = currentScreenWidth;
-        }
+        // This is the MAIN console - we do not want it to ever disappear!
+        mScreenWidth = qMax(40, currentScreenWidth);
 
+        // Note the values in the "parent" Host instance
+        mpHost->mScreenWidth = mScreenWidth;
         mpHost->mScreenHeight = mScreenHeight;
     }
     else
@@ -649,7 +636,12 @@ void TTextEdit::drawForeground( QPainter & painter, const QRect & r )
     }
     else
     {
-        mScrollVector = lineOffset - mLastRenderBottom;
+        // Was: mScrollVector = lineOffset - mLastRenderBottom;
+        if (mLastRenderBottom) {
+            mScrollVector = lineOffset - mLastRenderBottom;
+        } else {
+            mScrollVector = y2 + lineOffset;
+        }
     }
 
     bool noScroll = false;
@@ -799,6 +791,7 @@ void TTextEdit::drawForeground( QPainter & painter, const QRect & r )
         mScreenMap = pixmap.copy();
     }
     mScrollVector = 0;
+    // Only place this value is changed (apart from initialisation to 0):
     mLastRenderBottom = lineOffset;
     mForceUpdate = false;
 }


### PR DESCRIPTION
import: some fixes by Zoilder from the MudletRL fork:
* in `TBuffer::translateToPlainText(...)`: make some MXP related code execute   only if `Host::mFORCE_MXP_NEGOTIATION_OFF` is NOT set as well as another condition.
* in `TBuffer::wrap(...)`: change a `for(...) {...}` loop termination condition be a `<` rather than a `<=` test - which sounds like an "off-by-one" error fix-up.
* In `TTextEdit:updateScreenView()`: revise code that seems to prevent the width of a "main" console being set too small and NOT written to the "parent" `Host::mScreenWidth` variable - the original modification removed such a restriction completely, but I have just lowered the minimum from 100 to 40 and ensured it is always stored both in the local "main" console and to the parent record in the `Host` class for that console.
* In `TTextEdit::drawForeground(...)`: revise the behaviour *I think* when at the point where a console "split" becomes unnecessary...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>