### PR TITLE
Event-based gamepad functionality

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -424,6 +424,12 @@ mudlet::mudlet()
 
     connect(mpMainStatusBar, SIGNAL(messageChanged(QString)), this, SLOT(slot_statusBarMessageChanged(QString)));
 
+    connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, slot_gamepadButtonPress);
+    connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonReleaseEvent, this, slot_gamepadButtonRelease);
+    connect(QGamepadManager::instance(), &QGamepadManager::gamepadConnected, this, slot_gamepadConnected);
+    connect(QGamepadManager::instance(), &QGamepadManager::gamepadDisconnected, this, slot_gamepadDisconnected);
+    connect(QGamepadManager::instance(), &QGamepadManager::gamepadAxisEvent, this, slot_gamepadAxisEvent);
+
     // Edbee has a singleton that needs some initialisation
     initEdbee();
 }
@@ -2807,3 +2813,72 @@ void mudlet::requestProfilesToReloadMaps( QList<QString> affectedProfiles )
     emit signal_profileMapReloadRequested( affectedProfiles );
 }
 
+void mudlet::slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value)
+{
+    Host * pH = getActiveHost();
+    if( ! pH ) return;
+    TEvent event;
+    event.mArgumentList.append( "sysGamepadButtonPress" );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append( QString::number(button) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append( QString::number(value) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    pH->raiseEvent( event );
+}
+
+void mudlet::slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadButton button)
+{
+    Host * pH = getActiveHost();
+    if( ! pH ) return;
+    TEvent event;
+    event.mArgumentList.append( "sysGamepadButtonRelease" );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append( QString::number(button) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    pH->raiseEvent( event );
+}
+
+void mudlet::slot_gamepadConnected(int deviceId)
+{
+    Host * pH = getActiveHost();
+    if( ! pH ) return;
+    TEvent event;
+    event.mArgumentList.append( "sysGamepadConnected" );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    pH->raiseEvent( event );
+}
+
+void mudlet::slot_gamepadDisconnected(int deviceId)
+{
+    Host * pH = getActiveHost();
+    if( ! pH ) return;
+    TEvent event;
+    event.mArgumentList.append( "sysGamepadDisconnected" );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    pH->raiseEvent( event );
+}
+
+void mudlet::slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis axis, double value)
+{
+    Host * pH = getActiveHost();
+    if( ! pH ) return;
+    TEvent event;
+    event.mArgumentList.append( "sysGamepadAxisMove" );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append( QString::number(axis) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append( QString::number(value) );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    pH->raiseEvent( event );
+}

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3,7 +3,7 @@
  *   Copyright (C) 2013-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
- *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Tom Scheper - scheper@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -424,11 +424,16 @@ mudlet::mudlet()
 
     connect(mpMainStatusBar, SIGNAL(messageChanged(QString)), this, SLOT(slot_statusBarMessageChanged(QString)));
 #ifdef QT_GAMEPAD_LIB
-    connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, slot_gamepadButtonPress);
-    connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonReleaseEvent, this, slot_gamepadButtonRelease);
-    connect(QGamepadManager::instance(), &QGamepadManager::gamepadConnected, this, slot_gamepadConnected);
-    connect(QGamepadManager::instance(), &QGamepadManager::gamepadDisconnected, this, slot_gamepadDisconnected);
-    connect(QGamepadManager::instance(), &QGamepadManager::gamepadAxisEvent, this, slot_gamepadAxisEvent);
+    //connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, slot_gamepadButtonPress);
+    //connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonReleaseEvent, this, slot_gamepadButtonRelease);
+    //connect(QGamepadManager::instance(), &QGamepadManager::gamepadConnected, this, slot_gamepadConnected);
+    //connect(QGamepadManager::instance(), &QGamepadManager::gamepadDisconnected, this, slot_gamepadDisconnected);
+    //connect(QGamepadManager::instance(), &QGamepadManager::gamepadAxisEvent, this, slot_gamepadAxisEvent);
+    connect(QGamepadManager::instance(), SIGNAL(gamepadButtonPressEvent(int, QGamepadManager::GamepadButton, double)), this, SLOT(slot_gamepadButtonPress(int, QGamepadManager::GamepadButton, double)));
+    connect(QGamepadManager::instance(), SIGNAL(gamepadButtonReleaseEvent(int, QGamepadManager::GamepadButton)), this, SLOT(slot_gamepadButtonRelease(int, QGamepadManager::GamepadButton)));
+    connect(QGamepadManager::instance(), SIGNAL(gamepadAxisEvent(int, QGamepadManager::GamepadAxis, double)), this, SLOT(slot_gamepadAxisEvent(int, QGamepadManager::GamepadAxis, double)));
+    connect(QGamepadManager::instance(), SIGNAL(gamepadConnected(int)), this, SLOT(slot_gamepadConnected(int)));
+    connect(QGamepadManager::instance(), SIGNAL(gamepadDisconnected(int)), this, SLOT(slot_gamepadDisconnected(int)));
 #endif
     // Edbee has a singleton that needs some initialisation
     initEdbee();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -423,13 +423,13 @@ mudlet::mudlet()
     timerAutologin->start( 50 );
 
     connect(mpMainStatusBar, SIGNAL(messageChanged(QString)), this, SLOT(slot_statusBarMessageChanged(QString)));
-
+#ifdef QT_GAMEPAD_LIB
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, slot_gamepadButtonPress);
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonReleaseEvent, this, slot_gamepadButtonRelease);
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadConnected, this, slot_gamepadConnected);
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadDisconnected, this, slot_gamepadDisconnected);
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadAxisEvent, this, slot_gamepadAxisEvent);
-
+#endif
     // Edbee has a singleton that needs some initialisation
     initEdbee();
 }
@@ -2813,72 +2813,79 @@ void mudlet::requestProfilesToReloadMaps( QList<QString> affectedProfiles )
     emit signal_profileMapReloadRequested( affectedProfiles );
 }
 
+#ifdef QT_GAMEPAD_LIB
 void mudlet::slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value)
 {
-    Host * pH = getActiveHost();
-    if( ! pH ) return;
+    Host* pH = getActiveHost();
+    if (!pH)
+        return;
     TEvent event;
-    event.mArgumentList.append( "sysGamepadButtonPress" );
+    event.mArgumentList.append("sysGamepadButtonPress");
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentList.append(QString::number(deviceId));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    event.mArgumentList.append( QString::number(button) );
+    event.mArgumentList.append(QString::number(button));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    event.mArgumentList.append( QString::number(value) );
+    event.mArgumentList.append(QString::number(value));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    pH->raiseEvent( event );
+    pH->raiseEvent(event);
 }
 
 void mudlet::slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadButton button)
 {
-    Host * pH = getActiveHost();
-    if( ! pH ) return;
+    Host* pH = getActiveHost();
+    if (!pH)
+        return;
     TEvent event;
-    event.mArgumentList.append( "sysGamepadButtonRelease" );
+    event.mArgumentList.append("sysGamepadButtonRelease");
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentList.append(QString::number(deviceId));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    event.mArgumentList.append( QString::number(button) );
+    event.mArgumentList.append(QString::number(button));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    pH->raiseEvent( event );
+    pH->raiseEvent(event);
 }
 
 void mudlet::slot_gamepadConnected(int deviceId)
 {
-    Host * pH = getActiveHost();
-    if( ! pH ) return;
+    Host* pH = getActiveHost();
+    if (!pH)
+        return;
     TEvent event;
-    event.mArgumentList.append( "sysGamepadConnected" );
+    event.mArgumentList.append("sysGamepadConnected");
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentList.append(QString::number(deviceId));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    pH->raiseEvent( event );
+    pH->raiseEvent(event);
 }
 
 void mudlet::slot_gamepadDisconnected(int deviceId)
 {
-    Host * pH = getActiveHost();
-    if( ! pH ) return;
+    Host* pH = getActiveHost();
+    if (!pH)
+        return;
     TEvent event;
-    event.mArgumentList.append( "sysGamepadDisconnected" );
+    event.mArgumentList.append("sysGamepadDisconnected");
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentList.append(QString::number(deviceId));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    pH->raiseEvent( event );
+    pH->raiseEvent(event);
 }
 
 void mudlet::slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis axis, double value)
 {
-    Host * pH = getActiveHost();
-    if( ! pH ) return;
+    Host* pH = getActiveHost();
+    if (!pH)
+        return;
     TEvent event;
-    event.mArgumentList.append( "sysGamepadAxisMove" );
+    event.mArgumentList.append("sysGamepadAxisMove");
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( QString::number(deviceId) );
+    event.mArgumentList.append(QString::number(deviceId));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    event.mArgumentList.append( QString::number(axis) );
+    event.mArgumentList.append(QString::number(axis));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    event.mArgumentList.append( QString::number(value) );
+    event.mArgumentList.append(QString::number(value));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    pH->raiseEvent( event );
+    pH->raiseEvent(event);
 }
+#endif

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
  *   Copyright (C) 2015-2016 by Stephen Lyons - slysven@virginmedia.com    *
- *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -37,6 +37,7 @@
 #include <QQueue>
 #include <QTextOption>
 #include <QTime>
+#include <QGamepad>
 #include "post_guard.h"
 
 #include <assert.h>
@@ -275,6 +276,11 @@ private slots:
     void show_variable_dialog();
     void show_options_dialog();
     void slot_statusBarMessageChanged(QString);
+    void slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value);
+    void slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadButton button);
+    void slot_gamepadConnected(int deviceId);
+    void slot_gamepadDisconnected(int deviceId);
+    void slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis axis, double value);
 
 private:
     void initEdbee();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -37,7 +37,9 @@
 #include <QQueue>
 #include <QTextOption>
 #include <QTime>
-#include <QGamepad>
+#ifdef QT_GAMEPAD_LIB
+  #include <QGamepad>
+#endif
 #include "post_guard.h"
 
 #include <assert.h>
@@ -276,11 +278,13 @@ private slots:
     void show_variable_dialog();
     void show_options_dialog();
     void slot_statusBarMessageChanged(QString);
+#ifdef QT_GAMEPAD_LIB
     void slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value);
     void slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadButton button);
     void slot_gamepadConnected(int deviceId);
     void slot_gamepadDisconnected(int deviceId);
     void slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis axis, double value);
+#endif
 
 private:
     void initEdbee();

--- a/src/src.pro
+++ b/src/src.pro
@@ -61,7 +61,7 @@ msvc:QMAKE_CXXFLAGS += -MP
 # Mac specific flags.
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
 
-QT += network opengl uitools multimedia gui
+QT += network opengl uitools multimedia gui gamepad
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment

--- a/src/src.pro
+++ b/src/src.pro
@@ -63,7 +63,7 @@ msvc:QMAKE_CXXFLAGS += -MP
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
 
 QT += network opengl uitools multimedia gui
-qtHaveModule(gamepad): QT += gamepadgamepad
+qtHaveModule(gamepad): QT += gamepad
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,6 +1,7 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
 #    Copyright (C) 2013-2015 by Stephen Lyons - slysven@virginmedia.com    #
+#    Copyright (C) 2017 by Ian Adkins - ieadkins@gmail.com                 #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #

--- a/src/src.pro
+++ b/src/src.pro
@@ -62,7 +62,8 @@ msvc:QMAKE_CXXFLAGS += -MP
 # Mac specific flags.
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
 
-QT += network opengl uitools multimedia gui gamepad
+QT += network opengl uitools multimedia gui
+qtHaveModule(gamepad): QT += gamepadgamepad
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment


### PR DESCRIPTION
Should only be sending the events to whichever window is active, but I could be mistaken. Needs some testing. Note that for Windows users, you're limited to XInput devices, like Xbox 360/One controllers, some 3P controllers, and PS3 and PS4 controllers if you use the right software to spoof XInput with them. Other OS's should have access to all gamepads, although the QGamepad class is only really meant to handle Gamepads ala: https://en.wikipedia.org/wiki/Gamepad and might not function with joysticks/etc