### PR TITLE
initialize int nIrcPort with dlgIRC::DefaultHostPort value [Coverity]

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1256,7 +1256,7 @@ void dlgProfilePreferences::slot_save_and_exit()
     QString newIrcPort = ircHostPort->text();
     QString newIrcChannels = ircChannels->text();
     QStringList newChanList;
-    int nIrcPort;
+    int nIrcPort = dlgIRC::DefaultHostPort;
     bool restartIrcClient = false;
 
     if (newIrcHost.isEmpty()) {


### PR DESCRIPTION
This should address the Coverity issue in the IRC related code additions.