### PR TITLE
Removes false from sendIrc() return, ignores command filtering status

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10381,7 +10381,11 @@ int TLuaInterpreter::sendIrc( lua_State * L )
 
     QPair<bool, QString> rval = mudlet::self()->mpIrcClientMap.value(pHost)->sendMsg(target, msg);
 
-    lua_pushboolean(L, rval.first);
+    if (rval.first) {
+        lua_pushboolean(L, true);
+    } else {
+        lua_pushnil(L);
+    }
     lua_pushstring(L, rval.second.toUtf8().constData());
     return 2;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10375,7 +10375,7 @@ int TLuaInterpreter::sendIrc( lua_State * L )
     // wait for our client to be ready before sending messages.
     if (!mudlet::self()->mpIrcClientMap.value(pHost)->mReadyForSending) {
         lua_pushnil(L);
-        lua_pushstring(L, "not ready to send.");
+        lua_pushstring(L, "not ready to send");
         return 2;
     }
 
@@ -10462,12 +10462,12 @@ int TLuaInterpreter::getIrcConnectedHost(lua_State* L)
 {
     Host* pHost = &getHostFromLua(L);
     QString cHostName = "";
-    QString error = "no client active.";
+    QString error = "no client active";
     if (mudlet::self()->mpIrcClientMap.contains(pHost)) {
         cHostName = mudlet::self()->mpIrcClientMap.value(pHost)->getConnectedHost();
 
         if (cHostName.isEmpty()) {
-            error = "not yet connected.";
+            error = "not yet connected";
         }
     }
 
@@ -10598,7 +10598,7 @@ int TLuaInterpreter::setIrcChannels(lua_State* L)
 
     if (newchannels.count() == 0) {
         lua_pushnil(L);
-        lua_pushstring(L, "channels must contain at least 1 valid channel name!");
+        lua_pushstring(L, "channels must contain at least 1 valid channel name");
         return 2;
     }
 

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -173,7 +173,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
         mPingStarted = QDateTime::currentMSecsSinceEpoch();
     }
 
-    bool rv = connection->sendCommand(command);
+    connection->sendCommand(command);
 
     // if the command was a quit command we should close the IRC window.
     if (command->type() == IrcCommand::Quit) {
@@ -189,11 +189,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
         delete msg;
     }
 
-    if (rv) {
-        return QPair<bool, QString>(true, QStringLiteral("sent to server."));
-    } else {
-        return QPair<bool, QString>(false, QStringLiteral("filtered by client."));
-    }
+    return QPair<bool, QString>(true, QStringLiteral("sent to server."));
 }
 
 void dlgIRC::ircRestart(bool reloadConfigs)

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -144,7 +144,7 @@ void dlgIRC::startClient()
 QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& message)
 {
     if (message.isEmpty()) {
-        return QPair<bool, QString>(true, QStringLiteral("message processed by client."));
+        return QPair<bool, QString>(true, QStringLiteral("message processed by client"));
     }
 
     QString msgTarget = target;
@@ -160,12 +160,12 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
     commandParser->setTarget(lastParserTarget);
 
     if (!command) {
-        return QPair<bool, QString>(false, QStringLiteral("command or message could not be parsed."));
+        return QPair<bool, QString>(false, QStringLiteral("message could not be parsed"));
     }
 
     bool isCustomCommand = processCustomCommand(command);
     if (isCustomCommand) {
-        return QPair<bool, QString>(true, QStringLiteral("command processed by client."));
+        return QPair<bool, QString>(true, QStringLiteral("command processed by client"));
     }
 
     // update ping-started time if this command was a ping
@@ -179,7 +179,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
     if (command->type() == IrcCommand::Quit) {
         setAttribute(Qt::WA_DeleteOnClose);
         close();
-        return QPair<bool, QString>(true, QStringLiteral("closing client."));
+        return QPair<bool, QString>(true, QStringLiteral("closing client"));
     }
 
     // echo own messages (servers do not send our own messages back)
@@ -189,7 +189,7 @@ QPair<bool, QString> dlgIRC::sendMsg(const QString& target, const QString& messa
         delete msg;
     }
 
-    return QPair<bool, QString>(true, QStringLiteral("sent to server."));
+    return QPair<bool, QString>(true, QStringLiteral("sent to server"));
 }
 
 void dlgIRC::ircRestart(bool reloadConfigs)


### PR DESCRIPTION
maps any `false` + status return value to a nil + error format, and ignores return values from `connection->sendCommand()`