### PR TITLE
Remove mainwindow statusbar

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2401,6 +2401,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
     if (event->buttons() & Qt::RightButton) {
         auto popup = new QMenu(this);
+        popup->setToolTipsVisible(true);
 
         if (mCustomLinesRoomFrom > 0) {
             if (mDialogLock) {
@@ -2410,7 +2411,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             TRoom* pR = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
             if (pR) {
                 QAction* action = new QAction("undo", this);
-                action->setStatusTip(tr("undo last point"));
+                action->setToolTip(tr("Undo last point"));
                 if (pR->customLines.value(mCustomLinesRoomExit).count() > 1) {
                     connect(action, SIGNAL(triggered()), this, SLOT(slot_undoCustomLineLastPoint()));
                 } else {
@@ -2419,11 +2420,11 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
                 QAction* action2 = new QAction("properties", this);
                 action2->setText("properties...");
-                action2->setStatusTip(tr("change the properties of this line"));
+                action2->setToolTip(tr("Change the properties of this line"));
                 connect(action2, SIGNAL(triggered()), this, SLOT(slot_customLineProperties()));
 
                 QAction* action3 = new QAction("finish", this);
-                action3->setStatusTip(tr("finish drawing this line"));
+                action3->setToolTip(tr("Finish drawing this line"));
                 connect(action3, SIGNAL(triggered()), this, SLOT(slot_doneCustomLine()));
 
                 mPopupMenu = true;
@@ -2441,49 +2442,49 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
         if (!mLabelHilite && mCustomLineSelectedRoom == 0) {
             QAction* action = new QAction("move", this);
-            action->setStatusTip(tr("move room"));
+            action->setToolTip(tr("Move room"));
             connect(action, SIGNAL(triggered()), this, SLOT(slot_moveRoom()));
             QAction* action2 = new QAction("delete", this);
-            action2->setStatusTip(tr("delete room"));
+            action2->setToolTip(tr("Delete room"));
             connect(action2, SIGNAL(triggered()), this, SLOT(slot_deleteRoom()));
             QAction* action3 = new QAction("color", this);
-            action3->setStatusTip(tr("change room color"));
+            action3->setToolTip(tr("Change room color"));
             connect(action3, SIGNAL(triggered()), this, SLOT(slot_changeColor()));
             QAction* action4 = new QAction("spread", this);
-            action4->setStatusTip(tr("increase map X-Y spacing for the selected group of rooms"));
+            action4->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms"));
             connect(action4, SIGNAL(triggered()), this, SLOT(slot_spread()));
             QAction* action9 = new QAction("shrink", this);
-            action9->setStatusTip(tr("decrease map X-Y spacing for the selected group of rooms"));
+            action9->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms"));
             connect(action9, SIGNAL(triggered()), this, SLOT(slot_shrink()));
 
             //QAction * action5 = new QAction("user data", this );
-            //action5->setStatusTip(tr("set user data"));
+            //action5->setToolTip(tr("Set user data"));
             //connect( action5, SIGNAL(triggered()), this, SLOT(slot_setUserData()));
             QAction* action6 = new QAction("lock", this);
-            action6->setStatusTip(tr("lock room for speed walks"));
+            action6->setToolTip(tr("Lock room for speed walks"));
             connect(action6, SIGNAL(triggered()), this, SLOT(slot_lockRoom()));
             QAction* action17 = new QAction("unlock", this);
-            action17->setStatusTip(tr("unlock room for speed walks"));
+            action17->setToolTip(tr("Unlock room for speed walks"));
             connect(action17, SIGNAL(triggered()), this, SLOT(slot_unlockRoom()));
             QAction* action7 = new QAction("weight", this);
-            action7->setStatusTip(tr("set room weight"));
+            action7->setToolTip(tr("Set room weight"));
             connect(action7, SIGNAL(triggered()), this, SLOT(slot_setRoomWeight()));
             QAction* action8 = new QAction("exits", this);
-            action8->setStatusTip(tr("set room exits"));
+            action8->setToolTip(tr("Set room exits"));
             connect(action8, SIGNAL(triggered()), this, SLOT(slot_setExits()));
             QAction* action10 = new QAction("letter", this);
-            action10->setStatusTip(tr("set a letter to mark special rooms"));
+            action10->setToolTip(tr("Set a letter to mark special rooms"));
             connect(action10, SIGNAL(triggered()), this, SLOT(slot_setCharacter()));
             //        QAction * action11 = new QAction("image", this );
-            //        action11->setStatusTip(tr("set an image to mark special rooms"));
+            //        action11->setToolTip(tr("Set an image to mark special rooms"));
             //        connect( action11, SIGNAL(triggered()), this, SLOT(slot_setImage()));
 
             QAction* action12 = new QAction("move to", this);
-            action12->setStatusTip(tr("move selected group to a given position"));
+            action12->setToolTip(tr("Move selected group to a given position"));
             connect(action12, SIGNAL(triggered()), this, SLOT(slot_movePosition()));
 
             QAction* action13 = new QAction("area", this);
-            action13->setStatusTip(tr("set room area ID"));
+            action13->setToolTip(tr("Set room area ID"));
             connect(action13, SIGNAL(triggered()), this, SLOT(slot_setArea()));
 
             QAction* action14 = new QAction("custom exit lines", this);
@@ -2492,28 +2493,27 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 return;
             }
             if (pArea->gridMode) { // Disable custom exit lines in grid mode as they aren't visible anyway
-                action14->setStatusTip(tr("custom exit lines are not shown and are not editable in grid mode"));
+                action14->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode"));
                 action14->setEnabled(false);
             } else {
-                action14->setStatusTip(tr("replace an exit line with a custom line"));
+                action14->setToolTip(tr("Replace an exit line with a custom line"));
                 connect(action14, SIGNAL(triggered()), this, SLOT(slot_setCustomLine()));
             }
 
             QAction* action15 = new QAction("create Label", this);
-            action15->setStatusTip(tr("Create labels to show text or images."));
+            action15->setToolTip(tr("Create labels to show text or images."));
             connect(action15, SIGNAL(triggered()), this, SLOT(slot_createLabel()));
 
             QAction* action16 = new QAction("set location", this);
             if (mMultiSelectionSet.size() == 1) { // Only enable if ONE room is highlighted
-                action16->setStatusTip(tr("set player current location to here"));
+                action16->setToolTip(tr("Set player current location to here"));
                 connect(action16, SIGNAL(triggered()), this, SLOT(slot_setPlayerLocation()));
             } else {
                 action16->setEnabled(false);
-                action16->setStatusTip(tr("cannot set location when not exactly one room selected"));
+                action16->setToolTip(tr("Cannot set location when not exactly one room selected"));
             }
 
             mPopupMenu = true;
-            //            QMenu * popup = new QMenu( this );
 
             popup->addAction(action);
             popup->addAction(action8);
@@ -2538,10 +2538,10 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             popup->popup(mapToGlobal(event->pos()));
         } else if (mLabelHilite) {
             QAction* action = new QAction("move", this);
-            action->setStatusTip(tr("move label"));
+            action->setToolTip(tr("Move label"));
             connect(action, SIGNAL(triggered()), this, SLOT(slot_moveLabel()));
             QAction* action2 = new QAction("delete", this);
-            action2->setStatusTip(tr("delete label"));
+            action2->setToolTip(tr("Delete label"));
             connect(action2, SIGNAL(triggered()), this, SLOT(slot_deleteLabel()));
             mPopupMenu = true;
             popup->addAction(action);
@@ -2563,10 +2563,10 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     // on the exit direction - and we can now add even to it
                     {
                         connect(action, SIGNAL(triggered()), this, SLOT(slot_customLineAddPoint()));
-                        action->setStatusTip(tr("divide segment by adding a new point mid-way along"));
+                        action->setToolTip(tr("Divide segment by adding a new point mid-way along"));
                     } else {
                         action->setEnabled(false);
-                        action->setStatusTip(tr("select a point first, then add a new point mid-way along the segment towards room"));
+                        action->setToolTip(tr("Select a point first, then add a new point mid-way along the segment towards room"));
                     }
 
                     QAction* action2 = new QAction("remove point", this);
@@ -2575,26 +2575,26 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                         if (pR->customLines.value(mCustomLineSelectedExit).count() > 1) {
                             connect(action2, SIGNAL(triggered()), this, SLOT(slot_customLineRemovePoint()));
                             if ((mCustomLineSelectedPoint + 1) < pR->customLines.value(mCustomLineSelectedExit).count()) {
-                                action2->setStatusTip(tr("merge pair of segments by removing this point"));
+                                action2->setToolTip(tr("Merge pair of segments by removing this point"));
                             } else {
-                                action2->setStatusTip(tr("remove last segment by removing this point"));
+                                action2->setToolTip(tr("Remove last segment by removing this point"));
                             }
                         } else {
                             action2->setEnabled(false);
-                            action2->setStatusTip(tr(R"(use "delete line" to remove the only segment ending in an editable point)"));
+                            action2->setToolTip(tr(R"(use "delete line" to remove the only segment ending in an editable point)"));
                         }
                     } else {
                         action2->setEnabled(false);
-                        action2->setStatusTip(tr("select a point first, then remove it"));
+                        action2->setToolTip(tr("Select a point first, then remove it"));
                     }
 
                     QAction* action3 = new QAction("properties", this);
                     action3->setText("properties...");
-                    action3->setStatusTip(tr("change the properties of this custom line"));
+                    action3->setToolTip(tr("Change the properties of this custom line"));
                     connect(action3, SIGNAL(triggered()), this, SLOT(slot_customLineProperties()));
 
                     QAction* action4 = new QAction("delete line", this);
-                    action4->setStatusTip(tr("delete all of this custom line"));
+                    action4->setToolTip(tr("Delete all of this custom line"));
                     connect(action4, SIGNAL(triggered()), this, SLOT(slot_deleteCustomExitLine()));
 
                     mPopupMenu = true;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -218,17 +218,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pH) : QDialog(pF
     connect(mFORCE_MCCP_OFF, SIGNAL(clicked()), need_reconnect_for_specialoption, SLOT(show()));
     connect(mFORCE_GA_OFF, SIGNAL(clicked()), need_reconnect_for_specialoption, SLOT(show()));
 
-    comboBox_statusBarSetting->addItem(tr("Off"), QVariant(mudlet::self()->statusBarHidden));
-    comboBox_statusBarSetting->addItem(tr("Auto"), QVariant(mudlet::self()->statusBarAutoShown));
-    comboBox_statusBarSetting->addItem(tr("On"), QVariant(mudlet::self()->statusBarAlwaysShown));
-    comboBox_statusBarSetting->setMaxCount(3);
-    comboBox_statusBarSetting->setInsertPolicy(QComboBox::NoInsert);
-    comboBox_statusBarSetting->setMaxVisibleItems(3);
-    int _indexForStatusBarSetting = comboBox_statusBarSetting->findData(QVariant(mudlet::self()->mStatusBarState), Qt::UserRole);
-    if (_indexForStatusBarSetting >= 0) {
-        comboBox_statusBarSetting->setCurrentIndex(_indexForStatusBarSetting);
-    }
-
     checkBox_reportMapIssuesOnScreen->setChecked(mudlet::self()->showMapAuditErrors());
     Host* pHost = mpHost;
     if (pHost) {
@@ -1319,7 +1308,6 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mDoubleClickIgnore.insert(character);
     }
 
-    mudlet::self()->mStatusBarState = mudlet::StatusBarOptions(comboBox_statusBarSetting->currentData().toInt());
     pHost->mpMap->mSaveVersion = comboBox_mapFileSaveFormatVersion->currentData().toInt();
 
     QString oldIrcNick = dlgIRC::readIrcNickName(pHost);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -151,7 +151,6 @@ mudlet::mudlet()
 , replayTimer(0)
 , replayToolBar(0)
 , moduleTable(0)
-, mStatusBarState(statusBarAlwaysShown)
 , mshowMapAuditErrors(false)
 , mpAboutDlg(0)
 , mpModuleDlg(0)
@@ -166,7 +165,6 @@ mudlet::mudlet()
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(version);
     setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_main_48px.png")));
-    mpMainStatusBar = QMainWindow::statusBar();
     // On at least my platform (Linux) the status bar does not seem to exist
     // but getting the pointer to it causes it to be created automagically...
     mpMainToolBar = new QToolBar(this);
@@ -411,7 +409,6 @@ mudlet::mudlet()
     connect(timerAutologin, SIGNAL(timeout()), this, SLOT(startAutoLogin()));
     timerAutologin->start(50);
 
-    connect(mpMainStatusBar, SIGNAL(messageChanged(QString)), this, SLOT(slot_statusBarMessageChanged(QString)));
 #ifdef QT_GAMEPAD_LIB
     //connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, slot_gamepadButtonPress);
     //connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonReleaseEvent, this, slot_gamepadButtonRelease);
@@ -1987,12 +1984,6 @@ void mudlet::readSettings()
     mShowToolbar = settings.value("showToolbar", QVariant(0)).toBool();
     mEditorTextOptions = QTextOption::Flags(settings.value("editorTextOptions", QVariant(0)).toInt());
 
-    // By default the status bar will not be shown for new/upgraded
-    // installations - if the user wants the status bar shown either all the
-    // time or when it has something to show, they will have to enable that
-    // themselves, but that only has to be done once! - Slysven
-    mStatusBarState = StatusBarOptions(settings.value("statusBarOptions", statusBarHidden).toInt());
-
     mshowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();
     resize(size);
     move(pos);
@@ -2045,7 +2036,6 @@ void mudlet::writeSettings()
     settings.setValue("showToolbar", mShowToolbar);
     settings.setValue("maximized", isMaximized());
     settings.setValue("editorTextOptions", static_cast<int>(mEditorTextOptions));
-    settings.setValue("statusBarOptions", static_cast<int>(mStatusBarState));
     settings.setValue("reportMapIssuesToConsole", mshowMapAuditErrors);
 }
 
@@ -2787,26 +2777,6 @@ void mudlet::setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const boo
 {
     mEditorTextOptions = QTextOption::Flags((isTabsAndSpacesToBeShown ? QTextOption::ShowTabsAndSpaces : 0) | (isLinesAndParagraphsToBeShown ? QTextOption::ShowLineAndParagraphSeparators : 0));
     emit signal_editorTextOptionsChanged(mEditorTextOptions);
-}
-
-void mudlet::slot_statusBarMessageChanged(QString text)
-{
-    if (mStatusBarState & statusBarAutoShown) {
-        if (text.isEmpty()) {
-            mpMainStatusBar->hide();
-        } else {
-            mpMainStatusBar->show();
-        }
-    } else if (mStatusBarState & statusBarAlwaysShown) {
-        if (!mpMainStatusBar->isVisible()) {
-            mpMainStatusBar->show();
-        }
-    } else {
-        // Should be hidden
-        if (mpMainStatusBar->isVisible()) {
-            mpMainStatusBar->hide();
-        }
-    }
 }
 
 // Originally a slot_ but it does not actually need to be - Slysven

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -165,8 +165,6 @@ mudlet::mudlet()
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(version);
     setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_main_48px.png")));
-    // On at least my platform (Linux) the status bar does not seem to exist
-    // but getting the pointer to it causes it to be created automagically...
     mpMainToolBar = new QToolBar(this);
     mpMainToolBar->setObjectName("mpMainToolBar");
     addToolBar(mpMainToolBar);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -199,15 +199,6 @@ public:
     void setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const bool isLinesAndParagraphsToBeShown);
     static bool loadEdbeeTheme(const QString &themeName, const QString &themeFile);
 
-    enum StatusBarOption {
-        statusBarHidden = 0x0,    // Currently not on display
-        statusBarAutoShown = 0x1, // Currently shown but to hide as soon as there is no text to display
-        statusBarAlwaysShown = 0x2
-    };
-
-    Q_DECLARE_FLAGS(StatusBarOptions, StatusBarOption)
-    StatusBarOptions mStatusBarState;
-
     // Used by a profile to tell the mudlet class
     // to tell other profiles to reload the updated
     // maps (via signal_profileMapReloadRequested(...))
@@ -279,7 +270,6 @@ private slots:
     void show_key_dialog();
     void show_variable_dialog();
     void show_options_dialog();
-    void slot_statusBarMessageChanged(QString);
 #ifdef QT_GAMEPAD_LIB
     void slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value);
     void slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadButton button);
@@ -329,12 +319,9 @@ private:
     QPushButton* moduleHelpButton;
 
     HostManager mHostManager;
-    QStatusBar* mpMainStatusBar;
 
     bool mshowMapAuditErrors;
 };
-
-Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::StatusBarOptions)
 
 class TConsoleMonitor : public QObject
 {

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>742</width>
-    <height>685</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -744,13 +744,6 @@
           <string>Display options</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_10">
-          <item row="1" column="2">
-           <widget class="QComboBox" name="comboBox_statusBarSetting">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For some actions - particularly those involving a &lt;i&gt;context menu&lt;/i&gt; (mouse &amp;quot;right-click&amp;quot; action) Mudlet can put up hints about the currently selected action before it is activated on a status bar at the bottom of the screen. By default this is &lt;i&gt;off&lt;/i&gt; (never shown), even when there is soemthing to display. For use on &amp;quot;full-size&amp;quot; Computers you may wish to change this setting to (always) &lt;i&gt;on&lt;/i&gt; but for those with limited space on their screen they will probably want to keep it turned off perminently or only have it set to &lt;i&gt;auto&lt;/i&gt; so it only pop-ups when there is something to show.&lt;/p&gt;&lt;p&gt;This setting controls that feature, the choice made will be remembered between sessions, and it applies to all profiles.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="checkBox_USE_IRE_DRIVER_BUGFIX">
             <property name="toolTip">
@@ -768,16 +761,6 @@
             </property>
             <property name="text">
              <string>Show Spaces/Tabs</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="label_statusBarSetting">
-            <property name="text">
-             <string>Status Bar:</string>
-            </property>
-            <property name="buddy">
-             <cstring>comboBox_statusBarSetting</cstring>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Per user feedback on https://github.com/Mudlet/Mudlet/issues/1079, removed statusbar. It has done its purpose well and we've now superceded it with a connections dialog that comes up automatically, and as of this PR, tooltips in the right-click menu.