### PR TITLE
Fix incorrect iterators use in searching

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -270,8 +270,8 @@ void AliasUnit::reenableAllTriggers()
 TAlias* AliasUnit::findAlias(const QString& name)
 {
     //TAlias * pT = 0;
-    QMap<QString, TAlias*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TAlias*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TAlias* pT = it.value();
         return pT;
     }
@@ -281,8 +281,8 @@ TAlias* AliasUnit::findAlias(const QString& name)
 bool AliasUnit::enableAlias(const QString& name)
 {
     bool found = false;
-    QMap<QString, TAlias*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TAlias*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TAlias* pT = it.value();
         pT->setIsActive(true);
         ++it;
@@ -294,8 +294,8 @@ bool AliasUnit::enableAlias(const QString& name)
 bool AliasUnit::disableAlias(const QString& name)
 {
     bool found = false;
-    QMap<QString, TAlias*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TAlias*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TAlias* pT = it.value();
         pT->setIsActive(false);
         ++it;

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -80,8 +80,8 @@ void KeyUnit::compileAll()
 
 TKey* KeyUnit::findKey(QString& name)
 {
-    QMap<QString, TKey*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TKey*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TKey* pT = it.value();
         return pT;
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5973,32 +5973,32 @@ int TLuaInterpreter::isActive(lua_State* L)
     type = type.toLower();
     QString name = _name.c_str();
     if (type == "timer") {
-        QMap<QString, TTimer*>::const_iterator it1 = host.getTimerUnit()->mLookupTable.find(name);
-        while (it1 != host.getTimerUnit()->mLookupTable.end() && it1.key() == name) {
+        QMap<QString, TTimer*>::const_iterator it1 = host.getTimerUnit()->mLookupTable.constFind(name);
+        while (it1 != host.getTimerUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
                 cnt++;
             }
             it1++;
         }
     } else if (type == "trigger") {
-        QMap<QString, TTrigger*>::const_iterator it1 = host.getTriggerUnit()->mLookupTable.find(name);
-        while (it1 != host.getTriggerUnit()->mLookupTable.end() && it1.key() == name) {
+        QMap<QString, TTrigger*>::const_iterator it1 = host.getTriggerUnit()->mLookupTable.constFind(name);
+        while (it1 != host.getTriggerUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
                 cnt++;
             }
             it1++;
         }
     } else if (type == "alias") {
-        QMap<QString, TAlias*>::const_iterator it1 = host.getAliasUnit()->mLookupTable.find(name);
-        while (it1 != host.getAliasUnit()->mLookupTable.end() && it1.key() == name) {
+        QMap<QString, TAlias*>::const_iterator it1 = host.getAliasUnit()->mLookupTable.constFind(name);
+        while (it1 != host.getAliasUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
                 cnt++;
             }
             it1++;
         }
     } else if (type == "keybind") {
-        QMap<QString, TKey*>::const_iterator it1 = host.getKeyUnit()->mLookupTable.find(name);
-        while (it1 != host.getKeyUnit()->mLookupTable.end() && it1.key() == name) {
+        QMap<QString, TKey*>::const_iterator it1 = host.getKeyUnit()->mLookupTable.constFind(name);
+        while (it1 != host.getKeyUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
                 cnt++;
             }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -208,13 +208,13 @@ bool TRoomDB::__removeRoom(int id)
 
         // FIXME: make a proper exit controller so we don't need to do all these if statements
         // Remove the links from the rooms entering this room
-        QMultiHash<int, int>::const_iterator i = _entranceMap.find(id);
+        QMultiHash<int, int>::const_iterator i = _entranceMap.constFind(id);
         // The removeAllSpecialExitsToRoom below modifies the entranceMap - and
         // it is unsafe to modify (use copy operations on) something that an STL
         // iterator is active on - see "Implicit sharing iterator problem" in
         // "Container Class | Qt 5.x Core" - this is now avoid by taking a deep
         // copy and iterating through that instead whilst modifying the original
-        while (i != entranceMap.end() && i.key() == id) {
+        while (i != entranceMap.cend() && i.key() == id) {
             if (i.value() == id || (mpTempRoomDeletionSet && mpTempRoomDeletionSet->size() > 1 && mpTempRoomDeletionSet->contains(i.value()))) {
                 ++i;
                 continue; // Bypass rooms we know are also to be deleted

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -249,8 +249,8 @@ void TimerUnit::_removeTimer(TTimer* pT)
 bool TimerUnit::enableTimer(const QString& name)
 {
     bool found = false;
-    QMap<QString, TTimer*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTimer*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTimer* pT = it.value();
 
         if (!pT->isOffsetTimer()) {
@@ -288,8 +288,8 @@ bool TimerUnit::enableTimer(const QString& name)
 bool TimerUnit::disableTimer(const QString& name)
 {
     bool found = false;
-    QMap<QString, TTimer*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTimer*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTimer* pT = it.value();
         if (pT->isOffsetTimer()) {
             pT->setShouldBeActive(false);
@@ -306,8 +306,8 @@ bool TimerUnit::disableTimer(const QString& name)
 
 TTimer* TimerUnit::findTimer(const QString& name)
 {
-    QMap<QString, TTimer*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTimer*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTimer* pT = it.value();
         return pT;
     }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -291,8 +291,8 @@ void TriggerUnit::reenableAllTriggers()
 
 TTrigger* TriggerUnit::findTrigger(const QString& name)
 {
-    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTrigger* pT = it.value();
         return pT;
     }
@@ -302,8 +302,8 @@ TTrigger* TriggerUnit::findTrigger(const QString& name)
 bool TriggerUnit::enableTrigger(const QString& name)
 {
     bool found = false;
-    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTrigger* pT = it.value();
         pT->setIsActive(true);
         ++it;
@@ -315,8 +315,8 @@ bool TriggerUnit::enableTrigger(const QString& name)
 bool TriggerUnit::disableTrigger(const QString& name)
 {
     bool found = false;
-    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTrigger* pT = it.value();
         pT->setIsActive(false);
         ++it;
@@ -327,8 +327,8 @@ bool TriggerUnit::disableTrigger(const QString& name)
 
 void TriggerUnit::setTriggerStayOpen(const QString& name, int lines)
 {
-    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTrigger* pT = it.value();
         pT->mKeepFiring = lines;
         ++it;
@@ -337,8 +337,8 @@ void TriggerUnit::setTriggerStayOpen(const QString& name, int lines)
 
 bool TriggerUnit::killTrigger(const QString& name)
 {
-    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.find(name);
-    while (it != mLookupTable.end() && it.key() == name) {
+    QMap<QString, TTrigger*>::const_iterator it = mLookupTable.constFind(name);
+    while (it != mLookupTable.cend() && it.key() == name) {
         TTrigger* pT = it.value();
         if (pT->isTemporary()) //this function is only defined for tempTriggers, permanent objects cannot be removed
         {


### PR DESCRIPTION
We were using mising constant and non-constant iterators, and the non-constant ones can detach in Qt (https://wiki.qt.io/Iterators#QT_STRICT_ITERATORS).

Credit to https://github.com/KDE/clazy/blob/master/src/checks/level0/README-strict-iterators.md for discovering the issues.