### PR TITLE
Remove unused QString, not adding any value.

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1859,7 +1859,6 @@ bool mudlet::echoWindow(Host* pHost, const QString& name, const QString& text)
 bool mudlet::echoLink(Host* pHost, const QString& name, const QString& text, QStringList& func, QStringList& hint, bool customFormat)
 {
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
-    QString t = text;
     if (dockWindowConsoleMap.contains(name)) {
         dockWindowConsoleMap[name]->echoLink(text, func, hint, customFormat);
         return true;


### PR DESCRIPTION
It is funny that above in echoWindow() the same thing is done and then _that_ argument is passed to the function.