### PR TITLE
Replaced two cases where we can reference the string instead of makin…

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3740,7 +3740,7 @@ QString TBuffer::bufferToHtml(QPoint P1, QPoint P2, bool allowedTimestamps, int 
         // formatting according to TTextEdit.cpp: if( i2 < timeOffset )
         s.append(R"(<span style="color: rgb(200,150,0); background: rgb(22,22,22); )");
         s.append(R"(font-weight: normal; font-style: normal; text-decoration: normal">)");
-        s.append(timeBuffer[y].left(13));
+        s.append(timeBuffer[y].leftRef(13));
     }
     if (spacePadding > 0) {
         // used for "copy HTML", first line of selection

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1228,7 +1228,7 @@ void TTextEdit::copySelectionToClipboard()
         }
         // add timestamps to clipboard when "Show Time Stamps" is on and it is not one-line selection
         if (mShowTimeStamps && !mpBuffer->timeBuffer[y].isEmpty() && mPA.y() != mPB.y()) {
-            text.append(mpBuffer->timeBuffer[y].left(13));
+            text.append(mpBuffer->timeBuffer[y].leftRef(13));
         }
         int x = 0;
         if (y == mPA.y()) {


### PR DESCRIPTION
…g a copy

QStringRef: "This class is designed to improve the performance of substring handling when manipulating substrings obtained from existing QString instances. QStringRef avoids the memory allocation and reference counting overhead of a standard QString by simply referencing a part of the original string."

Found thanks to https://github.com/KDE/clazy/blob/master/src/checks/level0/README-qstring-ref.md