### PR TITLE
Possible fix for the highlighting crash

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -766,11 +766,16 @@ void TTextEdit::highlight()
         if (y == y1) {
             x = mPA.x();
         }
+
+        if (y >= static_cast<int>(mpBuffer->buffer.size())) {
+            break;
+        }
+        mpBuffer->dirty[y] = true;
+
         for (;; x++) {
             if ((y == mPB.y()) && (x > mPB.x())) {
                 break;
             }
-            mpBuffer->dirty[y] = true;
             if (x < static_cast<int>(mpBuffer->buffer[y].size())) {
                 mpBuffer->buffer[y][x].flags |= TCHAR_INVERSE;
             } else {
@@ -794,14 +799,16 @@ void TTextEdit::unHighlight(QRegion& region)
         if (y == y1) {
             x = mPA.x();
         }
+
+        if (y >= static_cast<int>(mpBuffer->buffer.size())) {
+            break;
+        }
+        mpBuffer->dirty[y] = true;
+
         for (;; x++) {
             if ((y == mPB.y()) && (x > mPB.x())) {
                 break;
             }
-            if (y >= static_cast<int>(mpBuffer->buffer.size())) {
-                break;
-            }
-            mpBuffer->dirty[y] = true;
             if (x < static_cast<int>(mpBuffer->buffer[y].size())) {
                 mpBuffer->buffer[y][x].flags &= ~(TCHAR_INVERSE);
                 mpBuffer->dirty[y] = true;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -78,7 +78,7 @@ public:
     void showEvent(QShowEvent* event) override;
     void updateScreenView();
     void highlight();
-    void unHighlight(QRegion&);
+    void unHighlight();
     void swap(QPoint& p1, QPoint& p2);
     void focusInEvent(QFocusEvent* event) override;
     int imageTopLine();
@@ -136,7 +136,7 @@ private:
     bool mCtrlSelecting;
     int mDragStartY;
     int mOldScrollPos;
-    QPoint mP_aussen;
+
     QPoint mPA;
     bool mPainterInit;
     QPoint mPB;


### PR DESCRIPTION
y sometimes was == size() of the buffer, so an off-by-one error.

Also fixed an inefficiency in resetting the y for every x inside the for loop.

Possible fix for https://github.com/Mudlet/Mudlet/issues/796.