### PR TITLE
BugFix: (Issue #1253) New timer starts with blank values

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5345,13 +5345,12 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
     clearDocument(mpSourceEditorEdbee); // Timer Select
 
     mpTimersMainArea->lineEdit_timer_command->clear();
-    mpTimersMainArea->lineEdit_timer_name->clear();
-    mpTimersMainArea->timeEdit_timer_hours->clear();
-    mpTimersMainArea->timeEdit_timer_minutes->clear();
-    mpTimersMainArea->timeEdit_timer_seconds->clear();
-    mpTimersMainArea->timeEdit_timer_msecs->clear();
-
+    mpTimersMainArea->timeEdit_timer_hours->setTime(QTime(0, 0, 0, 0));
+    mpTimersMainArea->timeEdit_timer_minutes->setTime(QTime(0, 0, 0, 0));
+    mpTimersMainArea->timeEdit_timer_seconds->setTime(QTime(0, 0, 0, 0));
+    mpTimersMainArea->timeEdit_timer_msecs->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->lineEdit_timer_name->setText(pItem->text(0));
+
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
     if (pT) {
@@ -5366,22 +5365,10 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
         mpTimersMainArea->lineEdit_timer_command->setText(command);
         mpTimersMainArea->lineEdit_timer_name->setText(name);
         QTime time = pT->getTime();
-        int hours = time.hour();
-        int minutes = time.minute();
-        int secs = time.second();
-        int msecs = time.msec();
-
-        QTime t2(hours, 0, 0, 0);
-        mpTimersMainArea->timeEdit_timer_hours->setTime(t2);
-
-        QTime t3(0, minutes, 0, 0);
-        mpTimersMainArea->timeEdit_timer_minutes->setTime(t3);
-
-        QTime t4(0, 0, secs);
-        mpTimersMainArea->timeEdit_timer_seconds->setTime(t4);
-
-        QTime t5(0, 0, 0, msecs);
-        mpTimersMainArea->timeEdit_timer_msecs->setTime(t5);
+        mpTimersMainArea->timeEdit_timer_hours->setTime(QTime(time.hour(), 0, 0, 0));
+        mpTimersMainArea->timeEdit_timer_minutes->setTime(QTime(0, time.minute(), 0, 0));
+        mpTimersMainArea->timeEdit_timer_seconds->setTime(QTime(0, 0, time.second(), 0));
+        mpTimersMainArea->timeEdit_timer_msecs->setTime(QTime(0, 0, 0, time.msec()));
 
         clearDocument(mpSourceEditorEdbee, pT->getScript());
 

--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -266,7 +266,7 @@
       <enum>QDateTimeEdit::HourSection</enum>
      </property>
      <property name="displayFormat">
-      <string>h</string>
+      <string>hh</string>
      </property>
     </widget>
    </item>
@@ -387,7 +387,7 @@
       <enum>QDateTimeEdit::MinuteSection</enum>
      </property>
      <property name="displayFormat">
-      <string>m</string>
+      <string>mm</string>
      </property>
     </widget>
    </item>
@@ -511,7 +511,7 @@
       <enum>QDateTimeEdit::SecondSection</enum>
      </property>
      <property name="displayFormat">
-      <string>s</string>
+      <string>ss</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Now specifies a time value (of zero) for each of the time section entry spin-boxes instead of using `clear()` in: `dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem *)` so they are left showing a zero if there is no previous value to display from an existing item. This should fix issue #1253...

Also:
* Refactors the setting of those same control widgets to eliminate some unneeded temporary intermediates variables.
* Adjusts the hours, minutes and seconds controls to show "00" instead of "0" - to reflect that they are divisions of time (00-24/00-59) rather than simple integers - bringing them into line with the recently "fixed" milliseconds.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>