### PR TITLE
Fixup: improve some things reported by Codacy

### DIFF
--- a/3rdparty/communi/include/IrcCore/ircglobal.h
+++ b/3rdparty/communi/include/IrcCore/ircglobal.h
@@ -37,31 +37,31 @@
  */
 #define IRC_STATIC
 #if defined(IRC_SHARED)
-#
+
 #  if defined(BUILD_IRC_CORE)
 #    define IRC_CORE_EXPORT Q_DECL_EXPORT
 #  else
 #    define IRC_CORE_EXPORT Q_DECL_IMPORT
 #  endif
-#
+
 #  if defined(BUILD_IRC_MODEL)
 #    define IRC_MODEL_EXPORT Q_DECL_EXPORT
 #  else
 #    define IRC_MODEL_EXPORT Q_DECL_IMPORT
 #  endif
-#
+
 #  if defined(BUILD_IRC_UTIL)
 #    define IRC_UTIL_EXPORT Q_DECL_EXPORT
 #  else
 #    define IRC_UTIL_EXPORT Q_DECL_IMPORT
 #  endif
-#
+
 #elif defined(IRC_STATIC) || defined(BUILD_IRC_CORE) || defined(BUILD_IRC_MODEL) || defined(BUILD_IRC_UTIL)
-#
+
 #    define IRC_CORE_EXPORT
 #    define IRC_MODEL_EXPORT
 #    define IRC_UTIL_EXPORT
-#
+
 #else
 #  error Installation problem: either IRC_SHARED or IRC_STATIC must be defined!
 #endif

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -39,11 +39,6 @@
 #include <QStringBuilder>
 #include "post_guard.h"
 
-// This is not liked by external Codacy analyser {https://www.codacy.com} as
-// it is formally reserved by C++ Standards for internal compiler use and
-// should not be being defined to nothing here:
-// #define _DEBUG_
-
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 : QDialog( parent )
 , mProfileList( QStringList() )

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -39,8 +39,10 @@
 #include <QStringBuilder>
 #include "post_guard.h"
 
-
-#define _DEBUG_
+// This is not liked by external Codacy analyser {https://www.codacy.com} as
+// it is formally reserved by C++ Standards for internal compiler use and
+// should not be being defined to nothing here:
+// #define _DEBUG_
 
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 : QDialog( parent )

--- a/src/mudlet-lua/genDoc.sh
+++ b/src/mudlet-lua/genDoc.sh
@@ -1,4 +1,4 @@
-
+#!/bin/sh
 # wipe all old html files
 cd mudlet-lua-doc/
 find . -name "*.html" -type f

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -475,4 +475,10 @@ DISTFILES += \
     ../cmake/FindYAJL.cmake \
     ../cmake/FindZIP.cmake \
     .clang-format \
-    CMakeLists.txt
+    CMakeLists.txt \
+    mudlet-lua/lua/ldoc.css \
+    mudlet-lua/genDoc.sh \
+    mudlet-lua/tests/README.md \
+    mudlet-lua/tests/DB.lua \
+    mudlet-lua/tests/GUIUtils.lua \
+    mudlet-lua/tests/Other.lua


### PR DESCRIPTION
Added a hash-bang entry to src/mudlet-lua/genDoc.sh

Commented out "almost illegal" `#define` of `_DEBUG_` to nothing in: `src/dlgConnectionProfiles.cpp` as that is reserved for _compilers' use_ in the C++ standards and should not be `#define`-d by the end user.

Removed some lines containing just a `#` character in `3rdparty/communi/include/IrcCore/ircglobal.h` as Codacy was reporting an un-closed `#if...#else` - the `#  endif` was present but it is not clear that isolated `#` characters are wise/safe to use in a C/C++ source code file.

Also added some non-source code files to main Qt project files including one modified by this commit so that they show up in the Qt Creator IDE.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>