### PR TITLE
Fixup: ensure edbee-lib editor widget is present in src code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,18 @@ ADD_SUBDIRECTORY(3rdparty/lua_yajl)
 IF(APPLE)
   ADD_SUBDIRECTORY(3rdparty/luazip)
 ENDIF()
-ADD_SUBDIRECTORY(3rdparty/edbee-lib/edbee-lib)
+
+IF(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/edbee-lib/CMakeLists.txt")
+  MESSAGE(STATUS "git submodule for required edbee-lib editor widget missing from source code, executing 'git submodule update --init' in ${CMAKE_HOME_DIRECTORY} to get it...")
+  EXECUTE_PROCESS(TIMEOUT 30
+    WORKING_DIRECTORY "${CMAKE_HOME_DIRECTORY}"
+    COMMAND git submodule update --init )
+ENDIF()
+
+IF(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/edbee-lib/CMakeLists.txt")
+  ADD_SUBDIRECTORY(3rdparty/edbee-lib/edbee-lib)
+ELSEIF()
+  MESSAGE(FATAL_ERROR "Cannot locate edbee-lib editor widget submodule source code, build abandoned!")
+ENDIF()
 
 ADD_SUBDIRECTORY(src)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -36,8 +36,17 @@ macx: {
     include(../3rdparty/luazip/luazip.pri)
 }
 
-# Include shiny, new (and quite substantial) editor widget
-include("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri");
+!exists("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri") {
+    message("git submodule for required edbee-lib editor widget missing from source code, executing 'git submodule update --init' to get it...")
+    system("git submodule update --init");
+}
+
+exists("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri") {
+    # Include shiny, new (and quite substantial) editor widget
+    include("../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri");
+} else {
+    error("Cannot locate edbee-lib editor widget submodule source code, build abandoned!")
+}
 
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:


### PR DESCRIPTION
This helps to avoid an initial failure to build should a developer not realise they need the separate edbee editor widget that Mudlet now uses.

Though this is documented in the Wiki, not everyone may RTFM and it can catch even experienced developers (including me) out should they start working on a fresh development platform...!

Signed-off-by: Stephen Lyons <stephen@Rachel.lyonsnet>