### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
-# This file does not not real code owners. We use it to automate the process
-# of assigning code reviews. But generally all members of the project own
-# the whole product.
+# This file does not signify real code owners. We use it to automate the 
+# process of assigning code reviews. But generally all members of the
+# project own the whole product.
 
 # Normally, *.ui, *.cpp and *.h files are reviewed by the core-cpp team only
 *.cpp                           @Mudlet/core-cpp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,30 @@
+# This file does not not real code owners. We use it to automate the process
+# of assigning code reviews. But generally all members of the project own
+# the whole product.
+
+# Normally, *.ui, *.cpp and *.h files are reviewed by the core-cpp team only
+*.cpp                           @Mudlet/core-cpp
+*.h                             @Mudlet/core-cpp
+*.ui                            @Mudlet/core-cpp
+
+# But the lua interface has additional reviewers
+/src/LuaInterface.cpp           @Mudlet/core-cpp @Mudlet/lua-interface
+/src/LuaInterface.h             @Mudlet/core-cpp @Mudlet/lua-interface
+
+# The lua-interface team is also reviewing everything below the mudlet-lua
+# folder and some pre-installed packages
+/src/mudlet-lua/                @Mudlet/lua-interface
+/src/3k-mapper.xml              @Mudlet/lua-interface
+/src/deleteOldProfiles.xml      @Mudlet/lua-interface
+/src/echo.xml                   @Mudlet/lua-interface
+/src/generic_mapper_script.xml  @Mudlet/lua-interface
+/src/mudlet-mapper.xml          @Mudlet/lua-interface
+/src/run-lua-code-v4.xml        @Mudlet/lua-interface
+
+# Travis CI and compiler files are reviewed by the infrastructure team
+.travis.yml                     @Mudlet/infrastructure
+/CI/                            @Mudlet/infrastructure
+*.pro                           @Mudlet/infrastructure
+*.pri                           @Mudlet/infrastructure
+CMakeLists.txt                  @Mudlet/infrastructure
+/cmake/                         @Mudlet/infrastructure


### PR DESCRIPTION
This file will autmoate the process of assigning code reviews. If you notice any
files or file types missing, we should add them.