### PR TITLE
Allow to register lua function objects to events

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10328,6 +10328,9 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 }
 
 
+// The function below is mostly unused now as it is overwritten in lua.
+// The overwriting function poses as a transperant proxy and internally uses
+// this function to get called events.
 int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
 {
     string event;

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -705,7 +705,7 @@ do
   local nametofunc = {}
   local handlers = {}
 
-  -- Registers a lua function to a list of events
+  -- Registers a lua function to a list of events.
   -- name:   Name of the function. This allows to overwrite existing definitions of functions
   --         and deregistering them
   -- events: List of events to register this function to. You can also give a string if you
@@ -751,7 +751,8 @@ do
         registerAnonymousEventHandler(event, "dispatchEventToFunctions")
       end
       if not table.contains(existinghandlers, name) then
-        existinghandlers[#existinghandlers + 1] = name
+        existinghandlers[#existinghandlers + 1] = name 
+        -- Above may fill gaps if handlers have been deleted, but that's okay.
       end
     end
   end
@@ -770,18 +771,21 @@ do
 
     nametofunc[name] = nil
     for _, handlerList in pairs(handlers) do
-      if table.contains(handlerList, name) then
-        table.remove(handlerList, table.index_of(handlerList, name))
+      for index, existingName in pairs(handlerList) do
+        if existingName == name then
+          handlerList[index] = nil -- This may create gaps, but we use pairs for that.
+        end
       end
     end
   end
 
   -- Dispatches an event to the registered lua functions.
+  -- The order of registered events is not preserved.
   -- name: The name of the event that was fired.
   -- ...:  All arguments passed to the raised event.
   function dispatchEventToFunctions(event, ...)
     if handlers[event] then
-      for _, funcName in ipairs(handlers[event]) do
+      for _, funcName in pairs(handlers[event]) do
         local handlerFunc = nametofunc[funcName]
         if handlerFunc then
           handlerFunc(event, ...)

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -760,8 +760,17 @@ do
   end
 
   function killAnonymousEventHandler(id)
+    if type(id) ~= "string" then
+      error(
+        string.format(
+          "Unexpected argument type in function killAnonymousEventHandler for argument #1. String expected, got %s.",
+          type(id)
+        )
+      )
+    end
+
     if id:starts("lua") then
-      local actualId = tonumber(id:match("%d+$")
+      local actualId = tonumber(id:match("%d+$"))
       if not actualId then
         return nil, string.format("'%s' is not a valid event handler ID.", id)
       end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -744,8 +744,10 @@ do
       -- wrap the original function to remove itself from the event handler list.
       local origFunc = func
       func = function(...)
-        origFunc(...)
-        killAnonymousEventHandler(eventHandlerId)
+        local keepEvaluating = origFunc(...)
+        if not keepEvaluating then
+          killAnonymousEventHandler(eventHandlerId)
+        end
       end
     end
 

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -717,10 +717,10 @@ do
   local origRegisterAnonymousEventHandler = registerAnonymousEventHandler
 
   function registerAnonymousEventHandler(event, func, isOneShot)
-    if type(event) ~= "string"then
+    if type(event) ~= "string" then
       error(
         string.format(
-          "Unexpected argument type in function registerAnonymousEventHandler for argument #1. String expected, got %s.",
+          "registerAnonymousEventHandler: bad argument #1 type (event name as string expected, got %s!)",
           type(event)
         )
       )
@@ -729,7 +729,7 @@ do
     if type(func) ~= "function" and type(func) ~= "string" then
       error(
         string.format(
-          "Unexpected argument type in function registerAnonymousEventHandler for argument #2. Function or string expected, got %s.",
+          "registerAnonymousEventHandler: bad argument #2 type (function as string or function type expected, got %s!)",
           type(func)
         )
       )
@@ -764,36 +764,28 @@ do
       index = newId
     }
     -- do not remove the line below as it must be part of the closure for one shot event handlers.
-    eventHandlerId = "lua" .. highestHandlerId
+    eventHandlerId = highestHandlerId
     return eventHandlerId
   end
 
   function killAnonymousEventHandler(id)
-    if type(id) ~= "string" then
+    if type(id) ~= "number" then
       error(
         string.format(
-          "Unexpected argument type in function killAnonymousEventHandler for argument #1. String expected, got %s.",
+          "killAnonymousEventHandler: bad argument #1 type (handler ID as number expected, got %s!)",
           type(id)
         )
       )
     end
 
-    if id:starts("lua") then
-      local actualId = tonumber(id:match("%d+$"))
-      if not actualId then
-        return nil, string.format("'%s' is not a valid event handler ID.", id)
-      end
-      local findObject = handlerIdsToHandlers[actualId]
-      if not findObject then
-        return nil, string.format("Handler with ID '%s' not found.", id)
-      end
-
-      handlerIdsToHandlers[actualId] = nil
-      handlers[findObject.event][findObject.index] = nil
-      return true
-    else
-      return nil, string.format("'%s' is not a valid event handler ID.", id)
+    local findObject = handlerIdsToHandlers[id]
+    if not findObject then
+      return nil, string.format("Handler with ID '%s' not found.", id)
     end
+
+    handlerIdsToHandlers[id] = nil
+    handlers[findObject.event][findObject.index] = nil
+    return true
   end
 
   -- Dispatches an event to the registered lua functions.

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -754,7 +754,7 @@ do
 
     local existinghandlers = handlers[event]
     if type(func) == "string" then
-      local functionString = string.format("%s(...)", func)
+      local functionString = string.format("return %s(...)", func)
       local functionExists = findStringEventHandler(existinghandlers, functionString)
       
       if not functionExists then


### PR DESCRIPTION
Before it was only possible to register lua code as strings to events.
This resulted in either being unable to use closures for events (by writing
code as anonymous event handler) or littering the global namespace (by
giving a global function name as event handler).

This solution trades a single global function (as event handler) for the
ability to use local functions (or even lambdas) as event handlers.

I will add wiki documentation as soon as I know in which mudlet version this will land.