### PR TITLE
BugFix: (Issue #1280) TRoom d'tor causes crash when not made by map loading

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -76,7 +76,9 @@ TRoom::~TRoom()
     static quint64 runCount = 0;
     QElapsedTimer timer;
     timer.start();
-    mpRoomDB->__removeRoom(id);
+    if (mpRoomDB) {
+        mpRoomDB->__removeRoom(id);
+    }
     quint64 thisTime = timer.nsecsElapsed();
     cumulativeMean += (((thisTime * 1.0e-9) - cumulativeMean) / ++runCount);
     if (runCount % 1000 == 0) {


### PR DESCRIPTION
The code to load a map into other profiles needs to scan through but not permanently store map data which includes the temporary creation of `TRoom` instances - unfortunately this was not being taken into account in the destructor for that class!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>