### PR TITLE
Refactor: reduce use of raw string literals for directories and file paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:beineri/opt-qt562-trusty'
-    - sourceline: 'ppa:beineri/opt-qt59-trusty'
+    - sourceline: 'ppa:beineri/opt-qt591-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
     - qt56base

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2009-2014 by Vadim Peretokin - vperetokin@gmail.com     *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@viginmedia.com          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,33 +22,32 @@
 
 #include "FontManager.h"
 
+#include "mudlet.h"
+
 #include "pre_guard.h"
 #include <QDir>
+#include <QDebug>
 #include <QFontDatabase>
 #include <QString>
 #include <QStringList>
 #include "post_guard.h"
 
-#include <iostream>
-#include <ostream>
-
-
 void FontManager::addFonts()
 {
     // load all font files we see. I'd also like to load files with mime type of "application/x-font-ttf" but Qt lacks a function to check for them
 
-    QDir dir = QDir::homePath() + "/.config/mudlet/";
+    QDir dir(mudlet::getMudletPath(mudlet::mainFontsPath));
 
     if (!dir.exists()) {
         return;
     }
 
-    // load all fonts in the 'fonts' folder
+    // load all fonts (in the 'fonts') folder
     loadFonts(dir.absolutePath());
 
-    // load all fonts in the subfolders of 'font'
+    // load all fonts in subfolders (of the 'font' folder)
     foreach (QString fontfolder, dir.entryList(QDir::Dirs | QDir::Readable | QDir::NoDotAndDotDot)) {
-        loadFonts(dir.absolutePath() + "/" + fontfolder);
+        loadFonts(QStringLiteral("%1/%2").arg(dir.absolutePath(), fontfolder));
     }
 }
 
@@ -56,14 +56,17 @@ void FontManager::loadFonts(const QString& folder)
 {
     // Check what happens with this: "Adding application fonts on Unix/X11 platforms without fontconfig is currently not supported."
     QStringList filters;
-    filters << "*.ttf"
-            << "*.otf";
+    filters << QStringLiteral("*.ttf")
+            << QStringLiteral("*.otf");
     QDir dir = folder;
     dir.setNameFilters(filters);
 
     foreach (QString fontfile, dir.entryList(QDir::Files | QDir::Readable | QDir::NoDotAndDotDot)) {
-        if (QFontDatabase::addApplicationFont(dir.absolutePath() + "/" + fontfile) == -1) {
-            std::cout << "Couldn't load the font in the file " << dir.absolutePath().toUtf8().data() << "/" << fontfile.toUtf8().data() << std::endl;
+        QString fontFilePathName = QStringLiteral("%1/%2").arg(dir.absolutePath(), fontfile);
+        if (QFontDatabase::addApplicationFont(fontFilePathName) == -1) {
+            // At the point that addFonts() is called we have a GUI application
+            // in the making and can use qDebug() and not rely on iostream class
+            qWarning() << "FontManager::loadFonts() ERROR - Could not load the font in the file: " << fontFilePathName;
         }
     }
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -168,10 +168,8 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 {
     // mLogStatus = mudlet::self()->mAutolog;
     mLuaInterface.reset(new LuaInterface(this));
-    QString directoryLogFile = QDir::homePath() + "/.config/mudlet/profiles/";
-    directoryLogFile.append(mHostName);
-    directoryLogFile.append("/log");
-    QString logFileName = directoryLogFile + "/errors.txt";
+    QString directoryLogFile = mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, QStringLiteral("log"));
+    QString logFileName = QStringLiteral("%1/errors.txt").arg(directoryLogFile);
     QDir dirLogFile;
     if (!dirLogFile.exists(directoryLogFile)) {
         dirLogFile.mkpath(directoryLogFile);
@@ -214,7 +212,7 @@ void Host::saveModules(int sync)
     }
     QMapIterator<QString, QStringList> it(modulesToWrite);
     QStringList modulesToSync;
-    QString dirName = QDir::homePath() + "/.config/mudlet/moduleBackups/";
+    QString dirName = mudlet::getMudletPath(mudlet::moduleBackupsPath);
     QDir savePath = QDir(dirName);
     if (!savePath.exists()) {
         savePath.mkpath(dirName);
@@ -223,21 +221,21 @@ void Host::saveModules(int sync)
         it.next();
         QStringList entry = it.value();
         QString filename_xml = entry[0];
+        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (1 of 6)
         QString time = QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
         QString moduleName = it.key();
-        QString tempDir;
         QString zipName;
         zip* zipFile = nullptr;
         // Filename extension tests should be case insensitive to work on MacOS Platforms...! - Slysven
         if (filename_xml.endsWith(QStringLiteral("mpackage"), Qt::CaseInsensitive) || filename_xml.endsWith(QStringLiteral("zip"), Qt::CaseInsensitive)) {
-            tempDir = QDir::homePath() + "/.config/mudlet/profiles/" + mHostName + "/" + moduleName;
-            filename_xml = tempDir + "/" + moduleName + ".xml";
+            QString packagePathName = mudlet::getMudletPath(mudlet::profilePackagePath, mHostName, moduleName);
+            filename_xml = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
             int err;
             zipFile = zip_open(entry[0].toStdString().c_str(), 0, &err);
             zipName = filename_xml;
-            QDir packageDir = QDir(tempDir);
+            QDir packageDir = QDir(packagePathName);
             if (!packageDir.exists()) {
-                packageDir.mkpath(tempDir);
+                packageDir.mkpath(packagePathName);
             }
         } else {
             savePath.rename(filename_xml, dirName + moduleName + time); //move the old file, use the key (module name) as the file
@@ -372,12 +370,13 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveLocation
 {
     QString directory_xml;
     if (saveLocation.isEmpty()) {
-        directory_xml = QStringLiteral("%1/.config/mudlet/profiles/%2/current").arg(QDir::homePath(), getName());
+        directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
     } else {
         directory_xml = saveLocation;
     }
 
-    QString filename_xml = QStringLiteral("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
+    // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (2 of 6)
+    QString filename_xml = QStringLiteral("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
     QDir dir_xml;
     if (!dir_xml.exists(directory_xml)) {
         dir_xml.mkpath(directory_xml);
@@ -735,8 +734,8 @@ bool Host::installPackage(const QString& fileName, int module)
     }
     QFile file2;
     if (fileName.endsWith(QStringLiteral(".zip"), Qt::CaseInsensitive) || fileName.endsWith(QStringLiteral(".mpackage"), Qt::CaseInsensitive)) {
-        QString _home = QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), getName());
-        QString _dest = QStringLiteral("%1/%2/").arg(_home, packageName);
+        QString _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
+        QString _dest = mudlet::getMudletPath(mudlet::profileHomePath, getName(), packageName);
         QDir _tmpDir(_home); // home directory for the PROFILE
         _tmpDir.mkpath(_dest);
 
@@ -1019,11 +1018,8 @@ bool Host::uninstallPackage(const QString& packageName, int module)
 
     getActionUnit()->updateToolbar();
 
-    QString _home = QDir::homePath();
-    _home.append("/.config/mudlet/profiles/");
-    _home.append(getName());
-    QString _dest = QString("%1/%2/").arg(_home, packageName);
-    removeDir(_dest, _dest);
+    QString dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
+    removeDir(dest, dest);
     saveProfile();
     //NOW we reset if we're uninstalling a module
     if (mpEditorDialog && module == 3) {
@@ -1102,7 +1098,7 @@ void Host::readPackageConfig(const QString& luaConfig, QString& packageName)
 // host name argument...
 QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& what)
 {
-    QFile file(QStringLiteral("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), getName(), item));
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, getName(), item));
     if (file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
         QDataStream ofs(&file);
         ofs << what;
@@ -1119,7 +1115,7 @@ QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& 
 // Similar to the above, a convenience for reading profile data for this host.
 QString Host::readProfileData(const QString& item)
 {
-    QFile file(QStringLiteral("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), getName(), item));
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, getName(), item));
     bool success = file.open(QIODevice::ReadOnly);
     QString ret;
     if (success) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -730,8 +730,9 @@ void TConsole::closeEvent(QCloseEvent* event)
 
             if (mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;
-                QString directory_map = QDir::homePath() + "/.config/mudlet/profiles/" + profile_name + "/map";
-                QString filename_map = directory_map + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + "map.dat";
+                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
+                // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (3 of 6)
+                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
                 }
@@ -766,8 +767,9 @@ void TConsole::closeEvent(QCloseEvent* event)
                 goto ASK;
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;
-                QString directory_map = QDir::homePath() + "/.config/mudlet/profiles/" + profile_name + "/map";
-                QString filename_map = directory_map + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + "map.dat";
+                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
+                // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (4 of 6)
+                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
                 }
@@ -812,14 +814,15 @@ void TConsole::toggleLogging(bool isMessageEnabled)
         // We don't support logging anything other than main console (at present?)
     }
 
-    QFile file(QStringLiteral("%1/.config/mudlet/autolog").arg(QDir::homePath()));
+    // CHECKME: This path seems suspicious, it is shared amoungst ALL profiles
+    // but the action is "Per Profile"...!
+    QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("autolog")));
     if (!mLogToLogFile) {
         file.open(QIODevice::WriteOnly | QIODevice::Text);
         QTextStream out(&file);
         file.close();
 
-        QString directoryLogFile = QStringLiteral("%1/.config/mudlet/profiles/%2/log").arg(QDir::homePath(), profile_name);
-        mLogFileName = QStringLiteral("%1/%2").arg(directoryLogFile, QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd#hh-mm-ss")));
+        QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, profile_name);
         // Revised file name derived from time so that alphabetical filename and
         // date sort order are the same...
         QDir dirLogFile;
@@ -829,9 +832,9 @@ void TConsole::toggleLogging(bool isMessageEnabled)
 
         mpHost->mIsCurrentLogFileInHtmlFormat = mpHost->mIsNextLogFileInHtmlFormat;
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
-            mLogFileName.append(QStringLiteral(".html"));
+            mLogFileName = QStringLiteral("%1/%2.html").arg(directoryLogFile, QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd#hh-mm-ss")));
         } else {
-            mLogFileName.append(QStringLiteral(".txt"));
+            mLogFileName = QStringLiteral("%1/%2.txt").arg(directoryLogFile, QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd#hh-mm-ss")));
         }
         mLogFile.setFileName(mLogFileName);
         mLogFile.open(QIODevice::WriteOnly);
@@ -925,9 +928,10 @@ void TConsole::slot_toggleReplayRecording()
     }
     mRecordReplay = !mRecordReplay;
     if (mRecordReplay) {
-        QString directoryLogFile = QDir::homePath() + "/.config/mudlet/profiles/" + profile_name + "/log";
-        QString mLogFileName = directoryLogFile + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
-        mLogFileName.append(".dat");
+        QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, profile_name);
+        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (5 of 6)
+        QString mLogFileName = QStringLiteral("%1/%2.dat")
+                               .arg(directoryLogFile, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
         QDir dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
             dirLogFile.mkpath(directoryLogFile);
@@ -1090,11 +1094,12 @@ void TConsole::setConsoleFgColor(int r, int g, int b)
     return time;
    } */
 
-
+// Actually means load a "replay" (which will currently be a *.dat) file
 void TConsole::loadRawFile(std::string n)
 {
-    QString directoryLogFile = QDir::homePath() + "/.config/mudlet/profiles/" + profile_name + "/log";
-    QString fileName = directoryLogFile + "/" + QString(n.c_str());
+    QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, profile_name);
+    QString fileName = QStringLiteral("%1/%2")
+                       .arg(directoryLogFile, QString(n.c_str()));
     mpHost->mTelnet.loadReplay(fileName);
 }
 
@@ -1434,10 +1439,11 @@ bool TConsole::saveMap(const QString& location)
 {
     QDir dir_map;
     QString filename_map;
-    QString directory_map = QDir::homePath() + "/.config/mudlet/profiles/" + profile_name + "/map";
+    QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
 
-    if (location == "") {
-        filename_map = directory_map + "/" + QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss") + "map.dat";
+    if (location.isEmpty()) {
+        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (6 of 6)
+        filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
     } else {
         filename_map = location;
     }
@@ -1554,7 +1560,7 @@ bool TConsole::importMap(const QString& location, QString* errMsg)
     if (!fileInfo.filePath().isEmpty()) {
         if (fileInfo.isRelative()) {
             // Resolve the name relative to the profile home directory:
-            filePathNameString = QDir::cleanPath(QStringLiteral("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), pHost->getName(), fileInfo.filePath()));
+            filePathNameString = QDir::cleanPath(mudlet::getMudletPath(mudlet::profileDataItemPath, pHost->getName(), fileInfo.filePath()));
         } else {
             if (fileInfo.exists()) {
                 filePathNameString = fileInfo.canonicalFilePath(); // Cannot use cannonical path if file doesn't exist!

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
 *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
-*   Copyright (C) 2013-2016 by Stephen Lyons - slysven@virginmedia.com    *
+*   Copyright (C) 2013-2017 by Stephen Lyons - slysven@virginmedia.com    *
 *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
 *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
 *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
@@ -4851,13 +4851,11 @@ int TLuaInterpreter::getLastLineNumber(lua_State* L)
 
 int TLuaInterpreter::getMudletHomeDir(lua_State* L)
 {
-    QString home = QDir::homePath();
-    home.append("/.config/mudlet/profiles/");
     Host& host = getHostFromLua(L);
-    QString name = host.getName();
-    home.append(name);
-    QString erg = QDir::toNativeSeparators(home);
-    lua_pushstring(L, erg.toLatin1().data());
+    QString nativeHomeDirectory = QDir::toNativeSeparators(mudlet::getMudletPath(mudlet::profileHomePath, host.getName()));
+    // Was using toLatin1() but that fails to accommodate Windows OS which allows
+    // none ASCII characters in user names...
+    lua_pushstring(L, nativeHomeDirectory.toUtf8().constData());
     return 1;
 }
 
@@ -12131,41 +12129,6 @@ void TLuaInterpreter::initLuaGlobals()
         QString msg = "[  OK  ]  - Lua module utf8 loaded.";
         mpHost->postMessage(msg);
     }
-
-    //    QString path = QDir::homePath()+"/.config/mudlet/mudlet-lua/lua/LuaGlobal.lua";
-    //    error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
-    //    if( error != 0 )
-    //    {
-    //        string e = "no error message available from Lua";
-    //        if( lua_isstring( pGlobalLua, 1 ) )
-    //        {
-    //            e = "[CRITICAL ERROR] LuaGlobal.lua compile error - please report";
-    //            e += lua_tostring( pGlobalLua, 1 );
-    //        }
-    //        gSysErrors << e.c_str();
-    //    }
-    //    else
-    //    {
-    //        gSysErrors << "[INFO] LuaGlobal.lua loaded successfully.";
-    //    }
-
-    /*path = QDir::homePath()+"/.config/mudlet/db.lua";
-	   error = luaL_dofile( pGlobalLua, path.toLatin1().data() );
-	   if( error != 0 )
-	   {
-	    string e = "no error message available from Lua";
-	    if( lua_isstring( pGlobalLua, 1 ) )
-	    {
-	        e = "[CRITICAL ERROR] db.lua compile error - please report";
-	        e += lua_tostring( pGlobalLua, 1 );
-	    }
-	    gSysErrors << e.c_str();
-	   }
-	   else
-	   {
-	    gSysErrors << "[INFO] db.lua loaded successfully.";
-	   }*/
-
 
     QString tn = "atcp";
     QStringList args;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4853,8 +4853,6 @@ int TLuaInterpreter::getMudletHomeDir(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     QString nativeHomeDirectory = QDir::toNativeSeparators(mudlet::getMudletPath(mudlet::profileHomePath, host.getName()));
-    // Was using toLatin1() but that fails to accommodate Windows OS which allows
-    // none ASCII characters in user names...
     lua_pushstring(L, nativeHomeDirectory.toUtf8().constData());
     return 1;
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
- *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2017 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -1245,7 +1245,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
     QStringList entries;
 
     if (location.isEmpty()) {
-        folder = QStringLiteral("%1/.config/mudlet/profiles/%2/map/").arg(QDir::homePath(), mpHost->getName());
+        folder = mudlet::getMudletPath(mudlet::profileMapsPath, mpHost->getName());
         QDir dir(folder);
         dir.setSorting(QDir::Time);
         entries = dir.entryList(QDir::Files, QDir::Time);
@@ -1253,7 +1253,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
     bool canRestore = true;
     if (entries.size() || !location.isEmpty()) {
-        QFile file(location.isEmpty() ? QStringLiteral("%1%2").arg(folder, entries.at(0)) : location);
+        QFile file(location.isEmpty() ? QStringLiteral("%1/%2").arg(folder, entries.at(0)) : location);
 
         if (!file.open(QFile::ReadOnly)) {
             QString errMsg = tr(R"([ ERROR ] - Unable to open (for reading) map file: "%1"!)").arg(file.fileName());
@@ -1505,7 +1505,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
 
     QString folder;
     QStringList entries;
-    folder = QStringLiteral("%1/.config/mudlet/profiles/%2/map/").arg(QDir::homePath(), profile);
+    folder = mudlet::getMudletPath(mudlet::profileMapsPath, profile);
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
@@ -1515,7 +1515,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
 
     // As the files are sorted by time this gets the latest one
-    QFile file(QStringLiteral("%1%2").arg(folder, entries.at(0)));
+    QFile file(QStringLiteral("%1/%2").arg(folder, entries.at(0)));
 
     if (!file.open(QFile::ReadOnly)) {
         QString errMsg = tr(R"([ ERROR ] - Unable to open (for reading) map file: "%1"!)").arg(file.fileName());
@@ -1994,7 +1994,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "\"%1\"\n"
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
-                            .arg(QStringLiteral("%1/.config/mudlet/profiles/%2/log/errors.txt").arg(QDir::homePath(), mpHost->getName()), title));
+                    .arg(mudlet::getMudletPath(mudlet::profileLogErrorsFilePath, mpHost->getName()), title));
     } else if (mIsFileViewingRecommended && mudlet::self()->showMapAuditErrors()) {
         postMessage(tr("[ INFO ]  - The equivalent to the above information about that last map\n"
                        "operation has been saved for review as the most recent report in\n"
@@ -2002,7 +2002,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "\"%1\"\n"
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
-                            .arg(QStringLiteral("%1/.config/mudlet/profiles/%2/log/errors.txt").arg(QDir::homePath(), mpHost->getName()), title));
+                    .arg(mudlet::getMudletPath(mudlet::profileLogErrorsFilePath, mpHost->getName()), title));
     }
 
     mIsFileViewingRecommended = false;
@@ -2046,7 +2046,7 @@ void TMap::downloadMap(const QString* remoteUrl, const QString* localFileName)
     }
 
     if (!localFileName || localFileName->isEmpty()) {
-        mLocalMapFileName = QStringLiteral("%1/.config/mudlet/profiles/%2/map.xml").arg(QDir::homePath(), pHost->getName());
+        mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, pHost->getName());
     } else {
         mLocalMapFileName = *localFileName;
     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -949,10 +949,8 @@ void cTelnet::processTelnetCommand(const string& command)
                     mpHost->mpConsole->print("<package is already installed>\n");
                     return;
                 }
-                QString _home = QDir::homePath();
-                _home.append("/.config/mudlet/profiles/");
-                _home.append(mpHost->getName());
-                mServerPackage = QString("%1/%2").arg(_home, fileName);
+
+                mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), fileName);
 
                 QNetworkReply* reply = mpDownloader->get(QNetworkRequest(QUrl(url)));
                 mpProgressDialog = new QProgressDialog("downloading game GUI from server", "Abort", 0, 4000000, mpHost->mpConsole);
@@ -1170,10 +1168,8 @@ void cTelnet::setGMCPVariables(const QString& msg)
             mpHost->mpConsole->print("<package is already installed>\n");
             return;
         }
-        QString _home = QDir::homePath();
-        _home.append("/.config/mudlet/profiles/");
-        _home.append(mpHost->getName());
-        mServerPackage = QString("%1/%2").arg(_home, fileName);
+
+        mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), fileName);
 
         QNetworkReply* reply = mpDownloader->get(QNetworkRequest(QUrl(url)));
         mpProgressDialog = new QProgressDialog("downloading game GUI from server", "Abort", 0, 4000000, mpHost->mpConsole);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -336,11 +336,12 @@ void dlgConnectionProfiles::slot_save_name()
 
         pItem->setText(newProfileName);
 
-        QDir currentPath(QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), currentProfileEditName));
+        QDir currentPath(mudlet::getMudletPath(mudlet::profileHomePath, currentProfileEditName));
         QDir dir;
 
         if (currentPath.exists()) {
-            QDir parentpath(QStringLiteral("%1/.config/mudlet/profiles/").arg(QDir::homePath()));
+            // CHECKME: previous code specified a path ending in a '/'
+            QDir parentpath(mudlet::getMudletPath(mudlet::profilesPath));
             if (!parentpath.rename(currentProfileEditName, newProfileName)) {
                 notificationArea->show();
                 notificationAreaIconLabelWarning->show();
@@ -349,7 +350,7 @@ void dlgConnectionProfiles::slot_save_name()
                 notificationAreaMessageBox->show();
                 notificationAreaMessageBox->setText(tr("Could not rename your profile data on the computer."));
             }
-        } else if (!dir.mkpath(QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), newProfileName))) {
+        } else if (!dir.mkpath(mudlet::getMudletPath(mudlet::profileHomePath, newProfileName))) {
             notificationArea->show();
             notificationAreaIconLabelWarning->show();
             notificationAreaIconLabelError->hide();
@@ -484,7 +485,7 @@ void dlgConnectionProfiles::slot_deleteprofile_check(const QString text)
 void dlgConnectionProfiles::slot_reallyDeleteProfile()
 {
     QString profile = profiles_tree_widget->currentItem()->text();
-    QDir dir(QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), profile));
+    QDir dir(mudlet::getMudletPath(mudlet::profileHomePath, profile));
     dir.removeRecursively(); // note: we should replace this with a function that pops up a progress dialog should the deletion be taking longer than a second
     fillout_form();
     profiles_tree_widget->setFocus();
@@ -533,7 +534,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
 
 QString dlgConnectionProfiles::readProfileData(QString profile, QString item)
 {
-    QFile file(QStringLiteral("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), profile, item));
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, profile, item));
     bool success = file.open(QIODevice::ReadOnly);
     QString ret;
     if (success) {
@@ -545,24 +546,9 @@ QString dlgConnectionProfiles::readProfileData(QString profile, QString item)
     return ret;
 }
 
-QStringList dlgConnectionProfiles::readProfileHistory(QString profile, QString item)
-{
-    QFile file(QStringLiteral("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), profile, item));
-    file.open(QIODevice::ReadOnly);
-    QDataStream ifs(&file);
-    QString ret;
-    QStringList historyList;
-    while (ifs.status() == QDataStream::Ok) {
-        ifs >> ret;
-        historyList << ret;
-    }
-    file.close();
-    return historyList;
-}
-
 QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& profile, const QString& item, const QString& what)
 {
-    QFile file(QStringLiteral("%1/.config/mudlet/profiles/%2/%3").arg(QDir::homePath(), profile, item));
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, profile, item));
     if (file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
         QDataStream ofs(&file);
         ofs << what;
@@ -831,7 +817,7 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
 
     profile_history->clear();
 
-    QDir dir(QStringLiteral("%1/.config/mudlet/profiles/%2/current/").arg(QDir::homePath(), profile_name));
+    QDir dir(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files | QDir::NoDotAndDotDot, QDir::Time);
 
@@ -922,7 +908,7 @@ void dlgConnectionProfiles::fillout_form()
     host_name_entry->clear();
     port_entry->clear();
 
-    mProfileList = QDir(QStringLiteral("%1/.config/mudlet/profiles").arg(QDir::homePath())).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    mProfileList = QDir(mudlet::getMudletPath(mudlet::profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
 
     // if only the default_host is present it means no profiles have yet been created
     if (mProfileList.isEmpty() || (mProfileList.size() == 1 && mProfileList.at(0) == QStringLiteral("default_host"))) {
@@ -1252,7 +1238,7 @@ void dlgConnectionProfiles::fillout_form()
         auto profile = profiles_tree_widget->item(i);
         auto profileName = profile->text();
 
-        QDateTime profile_lastRead = QFileInfo(QStringLiteral("%1/.config/mudlet/profiles/%2/current/").arg(QDir::homePath(), profileName)).lastModified();
+        QDateTime profile_lastRead = QFileInfo(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profileName)).lastModified();
         // Since Qt 5.x null QTimes and QDateTimes are invalid - and might not
         // work as expected - so test for validity of the test_date value as well
         if ((!test_date.isValid()) || profile_lastRead > test_date) {
@@ -1328,12 +1314,13 @@ void dlgConnectionProfiles::slot_copy_profile()
     port_entry->setReadOnly(false);
 
     // copy the folder on-disk
-    QDir dir(QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), oldname));
+    QDir dir(mudlet::getMudletPath(mudlet::profileHomePath, oldname));
     if (!dir.exists()) {
         return;
     }
 
-    copyFolder(QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), oldname), QStringLiteral("%1/.config/mudlet/profiles/%2").arg(QDir::homePath(), profile_name));
+    copyFolder(mudlet::getMudletPath(mudlet::profileHomePath, oldname),
+               mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
     mProfileList << profile_name;
     slot_item_clicked(pItem);
 }
@@ -1360,7 +1347,7 @@ void dlgConnectionProfiles::slot_connectToServer()
         return;
     }
 
-    QString folder = QStringLiteral("%1/.config/mudlet/profiles/%2/current/").arg(QDir::homePath(), profile_name);
+    QString folder(mudlet::getMudletPath(mudlet::profileXmlFilesPath, profile_name));
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -37,7 +37,6 @@ public:
     void fillout_form();
     QPair<bool, QString> writeProfileData(const QString& profile, const QString& item, const QString& what);
     QString readProfileData(QString, QString);
-    QStringList readProfileHistory(QString, QString);
     void accept() override;
 
 signals:

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -3,6 +3,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -714,7 +715,7 @@ QString dlgIRC::readIrcNickName(Host* pH)
 
 QString dlgIRC::readAppDefaultIrcNick()
 {
-    QFile file(QStringLiteral("%1/.config/mudlet/irc_nick").arg(QDir::homePath()));
+    QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("irc_nick")));
     bool opened = file.open(QIODevice::ReadOnly);
     QString rstr;
     if (opened) {
@@ -727,7 +728,7 @@ QString dlgIRC::readAppDefaultIrcNick()
 
 void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
 {
-    QFile file(QStringLiteral("%1/.config/mudlet/irc_nick").arg(QDir::homePath()));
+    QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("irc_nick")));
     bool opened = file.open(QIODevice::WriteOnly);
     if (opened) {
         QDataStream ifs(&file);

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,7 +22,7 @@
 
 #include "dlgNotepad.h"
 
-
+#include "mudlet.h"
 #include "Host.h"
 
 #include "pre_guard.h"
@@ -38,8 +39,8 @@ dlgNotepad::dlgNotepad(Host* pH) : mpHost(pH)
 
 void dlgNotepad::save()
 {
-    QString directoryFile = QDir::homePath() + "/.config/mudlet/profiles/" + mpHost->getName();
-    QString fileName = directoryFile + "/notes.txt";
+    QString directoryFile = mudlet::getMudletPath(mudlet::profileHomePath, mpHost->getName());
+    QString fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), QStringLiteral("notes.txt"));
     QDir dirFile;
     if (!dirFile.exists(directoryFile)) {
         dirFile.mkpath(directoryFile);
@@ -55,9 +56,7 @@ void dlgNotepad::save()
 
 void dlgNotepad::restore()
 {
-    QString directoryFile = QDir::homePath() + "/.config/mudlet/profiles/" + mpHost->getName();
-    QString fileName = directoryFile + "/notes.txt";
-    QDir dirFile;
+    QString fileName = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), QStringLiteral("notes.txt"));
     QFile file;
     file.setFileName(fileName);
     file.open(QIODevice::ReadOnly);
@@ -65,4 +64,5 @@ void dlgNotepad::restore()
     fileStream.setDevice(&file);
     QString txt = fileStream.readAll();
     notesEdit->setPlainText(txt);
+    file.close();
 }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2015, 2017 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,6 +23,7 @@
 #include "dlgPackageExporter.h"
 
 
+#include "mudlet.h"
 #include "Host.h"
 #include "TAction.h"
 #include "TAlias.h"
@@ -82,9 +83,9 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* host) :
     if (packagePath.isEmpty()) {
         return;
     }
-
-    tempDir = QDir::homePath() + "/.config/mudlet/profiles/" + mpHost->getName() + "/tmp/";
     packagePath.replace(R"(\)", "/");
+
+    tempDir = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), QStringLiteral("/tmp/"));
     tempDir = tempDir + "/" + packageName;
     QDir packageDir = QDir(tempDir);
     if (!packageDir.exists()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -427,13 +427,6 @@ int main(int argc, char* argv[])
     if (oldLinkFile.exists()) {
         // A One-time fix up past error that did not include the ".lnk" extension
         oldLinkFile.rename(homeLinkWindows);
-        QMessageBox::information(nullptr,
-                                 qApp->tr("Fixup", "main"),
-                                 QStringLiteral("<html><head/><body>%1</body></html>")
-                                 .arg(qApp->tr("<p>An error in some previous <i>Windows</i> versions of Mudlet failed to correctly make a symbolic link called \"mudlet-data\" from your <b>home</b> directory to where Mudlet stores <u>your</u> personal Mudlet game data; "
-                                         "this message is to advise you that a plain <i>file</i> with that name has been adjusted so that it is now a valid Windows <i>symlink</i>!</p>"
-                                         "<p>Unless you re-run an older version of Mudlet again you should not see this message again... 8-)</p>",
-                                               "main")));
     } else {
         QFile linkFile(homeLinkWindows);
         if (!linkFile.exists()) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -197,14 +197,14 @@ mudlet::mudlet()
     mainPane->setSizePolicy(sizePolicy);
     mainPane->setFocusPolicy(Qt::NoFocus);
 
-    QFile file_autolog(QDir::homePath() + "/.config/mudlet/autolog");
+    QFile file_autolog(getMudletPath(mainDataItemPath, QStringLiteral("autolog")));
     if (file_autolog.exists()) {
         mAutolog = true;
     } else {
         mAutolog = false;
     }
 
-    QFile file_use_smallscreen(QDir::homePath() + "/.config/mudlet/mudlet_option_use_smallscreen");
+    QFile file_use_smallscreen(getMudletPath(mainDataItemPath, QStringLiteral("mudlet_option_use_smallscreen")));
     if (file_use_smallscreen.exists()) {
         mpMainToolBar->setIconSize(QSize(16, 16));
     } else {
@@ -666,7 +666,8 @@ void mudlet::slot_module_clicked(QTableWidgetItem* pItem)
     }
 
     if (mpModuleTableHost->moduleHelp.contains(entry->text())) {
-        moduleHelpButton->setDisabled((!mpModuleTableHost->moduleHelp.value(entry->text()).contains(QLatin1String("helpURL")) || mpModuleTableHost->moduleHelp.value(entry->text()).value("helpURL").isEmpty()));
+        moduleHelpButton->setDisabled(( !mpModuleTableHost->moduleHelp.value(entry->text()).contains(QStringLiteral("helpURL"))
+                                      || mpModuleTableHost->moduleHelp.value(entry->text()).value(QStringLiteral("helpURL")).isEmpty()));
     } else {
         moduleHelpButton->setDisabled(true);
     }
@@ -1146,7 +1147,7 @@ bool mudlet::saveWindowLayout()
         return false;
     }
 
-    QString layoutFilePath = QStringLiteral("%1/.config/mudlet/windowLayout.dat").arg(QDir::homePath());
+    QString layoutFilePath = getMudletPath(mainDataItemPath, QStringLiteral("windowLayout.dat"));
 
     QFile layoutFile(layoutFilePath);
     if (layoutFile.open(QIODevice::WriteOnly)) {
@@ -1168,7 +1169,7 @@ bool mudlet::loadWindowLayout()
 {
     qDebug() << "mudlet::loadWindowLayout() - loading layout.";
 
-    QString layoutFilePath = QStringLiteral("%1/.config/mudlet/windowLayout.dat").arg(QDir::homePath());
+    QString layoutFilePath = getMudletPath(mainDataItemPath, QStringLiteral("windowLayout.dat"));
 
     QFile layoutFile(layoutFilePath);
     if (layoutFile.exists()) {
@@ -2457,9 +2458,8 @@ void mudlet::slot_replay()
     if (!pHost) {
         return;
     }
-    QString home = QDir::homePath() + "/.config/mudlet/profiles/";
-    home.append(pHost->getName());
-    home.append("/log/");
+
+    QString home = getMudletPath(profileReplayAndLogFilesPath, pHost->getName());
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Replay"), home, tr("*.dat"));
     if (fileName.isEmpty()) {
         return;
@@ -2470,8 +2470,7 @@ void mudlet::slot_replay()
         QMessageBox::warning(this, tr("Select Replay"), tr("Cannot read file %1:\n%2.").arg(fileName, file.errorString()));
         return;
     }
-    //QString directoryLogFile = QDir::homePath()+"/.config/mudlet/profiles/"+profile_name+"/log";
-    //QString fileName = directoryLogFile + "/"+QString(n.c_str());
+
     pHost->mTelnet.loadReplay(fileName);
 }
 
@@ -2487,7 +2486,7 @@ void mudlet::print(Host* pH, const QString& s)
 
 QString mudlet::readProfileData(const QString& profile, const QString& item)
 {
-    QFile file(QDir::homePath() + "/.config/mudlet/profiles/" + profile + "/" + item);
+    QFile file(getMudletPath(profileDataItemPath, profile, item));
     file.open(QIODevice::ReadOnly);
     if (!file.exists()) {
         return "";
@@ -2504,7 +2503,8 @@ QString mudlet::readProfileData(const QString& profile, const QString& item)
 // this slot is called via a timer in the constructor of mudlet::mudlet()
 void mudlet::startAutoLogin()
 {
-    QStringList hostList = QDir(QDir::homePath() + "/.config/mudlet/profiles").entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    QStringList hostList = QDir(getMudletPath(profilesPath))
+                           .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
     bool openedProfile = false;
 
     for (auto host : hostList) {
@@ -2542,12 +2542,12 @@ void mudlet::doAutoLogin(const QString& profile_name)
     LuaInterface* lI = pHost->getLuaInterface();
     lI->getVars(true);
 
-    QString folder = QDir::homePath() + "/.config/mudlet/profiles/" + profile_name + "/current/";
+    QString folder = getMudletPath(profileXmlFilesPath, profile_name);
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
-    if (entries.size() > 0) {
-        QFile file(folder + "/" + entries[0]);
+    if (!entries.isEmpty()) {
+        QFile file(QStringLiteral("%1/%2").arg(folder, entries.at(0)));
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer(pHost);
         qDebug() << "[LOADING PROFILE]:" << file.fileName();
@@ -2994,12 +2994,12 @@ bool mudlet::loadEdbeeTheme(const QString& themeName, const QString& themeFile)
     auto edbee = edbee::Edbee::instance();
     auto themeManager = edbee->themeManager();
 
-    QString themeLocation;
-    if (themeFile == QStringLiteral("Mudlet.tmTheme")) {
-        themeLocation = QStringLiteral(":/edbee_defaults/Mudlet.tmTheme");
-    } else {
-        themeLocation = QStringLiteral("%1/.config/mudlet/edbee/Colorsublime-Themes-master/themes/%2").arg(QDir::homePath(), themeFile);
-    }
+    // getMudletPath(...) needs the themeFile to determine if it is the
+    // "default" which is stored in the resource file and not downloaded into
+    // the cache:
+    QString themeLocation(
+                getMudletPath(editorWidgetThemePathFile,
+                              themeFile));
     auto result = themeManager->readThemeFile(themeLocation, themeName);
     if (result == nullptr) {
         qWarning() << themeManager->lastErrorMessage();
@@ -3099,3 +3099,115 @@ void mudlet::slot_module_manager_destroyed()
     mpModuleTableHost = nullptr;
 }
 
+// Convenience helper - may aide things if we want to put files in a different
+// place...!
+QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, const QString& extra2)
+{
+    switch(mode) {
+    case mainPath:
+        // The root of all mudlet data for the user - does not end in a '/'
+        return QStringLiteral("%1/.config/mudlet")
+                .arg(QDir::homePath());
+    case mainDataItemPath:
+        // Takes one extra argument as a file (or directory) relating to
+        // (profile independent) mudlet data - may end with a '/' if the extra
+        // argument does:
+        return QStringLiteral("%1/.config/mudlet/%2")
+                .arg(QDir::homePath(), extra1);
+    case mainFontsPath:
+        // (Added for 3.5.0) a revised location to store Mudlet provided fonts
+        return QStringLiteral("%1/.config/mudlet/fonts")
+                .arg(QDir::homePath());
+    case profilesPath:
+        // The directory containing all the saved user's profiles - does not end
+        // in '/'
+        return QStringLiteral("%1/.config/mudlet/profiles")
+                .arg(QDir::homePath());
+    case profileHomePath:
+        // Takes one extra argument (profile name) that returns the base
+        // directory for that profile - does NOT end in a '/' unless the
+        // supplied profle name does:
+        return QStringLiteral("%1/.config/mudlet/profiles/%2")
+                .arg(QDir::homePath(), extra1);
+    case profileXmlFilesPath:
+        // Takes one extra argument (profile name) that returns the directory
+        // for the profile game save XML files - ends in a '/'
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/current/")
+                .arg(QDir::homePath(), extra1);
+    case profileMapsPath:
+        // Takes one extra argument (profile name) that returns the directory
+        // for the profile game save maps files - does NOT end in a '/'
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/map")
+                .arg(QDir::homePath(), extra1);
+    case profileDateTimeStampedMapPathFileName:
+        // Takes two extra arguments (profile name, dataTime stamp) that returns
+        // the pathFile name for a dateTime stamped map file:
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/map/%3map.dat")
+                .arg(QDir::homePath(), extra1, extra2);
+    case profileMapPathFileName:
+        // Takes two extra arguments (profile name, mapFileName) that returns
+        // the pathFile name for any map file:
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/map/%3")
+                .arg(QDir::homePath(), extra1, extra2);
+    case profileXmlMapPathFileName:
+        // Takes one extra argument (profile name) that returns the pathFile
+        // name for the downloaded IRE Server provided XML map:
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/map.xml")
+                .arg(QDir::homePath(), extra1);
+    case profileDataItemPath:
+        // Takes two extra arguments (profile name, data item) that gives a
+        // path file name for, typically a data item stored as a single item
+        // (binary) profile data) file (ideally these can be moved to a per
+        // profile QSettings file but that is a future pipe-dream on my part
+        // SlySven):
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/%3")
+                .arg(QDir::homePath(), extra1, extra2);
+    case profilePackagePath:
+        // Takes two extra arguments (profile name, package name) returns the
+        // per profile directory used to store (unpacked) package contents
+        // - ends with a '/':
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/%3/")
+                .arg(QDir::homePath(), extra1, extra2);
+    case profilePackagePathFileName:
+        // Takes two extra arguments (profile name, package name) returns the
+        // filename of the XML file that contains the (per profile, unpacked)
+        // package mudlet items in that package/module:
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/%3/%3.xml")
+                .arg(QDir::homePath(), extra1, extra2);
+    case profileReplayAndLogFilesPath:
+        // Takes one extra argument (profile name) that returns the directory
+        // that contains replays (*.dat files) and logs (*.html or *.txt) files
+        // for that profile - does NOT end in '/':
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/log")
+                .arg(QDir::homePath(), extra1);
+    case profileLogErrorsFilePath:
+        // Takes one extra argument (profile name) that returns the pathFileName
+        // to the map auditing report file that is appended to each time a
+        // map is loaded:
+        return QStringLiteral("%1/.config/mudlet/profiles/%2/log/errors.txt")
+                .arg(QDir::homePath(), extra1);
+    case editorWidgetThemePathFile:
+        // Takes two extra arguments (profile name, theme name) that returns the
+        // pathFileName of the theme file used by the edbee editor - also
+        // handles the special case of the default theme "mudlet.thTheme" that
+        // is carried internally in the resource file:
+        if (extra1.compare(QStringLiteral("Mudlet.tmTheme"),Qt::CaseSensitive)) {
+            // No match
+            return QStringLiteral("%1/.config/mudlet/edbee/Colorsublime-Themes-master/themes/%2")
+                    .arg(QDir::homePath(), extra1);
+        } else {
+            // Match - return path to copy held in resource file
+            return QStringLiteral(":/edbee_defaults/Mudlet.tmTheme");
+        }
+    case editorWidgetThemeJsonFile:
+        // Returns the pathFileName to the external JSON file needed to process
+        // an edbee edtor widget theme:
+        return QStringLiteral("%1/.config/mudlet/edbee/Colorsublime-Themes-master/themes.json")
+                .arg(QDir::homePath());
+    case moduleBackupsPath:
+        // Returns the directory used to store module backups that is used in
+        // when saving/resyncing packages/modules - ends in a '/'
+        return QStringLiteral("%1/.config/mudlet/moduleBackups/")
+                .arg(QDir::homePath());
+    }
+}

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -212,6 +212,73 @@ public:
 
     static bool unzip(const QString &archivePath, const QString &destination, const QDir &tmpDir);
 
+    enum mudletPathType {
+        // The root of all mudlet data for the user - does not end in a '/'
+        mainPath = 0,
+        // Takes one extra argument as a file (or directory) relating to
+        // (profile independent) mudlet data - may end with a '/' if the extra
+        // argument does:
+        mainDataItemPath,
+        // (Added for 3.5.0) a revised location to store Mudlet provided fonts:
+        mainFontsPath,
+        // The directory containing all the saved user's profiles - does not end
+        // in '/':
+        profilesPath,
+        // Takes one extra argument (profile name) that returns the base
+        // directory for that profile - does NOT end in a '/' unless the
+        // supplied profle name does:
+        profileHomePath,
+        // Takes one extra argument (profile name) that returns the directory
+        // for the profile game save XML files - ends in a '/':
+        profileXmlFilesPath,
+        // Takes one extra argument (profile name) that returns the directory
+        // for the profile game save maps files - does NOT end in a '/'
+        profileMapsPath,
+        // Takes two extra arguments (profile name, dataTime stamp) that returns
+        // the pathFile name for a dateTime stamped map file:
+        profileDateTimeStampedMapPathFileName,
+        // Takes two extra arguments (profile name, mapFileName) that returns
+        // the pathFile name for any map file:
+        profileMapPathFileName,
+        // Takes one extra argument (profile name) that returns the pathFile
+        // name for the downloaded IRE Server provided XML map:
+        profileXmlMapPathFileName,
+        // Takes two extra arguments (profile name, data item) that gives a
+        // path file name for, typically a data item stored as a single item
+        // (binary) profile data) file (ideally these can be moved to a per
+        // profile QSettings file but that is a future pipe-dream on my part
+        // SlySven):
+        profileDataItemPath,
+        // Takes two extra arguments (profile name, package name) returns the
+        // per profile directory used to store (unpacked) package contents
+        // - ends with a '/':
+        profilePackagePath,
+        // Takes two extra arguments (profile name, package name) returns the
+        // filename of the XML file that contains the (per profile, unpacked)
+        // package mudlet items in that package/module:
+        profilePackagePathFileName,
+        // Takes one extra argument (profile name) that returns the directory
+        // that contains replays (*.dat files) and logs (*.html or *.txt) files
+        // for that profile - does NOT end in '/':
+        profileReplayAndLogFilesPath,
+        // Takes one extra argument (profile name) that returns the pathFileName
+        // to the map auditing report file that is appended to each time a
+        // map is loaded:
+        profileLogErrorsFilePath,
+        // Takes two extra arguments (profile name, theme name) that returns the
+        // pathFileName of the theme file used by the edbee editor - also
+        // handles the special case of the default theme "mudlet.thTheme" that
+        // is carried internally in the resource file:
+        editorWidgetThemePathFile,
+        // Returns the pathFileName to the external JSON file needed to process
+        // an edbee edtor widget theme:
+        editorWidgetThemeJsonFile,
+        // Returns the directory used to store module backups that is used in
+        // when saving/resyncing packages/modules - ends in a '/'
+        moduleBackupsPath
+    };
+    static QString getMudletPath(const mudletPathType, const QString& extra1 = QString(), const QString& extra2 = QString());
+
 public slots:
     void processEventLoopHack_timerRun();
     void slot_mapper();


### PR DESCRIPTION
Using a static method means that we can centralise the generation of strings used to access parts of the file system used to hold Mudlet user data - which may be useful if we change them for - say running from a thumb-drive or just to use an OS specific location for them. {Using a ".config/mudlet" sub-directory on Windows is not quite how that OS expects things to be done...!}

This also reduces the number of raw strings that will have to be wrapped in `QStringLiteral(...)` and the like for forthcoming __I18n__ work.

Also:
* The use of "mudlet-data" as a windows symlink sub-directory to ".config/mudlet" in the user home directory may not work because the Qt Documentation suggests that a ".lnk" extension is required - this commit adds that __FOR THAT OS ONLY__.

* Previous code placed (only some - for an unexplained reason not all the files were being copied) the ~~DejaVu~~ Bitstream Vera fonts that we include in the resources directly into the main mudlet user data folder - but the included documentation including the COPYRIGHT.TXT and other files ONLY relate to those font files and NOT to Mudlet as a whole.  I have taken the liberty of moving and loading them from a ./fonts/ subdirectory which makes more sense.  I have noted that, at least, the Debian Linux packager actually removes the font files from their configuration because they already include a shared system wide copy of the same fonts ~~and in a much newer (2.37 at present) version compared to the 1.10 that we bundle~~ - perhaps our code needs to check for the existence/availability of the fonts before we try to load ours into the Mudlet application at run-time!

Edited 2017/10/01 to remove error: the 2.37 refers to the DejaVu fonts which are a greatly expanded set of Fonts derived FROM the Bitstream Vera 1.10 ones.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>