### PR TITLE
Refactor: tweak some form/dialog details

### DIFF
--- a/src/dlgColorTrigger.h
+++ b/src/dlgColorTrigger.h
@@ -30,7 +30,7 @@ class Host;
 class TTrigger;
 
 
-class dlgColorTrigger : public QDialog, public Ui::color_trigger_dlg
+class dlgColorTrigger : public QDialog, public Ui::color_trigger
 {
     Q_OBJECT
 

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -26,7 +26,7 @@
 #include "ui_connection_profiles.h"
 #include "post_guard.h"
 
-class dlgConnectionProfiles : public QDialog, public Ui::profile_dialog
+class dlgConnectionProfiles : public QDialog, public Ui::connection_profiles
 {
     Q_OBJECT
 

--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -42,7 +42,7 @@
 
 class Host;
 
-class dlgIRC : public QMainWindow, public Ui::irc_dlg
+class dlgIRC : public QMainWindow, public Ui::irc
 {
     Q_OBJECT
 

--- a/src/dlgKeysMainArea.h
+++ b/src/dlgKeysMainArea.h
@@ -27,7 +27,7 @@
 #include "post_guard.h"
 
 
-class dlgKeysMainArea : public QWidget, public Ui::keys_main_area
+class dlgKeysMainArea : public QWidget, public Ui::keybindings_main_area
 {
     Q_OBJECT
 

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -30,7 +30,7 @@
 class Host;
 
 
-class dlgNotepad : public QMainWindow, public Ui::NotesEditor
+class dlgNotepad : public QMainWindow, public Ui::notes_editor
 {
     Q_OBJECT
 

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -60,7 +60,7 @@ public:
     }
 };
 
-class dlgRoomExits : public QDialog, public Ui::roomExits
+class dlgRoomExits : public QDialog, public Ui::room_exits
 {
     Q_OBJECT
 

--- a/src/dlgSystemMessageArea.h
+++ b/src/dlgSystemMessageArea.h
@@ -27,7 +27,7 @@
 #include "post_guard.h"
 
 
-class dlgSystemMessageArea : public QWidget, public Ui::systemMessageArea
+class dlgSystemMessageArea : public QWidget, public Ui::system_message_area
 {
     Q_OBJECT
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -68,7 +68,7 @@ class dlgAboutDialog;
 class dlgProfilePreferences;
 
 
-class mudlet : public QMainWindow, public Ui::MainWindow
+class mudlet : public QMainWindow, public Ui::main_window
 {
     Q_OBJECT
 

--- a/src/ui/color_trigger.ui
+++ b/src/ui/color_trigger.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>color_trigger_dlg</class>
- <widget class="QDialog" name="color_trigger_dlg">
+ <class>color_trigger</class>
+ <widget class="QDialog" name="color_trigger">
   <property name="windowModality">
    <enum>Qt::ApplicationModal</enum>
   </property>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>profile_dialog</class>
- <widget class="QDialog" name="profile_dialog">
+ <class>connection_profiles</class>
+ <widget class="QDialog" name="connection_profiles">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/custom_lines.ui
+++ b/src/ui/custom_lines.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>roomExits</class>
- <widget class="QDialog" name="roomExits">
+ <class>custom_lines</class>
+ <widget class="QDialog" name="custom_lines">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/custom_lines_properties.ui
+++ b/src/ui/custom_lines_properties.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <author>Stephen Lyons</author>
- <class>roomExitProperties</class>
- <widget class="QDialog" name="roomExitProperties">
+ <class>custom_line_properties</class>
+ <widget class="QDialog" name="custom_line_properties">
   <property name="windowModality">
    <enum>Qt::WindowModal</enum>
   </property>
@@ -277,7 +277,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>roomExitProperties</receiver>
+   <receiver>custom_line_properties</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -293,7 +293,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>roomExitProperties</receiver>
+   <receiver>custom_line_properties</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/ui/delete_profile_confirmation.ui
+++ b/src/ui/delete_profile_confirmation.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>delete_profile_dialog</class>
- <widget class="QDialog" name="delete_profile_dialog">
+ <class>delete_profile_confirmation</class>
+ <widget class="QDialog" name="delete_profile_confirmation">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -85,7 +85,7 @@ If you are, please type in the profile name as a confirmation:</string>
   <connection>
    <sender>cancel_button</sender>
    <signal>clicked()</signal>
-   <receiver>delete_profile_dialog</receiver>
+   <receiver>delete_profile_confirmation</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -101,7 +101,7 @@ If you are, please type in the profile name as a confirmation:</string>
   <connection>
    <sender>delete_button</sender>
    <signal>clicked()</signal>
-   <receiver>delete_profile_dialog</receiver>
+   <receiver>delete_profile_confirmation</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/ui/irc.ui
+++ b/src/ui/irc.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>irc_dlg</class>
- <widget class="QMainWindow" name="irc_dlg">
+ <class>irc</class>
+ <widget class="QMainWindow" name="irc">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/keybindings_main_area.ui
+++ b/src/ui/keybindings_main_area.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>keys_main_area</class>
- <widget class="QWidget" name="keys_main_area">
+ <class>keybindings_main_area</class>
+ <widget class="QWidget" name="keybindings_main_area">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/lacking_mapper_script.ui
+++ b/src/ui/lacking_mapper_script.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>no_mapping_script</class>
- <widget class="QDialog" name="no_mapping_script">
+ <class>lacking_mapper_script</class>
+ <widget class="QDialog" name="lacking_mapper_script">
   <property name="enabled">
    <bool>true</bool>
   </property>
@@ -133,7 +133,7 @@ p, li { white-space: pre-wrap; }
   <connection>
    <sender>find_scripts</sender>
    <signal>clicked()</signal>
-   <receiver>no_mapping_script</receiver>
+   <receiver>lacking_mapper_script</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow">
+ <class>main_window</class>
+ <widget class="QMainWindow" name="main_window">
   <property name="windowModality">
    <enum>Qt::NonModal</enum>
   </property>

--- a/src/ui/module_manager.ui
+++ b/src/ui/module_manager.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>packageDialog</class>
- <widget class="QDialog" name="module_manager_dialog">
+ <class>module_manager</class>
+ <widget class="QDialog" name="module_manager">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/notes_editor.ui
+++ b/src/ui/notes_editor.ui
@@ -1,6 +1,6 @@
 <ui version="4.0" >
- <class>NotesEditor</class>
- <widget class="QMainWindow" name="NotesEditor" >
+ <class>notes_editor</class>
+ <widget class="QMainWindow" name="notes_editor" >
   <property name="geometry" >
    <rect>
     <x>0</x>

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>packageDialog</class>
- <widget class="QDialog" name="packageDialog">
+ <class>package_manager</class>
+ <widget class="QDialog" name="package_manager">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -84,7 +84,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>packageDialog</receiver>
+   <receiver>package_manager</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -100,7 +100,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>packageDialog</receiver>
+   <receiver>package_manager</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/ui/package_manager_unpack.ui
+++ b/src/ui/package_manager_unpack.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>package_manager_unpack</class>
+ <widget class="QDialog" name="package_manager_unpack">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <author>Stephen Lyons</author>
- <class>roomExits</class>
- <widget class="QDialog" name="roomExits">
+ <class>room_exits</class>
+ <widget class="QDialog" name="room_exits">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -2175,7 +2175,7 @@ or LUA script</string>
   <connection>
    <sender>button_cancel</sender>
    <signal>clicked()</signal>
-   <receiver>roomExits</receiver>
+   <receiver>room_exits</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/ui/set_room_area.ui
+++ b/src/ui/set_room_area.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>set_room_area_dialog</class>
- <widget class="QDialog" name="set_room_area_dialog">
+ <class>set_room_area</class>
+ <widget class="QDialog" name="set_room_area">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -54,7 +54,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>set_room_area_dialog</receiver>
+   <receiver>set_room_area</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -70,7 +70,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>set_room_area_dialog</receiver>
+   <receiver>set_room_area</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>systemMessageArea</class>
- <widget class="QWidget" name="systemMessageArea">
+ <class>system_message_area</class>
+ <widget class="QWidget" name="system_message_area">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
Previous experiments/dry-runs have pointed out to me that some forms have "class" and possibly "widget" attribute names that do not match their file name and one of those is used to provide the "context" for the translation files so that an identifier is used that did not match the context! This commit renames the class/widgets to match the defining files but requires  that the C++ classes {marked by "INHERITED BY:" below} that use them to revise what they are derived from; the renaming (in ui file the same as the NEW name with a .ui extension and files affected) are:

* "_old name_" -> "_new name_" ==> _what is involved/used it_
* "color_trigger_dlg" -> "color_trigger" ==> INHERITED BY: `dlgColorTrigger` class
* "profile_dialog" -> "connection_profiles" ==> INHERITED BY: `dlgConnectionProfiles` class
* "roomExits" -> "custom_lines" ==> used in: `(void) T2DMap::slot_setCustomLine()`
* "roomExitProperties" -> "custom_line_properties" ==> used in: `(void) T2DMap::slot_customLineProperties()`
* "delete_profile_dialog" -> "delete_profile_confirmation" ==> used in: `(void) dlgConnectionProfiles::slot_deleteProfile()`
* "irc_dlg" -> "irc" ==> INHERITED BY: `dlgIRC` class
* "keys_main_area" -> "keybindings_main_area" ==> INHERITED BY: `dlgKeysMainArea` class
* "no_mapping_script" -> "lacking_mapper_script" ==> used in: `(void) mudlet::check_for_mappingscript()`
* "MainWindow" -> "main_window" ==> INHERITED BY: `mudlet` class
* "module_manager_dialog" -> "module_manager" ==> used in: `(void) mudlet::slot_module_manager()`
* "NotesEditor" -> "notes_editor" ==> INHERITED BY: `dlgNotepad` class
* "packageDialog" -> "package_manager" ==> used in: `(void) mudlet::slot_package_manager()`
* "Dialog" -> "package_manager_unpack" ==> used in: `(bool) Host::installPackage(const QString&, int)`
* "roomExits" -> "room_exits" ==> INHERITED BY: `dlgRoomExits` class
* "set_room_area_dialog" -> "set_room_area" ==> used in: `(void) T2DMap::slot_setArea()`
* "systemMessageArea" -> "system_message_area" ==> INHERITED BY: `dlgSystemMessageArea` class

This should improve working out where a string for translation comes from in the (to be created) ".ts" (source) files needed for that process...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>