### PR TITLE
Refactor: remove unneeded dialog titles from some forms + other tweaks

### DIFF
--- a/src/dlgSourceEditorArea.cpp
+++ b/src/dlgSourceEditorArea.cpp
@@ -30,8 +30,6 @@
 #include "edbee/views/textrenderer.h"
 #include "edbee/views/texttheme.h"
 
-//#include "ui_source_editor_area.h"
-
 dlgSourceEditorArea::dlgSourceEditorArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog

--- a/src/ui/about_dialog.ui
+++ b/src/ui/about_dialog.ui
@@ -588,7 +588,7 @@
       </palette>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="tabsClosable">
       <bool>false</bool>

--- a/src/ui/actions_main_area.ui
+++ b/src/ui/actions_main_area.ui
@@ -22,9 +22,6 @@
     <height>0</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout_5">
    <property name="leftMargin">
     <number>2</number>

--- a/src/ui/aliases_main_area.ui
+++ b/src/ui/aliases_main_area.ui
@@ -28,9 +28,6 @@
     <height>100</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="label_alias_name">

--- a/src/ui/color_trigger.ui
+++ b/src/ui/color_trigger.ui
@@ -13,9 +13,6 @@
     <height>270</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Dialog</string>
-  </property>
   <property name="modal">
    <bool>true</bool>
   </property>

--- a/src/ui/composer.ui
+++ b/src/ui/composer.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>News &amp; Message Composer</string>
+   <string>News and Message Composer</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/ui/keybindings_main_area.ui
+++ b/src/ui/keybindings_main_area.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Keys_main_area</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="label_key_name">

--- a/src/ui/module_manager.ui
+++ b/src/ui/module_manager.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Dialog</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0" rowminimumheight="0,230,0">
    <item row="0" column="0" colspan="2">
     <widget class="QTableWidget" name="moduleTable">

--- a/src/ui/notes_editor.ui
+++ b/src/ui/notes_editor.ui
@@ -9,9 +9,6 @@
     <height>600</height>
    </rect>
   </property>
-  <property name="windowTitle" >
-   <string>Note Pad</string>
-  </property>
   <widget class="QWidget" name="centralwidget" >
    <property name="geometry" >
     <rect>

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -10,9 +10,6 @@
     <height>490</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Dialog</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QWidget" name="widget" native="true">

--- a/src/ui/package_manager_unpack.ui
+++ b/src/ui/package_manager_unpack.ui
@@ -10,9 +10,6 @@
     <height>52</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Dialog</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
     <widget class="QLabel" name="label">

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -11,9 +11,6 @@
     <height>561</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Exits for Room &quot;&quot; [*]</string>
-  </property>
   <property name="windowIcon">
    <iconset resource="../mudlet_alpha.qrc">
     <normaloff>:/icons/mudlet_room_exits.png</normaloff>:/icons/mudlet_room_exits.png</iconset>

--- a/src/ui/scripts_main_area.ui
+++ b/src/ui/scripts_main_area.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Scripts_main_area</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="0,1,0" columnstretch="0,1,0">
    <item row="0" column="0">
     <widget class="QLabel" name="label_script_name">

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -28,9 +28,6 @@
     <height>88</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
    <item>
     <widget class="QFrame" name="notificationArea">

--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Timers_main_area</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="label_timer_name">

--- a/src/ui/trigger_editor.ui
+++ b/src/ui/trigger_editor.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Script editor</string>
-  </property>
   <widget class="QWidget" name="widget_main">
    <property name="sizePolicy">
     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/ui/trigger_pattern_edit.ui
+++ b/src/ui/trigger_pattern_edit.ui
@@ -22,9 +22,6 @@
     <height>34</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">
     <number>0</number>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -28,9 +28,6 @@
     <height>240</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">
     <number>0</number>

--- a/src/ui/vars_main_area.ui
+++ b/src/ui/vars_main_area.ui
@@ -16,9 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>variable_main_area</string>
-  </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>0</number>


### PR DESCRIPTION
Several forms/dialogues do not need a title (because they are incorporated into other forms; others that are floated free have their title set elsewhere - in both cases it is advantageous to remove strings that do NOT need to be made translatable when Mudlet is localised into a language and they just pollute the code/make extra strings that would automatically be marked as needing translation - so removing them is mildly useful.

The "composer" form/dialog used for certain MUDs had the title: "__News & Message Composer__" whereas it is simpler for translation to turn the "&" back to "and" as that character has to be escaped in XML files such as the ".ts" ones we will use to make "translations" and it may not display as the original in Qt Linguist (I think it will get replaced by its HTML/XML entity `&amp;` there!)

The default view in the "about_dialog" was defaulting to showing the third tab (the "3rd Party Code Licences" one) compared to the intended first one ("About Mudlet") - this commit restores it to the latter.

A commented out line in dlgSourceEditorArea.cpp can also be removed.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>