### PR TITLE
Fixed logging not to double-log the prompt

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3050,7 +3050,9 @@ inline int TBuffer::wrap(int startLine)
 void TBuffer::log(int fromLine, int toLine)
 {
     TBuffer* pB = &mpHost->mpConsole->buffer;
-    if (pB != this || !mpHost->mpConsole->mLogToLogFile) { return; }
+    if (pB != this || !mpHost->mpConsole->mLogToLogFile) {
+        return;
+    }
 
     if (fromLine >= size() || fromLine < 0) {
         return;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3086,9 +3086,18 @@ void TBuffer::log(int fromLine, int toLine)
         toLog = toLog % lineToLog;
     }
 
+    // record the last log call into a temporary buffer - we'll actually log
+    // on the next iteration after duplication detection has run
     lastTextToLog = std::move(toLog);
     lastLoggedFromLine = fromLine;
     lastloggedToLine = toLine;
+}
+
+// logs the remaining output when logging gets stopped, without duplication checks
+void TBuffer::logRemainingOutput()
+{
+    mpHost->mpConsole->mLogStream << lastTextToLog;
+    mpHost->mpConsole->mLogStream.flush();
 }
 
 // returns how many new lines have been inserted by the wrapping action

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -152,6 +152,7 @@ public:
     static const QList<QString> getComputerEncodingNames() { return csmEncodingTable.keys(); };
     static const QList<QString> getFriendlyEncodingNames();
     static const QString& getComputerEncoding(const QString& encoding);
+    void logRemainingOutput();
 
 
     std::deque<TChar> bufferLine;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -31,6 +31,7 @@
 #include <QPoint>
 #include <QPointer>
 #include <QString>
+#include <QStringBuilder>
 #include <QStringList>
 #include <QTime>
 #include <QVector>
@@ -314,6 +315,11 @@ private:
     // a packet:
     std::string mIncompleteUtf8SequenceBytes;
 
+    // keeps track of the previously logged buffer lines to ensure no log duplication
+    // happens when you enter a command
+    int lastLoggedFromLine;
+    int lastloggedToLine;
+    QString lastTextToLog;
 };
 
 #endif // MUDLET_TBUFFER_H

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -893,6 +893,7 @@ void TConsole::toggleLogging(bool isMessageEnabled)
         }
         logButton->setToolTip(tr("<html><head/><body><p>Stop logging MUD output to log file.</p></body></html>"));
     } else {
+        buffer.logRemainingOutput();
         if (mpHost->mIsCurrentLogFileInHtmlFormat) {
             mLogStream << "</div></body>\n";
             mLogStream << "</html>\n";


### PR DESCRIPTION
Before this, logging would first log the previous prompt - and then when the player command was received, it would log the prompt _again_ with the command. It looked like this:

```
6800h, 9300m, 6300e, 10p elrx<>-
6800h, 9300m, 6300e, 10p elrx<>-x
You see a single exit leading down.
6800h, 9300m, 6300e, 10p elrx<>-
6800h, 9300m, 6300e, 10p elrx<>-x
You see a single exit leading down.
6800h, 9300m, 6300e, 10p elrx<>-
```

This fixes that and only logs the line as you actually see it:

```
6800h, 9300m, 6300e, 10p elrx<>-x
You see a single exit leading down.
6800h, 9300m, 6300e, 10p elrx<>-x
You see a single exit leading down.
6800h, 9300m, 6300e, 10p elrx<>-
```