### PR TITLE
Fixed a rare crash with search

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2552,6 +2552,9 @@ void TConsole::slot_searchBufferUp()
     if (_txt != mSearchQuery) {
         mSearchQuery = _txt;
         mCurrentSearchResult = buffer.lineBuffer.size();
+    } else {
+        // make sure the line to search from does not exceed the buffer, which can grow and shrink dynamically
+        mCurrentSearchResult = std::min(mCurrentSearchResult, buffer.lineBuffer.size());
     }
     if (buffer.lineBuffer.size() < 1) {
         return;


### PR DESCRIPTION
In the case someone repeatedly searched for the same thing, the last search result happened to be right at the top of the buffer, and then the buffer was shrunk because some lines were batch deleted, the index to start searching lines from was never adjusted - and caused a crash.

This should fix it by choosing a minimum available value of the total lines or the last index to search from.

Fixes https://github.com/Mudlet/Mudlet/issues/497.