### PR TITLE
BugFix: a recent update to Qt 5.9 to 5.9.1 broke Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:beineri/opt-qt562-trusty'
-    - sourceline: 'ppa:beineri/opt-qt59-trusty'
+    - sourceline: 'ppa:beineri/opt-qt591-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
     - qt56base


### PR DESCRIPTION
The repository we need to use for Qt 5.9.x has a different name and the old one had gone away - causing Travis Builds to fail on Linux.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>