### PR TITLE
BugFix: module/package handling error

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -735,8 +735,10 @@ bool Host::installPackage(const QString& fileName, int module)
     QFile file2;
     if (fileName.endsWith(QStringLiteral(".zip"), Qt::CaseInsensitive) || fileName.endsWith(QStringLiteral(".mpackage"), Qt::CaseInsensitive)) {
         QString _home = mudlet::getMudletPath(mudlet::profileHomePath, getName());
-        QString _dest = mudlet::getMudletPath(mudlet::profileHomePath, getName(), packageName);
-        QDir _tmpDir(_home); // home directory for the PROFILE
+        QString _dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
+        // home directory for the PROFILE
+        QDir _tmpDir(_home);
+        // directory to store the expanded archive file contents
         _tmpDir.mkpath(_dest);
 
         // TODO: report failure to create destination folder for package/module in profile

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2924,7 +2924,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     QMapIterator<QString, QString> itPath(directoriesNeededMap);
     while (itPath.hasNext()) {
         itPath.next();
-        QString folderToCreate = QStringLiteral("%1/%2").arg(destination, itPath.value());
+        QString folderToCreate = QStringLiteral("%1%2").arg(destination, itPath.value());
         if (!tmpDir.exists(folderToCreate)) {
             if (!tmpDir.mkpath(folderToCreate)) {
                 zip_close(archive);


### PR DESCRIPTION
In #1286 I made what I think is a copy paste error and ended up with the wrong string being used in: `(bool) Host::installPackage(const QString&, int)` for the directory to be used to unzip (archive) file format packages/modules (there was a `/` missing between the profile's HOME directory name and the "packageName" of the concerned module being the file name contained in the `config.lua` should that differ from the base name of the archive file).

For archives where all the files are contained in a single directory the effect is to create a folder/file in the wrong place in the mudlet part of file-system and to expand all the modules in the profile's HOME directory (the fact that they all contain a file called `config.lua` is not an issue as the modules are unpacked in sequence and that file is read for each file before being overwritten by the next package) what will be problematic is a newly installed package will not have been expanded and will not be in the right place if a bugged version of mudlet is the only one that has been used.

For modules that contain sub-directories this bug makes an even bigger mess in the profile's home directory... 8-(

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>