### PR TITLE
Trim sensitive name in editor

### DIFF
--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -27,3 +27,13 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 }
+
+void dlgAliasMainArea::trimName()
+{
+    lineEdit_alias_name->setText(lineEdit_alias_name->text().trimmed());
+}
+
+void dlgAliasMainArea::on_lineEdit_alias_name_editingFinished()
+{
+    trimName();
+}

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -27,7 +27,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
+    connect(lineEdit_alias_name, SIGNAL(editingFinished()), this, SLOT(slot_editing_name_finished()));
 }
 
 void dlgAliasMainArea::trimName()

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -26,6 +26,8 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog
     setupUi(this);
+
+    connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
 }
 
 void dlgAliasMainArea::trimName()
@@ -33,7 +35,7 @@ void dlgAliasMainArea::trimName()
     lineEdit_alias_name->setText(lineEdit_alias_name->text().trimmed());
 }
 
-void dlgAliasMainArea::on_lineEdit_alias_name_editingFinished()
+void dlgAliasMainArea::slot_editing_name_finished()
 {
     trimName();
 }

--- a/src/dlgAliasMainArea.h
+++ b/src/dlgAliasMainArea.h
@@ -35,6 +35,9 @@ class dlgAliasMainArea : public QWidget, public Ui::aliases_main_area
 
 public:
     dlgAliasMainArea(QWidget*);
+    void trimName();
+private slots:
+    void on_lineEdit_alias_name_editingFinished();
 };
 
 #endif // MUDLET_DLGALIASESMAINAREA_H

--- a/src/dlgAliasMainArea.h
+++ b/src/dlgAliasMainArea.h
@@ -35,6 +35,9 @@ class dlgAliasMainArea : public QWidget, public Ui::aliases_main_area
 
 public:
     dlgAliasMainArea(QWidget*);
+
+    // public function allow to trim even when QLineEdit::editingFinished()
+    // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
 private slots:
     void slot_editing_name_finished();

--- a/src/dlgAliasMainArea.h
+++ b/src/dlgAliasMainArea.h
@@ -37,7 +37,7 @@ public:
     dlgAliasMainArea(QWidget*);
     void trimName();
 private slots:
-    void on_lineEdit_alias_name_editingFinished();
+    void slot_editing_name_finished();
 };
 
 #endif // MUDLET_DLGALIASESMAINAREA_H

--- a/src/dlgScriptsMainArea.cpp
+++ b/src/dlgScriptsMainArea.cpp
@@ -27,3 +27,13 @@ dlgScriptsMainArea::dlgScriptsMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 }
+
+void dlgScriptsMainArea::trimName()
+{
+    lineEdit_script_name->setText(lineEdit_script_name->text().trimmed());
+}
+
+void dlgScriptsMainArea::on_lineEdit_script_name_editingFinished()
+{
+    trimName();
+}

--- a/src/dlgScriptsMainArea.cpp
+++ b/src/dlgScriptsMainArea.cpp
@@ -26,6 +26,8 @@ dlgScriptsMainArea::dlgScriptsMainArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog
     setupUi(this);
+
+    connect(lineEdit_script_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
 }
 
 void dlgScriptsMainArea::trimName()
@@ -33,7 +35,7 @@ void dlgScriptsMainArea::trimName()
     lineEdit_script_name->setText(lineEdit_script_name->text().trimmed());
 }
 
-void dlgScriptsMainArea::on_lineEdit_script_name_editingFinished()
+void dlgScriptsMainArea::slot_editing_name_finished()
 {
     trimName();
 }

--- a/src/dlgScriptsMainArea.cpp
+++ b/src/dlgScriptsMainArea.cpp
@@ -28,6 +28,7 @@ dlgScriptsMainArea::dlgScriptsMainArea(QWidget* pF) : QWidget(pF)
     setupUi(this);
 
     connect(lineEdit_script_name, SIGNAL(editingFinished()), this, SLOT(slot_editing_name_finished()));
+    connect(lineEdit_script_event_handler_entry, SIGNAL(editingFinished()), this, SLOT(slot_editing_event_name_finished()));
 }
 
 void dlgScriptsMainArea::trimName()
@@ -35,7 +36,17 @@ void dlgScriptsMainArea::trimName()
     lineEdit_script_name->setText(lineEdit_script_name->text().trimmed());
 }
 
+void dlgScriptsMainArea::trimEventHandlerName()
+{
+    lineEdit_script_event_handler_entry->setText(lineEdit_script_event_handler_entry->text().trimmed());
+}
+
 void dlgScriptsMainArea::slot_editing_name_finished()
 {
     trimName();
+}
+
+void dlgScriptsMainArea::slot_editing_event_name_finished()
+{
+    trimEventHandlerName();
 }

--- a/src/dlgScriptsMainArea.cpp
+++ b/src/dlgScriptsMainArea.cpp
@@ -27,7 +27,7 @@ dlgScriptsMainArea::dlgScriptsMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_script_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
+    connect(lineEdit_script_name, SIGNAL(editingFinished()), this, SLOT(slot_editing_name_finished()));
 }
 
 void dlgScriptsMainArea::trimName()

--- a/src/dlgScriptsMainArea.h
+++ b/src/dlgScriptsMainArea.h
@@ -35,9 +35,14 @@ class dlgScriptsMainArea : public QWidget, public Ui::scripts_main_area
 
 public:
     dlgScriptsMainArea(QWidget*);
+
+    // public function allow to trim even when QLineEdit::editingFinished()
+    // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
+    void trimEventHandlerName();
 private slots:
     void slot_editing_name_finished();
+    void slot_editing_event_name_finished();
 };
 
 #endif // MUDLET_DLGSCRIPTSMAINAREA_H

--- a/src/dlgScriptsMainArea.h
+++ b/src/dlgScriptsMainArea.h
@@ -35,6 +35,9 @@ class dlgScriptsMainArea : public QWidget, public Ui::scripts_main_area
 
 public:
     dlgScriptsMainArea(QWidget*);
+    void trimName();
+private slots:
+    void on_lineEdit_script_name_editingFinished();
 };
 
 #endif // MUDLET_DLGSCRIPTSMAINAREA_H

--- a/src/dlgScriptsMainArea.h
+++ b/src/dlgScriptsMainArea.h
@@ -37,7 +37,7 @@ public:
     dlgScriptsMainArea(QWidget*);
     void trimName();
 private slots:
-    void on_lineEdit_script_name_editingFinished();
+    void slot_editing_name_finished();
 };
 
 #endif // MUDLET_DLGSCRIPTSMAINAREA_H

--- a/src/dlgTimersMainArea.cpp
+++ b/src/dlgTimersMainArea.cpp
@@ -27,3 +27,13 @@ dlgTimersMainArea::dlgTimersMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 }
+
+void dlgTimersMainArea::trimName()
+{
+    lineEdit_timer_name->setText(lineEdit_timer_name->text().trimmed());
+}
+
+void dlgTimersMainArea::on_lineEdit_timer_name_editingFinished()
+{
+    trimName();
+}

--- a/src/dlgTimersMainArea.cpp
+++ b/src/dlgTimersMainArea.cpp
@@ -26,6 +26,8 @@ dlgTimersMainArea::dlgTimersMainArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog
     setupUi(this);
+
+    connect(lineEdit_timer_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
 }
 
 void dlgTimersMainArea::trimName()
@@ -33,7 +35,7 @@ void dlgTimersMainArea::trimName()
     lineEdit_timer_name->setText(lineEdit_timer_name->text().trimmed());
 }
 
-void dlgTimersMainArea::on_lineEdit_timer_name_editingFinished()
+void dlgTimersMainArea::slot_editing_name_finished()
 {
     trimName();
 }

--- a/src/dlgTimersMainArea.cpp
+++ b/src/dlgTimersMainArea.cpp
@@ -27,7 +27,7 @@ dlgTimersMainArea::dlgTimersMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_timer_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
+    connect(lineEdit_timer_name, SIGNAL(editingFinished()), this, SLOT(slot_editing_name_finished()));
 }
 
 void dlgTimersMainArea::trimName()

--- a/src/dlgTimersMainArea.h
+++ b/src/dlgTimersMainArea.h
@@ -37,7 +37,7 @@ public:
     dlgTimersMainArea(QWidget*);
     void trimName();
 private slots:
-    void on_lineEdit_timer_name_editingFinished();
+    void slot_editing_name_finished();
 };
 
 #endif // MUDLET_DLGTIMERSMAINAREA_H

--- a/src/dlgTimersMainArea.h
+++ b/src/dlgTimersMainArea.h
@@ -35,6 +35,9 @@ class dlgTimersMainArea : public QWidget, public Ui::timers_main_area
 
 public:
     dlgTimersMainArea(QWidget*);
+    void trimName();
+private slots:
+    void on_lineEdit_timer_name_editingFinished();
 };
 
 #endif // MUDLET_DLGTIMERSMAINAREA_H

--- a/src/dlgTimersMainArea.h
+++ b/src/dlgTimersMainArea.h
@@ -35,6 +35,9 @@ class dlgTimersMainArea : public QWidget, public Ui::timers_main_area
 
 public:
     dlgTimersMainArea(QWidget*);
+
+    // public function allow to trim even when QLineEdit::editingFinished()
+    // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
 private slots:
     void slot_editing_name_finished();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3886,6 +3886,7 @@ void dlgTriggerEditor::saveTrigger()
         return;
     }
 
+    mpTriggersMainArea->trimName();
     QString name = mpTriggersMainArea->lineEdit_trigger_name->text();
     QString command = mpTriggersMainArea->lineEdit_trigger_command->text();
     bool isMultiline = mpTriggersMainArea->checkBox_multlinetrigger->isChecked();
@@ -4035,6 +4036,8 @@ void dlgTriggerEditor::saveTimer()
     if (!pItem) {
         return;
     }
+
+    mpTimersMainArea->trimName();
     QString name = mpTimersMainArea->lineEdit_timer_name->text();
     QString script = mpSourceEditorEdbeeDocument->text();
 
@@ -4107,6 +4110,7 @@ void dlgTriggerEditor::saveAlias()
         return;
     }
 
+    mpAliasMainArea->trimName();
     QString name = mpAliasMainArea->lineEdit_alias_name->text();
     QString regex = mpAliasMainArea->lineEdit_alias_pattern->text();
     if ((name.size() < 1) || (name == "New Alias")) {
@@ -4347,6 +4351,8 @@ void dlgTriggerEditor::saveScript()
     }
 
     QString old_name;
+
+    mpScriptsMainArea->trimName();
     QString name = mpScriptsMainArea->lineEdit_script_name->text();
     QString script = mpSourceEditorEdbeeDocument->text();
     mpScriptsMainAreaEditHandlerItem = nullptr;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6869,6 +6869,7 @@ void dlgTriggerEditor::slot_script_main_area_delete_handler()
 
 void dlgTriggerEditor::slot_script_main_area_add_handler()
 {
+    mpScriptsMainArea->trimEventHandlerName();
     if (mIsScriptsMainAreaEditHandler) {
         if (!mpScriptsMainAreaEditHandlerItem) {
             mIsScriptsMainAreaEditHandler = false;

--- a/src/dlgTriggersMainArea.cpp
+++ b/src/dlgTriggersMainArea.cpp
@@ -26,6 +26,8 @@ dlgTriggersMainArea::dlgTriggersMainArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog
     setupUi(this);
+
+    connect(lineEdit_trigger_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
 }
 
 void dlgTriggersMainArea::trimName()
@@ -33,7 +35,7 @@ void dlgTriggersMainArea::trimName()
     lineEdit_trigger_name->setText(lineEdit_trigger_name->text().trimmed());
 }
 
-void dlgTriggersMainArea::on_lineEdit_trigger_name_editingFinished()
+void dlgTriggersMainArea::slot_editing_name_finished()
 {
     trimName();
 }

--- a/src/dlgTriggersMainArea.cpp
+++ b/src/dlgTriggersMainArea.cpp
@@ -27,3 +27,13 @@ dlgTriggersMainArea::dlgTriggersMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 }
+
+void dlgTriggersMainArea::trimName()
+{
+    lineEdit_trigger_name->setText(lineEdit_trigger_name->text().trimmed());
+}
+
+void dlgTriggersMainArea::on_lineEdit_trigger_name_editingFinished()
+{
+    trimName();
+}

--- a/src/dlgTriggersMainArea.cpp
+++ b/src/dlgTriggersMainArea.cpp
@@ -27,7 +27,7 @@ dlgTriggersMainArea::dlgTriggersMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_trigger_name, &QLineEdit::editingFinished, this, slot_editing_name_finished);
+    connect(lineEdit_trigger_name, SIGNAL(editingFinished()), this, SLOT(slot_editing_name_finished()));
 }
 
 void dlgTriggersMainArea::trimName()

--- a/src/dlgTriggersMainArea.h
+++ b/src/dlgTriggersMainArea.h
@@ -35,6 +35,9 @@ class dlgTriggersMainArea : public QWidget, public Ui::trigger_main_area
 
 public:
     dlgTriggersMainArea(QWidget*);
+
+    // public function allow to trim even when QLineEdit::editingFinished()
+    // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
 private slots:
     void slot_editing_name_finished();

--- a/src/dlgTriggersMainArea.h
+++ b/src/dlgTriggersMainArea.h
@@ -35,6 +35,9 @@ class dlgTriggersMainArea : public QWidget, public Ui::trigger_main_area
 
 public:
     dlgTriggersMainArea(QWidget*);
+    void trimName();
+private slots:
+    void on_lineEdit_trigger_name_editingFinished();
 };
 
 #endif // MUDLET_DLGTRIGGERSMAINAREA_H

--- a/src/dlgTriggersMainArea.h
+++ b/src/dlgTriggersMainArea.h
@@ -37,7 +37,7 @@ public:
     dlgTriggersMainArea(QWidget*);
     void trimName();
 private slots:
-    void on_lineEdit_trigger_name_editingFinished();
+    void slot_editing_name_finished();
 };
 
 #endif // MUDLET_DLGTRIGGERSMAINAREA_H


### PR DESCRIPTION
The save function do trim the name before saving. 
This happens in the relative `QLineEdit editingFinished` slot as well, in an attempt to alleviate the copy/paste issue before saving as reported in issue #1119 

I'm not sure this solution respects the project standard so please, double-check and let me know.