### PR TITLE
Up libzip requirement to 1.x for Unicode support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     - sourceline: 'ppa:beineri/opt-qt562-trusty'
     - sourceline: 'ppa:beineri/opt-qt591-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
+    - sourceline: 'ppa:jonathonf/php7'
     packages:
     - qt56base
     - qt56multimedia
@@ -23,7 +24,7 @@ addons:
     - liblua5.1-0-dev
     - libboost-graph1.55-dev
     - zlib1g-dbg
-    - libzip-dev
+    - libzip
     - libpulse-dev
     - libyajl-dev
     - gcc-5 g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
     - liblua5.1-0-dev
     - libboost-graph1.55-dev
     - zlib1g-dbg
-    - libzip
+    - libzip-dev
     - libpulse-dev
     - libyajl-dev
     - gcc-5 g++-5

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -11,7 +11,7 @@ if ("$Env:QT_BASE_DIR" -eq "C:\Qt\5.6\mingw49_32") {
   COPY C:\src\lua-5.1.5\lua-5.1.5\src\lua51.dll .
   COPY C:\src\openssl-1.0.2l\libeay32.dll .
   COPY C:\src\openssl-1.0.2l\ssleay32.dll .
-  COPY $Env:MINGW_BASE_DIR\bin\libzip-2.dll .
+  COPY $Env:MINGW_BASE_DIR\bin\libzip-5.dll .
   COPY $Env:MINGW_BASE_DIR\bin\libhunspell-1.4-0.dll .
   COPY $Env:MINGW_BASE_DIR\bin\libpcre-1.dll .
   COPY $Env:MINGW_BASE_DIR\bin\libsqlite3-0.dll .

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -143,9 +143,9 @@ function InstallZlib() {
 }
 
 function InstallLibzip() {
-  DownloadFile "https://launchpad.net/ubuntu/+archive/primary/+files/libzip_0.11.2.orig.tar.gz" "libzip_0.11.2.orig.tar.gz"
-  ExtractTar "libzip_0.11.2.orig.tar.gz" "libzip"
-  Set-Location libzip\libzip-0.11.2
+  DownloadFile "https://libzip.org/download/libzip-1.3.0.tar.gz" "libzip-1.3.0.tar.gz"
+  ExtractTar "libzip-1.3.0.tar.gz" "libzip"
+  Set-Location libzip\libzip-1.3.0
   RunConfigure
   RunMake
   RunMakeInstall


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added a [random PPA](https://launchpad.net/~jonathonf/+archive/ubuntu/php7?field.series_filter=trusty) I found that has a newer libzip. I'm not certain if it has the development headers, however.

#### Motivation for adding to Mudlet
We need the ZIP_FL_ENC_UTF_8 flag to support encoding i18n names for 4.0.

#### Other info (issues closed, discussion etc)
Addresses issues @SlySven's been running into [here](https://gitter.im/Mudlet/Mudlet?at=59e252ac614889d475b4ef74) and [here](https://github.com/Mudlet/Mudlet/pull/1355#issuecomment-339213256).