### PR TITLE
Remove duplicate setExit() from mudlet-lua

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -545,32 +545,6 @@ function getColorWildcard(color)
         return results[1] and results or false
 end
 
-
-do
-	local oldsetExit = setExit
-
-	local exitmap = {
-	  n = 1,
-	  ne = 2,
-	  nw = 3,
-	  e = 4,
-	  w = 5,
-	  s = 6,
-	  se = 7,
-	  sw = 8,
-	  u = 9,
-	  d = 10,
-	  ["in"] = 11,
-	  out = 12
-	}
-
-	function setExit(from, to, direction)
-	  if type(direction) == "string" and not exitmap[direction] then return false end
-
-	  return oldsetExit(from, to, type(direction) == "string" and exitmap[direction] or direction)
-	end
-end
-
 do
 	local oldlockExit = lockExit
 	local oldhasExitLock = hasExitLock


### PR DESCRIPTION
As per #835, some tests were made that show `setExit()` is no longer needed in mudlet-lua. After removing the duplicate code and testing the function in Mudlet, these were the results:

```
lua addRoom(createRoomID())
true

lua addRoom(createRoomID())
true

lua getRooms()
{
  "",
  ""
}

lua setRoomName(1, "Room One")
true

lua getRooms()
{
  "Room One",
  ""
}
lua setRoomName(2, "Room Two")
true

lua getRoomExits(1)
{}
lua getRoomExits(2)
{}
lua setExit(1, 2, "south")
true

lua getRoomExits(1)
{
  south = 2
}
lua setExit(2, 1, "north")
true

lua getRoomExits(1)
{
  south = 2
}
lua getRoomExits(2)
{
  north = 1
}

lua addRoom(createRoomID())
true

lua setRoomName(3, "Room Three")
true

lua setExit(1, 3, "e")
true

lua setExit(3, 1, "d")
true

lua getRoomExits(1)
{
  east = 3,
  south = 2
}
lua getRoomExits(3)
{
  down = 1
}

lua addRoom(createRoomID())
true

lua setRoomName(4, "Room Four")
true

lua setExit(1, 4, 9)
true

lua setExit(4, 1, 2)
true

lua getRoomExits(1)
{
  up = 4,
  east = 3,
  south = 2
}
lua getRoomExits(4)
{
  northeast = 1
}
```