### PR TITLE
Removed unnecessary null check

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -152,9 +152,7 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
 
     if (pNewParent) {
         pNewParent->Tree<TAction>::addChild(pChild, parentPosition, childPosition);
-        if (pChild) {
-            pChild->Tree<TAction>::setParent(pNewParent);
-        }
+        pChild->Tree<TAction>::setParent(pNewParent);
         pChild->setDataChanged();
         pNewParent->setDataChanged();
         //cout << "dumping family of newParent:"<<endl;

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -124,9 +124,7 @@ void AliasUnit::reParentAlias(int childID, int oldParentID, int newParentID, int
     }
     if (pNewParent) {
         pNewParent->addChild(pChild, parentPosition, childPosition);
-        if (pChild) {
-            pChild->setParent(pNewParent);
-        }
+        pChild->setParent(pNewParent);
         //cout << "dumping family of newParent:"<<endl;
         //pNewParent->Dump();
     } else {

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -174,9 +174,7 @@ void KeyUnit::reParentKey(int childID, int oldParentID, int newParentID, int par
     }
     if (pNewParent) {
         pNewParent->addChild(pChild, parentPosition, childPosition);
-        if (pChild) {
-            pChild->setParent(pNewParent);
-        }
+        pChild->setParent(pNewParent);
         //cout << "dumping family of newParent:"<<endl;
         //pNewParent->Dump();
     } else {

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -105,9 +105,7 @@ void ScriptUnit::reParentScript(int childID, int oldParentID, int newParentID, i
     }
     if (pNewParent) {
         pNewParent->addChild(pChild, parentPosition, childPosition);
-        if (pChild) {
-            pChild->setParent(pNewParent);
-        }
+        pChild->setParent(pNewParent);
         //cout << "dumping family of newParent:"<<endl;
         //pNewParent->Dump();
     } else {

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -123,9 +123,7 @@ void TimerUnit::reParentTimer(int childID, int oldParentID, int newParentID, int
     }
     if (pNewParent) {
         pNewParent->addChild(pChild, parentPosition, childPosition);
-        if (pChild) {
-            pChild->setParent(pNewParent);
-        }
+        pChild->setParent(pNewParent);
     } else {
         pChild->Tree<TTimer>::setParent(nullptr);
         addTimerRootNode(pChild, parentPosition, childPosition);

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -125,9 +125,7 @@ void TriggerUnit::reParentTrigger(int childID, int oldParentID, int newParentID,
     }
     if (pNewParent) {
         pNewParent->addChild(pChild, parentPosition, childPosition);
-        if (pChild) {
-            pChild->setParent(pNewParent);
-        }
+        pChild->setParent(pNewParent);
     } else {
         pChild->Tree<TTrigger>::setParent(nullptr);
         addTriggerRootNode(pChild, parentPosition, childPosition, true);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removed unnecessary null check, it was confusing the static analyser:
```
Logic error: Called C++ object pointer is null
 1: Assuming 'pChild' is non-null in /home/vadi/Programs/Mudlet/mudlet/src/TimerUnit.cpp:112
 2: Value assigned to 'pChild' in /home/vadi/Programs/Mudlet/mudlet/src/TimerUnit.cpp:122
 3: Assuming 'pNewParent' is non-null in /home/vadi/Programs/Mudlet/mudlet/src/TimerUnit.cpp:124
 4: Assuming 'pChild' is null in /home/vadi/Programs/Mudlet/mudlet/src/TimerUnit.cpp:126
 5: Called C++ object pointer is null in /home/vadi/Programs/Mudlet/mudlet/src/TimerUnit.cpp:134
```

Line 4 is will never happen since it's guarded by TimerUnit.cpp:112.

#### Motivation for adding to Mudlet
Less warnings in the analyser the better.

#### Other info (issues closed, discussion etc)
