### PR TITLE
Fix untinitialised scalar value

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -762,6 +762,8 @@ TBuffer::TBuffer(Host* pH)
 , maxy()
 , hadLF()
 , mCode()
+, lastLoggedFromLine(0)
+, lastloggedToLine(0)
 {
     clear();
     newLines = 0;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
I forgot to initialise the two new variables, added them to the constructor.

#### Motivation for adding to Mudlet
Less Coverity warnings.

#### Other info (issues closed, discussion etc)
