### PR TITLE
Enhance: add Coverity Badge to collection...! [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Mudlet
 
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true)](https://ci.appveyor.com/project/Mudlet/mudlet/branch/development) [![GitHub Build Status](https://travis-ci.org/Mudlet/Mudlet.svg?branch=development)](https://travis-ci.org/Mudlet/Mudlet) [![GitHub stars](https://img.shields.io/github/stars/Mudlet/Mudlet.svg)](https://github.com/Mudlet/Mudlet/stargazers) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Mudlet/Mudlet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true)](https://ci.appveyor.com/project/Mudlet/mudlet/branch/development) [![GitHub Build Status](https://travis-ci.org/Mudlet/Mudlet.svg?branch=development)](https://travis-ci.org/Mudlet/Mudlet) [![GitHub stars](https://img.shields.io/github/stars/Mudlet/Mudlet.svg)](https://github.com/Mudlet/Mudlet/stargazers) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Mudlet/Mudlet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Coverity Scan Build Status](https://scan.coverity.com/projects/11955/badge.svg)](https://scan.coverity.com/projects/mudlet-mudlet?tab=overview)
 
 Mudlet is a quality MUD client, designed to take mudding to a new level.
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -477,7 +477,7 @@ OTHER_FILES += \
     ${LUA.files} \
     ${LUA_GEYSER.files} \
     ${DISTFILES} \
-    ../README \
+    ../README.md \
     ../COMPILE \
     ../COPYING \
     ../Doxyfile \


### PR DESCRIPTION
Since we have been added other badges, why not this one!

Note that since this is a non-code change I have set it not to invoke the CI stages - however I think this means it will need an Admin to allow it to be merged without CI pass reports!

Have also taken the liberty of emending the non-existent README entry in the list in the qmake project file under "Other files" to README.md so that the file edited herein can be seen and edited from within Qt Creator easily.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>