### PR TITLE
BugFix: Coverity 1415093 Using invalid iterator

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -842,25 +842,28 @@ int TLuaInterpreter::selectCaptureGroup(lua_State* L)
         lua_pushnumber(L, -1);
         return 1;
     }
-    luaNumOfMatch--; //we want capture groups to start with 1 instead of 0
-    if (luaNumOfMatch < static_cast<int>(host.getLuaInterpreter()->mCaptureGroupList.size())) {
+    // We want capture groups to start with 1 instead of 0 so predecrement
+    // luaNumOfMatch :
+    if (--luaNumOfMatch < static_cast<int>(host.getLuaInterpreter()->mCaptureGroupList.size())) {
         TLuaInterpreter* pL = host.getLuaInterpreter();
         auto iti = pL->mCaptureGroupPosList.begin();
         auto its = pL->mCaptureGroupList.begin();
+        int begin = *iti;
+        std::string& s = *its;
 
         for (int i = 0; iti != pL->mCaptureGroupPosList.end(); ++iti, ++i) {
+            begin = *iti;
             if (i >= luaNumOfMatch) {
                 break;
             }
         }
         for (int i = 0; its != pL->mCaptureGroupList.end(); ++its, ++i) {
+            s = *its;
             if (i >= luaNumOfMatch) {
                 break;
             }
         }
 
-        int begin = *iti;
-        std::string& s = *its;
         int length = s.size();
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::white), QColor(Qt::red)) << "selectCaptureGroup(" << begin << ", " << length << ")\n" >> 0;


### PR DESCRIPTION
This commit should address the above issue in:
`(int) TLuaInterpreter::selectCaptureGroup(lua_State*)`

See [Coverity-1415093](https://scan7.coverity.com/reports.htm#v27731/p14359/fileInstanceId=38807018&defectInstanceId=8378731&mergedDefectId=1415093)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>