### PR TITLE
BugFix: Coverity 1459636 Unchecked return value

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -764,7 +764,6 @@ bool XMLexport::exportToClipboard(TTrigger* pT)
         return false;
     }
 
-    writeStartDocument();
     writeDTD("<!DOCTYPE MudletPackage>");
 
     writeStartElement("MudletPackage");
@@ -1022,6 +1021,7 @@ bool XMLexport::exportToClipboard(TAction* pT)
     QClipboard* cb = QApplication::clipboard();
     cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
 
+    xmlBuffer.close();
     return true;
 }
 
@@ -1238,6 +1238,7 @@ bool XMLexport::exportToClipboard(TScript* pT)
     QClipboard* cb = QApplication::clipboard();
     cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
 
+    xmlBuffer.close();
     return true;
 }
 
@@ -1340,6 +1341,7 @@ bool XMLexport::exportToClipboard(TKey* pT)
     QClipboard* cb = QApplication::clipboard();
     cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
 
+    xmlBuffer.close();
     return true;
 }
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -750,15 +750,19 @@ bool XMLexport::exportTrigger(QIODevice* device)
 
 bool XMLexport::exportToClipboard(TTrigger* pT)
 {
-    setAutoFormatting(true);
+    // The use of pT is a cludge - it was already used in the previously invoked
+    // in this XMLexport instance's constructor (and stored in mpTrigger) and it
+    // is only used here for its signature.
+    Q_UNUSED(pT);
 
-    QClipboard* cb = QApplication::clipboard();
-
-    QByteArray ba = "";
-    QBuffer xmlBuffer(&ba);
-
-    setDevice(&xmlBuffer);
+    QBuffer xmlBuffer;
     xmlBuffer.open(QIODevice::WriteOnly);
+
+    writeStartDocument();
+    if (hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
 
     writeStartDocument();
     writeDTD("<!DOCTYPE MudletPackage>");
@@ -767,14 +771,21 @@ bool XMLexport::exportToClipboard(TTrigger* pT)
     writeAttribute(QStringLiteral("version"), mudlet::self()->scmMudletXmlDefaultVersion);
 
     writeStartElement("TriggerPackage");
-    writeTrigger(mpTrigger);
+    bool isOk = writeTrigger(mpTrigger);
     writeEndElement(); //TriggerPackage
 
     writeEndElement(); //MudletPackage
     writeEndDocument();
 
-    cb->setText(QString(ba), QClipboard::Clipboard);
-    setAutoFormatting(false);
+    if (!isOk || hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
+
+    QClipboard* cb = QApplication::clipboard();
+    cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
+
+    xmlBuffer.close();
     return true;
 }
 
@@ -850,7 +861,6 @@ bool XMLexport::writeTrigger(TTrigger* pT)
     return (isOk && (!hasError()));
 }
 
-
 bool XMLexport::exportAlias(QIODevice* device)
 {
     setDevice(device);
@@ -877,18 +887,19 @@ bool XMLexport::exportAlias(QIODevice* device)
 
 bool XMLexport::exportToClipboard(TAlias* pT)
 {
-    setAutoFormatting(true);
+    // The use of pT is a cludge - it was already used in the previously invoked
+    // in this XMLexport instance's constructor (and stored in mpAlias) and it
+    // is only used here for its signature.
+    Q_UNUSED(pT);
 
-    QClipboard* cb = QApplication::clipboard();
+    // autoFormatting is set to true in constructor
 
-    QByteArray ba = "";
-    QBuffer xmlBuffer(&ba);
-
-    setDevice(&xmlBuffer);
+    QBuffer xmlBuffer;
     xmlBuffer.open(QIODevice::WriteOnly);
 
     writeStartDocument();
     if (hasError()) {
+        xmlBuffer.close();
         return false;
     }
 
@@ -904,10 +915,16 @@ bool XMLexport::exportToClipboard(TAlias* pT)
     writeEndElement(); // </MudletPackage>
     writeEndDocument();
 
-    cb->setText(QString(ba), QClipboard::Clipboard);
-    setAutoFormatting(false);
+    if (!isOk || hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
 
-    return (isOk && (!hasError()));
+    QClipboard* cb = QApplication::clipboard();
+    cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
+
+    xmlBuffer.close();
+    return true;
 }
 
 bool XMLexport::writeAlias(TAlias* pT)
@@ -969,18 +986,19 @@ bool XMLexport::exportAction(QIODevice* device)
 
 bool XMLexport::exportToClipboard(TAction* pT)
 {
-    setAutoFormatting(true);
+    // The use of pT is a cludge - it was already used in the previously invoked
+    // in this XMLexport instance's constructor (and stored in mpAction) and it
+    // is only used here for its signature.
+    Q_UNUSED(pT);
 
-    QClipboard* cb = QApplication::clipboard();
+    // autoFormatting is set to true in constructor
 
-    QByteArray ba = "";
-    QBuffer xmlBuffer(&ba);
-
-    setDevice(&xmlBuffer);
+    QBuffer xmlBuffer;
     xmlBuffer.open(QIODevice::WriteOnly);
 
     writeStartDocument();
     if (hasError()) {
+        xmlBuffer.close();
         return false;
     }
 
@@ -996,10 +1014,15 @@ bool XMLexport::exportToClipboard(TAction* pT)
     writeEndElement(); // </MudletPackage>
     writeEndDocument();
 
-    cb->setText(QString(ba), QClipboard::Clipboard);
-    setAutoFormatting(false);
+    if (!isOk || hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
 
-    return (isOk && (!hasError()));
+    QClipboard* cb = QApplication::clipboard();
+    cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
+
+    return true;
 }
 
 bool XMLexport::writeAction(TAction* pT)
@@ -1078,18 +1101,19 @@ bool XMLexport::exportTimer(QIODevice* device)
 
 bool XMLexport::exportToClipboard(TTimer* pT)
 {
-    setAutoFormatting(true);
+    // The use of pT is a cludge - it was already used in the previously invoked
+    // in this XMLexport instance's constructor (and stored in mpTimer) and it
+    // is only used here for its signature.
+    Q_UNUSED(pT);
 
-    QClipboard* cb = QApplication::clipboard();
+    // autoFormatting is set to true in constructor
 
-    QByteArray ba = "";
-    QBuffer xmlBuffer(&ba);
-
-    setDevice(&xmlBuffer);
+    QBuffer xmlBuffer;
     xmlBuffer.open(QIODevice::WriteOnly);
 
     writeStartDocument();
     if (hasError()) {
+        xmlBuffer.close();
         return false;
     }
 
@@ -1105,10 +1129,16 @@ bool XMLexport::exportToClipboard(TTimer* pT)
     writeEndElement(); // </MudletPackage>
     writeEndDocument();
 
-    cb->setText(QString(ba), QClipboard::Clipboard);
-    setAutoFormatting(false);
+    if (!isOk || hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
 
-    return (isOk && (!hasError()));
+    QClipboard* cb = QApplication::clipboard();
+    cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
+
+    xmlBuffer.close();
+    return true;
 }
 
 bool XMLexport::writeTimer(TTimer* pT)
@@ -1146,7 +1176,6 @@ bool XMLexport::writeTimer(TTimer* pT)
     return (isOk && (!hasError()));
 }
 
-
 bool XMLexport::exportScript(QIODevice* device)
 {
     setDevice(device);
@@ -1173,18 +1202,19 @@ bool XMLexport::exportScript(QIODevice* device)
 
 bool XMLexport::exportToClipboard(TScript* pT)
 {
-    setAutoFormatting(true);
+    // The use of pT is a cludge - it was already used in the previously invoked
+    // in this XMLexport instance's constructor (and stored in mpScript) and it
+    // is only used here for its signature.
+    Q_UNUSED(pT);
 
-    QClipboard* cb = QApplication::clipboard();
+    // autoFormatting is set to true in constructor
 
-    QByteArray ba = "";
-    QBuffer xmlBuffer(&ba);
-
-    setDevice(&xmlBuffer);
+    QBuffer xmlBuffer;
     xmlBuffer.open(QIODevice::WriteOnly);
 
     writeStartDocument();
     if (hasError()) {
+        xmlBuffer.close();
         return false;
     }
 
@@ -1200,10 +1230,15 @@ bool XMLexport::exportToClipboard(TScript* pT)
     writeEndElement(); // </MudletPackage>
     writeEndDocument();
 
-    cb->setText(QString(ba), QClipboard::Clipboard);
-    setAutoFormatting(false);
+    if (!isOk || hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
 
-    return (isOk && (!hasError()));
+    QClipboard* cb = QApplication::clipboard();
+    cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
+
+    return true;
 }
 
 bool XMLexport::writeScript(TScript* pT)
@@ -1243,7 +1278,6 @@ bool XMLexport::writeScript(TScript* pT)
     return (isOk && (!hasError()));
 }
 
-
 bool XMLexport::exportKey(QIODevice* device)
 {
     setDevice(device);
@@ -1270,18 +1304,19 @@ bool XMLexport::exportKey(QIODevice* device)
 
 bool XMLexport::exportToClipboard(TKey* pT)
 {
-    setAutoFormatting(true);
+    // The use of pT is a cludge - it was already used in the previously invoked
+    // in this XMLexport instance's constructor (and stored in mpKey) and it
+    // is only used here for its signature.
+    Q_UNUSED(pT);
 
-    QClipboard* cb = QApplication::clipboard();
+    // autoFormatting is set to true in constructor
 
-    QByteArray ba = "";
-    QBuffer xmlBuffer(&ba);
-
-    setDevice(&xmlBuffer);
+    QBuffer xmlBuffer;
     xmlBuffer.open(QIODevice::WriteOnly);
 
     writeStartDocument();
     if (hasError()) {
+        xmlBuffer.close();
         return false;
     }
 
@@ -1297,10 +1332,15 @@ bool XMLexport::exportToClipboard(TKey* pT)
     writeEndElement(); // </MudletPackage>
     writeEndDocument();
 
-    cb->setText(QString(ba), QClipboard::Clipboard);
-    setAutoFormatting(false);
+    if (!isOk || hasError()) {
+        xmlBuffer.close();
+        return false;
+    }
 
-    return (isOk && (!hasError()));
+    QClipboard* cb = QApplication::clipboard();
+    cb->setText(QString(xmlBuffer.buffer()), QClipboard::Clipboard);
+
+    return true;
 }
 
 bool XMLexport::writeKey(TKey* pT)


### PR DESCRIPTION
This commit should address the above issue in:
`(bool) XMLexport::exportToClipboard(TTrigger*)`

It also removes some unneeded bits of code in that and the other `exportToClipboard(`...`)` methods and adds explicit `close()` calls for the temporary `QBuffer` entities created.

See [Coverity-1459636](https://scan7.coverity.com/reports.htm#v27731/p14359/fileInstanceId=38807038&defectInstanceId=8378712&mergedDefectId=1459636)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>