### PR TITLE
Added prompt pattern type trigger

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -412,8 +412,8 @@ public:
     static int getServerEncoding(lua_State*);
     static int getServerEncodingsList(lua_State*);
     static int alert(lua_State* L);
-    static int tempPromptTrigger(lua_State* L);
-    static int permPromptTrigger(lua_State* L);
+    static int tempPromptTrigger(lua_State*);
+    static int permPromptTrigger(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 public slots:

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -109,6 +109,7 @@ public:
     int startTempLineTrigger(int, int, const QString&);
     int startTempRegexTrigger(const QString&, const QString&);
     int startTempColorTrigger(int, int, const QString&);
+    int startTempPromptTrigger(const QString& function);
     int startPermRegexTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
     int startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& regex, const QString& function);
     int startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
@@ -406,11 +407,12 @@ public:
     static int setDefaultAreaVisible(lua_State*);
     static int getProfileName(lua_State*);
     static int raiseGlobalEvent(lua_State*);
-    static int setServerEncoding(lua_State *);
-    static int getServerEncoding(lua_State *);
-    static int getServerEncodingsList(lua_State *);
+    static int setServerEncoding(lua_State*);
+    static int getServerEncoding(lua_State*);
+    static int getServerEncodingsList(lua_State*);
     static int alert(lua_State* L);
-// PLACEMARKER: End of Lua functions declarations
+    static int tempPromptTrigger(lua_State* L);
+    // PLACEMARKER: End of Lua functions declarations
 
 public slots:
     void slot_replyFinished(QNetworkReply*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -113,9 +113,10 @@ public:
     int startPermRegexTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
     int startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& regex, const QString& function);
     int startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
+    int startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
     int startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
     int startPermAlias(const QString& name, const QString& parent, const QString& regex, const QString& function);
-    int startPermKey(QString&, QString&, int &, int &, QString&);
+    int startPermKey(QString&, QString&, int&, int&, QString&);
 
     static int getCustomLines(lua_State*);
     static int addCustomLine(lua_State*);
@@ -412,6 +413,7 @@ public:
     static int getServerEncodingsList(lua_State*);
     static int alert(lua_State* L);
     static int tempPromptTrigger(lua_State* L);
+    static int permPromptTrigger(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 public slots:

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -160,7 +160,7 @@ bool TTrigger::setRegexCodeList(QStringList regexList, QList<int> propertyList)
     bool state = true;
 
     for (int i = 0; i < regexList.size(); i++) {
-        if (regexList[i].size() < 1) {
+        if (regexList[i].isEmpty() && propertyList.at(i) != REGEX_PROMPT) {
             continue;
         }
 
@@ -750,6 +750,24 @@ bool TTrigger::match_lua_code(int regexNumber)
     return false;
 }
 
+bool TTrigger::match_prompt(int patternNumber)
+{
+    if (mpHost->mpConsole->mIsPromptLine) {
+        if (mudlet::debugMode) {
+            TDebug(QColor(Qt::yellow), QColor(Qt::black)) << "Trigger name=" << mName << "(" << mRegexCodeList.value(patternNumber) << ") matched.\n" >> 0;
+        }
+        if (mIsMultiline) {
+            std::list<std::string> captureList;
+            std::list<int> posList;
+            updateMultistates(patternNumber, captureList, posList);
+            return true;
+        }
+        execute();
+        return true;
+    }
+    return false;
+}
+
 bool TTrigger::match_exact_match(const QString& toMatch, const QString& line, int regexNumber, int posOffset)
 {
     QString text = toMatch;
@@ -837,38 +855,42 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
         }
 
         int size = mRegexCodePropertyList.size();
-        for (int i = 0;; i++) {
-            if (i >= size) {
+        for (int patternNumber = 0;; patternNumber++) {
+            if (patternNumber >= size) {
                 break;
             }
             ret = false;
-            switch (mRegexCodePropertyList.value(i)) {
+            switch (mRegexCodePropertyList.value(patternNumber)) {
             case REGEX_SUBSTRING:
-                ret = match_substring(toMatch, mRegexCodeList[i], i, posOffset);
+                ret = match_substring(toMatch, mRegexCodeList[patternNumber], patternNumber, posOffset);
                 break;
 
             case REGEX_PERL:
-                ret = match_perl(subject, toMatch, i, posOffset);
+                ret = match_perl(subject, toMatch, patternNumber, posOffset);
                 break;
 
             case REGEX_BEGIN_OF_LINE_SUBSTRING:
-                ret = match_begin_of_line_substring(toMatch, mRegexCodeList[i], i, posOffset);
+                ret = match_begin_of_line_substring(toMatch, mRegexCodeList[patternNumber], patternNumber, posOffset);
                 break;
 
             case REGEX_EXACT_MATCH:
-                ret = match_exact_match(toMatch, mRegexCodeList[i], i, posOffset);
+                ret = match_exact_match(toMatch, mRegexCodeList[patternNumber], patternNumber, posOffset);
                 break;
 
             case REGEX_LUA_CODE:
-                ret = match_lua_code(i);
+                ret = match_lua_code(patternNumber);
                 break;
 
             case REGEX_LINE_SPACER:
-                ret = match_line_spacer(i);
+                ret = match_line_spacer(patternNumber);
                 break;
 
             case REGEX_COLOR_PATTERN:
-                ret = match_color_pattern(line, i);
+                ret = match_color_pattern(line, patternNumber);
+                break;
+
+            case REGEX_PROMPT:
+                ret = match_prompt(patternNumber);
                 break;
             }
             // policy: one match is enough to fire on OR-trigger, but in the case of
@@ -880,7 +902,7 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
                     break;
                 }
             } else {
-                if ((!ret) && (i >= highestCondition)) {
+                if ((!ret) && (patternNumber >= highestCondition)) {
                     break;
                 }
             }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -160,7 +160,7 @@ bool TTrigger::setRegexCodeList(QStringList regexList, QList<int> propertyList)
     bool state = true;
 
     for (int i = 0; i < regexList.size(); i++) {
-        if (regexList[i].isEmpty() && propertyList.at(i) != REGEX_PROMPT) {
+        if (regexList.at(i).isEmpty() && propertyList.at(i) != REGEX_PROMPT) {
             continue;
         }
 

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -50,6 +50,7 @@ class TMatchState;
 #define REGEX_LUA_CODE 4
 #define REGEX_LINE_SPACER 5
 #define REGEX_COLOR_PATTERN 6
+#define REGEX_PROMPT 7
 
 #define OVECCOUNT 30 // should be a multiple of 3
 
@@ -116,6 +117,7 @@ public:
     bool match_lua_code(int);
     bool match_line_spacer(int regexNumber);
     bool match_color_pattern(int, int);
+    bool match_prompt(int patternNumber);
     void setConditionLineDelta(int delta) { mConditionLineDelta = delta; }
     int getConditionLineDelta() { return mConditionLineDelta; }
     bool registerTrigger();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -595,7 +595,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                      << "exact match"
                      << "Lua function"
                      << "line spacer"
-                     << "color trigger";
+                     << "color trigger"
+                     << "prompt";
         QComboBox* pBox = pItem->comboBox_patternType;
         pBox->addItems(_patternList);
         pBox->setItemData(0, QVariant(i));
@@ -607,6 +608,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         pItem->mRow = i;
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         pItem->label_patternNumber->setText(QString::number(i+1));
         pItem->label_patternNumber->show();
     }
@@ -3886,7 +3888,8 @@ void dlgTriggerEditor::saveTrigger()
     QList<int> regexPropertyList;
     for (int i = 0; i < 50; i++) {
         QString pattern = mTriggerPatternEdit.at(i)->lineEdit_pattern->text();
-        if (pattern.size() < 1) {
+        int patternType = mTriggerPatternEdit.at(i)->comboBox_patternType->currentIndex();
+        if (pattern.isEmpty() && patternType != REGEX_PROMPT) {
             continue;
         }
         regexList << pattern;
@@ -3912,6 +3915,9 @@ void dlgTriggerEditor::saveTrigger()
             break;
         case 6:
             regexPropertyList << REGEX_COLOR_PATTERN;
+            break;
+        case 7:
+            regexPropertyList << REGEX_PROMPT;
             break;
         }
     }
@@ -4757,42 +4763,56 @@ void dlgTriggerEditor::slot_set_pattern_type_color(int type)
         pItem->lineEdit_pattern->show();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         break;
     case 1:
         palette.setColor(QPalette::Text, QColor(Qt::blue));
         pItem->lineEdit_pattern->show();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         break;
     case 2:
         palette.setColor(QPalette::Text, QColor(195, 0, 0));
         pItem->lineEdit_pattern->show();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         break;
     case 3:
         palette.setColor(QPalette::Text, QColor(0, 195, 0));
         pItem->lineEdit_pattern->show();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         break;
     case 4:
         palette.setColor(QPalette::Text, QColor(0, 155, 155));
         pItem->lineEdit_pattern->show();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         break;
     case 5:
         palette.setColor(QPalette::Text, QColor(137, 0, 205));
         pItem->lineEdit_pattern->show();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->hide();
         break;
     case 6:
         palette.setColor(QPalette::Text, QColor(100, 100, 100));
         pItem->lineEdit_pattern->hide();
         pItem->pushButton_fgColor->show();
         pItem->pushButton_bgColor->show();
+        pItem->pushButton_prompt->hide();
+        break;
+    case 7:
+        palette.setColor(QPalette::Text, QColor(Qt::black));
+        pItem->lineEdit_pattern->hide();
+        pItem->pushButton_fgColor->hide();
+        pItem->pushButton_bgColor->hide();
+        pItem->pushButton_prompt->show();
         break;
     }
     pItem->lineEdit_pattern->setPalette(palette);
@@ -4846,6 +4866,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(0);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->hide();
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->show();
                 break;
             case REGEX_PERL:
@@ -4853,6 +4875,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(1);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->hide();
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->show();
                 break;
             case REGEX_BEGIN_OF_LINE_SUBSTRING:
@@ -4860,6 +4884,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(2);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->hide();
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->show();
                 break;
             case REGEX_EXACT_MATCH:
@@ -4867,6 +4893,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(3);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->hide();
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->show();
                 break;
             case REGEX_LUA_CODE:
@@ -4874,6 +4902,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(4);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->hide();
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->show();
                 break;
             case REGEX_LINE_SPACER:
@@ -4881,6 +4911,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(5);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->hide();
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->show();
                 break;
             case REGEX_COLOR_PATTERN:
@@ -4888,6 +4920,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(6);
                 pItem->pushButton_fgColor->show();
                 pItem->pushButton_bgColor->show();
+                pItem->pushButton_prompt->hide();
                 pItem->lineEdit_pattern->hide();
                 if (!pT->mColorPatternList[i]) {
                     break;
@@ -4895,11 +4928,19 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pItem->pushButton_fgColor->setStyleSheet(QStringLiteral("QPushButton{background-color: %1;}").arg(QColor(pT->mColorPatternList[i]->fgR, pT->mColorPatternList[i]->fgG, pT->mColorPatternList[i]->fgB).name()));
                 pItem->pushButton_bgColor->setStyleSheet(QStringLiteral("QPushButton{background-color: %1;}").arg(QColor(pT->mColorPatternList[i]->bgR, pT->mColorPatternList[i]->bgG, pT->mColorPatternList[i]->bgB).name()));
                 break;
+            case REGEX_PROMPT:
+                palette.setColor(QPalette::Text, QColor(Qt::gray));
+                pBox->setCurrentIndex(7);
+                pItem->pushButton_fgColor->hide();
+                pItem->pushButton_bgColor->hide();
+                pItem->pushButton_prompt->show();
+                pItem->lineEdit_pattern->hide();
+                break;
             }
 
             pItem->lineEdit_pattern->setPalette(palette);
-            pItem->lineEdit_pattern->setText(patternList[i]);
         }
+        // reset the rest of the patterns that don't have any data
         for (int i = patternList.size(); i < 50; i++) {
             mTriggerPatternEdit[i]->lineEdit_pattern->clear();
             if (mTriggerPatternEdit[i]->lineEdit_pattern->isHidden()) {
@@ -4907,6 +4948,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
             }
             mTriggerPatternEdit[i]->pushButton_fgColor->hide();
             mTriggerPatternEdit[i]->pushButton_bgColor->hide();
+            mTriggerPatternEdit[i]->pushButton_prompt->hide();
             mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(0);
         }
         // Scroll to the last used pattern:

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4812,6 +4812,13 @@ void dlgTriggerEditor::slot_set_pattern_type_color(int type)
         pItem->lineEdit_pattern->hide();
         pItem->pushButton_fgColor->hide();
         pItem->pushButton_bgColor->hide();
+        if (mpHost->mTelnet.mGA_Driver) {
+            pItem->pushButton_prompt->setText(tr("match on the prompt line"));
+            pItem->pushButton_prompt->setToolTip(QString());
+        } else {
+            pItem->pushButton_prompt->setText(tr("match on the prompt line (disabled)"));
+            pItem->pushButton_prompt->setToolTip(tr("A Go-Ahead (GA) signal from the game is required to make this feature work"));
+        }
         pItem->pushButton_prompt->show();
         break;
     }
@@ -4933,7 +4940,14 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pBox->setCurrentIndex(7);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();
-                pItem->pushButton_prompt->show();
+                    if (mpHost->mTelnet.mGA_Driver) {
+                        pItem->pushButton_prompt->setText(tr("match on the prompt line"));
+                        pItem->pushButton_prompt->setToolTip(QString());
+                    } else {
+                        pItem->pushButton_prompt->setText(tr("match on the prompt line (disabled)"));
+                        pItem->pushButton_prompt->setToolTip(tr("A Go-Ahead (GA) signal from the game is required to make this feature work"));
+                    }
+                    pItem->pushButton_prompt->show();
                 pItem->lineEdit_pattern->hide();
                 break;
             }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4929,7 +4929,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pItem->pushButton_bgColor->setStyleSheet(QStringLiteral("QPushButton{background-color: %1;}").arg(QColor(pT->mColorPatternList[i]->bgR, pT->mColorPatternList[i]->bgG, pT->mColorPatternList[i]->bgB).name()));
                 break;
             case REGEX_PROMPT:
-                palette.setColor(QPalette::Text, QColor(Qt::gray));
+                palette.setColor(QPalette::Text, QColor(Qt::black));
                 pBox->setCurrentIndex(7);
                 pItem->pushButton_fgColor->hide();
                 pItem->pushButton_bgColor->hide();

--- a/src/ui/trigger_pattern_edit.ui
+++ b/src/ui/trigger_pattern_edit.ui
@@ -26,7 +26,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -108,6 +117,33 @@
      </property>
      <property name="text">
       <string>Background Color</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_prompt">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>33</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>7</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>match on the prompt</string>
      </property>
     </widget>
    </item>

--- a/src/ui/trigger_pattern_edit.ui
+++ b/src/ui/trigger_pattern_edit.ui
@@ -143,7 +143,7 @@
       </font>
      </property>
      <property name="text">
-      <string>match on the prompt</string>
+      <string>match on the prompt line</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a `prompt` trigger pattern and `tempPromptTrigger()` Lua function.

#### Motivation for adding to Mudlet
Addresses https://github.com/Mudlet/Mudlet/issues/1353 as well as [feedback here](http://forums.achaea.com/discussion/comment/379459/#Comment_379459). 

tempPromptTrigger() was also a useful function, for example I had to define my own in in [Svof](https://svof.github.io/svof/#svo.prompttrigger).

#### Other info (issues closed, discussion etc)

Download preview Mudlet:
[Windows](https://ci.appveyor.com/api/buildjobs/4wi1ukxsyr1ihjo0/artifacts/src%2Fmudlet.zip)
[macOS](https://transfer.sh/7U9xZ/Mudlet-3.5.0-testing-PR1373-a554288.dmg)
[Linux](https://transfer.sh/auhil/Mudlet-3.5.0-testing-PR1373-a554288-linux-x64.AppImage.tar)
