### PR TITLE
Apply modernize-use-emplace

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -369,7 +369,7 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
                 if (!found) {
                     pTB = new TEasyButtonBar(rootAction, (*childActionIterator)->getName(), mpHost->mpConsole->mpTopToolBar);
                     mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
-                    mEasyButtonBarList.push_back(pTB);
+                    mEasyButtonBarList.emplace_back(pTB);
                     (*childActionIterator)->mpEasyButtonBar = pTB; // wird fuer drag&drop gebraucht
                 }
                 if ((*childActionIterator)->mOrientation == 1) {
@@ -394,7 +394,7 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
         if (!found) {
             pTB = new TEasyButtonBar(rootAction, rootAction->getName(), mpHost->mpConsole->mpTopToolBar);
             mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
-            mEasyButtonBarList.push_back(pTB);
+            mEasyButtonBarList.emplace_back(pTB);
             rootAction->mpEasyButtonBar = pTB; // wird fuer drag&drop gebraucht
         }
         if (rootAction->mOrientation == 1) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -445,7 +445,7 @@ bool TTrigger::match_begin_of_line_substring(const QString& toMatch, const QStri
     if (toMatch.startsWith(regex)) {
         std::list<std::string> captureList;
         std::list<int> posList;
-        captureList.push_back(regex.toLatin1().data());
+        captureList.emplace_back(regex.toLatin1().data());
         posList.push_back(0 + posOffset);
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::darkCyan), QColor(Qt::black)) << "Trigger name=" << mName << "(" << mRegexCodeList.value(regexNumber) << ") matched.\n" >> 0;
@@ -545,11 +545,11 @@ bool TTrigger::match_substring(const QString& toMatch, const QString& regex, int
     if (where != -1) {
         std::list<std::string> captureList;
         std::list<int> posList;
-        captureList.push_back(regex.toLatin1().data());
+        captureList.emplace_back(regex.toLatin1().data());
         posList.push_back(where + posOffset);
         if (mPerlSlashGOption) {
             while ((where = toMatch.indexOf(regex, where + 1)) != -1) {
-                captureList.push_back(regex.toLatin1().data());
+                captureList.emplace_back(regex.toLatin1().data());
                 posList.push_back(where + posOffset);
             }
         }
@@ -759,7 +759,7 @@ bool TTrigger::match_exact_match(const QString& toMatch, const QString& line, in
     if (text == line) {
         std::list<std::string> captureList;
         std::list<int> posList;
-        captureList.push_back(line.toLatin1().data());
+        captureList.emplace_back(line.toLatin1().data());
         posList.push_back(0 + posOffset);
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::yellow), QColor(Qt::black)) << "Trigger name=" << mName << "(" << mRegexCodeList.value(regexNumber) << ") matched.\n" >> 0;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Applied clang-tidy's `modernize-use-emplace` to use `emplace_back` instead of `push_back` where we can.

#### Motivation for adding to Mudlet
`emplace_back` constructs the object in-place instead of creating it first and then copying or moving it over: http://en.cppreference.com/w/cpp/container/list/emplace_back