### PR TITLE
Fix Search Engine not defaulting to anything

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -192,9 +192,12 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     mDoubleClickIgnore.insert('\'');
 
     // search engine load entries
-    mSearchEngineData.insert("Bing", "https://www.bing.com/search?q=");
-    mSearchEngineData.insert("DuckDuckGo", "https://duckduckgo.com/?q=");
-    mSearchEngineData.insert("Google", "https://www.google.com/search?q=");
+    mSearchEngineData = QMap<QString, QString>(
+    {
+                    {"Bing",       "https://www.bing.com/search?q="},
+                    {"DuckDuckGo", "https://duckduckgo.com/?q="},
+                    {"Google",     "https://www.google.com/search?q="}
+    });
 }
 
 Host::~Host()
@@ -463,11 +466,11 @@ void Host::reenableAllTriggers()
 
 QPair<QString, QString> Host::getSearchEngine()
 {
-    QPair<QString, QString> ret = QPair<QString, QString>();
+    auto ret = QPair<QString, QString>();
     ret.first = QString("Google");
     ret.second = mSearchEngineData[ret.first];
 
-    auto iterator = mSearchEngineData.find(mSearchEngineName);
+    auto iterator = mSearchEngineData.constFind(mSearchEngineName);
     if(iterator != mSearchEngineData.end())
     {
         ret.first = iterator.key();

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -466,18 +466,10 @@ void Host::reenableAllTriggers()
 
 QPair<QString, QString> Host::getSearchEngine()
 {
-    auto ret = QPair<QString, QString>();
-    ret.first = QString("Google");
-    ret.second = mSearchEngineData[ret.first];
-
-    auto iterator = mSearchEngineData.constFind(mSearchEngineName);
-    if(iterator != mSearchEngineData.end())
-    {
-        ret.first = iterator.key();
-        ret.second = iterator.value();
-    }
-
-    return ret;
+    if(mSearchEngineData.contains(mSearchEngineName))
+        return qMakePair(mSearchEngineName, mSearchEngineData.value(mSearchEngineName));
+    else
+        return qMakePair(QStringLiteral("Google"), mSearchEngineData.value(QStringLiteral("Google")));
 }
 
 void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -190,6 +190,11 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     mGMCP_merge_table_keys.append("Char.Status");
     mDoubleClickIgnore.insert('"');
     mDoubleClickIgnore.insert('\'');
+
+    // search engine load entries
+    mSearchEngineData.insert("Bing", "https://www.bing.com/search?q=");
+    mSearchEngineData.insert("DuckDuckGo", "https://duckduckgo.com/?q=");
+    mSearchEngineData.insert("Google", "https://www.google.com/search?q=");
 }
 
 Host::~Host()
@@ -454,6 +459,22 @@ void Host::reenableAllTriggers()
     mTriggerUnit.reenableAllTriggers();
     mAliasUnit.reenableAllTriggers();
     mTimerUnit.reenableAllTriggers();
+}
+
+QPair<QString, QString> Host::getSearchEngine()
+{
+    QPair<QString, QString> ret = QPair<QString, QString>();
+    ret.first = QString("Google");
+    ret.second = mSearchEngineData[ret.first];
+
+    auto iterator = mSearchEngineData.find(mSearchEngineName);
+    if(iterator != mSearchEngineData.end())
+    {
+        ret.first = iterator.key();
+        ret.second = iterator.value();
+    }
+
+    return ret;
 }
 
 void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)

--- a/src/Host.h
+++ b/src/Host.h
@@ -146,6 +146,9 @@ public:
     void stopAllTriggers();
     void reenableAllTriggers();
 
+    // get Search Engine
+    QPair<QString, QString> getSearchEngine();
+
     void set_USE_IRE_DRIVER_BUGFIX(bool b)
     {
         mUSE_IRE_DRIVER_BUGFIX = b;
@@ -248,7 +251,8 @@ public:
     QString mEditorThemeFile;
 
     // search engine URL prefix to search query
-    QPair<QString, QString> mSearchEngine;
+    QMap<QString, QString> mSearchEngineData;
+    QString mSearchEngineName;
 
     // trigger/alias/script/etc ID whose Lua code to show when previewing a theme
     // remembering this value to show what the user has selected does have its

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1179,7 +1179,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         action2->setStatusTip(tr("copy selected text with colors as HTML (for web browsers)"));
         connect(action2, SIGNAL(triggered()), this, SLOT(slot_copySelectionToClipboardHTML()));
 
-        QString selectedEngine = mpHost->mSearchEngine.first;
+        QString selectedEngine = mpHost->getSearchEngine().first;
         QAction* action3 = new QAction(("search on " + selectedEngine), this);
         connect(action3, SIGNAL(triggered()), this, SLOT(slot_searchSelectionOnline()));
 
@@ -1337,7 +1337,7 @@ void TTextEdit::searchSelectionOnline()
 {
     QString selectedText = getSelectedText(' ');
     QString url = QUrl::toPercentEncoding(selectedText.trimmed());
-    url.prepend(mpHost->mSearchEngine.second);
+    url.prepend(mpHost->getSearchEngine().second);
     QDesktopServices::openUrl(QUrl(url));
 }
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -354,8 +354,8 @@ bool XMLexport::writeHost(Host* pHost)
     writeAttribute("mEditorThemeFile", pHost->mEditorThemeFile);
     writeAttribute("mThemePreviewItemID", QString::number(pHost->mThemePreviewItemID));
     writeAttribute("mThemePreviewType", pHost->mThemePreviewType);
-    writeAttribute("mSearchEngineName", pHost->mSearchEngine.first);
-    writeAttribute("mSearchEngineURL", pHost->mSearchEngine.second);
+    writeAttribute("mSearchEngineName", pHost->mSearchEngineName);
+
     QString ignore;
     QSetIterator<QChar> it(pHost->mDoubleClickIgnore);
     while (it.hasNext()) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -808,14 +808,11 @@ void XMLimport::readHostPackage(Host* pHost)
 
     if(attributes().hasAttribute(QLatin1String("mSearchEngineName")))
     {
-        pHost->mSearchEngine = QPair<QString, QString>(
-                    attributes().value(QLatin1String("mSearchEngineName")).toString(),
-                    attributes().value(QLatin1String("mSearchEngineURL")).toString()
-                    );
+        pHost->mSearchEngineName = attributes().value(QLatin1String("mSearchEngineName")).toString();
     }
     else
     {
-        pHost->mSearchEngine = QPair<QString, QString>("Google", "https://www.google.com/search?q=");
+        pHost->mSearchEngineName = QString("Google");
     }
 
     pHost->mFORCE_MXP_NEGOTIATION_OFF = (attributes().value("mFORCE_MXP_NEGOTIATION_OFF") == "yes");

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -425,11 +425,7 @@ void dlgProfilePreferences::loadEditorTab()
     }
 
     // search engine load
-    // populate combobox
-    for(auto engineText : mpHost->mSearchEngineData.keys())
-    {
-        search_engine_combobox->addItem(engineText);
-    }
+    search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
 
     connect(search_engine_combobox, SIGNAL(currentTextChanged(const QString)), this, SLOT(slot_search_engine_edited(const QString)));
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -425,13 +425,8 @@ void dlgProfilePreferences::loadEditorTab()
     }
 
     // search engine load
-    // insert might be (/should?) moved elsewhere
-    mSearchEngineMap.insert("Bing", "https://www.bing.com/search?q=");
-    mSearchEngineMap.insert("DuckDuckGo", "https://duckduckgo.com/?q=");
-    mSearchEngineMap.insert("Google", "https://www.google.com/search?q=");
-
     // populate combobox
-    for(auto engineText : mSearchEngineMap.keys())
+    for(auto engineText : mpHost->mSearchEngineData.keys())
     {
         search_engine_combobox->addItem(engineText);
     }
@@ -439,14 +434,14 @@ void dlgProfilePreferences::loadEditorTab()
     connect(search_engine_combobox, SIGNAL(currentTextChanged(const QString)), this, SLOT(slot_search_engine_edited(const QString)));
 
     // set to saved value or default to Google
-    int savedText = search_engine_combobox->findText(mpHost->mSearchEngine.first);
+    int savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
     setSearchEngine(search_engine_combobox->currentText());
 }
 
 void dlgProfilePreferences::setSearchEngine(const QString &text)
 {
-    mpHost->mSearchEngine = QPair<QString, QString>(text, mSearchEngineMap[text]);
+    mpHost->mSearchEngineName = text;
 }
 
 void dlgProfilePreferences::slot_search_engine_edited(const QString &text)


### PR DESCRIPTION
...when loading a profile with no SearchEngineName. #1378

tested switching 3.5 release to 3.5 development. Defaults to Google.

Everything relates to `QMap mSearchEngineData` built in the Host constructor so we can just save the `mSearchEngineName` to the profile and get what we need through `getSearchEngine()`.

If you'd like to manage this in a different way please let me know.
