### PR TITLE
Fix a few cppcoreguidelines-pro-bounds-constant-array-index warnings

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -145,7 +145,7 @@ cTelnet::cTelnet(Host* pH)
 void cTelnet::reset()
 {
     //prepare option variables
-    for (const int i = 0; i < 256; i++) {
+    for (int i = 0; i < 256; i++) {
         myOptionState[i] = false;
         hisOptionState[i] = false;
         announcedState[i] = false;
@@ -1000,7 +1000,7 @@ void cTelnet::processTelnetCommand(const string& command)
                     cmd += TN_SB;
                     cmd += OPT_STATUS;
                     cmd += TNSB_IS;
-                    for (const short i = 0; i < 256; i++) {
+                    for (short i = 0; i < 256; i++) {
                         if (myOptionState[i]) {
                             cmd += TN_WILL;
                             cmd += i;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -145,7 +145,7 @@ cTelnet::cTelnet(Host* pH)
 void cTelnet::reset()
 {
     //prepare option variables
-    for (int i = 0; i < 256; i++) {
+    for (const int i = 0; i < 256; i++) {
         myOptionState[i] = false;
         hisOptionState[i] = false;
         announcedState[i] = false;
@@ -555,7 +555,7 @@ void cTelnet::processTelnetCommand(const string& command)
     case TN_WILL: {
         //server wants to enable some option (or he sends a timing-mark)...
         option = command[2];
-        int idxOption = static_cast<int>(option);
+        const auto idxOption = static_cast<int>(option);
 
         if (option == static_cast<char>(25)) //EOR support (END OF RECORD=TN_GA
         {
@@ -1000,7 +1000,7 @@ void cTelnet::processTelnetCommand(const string& command)
                     cmd += TN_SB;
                     cmd += OPT_STATUS;
                     cmd += TNSB_IS;
-                    for (short i = 0; i < 256; i++) {
+                    for (const short i = 0; i < 256; i++) {
                         if (myOptionState[i]) {
                             cmd += TN_WILL;
                             cmd += i;

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -558,8 +558,7 @@ void GLWidget::paintGL()
             exitList.push_back(pR->getUp());
             exitList.push_back(pR->getDown());
             int e = pR->z;
-            int ef;
-            ef = abs(e % 26);
+            const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, ebenenColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 1);
             glDisable(GL_DEPTH_TEST);
@@ -1402,7 +1401,7 @@ void GLWidget::paintGL()
             }
 
             int e = pR->z;
-            int ef = abs(e % 26);
+            const int ef = abs(e % 26);
             glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, ebenenColor[ef]);
             glMateriali(GL_FRONT, GL_SHININESS, 36); //gut:96
 
@@ -2091,9 +2090,8 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         glMatrixMode(GL_PROJECTION);
         glPopMatrix();
         hits = glRenderMode(GL_RENDER);
-        int i;
 
-        for (i = 0; i < hits; i++) {
+        for (const int i = 0; i < hits; i++) {
             mTarget = buff[i * 4 + 3];
             //TODO: Mehrfachbelegungen
             //            unsigned int minZ = buff[i * 4 + 1];

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -2091,7 +2091,7 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         glPopMatrix();
         hits = glRenderMode(GL_RENDER);
 
-        for (const int i = 0; i < hits; i++) {
+        for (int i = 0; i < hits; i++) {
             mTarget = buff[i * 4 + 3];
             //TODO: Mehrfachbelegungen
             //            unsigned int minZ = buff[i * 4 + 1];


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fixed a few cases where [cppcoreguidelines-pro-bounds-constant-array-index](http://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-bounds-constant-array-index.html) was lighting up.

The reason why is started looking into was for unsafe use of `[]` to read a value, however, this was flagging writes as well with the following:

>  do not use array subscript when the index is not an integer constant expression; use gsl::at() instead

Can't say I understand it but making the index be a const variable seems to do the trick.

#### Motivation for adding to Mudlet
Seems like a good thing to do.

#### Other info (issues closed, discussion etc)
