### PR TITLE
Refactor: de-spaghetti-fy toolbar & editor treeWidget icon sizing code

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -260,8 +260,8 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pH) : QDialog(pF
         leftBorderWidth->setValue(pHost->mBorderLeftWidth);
         qDebug() << "loading: left border width:" << pHost->mBorderLeftWidth;
         rightBorderWidth->setValue(pHost->mBorderRightWidth);
-        MainIconSize->setValue(mudlet::self()->mMainIconSize);
-        TEFolderIconSize->setValue(mudlet::self()->mTEFolderIconSize);
+        MainIconSize->setValue(mudlet::self()->mToolbarIconSize);
+        TEFolderIconSize->setValue(mudlet::self()->mEditorTreeWidgetIconSize);
         showMenuBar->setChecked(mudlet::self()->mShowMenuBar);
         if (!showMenuBar->isChecked()) {
             showToolbar->setChecked(true);
@@ -1324,22 +1324,10 @@ void dlgProfilePreferences::slot_save_and_exit()
     pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
     //pHost->mMXPMode = mMXPMode->currentIndex();
     pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
-    mudlet::self()->mMainIconSize = MainIconSize->value();
-    mudlet::self()->mTEFolderIconSize = TEFolderIconSize->value();
-    mudlet::self()->setIcoSize(MainIconSize->value());
-    pHost->mpEditorDialog->setTBIconSize(0);
-    mudlet::self()->mShowMenuBar = showMenuBar->isChecked();
-    if (showMenuBar->isChecked()) {
-        mudlet::self()->menuBar()->show();
-    } else {
-        mudlet::self()->menuBar()->hide();
-    }
-    mudlet::self()->mShowToolbar = showToolbar->isChecked();
-    if (showToolbar->isChecked()) {
-        mudlet::self()->mpMainToolBar->show();
-    } else {
-        mudlet::self()->mpMainToolBar->hide();
-    }
+    mudlet::self()->setToolBarIconSize(MainIconSize->value());
+    mudlet::self()->setEditorTreeWidgetIconSize(TEFolderIconSize->value());
+    mudlet::self()->setMenuBarVisible(showMenuBar->isChecked());
+    mudlet::self()->setToolBarVisible(showToolbar->isChecked());
     pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
     pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();
     pHost->mNoAntiAlias = !mNoAntiAlias->isChecked();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -425,8 +425,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar = new QToolBar();
     toolBar2 = new QToolBar();
 
-    connect(mudlet::self(), SIGNAL(signal_setToolBarIconSize(const unsigned int)), this, SLOT(slot_setToolBarIconSize(const unsigned int)));
-    connect(mudlet::self(), SIGNAL(signal_setTreeIconSize(const unsigned int)), this, SLOT(slot_setTreeWidgetIconSize(const unsigned int)));
+    connect(mudlet::self(), SIGNAL(signal_setToolBarIconSize(const int)), this, SLOT(slot_setToolBarIconSize(const int)));
+    connect(mudlet::self(), SIGNAL(signal_setTreeIconSize(const int)), this, SLOT(slot_setTreeWidgetIconSize(const int)));
     slot_setToolBarIconSize(mudlet::self()->mToolbarIconSize);
     slot_setTreeWidgetIconSize(mudlet::self()->mEditorTreeWidgetIconSize);
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -659,8 +659,12 @@ void dlgTriggerEditor::slot_viewErrorsAction()
 }
 
 
-void dlgTriggerEditor::slot_setToolBarIconSize(const unsigned int s)
+void dlgTriggerEditor::slot_setToolBarIconSize(const int s)
 {
+    if (s <= 0) {
+        return;
+    }
+
     if (s > 2) {
         toolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
         toolBar2->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
@@ -674,8 +678,12 @@ void dlgTriggerEditor::slot_setToolBarIconSize(const unsigned int s)
     toolBar2->setIconSize(newSize);
 }
 
-void dlgTriggerEditor::slot_setTreeWidgetIconSize(const unsigned int s)
+void dlgTriggerEditor::slot_setTreeWidgetIconSize(const int s)
 {
+    if (s <= 0) {
+        return;
+    }
+
     QSize newSize(s * 8, s * 8);
     treeWidget_triggers->setIconSize(newSize);
     treeWidget_aliases->setIconSize(newSize);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -423,8 +423,13 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(showDebugAreaAction, SIGNAL(triggered()), this, SLOT(slot_debug_mode()));
 
     toolBar = new QToolBar();
-    toolBar->setIconSize(QSize(mudlet::self()->mMainIconSize * 8, mudlet::self()->mMainIconSize * 8));
-    toolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    toolBar2 = new QToolBar();
+
+    connect(mudlet::self(), SIGNAL(signal_setToolBarIconSize(const unsigned int)), this, SLOT(slot_setToolBarIconSize(const unsigned int)));
+    connect(mudlet::self(), SIGNAL(signal_setTreeIconSize(const unsigned int)), this, SLOT(slot_setTreeWidgetIconSize(const unsigned int)));
+    slot_setToolBarIconSize(mudlet::self()->mToolbarIconSize);
+    slot_setTreeWidgetIconSize(mudlet::self()->mEditorTreeWidgetIconSize);
+
     toolBar->setMovable(true);
     toolBar->addAction(toggleActiveAction);
     toolBar->addAction(saveAction);
@@ -441,10 +446,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar->addAction(saveProfileAsAction);
     toolBar->addAction(profileSaveAction);
 
-
-    toolBar2 = new QToolBar();
-    toolBar2->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    toolBar2->setIconSize(QSize(mudlet::self()->mMainIconSize * 8, mudlet::self()->mMainIconSize * 8));
     connect(button_displayAllVariables, SIGNAL(toggled(bool)), this, SLOT(slot_toggleHiddenVariables(bool)));
 
     connect(mpVarsMainArea->checkBox_variable_hidden, SIGNAL(clicked(bool)), this, SLOT(slot_toggleHiddenVar(bool)));
@@ -568,7 +569,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     frame_rightBottom->hide();
 
     readSettings();
-    setTBIconSize(0);
 
     treeWidget_searchResults->setColumnCount(4);
     QStringList labelList;
@@ -659,24 +659,31 @@ void dlgTriggerEditor::slot_viewErrorsAction()
 }
 
 
-void dlgTriggerEditor::setTBIconSize(int s)
+void dlgTriggerEditor::slot_setToolBarIconSize(const unsigned int s)
 {
-    if (mudlet::self()->mMainIconSize > 2) {
+    if (s > 2) {
         toolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
         toolBar2->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     } else {
         toolBar->setToolButtonStyle(Qt::ToolButtonIconOnly);
         toolBar2->setToolButtonStyle(Qt::ToolButtonIconOnly);
     }
-    toolBar->setIconSize(QSize(mudlet::self()->mMainIconSize * 8, mudlet::self()->mMainIconSize * 8));
-    toolBar2->setIconSize(QSize(mudlet::self()->mMainIconSize * 8, mudlet::self()->mMainIconSize * 8));
-    treeWidget_triggers->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
-    treeWidget_aliases->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
-    treeWidget_timers->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
-    treeWidget_scripts->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
-    treeWidget_keys->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
-    treeWidget_actions->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
-    treeWidget_variables->setIconSize(QSize(mudlet::self()->mTEFolderIconSize * 8, mudlet::self()->mTEFolderIconSize * 8));
+
+    QSize newSize(s * 8, s * 8);
+    toolBar->setIconSize(newSize);
+    toolBar2->setIconSize(newSize);
+}
+
+void dlgTriggerEditor::slot_setTreeWidgetIconSize(const unsigned int s)
+{
+    QSize newSize(s * 8, s * 8);
+    treeWidget_triggers->setIconSize(newSize);
+    treeWidget_aliases->setIconSize(newSize);
+    treeWidget_timers->setIconSize(newSize);
+    treeWidget_scripts->setIconSize(newSize);
+    treeWidget_keys->setIconSize(newSize);
+    treeWidget_actions->setIconSize(newSize);
+    treeWidget_variables->setIconSize(newSize);
 }
 
 void dlgTriggerEditor::slot_choseButtonColor()
@@ -695,12 +702,12 @@ void dlgTriggerEditor::closeEvent(QCloseEvent* event)
 
 void dlgTriggerEditor::readSettings()
 {
-    /*In case sensitive environments, two different config directories
-	   were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
-	   Furthermore, we skip the version from the application name to follow the convention.
-	   For compatibility with older settings, if no config is loaded
-	   from the config directory "mudlet", application "Mudlet", we try to load from the config
-	   directory "Mudlet", application "Mudlet 1.0". */
+    /* In case sensitive environments, two different config directories
+       were used: "Mudlet" for QSettings, and "mudlet" anywhere else.
+       Furthermore, we skip the version from the application name to follow the convention.
+       For compatibility with older settings, if no config is loaded
+       from the config directory "mudlet", application "Mudlet", we try to load from the config
+       directory "Mudlet", application "Mudlet 1.0". */
     QSettings settings_new("mudlet", "Mudlet");
     QSettings settings((settings_new.contains("pos") ? "mudlet" : "Mudlet"), (settings_new.contains("pos") ? "Mudlet" : "Mudlet 1.0"));
 
@@ -713,10 +720,10 @@ void dlgTriggerEditor::readSettings()
 
 void dlgTriggerEditor::writeSettings()
 {
-    /*In case sensitive environments, two different config directories
-	   were used: "Mudlet" for QSettings, and "mudlet" anywhere else. We change the QSettings directory
-	   (the organization name) to "mudlet".
-	   Furthermore, we skip the version from the application name to follow the convention.*/
+    /* In case sensitive environments, two different config directories
+       were used: "Mudlet" for QSettings, and "mudlet" anywhere else. We change the QSettings directory
+       (the organization name) to "mudlet".
+       Furthermore, we skip the version from the application name to follow the convention.*/
     QSettings settings("mudlet", "Mudlet");
     settings.setValue("script_editor_pos", pos());
     settings.setValue("script_editor_size", size());

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -264,7 +264,8 @@ public slots:
     void grab_key_callback(int key, int modifier);
     void slot_profileSaveAction();
     void slot_profileSaveAsAction();
-    void setTBIconSize(int);
+    void slot_setToolBarIconSize(const unsigned int);
+    void slot_setTreeWidgetIconSize(const unsigned int);
     void slot_color_trigger_fg();
     void slot_color_trigger_bg();
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -264,8 +264,8 @@ public slots:
     void grab_key_callback(int key, int modifier);
     void slot_profileSaveAction();
     void slot_profileSaveAsAction();
-    void slot_setToolBarIconSize(const unsigned int);
-    void slot_setTreeWidgetIconSize(const unsigned int);
+    void slot_setToolBarIconSize(const int);
+    void slot_setTreeWidgetIconSize(const int);
     void slot_color_trigger_fg();
     void slot_color_trigger_bg();
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2119,10 +2119,10 @@ void mudlet::readSettings()
     }
 }
 
-void mudlet::setToolBarIconSize(const unsigned int s)
+void mudlet::setToolBarIconSize(const int s)
 {
 
-    if (mToolbarIconSize == s) {
+    if (mToolbarIconSize == s || s <= 0) {
         return;
     }
 
@@ -2141,9 +2141,9 @@ void mudlet::setToolBarIconSize(const unsigned int s)
     emit signal_setToolBarIconSize(s);
 }
 
-void mudlet::setEditorTreeWidgetIconSize(const unsigned int s)
+void mudlet::setEditorTreeWidgetIconSize(const int s)
 {
-    if (mEditorTreeWidgetIconSize == s) {
+    if (mEditorTreeWidgetIconSize == s || s <= 0) {
         return;
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2089,9 +2089,9 @@ void mudlet::readSettings()
     // a netbook or not before this gets called so only change if there is a
     // setting stored:
     if (settings.contains("mainiconsize")) {
-        setToolBarIconSize(settings.value("mainiconsize").toUInt());
+        setToolBarIconSize(settings.value("mainiconsize").toInt());
     }
-    setEditorTreeWidgetIconSize(settings.value("tefoldericonsize", QVariant(3)).toUInt());
+    setEditorTreeWidgetIconSize(settings.value("tefoldericonsize", QVariant(3)).toInt());
     setMenuBarVisible(settings.value("showMenuBar", QVariant(false)).toBool());
     setToolBarVisible(settings.value("showToolbar", QVariant(true)).toBool());
     mEditorTextOptions = QTextOption::Flags(settings.value("editorTextOptions", QVariant(0)).toInt());

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -157,9 +157,12 @@ public:
     bool mShowMenuBar;
     bool mShowToolbar;
     bool isGoingDown() { return mIsGoingDown; }
-    int mMainIconSize;
-    int mTEFolderIconSize;
-    void setIcoSize(int s);
+    unsigned int mToolbarIconSize;
+    unsigned int mEditorTreeWidgetIconSize;
+    void setToolBarIconSize(const unsigned int);
+    void setEditorTreeWidgetIconSize(const unsigned int);
+    void setToolBarVisible(const bool);
+    void setMenuBarVisible(const bool);
     void replayStart();
     bool setConsoleBufferSize(Host* pHost, const QString& name, int x1, int y1);
     void replayOver();
@@ -325,6 +328,8 @@ protected:
 signals:
     void signal_editorTextOptionsChanged(QTextOption::Flags);
     void signal_profileMapReloadRequested(QList<QString>);
+    void signal_setToolBarIconSize(const unsigned int);
+    void signal_setTreeIconSize(const unsigned int);
 
 private slots:
     void slot_close_profile();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -157,10 +157,10 @@ public:
     bool mShowMenuBar;
     bool mShowToolbar;
     bool isGoingDown() { return mIsGoingDown; }
-    unsigned int mToolbarIconSize;
-    unsigned int mEditorTreeWidgetIconSize;
-    void setToolBarIconSize(const unsigned int);
-    void setEditorTreeWidgetIconSize(const unsigned int);
+    int mToolbarIconSize;
+    int mEditorTreeWidgetIconSize;
+    void setToolBarIconSize(const int);
+    void setEditorTreeWidgetIconSize(const int);
     void setToolBarVisible(const bool);
     void setMenuBarVisible(const bool);
     void replayStart();
@@ -328,8 +328,8 @@ protected:
 signals:
     void signal_editorTextOptionsChanged(QTextOption::Flags);
     void signal_profileMapReloadRequested(QList<QString>);
-    void signal_setToolBarIconSize(const unsigned int);
-    void signal_setTreeIconSize(const unsigned int);
+    void signal_setToolBarIconSize(const int);
+    void signal_setTreeIconSize(const int);
 
 private slots:
     void slot_close_profile();


### PR DESCRIPTION
The code that sized/resized the main (and replay) and editor toolbar icons and editor treeWidget icons was inconsistent - when adjusted in the preferences it only adjusted the editor of the current profile even if others were also present.  Also some methods had an argument to receive the size setting but ignored it and read the value directly from the variable that stored it in the `mudlet` class.

Also:
* converted some tabs in the source code to spaces.
* added `mudlet::setToolbarVisible(bool)` and `mudlet::setMenuBarVisible(bool)` to simplify the coding when the relevant mudlet class items had their visibility adjusted in the preferences dialog.
* added code to ensure replay toolbar also gets it's icons adjusted when the main one to which it is docked gets adjusted.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>