### PR TITLE
Add right clicks to Labels, and passing click type to the Lua functions

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -83,9 +83,12 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
-    if (event->button() == Qt::LeftButton) {
+    if (event->button() == Qt::LeftButton || event->button() == Qt::RightButton) {
         if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
+            TEvent mReleaseParamsWButton = mReleaseParams;
+            mReleaseParamsWButton.mArgumentList.prepend(event->button() == Qt::LeftButton ? "LeftButton" : "RightButton");
+            mReleaseParamsWButton.mArgumentTypeList.prepend(ARGUMENT_TYPE_STRING);
+            mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParamsWButton);
         }
         event->accept();
         return;

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -67,9 +67,12 @@ void TLabel::setLeave(Host* pHost, const QString& func, const TEvent& args)
 
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
-    if (event->button() == Qt::LeftButton) {
+    if (event->button() == Qt::LeftButton || event->button() == Qt::RightButton) {
         if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
+            TEvent mClickParamsWButton = mClickParams;
+            mClickParamsWButton.mArgumentList.prepend(event->button() == Qt::LeftButton ? "LeftButton" : "RightButton");
+            mClickParamsWButton.mArgumentTypeList.prepend(ARGUMENT_TYPE_STRING);
+            mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParamsWButton);
         }
         event->accept();
         return;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds the passing of "LeftButton" or "RightButton" as the first argument to the Lua functions setClickCallback and setReleaseCallback corresponding to the QMouseEvent::button used.

#### Motivation for adding to Mudlet
GUI makers can utilize left and right clicks to make interfaces more powerful and more intuitive.

#### Other info (issues closed, discussion etc)
Note this will break existing Mudlet packages that utilize arguments in setClickCallback and setReleaseCallback already, as now "LeftButton" or "RightButton" will occupy the first argument. 
