### PR TITLE
Add support for all Qt::MouseButton to label click/release callback

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -102,7 +102,7 @@ void TLabel::mousePressEvent(QMouseEvent* event)
     if (mMouseButtons.contains(event->button())) {
         if (mpHost) {
             TEvent tmpClickParams = mClickParams;
-            tmpClickParams.mArgumentList.append(mMouseButtons[event->button()]);
+            tmpClickParams.mArgumentList.append(mMouseButtons.value(event->button()));
             tmpClickParams.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mpHost->getLuaInterpreter()->callEventHandler(mClick, tmpClickParams);
         }
@@ -118,7 +118,7 @@ void TLabel::mouseReleaseEvent(QMouseEvent* event)
     if (mMouseButtons.contains(event->button())) {
         if (mpHost) {
             TEvent tmpReleaseParams = mReleaseParams;
-            tmpReleaseParams.mArgumentList.append(mMouseButtons[event->button()]);
+            tmpReleaseParams.mArgumentList.append(mMouseButtons.value(event->button()));
             tmpReleaseParams.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mpHost->getLuaInterpreter()->callEventHandler(mRelease, tmpReleaseParams);
         }

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -29,6 +29,38 @@
 #include <QtEvents>
 #include "post_guard.h"
 
+QMap<Qt::MouseButton, QString> TLabel::mMouseButtons = {
+    {Qt::NoButton, QStringLiteral("NoButton")},
+    {Qt::LeftButton, QStringLiteral("LeftButton")},
+    {Qt::RightButton, QStringLiteral("RightButton")},
+    {Qt::MidButton, QStringLiteral("MidButton")},
+    {Qt::BackButton, QStringLiteral("BackButton")},
+    {Qt::ForwardButton, QStringLiteral("ForwardButton")},
+    {Qt::TaskButton, QStringLiteral("TaskButton")},
+    {Qt::ExtraButton4, QStringLiteral("ExtraButton4")},
+    {Qt::ExtraButton5, QStringLiteral("ExtraButton5")},
+    {Qt::ExtraButton6, QStringLiteral("ExtraButton6")},
+    {Qt::ExtraButton7, QStringLiteral("ExtraButton7")},
+    {Qt::ExtraButton8, QStringLiteral("ExtraButton8")},
+    {Qt::ExtraButton9, QStringLiteral("ExtraButton9")},
+    {Qt::ExtraButton10, QStringLiteral("ExtraButton10")},
+    {Qt::ExtraButton11, QStringLiteral("ExtraButton11")},
+    {Qt::ExtraButton12, QStringLiteral("ExtraButton12")},
+    {Qt::ExtraButton13, QStringLiteral("ExtraButton13")},
+    {Qt::ExtraButton14, QStringLiteral("ExtraButton14")},
+    {Qt::ExtraButton15, QStringLiteral("ExtraButton15")},
+    {Qt::ExtraButton16, QStringLiteral("ExtraButton16")},
+    {Qt::ExtraButton17, QStringLiteral("ExtraButton17")},
+    {Qt::ExtraButton18, QStringLiteral("ExtraButton18")},
+    {Qt::ExtraButton19, QStringLiteral("ExtraButton19")},
+    {Qt::ExtraButton20, QStringLiteral("ExtraButton20")},
+    {Qt::ExtraButton21, QStringLiteral("ExtraButton21")},
+    {Qt::ExtraButton22, QStringLiteral("ExtraButton22")},
+    {Qt::ExtraButton23, QStringLiteral("ExtraButton23")},
+    {Qt::ExtraButton24, QStringLiteral("ExtraButton24")},
+
+};
+
 
 TLabel::TLabel(QWidget* pW) : QLabel(pW), mpHost(nullptr), mouseInside()
 {
@@ -67,9 +99,12 @@ void TLabel::setLeave(Host* pHost, const QString& func, const TEvent& args)
 
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
-    if (event->button() == Qt::LeftButton) {
+    if (mMouseButtons.contains(event->button())) {
         if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
+            TEvent tmpClickParams = mClickParams;
+            tmpClickParams.mArgumentList.append(mMouseButtons[event->button()]);
+            tmpClickParams.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mpHost->getLuaInterpreter()->callEventHandler(mClick, tmpClickParams);
         }
         event->accept();
         return;
@@ -80,9 +115,12 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
-    if (event->button() == Qt::LeftButton) {
+    if (mMouseButtons.contains(event->button())) {
         if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
+            TEvent tmpReleaseParams = mReleaseParams;
+            tmpReleaseParams.mArgumentList.append(mMouseButtons[event->button()]);
+            tmpReleaseParams.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mpHost->getLuaInterpreter()->callEventHandler(mRelease, tmpReleaseParams);
         }
         event->accept();
         return;

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -2,6 +2,7 @@
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,35 +30,17 @@
 #include <QtEvents>
 #include "post_guard.h"
 
-QMap<Qt::MouseButton, QString> TLabel::mMouseButtons = {
-    {Qt::NoButton, QStringLiteral("NoButton")},
-    {Qt::LeftButton, QStringLiteral("LeftButton")},
-    {Qt::RightButton, QStringLiteral("RightButton")},
-    {Qt::MidButton, QStringLiteral("MidButton")},
-    {Qt::BackButton, QStringLiteral("BackButton")},
-    {Qt::ForwardButton, QStringLiteral("ForwardButton")},
-    {Qt::TaskButton, QStringLiteral("TaskButton")},
-    {Qt::ExtraButton4, QStringLiteral("ExtraButton4")},
-    {Qt::ExtraButton5, QStringLiteral("ExtraButton5")},
-    {Qt::ExtraButton6, QStringLiteral("ExtraButton6")},
-    {Qt::ExtraButton7, QStringLiteral("ExtraButton7")},
-    {Qt::ExtraButton8, QStringLiteral("ExtraButton8")},
-    {Qt::ExtraButton9, QStringLiteral("ExtraButton9")},
-    {Qt::ExtraButton10, QStringLiteral("ExtraButton10")},
-    {Qt::ExtraButton11, QStringLiteral("ExtraButton11")},
-    {Qt::ExtraButton12, QStringLiteral("ExtraButton12")},
-    {Qt::ExtraButton13, QStringLiteral("ExtraButton13")},
-    {Qt::ExtraButton14, QStringLiteral("ExtraButton14")},
-    {Qt::ExtraButton15, QStringLiteral("ExtraButton15")},
-    {Qt::ExtraButton16, QStringLiteral("ExtraButton16")},
-    {Qt::ExtraButton17, QStringLiteral("ExtraButton17")},
-    {Qt::ExtraButton18, QStringLiteral("ExtraButton18")},
-    {Qt::ExtraButton19, QStringLiteral("ExtraButton19")},
-    {Qt::ExtraButton20, QStringLiteral("ExtraButton20")},
-    {Qt::ExtraButton21, QStringLiteral("ExtraButton21")},
-    {Qt::ExtraButton22, QStringLiteral("ExtraButton22")},
-    {Qt::ExtraButton23, QStringLiteral("ExtraButton23")},
-    {Qt::ExtraButton24, QStringLiteral("ExtraButton24")},
+const QMap<Qt::MouseButton, QString> TLabel::mMouseButtons = {
+        {Qt::NoButton, QStringLiteral("NoButton")},           {Qt::LeftButton, QStringLiteral("LeftButton")},       {Qt::RightButton, QStringLiteral("RightButton")},
+        {Qt::MidButton, QStringLiteral("MidButton")},         {Qt::BackButton, QStringLiteral("BackButton")},       {Qt::ForwardButton, QStringLiteral("ForwardButton")},
+        {Qt::TaskButton, QStringLiteral("TaskButton")},       {Qt::ExtraButton4, QStringLiteral("ExtraButton4")},   {Qt::ExtraButton5, QStringLiteral("ExtraButton5")},
+        {Qt::ExtraButton6, QStringLiteral("ExtraButton6")},   {Qt::ExtraButton7, QStringLiteral("ExtraButton7")},   {Qt::ExtraButton8, QStringLiteral("ExtraButton8")},
+        {Qt::ExtraButton9, QStringLiteral("ExtraButton9")},   {Qt::ExtraButton10, QStringLiteral("ExtraButton10")}, {Qt::ExtraButton11, QStringLiteral("ExtraButton11")},
+        {Qt::ExtraButton12, QStringLiteral("ExtraButton12")}, {Qt::ExtraButton13, QStringLiteral("ExtraButton13")}, {Qt::ExtraButton14, QStringLiteral("ExtraButton14")},
+        {Qt::ExtraButton15, QStringLiteral("ExtraButton15")}, {Qt::ExtraButton16, QStringLiteral("ExtraButton16")}, {Qt::ExtraButton17, QStringLiteral("ExtraButton17")},
+        {Qt::ExtraButton18, QStringLiteral("ExtraButton18")}, {Qt::ExtraButton19, QStringLiteral("ExtraButton19")}, {Qt::ExtraButton20, QStringLiteral("ExtraButton20")},
+        {Qt::ExtraButton21, QStringLiteral("ExtraButton21")}, {Qt::ExtraButton22, QStringLiteral("ExtraButton22")}, {Qt::ExtraButton23, QStringLiteral("ExtraButton23")},
+        {Qt::ExtraButton24, QStringLiteral("ExtraButton24")},
 
 };
 

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -5,6 +5,7 @@
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
+ *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -63,7 +64,7 @@ public:
     TEvent mEnterParams;
     bool mouseInside;
 
-    static QMap<Qt::MouseButton, QString> mMouseButtons;
+    static const QMap<Qt::MouseButton, QString> mMouseButtons;
 };
 
 #endif // MUDLET_TLABEL_H

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -62,6 +62,8 @@ public:
     TEvent mLeaveParams;
     TEvent mEnterParams;
     bool mouseInside;
+
+    static QMap<Qt::MouseButton, QString> mMouseButtons;
 };
 
 #endif // MUDLET_TLABEL_H


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added map to TLabel.h to map Qt::MouseButton to strings, which, upon TLabel::mousePressEvent or TLabel::mouseRelease events, are appended to the existing callback parameters. Appending the string in this manner prevents breaking existing Mudlet scripts.
#### Motivation for adding to Mudlet
Allows more customization for GUI makers
#### Other info (issues closed, discussion etc)
Originally #1398, felt like the changes/scope warranted a different PR 
