### PR TITLE
Fix mapper not receiving mouse events while sharing space with Labels

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -26,180 +26,160 @@
 #include "Host.h"
 #include "TEvent.h"
 
+#include "post_guard.h"
 #include "pre_guard.h"
 #include <QtEvents>
-#include "post_guard.h"
 
-
-TLabel::TLabel(QWidget* pW) : QLabel(pW), mpHost(nullptr), mouseInside()
-{
-    setMouseTracking(true);
+TLabel::TLabel(QWidget *pW) : QLabel(pW), mpHost(nullptr), mouseInside() {
+  setMouseTracking(true);
 }
 
 QString nothing = "";
 
-void TLabel::setClick(Host* pHost, const QString& func, const TEvent& args)
-{
-    mpHost = pHost;
-    mClick = func;
-    mClickParams = args;
+void TLabel::setClick(Host *pHost, const QString &func, const TEvent &args) {
+  mpHost = pHost;
+  mClick = func;
+  mClickParams = args;
 }
 
-void TLabel::setRelease(Host* pHost, const QString& func, const TEvent& args)
-{
-    mpHost = pHost;
-    mRelease = func;
-    mReleaseParams = args;
+void TLabel::setRelease(Host *pHost, const QString &func, const TEvent &args) {
+  mpHost = pHost;
+  mRelease = func;
+  mReleaseParams = args;
 }
 
-void TLabel::setEnter(Host* pHost, const QString& func, const TEvent& args)
-{
-    mpHost = pHost;
-    mEnter = func;
-    mEnterParams = args;
+void TLabel::setEnter(Host *pHost, const QString &func, const TEvent &args) {
+  mpHost = pHost;
+  mEnter = func;
+  mEnterParams = args;
 }
 
-void TLabel::setLeave(Host* pHost, const QString& func, const TEvent& args)
-{
-    mpHost = pHost;
-    mLeave = func;
-    mLeaveParams = args;
+void TLabel::setLeave(Host *pHost, const QString &func, const TEvent &args) {
+  mpHost = pHost;
+  mLeave = func;
+  mLeaveParams = args;
 }
 
-void TLabel::mousePressEvent(QMouseEvent* event)
-{
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+void TLabel::mousePressEvent(QMouseEvent *event) {
+  if (forwardEventToMapper(event)) {
+    return;
+  }
 
-    if (event->button() == Qt::LeftButton) {
-        if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
-        }
-        event->accept();
-        return;
+  if (event->button() == Qt::LeftButton) {
+    if (mpHost) {
+      mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
     }
+    event->accept();
+    return;
+  }
 
-    QWidget::mousePressEvent(event);
+  QWidget::mousePressEvent(event);
 }
 
-void TLabel::mouseReleaseEvent(QMouseEvent* event)
-{
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+void TLabel::mouseReleaseEvent(QMouseEvent *event) {
+  if (forwardEventToMapper(event)) {
+    return;
+  }
 
-    if (event->button() == Qt::LeftButton) {
-        if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
-        }
-        event->accept();
-        return;
+  if (event->button() == Qt::LeftButton) {
+    if (mpHost) {
+      mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
     }
+    event->accept();
+    return;
+  }
 
-    QWidget::mouseReleaseEvent(event);
+  QWidget::mouseReleaseEvent(event);
 }
 
-void TLabel::mouseMoveEvent(QMouseEvent* event)
-{
-    if (forwardEventToMapper(event)) {
-        return;
-    }
-
+void TLabel::mouseMoveEvent(QMouseEvent *event) {
+  if (forwardEventToMapper(event)) {
+    return;
+  }
 }
 
-void TLabel::wheelEvent(QWheelEvent* event)
-{
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+void TLabel::wheelEvent(QWheelEvent *event) {
+  if (forwardEventToMapper(event)) {
+    return;
+  }
 }
 
-void TLabel::leaveEvent(QEvent* event)
-{
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+void TLabel::leaveEvent(QEvent *event) {
+  if (forwardEventToMapper(event)) {
+    return;
+  }
 
-    if (mLeave != "") {
-        if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mLeave, mLeaveParams);
-        }
-        event->accept();
-        return;
+  if (mLeave != "") {
+    if (mpHost) {
+      mpHost->getLuaInterpreter()->callEventHandler(mLeave, mLeaveParams);
     }
-    QWidget::leaveEvent(event);
+    event->accept();
+    return;
+  }
+  QWidget::leaveEvent(event);
 }
 
-void TLabel::enterEvent(QEvent* event)
-{
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+void TLabel::enterEvent(QEvent *event) {
+  if (forwardEventToMapper(event)) {
+    return;
+  }
 
-    if (mEnter != "") {
-        if (mpHost) {
-            mpHost->getLuaInterpreter()->callEventHandler(mEnter, mEnterParams);
-        }
-        event->accept();
-        return;
+  if (mEnter != "") {
+    if (mpHost) {
+      mpHost->getLuaInterpreter()->callEventHandler(mEnter, mEnterParams);
     }
-    QWidget::enterEvent(event);
+    event->accept();
+    return;
+  }
+  QWidget::enterEvent(event);
 }
 
-bool TLabel::forwardEventToMapper(QEvent* event)
-{
-    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonRelease || event->type() == QEvent::MouseMove)
-    {
-        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-        QWidget* qw = qApp->widgetAt(mouseEvent->globalPos());
+bool TLabel::forwardEventToMapper(QEvent *event) {
+  if (event->type() == QEvent::MouseButtonPress ||
+      event->type() == QEvent::MouseButtonRelease ||
+      event->type() == QEvent::MouseMove) {
+    auto mouseEvent = static_cast<QMouseEvent *>(event);
+    QWidget *qw = qApp->widgetAt(mouseEvent->globalPos());
 
-        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
-        {
-            QMouseEvent newEvent(mouseEvent->type(), qw->mapFromGlobal(mouseEvent->globalPos()), mouseEvent->button(), mouseEvent->buttons(), mouseEvent->modifiers());
-            qApp->sendEvent(qw, &newEvent);
-            return true;
-
-        }
-        return false;
-
+    if (qw &&
+        this->parentWidget()
+            ->findChild<QWidget *>(QStringLiteral("mapper"))
+            ->isAncestorOf(qw)) {
+      QMouseEvent newEvent(
+          mouseEvent->type(), qw->mapFromGlobal(mouseEvent->globalPos()),
+          mouseEvent->button(), mouseEvent->buttons(), mouseEvent->modifiers());
+      qApp->sendEvent(qw, &newEvent);
+      return true;
     }
-    else if (event->type() == QEvent::Enter || event->type() == QEvent::Leave)
-    {
-        QWidget* qw = qApp->widgetAt(QCursor::pos());
 
-        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
-        {
-            QEvent newEvent(event->type());
-            qApp->sendEvent(qw, &newEvent);
-            return true;
+  } else if (event->type() == QEvent::Enter || event->type() == QEvent::Leave) {
+    QWidget *qw = qApp->widgetAt(QCursor::pos());
 
-        }
-        return false;
+    if (qw &&
+        this->parentWidget()
+            ->findChild<QWidget *>(QStringLiteral("mapper"))
+            ->isAncestorOf(qw)) {
+      QEvent newEvent(event->type());
+      qApp->sendEvent(qw, &newEvent);
+      return true;
     }
-    else if (event->type() == QEvent::Wheel)
-    {
-        QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
-        QWidget* qw = qApp->widgetAt(wheelEvent->globalPos());
 
-        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
-        {
-            QWheelEvent newEvent(
-                        qw->mapFromGlobal(wheelEvent->globalPos()),
-                        wheelEvent->globalPos(),
-                        wheelEvent->pixelDelta(),
-                        wheelEvent->angleDelta(),
-                        wheelEvent->angleDelta().y()/8,
-                        Qt::Vertical,
-                        wheelEvent->buttons(),
-                        wheelEvent->modifiers(),
-                        wheelEvent->phase());
-            qApp->sendEvent(qw, &newEvent);
-            return true;
+  } else if (event->type() == QEvent::Wheel) {
+    auto wheelEvent = static_cast<QWheelEvent *>(event);
+    QWidget *qw = qApp->widgetAt(wheelEvent->globalPos());
 
-        }
-        return false;
+    if (qw &&
+        this->parentWidget()
+            ->findChild<QWidget *>(QStringLiteral("mapper"))
+            ->isAncestorOf(qw)) {
+      QWheelEvent newEvent(
+          qw->mapFromGlobal(wheelEvent->globalPos()), wheelEvent->globalPos(),
+          wheelEvent->pixelDelta(), wheelEvent->angleDelta(),
+          wheelEvent->angleDelta().y() / 8, Qt::Vertical, wheelEvent->buttons(),
+          wheelEvent->modifiers(), wheelEvent->phase());
+      qApp->sendEvent(qw, &newEvent);
+      return true;
     }
-    return false;
+  }
+  return false;
 }
-

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -82,6 +82,13 @@ void TLabel::mousePressEvent(QMouseEvent* event)
     QWidget::mousePressEvent(event);
 }
 
+void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
+    }
+}
+
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
     if (forwardEventToMapper(event)) {
@@ -147,30 +154,37 @@ void TLabel::enterEvent(QEvent* event)
 
 bool TLabel::forwardEventToMapper(QEvent* event)
 {
-    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonRelease || event->type() == QEvent::MouseMove) {
+    switch (event->type()) {
+    case (QEvent::MouseButtonPress):
+    case (QEvent::MouseButtonDblClick):
+    case (QEvent::MouseButtonRelease):
+    case (QEvent::MouseMove): {
         auto mouseEvent = static_cast<QMouseEvent*>(event);
         QWidget* qw = qApp->widgetAt(mouseEvent->globalPos());
 
-        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+        if (qw && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper")) && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
             QMouseEvent newEvent(mouseEvent->type(), qw->mapFromGlobal(mouseEvent->globalPos()), mouseEvent->button(), mouseEvent->buttons(), mouseEvent->modifiers());
             qApp->sendEvent(qw, &newEvent);
             return true;
         }
-
-    } else if (event->type() == QEvent::Enter || event->type() == QEvent::Leave) {
+        break;
+    }
+    case (QEvent::Enter):
+    case (QEvent::Leave): {
         QWidget* qw = qApp->widgetAt(QCursor::pos());
 
-        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+        if (qw && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper")) && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
             QEvent newEvent(event->type());
             qApp->sendEvent(qw, &newEvent);
             return true;
         }
-
-    } else if (event->type() == QEvent::Wheel) {
+        break;
+    }
+    case (QEvent::Wheel): {
         auto wheelEvent = static_cast<QWheelEvent*>(event);
         QWidget* qw = qApp->widgetAt(wheelEvent->globalPos());
 
-        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+        if (qw && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper")) && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
             QWheelEvent newEvent(qw->mapFromGlobal(wheelEvent->globalPos()),
                                  wheelEvent->globalPos(),
                                  wheelEvent->pixelDelta(),
@@ -183,6 +197,8 @@ bool TLabel::forwardEventToMapper(QEvent* event)
             qApp->sendEvent(qw, &newEvent);
             return true;
         }
+        break;
+    }
     }
     return false;
 }

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -84,9 +84,7 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 
 void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+    static_cast<void>(forwardEventToMapper(event));
 }
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
@@ -115,9 +113,7 @@ void TLabel::mouseMoveEvent(QMouseEvent* event)
 
 void TLabel::wheelEvent(QWheelEvent* event)
 {
-    if (forwardEventToMapper(event)) {
-        return;
-    }
+    static_cast<void>(forwardEventToMapper(event));
 }
 
 void TLabel::leaveEvent(QEvent* event)
@@ -154,6 +150,12 @@ void TLabel::enterEvent(QEvent* event)
 
 bool TLabel::forwardEventToMapper(QEvent* event)
 {
+    // This function implements a workaround to the issue of the mapper not receiving
+    //   mouse events while sharing space with labels, regardless of z-level. It works
+    //   by checking, when a label receives a mouse event, if the top-most widget at
+    //   the event's location is a child of the mapper object. If so, it redirects the
+    //   event there manually.
+
     switch (event->type()) {
     case (QEvent::MouseButtonPress):
     case (QEvent::MouseButtonDblClick):

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -19,6 +19,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <QApplication>
 
 #include "TLabel.h"
 
@@ -67,6 +68,18 @@ void TLabel::setLeave(Host* pHost, const QString& func, const TEvent& args)
 
 void TLabel::mousePressEvent(QMouseEvent* event)
 {
+    // Workaround for mapper not receiving mouse events while sharing space with a label
+    QWidget* qw = qApp->widgetAt(event->globalPos());
+
+    if (qw)
+        if (this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
+        {
+            QMouseEvent newEvent(event->type(), qw->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+            qApp->sendEvent(qw, &newEvent);
+            return;
+        }
+
+
     if (event->button() == Qt::LeftButton) {
         if (mpHost) {
             mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
@@ -80,6 +93,17 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
+    // Workaround for mapper not receiving mouse events while sharing space with a label
+    QWidget* qw = qApp->widgetAt(event->globalPos());
+
+    if (qw)
+        if (this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
+        {
+            QMouseEvent newEvent(event->type(), qw->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+            qApp->sendEvent(qw, &newEvent);
+            return;
+
+        }
     if (event->button() == Qt::LeftButton) {
         if (mpHost) {
             mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
@@ -91,8 +115,59 @@ void TLabel::mouseReleaseEvent(QMouseEvent* event)
     QWidget::mouseReleaseEvent(event);
 }
 
+void TLabel::mouseMoveEvent(QMouseEvent* event)
+{
+    // Workaround for mapper not receiving mouse events while sharing space with a label
+    QWidget* qw = qApp->widgetAt(event->globalPos());
+
+    if (qw)
+        if (this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
+        {
+            QMouseEvent newEvent(event->type(), qw->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+            qApp->sendEvent(qw, &newEvent);
+            return;
+
+        }
+
+}
+
+void TLabel::wheelEvent(QWheelEvent* event)
+{
+    // Workaround for mapper not receiving mouse events while sharing space with a label
+    QWidget* qw = qApp->widgetAt(event->globalPos());
+
+    if (qw)
+        if (this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
+        {
+            QWheelEvent newEvent(
+                        qw->mapFromGlobal(event->globalPos()),
+                        event->globalPos(),
+                        event->pixelDelta(),
+                        event->angleDelta(),
+                        event->angleDelta().y()/8,
+                        Qt::Vertical,
+                        event->buttons(),
+                        event->modifiers(),
+                        event->phase());
+            qApp->sendEvent(qw, &newEvent);
+            return;
+
+        }
+}
+
 void TLabel::leaveEvent(QEvent* event)
 {
+    QWidget* qw = qApp->widgetAt(QCursor::pos());
+
+    if (qw)
+        if (this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
+        {
+            QEvent newEvent(event->type());
+            qApp->sendEvent(qw, &newEvent);
+            return;
+
+        }
+
     if (mLeave != "") {
         if (mpHost) {
             mpHost->getLuaInterpreter()->callEventHandler(mLeave, mLeaveParams);
@@ -105,6 +180,16 @@ void TLabel::leaveEvent(QEvent* event)
 
 void TLabel::enterEvent(QEvent* event)
 {
+    QWidget* qw = qApp->widgetAt(QCursor::pos());
+
+    if (qw)
+        if (this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw))
+        {
+            QEvent newEvent(event->type());
+            qApp->sendEvent(qw, &newEvent);
+            return;
+
+        }
     if (mEnter != "") {
         if (mpHost) {
             mpHost->getLuaInterpreter()->callEventHandler(mEnter, mEnterParams);
@@ -114,3 +199,4 @@ void TLabel::enterEvent(QEvent* event)
     }
     QWidget::enterEvent(event);
 }
+

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -26,160 +26,163 @@
 #include "Host.h"
 #include "TEvent.h"
 
-#include "post_guard.h"
 #include "pre_guard.h"
 #include <QtEvents>
+#include "post_guard.h"
 
-TLabel::TLabel(QWidget *pW) : QLabel(pW), mpHost(nullptr), mouseInside() {
-  setMouseTracking(true);
+TLabel::TLabel(QWidget* pW) : QLabel(pW), mpHost(nullptr), mouseInside()
+{
+    setMouseTracking(true);
 }
 
 QString nothing = "";
 
-void TLabel::setClick(Host *pHost, const QString &func, const TEvent &args) {
-  mpHost = pHost;
-  mClick = func;
-  mClickParams = args;
+void TLabel::setClick(Host* pHost, const QString& func, const TEvent& args)
+{
+    mpHost = pHost;
+    mClick = func;
+    mClickParams = args;
 }
 
-void TLabel::setRelease(Host *pHost, const QString &func, const TEvent &args) {
-  mpHost = pHost;
-  mRelease = func;
-  mReleaseParams = args;
+void TLabel::setRelease(Host* pHost, const QString& func, const TEvent& args)
+{
+    mpHost = pHost;
+    mRelease = func;
+    mReleaseParams = args;
 }
 
-void TLabel::setEnter(Host *pHost, const QString &func, const TEvent &args) {
-  mpHost = pHost;
-  mEnter = func;
-  mEnterParams = args;
+void TLabel::setEnter(Host* pHost, const QString& func, const TEvent& args)
+{
+    mpHost = pHost;
+    mEnter = func;
+    mEnterParams = args;
 }
 
-void TLabel::setLeave(Host *pHost, const QString &func, const TEvent &args) {
-  mpHost = pHost;
-  mLeave = func;
-  mLeaveParams = args;
+void TLabel::setLeave(Host* pHost, const QString& func, const TEvent& args)
+{
+    mpHost = pHost;
+    mLeave = func;
+    mLeaveParams = args;
 }
 
-void TLabel::mousePressEvent(QMouseEvent *event) {
-  if (forwardEventToMapper(event)) {
-    return;
-  }
-
-  if (event->button() == Qt::LeftButton) {
-    if (mpHost) {
-      mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
-    }
-    event->accept();
-    return;
-  }
-
-  QWidget::mousePressEvent(event);
-}
-
-void TLabel::mouseReleaseEvent(QMouseEvent *event) {
-  if (forwardEventToMapper(event)) {
-    return;
-  }
-
-  if (event->button() == Qt::LeftButton) {
-    if (mpHost) {
-      mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
-    }
-    event->accept();
-    return;
-  }
-
-  QWidget::mouseReleaseEvent(event);
-}
-
-void TLabel::mouseMoveEvent(QMouseEvent *event) {
-  if (forwardEventToMapper(event)) {
-    return;
-  }
-}
-
-void TLabel::wheelEvent(QWheelEvent *event) {
-  if (forwardEventToMapper(event)) {
-    return;
-  }
-}
-
-void TLabel::leaveEvent(QEvent *event) {
-  if (forwardEventToMapper(event)) {
-    return;
-  }
-
-  if (mLeave != "") {
-    if (mpHost) {
-      mpHost->getLuaInterpreter()->callEventHandler(mLeave, mLeaveParams);
-    }
-    event->accept();
-    return;
-  }
-  QWidget::leaveEvent(event);
-}
-
-void TLabel::enterEvent(QEvent *event) {
-  if (forwardEventToMapper(event)) {
-    return;
-  }
-
-  if (mEnter != "") {
-    if (mpHost) {
-      mpHost->getLuaInterpreter()->callEventHandler(mEnter, mEnterParams);
-    }
-    event->accept();
-    return;
-  }
-  QWidget::enterEvent(event);
-}
-
-bool TLabel::forwardEventToMapper(QEvent *event) {
-  if (event->type() == QEvent::MouseButtonPress ||
-      event->type() == QEvent::MouseButtonRelease ||
-      event->type() == QEvent::MouseMove) {
-    auto mouseEvent = static_cast<QMouseEvent *>(event);
-    QWidget *qw = qApp->widgetAt(mouseEvent->globalPos());
-
-    if (qw &&
-        this->parentWidget()
-            ->findChild<QWidget *>(QStringLiteral("mapper"))
-            ->isAncestorOf(qw)) {
-      QMouseEvent newEvent(
-          mouseEvent->type(), qw->mapFromGlobal(mouseEvent->globalPos()),
-          mouseEvent->button(), mouseEvent->buttons(), mouseEvent->modifiers());
-      qApp->sendEvent(qw, &newEvent);
-      return true;
+void TLabel::mousePressEvent(QMouseEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
     }
 
-  } else if (event->type() == QEvent::Enter || event->type() == QEvent::Leave) {
-    QWidget *qw = qApp->widgetAt(QCursor::pos());
-
-    if (qw &&
-        this->parentWidget()
-            ->findChild<QWidget *>(QStringLiteral("mapper"))
-            ->isAncestorOf(qw)) {
-      QEvent newEvent(event->type());
-      qApp->sendEvent(qw, &newEvent);
-      return true;
+    if (event->button() == Qt::LeftButton) {
+        if (mpHost) {
+            mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams);
+        }
+        event->accept();
+        return;
     }
 
-  } else if (event->type() == QEvent::Wheel) {
-    auto wheelEvent = static_cast<QWheelEvent *>(event);
-    QWidget *qw = qApp->widgetAt(wheelEvent->globalPos());
+    QWidget::mousePressEvent(event);
+}
 
-    if (qw &&
-        this->parentWidget()
-            ->findChild<QWidget *>(QStringLiteral("mapper"))
-            ->isAncestorOf(qw)) {
-      QWheelEvent newEvent(
-          qw->mapFromGlobal(wheelEvent->globalPos()), wheelEvent->globalPos(),
-          wheelEvent->pixelDelta(), wheelEvent->angleDelta(),
-          wheelEvent->angleDelta().y() / 8, Qt::Vertical, wheelEvent->buttons(),
-          wheelEvent->modifiers(), wheelEvent->phase());
-      qApp->sendEvent(qw, &newEvent);
-      return true;
+void TLabel::mouseReleaseEvent(QMouseEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
     }
-  }
-  return false;
+
+    if (event->button() == Qt::LeftButton) {
+        if (mpHost) {
+            mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams);
+        }
+        event->accept();
+        return;
+    }
+
+    QWidget::mouseReleaseEvent(event);
+}
+
+void TLabel::mouseMoveEvent(QMouseEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
+    }
+}
+
+void TLabel::wheelEvent(QWheelEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
+    }
+}
+
+void TLabel::leaveEvent(QEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
+    }
+
+    if (mLeave != "") {
+        if (mpHost) {
+            mpHost->getLuaInterpreter()->callEventHandler(mLeave, mLeaveParams);
+        }
+        event->accept();
+        return;
+    }
+    QWidget::leaveEvent(event);
+}
+
+void TLabel::enterEvent(QEvent* event)
+{
+    if (forwardEventToMapper(event)) {
+        return;
+    }
+
+    if (mEnter != "") {
+        if (mpHost) {
+            mpHost->getLuaInterpreter()->callEventHandler(mEnter, mEnterParams);
+        }
+        event->accept();
+        return;
+    }
+    QWidget::enterEvent(event);
+}
+
+bool TLabel::forwardEventToMapper(QEvent* event)
+{
+    if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonRelease || event->type() == QEvent::MouseMove) {
+        auto mouseEvent = static_cast<QMouseEvent*>(event);
+        QWidget* qw = qApp->widgetAt(mouseEvent->globalPos());
+
+        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+            QMouseEvent newEvent(mouseEvent->type(), qw->mapFromGlobal(mouseEvent->globalPos()), mouseEvent->button(), mouseEvent->buttons(), mouseEvent->modifiers());
+            qApp->sendEvent(qw, &newEvent);
+            return true;
+        }
+
+    } else if (event->type() == QEvent::Enter || event->type() == QEvent::Leave) {
+        QWidget* qw = qApp->widgetAt(QCursor::pos());
+
+        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+            QEvent newEvent(event->type());
+            qApp->sendEvent(qw, &newEvent);
+            return true;
+        }
+
+    } else if (event->type() == QEvent::Wheel) {
+        auto wheelEvent = static_cast<QWheelEvent*>(event);
+        QWidget* qw = qApp->widgetAt(wheelEvent->globalPos());
+
+        if (qw && this->parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+            QWheelEvent newEvent(qw->mapFromGlobal(wheelEvent->globalPos()),
+                                 wheelEvent->globalPos(),
+                                 wheelEvent->pixelDelta(),
+                                 wheelEvent->angleDelta(),
+                                 wheelEvent->angleDelta().y() / 8,
+                                 Qt::Vertical,
+                                 wheelEvent->buttons(),
+                                 wheelEvent->modifiers(),
+                                 wheelEvent->phase());
+            qApp->sendEvent(qw, &newEvent);
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -49,6 +49,8 @@ public:
     void setLeave(Host* pHost, const QString& func, const TEvent& args);
     void mousePressEvent(QMouseEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
+    void wheelEvent(QWheelEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
     void leaveEvent(QEvent*) override;
     void enterEvent(QEvent*) override;
 

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -46,6 +46,7 @@ public:
     void setEnter(Host* pHost, const QString& func, const TEvent& args);
     void setLeave(Host* pHost, const QString& func, const TEvent& args);
     void mousePressEvent(QMouseEvent*) override;
+    void mouseDoubleClickEvent(QMouseEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
     void wheelEvent(QWheelEvent*) override;
     void mouseMoveEvent(QMouseEvent*) override;

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -24,45 +24,46 @@
 
 #include "TEvent.h"
 
-#include "post_guard.h"
 #include "pre_guard.h"
 #include <QLabel>
 #include <QPointer>
 #include <QString>
+#include "post_guard.h"
 
 class Host;
 
 class QMouseEvent;
 
-class TLabel : public QLabel {
-  Q_OBJECT
+class TLabel : public QLabel
+{
+    Q_OBJECT
 
 public:
-  Q_DISABLE_COPY(TLabel)
-  TLabel(QWidget *pW = 0);
-  void setClick(Host *pHost, const QString &func, const TEvent &args);
-  void setRelease(Host *pHost, const QString &func, const TEvent &args);
-  void setEnter(Host *pHost, const QString &func, const TEvent &args);
-  void setLeave(Host *pHost, const QString &func, const TEvent &args);
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
-  void wheelEvent(QWheelEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void leaveEvent(QEvent *) override;
-  void enterEvent(QEvent *) override;
+    Q_DISABLE_COPY(TLabel)
+    TLabel(QWidget* pW = 0);
+    void setClick(Host* pHost, const QString& func, const TEvent& args);
+    void setRelease(Host* pHost, const QString& func, const TEvent& args);
+    void setEnter(Host* pHost, const QString& func, const TEvent& args);
+    void setLeave(Host* pHost, const QString& func, const TEvent& args);
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+    void wheelEvent(QWheelEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void leaveEvent(QEvent*) override;
+    void enterEvent(QEvent*) override;
 
-  bool forwardEventToMapper(QEvent *);
+    bool forwardEventToMapper(QEvent*);
 
-  QPointer<Host> mpHost;
-  QString mClick;
-  QString mRelease;
-  QString mEnter;
-  QString mLeave;
-  TEvent mClickParams;
-  TEvent mReleaseParams;
-  TEvent mLeaveParams;
-  TEvent mEnterParams;
-  bool mouseInside;
+    QPointer<Host> mpHost;
+    QString mClick;
+    QString mRelease;
+    QString mEnter;
+    QString mLeave;
+    TEvent mClickParams;
+    TEvent mReleaseParams;
+    TEvent mLeaveParams;
+    TEvent mEnterParams;
+    bool mouseInside;
 };
 
 #endif // MUDLET_TLABEL_H

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -22,50 +22,47 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-
 #include "TEvent.h"
 
+#include "post_guard.h"
 #include "pre_guard.h"
 #include <QLabel>
 #include <QPointer>
 #include <QString>
-#include "post_guard.h"
 
 class Host;
 
 class QMouseEvent;
 
-
-class TLabel : public QLabel
-{
-    Q_OBJECT
+class TLabel : public QLabel {
+  Q_OBJECT
 
 public:
-    Q_DISABLE_COPY(TLabel)
-    TLabel(QWidget* pW = 0);
-    void setClick(Host* pHost, const QString& func, const TEvent& args);
-    void setRelease(Host* pHost, const QString& func, const TEvent& args);
-    void setEnter(Host* pHost, const QString& func, const TEvent& args);
-    void setLeave(Host* pHost, const QString& func, const TEvent& args);
-    void mousePressEvent(QMouseEvent*) override;
-    void mouseReleaseEvent(QMouseEvent*) override;
-    void wheelEvent(QWheelEvent*) override;
-    void mouseMoveEvent(QMouseEvent*) override;
-    void leaveEvent(QEvent*) override;
-    void enterEvent(QEvent*) override;
+  Q_DISABLE_COPY(TLabel)
+  TLabel(QWidget *pW = 0);
+  void setClick(Host *pHost, const QString &func, const TEvent &args);
+  void setRelease(Host *pHost, const QString &func, const TEvent &args);
+  void setEnter(Host *pHost, const QString &func, const TEvent &args);
+  void setLeave(Host *pHost, const QString &func, const TEvent &args);
+  void mousePressEvent(QMouseEvent *) override;
+  void mouseReleaseEvent(QMouseEvent *) override;
+  void wheelEvent(QWheelEvent *) override;
+  void mouseMoveEvent(QMouseEvent *) override;
+  void leaveEvent(QEvent *) override;
+  void enterEvent(QEvent *) override;
 
-    bool forwardEventToMapper(QEvent*);
+  bool forwardEventToMapper(QEvent *);
 
-    QPointer<Host> mpHost;
-    QString mClick;
-    QString mRelease;
-    QString mEnter;
-    QString mLeave;
-    TEvent mClickParams;
-    TEvent mReleaseParams;
-    TEvent mLeaveParams;
-    TEvent mEnterParams;
-    bool mouseInside;
+  QPointer<Host> mpHost;
+  QString mClick;
+  QString mRelease;
+  QString mEnter;
+  QString mLeave;
+  TEvent mClickParams;
+  TEvent mReleaseParams;
+  TEvent mLeaveParams;
+  TEvent mEnterParams;
+  bool mouseInside;
 };
 
 #endif // MUDLET_TLABEL_H

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -54,6 +54,8 @@ public:
     void leaveEvent(QEvent*) override;
     void enterEvent(QEvent*) override;
 
+    bool forwardEventToMapper(QEvent*);
+
     QPointer<Host> mpHost;
     QString mClick;
     QString mRelease;


### PR DESCRIPTION
This commit mostly resolves Issue #764 

Added workaround for the mapper not receiving mouse events while
sharing space with a Label. This commit checks mouse click events in
Labels before allowing the Label to process the event. If the topmost
element at the cursor position is a child of the QWidget with
objectName "mapper", the event is manually redirected to that element.
This commit also adds overrides for wheelEvent and mouseMoveEvent to
 the TLabel class, for redirection purposes.

The only unresolved issue is the 3D map not being drawn over Labels.