### PR TITLE
Condense repeated code in TLuaInterpreter's label callback methods

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3000,26 +3000,26 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
     return 0;
 }
 
-int TLuaInterpreter::setLabelClickCallback(lua_State* L)
+int TLuaInterpreter::setLabelCallback(lua_State* L, QString funcName)
 {
     Host& host = getHostFromLua(L);
 
     QString labelName;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "setLabelClickCallback: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "(%s: bad argument #1 type (label name as string expected, got %s!))", funcName.toUtf8().constData(), luaL_typename(L, 1));
         return lua_error(L);
     } else {
         labelName = QString::fromUtf8(lua_tostring(L, 1));
         if (labelName.isEmpty()) {
             lua_pushnil(L);
-            lua_pushstring(L, "setLabelClickCallback: bad argument #1 value (label name cannot be an empty string.)");
+            lua_pushfstring(L, R"(%s: bad argument #1 value (label name cannot be an empty string.))", funcName.toUtf8().constData());
             return 2;
         }
     }
 
     QString eventName;
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "setLabelClickCallback: bad argument #2 type (event name as string expected, got %s!)", luaL_typename(L, 2));
+        lua_pushfstring(L, R"(%s: bad argument #2 type (event name as string expected, got %s!))", funcName.toUtf8().constData(), luaL_typename(L, 2));
         return lua_error(L);
     } else {
         eventName = QString::fromUtf8(lua_tostring(L, 2));
@@ -3042,202 +3042,53 @@ int TLuaInterpreter::setLabelClickCallback(lua_State* L)
             event.mArgumentTypeList.append(ARGUMENT_TYPE_NIL);
         } else {
             lua_pushfstring(L,
-                            "setLabelClickCallback: bad argument #%d type (boolean, number, string or nil\n"
+                            "%s: bad argument #%d type (boolean, number, string or nil\n"
                                     "expected, got a %s!)",
+                            funcName.toUtf8().constData(),
                             i,
                             luaL_typename(L, i));
             return lua_error(L);
         }
     }
 
-    if (mudlet::self()->setLabelClickCallback(&host, labelName, eventName, event)) {
+    bool lua_result;
+    if (funcName == QStringLiteral("setLabelClickCallback"))
+        lua_result = mudlet::self()->setLabelClickCallback(&host, labelName, eventName, event);
+    else if (funcName == QStringLiteral("setLabelReleaseCallback"))
+        lua_result = mudlet::self()->setLabelReleaseCallback(&host, labelName, eventName, event);
+    else if (funcName == QStringLiteral("setLabelOnEnter"))
+        lua_result = mudlet::self()->setLabelOnEnter(&host, labelName, eventName, event);
+    else if (funcName == QStringLiteral("setLabelOnLeave"))
+        lua_result = mudlet::self()->setLabelOnLeave(&host, labelName, eventName, event);
+
+    if (lua_result) {
         lua_pushboolean(L, true);
         return 1;
     } else {
         lua_pushnil(L);
-        lua_pushfstring(L, R"(setLabelClickCallback: bad argument #1 value (label name "%s" not found.))", labelName.toUtf8().constData());
+        lua_pushfstring(L, R"(%s: bad argument #1 value (label name "%s" not found.))", funcName.toUtf8().constData(), labelName.toUtf8().constData());
         return 2;
     }
+}
+
+int TLuaInterpreter::setLabelClickCallback(lua_State* L)
+{
+    return setLabelCallback(L, QStringLiteral("setLabelClickCallback"));
 }
 
 int TLuaInterpreter::setLabelReleaseCallback(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
-    QString labelName;
-    if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "setLabelReleaseCallback: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
-        return lua_error(L);
-    } else {
-        labelName = QString::fromUtf8(lua_tostring(L, 1));
-        if (labelName.isEmpty()) {
-            lua_pushnil(L);
-            lua_pushstring(L, "setLabelReleaseCallback: bad argument #1 value (label name cannot be an empty string.)");
-            return 2;
-        }
-    }
-
-    QString eventName;
-    if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "setLabelReleaseCallback: bad argument #2 type (event name as string expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
-    } else {
-        eventName = QString::fromUtf8(lua_tostring(L, 2));
-    }
-
-    TEvent event;
-    int n = lua_gettop(L);
-    for (int i = 3; i <= n; ++i) {
-        if (lua_isnumber(L, i)) {
-            event.mArgumentList.append(QString::number(lua_tonumber(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        } else if (lua_isstring(L, i)) {
-            event.mArgumentList.append(QString::fromUtf8(lua_tostring(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        } else if (lua_isboolean(L, i)) {
-            event.mArgumentList.append(QString::number(lua_toboolean(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
-        } else if (lua_isnil(L, i)) {
-            event.mArgumentList.append(QString());
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_NIL);
-        } else {
-            lua_pushfstring(L,
-                            "setLabelReleaseCallback: bad argument #%d type (boolean, number, string or nil\n"
-                                    "expected, got a %s!)",
-                            i,
-                            luaL_typename(L, i));
-            return lua_error(L);
-        }
-    }
-
-    if (mudlet::self()->setLabelReleaseCallback(&host, labelName, eventName, event)) {
-        lua_pushboolean(L, true);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        lua_pushfstring(L, R"(setLabelReleaseCallback: bad argument #1 value (label name "%s" not found.))", labelName.toUtf8().constData());
-        return 2;
-    }
+    return setLabelCallback(L, QStringLiteral("setLabelReleaseCallback"));
 }
 
 int TLuaInterpreter::setLabelOnEnter(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
-    QString labelName;
-    if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "setLabelOnEnter: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
-        return lua_error(L);
-    } else {
-        labelName = QString::fromUtf8(lua_tostring(L, 1));
-        if (labelName.isEmpty()) {
-            lua_pushnil(L);
-            lua_pushstring(L, "setLabelOnEnter: bad argument #1 value (label name cannot be an empty string.)");
-            return 2;
-        }
-    }
-
-    QString eventName;
-    if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "setLabelOnEnter: bad argument #2 type (event name as string expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
-    } else {
-        eventName = QString::fromUtf8(lua_tostring(L, 2));
-    }
-
-    TEvent event;
-    int n = lua_gettop(L);
-    for (int i = 3; i <= n; ++i) {
-        if (lua_isnumber(L, i)) {
-            event.mArgumentList.append(QString::number(lua_tonumber(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        } else if (lua_isstring(L, i)) {
-            event.mArgumentList.append(QString::fromUtf8(lua_tostring(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        } else if (lua_isboolean(L, i)) {
-            event.mArgumentList.append(QString::number(lua_toboolean(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
-        } else if (lua_isnil(L, i)) {
-            event.mArgumentList.append(QString());
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_NIL);
-        } else {
-            lua_pushfstring(L,
-                            "setLabelOnEnter: bad argument #%d type (boolean, number, string or nil expected,\n"
-                                    "got a %s!)",
-                            i,
-                            luaL_typename(L, i));
-            return lua_error(L);
-        }
-    }
-
-    if (mudlet::self()->setLabelOnEnter(&host, labelName, eventName, event)) {
-        lua_pushboolean(L, true);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        lua_pushfstring(L, R"(setLabelOnEnter: bad argument #1 value (label name "%s" not found.))", labelName.toUtf8().constData());
-        return 2;
-    }
+    return setLabelCallback(L, QStringLiteral("setLabelOnEnter"));
 }
 
 int TLuaInterpreter::setLabelOnLeave(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
-    QString labelName;
-    if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "setLabelOnLeave: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
-        return lua_error(L);
-    } else {
-        labelName = QString::fromUtf8(lua_tostring(L, 1));
-        if (labelName.isEmpty()) {
-            lua_pushnil(L);
-            lua_pushstring(L, "setLabelOnLeave: bad argument #1 value (label name cannot be an empty string.)");
-            return 2;
-        }
-    }
-
-    QString eventName;
-    if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "setLabelOnLeave: bad argument #2 type (event name as string expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
-    } else {
-        eventName = QString::fromUtf8(lua_tostring(L, 2));
-    }
-
-    TEvent event;
-    int n = lua_gettop(L);
-    for (int i = 3; i <= n; ++i) {
-        if (lua_isnumber(L, i)) {
-            event.mArgumentList.append(QString::number(lua_tonumber(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        } else if (lua_isstring(L, i)) {
-            event.mArgumentList.append(QString::fromUtf8(lua_tostring(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        } else if (lua_isboolean(L, i)) {
-            event.mArgumentList.append(QString::number(lua_toboolean(L, i)));
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_BOOLEAN);
-        } else if (lua_isnil(L, i)) {
-            event.mArgumentList.append(QString());
-            event.mArgumentTypeList.append(ARGUMENT_TYPE_NIL);
-        } else {
-            lua_pushfstring(L,
-                            "setLabelOnLeave: bad argument type #%d (boolean, number, string or nil expected,\n"
-                                    "got a %s!)",
-                            i,
-                            luaL_typename(L, i));
-            return lua_error(L);
-        }
-    }
-
-    if (mudlet::self()->setLabelOnLeave(&host, labelName, eventName, event)) {
-        lua_pushboolean(L, true);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        lua_pushfstring(L, R"(setLabelOnLeave: bad argument #1 value (label name "%s" not found.))", labelName.toUtf8().constData());
-        return 2;
-    }
+    return setLabelCallback(L, QStringLiteral("setLabelOnLeave"));
 }
 
 int TLuaInterpreter::setTextFormat(lua_State* L)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3000,26 +3000,26 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
     return 0;
 }
 
-int TLuaInterpreter::setLabelCallback(lua_State* L, QString funcName)
+int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 {
     Host& host = getHostFromLua(L);
 
     QString labelName;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "(%s: bad argument #1 type (label name as string expected, got %s!))", funcName.toUtf8().constData(), luaL_typename(L, 1));
+        lua_pushfstring(L, "%s: bad argument #1 type (label name as string expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 1));
         return lua_error(L);
     } else {
         labelName = QString::fromUtf8(lua_tostring(L, 1));
         if (labelName.isEmpty()) {
             lua_pushnil(L);
-            lua_pushfstring(L, R"(%s: bad argument #1 value (label name cannot be an empty string.))", funcName.toUtf8().constData());
+            lua_pushfstring(L, "%s: bad argument #1 value (label name cannot be an empty string.)", funcName.toUtf8().constData());
             return 2;
         }
     }
 
     QString eventName;
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, R"(%s: bad argument #2 type (event name as string expected, got %s!))", funcName.toUtf8().constData(), luaL_typename(L, 2));
+        lua_pushfstring(L, "%s: bad argument #2 type (event name as string expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 2));
         return lua_error(L);
     } else {
         eventName = QString::fromUtf8(lua_tostring(L, 2));
@@ -3066,7 +3066,7 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, QString funcName)
         return 1;
     } else {
         lua_pushnil(L);
-        lua_pushfstring(L, R"(%s: bad argument #1 value (label name "%s" not found.))", funcName.toUtf8().constData(), labelName.toUtf8().constData());
+        lua_pushfstring(L, R"("%s": bad argument #1 value (label name "%s" not found.))", funcName.toUtf8().constData(), labelName.toUtf8().constData());
         return 2;
     }
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -428,7 +428,7 @@ private:
     std::list<std::list<std::string>> mMultiCaptureGroupList;
     std::list<std::list<int>> mMultiCaptureGroupPosList;
     void logError(std::string& e, const QString&, const QString& function);
-    static int setLabelCallback(lua_State*, QString funcName);
+    static int setLabelCallback(lua_State*, const QString& funcName);
 
     QMap<QNetworkReply*, QString> downloadMap;
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -428,6 +428,7 @@ private:
     std::list<std::list<std::string>> mMultiCaptureGroupList;
     std::list<std::list<int>> mMultiCaptureGroupPosList;
     void logError(std::string& e, const QString&, const QString& function);
+    static int setLabelCallback(lua_State*, QString funcName);
 
     QMap<QNetworkReply*, QString> downloadMap;
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The majority of code in TLuaInterpreter functions
setLabelClickCallback, setLabelReleaseCallback, setLabelOnEnter,
setLabelOnLeave was repeated, with the only difference being the
function to set the callback to. This commit condenses the
repeated code to a new function setLabelCallback. This will
facilitate the addition of label callbacks in the future.

#### Motivation for adding to Mudlet
This change will facilitate the addition of more label callbacks, 
including mouseDoubleClick, mouseWheel, and mouseMove
events.
#### Other info (issues closed, discussion etc)
