### PR TITLE
Patch UserWindow Crash condition

### DIFF
--- a/src/TDockWidget.cpp
+++ b/src/TDockWidget.cpp
@@ -22,6 +22,7 @@
 TDockWidget::TDockWidget(Host* pH, const QString& consoleName) : QDockWidget()
 {
     mpHost = pH;
+    hasLayoutAlready = false;
     widgetConsoleName = consoleName;
 }
 

--- a/src/TDockWidget.h
+++ b/src/TDockWidget.h
@@ -34,6 +34,7 @@
 class TDockWidget : public QDockWidget {
 public:
     QString widgetConsoleName;
+    bool hasLayoutAlready;
 
     TDockWidget(Host * , const QString &);
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -145,6 +145,8 @@ mudlet::mudlet()
 , version(QString("Mudlet ") + QString(APP_VERSION) + QString(APP_BUILD))
 , mpCurrentActiveHost(nullptr)
 , mIsGoingDown(false)
+, mIsLoadingLayout(false)
+, mHasSavedLayout(false)
 , actionReplaySpeedDown(nullptr)
 , actionReplaySpeedUp(nullptr)
 , actionSpeedDisplay(nullptr)
@@ -1179,6 +1181,10 @@ bool mudlet::saveWindowLayout()
 
 bool mudlet::loadWindowLayout()
 {
+    if (mIsLoadingLayout) {
+        qDebug() << "mudlet::loadWindowLayout() - already loading...";
+        return false;
+    }
     qDebug() << "mudlet::loadWindowLayout() - loading layout.";
 
     QString layoutFilePath = getMudletPath(mainDataItemPath, QStringLiteral("windowLayout.dat"));
@@ -1330,8 +1336,9 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
 
         setFontSize(pHost, name, 10);
 
-        if (loadLayout) {
+        if (loadLayout && !dockWindowMap[name]->hasLayoutAlready) {
             loadWindowLayout();
+            dockWindowMap[name]->hasLayoutAlready = true;
         }
 
         return true;
@@ -1340,8 +1347,9 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         dockWindowMap[name]->show();
         dockWindowConsoleMap[name]->showWindow(name);
 
-        if (loadLayout) {
+        if (loadLayout && !dockWindowMap[name]->hasLayoutAlready) {
             loadWindowLayout();
+            dockWindowMap[name]->hasLayoutAlready = true;
         }
 
         return true;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
By default calling `openUserWindow()` would load the window layout from disk each time it was called.  This behavior is normally OK except when the user is able to interact with the window layout state while the window layout state is being restored.  
The changes in this PR cause the layout to be loaded only once per each uniquely named UserWindow object which allow the `openUserWindow()` calls to be used within timers and prevent them from always reloading window layout data when called a second time.   

#### Motivation for adding to Mudlet
It patches a crash condition related to loading the window layout state at the same time as a user-initiated window Move event is being processed to update the current window layout state.  

#### Other info (issues closed, discussion etc)
- This PR addresses the crash condition in issue #1403  
- If the user needs to manually/force window layout to be loaded for a previously opened UserWindow they can call `loadWindowLayout()`  after the initial `openUserWindow()` call is made.
- Any events which would update the window layout state while `restoreState()` is processing window layout data may cause a crash.  This being the case, using `loadWindowLayout()` in a timer script is probably still going to cause an application crash if the user attempts to move windows or take actions that update the window layout state while it is still loading.
