### PR TITLE
Fix .desktop file for Linux builds to work again

### DIFF
--- a/mudlet.desktop
+++ b/mudlet.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
-Version=1.0
-Encoding=UTF-8
+Version=1.1
 Name=Mudlet
 X-AppInstall-Package=mudlet
 GenericName=Mud Client
@@ -9,4 +8,4 @@ Exec=mudlet
 Terminal=false
 Type=Application
 Icon=mudlet
-Categories=Game;AdventureGame;RolePlaying;ActionGame
+Categories=Game;AdventureGame;RolePlaying;ActionGame;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added a super-vital `;` to the string list...

#### Motivation for adding to Mudlet
Fixing CI builds to work, they are broken right now as these pedantic issues are now treated as errors.

#### Other info (issues closed, discussion etc)
See https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html for details.

```
/home/travis/build/Mudlet/installers/generic-linux/build/mudlet.desktop: error: value "3.5.0-testing-PR1413-8324574" for key "Version" in group "Desktop Entry" is not a known version

/home/travis/build/Mudlet/installers/generic-linux/build/mudlet.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated

/home/travis/build/Mudlet/installers/generic-linux/build/mudlet.desktop: error: value "Game;AdventureGame;RolePlaying;ActionGame" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
```