### PR TITLE
Remove version information entirely

### DIFF
--- a/mudlet.desktop
+++ b/mudlet.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Version=1.1
 Name=Mudlet
 X-AppInstall-Package=mudlet
 GenericName=Mud Client


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
AppImage validation is still complaining with:

> mudlet.desktop: error: value "1.1" for key "Version" in group "Desktop Entry" is not a known version
> ERROR: Desktop file contains errors. Please fix them. Please see
>        https://standards.freedesktop.org/desktop-entry-spec/latest/
>        for more information.

That is despite the standard clearly saying 1.1 is what should be used:

> Version of the Desktop Entry Specification that the desktop entry conforms with. Entries that confirm with this version of the specification should use 1.1. Note that the version field is not required to be present.

#### Motivation for adding to Mudlet
Fix AppImage builds to work.

#### Other info (issues closed, discussion etc)
