### PR TITLE
Merge UserWindow and MiniConsole font size handling

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2200,7 +2200,7 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
         pC->setContentsMargins(0, 0, 0, 0);
         pC->move(x, y);
         std::string _n = name.toStdString();
-        pC->setMiniConsoleFontSize(_n, 12);
+        pC->setMiniConsoleFontSize(12);
         pC->show();
         return pC;
     } else {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1820,23 +1820,15 @@ void TConsole::_luaWrapLine(int line)
     buffer.wrapLine(line, mWrapAt, mIndentCount, ch);
 }
 
-bool TConsole::setMiniConsoleFontSize(std::string& buf, int size)
+bool TConsole::setMiniConsoleFontSize(int size)
 {
-    std::string key = buf;
-    if (mSubConsoleMap.find(key) != mSubConsoleMap.end()) {
-        TConsole* pC = mSubConsoleMap[key];
-        if (!pC) {
-            return false;
-        }
-        pC->console->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
-        pC->console->updateScreenView();
-        pC->console->forceUpdate();
-        pC->console2->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
-        pC->console2->updateScreenView();
-        pC->console2->forceUpdate();
-        return true;
-    }
-    return false;
+    console->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
+    console->updateScreenView();
+    console->forceUpdate();
+    console2->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
+    console2->updateScreenView();
+    console2->forceUpdate();
+    return true;
 }
 
 QString TConsole::getCurrentLine()

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -140,7 +140,7 @@ public:
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
     QString getCurrentLine(std::string&);
     void selectCurrentLine(std::string&);
-    bool setMiniConsoleFontSize(std::string&, int);
+    bool setMiniConsoleFontSize(int);
     void setBold(bool);
     void setLink(const QString& linkText, QStringList& linkFunction, QStringList& linkHint);
     void setItalics(bool);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -944,24 +944,27 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 
 int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 {
-    string luaSendText = "";
+    string windowName = "";
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "setMiniConsoleFontSize: wrong argument type");
-        lua_error(L);
-        return 1;
+        lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #1 type (MiniConsole name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
     } else {
-        luaSendText = lua_tostring(L, 1);
+        windowName = lua_tostring(L, 1);
     }
-    int luaNumOfMatch;
+    int luaNumOfsizeMatch;
     if (!lua_isnumber(L, 2)) {
-        lua_pushstring(L, "setMiniConsoleFontSize: wrong argument type");
-        lua_error(L);
-        return 1;
+        lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #2 type (font size as number expected, got %s!)", luaL_typename(L, 2));
+        return lua_error(L);
     } else {
-        luaNumOfMatch = lua_tointeger(L, 2);
+        size = lua_tointeger(L, 2);
     }
     Host& host = getHostFromLua(L);
-    host.mpConsole->setMiniConsoleFontSize(luaSendText, luaNumOfMatch);
+    if (mudlet::self()->setFontSize(host, windowName, size)) {
+        lua_pushboolean(L, true);
+    } else {
+        lua_pushnil(L);
+        lua_pushfstring(L, R"(MiniConsole "%s" not found)", windowName.toUtf8().constData());
+    }
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -951,19 +951,19 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
     } else {
         windowName = lua_tostring(L, 1);
     }
-    int luaNumOfsizeMatch;
+    int size;
     if (!lua_isnumber(L, 2)) {
         lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #2 type (font size as number expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     } else {
         size = lua_tointeger(L, 2);
     }
-    Host& host = getHostFromLua(L);
-    if (mudlet::self()->setFontSize(host, windowName, size)) {
+    Host* host = &getHostFromLua(L);
+    if (mudlet::self()->setFontSize(host, QString::fromUtf8(windowName), size) {
         lua_pushboolean(L, true);
     } else {
         lua_pushnil(L);
-        lua_pushfstring(L, R"(MiniConsole "%s" not found)", windowName.toUtf8().constData());
+        lua_pushfstring(L, R"(MiniConsole "%s" not found)", windowName);
     }
     return 0;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -959,7 +959,7 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
         size = lua_tointeger(L, 2);
     }
     Host* host = &getHostFromLua(L);
-    if (mudlet::self()->setFontSize(host, windowName, size) {
+    if (mudlet::self()->setFontSize(host, windowName, size)) {
         lua_pushboolean(L, true);
     } else {
         lua_pushnil(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -944,12 +944,12 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 
 int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 {
-    string windowName = "";
+    QString windowName;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #1 type (MiniConsole name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     } else {
-        windowName = lua_tostring(L, 1);
+        windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
     int size;
     if (!lua_isnumber(L, 2)) {
@@ -959,7 +959,7 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
         size = lua_tointeger(L, 2);
     }
     Host* host = &getHostFromLua(L);
-    if (mudlet::self()->setFontSize(host, QString::fromUtf8(windowName), size) {
+    if (mudlet::self()->setFontSize(host, windowName, size) {
         lua_pushboolean(L, true);
     } else {
         lua_pushnil(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -963,7 +963,7 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
         lua_pushboolean(L, true);
     } else {
         lua_pushnil(L);
-        lua_pushfstring(L, R"(MiniConsole "%s" not found)", windowName);
+        lua_pushfstring(L, R"(MiniConsole "%s" not found)", windowName.toUtf8().constData());
     }
     return 0;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1333,9 +1333,8 @@ int mudlet::getFontSize(Host* pHost, const QString& name)
     }
 
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
-    QMap<QString, TDockWidget*>& dockWindowMap = mHostDockConsoleMap[pHost];
 
-    if (dockWindowMap.contains(name) && dockWindowConsoleMap.contains(name)) {
+    if (dockWindowConsoleMap.contains(name)) {
         return dockWindowConsoleMap.value(name)->console->mDisplayFont.pointSize();
     } else {
         return -1;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1315,16 +1315,10 @@ bool mudlet::setFontSize(Host* pHost, const QString& name, int size)
     }
 
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
-    QMap<QString, TDockWidget*>& dockWindowMap = mHostDockConsoleMap[pHost];
 
-    if (dockWindowMap.contains(name) && dockWindowConsoleMap.contains(name)) {
+    if (dockWindowConsoleMap.contains(name)) {
         TConsole* pC = dockWindowConsoleMap.value(name);
-        pC->console->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
-        pC->console->updateScreenView();
-        pC->console->forceUpdate();
-        pC->console2->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
-        pC->console2->updateScreenView();
-        pC->console2->forceUpdate();
+        pC->setMiniConsoleFontSize(size);
 
         return true;
     } else {
@@ -1416,7 +1410,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
         if (pC) {
             dockWindowConsoleMap[name] = pC;
             std::string _n = name.toStdString();
-            pC->setMiniConsoleFontSize(_n, 12);
+            pC->setMiniConsoleFontSize(12);
             return true;
         }
     } else {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This merges the font size handling (setFontSize, getFontSize) of UserWindow and MiniConsole.

The distinction is an older remnant, but from a user point of view, UserWindows and Consoles are not much different. There are examples of functions working for both types.

#### Motivation for adding to Mudlet
Simplify scripting for users.