### PR TITLE
Fixed memory leak with predefined MUDs

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1173,6 +1173,7 @@ void dlgConnectionProfiles::fillout_form()
             || (!mProfileList.at(i).compare(QStringLiteral("3Kingdoms"), Qt::CaseInsensitive))
             || (!mProfileList.at(i).compare(QStringLiteral("Midnight Sun 2"), Qt::CaseInsensitive))
             || (!mProfileList.at(i).compare(QStringLiteral("WoTMUD"), Qt::CaseInsensitive))) {
+            delete pItem;
             continue;
         }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
pItem is allocated just before and not deleted when we skip out the loop. We normally don't have to delete it because Qt takes over the memory management when we add it to the treewidget.

#### Motivation for adding to Mudlet
Smidgeon less memory used.

#### Other info (issues closed, discussion etc)
This is where I wish Qt wasn't hampering us from using smart pointers :(