### PR TITLE
Check for existance of TConsole pointer before using it

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1406,8 +1406,8 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
     if (!dockWindowConsoleMap.contains(name)) {
         TConsole* pC = pHost->mpConsole->createMiniConsole(name, x, y, width, height);
-        pC->mConsoleName = name;
         if (pC) {
+            pC->mConsoleName = name;
             dockWindowConsoleMap[name] = pC;
             std::string _n = name.toStdString();
             pC->setMiniConsoleFontSize(12);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This fixes a possible issue of dereferencing a pointer first then checking for its existence.

#### Motivation for adding to Mudlet
A crash free(er) Mudlet!