### PR TITLE
BugFix: ensure Central Debug Console closes at application exit

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -118,7 +118,7 @@ bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
 const QString mudlet::scmMudletXmlDefaultVersion = QString::number(1.001f, 'f', 3);
 
 QPointer<TConsole> mudlet::mpDebugConsole = nullptr;
-QMainWindow* mudlet::mpDebugArea = nullptr;
+QPointer<QMainWindow> mudlet::mpDebugArea = nullptr;
 bool mudlet::debugMode = false;
 static const QString timeFormat = "hh:mm:ss";
 const bool mudlet::scmIsDevelopmentVersion = !QByteArray(APP_BUILD).isEmpty();
@@ -2123,8 +2123,9 @@ void mudlet::closeEvent(QCloseEvent* event)
     writeSettings();
 
     goingDown();
-    if (mpDebugConsole) {
-        mpDebugConsole->close();
+    if (mpDebugArea) {
+        mpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
+        mpDebugArea->close();
     }
     foreach (TConsole* pC, mConsoleMap) {
         if (pC->mpHost->getName() != "default_host") {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -156,7 +156,7 @@ public:
     void processEventLoopHack();
     static const QString scmMudletXmlDefaultVersion;
     static QPointer<TConsole> mpDebugConsole;
-    static QMainWindow* mpDebugArea;
+    static QPointer<QMainWindow> mpDebugArea;
     static bool debugMode;
     QMap<Host*, TConsole*> mConsoleMap;
     QMap<Host*, QMap<QString, TConsole*>> mHostConsoleMap;


### PR DESCRIPTION
It seems that a recent change (the addition of the updater code) may have included code that modifies the `(bool)QtGUIApplication::quitOnLastWindowClosed` flag and that and/or the removal of the `qApp->quit()` call at the bottom of `(void) mudlet::closeEvent(QCloseEvent*)` seems to be why the Central Debug Console - if visible - prevents the Mudlet application from shutting down.  As far as I can tell the previous `mudlet::closeEvent()` only closed the `TConsole` instance inside the Console but it did not close the `QMainWindow` {pointed to in `(QMainWindow*) mudlet::mpDebugArea`} itself.

This commit seems to fix the issue by using the `close()` method of the `QMainWindow` rather then what is it's central widget (the `TConsole` that has the `isDebugConsole` flag set).  For safety's sake I have converted the `mudlet::mpDebugArea` pointer from a `T*` to `a QPointer<T>` form, so that a
test for it's continued existence in the `mudlet::closeEvent()` is more likely to work in unanticipated or unusual situations...!

Similarly I also ensure that the `Qt::WA_DeleteOnClose` flag is set on the `QMainWindow` of the Central Debug Console just before we close it - just to make absolutely sure it dies...! }8->

This should close #1435 "Mudlet application does not shut-down when Central Debug Console is active".

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>