### PR TITLE
BugFix: ensure Updater option control works when no profile loaded

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1608,10 +1608,6 @@ void dlgProfilePreferences::slot_save_and_exit()
             pHost->mSpellDic = dictList->currentItem()->text();
         }
 
-#if defined(INCLUDE_UPDATER)
-	    mudlet::self()->updater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
-#endif
-
         pHost->mEnableSpellCheck = enableSpellCheck->isChecked();
         pHost->mWrapAt = wrap_at_spinBox->value();
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
@@ -1763,6 +1759,10 @@ void dlgProfilePreferences::slot_save_and_exit()
 
         pHost->mSearchEngineName = search_engine_combobox->currentText();
     }
+
+#if defined(INCLUDE_UPDATER)
+    mudlet::self()->updater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
+#endif
 
     mudlet::self()->setToolBarIconSize(MainIconSize->value());
     mudlet::self()->setEditorTreeWidgetIconSize(TEFolderIconSize->value());

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -94,6 +94,20 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
         clearHostDetails();
     }
 
+#if defined(INCLUDE_UPDATER)
+    if (mudlet::scmIsDevelopmentVersion) {
+        // tick the box and make it be "un-untickable" as automatic updates are
+        // disabled in dev builds
+        checkbox_noAutomaticUpdates->setChecked(true);
+        checkbox_noAutomaticUpdates->setDisabled(true);
+        checkbox_noAutomaticUpdates->setToolTip(tr("Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet"));
+    } else {
+        checkbox_noAutomaticUpdates->setChecked(!mudlet::self()->updater->updateAutomatically());
+    }
+#else
+    groupBox_updates->hide();
+#endif
+
     // Enforce selection of the first tab - despite any cock-ups when using the
     // Qt Designer utility when the dialog was saved with a different one
     // on top! 8-)
@@ -224,7 +238,13 @@ void dlgProfilePreferences::enableHostDetails()
 void dlgProfilePreferences::initWithHost(Host* pHost)
 {
     loadEditorTab();
-    loadSpecialSettingsTab();
+
+    // search engine load
+    search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
+
+    // set to saved value or default to Google
+    int savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
+    search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(pHost->mFORCE_MXP_NEGOTIATION_OFF);
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
@@ -431,6 +451,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // CHECKME: Have moved ALL the connects, where possible, to the end so that
     // none are triggered by the setup operations...
+    connect(search_engine_combobox, SIGNAL(currentTextChanged(const QString)), this, SLOT(slot_search_engine_edited(const QString)));
+
     connect(pushButton_command_line_foreground_color, SIGNAL(clicked()), this, SLOT(setCommandLineFgColor()));
     connect(pushButton_command_line_background_color, SIGNAL(clicked()), this, SLOT(setCommandLineBgColor()));
 
@@ -716,32 +738,6 @@ void dlgProfilePreferences::loadEditorTab()
     if (tabWidget->currentIndex() == 3) {
         slot_editor_tab_selected(3);
     }
-}
-
-void dlgProfilePreferences::loadSpecialSettingsTab()
-{
-    // search engine load
-    search_engine_combobox->addItems(QStringList(mpHost->mSearchEngineData.keys()));
-
-    // set to saved value or default to Google
-    int savedText = search_engine_combobox->findText(mpHost->getSearchEngine().first);
-    search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
-
-    connect(search_engine_combobox, SIGNAL(currentTextChanged(const QString)), this, SLOT(slot_search_engine_edited(const QString)));
-
-
-#if !defined(INCLUDE_UPDATER)
-    groupBox_updates->hide();
-#else
-    if (mudlet::scmIsDevelopmentVersion) {
-        // tick the box and make it be untickable as automatic updates are disabled in dev builds
-        checkbox_noAutomaticUpdates->setChecked(true);
-        checkbox_noAutomaticUpdates->setDisabled(true);
-        checkbox_noAutomaticUpdates->setToolTip(tr("Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet"));
-    } else {
-        checkbox_noAutomaticUpdates->setChecked(!mudlet::self()->updater->updateAutomatically());
-    }
-#endif
 }
 
 void dlgProfilePreferences::setColors()

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -142,7 +142,6 @@ private:
     void disableHostDetails();
     void enableHostDetails();
     void clearHostDetails();
-    void loadSpecialSettingsTab();
     
     int mFontSize;
     QPointer<Host> mpHost;


### PR DESCRIPTION
The code that initialises the control of the updater must be initialised so that development versions do not have it enabled.  Unfortunate because two recent PRs (one of mine to allow the Profile Preferences to operate safely without a profile loaded and one of Vadim's to add the updater) both modified chunks of the `dlgProfilePrefences` class the merge algorithm allowed the new control for the updater to be placed in amongst other code that was shifted to only work when there WAS a profile loaded when
in fact it was an exceptional piece that should have stayed in the constructor.  As the code that had to be relocated was around half of a chunk that seems to have been hived off into a separate method `(void) dlgProfilePreferences::loadSpecialSettingsTab()` it was cleaner to re-position the remaining code back into the single place it was called from and remove the function completely.

This closes #1449 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>