### PR TITLE
Only create mudlet-data symlink on first launch. This enables users to delete the symlink if they do not want it.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,7 +446,7 @@ int main(int argc, char* argv[])
     }
 #else
     QFile linkFile(homeLink);
-    if (!linkFile.exists()) {
+    if (!linkFile.exists() && first_launch) {
         QFile::link(homeDirectory, homeLink);
     }
 #endif


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

When Mudlet is launched, the current behavior is to create a symlink to the  "\~/.config/mudlet" directory in the root of the user's home directory "\~/mudlet-data". This change causes Mudlet to only create this symlink if it is the first launch. This enables users to delete the symlink if they do not want it without it being recreated again the next launch.

#### Motivation for adding to Mudlet

I personally do not want the above mentioned symlink in my user's home directory and deleted it. When it reappeared upon launching Mudlet again, I was motivated to modify the source code.