### PR TITLE
fixes #1433 settings now uses existing pointSize

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -55,7 +55,7 @@
 
 dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 : QDialog(pF)
-, mFontSize(10)
+, mFontSize(pHost->mDisplayFont.pointSize())
 , mpHost(pHost)
 , mpMenu(nullptr)
 {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -55,7 +55,7 @@
 
 dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 : QDialog(pF)
-, mFontSize(pHost->mDisplayFont.pointSize())
+, mFontSize(10)
 , mpHost(pHost)
 , mpMenu(nullptr)
 {
@@ -223,6 +223,8 @@ void dlgProfilePreferences::enableHostDetails()
 
 void dlgProfilePreferences::initWithHost(Host* pHost)
 {
+    mFontSize = pHost->mDisplayFont.pointSize();
+
     loadEditorTab();
     loadSpecialSettingsTab();
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -223,8 +223,6 @@ void dlgProfilePreferences::enableHostDetails()
 
 void dlgProfilePreferences::initWithHost(Host* pHost)
 {
-    mFontSize = pHost->mDisplayFont.pointSize();
-
     loadEditorTab();
     loadSpecialSettingsTab();
 
@@ -296,6 +294,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     need_reconnect_for_specialoption->hide();
 
     fontComboBox->setCurrentFont(pHost->mDisplayFont);
+    mFontSize = pHost->mDisplayFont.pointSize();
     if (mFontSize < 0) {
         mFontSize = 10;
     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

As noted by issue #1433 the settings dialogue does not remember the currently used displayFont pointSize. This change updates the initializer list for dlgProfilePreferences to use the existing pointSize when initializing mFontSize instead of setting it to the hard coded value of 10.

#### Motivation for adding to Mudlet

Like the person who reported the issue, I also noticed that the settings dialogue did not remember the previously set value. I felt motivated to make this change so that I did not have to re-enter my preferred font size every time I open the settings dialogue.