### PR TITLE
Registering two new lua functions:

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12902,58 +12902,68 @@ Host& getHostFromLua(lua_State* L)
     return *h;
 }
 
-int TLuaInterpreter::getColumnCount( lua_State * L )
+int TLuaInterpreter::getColumnCount(lua_State* L)
 {
     QString windowName;
 
-    if ( ! lua_gettop( L ) ) {
+    if (!lua_gettop(L)) {
         windowName = QStringLiteral("main");
-    }
-    else if ( ! lua_isstring(L, 1) ) {
+    } else if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getColumnCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
-        lua_error( L );
+        lua_error(L);
         return 1;
-    }
-    else {
+    } else {
         windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
 
     int columns;
-    Host * pHost = &getHostFromLua(L);
+    Host* pHost = &getHostFromLua(L);
 
-    if ( windowName.isEmpty() || ! windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) )
+    if (windowName.isEmpty() || !windowName.compare(QStringLiteral("main"), Qt::CaseSensitive)) {
         columns = pHost->mpConsole->console->getColumnCount();
-    else
+    } else {
         columns = mudlet::self()->getColumnCount(pHost, windowName);
+    }
 
-    lua_pushnumber( L, columns );
+    if (columns < 0) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "window \"%s\" not found", windowName.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushnumber(L, columns);
     return 1;
 }
 
-int TLuaInterpreter::getRowCount( lua_State * L )
+int TLuaInterpreter::getRowCount(lua_State* L)
 {
     QString windowName;
 
-    if ( ! lua_gettop( L ) ) {
+    if (!lua_gettop(L)) {
         windowName = QStringLiteral("main");
-    }
-    else if ( ! lua_isstring(L, 1) ) {
+    } else if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getRowCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
-        lua_error( L );
+        lua_error(L);
         return 1;
-    }
-    else {
+    } else {
         windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
 
-    int columns;
-    Host * pHost = &getHostFromLua(L);
+    int rows;
+    Host* pHost = &getHostFromLua(L);
 
-    if ( windowName.isEmpty() || ! windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) )
-        columns = pHost->mpConsole->console->getRowCount();
-    else
-        columns = mudlet::self()->getRowCount(pHost, windowName);
+    if (windowName.isEmpty() || !windowName.compare(QStringLiteral("main"), Qt::CaseSensitive)) {
+        rows = pHost->mpConsole->console->getRowCount();
+    } else {
+        rows = mudlet::self()->getRowCount(pHost, windowName);
+    }
 
-    lua_pushnumber( L, columns );
+    if (rows < 0) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "window \"%s\" not found", windowName.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushnumber(L, rows);
     return 1;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -422,8 +422,8 @@ public:
     static int alert(lua_State* L);
     static int tempPromptTrigger(lua_State*);
     static int permPromptTrigger(lua_State*);
-    static int getColumnCount( lua_State * L );
-    static int getRowCount( lua_State * L );
+    static int getColumnCount(lua_State*);
+    static int getRowCount(lua_State*);
 
     // PLACEMARKER: End of Lua functions declarations
     static const QMap<Qt::MouseButton, QString> mMouseButtons;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -422,6 +422,9 @@ public:
     static int alert(lua_State* L);
     static int tempPromptTrigger(lua_State*);
     static int permPromptTrigger(lua_State*);
+    static int getColumnCount( lua_State * L );
+    static int getRowCount( lua_State * L );
+
     // PLACEMARKER: End of Lua functions declarations
     static const QMap<Qt::MouseButton, QString> mMouseButtons;
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1545,3 +1545,16 @@ int TTextEdit::bufferScrollDown(int lines)
         return lines;
     }
 }
+
+int TTextEdit::getColumnCount()
+{
+    // Not using 'mFontWidth' as currently it is the with of the 'W' char and
+    // we should use the "space" width for this, as discussed on #1438
+    return width() / QFontMetrics(mpHost->mDisplayFont).width(QChar(' '));
+}
+
+int TTextEdit::getRowCount()
+{
+    return height() / mFontHeight;
+}
+

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1548,13 +1548,26 @@ int TTextEdit::bufferScrollDown(int lines)
 
 int TTextEdit::getColumnCount()
 {
-    // Not using 'mFontWidth' as currently it is the with of the 'W' char and
-    // we should use the "space" width for this, as discussed on #1438
-    return width() / QFontMetrics(mpHost->mDisplayFont).width(QChar(' '));
+    int charWidth;
+
+    if (!mIsDebugConsole && !mIsMiniConsole) {
+        charWidth = qRound(QFontMetricsF(mpHost->mDisplayFont).averageCharWidth());
+    } else {
+        charWidth = qRound(QFontMetricsF(mDisplayFont).averageCharWidth());
+    }
+
+    return width() / charWidth;
 }
 
 int TTextEdit::getRowCount()
 {
-    return height() / mFontHeight;
-}
+    int rowHeight;
 
+    if (!mIsDebugConsole && !mIsMiniConsole) {
+        rowHeight = qRound(QFontMetricsF(mpHost->mDisplayFont).lineSpacing());
+    } else {
+        rowHeight = qRound(QFontMetricsF(mDisplayFont).lineSpacing());
+    }
+
+    return height() / rowHeight;
+}

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -83,6 +83,8 @@ public:
     void setIsMiniConsole() { mIsMiniConsole = true; }
     void copySelectionToClipboardHTML();
     void searchSelectionOnline();
+    int getColumnCount();
+    int getRowCount();
 
     QColor mBgColor;
     int mCursorY;

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -125,6 +125,16 @@ function Geyser.MiniConsole:setLink(...)
   setLink(self.name, ...)
 end
 
+--- Returns the number of simultaneous rows that this miniconsole can show at once
+function Geyser.MiniConsole:getRowCount()
+    return getRowCount(self.name)
+end
+
+--- Returns the number of simultaneous columns (characters) that this miniconsole can show at once on a single row
+function Geyser.MiniConsole:getColumnCount()
+    return getColumnCount(self.name)
+end
+
 -- Save a reference to our parent constructor
 Geyser.MiniConsole.parent = Geyser.Window
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3421,26 +3421,26 @@ void mudlet::showChangelogIfUpdated()
 }
 #endif // INCLUDE_UPDATER
 
-int mudlet::getColumnCount( Host * pHost, QString & name )
+int mudlet::getColumnCount(Host* pHost, QString& name)
 {
-    QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
+    QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
 
-    if( dockWindowConsoleMap.contains( name ) ) {
-        return dockWindowConsoleMap[name]->console->getColumnCount();
+    if (!dockWindowConsoleMap.contains(name)) {
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesn't exist\n" >> 0;
+        return -1;
     }
 
-    TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: window doesn't exist\n" >> 0;
-    return 0;
+    return dockWindowConsoleMap[name]->console->getColumnCount();
 }
 
-int mudlet::getRowCount( Host * pHost, QString & name )
+int mudlet::getRowCount(Host* pHost, QString& name)
 {
-    QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
+    QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
 
-    if( dockWindowConsoleMap.contains( name ) ){
-        return dockWindowConsoleMap[name]->console->getRowCount();
+    if (!dockWindowConsoleMap.contains(name)) {
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesn't exist\n" >> 0;
+        return -1;
     }
 
-    TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: window doesn't exist\n" >> 0;
-    return 0;
+    return dockWindowConsoleMap[name]->console->getRowCount();
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1818,7 +1818,7 @@ int mudlet::getLineNumber(Host* pHost, QString& name)
     if (dockWindowConsoleMap.contains(name)) {
         return dockWindowConsoleMap[name]->getLineNumber();
     } else {
-        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesnt exit\n" >> 0;
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesn't exist\n" >> 0;
     }
     return -1;
 }
@@ -1829,7 +1829,7 @@ int mudlet::getColumnNumber(Host* pHost, QString& name)
     if (dockWindowConsoleMap.contains(name)) {
         return dockWindowConsoleMap[name]->getColumnNumber();
     } else {
-        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesnt exit\n" >> 0;
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesn't exist\n" >> 0;
     }
     return -1;
 }
@@ -1841,7 +1841,7 @@ int mudlet::getLastLineNumber(Host* pHost, const QString& name)
     if (dockWindowConsoleMap.contains(name)) {
         return dockWindowConsoleMap[name]->getLastLineNumber();
     } else {
-        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesnt exit\n" >> 0;
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: window doesn't exist\n" >> 0;
     }
     return -1;
 }
@@ -3420,3 +3420,27 @@ void mudlet::showChangelogIfUpdated()
     updater->showChangelog();
 }
 #endif // INCLUDE_UPDATER
+
+int mudlet::getColumnCount( Host * pHost, QString & name )
+{
+    QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
+
+    if( dockWindowConsoleMap.contains( name ) ) {
+        return dockWindowConsoleMap[name]->console->getColumnCount();
+    }
+
+    TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: window doesn't exist\n" >> 0;
+    return 0;
+}
+
+int mudlet::getRowCount( Host * pHost, QString & name )
+{
+    QMap<QString, TConsole *> & dockWindowConsoleMap = mHostConsoleMap[pHost];
+
+    if( dockWindowConsoleMap.contains( name ) ){
+        return dockWindowConsoleMap[name]->console->getRowCount();
+    }
+
+    TDebug(QColor(Qt::white),QColor(Qt::red))<<"ERROR: window doesn't exist\n" >> 0;
+    return 0;
+}

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -185,8 +185,8 @@ public:
     bool deselect(Host* pHost, const QString& name);
     void stopSounds();
     void playSound(QString s, int);
-    int getColumnCount(Host * pHost, QString & name );
-    int getRowCount(Host * pHost, QString & name );
+    int getColumnCount(Host* pHost, QString& name);
+    int getRowCount(Host* pHost, QString& name);
 
     static const bool scmIsDevelopmentVersion;
     QTime mReplayTime;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -185,6 +185,9 @@ public:
     bool deselect(Host* pHost, const QString& name);
     void stopSounds();
     void playSound(QString s, int);
+    int getColumnCount(Host * pHost, QString & name );
+    int getRowCount(Host * pHost, QString & name );
+
     static const bool scmIsDevelopmentVersion;
     QTime mReplayTime;
     int mReplaySpeed;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Registering two new lua functions:
- `getColumnCount()`: Returns the number of characters than can fit on the width of a given window.
- `getRowCount()`: Same thing but using the height to calculate the number.

#### Motivation for adding to Mudlet
See issue #1438 

#### Other info (issues closed, discussion etc)
I've seen that Mudlet is already calculating the font width for a TTextEdit, but it takes into consideration the 'W' character (not the ' ' as discussed on the issue mentioned earlier) `mFontWidth = QFontMetrics(mpHost->mDisplayFont).width(QChar('W'));`. 

As discussed, I'm using the space, but if this were to change we could refactor `getColumnCount()` to use it and not calculate the width on each call.