### PR TITLE
Add UserWindow move and resize support.

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2795,11 +2795,11 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
     return 0;
 }
 
-int TLuaInterpreter::resizeUserWindow(lua_State* L)
+int TLuaInterpreter::resizeWindow(lua_State* L)
 {
     string luaSendText = "";
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "resizeUserWindow: wrong argument type");
+        lua_pushstring(L, "resizeWindow: wrong argument type");
         lua_error(L);
         return 1;
     } else {
@@ -2807,7 +2807,7 @@ int TLuaInterpreter::resizeUserWindow(lua_State* L)
     }
     double x1;
     if (!lua_isnumber(L, 2)) {
-        lua_pushstring(L, "resizeUserWindow: wrong argument type");
+        lua_pushstring(L, "resizeWindow: wrong argument type");
         lua_error(L);
         return 1;
     } else {
@@ -2815,7 +2815,7 @@ int TLuaInterpreter::resizeUserWindow(lua_State* L)
     }
     double y1;
     if (!lua_isnumber(L, 3)) {
-        lua_pushstring(L, "resizeUserWindow: wrong argument type");
+        lua_pushstring(L, "resizeWindow: wrong argument type");
         lua_error(L);
         return 1;
     } else {
@@ -12009,7 +12009,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "startStopWatch", TLuaInterpreter::startStopWatch);
     lua_register(pGlobalLua, "resetStopWatch", TLuaInterpreter::resetStopWatch);
     lua_register(pGlobalLua, "closeUserWindow", TLuaInterpreter::closeUserWindow);
-    lua_register(pGlobalLua, "resizeWindow", TLuaInterpreter::resizeUserWindow);
+    lua_register(pGlobalLua, "resizeWindow", TLuaInterpreter::resizeWindow);
     lua_register(pGlobalLua, "appendBuffer", TLuaInterpreter::appendBuffer);
     lua_register(pGlobalLua, "setBackgroundImage", TLuaInterpreter::setBackgroundImage);
     lua_register(pGlobalLua, "setBackgroundColor", TLuaInterpreter::setBackgroundColor);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -300,7 +300,7 @@ public:
     static int showUserWindow(lua_State*);
     static int hideUserWindow(lua_State*);
     static int closeUserWindow(lua_State*);
-    static int resizeUserWindow(lua_State*);
+    static int resizeWindow(lua_State*);
     static int createStopWatch(lua_State*);
     static int stopStopWatch(lua_State*);
     static int getStopWatchTime(lua_State*);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1642,9 +1642,15 @@ bool mudlet::resizeWindow(Host* pHost, const QString& name, int x1, int y1)
         return true;
     }
 
+    QMap<QString, TDockWidget*>& dockWindowMap = mHostDockConsoleMap[pHost];
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
-    if (dockWindowConsoleMap.contains(name)) {
+    if (dockWindowConsoleMap.contains(name) && !dockWindowMap.contains(name)) {
         dockWindowConsoleMap[name]->resize(x1, y1);
+        return true;
+    }
+
+    if (dockWindowMap.contains(name)) {
+        dockWindowMap[name]->resize(x1, y1);
         return true;
     }
 
@@ -1698,11 +1704,17 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
         return true;
     }
 
+    QMap<QString, TDockWidget*>& dockWindowMap = mHostDockConsoleMap[pHost];
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
-    if (dockWindowConsoleMap.contains(name)) {
+    if (dockWindowConsoleMap.contains(name) && !dockWindowMap.contains(name)) {
         dockWindowConsoleMap[name]->move(x1, y1);
         dockWindowConsoleMap[name]->mOldX = x1;
         dockWindowConsoleMap[name]->mOldY = y1;
+        return true;
+    }
+
+    if (dockWindowMap.contains(name)) {
+        dockWindowMap[name]->move(x1, y1);
         return true;
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1650,6 +1650,10 @@ bool mudlet::resizeWindow(Host* pHost, const QString& name, int x1, int y1)
     }
 
     if (dockWindowMap.contains(name)) {
+        if (!dockWindowMap[name]->isFloating()) {
+            return false;
+        }
+
         dockWindowMap[name]->resize(x1, y1);
         return true;
     }
@@ -1714,6 +1718,10 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
     }
 
     if (dockWindowMap.contains(name)) {
+        if (!dockWindowMap[name]->isFloating()) {
+            dockWindowMap[name]->setFloating(true);
+        }
+
         dockWindowMap[name]->move(x1, y1);
         return true;
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds Lua API support for move and resize calls on UserWindow instances using `moveWindow()` and `resizeWindow()` lua method calls.    
The method `TLuaInterpreter::resizeUserWindow` was changed to `TLuaInterpreter::resizeWindow` to follow related naming conventions.

#### Motivation for adding to Mudlet
The move and resize Lua methods work only on MiniConsoles and have less-than-helpful impact on the UserWindow instances.   
