### PR TITLE
BugFix: color triggers get erased in 3.6.1

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4946,6 +4946,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
                 pItem->pushButton_fgColor->show();
                 pItem->pushButton_bgColor->show();
                 pItem->pushButton_prompt->hide();
+                // Although not shown it holds the data about the colours selected:
+                pItem->lineEdit_pattern->setText(patternList.at(i));
                 pItem->lineEdit_pattern->hide();
                 if (!pT->mColorPatternList[i]) {
                     break;


### PR DESCRIPTION
In https://github.com/Mudlet/Mudlet/commit/5ce683b1b0e4b1037dee7702aaa872e8fbfdfa34 the writing of the (encoded) colour trigger data into the `(QLineEdit*) pItem->lineEdit_pattern` in `(void) dlgTriggerEditor::slot_trigger_selected(QTreeWidget*)` was removed if the trigger item is a colour one - probably because in that type that element is hidden from the user (as it was then also removed for the new Prompt type trigger).

This closes Issue #1468 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>