### PR TITLE
BugFix: allow Lua setTextFormat to control strike-out format correctly

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3348,7 +3348,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
     }
 
     bool strikeout = false;
-    if (s > n) // s has not been incremented yet so this means we still have another argument!
+    if (s < n) // s has not been incremented yet so this means we still have another argument!
     {
         if (lua_isboolean(L, ++s)) {
             strikeout = lua_toboolean(L, s);


### PR DESCRIPTION
The option to set this format feature is optional (defaults to `false`) but the condition to check for enough arguments to control this was reversed so the code to set the option would be unreachable and so the option was never applied (and would clear it if set elsewhere, say with `setStrikeOut([window name], true)`.

This corrects the bug I mentioned I found in #1474 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>