### PR TITLE
Add a Discord badge/link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Mudlet
 
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true)](https://ci.appveyor.com/project/Mudlet/mudlet/branch/development) [![GitHub Build Status](https://travis-ci.org/Mudlet/Mudlet.svg?branch=development)](https://travis-ci.org/Mudlet/Mudlet) [![GitHub stars](https://img.shields.io/github/stars/Mudlet/Mudlet.svg)](https://github.com/Mudlet/Mudlet/stargazers) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Mudlet/Mudlet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true)](https://ci.appveyor.com/project/Mudlet/mudlet/branch/development) [![GitHub Build Status](https://travis-ci.org/Mudlet/Mudlet.svg?branch=development)](https://travis-ci.org/Mudlet/Mudlet) [![GitHub stars](https://img.shields.io/github/stars/Mudlet/Mudlet.svg)](https://github.com/Mudlet/Mudlet/stargazers) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Mudlet/Mudlet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Discord](https://img.shields.io/badge/discord-join%20chat-7289DA.svg)](https://discord.gg/kuYvMQ9)
 
 Mudlet is a quality MUD client, designed to take mudding to a new level.
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions  
This adds a badge similar to the others for build status and gitter link but for the Mudlet Discord server.   
Using https://shields.io/ to create the discord badge.

#### Motivation for adding to Mudlet
Just to add another pretty badge to the list, for Discord. 

#### Other info (issues closed, discussion etc)
Working sample of the badge:  
[![Discord](https://img.shields.io/badge/discord-join%20chat-7289DA.svg)](https://discord.gg/kuYvMQ9)