### PR TITLE
Q_OS_UNIX goes off for macOS when the code is not intended to

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12453,7 +12453,16 @@ void TLuaInterpreter::initIndenterGlobals()
 
 
 
-#if defined(Q_OS_UNIX)
+#if defined(Q_OS_MAC)
+        //macOS app bundle would like the search path to also be set to the current binary directory
+        luaL_dostring(pIndenterState, QStringLiteral("package.cpath = package.cpath .. ';%1/?.so'")
+                      .arg(QCoreApplication::applicationDirPath())
+                      .toUtf8().constData());
+        luaL_dostring(pIndenterState, QStringLiteral("package.path = package.path .. ';%1/?.lua'")
+                      .arg(QCoreApplication::applicationDirPath())
+                      .toUtf8().constData());
+
+#elif defined(Q_OS_UNIX)
     // Need to tweak the lua path for the installed *nix case and to allow
     // running from a shadow build directory, the latter means we HAVE to rename
     // where the module code is stored or use a symbolic link from "lcf" to
@@ -12470,15 +12479,6 @@ void TLuaInterpreter::initIndenterGlobals()
 
     //AppInstaller on Linux would like the search path to also be set to the current binary directory
     luaL_dostring(pIndenterState, QStringLiteral("package.cpath = package.cpath .. ';%1/lib/?.so'")
-                  .arg(QCoreApplication::applicationDirPath())
-                  .toUtf8().constData());
-
-#elif defined(Q_OS_MAC)
-    //macOS app bundle would like the search path to also be set to the current binary directory
-    luaL_dostring(pIndenterState, QStringLiteral("package.cpath = package.cpath .. ';%1/?.so'")
-                  .arg(QCoreApplication::applicationDirPath())
-                  .toUtf8().constData());
-    luaL_dostring(pIndenterState, QStringLiteral("package.path = package.path .. ';%1/?.lua'")
                   .arg(QCoreApplication::applicationDirPath())
                   .toUtf8().constData());
 #endif


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix the code formatter to load on macOS again.
#### Motivation for adding to Mudlet
Fix regression in 3.7.0.
#### Other info (issues closed, discussion etc)
Somehow `Q_OS_UNIX` was snuck in when we do not support UNIX as an operating system... and it introduced a regression by grabbing the wrong operating system, namely macOS.