### PR TITLE
BugFix: remove unneeded connect/disconnect(...) for Search Engine selector

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -452,8 +452,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // CHECKME: Have moved ALL the connects, where possible, to the end so that
     // none are triggered by the setup operations...
-    connect(search_engine_combobox, SIGNAL(currentTextChanged(const QString)), this, SLOT(slot_search_engine_edited(const QString)));
-
     connect(pushButton_command_line_foreground_color, SIGNAL(clicked()), this, SLOT(setCommandLineFgColor()));
     connect(pushButton_command_line_background_color, SIGNAL(clicked()), this, SLOT(setCommandLineBgColor()));
 
@@ -588,8 +586,6 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(pushButton_saveMap, SIGNAL(clicked()));
 
     disconnect(comboBox_encoding, SIGNAL(currentTextChanged(const QString&)));
-
-    disconnect(search_engine_combobox, SIGNAL(currentTextChanged(const QString)));
 }
 
 void dlgProfilePreferences::clearHostDetails()


### PR DESCRIPTION
I think this was a merge error, but these are no longer needed as the selection of search engine is now determined when the profile preferences dialog is closed instead of being set immediately the control is adjusted.

The effects of them being present are run-time error messages because the specified slot function is no longer needed or present in the code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>