### PR TITLE
Fix RPMLint msg: Returns random data in a function

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1390,6 +1390,8 @@ QString TTextEdit::getSelectedText(char newlineChar)
         // we never append the last character of a buffer line se we set our own
         text.append(newlineChar);
     }
+    qDebug() << "TTextEdit::getSelectedText(...) INFO - unexpectedly hit bottom of method so returning:" << text;
+    return text;
 }
 
 void TTextEdit::mouseReleaseEvent(QMouseEvent* event)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3402,6 +3402,8 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
         // when saving/resyncing packages/modules - ends in a '/'
         return QStringLiteral("%1/.config/mudlet/moduleBackups/").arg(QDir::homePath());
     }
+    Q_UNREACHABLE();
+    return QString();
 }
 
 #if defined(INCLUDE_UPDATER)


### PR DESCRIPTION
In mudlet::getMudletPath, I chose to return an empty string, and in TTextEdit:getSelectedText, I returned whatever happens to have been added to the buffer before hitting the end of the loop. Maybe ideally, an error should be thrown as this code should never be reached, but at least this way it won't cause any other problems.

#### Brief overview of PR changes/additions
This patch adds default return values to two functions that did not have them. Technically this code should never actually be reached.

#### Motivation for adding to Mudlet
I'm creating an updated package for openSUSE Tumbleweed, and RPMlint would not let me continue with this problem.

#### Other info (issues closed, discussion etc)
