### PR TITLE
Enhance: improve and extend lua OS platform identification getOS() command

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10827,6 +10827,57 @@ int TLuaInterpreter::getServerEncodingsList(lua_State* L)
     return 1;
 }
 
+// Determine operating system, moved from a linux/macos/windows only script in
+// "Other.lua" to provide better identification for "other" OSs
+int TLuaInterpreter::getOS(lua_State* L)
+{
+#if defined(Q_OS_CYGWIN)
+    // Try for this one before Q_OS_WIN32 as both are likely to be defined on
+    // a Cygwin platform
+    // CHECK: hopefully will NOT be triggered on mingw/msys
+    lua_pushstring(L, "cygwin");
+    return 1;
+#elif defined(Q_OS_WIN32)
+    lua_pushstring(L, "windows");
+    return 1;
+#elif defined(Q_OS_MACOS)
+    lua_pushstring(L, "mac");
+    return 1;
+#elif defined(Q_OS_HURD)
+    // One can hope/dream!
+    lua_pushstring(L, "hurd");
+    return 1;
+#elif defined(Q_OS_FREEBSD)
+    // Only defined on FreeBSD but NOT Debian kFreeBSD so we should check for
+    // this first
+    lua_pushstring(L, "freebsd");
+    return 1;
+#elif defined(Q_OS_FREEBSD_KERNEL)
+    // Defined for BOTH Debian kFreeBSD hybrid with a GNU userland and
+    // main FreeBSD so it must be after Q_OS_FREEBSD check; included for Debian
+    // packager who may want to have this!
+    lua_pushstring(L, "kfreebsd");
+    return 1;
+#elif defined(Q_OS_OPENBSD)
+    lua_pushstring(L, "openbsd");
+    return 1;
+#elif defined(Q_OS_NETBSD)
+    lua_pushstring(L, "netbsd");
+    return 1;
+#elif defined(Q_OS_BSD4)
+    // Generic *nix - must be before unix and after other more specific results
+    lua_pushstring(L, "bsd4");
+    return 1;
+#elif defined(Q_OS_UNIX)
+    // Most generic *nix - must be after bsd4 and other more specific results
+    lua_pushstring(L, "unix");
+    return 1;
+#else
+    lua_pushstring(L, "unknown");
+    return 1;
+#endif
+}
+
 bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
 {
     if (code.size() < 1) {
@@ -12287,6 +12338,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "permPromptTrigger", TLuaInterpreter::permPromptTrigger);
     lua_register(pGlobalLua, "getColumnCount", TLuaInterpreter::getColumnCount);
     lua_register(pGlobalLua, "getRowCount", TLuaInterpreter::getRowCount);
+    lua_register(pGlobalLua, "getOS", TLuaInterpreter::getOS);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     luaopen_yajl(pGlobalLua);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10827,8 +10827,6 @@ int TLuaInterpreter::getServerEncodingsList(lua_State* L)
     return 1;
 }
 
-// Determine operating system, moved from a linux/macos/windows only script in
-// "Other.lua" to provide better identification for "other" OSs
 int TLuaInterpreter::getOS(lua_State* L)
 {
 #if defined(Q_OS_CYGWIN)
@@ -10836,46 +10834,36 @@ int TLuaInterpreter::getOS(lua_State* L)
     // a Cygwin platform
     // CHECK: hopefully will NOT be triggered on mingw/msys
     lua_pushstring(L, "cygwin");
-    return 1;
 #elif defined(Q_OS_WIN32)
     lua_pushstring(L, "windows");
-    return 1;
 #elif defined(Q_OS_MACOS)
     lua_pushstring(L, "mac");
-    return 1;
 #elif defined(Q_OS_HURD)
     // One can hope/dream!
     lua_pushstring(L, "hurd");
-    return 1;
 #elif defined(Q_OS_FREEBSD)
     // Only defined on FreeBSD but NOT Debian kFreeBSD so we should check for
     // this first
     lua_pushstring(L, "freebsd");
-    return 1;
 #elif defined(Q_OS_FREEBSD_KERNEL)
     // Defined for BOTH Debian kFreeBSD hybrid with a GNU userland and
     // main FreeBSD so it must be after Q_OS_FREEBSD check; included for Debian
     // packager who may want to have this!
     lua_pushstring(L, "kfreebsd");
-    return 1;
 #elif defined(Q_OS_OPENBSD)
     lua_pushstring(L, "openbsd");
-    return 1;
 #elif defined(Q_OS_NETBSD)
     lua_pushstring(L, "netbsd");
-    return 1;
 #elif defined(Q_OS_BSD4)
     // Generic *nix - must be before unix and after other more specific results
     lua_pushstring(L, "bsd4");
-    return 1;
 #elif defined(Q_OS_UNIX)
     // Most generic *nix - must be after bsd4 and other more specific results
     lua_pushstring(L, "unix");
-    return 1;
 #else
     lua_pushstring(L, "unknown");
-    return 1;
 #endif
+    return 1;
 }
 
 bool TLuaInterpreter::compileAndExecuteScript(const QString& code)

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -424,7 +424,7 @@ public:
     static int permPromptTrigger(lua_State*);
     static int getColumnCount(lua_State*);
     static int getRowCount(lua_State*);
-
+    static int getOS(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
     static const QMap<Qt::MouseButton, QString> mMouseButtons;
     void freeLuaRegistryIndex(int index);

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -217,31 +217,6 @@ function xor(a, b)
 end
 
 
-
---- Determine operating system.
----
---- @usage
----   <pre>
----   if "linux" == getOS() then
----       echo("We are using GNU/Linux!")
----   end
----   </pre>
----
---- @return "linux", "mac" or "windows" string
-function getOS()
-  if string.char(getMudletHomeDir():byte()) == "/" then
-    if io.exists("/Applications") then
-      return "mac"
-    else
-      return "linux"
-    end
-  else
-    return "windows"
-  end
-end
-
-
-
 --- This function flags a variable to be saved by Mudlet's variable persistence system.
 --- Variables are automatically unpacked into the global namespace when the profile is loaded.
 --- They are saved to "SavedVariables.lua" when the profile is closed or saved.


### PR DESCRIPTION
This will help my FreeBSD porting as the original script would return the incorrect string `"linux"` on that...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>