### PR TITLE
Revise: fixup incorrect Q_OS_XXXX values {Main part}

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -969,7 +969,7 @@ void TConsole::changeColors()
         console->setPalette(palette);
         console2->setPalette(palette);
     } else if (mIsSubConsole) {
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         mDisplayFont.setStyleStrategy((QFont::StyleStrategy)(QFont::NoAntialias | QFont::PreferQuality));
         QPixmap pixmap = QPixmap(2000, 600);
         QPainter p(&pixmap);
@@ -1013,7 +1013,7 @@ void TConsole::changeColors()
         }
         mpHost->mDisplayFont.setFixedPitch(true);
         mDisplayFont.setFixedPitch(true);
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         QPixmap pixmap = QPixmap(2000, 600);
         QPainter p(&pixmap);
         QFont _font = mpHost->mDisplayFont;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4832,7 +4832,7 @@ int TLuaInterpreter::getMudletLuaDefaultPaths(lua_State* L)
 {
     int index = 1;
     lua_newtable(L);
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     lua_createtable(L, 3, 0);
 #else
     lua_createtable(L, 2, 0);
@@ -4841,7 +4841,7 @@ int TLuaInterpreter::getMudletLuaDefaultPaths(lua_State* L)
     QString nativePath = QDir::toNativeSeparators(QCoreApplication::applicationDirPath() + "/mudlet-lua/lua/");
     lua_pushstring(L, nativePath.toUtf8().constData());
     lua_rawseti(L, -2, index++);
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     // add macOS lua path relative to the binary itself, which is part of the Mudlet.app package
     nativePath = QDir::toNativeSeparators(QCoreApplication::applicationDirPath() + "/../Resources/mudlet-lua/lua/");
     lua_pushstring(L, nativePath.toUtf8().constData());
@@ -12489,7 +12489,7 @@ void TLuaInterpreter::initIndenterGlobals()
 
 
 
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
         //macOS app bundle would like the search path to also be set to the current binary directory
         luaL_dostring(pIndenterState, QStringLiteral("package.cpath = package.cpath .. ';%1/?.so'")
                       .arg(QCoreApplication::applicationDirPath())
@@ -12544,7 +12544,7 @@ void TLuaInterpreter::initIndenterGlobals()
 
 void TLuaInterpreter::loadGlobal()
 {
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     // Load relatively to MacOS inside Resources when we're in a .app bundle,
     // as mudlet-lua always gets copied in by the build script into the bundle
     QString path = QCoreApplication::applicationDirPath() + "/../Resources/mudlet-lua/lua/LuaGlobal.lua";

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -75,7 +75,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isDe
         }
 
         mpHost->mDisplayFont.setFixedPitch(true);
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * 2, mFontHeight * 2);
         QPainter p(&pixmap);
         p.setFont(mpHost->mDisplayFont);
@@ -93,7 +93,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isDe
         mFontWidth = QFontMetrics(mDisplayFont).width(QChar('W'));
         mScreenWidth = 100;
         mDisplayFont.setFixedPitch(true);
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * 2, mFontHeight * 2);
         QPainter p(&pixmap);
         p.setFont(mDisplayFont);
@@ -190,7 +190,7 @@ void TTextEdit::initDefaultSettings()
     mFgColor = QColor(192, 192, 192);
     mBgColor = QColor(Qt::black);
     mDisplayFont = QFont("Bitstream Vera Sans Mono", 10, QFont::Normal);
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
     int width = mScreenWidth * mFontWidth * 2;
     int height = mFontHeight * 2;
     // sometimes mScreenWidth is 0, and QPainter doesn't like dimensions of 0x#. Need to work out why is
@@ -221,7 +221,7 @@ void TTextEdit::updateScreenView()
         mFontDescent = QFontMetrics(mDisplayFont).descent();
         mFontAscent = QFontMetrics(mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         QPixmap pixmap = QPixmap(2000, 600);
         QPainter p(&pixmap);
         mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, 0);
@@ -245,7 +245,7 @@ void TTextEdit::updateScreenView()
         mFontHeight = mFontAscent + mFontDescent;
         mBgColor = mpHost->mBgColor;
         mFgColor = mpHost->mFgColor;
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * 2, mFontHeight * 2);
         QPainter p(&pixmap);
         mpHost->mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, 0);
@@ -264,7 +264,7 @@ void TTextEdit::updateScreenView()
         mFontDescent = QFontMetrics(mDisplayFont).descent();
         mFontAscent = QFontMetrics(mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         int width = mScreenWidth * mFontWidth * 2;
         int height = mFontHeight * 2;
         // sometimes mScreenWidth is 0, and QPainter doesn't like dimensions of 0x#. Need to work out why is
@@ -399,7 +399,7 @@ inline void TTextEdit::drawCharacters(QPainter& painter, const QRect& rect, QStr
         font.setUnderline(isUnderline);
         font.setItalic(isItalics);
         font.setStrikeOut(isStrikeOut);
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         font.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
 #endif
         painter.setFont(font);
@@ -407,7 +407,7 @@ inline void TTextEdit::drawCharacters(QPainter& painter, const QRect& rect, QStr
     if (painter.pen().color() != fgColor) {
         painter.setPen(fgColor);
     }
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
     QPointF _p(rect.x(), rect.bottom() - mFontDescent);
     painter.drawText(_p, text);
 #else

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -993,7 +993,7 @@ void dlgConnectionProfiles::fillout_form()
 
 // collapse the width as the default is too big and set the height to a reasonable default
 // to fit all of the 'Welcome' message
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
         // macOS requires 15px more width to get 3 columns of MUD listings in
         resize(minimumSize().width() + 15, 300);
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,7 @@ using namespace std;
 
 TConsole* spDebugConsole = nullptr;
 
-#if defined(Q_OS_WIN)
+#if defined(Q_OS_WIN32)
 bool runUpdate();
 #endif
 
@@ -364,7 +364,7 @@ int main(int argc, char* argv[])
      * If we get to HERE then we are going to run a GUI application... *
      *******************************************************************/
 
-#if defined(Q_OS_WIN) && defined(INCLUDE_UPDATER)
+#if defined(Q_OS_WIN32) && defined(INCLUDE_UPDATER)
     auto abortLaunch = runUpdate();
     if (abortLaunch) {
         return 0;
@@ -613,7 +613,7 @@ int main(int argc, char* argv[])
     return app->exec();
 }
 
-#if defined(Q_OS_WIN) && defined(INCLUDE_UPDATER)
+#if defined(Q_OS_WIN32) && defined(INCLUDE_UPDATER)
 // small detour for Windows - check if there's an updated Mudlet
 // available to install. If there is, quit and run it - Squirrel
 // will update Mudlet and then launch it once it's done

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -55,7 +55,7 @@ void Updater::checkUpdatesOnStart()
     setupOnMacOS();
 #elif defined(Q_OS_LINUX)
     setupOnLinux();
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN32)
     setupOnWindows();
 #endif
 }
@@ -97,7 +97,7 @@ void Updater::finishSetup()
 {
 #if defined(Q_OS_LINUX)
     qWarning() << "Successfully updated Mudlet to" << feed->getUpdates().first().getVersion();
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN32)
     qWarning() << "Mudlet prepped to update to" << feed->getUpdates().first().getVersion() << "on restart";
 #endif
     recordUpdateTime();
@@ -114,7 +114,7 @@ void Updater::setupOnMacOS()
 }
 #endif // Q_OS_MACOS
 
-#if defined(Q_OS_WIN)
+#if defined(Q_OS_WIN32)
 void Updater::setupOnWindows()
 {
     QObject::connect(feed, &dblsqd::Feed::ready, [=]() { qWarning() << "Checked for updates:" << feed->getUpdates().size() << "update(s) available"; });
@@ -290,7 +290,7 @@ void Updater::installOrRestartClicked(QAbstractButton* button, QString filePath)
 // otherwise the button says 'Install', so install the update
 #if defined(Q_OS_LINUX)
     QFuture<void> future = QtConcurrent::run(this, &Updater::untarOnLinux, filePath);
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN32)
     QFuture<void> future = QtConcurrent::run(this, &Updater::prepareSetupOnWindows, filePath);
 #endif
 
@@ -299,7 +299,7 @@ void Updater::installOrRestartClicked(QAbstractButton* button, QString filePath)
     connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
 #if defined(Q_OS_LINUX)
         updateBinaryOnLinux();
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN32)
         finishSetup();
 #endif
         installOrRestartButton->setText(tr("Restart to apply update"));
@@ -334,7 +334,7 @@ void Updater::recordUpdateTime() const
 bool Updater::shouldShowChangelog()
 {
 // Don't show changelog for automatic updates on Sparkle - Sparkle doesn't support it
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     return false;
 #endif
 

--- a/src/updater.h
+++ b/src/updater.h
@@ -55,7 +55,7 @@ private:
 #if defined(Q_OS_LINUX)
     void setupOnLinux();
     void untarOnLinux(const QString& fileName);
-#elif defined(Q_OS_WIN)
+#elif defined(Q_OS_WIN32)
     void setupOnWindows();
     void prepareSetupOnWindows(const QString& fileName);
 #elif defined(Q_OS_MACOS)


### PR DESCRIPTION
`Q_OS_WIN` includes `Q_OS_WINRT` which is not what we want - use `Q_OS_WIN32` (which is also set on 64-bit windows).

`Q_OS_MAC` is a deprecated synonym for `Q_OS_DARWIN`, and Qt documentation says "Do not use."

There are three places that are NOT fixed by this commit however they will clash with a pending PR #1506 that needs to modify the same lines so will be fixed by a commit in that set of changes.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>