### PR TITLE
BugFix: restore "linux" to list of OSs reported by lua getOS()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10838,6 +10838,8 @@ int TLuaInterpreter::getOS(lua_State* L)
     lua_pushstring(L, "windows");
 #elif defined(Q_OS_MACOS)
     lua_pushstring(L, "mac");
+#elif defined(Q_OS_LINUX)
+    lua_pushstring(L, "linux");
 #elif defined(Q_OS_HURD)
     // One can hope/dream!
     lua_pushstring(L, "hurd");


### PR DESCRIPTION
#### Brief overview of PR changes/additions
When I extended the range of platforms and moved this function recently from the external Other.lua file to the C++ core (where there is a whole smorgasbord of OS macros) I was working from FreeBSD and did not spot that had lost the "linux" one - so that users on that platform would get a generic "unix" response, this commit fixes that.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Motivation for adding to Mudlet
Fixing an obvious error that I did not spot previously. :blush:

#### Other info (issues closed, discussion etc)
