### PR TITLE
Revise: improve non-XY exits/stub exits/doors indications on 2D Map

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1561,108 +1561,223 @@ void T2DMap::paintEvent(QPaintEvent* e)
             }
         }
 
+        // Change these from const to static to tweak them whilst running in a debugger...!
+        const float allInsideTipOffsetFactor = 1 / 20.0f;
+        const float upDownXOrYFactor = 1 / 3.1f;
+        const float inOuterXFactor = 1 / 4.5f;
+        const float inUpDownYFactor = 1 / 7.0f;
+        const float outOuterXFactor = 1 / 2.2f;
+        const float outUpDownYFactor = 1 / 5.5f;
+        const float outInterXFactor = 1 / 3.5f;
+        const float outerRealDoorPenThicknessFactor = 0.050f;
+        const float outerStubDoorPenThicknessFactor = 0.025f;
+        const float innerRealDoorPenThicknessFactor = 0.025f;
+        const float innerStubDoorPenThicknessFactor = 0.0125f;
+
         QColor lc;
-        if (c.red() + c.green() + c.blue() > 200) {
+        if (c.lightness() > 127) {
             lc = QColor(Qt::black);
         } else {
             lc = QColor(Qt::white);
         }
         pen = p.pen();
         pen.setColor(lc);
-        pen.setWidthF(0); //wegBreite?);
         pen.setCosmetic(mMapperUseAntiAlias);
         pen.setCapStyle(Qt::RoundCap);
         pen.setJoinStyle(Qt::RoundJoin);
-        p.setPen(pen);
+        QPen innerPen = pen;
+        p.save();
 
-        //FIXME: redo exit stubs here since the room will draw over up/down stubs -- its repetitive though
-        QMap<int, QVector3D> unitVectors = mpMap->unitVectors;
-        for (int k = 0; k < pR->exitStubs.size(); k++) {
-            int direction = pR->exitStubs[k];
-            QVector3D uDirection = unitVectors[direction];
-            if (direction > 8) {
-                float rx = pR->x * mTX + mRX;
-                float ry = pR->y * -1 * mTY + mRY;
-                QPolygonF _poly;
-                QPointF _pt;
-                _pt = QPointF(rx, ry + (mTY * rSize) * uDirection.z() / 20.0);
-                _poly.append(_pt);
-                _pt = QPointF(rx + (mTX * rSize) / 3.1, ry + (mTY * rSize) * uDirection.z() / 3.1);
-                _poly.append(_pt);
-                _pt = QPointF(rx - (mTX * rSize) / 3.1, ry + (mTY * rSize) * uDirection.z() / 3.1);
-                _poly.append(_pt);
-                QBrush brush = p.brush();
-                brush.setColor(Qt::black);
-                brush.setStyle(Qt::NoBrush);
-                p.setBrush(brush);
-                p.drawPolygon(_poly);
+        QBrush innerBrush = p.brush();
+        innerBrush.setStyle(Qt::NoBrush);
+        if (pR->getUp() > 0 || pR->exitStubs.contains(DIR_UP)) {
+            QPolygonF poly_up;
+            poly_up.append(QPointF(rx, ry + (mTY * rSize * allInsideTipOffsetFactor)));
+            poly_up.append(QPointF(rx - (mTX * rSize * upDownXOrYFactor), ry + (mTY * rSize * upDownXOrYFactor)));
+            poly_up.append(QPointF(rx + (mTX * rSize * upDownXOrYFactor), ry + (mTY * rSize * upDownXOrYFactor)));
+            bool isDoor = true;
+            QBrush brush = p.brush();
+            switch (pR->doors.value(QStringLiteral("up"))) {
+            case 1: //open door
+                brush.setColor(QColor(10, 155, 10));
+                innerPen.setColor(QColor(10, 155, 10));
+                break;
+            case 2: //closed door
+                brush.setColor(QColor(155, 155, 10));
+                innerPen.setColor(QColor(155, 155, 10));
+                break;
+            case 3:
+                brush.setColor(QColor(155, 10, 10));
+                innerPen.setColor(QColor(155, 10, 10));
+                break;
+            default:
+                brush.setColor(lc);
+                isDoor = false;
+            }
+            if (pR->getUp() > 0) {
+                pen.setWidthF(mTX * rSize * outerRealDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerRealDoorPenThicknessFactor);
+                brush.setStyle(Qt::Dense4Pattern);
+            } else {
+                pen.setWidthF(mTX * rSize * outerStubDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerStubDoorPenThicknessFactor);
+                brush.setStyle(Qt::DiagCrossPattern);
+            }
+            p.setPen(pen);
+            p.setBrush(brush);
+            p.drawPolygon(poly_up);
+            if (isDoor) {
+                // Draw a narrower triangle on top of the existing one if there
+                // is a door - to help emphasis the coloured door if the brush
+                // from the main one is not obvious given the main room colour.
+                p.setPen(innerPen);
+                p.setBrush(innerBrush);
+                p.drawPolygon(poly_up);
             }
         }
 
-        if (pR->getUp() > 0) {
-            QPolygonF _poly;
-            QPointF _pt;
-            _pt = QPointF(rx, ry + (mTY * rSize) / 20.0);
-            _poly.append(_pt);
-            _pt = QPointF(rx - (mTX * rSize) / 3.1, ry + (mTY * rSize) / 3.1);
-            _poly.append(_pt);
-            _pt = QPointF(rx + (mTX * rSize) / 3.1, ry + (mTY * rSize) / 3.1);
-            _poly.append(_pt);
+        if (pR->getDown() > 0 || pR->exitStubs.contains(DIR_DOWN)) {
+            QPolygonF poly_down;
+            poly_down.append(QPointF(rx, ry - (mTY * rSize * allInsideTipOffsetFactor)));
+            poly_down.append(QPointF(rx - (mTX * rSize * upDownXOrYFactor), ry - (mTY * rSize * upDownXOrYFactor)));
+            poly_down.append(QPointF(rx + (mTX * rSize * upDownXOrYFactor), ry - (mTY * rSize * upDownXOrYFactor)));
+            bool isDoor = true;
             QBrush brush = p.brush();
-            brush.setColor(Qt::black);
-            brush.setStyle(Qt::SolidPattern);
+            switch (pR->doors.value(QStringLiteral("down"))) {
+            case 1: //open door
+                brush.setColor(QColor(10, 155, 10));
+                innerPen.setColor(QColor(10, 155, 10));
+                break;
+            case 2: //closed door
+                brush.setColor(QColor(155, 155, 10));
+                innerPen.setColor(QColor(155, 155, 10));
+                break;
+            case 3:
+                brush.setColor(QColor(155, 10, 10));
+                innerPen.setColor(QColor(155, 10, 10));
+                break;
+            default:
+                brush.setColor(lc);
+                isDoor = false;
+            }
+            if (pR->getDown() > 0) {
+                pen.setWidthF(mTX * rSize * outerRealDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerRealDoorPenThicknessFactor);
+                brush.setStyle(Qt::Dense4Pattern);
+            } else {
+                pen.setWidthF(mTX * rSize * outerStubDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerStubDoorPenThicknessFactor);
+                brush.setStyle(Qt::DiagCrossPattern);
+            }
+            p.setPen(pen);
             p.setBrush(brush);
-            p.drawPolygon(_poly);
+            p.drawPolygon(poly_down);
+            if (isDoor) {
+                p.setPen(innerPen);
+                p.setBrush(innerBrush);
+                p.drawPolygon(poly_down);
+            }
         }
 
-        if (pR->getDown() > 0) {
-            QPolygonF _poly;
-            QPointF _pt;
-            _pt = QPointF(rx, ry - (mTY * rSize) / 20.0);
-            _poly.append(_pt);
-            _pt = QPointF(rx - (mTX * rSize) / 3.1, ry - (mTY * rSize) / 3.1);
-            _poly.append(_pt);
-            _pt = QPointF(rx + (mTX * rSize) / 3.1, ry - (mTY * rSize) / 3.1);
-            _poly.append(_pt);
+        if (pR->getIn() > 0 || pR->exitStubs.contains(DIR_IN)) {
+            QPolygonF poly_in_left;
+            QPolygonF poly_in_right;
+            poly_in_left.append(QPointF(rx - (mTX * rSize * allInsideTipOffsetFactor), ry));
+            poly_in_left.append(QPointF(rx - (mTX * rSize * inOuterXFactor), ry + (mTY * rSize * inUpDownYFactor)));
+            poly_in_left.append(QPointF(rx - (mTX * rSize * inOuterXFactor), ry - (mTY * rSize * inUpDownYFactor)));
+            poly_in_right.append(QPointF(rx + (mTX * rSize * allInsideTipOffsetFactor), ry));
+            poly_in_right.append(QPointF(rx + (mTX * rSize * inOuterXFactor), ry + (mTY * rSize * inUpDownYFactor)));
+            poly_in_right.append(QPointF(rx + (mTX * rSize * inOuterXFactor), ry - (mTY * rSize * inUpDownYFactor)));
+            bool isDoor = true;
             QBrush brush = p.brush();
-            brush.setColor(Qt::black);
-            brush.setStyle(Qt::SolidPattern);
+            switch (pR->doors.value(QStringLiteral("in"))) {
+            case 1: //open door
+                brush.setColor(QColor(10, 155, 10));
+                innerPen.setColor(QColor(10, 155, 10));
+                break;
+            case 2: //closed door
+                brush.setColor(QColor(155, 155, 10));
+                innerPen.setColor(QColor(155, 155, 10));
+                break;
+            case 3:
+                brush.setColor(QColor(155, 10, 10));
+                innerPen.setColor(QColor(155, 10, 10));
+                break;
+            default:
+                brush.setColor(lc);
+                isDoor = false;
+            }
+            if (pR->getIn() > 0) {
+                pen.setWidthF(mTX * rSize * outerRealDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerRealDoorPenThicknessFactor);
+                brush.setStyle(Qt::Dense4Pattern);
+            } else {
+                pen.setWidthF(mTX * rSize * outerStubDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerStubDoorPenThicknessFactor);
+                brush.setStyle(Qt::DiagCrossPattern);
+            }
             p.setBrush(brush);
-            p.drawPolygon(_poly);
+            p.setPen(pen);
+            p.drawPolygon(poly_in_left);
+            p.drawPolygon(poly_in_right);
+            if (isDoor) {
+                p.setPen(innerPen);
+                p.setBrush(innerBrush);
+                p.drawPolygon(poly_in_left);
+                p.drawPolygon(poly_in_right);
+            }
         }
 
-        if (pR->getIn() > 0) {
-            QPolygonF _poly;
-            QPointF _pt;
-            _pt = QPointF(rx + (mTX * rSize) / 20.0, ry);
-            _poly.append(_pt);
-            _pt = QPointF(rx - (mTX * rSize) / 3.1, ry - (mTY * rSize) / 3.1);
-            _poly.append(_pt);
-            _pt = QPointF(rx - (mTX * rSize) / 3.1, ry + (mTY * rSize) / 3.1);
-            _poly.append(_pt);
+        if (pR->getOut() > 0 || pR->exitStubs.contains(DIR_OUT)) {
+            QPolygonF poly_out_left;
+            QPolygonF poly_out_right;
+            poly_out_left.append(QPointF(rx - (mTX * rSize * outOuterXFactor), ry));
+            poly_out_left.append(QPointF(rx - (mTX * rSize * outInterXFactor), ry + (mTY * rSize * outUpDownYFactor)));
+            poly_out_left.append(QPointF(rx - (mTX * rSize * outInterXFactor), ry - (mTY * rSize * outUpDownYFactor)));
+            poly_out_right.append(QPointF(rx + (mTX * rSize * outOuterXFactor), ry));
+            poly_out_right.append(QPointF(rx + (mTX * rSize * outInterXFactor), ry + (mTY * rSize * outUpDownYFactor)));
+            poly_out_right.append(QPointF(rx + (mTX * rSize * outInterXFactor), ry - (mTY * rSize * outUpDownYFactor)));
+            bool isDoor = true;
             QBrush brush = p.brush();
-            brush.setColor(Qt::black);
-            brush.setStyle(Qt::SolidPattern);
+            switch (pR->doors.value(QStringLiteral("out"))) {
+            case 1: //open door
+                brush.setColor(QColor(10, 155, 10));
+                innerPen.setColor(QColor(10, 155, 10));
+                break;
+            case 2: //closed door
+                brush.setColor(QColor(155, 155, 10));
+                innerPen.setColor(QColor(155, 155, 10));
+                break;
+            case 3:
+                brush.setColor(QColor(155, 10, 10));
+                innerPen.setColor(QColor(155, 10, 10));
+                break;
+            default:
+                brush.setColor(lc);
+                isDoor = false;
+            }
+            if (pR->getOut() > 0) {
+                pen.setWidthF(mTX * rSize * outerRealDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerRealDoorPenThicknessFactor);
+                brush.setStyle(Qt::Dense4Pattern);
+            } else {
+                pen.setWidthF(mTX * rSize * outerStubDoorPenThicknessFactor);
+                innerPen.setWidthF(mTX * rSize * innerStubDoorPenThicknessFactor);
+                brush.setStyle(Qt::DiagCrossPattern);
+            }
             p.setBrush(brush);
-            p.drawPolygon(_poly);
+            p.setPen(pen);
+            p.drawPolygon(poly_out_left);
+            p.drawPolygon(poly_out_right);
+            if (isDoor) {
+                p.setPen(innerPen);
+                p.setBrush(innerBrush);
+                p.drawPolygon(poly_out_left);
+                p.drawPolygon(poly_out_right);
+            }
         }
 
-        if (pR->getOut() > 0) {
-            QPolygonF _poly;
-            QPointF _pt;
-            _pt = QPointF(rx - (mTX * rSize) / 20.0, ry);
-            _poly.append(_pt);
-            _pt = QPointF(rx + (mTX * rSize) / 3.1, ry - (mTY * rSize) / 3.1);
-            _poly.append(_pt);
-            _pt = QPointF(rx + (mTX * rSize) / 3.1, ry + (mTY * rSize) / 3.1);
-            _poly.append(_pt);
-            QBrush brush = p.brush();
-            brush.setColor(Qt::black);
-            brush.setStyle(Qt::SolidPattern);
-            p.setBrush(brush);
-            p.drawPolygon(_poly);
-        }
-
+        p.restore();
         if (pArea->gridMode) {
             QMapIterator<int, QPoint> it(mAreaExitList);
             while (it.hasNext()) {

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -555,7 +555,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a green (Open) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -571,7 +571,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with an orange (Closed) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -587,7 +587,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a red (Locked) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1042,7 +1042,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a green (Open) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1058,7 +1058,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with an orange (Closed) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1074,7 +1074,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a red (Locked) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1620,7 +1620,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a green (Open) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1636,7 +1636,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with an orange (Closed) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1652,7 +1652,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a red (Locked) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1760,7 +1760,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Green (Open) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a green (Open) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1776,7 +1776,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orange (Closed) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with an orange (Closed) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>
@@ -1792,7 +1792,7 @@
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Red (Locked) door symbol would be drawn on 2D Map (but not currently), can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A symbol is drawn with a red (Locked) fill color on 2D Map, can be set on either a stub or a real exit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string/>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I found that the existing triangular markings drawn on the room symbols to indicate non-XY exits (i.e. up, down, in and out) mask any glyph drawn on as a symbol because for the real exits they are completely filled in black.

This commit enhances the design so that a mid shade "brush" is used instead for real exits and a light cross-hatch brush is used for stub exits. Importantly the colour used for the brush is either a contrasting black or white - the same as the pen used to draw the outline but it is now drawn in the same colour as the door markings on XY plain exits - so that doors can now be indicated on those up/down/in/out exits or stubs.

The tool-tips in the room exits dialogue have been amended to suit this long-planned (by me) enhancement!

The pen used to draw the outline is also made a non-zero width size.

Stub in and out exits were not being properly drawn in the prior code as there was a code limitation that ended up just drawing a horizontal line. Now both stub and real exits of these types are now drawn as a PAIR of triangles, with IN exits being an inward pointing pair each around half the size of the prior one, and OUT exits being an outward pointing pair outside the IN one.  I think it is more intuitive what the new versions are indicating...!

#### Motivation for adding to Mudlet
I was aware of the limited functionality/issue of the previous code and it become more obvious whilst working on #1543 - where I originally tried to put this.

#### Other info (issues closed, discussion etc)
This was reverted out of the other PR and extended slightly - to overdraw a thinner unfilled triangle to help show a door when the underlying room colour is not neutral...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>
