### PR TITLE
BugFix: allow font-load from sub-directory w/versions without bundled fonts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -469,13 +469,13 @@ int main(int argc, char* argv[])
         first_launch = true;
     }
 
-#if defined(INCLUDE_FONTS)
     if (show_splash) {
         splash_message.append("Done.\n\nLoading font files... ");
         splash.showMessage(splash_message, Qt::AlignHCenter | Qt::AlignTop);
         app->processEvents();
     }
 
+#if defined(INCLUDE_FONTS)
     QString bitstreamVeraFontDirectory(QStringLiteral("%1/ttf-bitstream-vera-1.10").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
     if (!dir.exists(bitstreamVeraFontDirectory)) {
         dir.mkpath(bitstreamVeraFontDirectory);
@@ -534,6 +534,10 @@ int main(int argc, char* argv[])
     copyFont(ubuntuFontDirectory, QLatin1String("fonts/ubuntu-font-family-0.83"), QLatin1String("UbuntuMono-RI.ttf"));
 #endif
 
+    mudlet::debugMode = false;
+    FontManager fm;
+    fm.addFonts();
+
     if (show_splash) {
         splash_message.append("Done.\n\n"
                               "All data has been loaded successfully.\n\n"
@@ -541,12 +545,6 @@ int main(int argc, char* argv[])
         splash.showMessage(splash_message, Qt::AlignHCenter | Qt::AlignTop);
         app->processEvents();
     }
-
-    mudlet::debugMode = false;
-#if defined(INCLUDE_FONTS)
-    FontManager fm;
-    fm.addFonts();
-#endif
 
     QString homeLink = QStringLiteral("%1/mudlet-data").arg(QDir::homePath());
 #ifdef Q_OS_WIN32


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I, perhaps carelessly, disabled the code to install fonts from the place where Mudlet extracts the bundled fonts to and then loads them in (in versions WITH bundled fonts) to be done for the versions WITHOUT those fonts.  This means that a module that includes a font for a particular MUD could not rely on Mudlet using a font placed in that part of the mudlet area of the user's file-system by loading the font in.

This commit remedies that error, I hope.

#### Motivation for adding to Mudlet
So that all versions behave the same should modules include font resources that they hope to use.

#### Other info (issues closed, discussion etc)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>
