### PR TITLE
Add support for capturing keypad arrow keys

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7667,6 +7667,25 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
     file.close();
 }
 
+bool dlgTriggerEditor::eventFilter(QObject* obj, QEvent* event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        switch (keyEvent->key())
+        {
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+        case Qt::Key_Left:
+        case Qt::Key_Right:
+            this->event(event);
+            return true;
+        default:
+            return false;
+        }
+    }
+    return false;
+}
+
 bool dlgTriggerEditor::event(QEvent* event)
 {
     if (mIsGrabKey) {
@@ -7683,6 +7702,7 @@ bool dlgTriggerEditor::event(QEvent* event)
                         action->setShortcut(tr("Ctrl+Shift+S"));
                     }
                 }
+                QCoreApplication::instance()->removeEventFilter(this);
                 ke->accept();
                 return true;
             case 0x01000020:
@@ -7701,6 +7721,7 @@ bool dlgTriggerEditor::event(QEvent* event)
                         action->setShortcut(tr("Ctrl+Shift+S"));
                     }
                 }
+                QCoreApplication::instance()->removeEventFilter(this);
                 ke->accept();
                 return true;
             }
@@ -7721,6 +7742,7 @@ void dlgTriggerEditor::slot_grab_key()
             action->setShortcut(tr(""));
         }
     }
+    QCoreApplication::instance()->installEventFilter(this);
 }
 
 void dlgTriggerEditor::grab_key_callback(int key, int modifier)
@@ -8049,7 +8071,7 @@ void dlgTriggerEditor::slot_clearSearchResults()
     textRanges->clear();
     controller->update();
 }
- 
+
 // shows a custom right-click menu for the editor, including the indent action
 void dlgTriggerEditor::slot_editorContextMenu()
 {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7667,7 +7667,7 @@ void dlgTriggerEditor::slot_profileSaveAsAction()
     file.close();
 }
 
-bool dlgTriggerEditor::eventFilter(QObject* obj, QEvent* event)
+bool dlgTriggerEditor::eventFilter(QObject*, QEvent* event)
 {
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -166,6 +166,7 @@ public:
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
     void enterEvent(QEvent* pE) override;
+    bool eventFilter(QObject* obj, QEvent* event);
     void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_key(QTreeWidgetItem* pWidgetItemParent);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -166,7 +166,7 @@ public:
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
     void enterEvent(QEvent* pE) override;
-    bool eventFilter(QObject* obj, QEvent* event);
+    bool eventFilter(QObject*, QEvent* event) override;
     void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_key(QTreeWidgetItem* pWidgetItemParent);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added event filter to allow capturing of keypad arrow key
#### Motivation for adding to Mudlet
I made a pull request some years ago to allow keypad keys to be used at hotkeys.  This worked successfully but I've found that in the current release there is no actual way to create them.  The reason is that (at least on Windows) if you have NumLock on and press Shift it effectively turns NumLock off.  So pressing e.g. Shift+KP4 is treated the same as pressing the left arrow, which causes focus to move back to the text field instead of capturing it.  What this change does is install a global event filter during the "grab key" sequence to allow these keys to be used, and then removes it again once the key is captured.