### PR TITLE
BugFix: make "close" button work on "lacking mapper script" dialog

### DIFF
--- a/src/ui/lacking_mapper_script.ui
+++ b/src/ui/lacking_mapper_script.ui
@@ -117,7 +117,7 @@ p, li { white-space: pre-wrap; }
   <connection>
    <sender>close</sender>
    <signal>clicked()</signal>
-   <receiver>no_mapping_script</receiver>
+   <receiver>lacking_mapper_script</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
A previous form name change must have disconnected a signal/slot connection that was defined within the form/dialog XML (and not visible in the C++ application core) - the effect of which was that the "close" button did not work on that dialog...

It turns out that this may have been caused by commit: https://github.com/Mudlet/Mudlet/commit/5c342dd6e67dc8325dd85404137d4118354ea04f which tried to clean up variations between form names and class names so that future use of these for "context" resolution by `QObject::tr()` and related methods used the same identifiers across the application (so that the place(s) that the translation was needed for were correctly identified to the translator).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>