### PR TITLE
Revise: prevent qmake spamming Windows builds unnecessarily

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -628,14 +628,14 @@ FORMS += \
 RESOURCES = mudlet.qrc
 contains(DEFINES, INCLUDE_FONTS) {
     RESOURCES += mudlet_fonts.qrc
-    !build-pass{
+    !build_pass{
         # On windows or on platforms that support CONFIG having debug_and_release"
         # then there can be three passes through this file and we only want the
-        # message once (the non build-pass in that case):
+        # message once (the non build_pass in that case):
         message("Including additional font resources within the Mudlet executable")
     }
 } else {
-    !build-pass{
+    !build_pass{
         message("No font resources are to be included within the Mudlet executable")
     }
 }
@@ -644,16 +644,16 @@ linux|macx|win32 {
     contains( DEFINES, INCLUDE_UPDATER ) {
         HEADERS += updater.h
         SOURCES += updater.cpp
-        !build-pass{
+        !build_pass{
             message("The updater code is included in this configuration")
         }
     } else {
-        !build-pass{
+        !build_pass{
             message("The updater code is excluded from this configuration")
         }
     }
 } else {
-    !build-pass{
+    !build_pass{
         message("The Updater code is excluded as on-line updating is not available on this platform")
     }
 }


### PR DESCRIPTION
Some build configuration details only need to be reported on the first pass of the three that occur on Windows (or any other platform where the Qt `CONFIG` variable contains `debug_and_release`).  On the first pass `build_pass` is NOT present in `CONFIG` but it and `debug` or `release` as appropriate is added to that variable.

The trouble is that I made a previous typo and used `build-pass` instead, this commit corrects that.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>