### PR TITLE
Enhance: convert Triggers/Aliases to work with non-ASCII text

### DIFF
--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -267,7 +267,7 @@ function InstallZziplib() {
 https://github.com/gdraheim/zziplib/archive/v0.13.62.tar.gz
   # DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
   # Switched to using GitHub which seems to be by the same maintainer
-  DownloadFile "https://github.com/gdraheim/zziplib/archive/v0.13.62.tar.gz" "zziplib-0.13.62.tar.gz"
+  DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.62" "zziplib-0.13.62.tar.gz"
   ExtractTar "zziplib-0.13.62.tar.gz" "zziplib"
   Set-Location zziplib\zziplib-0.13.62
   Step "changing configure script"

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -265,7 +265,7 @@ function InstallLibzip() {
 
 function InstallZziplib() {
   DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
-  ExtractTar "zziplib-0.13.62.tar.gz" "zziplib"
+  ExtractTar "zziplib-0.13.62.tar.bz2" "zziplib"
   Set-Location zziplib\zziplib-0.13.62
   Step "changing configure script"
   (Get-Content configure -Raw) -replace 'uname -msr', 'uname -ms' | Out-File -encoding ASCII configure >> "$logFile" 2>&1

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -226,7 +226,7 @@ function InstallPcre() {
   DownloadFile "https://ftp.pcre.org/pub/pcre/pcre-8.38.tar.gz" "pcre-8.38.tar.gz"
   ExtractTar "pcre-8.38.tar.gz" "pcre-8.38"
   Set-Location pcre-8.38\pcre-8.38
-  RunConfigure "--enable-utf --enable-unicode-properties"
+  RunConfigure "--enable-utf --enable-unicode-properties --prefix=$Env:MINGW_BASE_DIR_BASH"
   RunMake
   RunMakeInstall
 }

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -266,9 +266,13 @@ function InstallLibzip() {
 function InstallZziplib() {
   # DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
   # Switched to using GitHub which seems to be by the same maintainer
-  DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.62" "zziplib-0.13.62.tar.gz"
-  ExtractTar "zziplib-0.13.62.tar.gz" "zziplib"
-  Set-Location zziplib\zziplib-0.13.62
+  # DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.62" "zziplib-0.13.62.tar.gz"
+  # The tar.gz from the above source does not contain exactly the same files as
+  # the tar.bz and fails to build in our setup - assuming that there might have
+  # been some fixes in the last few years we will switch to the latest one:
+  DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.68" "zziplib-0.13.68.tar.gz"
+  ExtractTar "zziplib-0.13.68.tar.gz" "zziplib"
+  Set-Location zziplib\zziplib-0.13.68
   Step "changing configure script"
   (Get-Content configure -Raw) -replace 'uname -msr', 'uname -ms' | Out-File -encoding ASCII configure >> "$logFile" 2>&1
   RunConfigure "--disable-mmap --prefix=$Env:MINGW_BASE_DIR_BASH"

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -223,10 +223,10 @@ function InstallLua() {
 }
 
 function InstallPcre() {
-  DownloadFile "https://sourceforge.net/projects/pcre/files/pcre/8.38/pcre-8.38.tar.gz/download" "pcre-8.38.tar.gz"
+  DownloadFile "https://ftp.pcre.org/pub/pcre/pcre-8.38.tar.gz" "pcre-8.38.tar.gz"
   ExtractTar "pcre-8.38.tar.gz" "pcre-8.38"
   Set-Location pcre-8.38\pcre-8.38
-  RunConfigure
+  RunConfigure "--enable-utf --enable-unicode-properties"
   RunMake
   RunMakeInstall
 }

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -264,7 +264,6 @@ function InstallLibzip() {
 }
 
 function InstallZziplib() {
-https://github.com/gdraheim/zziplib/archive/v0.13.62.tar.gz
   # DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
   # Switched to using GitHub which seems to be by the same maintainer
   DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.62" "zziplib-0.13.62.tar.gz"

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -264,8 +264,11 @@ function InstallLibzip() {
 }
 
 function InstallZziplib() {
-  DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
-  ExtractTar "zziplib-0.13.62.tar.bz2" "zziplib"
+https://github.com/gdraheim/zziplib/archive/v0.13.62.tar.gz
+  # DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
+  # Switched to using GitHub which seems to be by the same maintainer
+  DownloadFile "https://github.com/gdraheim/zziplib/archive/v0.13.62.tar.gz" "zziplib-0.13.62.tar.gz"
+  ExtractTar "zziplib-0.13.62.tar.gz" "zziplib"
   Set-Location zziplib\zziplib-0.13.62
   Step "changing configure script"
   (Get-Content configure -Raw) -replace 'uname -msr', 'uname -ms' | Out-File -encoding ASCII configure >> "$logFile" 2>&1

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -264,15 +264,9 @@ function InstallLibzip() {
 }
 
 function InstallZziplib() {
-  # DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
-  # Switched to using GitHub which seems to be by the same maintainer
-  # DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.62" "zziplib-0.13.62.tar.gz"
-  # The tar.gz from the above source does not contain exactly the same files as
-  # the tar.bz and fails to build in our setup - assuming that there might have
-  # been some fixes in the last few years we will switch to the latest one:
-  DownloadFile "https://codeload.github.com/gdraheim/zziplib/tar.gz/v0.13.68" "zziplib-0.13.68.tar.gz"
-  ExtractTar "zziplib-0.13.68.tar.gz" "zziplib"
-  Set-Location zziplib\zziplib-0.13.68
+  DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
+  ExtractTar "zziplib-0.13.62.tar.gz" "zziplib"
+  Set-Location zziplib\zziplib-0.13.62
   Step "changing configure script"
   (Get-Content configure -Raw) -replace 'uname -msr', 'uname -ms' | Out-File -encoding ASCII configure >> "$logFile" 2>&1
   RunConfigure "--disable-mmap --prefix=$Env:MINGW_BASE_DIR_BASH"

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -93,7 +93,13 @@ bool TAlias::match(const QString& toMatch)
         return false; //regex compile error
     }
 
+#if defined(Q_OS_WIN32)
+    // strndup(3) - a safe strdup(3) does not seem to be available on mingw32 with GCC-4.9.2
+    char* subject = (char*)malloc(strlen(toMatch.toUtf8().constData()) + 1);
+    strcpy(subject, toMatch.toUtf8().constData());
+#else
     char* subject = strndup(toMatch.toUtf8().constData(), strlen(toMatch.toUtf8().constData()));
+#endif
     unsigned char* name_table;
     int namecount;
     int name_entry_size;

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -93,12 +93,8 @@ bool TAlias::match(const QString& toMatch)
         return false; //regex compile error
     }
 
-    //const char *error;
-    char* subject = (char*)malloc(strlen(toMatch.toLocal8Bit().data()) + 1);
-    strcpy(subject, toMatch.toLocal8Bit().data());
+    char* subject = strndup(toMatch.toUtf8().constData(), strlen(toMatch.toUtf8().constData()));
     unsigned char* name_table;
-    //int erroffset;
-    //int find_all;
     int namecount;
     int name_entry_size;
 
@@ -116,22 +112,13 @@ bool TAlias::match(const QString& toMatch)
     }
 
     if (rc < 0) {
-        switch (rc) {
-        case PCRE_ERROR_NOMATCH:
-            goto MUD_ERROR;
-
-        default:
-            goto MUD_ERROR;
-        }
-    }
-    if (rc > 0) {
+        goto MUD_ERROR;
+    } else if (rc == 0) {
+        qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
+    } else {
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::cyan), QColor(Qt::black)) << "Alias name=" << mName << "(" << mRegexCode << ") matched.\n" >> 0;
         }
-    }
-
-    if (rc == 0) {
-        qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
     }
 
     matchCondition = true; // alias has matched
@@ -183,22 +170,18 @@ bool TAlias::match(const QString& toMatch)
         }
 
         rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, 30);
-
         if (rc == PCRE_ERROR_NOMATCH) {
             if (options == 0) {
                 break;
             }
             ovector[1] = start_offset + 1;
             continue;
-        }
-
-        if (rc < 0) {
+        } else if (rc < 0) {
             goto END;
-        }
-
-        if (rc == 0) {
+        } else if (rc == 0) {
             qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
         }
+
         for (i = 0; i < rc; i++) {
             char* substring_start = subject + ovector[2 * i];
             int substring_length = ovector[2 * i + 1] - ovector[2 * i];
@@ -251,10 +234,11 @@ void TAlias::setRegexCode(const QString& code)
 void TAlias::compileRegex()
 {
     const char* error;
-    const QByteArray& local8Bit = mRegexCode.toLocal8Bit();
     int erroffset;
 
-    QSharedPointer<pcre> re(pcre_compile(local8Bit.constData(), 0, &error, &erroffset, nullptr), pcre_deleter);
+    // PCRE_UTF8 needed to run compile in UTF-8 mode
+    // PCRE_UCP needed for \d, \w etc. to use Unicode properties:
+    QSharedPointer<pcre> re(pcre_compile(mRegexCode.toUtf8().constData(), PCRE_UTF8 | PCRE_UCP, &error, &erroffset, nullptr), pcre_deleter);
 
     if (re == nullptr) {
         mOK_init = false;

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -71,6 +71,7 @@ void TKey::setName(const QString& name)
     mpHost->getKeyUnit()->mLookupTable.insertMulti(name, this);
 }
 
+// This method is potentially flawed in that only the first child match is ever executed...!
 bool TKey::match(int key, int modifier)
 {
     if (isActive()) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1357,7 +1357,13 @@ int TLuaInterpreter::paste(lua_State* L)
     return 0;
 }
 
-// The text MUST be presented in the ENCODING selected to be used by the SERVER
+// Takes one argument, a string and sends it to the trigger processing system
+// almost as if it came from the MUD Server. This string must be byte encoded
+// in a manner to match the currently selected Server Encoding. The trigger
+// processing system will recognise that this data is internal and, should it be
+// retaining a few bytes from the MUD server because a previous character was
+// split between two network packets, will not try to prepend those stored bytes
+// - instead it will hang on to them until the next network packet is processed.
 int TLuaInterpreter::feedTriggers(lua_State* L)
 {
     Host& host = getHostFromLua(L);
@@ -6131,14 +6137,14 @@ int TLuaInterpreter::permAlias(lua_State* L)
     QString name = QString::fromUtf8(lua_tostring(L, 1));
 
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "permAlias: bad argument #2 type (alias parent as string expected, got %s!)",
+        lua_pushfstring(L, "permAlias: bad argument #2 type (alias group/parent as string expected, got %s!)",
                         luaL_typename(L, 2));
         return lua_error(L);
     }
     QString parent = QString::fromUtf8(lua_tostring(L, 2));
 
     if (!lua_isstring(L, 3)) {
-        lua_pushfstring(L, "permAlias: bad argument #3 type (regexp-type pattern as string expected, got %s!)",
+        lua_pushfstring(L, "permAlias: bad argument #3 type (regexp pattern as string expected, got %s!)",
                         luaL_typename(L, 3));
         return lua_error(L);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -936,7 +936,7 @@ int TLuaInterpreter::getLines(lua_State* L)
     lua_newtable(L);
     for (int i = 0; i < strList.size(); i++) {
         lua_pushnumber(L, i + 1);
-        lua_pushstring(L, strList[i].toLatin1().data());
+        lua_pushstring(L, strList.at(i).toUtf8().constData());
         lua_settable(L, -3);
     }
     return 1;
@@ -993,7 +993,7 @@ int TLuaInterpreter::getCurrentLine(lua_State* L)
 
     Host& host = getHostFromLua(L);
     QString line = host.mpConsole->getCurrentLine(luaSendText);
-    lua_pushstring(L, line.toLatin1().data());
+    lua_pushstring(L, line.toUtf8().constData());
     return 1;
 }
 
@@ -1357,7 +1357,7 @@ int TLuaInterpreter::paste(lua_State* L)
     return 0;
 }
 
-
+// The text MUST be presented in the ENCODING selected to be used by the SERVER
 int TLuaInterpreter::feedTriggers(lua_State* L)
 {
     Host& host = getHostFromLua(L);
@@ -5479,19 +5479,16 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString exactMatchPattern;
-    int triggerID;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempExactMatchTrigger: bad argument #1 type (exact match pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
+    QString exactMatchPattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    exactMatchPattern = QString::fromUtf8(lua_tostring(L, 1));
-
+    int triggerID;
     if (lua_isstring(L, 2)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 2));
-        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, luaFunction);
+        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString::fromUtf8(lua_tostring(L, 2)));
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString());
 
@@ -5513,19 +5510,16 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString pattern;
-    int triggerID;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #1 type (pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
+    QString pattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    pattern = QString::fromUtf8(lua_tostring(L, 1));
-
+    int triggerID;
     if (lua_isstring(L, 2)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 2));
-        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, luaFunction);
+        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString::fromUtf8(lua_tostring(L, 2)));
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString());
 
@@ -5547,19 +5541,17 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString substringPattern;
-    int triggerID;
 
+    QString substringPattern;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempTrigger: bad argument #1 type (substring pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-
     substringPattern = QString::fromUtf8(lua_tostring(L, 1));
 
+    int triggerID;
     if (lua_isstring(L, 2)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 2));
-        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, luaFunction);
+        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString::fromUtf8(lua_tostring(L, 2)));
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString());
 
@@ -5581,11 +5573,10 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    int triggerID;
 
+    int triggerID;
     if (lua_isstring(L, 1)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 1));
-        triggerID = pLuaInterpreter->startTempPromptTrigger(luaFunction);
+        triggerID = pLuaInterpreter->startTempPromptTrigger(QString::fromUtf8(lua_tostring(L, 1)));
     } else if (lua_isfunction(L, 1)) {
         triggerID = pLuaInterpreter->startTempPromptTrigger(QString());
 
@@ -5607,24 +5598,22 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    int foregroundColor, backgroundColor;
-    int triggerID;
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "tempColorTrigger: bad argument #1 type (foreground color as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
+    int foregroundColor = lua_tointeger(L, 1);
+
     if (!lua_isnumber(L, 2)) {
         lua_pushfstring(L, "tempColorTrigger: bad argument #2 type (background color as number expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
+    int backgroundColor = lua_tointeger(L, 2);
 
-    foregroundColor = lua_tointeger(L, 1);
-    backgroundColor = lua_tointeger(L, 2);
-
+    int triggerID;
     if (lua_isstring(L, 3)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 3));
-        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, luaFunction);
+        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString::fromUtf8(lua_tostring(L, 3)));
     } else if (lua_isfunction(L, 3)) {
         triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString());
 
@@ -5646,8 +5635,6 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    int from, howMany;
-    int triggerID;
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "tempLineTrigger: bad argument #1 type (line to start matching from as number expected, got %s!)", luaL_typename(L, 1));
@@ -5657,12 +5644,11 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    from = lua_tointeger(L, 1);
-    howMany = lua_tointeger(L, 2);
-
+    int from = lua_tointeger(L, 1);
+    int howMany = lua_tointeger(L, 2);
+    int triggerID;
     if (lua_isstring(L, 3)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 3));
-        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, luaFunction);
+        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString::fromUtf8(lua_tostring(L, 3)));
     } else if (lua_isfunction(L, 3)) {
         triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString());
 
@@ -5683,14 +5669,6 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    bool multiLine, matchAll, highlight, playSound, filter, colorTrigger;
-    int fireLength, lineDelta;
-    QString fgColor, bgColor;
-    QStringList regexList;
-    QString parent, script, triggerName, pattern, soundFile;
-    QColor hlFgColor, hlBgColor;
-    QList<int> propertyList;
-    int triggerID;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #1 type (trigger name create or add to as string expected, got %s!)", luaL_typename(L, 1));
@@ -5718,45 +5696,60 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    parent = QString::fromUtf8(lua_tostring(L, 1));
-    pattern = QString::fromUtf8(lua_tostring(L, 2));
-    multiLine = lua_tonumber(L, 4);
+    QString triggerName = QString::fromUtf8(lua_tostring(L, 1));
+    bool multiLine = lua_tonumber(L, 4);
+
+    bool colorTrigger;
+    QString fgColor;
     if (lua_isnumber(L, 5)) {
         colorTrigger = false;
     } else {
         colorTrigger = true;
         fgColor = lua_tostring(L, 5);
     }
+
+    QString bgColor;
     if (lua_isnumber(L, 6)) {
         colorTrigger = false;
     } else {
         bgColor = lua_tostring(L, 6);
     }
-    filter = lua_tonumber(L, 7);
-    matchAll = lua_tonumber(L, 8);
+
+    bool filter = lua_tonumber(L, 7);
+    bool matchAll = lua_tonumber(L, 8);
+
+    bool highlight;
+    QColor hlFgColor;
     if (lua_isnumber(L, 9)) {
         highlight = false;
     } else {
         highlight = true;
         hlFgColor.setNamedColor(lua_tostring(L, 9));
     }
+    QColor hlBgColor;
     if (lua_isnumber(L, 9)) {
         highlight = false;
     } else {
         highlight = true;
         hlBgColor.setNamedColor(lua_tostring(L, 9));
     }
+
+    QString soundFile;
+    bool playSound;
     if (lua_isstring(L, 10)) {
         playSound = true;
         soundFile = QString::fromUtf8(lua_tostring(L, 10));
     } else {
         playSound = false;
     }
-    fireLength = lua_tonumber(L, 11);
-    lineDelta = lua_tonumber(L, 12);
 
+    int fireLength = lua_tonumber(L, 11);
+    int lineDelta = lua_tonumber(L, 12);
+
+    QString pattern = QString::fromUtf8(lua_tostring(L, 2));
+    QStringList regexList;
+    QList<int> propertyList;
     TTrigger* pP = host.getTriggerUnit()->findTrigger(triggerName);
-
     if (!pP) {
         regexList << pattern;
         if (colorTrigger) {
@@ -5775,7 +5768,6 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     pT->setTemporary(true);
     pT->registerTrigger();
     pT->setName(pattern);
-    //pT->setIsMultiline( multiLine );
     pT->mPerlSlashGOption = matchAll; //match all
     pT->mFilterTrigger = filter;
     pT->setConditionLineDelta(lineDelta); //line delta
@@ -5791,8 +5783,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 3)) {
-        script = QString::fromUtf8(lua_tostring(L, 3));
-        pT->setScript(script);
+        pT->setScript(QString::fromUtf8(lua_tostring(L, 3)));
     } else if (lua_isfunction(L, 3)) {
         pT->setScript(QString());
 
@@ -5984,19 +5975,16 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString regexPattern;
-    int triggerID;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempRegexTrigger: bad argument #1 type (regex pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
+    QString regexPattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    regexPattern = QString::fromUtf8(lua_tostring(L, 1));
-
+    int triggerID;
     if (lua_isstring(L, 2)) {
-        QString luaFunction = QString::fromUtf8(lua_tostring(L, 2));
-        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, luaFunction);
+        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString::fromUtf8(lua_tostring(L, 2)));
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString());
 
@@ -6016,30 +6004,23 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 
 int TLuaInterpreter::tempAlias(lua_State* L)
 {
-    string luaRegex;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "tempAlias: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        luaRegex = lua_tostring(L, 1);
+        lua_pushfstring(L, "tempAlias: bad argument #1 type (regex-type pattern as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
+    QString regex = QString::fromUtf8(lua_tostring(L, 1));
 
-    string luaFunction;
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "tempAlias: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        luaFunction = lua_tostring(L, 2);
+        lua_pushfstring(L, "tempAlias: bad argument #2 type (lua script as string expected, got %s!)",
+                        luaL_typename(L, 2));
+        return lua_error(L);
     }
+    QString script = QString::fromUtf8(lua_tostring(L, 2));
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString _luaFunction = luaFunction.c_str();
-    QString _luaRegex = luaRegex.c_str();
-    int aliasID = pLuaInterpreter->startTempAlias(_luaRegex, _luaFunction);
-    lua_pushnumber(L, aliasID);
+    lua_pushnumber(L, pLuaInterpreter->startTempAlias(regex, script));
     return 1;
 }
 
@@ -6081,28 +6062,25 @@ int TLuaInterpreter::exists(lua_State* L)
 
 int TLuaInterpreter::isActive(lua_State* L)
 {
-    string _name;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "isActive: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        _name = lua_tostring(L, 1);
+        lua_pushfstring(L, "isActive: bad argument #1 type (item name as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
-    string _type;
+    QString name = QString::fromUtf8(lua_tostring(L, 1));
+
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "isActive: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        _type = lua_tostring(L, 2);
+        lua_pushfstring(L, "isActive: bad argument #1 type (item type as string expected, got %s!)",
+                        luaL_typename(L, 2));
+        return lua_error(L);
     }
+    // Although we only use 4 ASCII strings the user may not enter a purely
+    // ASCII value which we might have to report...
+    QString type = QString::fromUtf8(lua_tostring(L, 2));
+
     Host& host = getHostFromLua(L);
     int cnt = 0;
-    QString type = _type.c_str();
-    type = type.toLower();
-    QString name = _name.c_str();
-    if (type == "timer") {
+    if (type.compare(QLatin1String("timer"), Qt::CaseInsensitive) == 0) {
         QMap<QString, TTimer*>::const_iterator it1 = host.getTimerUnit()->mLookupTable.constFind(name);
         while (it1 != host.getTimerUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
@@ -6110,7 +6088,7 @@ int TLuaInterpreter::isActive(lua_State* L)
             }
             it1++;
         }
-    } else if (type == "trigger") {
+    } else if (type.compare(QLatin1String("trigger"), Qt::CaseInsensitive) == 0) {
         QMap<QString, TTrigger*>::const_iterator it1 = host.getTriggerUnit()->mLookupTable.constFind(name);
         while (it1 != host.getTriggerUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
@@ -6118,7 +6096,7 @@ int TLuaInterpreter::isActive(lua_State* L)
             }
             it1++;
         }
-    } else if (type == "alias") {
+    } else if (type.compare(QLatin1String("alias"), Qt::CaseInsensitive) == 0) {
         QMap<QString, TAlias*>::const_iterator it1 = host.getAliasUnit()->mLookupTable.constFind(name);
         while (it1 != host.getAliasUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
@@ -6126,7 +6104,7 @@ int TLuaInterpreter::isActive(lua_State* L)
             }
             it1++;
         }
-    } else if (type == "keybind") {
+    } else if (type.compare(QLatin1String("keybind"), Qt::CaseInsensitive) == 0) {
         QMap<QString, TKey*>::const_iterator it1 = host.getKeyUnit()->mLookupTable.constFind(name);
         while (it1 != host.getKeyUnit()->mLookupTable.cend() && it1.key() == name) {
             if (it1.value()->isActive()) {
@@ -6134,58 +6112,48 @@ int TLuaInterpreter::isActive(lua_State* L)
             }
             it1++;
         }
+    } else {
+        lua_pushnil(L);
+        lua_pushfstring(L, "invalid type '%s' given, it should be one (case insensitive) of: 'alias', 'keybind', 'timer' or 'trigger'",
+                        type.toUtf8().constData());
     }
     lua_pushnumber(L, cnt);
     return 1;
 }
 
-
 int TLuaInterpreter::permAlias(lua_State* L)
 {
-    string luaName;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "permAlias: need a name for this alias");
-        lua_error(L);
-        return 1;
-    } else {
-        luaName = lua_tostring(L, 1);
+        lua_pushfstring(L, "permAlias: bad argument #1 type (alias name as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
+    QString name = QString::fromUtf8(lua_tostring(L, 1));
 
-    string luaParent;
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "permAlias: need a parent alias/group to add this alias to");
-        lua_error(L);
-        return 1;
-    } else {
-        luaParent = lua_tostring(L, 2);
+        lua_pushfstring(L, "permAlias: bad argument #2 type (alias parent as string expected, got %s!)",
+                        luaL_typename(L, 2));
+        return lua_error(L);
     }
+    QString parent = QString::fromUtf8(lua_tostring(L, 2));
 
-    string luaRegex;
     if (!lua_isstring(L, 3)) {
-        lua_pushstring(L, "permAlias: need the pattern for the alias");
-        lua_error(L);
-        return 1;
-    } else {
-        luaRegex = lua_tostring(L, 3);
+        lua_pushfstring(L, "permAlias: bad argument #3 type (regexp-type pattern as string expected, got %s!)",
+                        luaL_typename(L, 3));
+        return lua_error(L);
     }
+    QString regex = QString::fromUtf8(lua_tostring(L, 3));
 
-    string luaFunction;
     if (!lua_isstring(L, 4)) {
-        lua_pushstring(L, "permAlias: need Lua code for this alias");
-        lua_error(L);
-        return 1;
-    } else {
-        luaFunction = lua_tostring(L, 4);
+        lua_pushfstring(L, "permAlias: bad argument #4 type (lua script as string expected, got %s!)",
+                        luaL_typename(L, 4));
+        return lua_error(L);
     }
+    QString script = QString::fromUtf8(lua_tostring(L, 4));
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString _luaName = luaName.c_str();
-    QString _luaParent = luaParent.c_str();
-    QString _luaFunction = luaFunction.c_str();
-    QString _luaRegex = luaRegex.c_str();
-    int aliasID = pLuaInterpreter->startPermAlias(_luaName, _luaParent, _luaRegex, _luaFunction);
-    lua_pushnumber(L, aliasID);
+    lua_pushnumber(L, pLuaInterpreter->startPermAlias(name, parent, regex, script));
     return 1;
 }
 
@@ -6238,57 +6206,46 @@ int TLuaInterpreter::permTimer(lua_State* L)
 
 int TLuaInterpreter::permSubstringTrigger(lua_State* L)
 {
-    string name;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "permSubstringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        name = lua_tostring(L, 1);
+        lua_pushfstring(L, "permSubstringTrigger: bad argument #1 type (trigger name as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
+    QString name = QString::fromUtf8(lua_tostring(L, 1));
 
-    string parent;
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "permSubstringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        parent = lua_tostring(L, 2);
+        lua_pushfstring(L, "permSubstringTrigger: bad argument #2 type (trigger parent as string expected, got %s!)",
+                        luaL_typename(L, 2));
+        return lua_error(L);
     }
-    QStringList _regList;
+    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+
+    QStringList regList;
     if (!lua_istable(L, 3)) {
-        lua_pushstring(L, "permSubstringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        while (lua_next(L, 3) != 0) {
-            // key at index -2 and value at index -1
-            if (lua_type(L, -1) == LUA_TSTRING) {
-                QString regex = lua_tostring(L, -1);
-                _regList << regex;
-            }
-            // removes value, but keeps key for next iteration
-            lua_pop(L, 1);
+        lua_pushfstring(L, "permSubstringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
+                        luaL_typename(L, 3));
+        return lua_error(L);
+    }
+    lua_pushnil(L);
+    while (lua_next(L, 3) != 0) {
+        // key at index -2 and value at index -1
+        if (lua_type(L, -1) == LUA_TSTRING) {
+            regList << QString::fromUtf8(lua_tostring(L, -1));
         }
+        // removes value, but keeps key for next iteration
+        lua_pop(L, 1);
     }
 
-    string luaFunction;
     if (!lua_isstring(L, 4)) {
-        lua_pushstring(L, "permSubstringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        luaFunction = lua_tostring(L, 4);
+        lua_pushfstring(L, "permSubstringTrigger: bad argument #4 type (lua script as string expected, got %s!)",
+                        luaL_typename(L, 4));
+        return lua_error(L);
     }
+    QString script = QString::fromUtf8(lua_tostring(L, 4));
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString _name = name.c_str();
-    QString _parent = parent.c_str();
-    QString _luaFunction = luaFunction.c_str();
-    int ret = pLuaInterpreter->startPermSubstringTrigger(_name, _parent, _regList, _luaFunction);
-    lua_pushnumber(L, ret);
+    lua_pushnumber(L, pLuaInterpreter->startPermSubstringTrigger(name, parent, regList, script));
     return 1;
 }
 
@@ -6413,116 +6370,93 @@ int TLuaInterpreter::tempKey(lua_State* L)
 
 int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
 {
-    string name;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "permBeginOfLineStringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        name = lua_tostring(L, 1);
+        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #1 type (trigger name as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
+    QString name = QString::fromUtf8(lua_tostring(L, 1));
 
-    string parent;
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "permBeginOfLineStringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        parent = lua_tostring(L, 2);
+        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #2 type (trigger parent as string expected, got %s!)",
+                        luaL_typename(L, 2));
+        return lua_error(L);
     }
-    QStringList _regList;
+    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+
+    QStringList regList;
     if (!lua_istable(L, 3)) {
-        lua_pushstring(L, "permBeginOfLineStringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        while (lua_next(L, 3) != 0) {
-            // key at index -2 and value at index -1
-            if (lua_type(L, -1) == LUA_TSTRING) {
-                QString regex = lua_tostring(L, -1);
-                _regList << regex;
-            }
-            // removes value, but keeps key for next iteration
-            lua_pop(L, 1);
+        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
+                        luaL_typename(L, 3));
+        return lua_error(L);
+    }
+    lua_pushnil(L);
+    while (lua_next(L, 3) != 0) {
+        // key at index -2 and value at index -1
+        if (lua_type(L, -1) == LUA_TSTRING) {
+            regList << QString::fromUtf8(lua_tostring(L, -1));
         }
+        // removes value, but keeps key for next iteration
+        lua_pop(L, 1);
     }
 
-    string luaFunction;
     if (!lua_isstring(L, 4)) {
-        lua_pushstring(L, "permBeginOfLineStringTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        luaFunction = lua_tostring(L, 4);
+        lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #4 type (lua script as string expected, got %s!)",
+                        luaL_typename(L, 4));
+        return lua_error(L);
     }
+    QString script = QString::fromUtf8(lua_tostring(L, 4));
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString _name = name.c_str();
-    QString _parent = parent.c_str();
-    QString _luaFunction = luaFunction.c_str();
-    int ret = pLuaInterpreter->startPermBeginOfLineStringTrigger(_name, _parent, _regList, _luaFunction);
-    lua_pushnumber(L, ret);
+    lua_pushnumber(L, pLuaInterpreter->startPermBeginOfLineStringTrigger(name, parent, regList, script));
     return 1;
 }
 
 int TLuaInterpreter::permRegexTrigger(lua_State* L)
 {
-    string name;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "permRegexTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        name = lua_tostring(L, 1);
+        lua_pushfstring(L, "permRegexTrigger: bad argument #1 type (trigger name as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
+    QString name = QString::fromUtf8(lua_tostring(L, 1));
 
-    string parent;
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "permRegexTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        parent = lua_tostring(L, 2);
+        lua_pushfstring(L, "permRegexTrigger: bad argument #2 type (trigger parent as string expected, got %s!)",
+                        luaL_typename(L, 2));
+        return lua_error(L);
     }
-    QStringList _regList;
+    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+
+    QStringList regList;
     if (!lua_istable(L, 3)) {
-        lua_pushstring(L, "permRegexTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        while (lua_next(L, 3) != 0) {
-            // key at index -2 and value at index -1
-            if (lua_type(L, -1) == LUA_TSTRING) {
-                QString regex = lua_tostring(L, -1);
-                _regList << regex;
-            }
-            // removes value, but keeps key for next iteration
-            lua_pop(L, 1);
+        lua_pushfstring(L, "permRegexTrigger: bad argument #3 type (sub-strings list as table expected, got %s!)",
+                        luaL_typename(L, 3));
+        return lua_error(L);
+    }
+    lua_pushnil(L);
+    while (lua_next(L, 3) != 0) {
+        // key at index -2 and value at index -1
+        if (lua_type(L, -1) == LUA_TSTRING) {
+            regList << QString::fromUtf8(lua_tostring(L, -1));
         }
+        // removes value, but keeps key for next iteration
+        lua_pop(L, 1);
     }
 
-    string luaFunction;
     if (!lua_isstring(L, 4)) {
-        lua_pushstring(L, "permRegexTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        luaFunction = lua_tostring(L, 4);
+        lua_pushfstring(L, "permRegexTrigger: bad argument #4 type (lua script as string expected, got %s!)",
+                        luaL_typename(L, 4));
+        return lua_error(L);
     }
+    QString script = QString::fromUtf8(lua_tostring(L, 4));
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    QString _name = name.c_str();
-    QString _parent = parent.c_str();
-    QString _luaFunction = luaFunction.c_str();
-    int ret = pLuaInterpreter->startPermRegexTrigger(_name, _parent, _regList, _luaFunction);
-    lua_pushnumber(L, ret);
+    lua_pushnumber(L, pLuaInterpreter->startPermRegexTrigger(name, parent, regList, script));
     return 1;
 }
-
 
 int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
@@ -10897,8 +10831,7 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
         return false;
     }
 
-    int error = luaL_dostring(L, code.toLatin1().data());
-    QString n;
+    int error = luaL_dostring(L, code.toUtf8().constData());
     if (error != 0) {
         string e = "no error message available from Lua";
         if (lua_isstring(L, 1)) {
@@ -10979,19 +10912,7 @@ bool TLuaInterpreter::compileScript(const QString& code)
         return false;
     }
 
-    /*lua_newtable( L );
-
-	   // set values
-	   for( int i=0; i<matches.size(); i++ )
-	   {
-	    lua_pushnumber( L, i+1 ); // Lua indexes start with 1
-	    lua_pushstring( L, matches[i].toLatin1().data() );
-	    lua_settable( L, -3 );
-	   }
-	   lua_setglobal( L, "matches" );*/
-
-    int error = luaL_dostring(L, code.toLatin1().data());
-    QString n;
+    int error = luaL_dostring(L, code.toUtf8().constData());
     if (error != 0) {
         string e = "no error message available from Lua";
         if (lua_isstring(L, 1)) {
@@ -11023,7 +10944,9 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
         return false;
     }
 
-    int error = (luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), name.toUtf8().constData()) || lua_pcall(L, 0, 0, 0));
+    int error = (luaL_loadbuffer(L, code.toUtf8().constData(),
+                                 strlen(code.toUtf8().constData()),
+                                 name.toUtf8().constData()) || lua_pcall(L, 0, 0, 0));
 
     QString n;
     if (error != 0) {
@@ -11522,8 +11445,8 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName)
         lua_setglobal(L, "matches");
     }
 
-    lua_getglobal(L, function.toLatin1().data());
-    lua_getfield(L, LUA_GLOBALSINDEX, function.toLatin1().data());
+    lua_getglobal(L, function.toUtf8().constData());
+    lua_getfield(L, LUA_GLOBALSINDEX, function.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error != 0) {
         int nbpossible_errors = lua_gettop(L);
@@ -11649,8 +11572,8 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
         lua_setglobal(L, "multimatches");
     }
 
-    lua_getglobal(L, function.toLatin1().data());
-    lua_getfield(L, LUA_GLOBALSINDEX, function.toLatin1().data());
+    lua_getglobal(L, function.toUtf8().constData());
+    lua_getfield(L, LUA_GLOBALSINDEX, function.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error != 0) {
         int nbpossible_errors = lua_gettop(L);
@@ -11890,7 +11813,7 @@ double TLuaInterpreter::condenseMapLoad()
             string e = "";
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
-                QString _f = luaFunction.toLatin1();
+                QString _f = luaFunction.toUtf8().constData();
                 logError(e, luaFunction, _f);
                 if (mudlet::debugMode) {
                     TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running " << luaFunction << " ERROR:" << e.c_str() << "\n" >> 0;
@@ -12574,7 +12497,7 @@ void TLuaInterpreter::loadGlobal()
     QString path = "../src/mudlet-lua/lua/LuaGlobal.lua";
 #endif
 
-    int error = luaL_dofile(pGlobalLua, path.toLatin1().data());
+    int error = luaL_dofile(pGlobalLua, path.toUtf8().constData());
     if (error != 0) {
         // For the installer we do not go down a level to search for this. So
         // we check again for the user case of a windows install.
@@ -12585,7 +12508,7 @@ void TLuaInterpreter::loadGlobal()
         if (!QFileInfo::exists(path)) {
             path = "mudlet-lua/lua/LuaGlobal.lua";
         }
-        error = luaL_dofile(pGlobalLua, path.toLatin1().data());
+        error = luaL_dofile(pGlobalLua, path.toUtf8().constData());
         if (error == 0) {
             mpHost->postMessage("[  OK  ]  - Mudlet-lua API & Geyser Layout manager loaded.");
             return;
@@ -12597,7 +12520,7 @@ void TLuaInterpreter::loadGlobal()
 
     // Finally try loading from LUA_DEFAULT_PATH
     path = LUA_DEFAULT_PATH "/LuaGlobal.lua";
-    error = luaL_dofile(pGlobalLua, path.toLatin1().data());
+    error = luaL_dofile(pGlobalLua, path.toUtf8().constData());
     if (error != 0) {
         string e = "no error message available from Lua";
         if (lua_isstring(pGlobalLua, -1)) {

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -248,7 +248,13 @@ int TriggerUnit::getNewID()
 void TriggerUnit::processDataStream(const QString& data, int line)
 {
     if (!data.isEmpty()) {
+#if defined(Q_OS_WIN32)
+        // strndup(3) - a safe strdup(3) does not seem to be available on mingw32 with GCC-4.9.2
+        char* subject = (char*)malloc(strlen(data.toUtf8().data()) + 1);
+        strcpy(subject, data.toUtf8().data());
+#else
         char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
+#endif
         for (auto trigger : mTriggerRootNodeList) {
             trigger->match(subject, data, line);
         }

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -247,10 +247,8 @@ int TriggerUnit::getNewID()
 
 void TriggerUnit::processDataStream(const QString& data, int line)
 {
-    if (data.size() > 0) {
-        char* subject = (char*)malloc(strlen(data.toLocal8Bit().data()) + 1);
-        strcpy(subject, data.toLocal8Bit().data());
-
+    if (!data.isEmpty()) {
+        char* subject = strndup(data.toUtf8().constData(), strlen(data.toUtf8().constData()));
         for (auto trigger : mTriggerRootNodeList) {
             trigger->match(subject, data, line);
         }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -926,7 +926,7 @@ void cTelnet::processTelnetCommand(const string& command)
                 return;
             }
             _m = _m.mid(3, command.size() - 5);
-            mpHost->mLuaInterpreter.msdp2Lua(_m.toLocal8Bit().data(), _m.length());
+            mpHost->mLuaInterpreter.msdp2Lua(_m.toUtf8().data(), _m.length());
             return;
         }
         // ATCP


### PR DESCRIPTION
Adds flags to pcre_compile(...) calls.

Converts some places where `TLuaInterpreter` and other classes using `QString::fromUtf8()` and `QString::toUtf8()` (the latter where `QString::toLocal8Bit()` or `QString::toLatin1()` were used where it might be relevant - there are still more other places where this conversion is needed.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>