### PR TITLE
Fixed bug with replaceAll

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -595,16 +595,16 @@ end
 ---   replaceAll("you", "you and me")
 ---   </pre>
 function replaceAll(word, what)
+  local getCurrentLine, selectSection, replace = getCurrentLine, selectSection, replace
   local startp, endp = 1, 1
-  local found = 0
   while true do
-    startp, endp = getCurrentLine():find(word, (found*(endp + (#what - #word) + 1)))
+    startp, endp = getCurrentLine():find(word, endp)
     if not startp then
       break
     end
-    found = 1
     selectSection(startp - 1, endp - startp + 1)
     replace(what)
+    endp = endp + (#what - #word) + 1 -- recalculate the new word ending to start search from there
   end
 end
 

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -597,7 +597,7 @@ end
 function replaceAll(word, what)
   local startp, endp = 1, 1
   while true do
-    startp, endp = getCurrentLine():find(word, endp + (#what - #word) + 1)
+    startp, endp = getCurrentLine():find(word)
     if not startp then
       break
     end

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -596,11 +596,13 @@ end
 ---   </pre>
 function replaceAll(word, what)
   local startp, endp = 1, 1
+  local found = 0
   while true do
-    startp, endp = getCurrentLine():find(word)
+    startp, endp = getCurrentLine():find(word, (found*(endp + (#what - #word) + 1)))
     if not startp then
       break
     end
+    found = 1
     selectSection(startp - 1, endp - startp + 1)
     replace(what)
   end


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
replaceAll currently fails if the length of the replaced string and the replacement string significantly differ. This is caused from an unnecessary index argument to find on line 600. Removing the argument seems to fix the issue.
#### Motivation for adding to Mudlet
I was writing a script which uses replaceAll and noticed some odd behaviour. 
