### PR TITLE
BugFix: ensure changing out exit door induces a check for modifications

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -2052,6 +2052,7 @@ void dlgRoomExits::init(int id)
     connect( doortype_se,          SIGNAL(buttonClicked(int)),                   this, SLOT(slot_checkModified()));
     connect( doortype_in,          SIGNAL(buttonClicked(int)),                   this, SLOT(slot_checkModified()));
     connect( doortype_down,        SIGNAL(buttonClicked(int)),                   this, SLOT(slot_checkModified()));
+    connect( doortype_out,         SIGNAL(buttonClicked(int)),                   this, SLOT(slot_checkModified()));
 }
 
 TExit* dlgRoomExits::makeExitFromControls(int direction)


### PR DESCRIPTION
Somehow one line of code is absent from `void dlgRoomExits::init(int id)` - it seems as if it was missing all the time as this can be traced back to *exactly* four years ago to a commit of mine:
https://github.com/Mudlet/Mudlet/commit/d8ff7e0c12a358071e00f38e083a641848d6ab17

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>