### PR TITLE
Enhance: indicate other profile with new data when multi-playing

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -152,6 +152,10 @@ cTelnet::cTelnet(Host* pH)
 
     mpDownloader = new QNetworkAccessManager(this);
     connect(mpDownloader, SIGNAL(finished(QNetworkReply*)), this, SLOT(replyFinished(QNetworkReply*)));
+    if (mudlet::self()) {
+        // mudlet::self() Will be null for default_host case which wont work here:
+        connect(this, SIGNAL(signal_newDataAlert(const QString&)), mudlet::self(), SLOT(slot_newDataOnHost(const QString&)));
+    }
 }
 
 void cTelnet::reset()
@@ -1510,6 +1514,8 @@ void cTelnet::postData()
     if (mAlertOnNewData) {
         QApplication::alert(mudlet::self(), 0);
     }
+    // Turn the tab text red if this is not the currently active host:
+    emit signal_newDataAlert(mpHost->getName());
 }
 
 void cTelnet::initStreamDecompressor()

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -147,6 +147,9 @@ public slots:
     void slot_send_login();
     void slot_send_pass();
 
+signals:
+    // Raised when new data is incomming to trigger Alert handling in mudlet class:
+    void signal_newDataAlert(const QString&);
 
 private:
     cTelnet() {}

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1016,6 +1016,10 @@ void mudlet::slot_tab_changed(int tabID)
         return;
     }
 
+    // Automatically reset the colour of the tab back to "normal" to undo the
+    // effect of it being coloured on new data by using an invalid QColor:
+    mpTabBar->setTabTextColor(tabID, QColor());
+
     if (mConsoleMap.contains(mpCurrentActiveHost)) {
         mpCurrentActiveHost->mpConsole->hide();
         QString host = mpTabBar->tabText(tabID);
@@ -3607,4 +3611,24 @@ bool mudlet::loadReplay(Host* pHost, const QString& replayFileName, QString* pEr
     }
 
     return pHost->mTelnet.loadReplay(absoluteReplayFileName, pErrMsg);
+}
+
+// This is not the "mark the application as needing attention" function but the
+// one that marks a profile that is not the current one as having new data...
+void mudlet::slot_newDataOnHost(const QString& hostName)
+{
+    Host* pHost = mHostManager.getHost(hostName);
+    if (pHost && pHost != mpCurrentActiveHost) {
+        if (mpTabBar->isVisible()) {
+            // The data is not for the currently active host, so find out which
+            // one it is for and set the text colour on the tab on the shown tab-bar:
+            for (int i, total = mpTabBar->count(); i < total; ++i) {
+                if (mpTabBar->tabText(i) == hostName) {
+                    // Found the matching tab - turn it red:
+                    mpTabBar->setTabTextColor(i, Qt::red);
+                    break;
+                }
+            }
+        }
+    }
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -359,6 +359,8 @@ public slots:
     void slot_restoreMainMenu() { setMenuBarVisibility(visibleAlways); }
     void slot_restoreMainToolBar() { setToolBarVisibility(visibleAlways); }
     void slot_handleToolbarVisibilityChanged(bool);
+    void slot_newDataOnHost(const QString&);
+
 
 protected:
     void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
Following a discussion on Discord on the Help channel I realised that if more than one profile is open and Multi-View mode is not selected then any profile which is not the currently selected one will be hidden from view - and if any data comes in from the MUD server it will not be obvious to the user.

This commit turns the text on the tab of the "other" profile red when new data arrives - which is reset back to the standard colour when the user switches to that profile to see the new stuff.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>