### PR TITLE
Change source for zziplib sources

### DIFF
--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -264,16 +264,8 @@ function InstallLibzip() {
 }
 
 function InstallZziplib() {
-  if($Env:APPVEYOR){
-    # The environmental variable APPVEYOR is set to TRUE on AppVeyor CI system
-    # Use a specific US Mirror - as an attempt to get around intermittent
-    # failures when using the generic SourceForge URL:
-    DownloadFile "https://superb-sea2.dl.sourceforge.net/project/zziplib/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2" "zziplib-0.13.62.tar.bz2"
-  } else {
-    # Use the original one:
-    DownloadFile "https://sourceforge.net/projects/zziplib/files/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2/download" "zziplib-0.13.62.tar.bz2"
-  }
-  ExtractTar "zziplib-0.13.62.tar.bz2" "zziplib"
+  DownloadFile "https://github.com/gdraheim/zziplib/archive/v0.13.62.tar.gz" "zziplib-0.13.62.tar.gz"
+  ExtractTar "zziplib-0.13.62.tar.gz" "zziplib"
   Set-Location zziplib\zziplib-0.13.62
   Step "changing configure script"
   (Get-Content configure -Raw) -replace 'uname -msr', 'uname -ms' | Out-File -encoding ASCII configure >> "$logFile" 2>&1


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This changes the source of the zziplib sources away from sourceforge.

#### Motivation for adding to Mudlet
 Sourceforge has become unreliable to get sources from. Hopefully Github provides more stable downloads.

#### Other info (issues closed, discussion etc)
I refrained from upgrading the version for now for a later PR.