### PR TITLE
BugFix: allow non-default Toolbar size settings to be saved

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -475,9 +475,11 @@ mudlet::mudlet()
 #endif // !Q_OS_MACOS
 #endif // INCLUDE_UPDATER
 
-    // mToolbarIconSize has been set to 0 in the initialisation list so either
-    // value will be accepted:
-    setToolBarIconSize(file_use_smallscreen.exists() ? 2 : 3);
+    // mToolbarIconSize has been set to 0 in the initialisation list but if it
+    // has not been changed from that in readSettings() then set it now:
+    if (!mToolbarIconSize) {
+        setToolBarIconSize(file_use_smallscreen.exists() ? 2 : 3);
+    }
 
 #ifdef QT_GAMEPAD_LIB
     //connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, slot_gamepadButtonPress);


### PR DESCRIPTION
The code to ensure a sensible default was not being limited to only working if a valid size had **NOT** been retrieved from the settings and was overriding the latter when it should not have been.

Closes issue #1598 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>