### PR TITLE
Workaround latency spikes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -461,6 +461,12 @@ int main(int argc, char* argv[])
     // seed random number generator (should be done once per lifetime)
     qsrand(static_cast<quint64>(QTime::currentTime().msecsSinceStartOfDay()));
 
+    // workaround latency spikes with wifi on Qt < 5.9.4, see https://github.com/Mudlet/Mudlet/issues/1587
+    // set the timeout to 5min
+    if (qgetenv("QT_BEARER_POLL_TIMEOUT").isEmpty()) {
+        qputenv("QT_BEARER_POLL_TIMEOUT", "300000");
+    }
+
     QString homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
     QDir dir;
     bool first_launch = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -463,9 +463,11 @@ int main(int argc, char* argv[])
 
     // workaround latency spikes with wifi on Qt < 5.9.4, see https://github.com/Mudlet/Mudlet/issues/1587
     // set the timeout to 5min
+#if (QT_VERSION < QT_VERSION_CHECK(5, 9, 4))
     if (qgetenv("QT_BEARER_POLL_TIMEOUT").isEmpty()) {
         qputenv("QT_BEARER_POLL_TIMEOUT", "300000");
     }
+#endif
 
     QString homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
     QDir dir;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds the qt poll bearer workaround
#### Motivation for adding to Mudlet
Fixes  https://github.com/Mudlet/Mudlet/issues/1587
#### Other info (issues closed, discussion etc)
We should update to the latest Qt and remove this workaround, however we are blocked by https://github.com/Mudlet/Mudlet/issues/1176.