### PR TITLE
Add Lua function getEpoch()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10151,10 +10151,7 @@ int TLuaInterpreter::getTime(lua_State* L)
 // returns: seconds since unix epoch with milliseconds (e.g. 1523555867.191)
 int TLuaInterpreter::getEpoch(lua_State *L)
 {
-    QDateTime time = QDateTime::currentDateTime();
-
-    lua_pushnumber(L, double(time.toMSecsSinceEpoch()) / 1000.0);
-
+    lua_pushnumber(L, static_cast<double>(QDateTime::currentDateTime().toMSecsSinceEpoch() / 1000.0));
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10147,6 +10147,18 @@ int TLuaInterpreter::getTime(lua_State* L)
 }
 
 
+// syntax: getEpoch()
+// returns: seconds since unix epoch with milliseconds (e.g. 1523555867.191)
+int TLuaInterpreter::getEpoch(lua_State *L)
+{
+    QDateTime time = QDateTime::currentDateTime();
+
+    lua_pushnumber(L, double(time.toMSecsSinceEpoch()) / 1000.0);
+
+    return 1;
+}
+
+
 int TLuaInterpreter::appendBuffer(lua_State* L)
 {
     string a1;
@@ -12115,6 +12127,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "killAlias", TLuaInterpreter::killAlias);
     lua_register(pGlobalLua, "setLabelStyleSheet", TLuaInterpreter::setLabelStyleSheet);
     lua_register(pGlobalLua, "getTime", TLuaInterpreter::getTime);
+    lua_register(pGlobalLua, "getEpoch", TLuaInterpreter::getEpoch);
     lua_register(pGlobalLua, "invokeFileDialog", TLuaInterpreter::invokeFileDialog);
     lua_register(pGlobalLua, "getTimestamp", TLuaInterpreter::getTimestamp);
     lua_register(pGlobalLua, "setLink", TLuaInterpreter::setLink);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -372,6 +372,7 @@ public:
     static int permBeginOfLineStringTrigger(lua_State*);
     static int setLabelStyleSheet(lua_State*);
     static int getTime(lua_State*);
+    static int getEpoch(lua_State*);
     static int invokeFileDialog(lua_State*);
     static int getTimestamp(lua_State*);
     static int setLink(lua_State*);

--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -702,7 +702,14 @@ if false then
   function getTime(returnType, format)
   end
 
-
+  --- Return seconds since unix epoch with milliseconds
+  ---
+  --- @usage Get seconds since unix epoch with milliseconds
+  ---   <pre>
+  ---   getEpoch()
+  ---   </pre>
+  function getEpoch()
+  end
 
   --- Returns the timestamp string as it's seen when you enable the timestamps view (blue 'i' button bottom right of the Mudlet screen).
   ---


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add a new function to Mudlet CoreLua getEpoch() returns number of seconds from unix epoch with milliseconds precision.
#### Motivation for adding to Mudlet
There did not appear to be a straightforward way to get number of seconds since unix epoch with milliseconds precision. This addition was desired to aid in scripts that require a higher accuracy source of time, for example to calculate durations of cure balances or similar events in the MUD.

#### Other info (issues closed, discussion etc)
Some were using os.clock() which is CPU TIME not time of day - and its behavior is not consistent across all platforms. os.clock() is thus the incorrect method. os.time() is better but did not have milliseconds precision. The best known way to achieve what getEpoch() does was to append os.time() to getTime(true, ".z") and convert it to a number, which is not desirablefor  performance and accuracy reasons.