### PR TITLE
Remove qt bearer poll timeout

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -465,7 +465,7 @@ int main(int argc, char* argv[])
     // set the timeout to 5min
 #if (QT_VERSION < QT_VERSION_CHECK(5, 9, 4))
     if (qgetenv("QT_BEARER_POLL_TIMEOUT").isEmpty()) {
-        qputenv("QT_BEARER_POLL_TIMEOUT", "300000");
+        qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,7 +462,7 @@ int main(int argc, char* argv[])
     qsrand(static_cast<quint64>(QTime::currentTime().msecsSinceStartOfDay()));
 
     // workaround latency spikes with wifi on Qt < 5.9.4, see https://github.com/Mudlet/Mudlet/issues/1587
-    // set the timeout to 5min
+    // set the timeout to infinite
 #if (QT_VERSION < QT_VERSION_CHECK(5, 9, 4))
     if (qgetenv("QT_BEARER_POLL_TIMEOUT").isEmpty()) {
         qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove qt bearer poll timeout
#### Motivation for adding to Mudlet
Having Mudlet lag every 5min is not acceptable, which it turns out the previous option did. 

See discussion at https://github.com/Mudlet/Mudlet/pull/1605#issuecomment-380891899
#### Other info (issues closed, discussion etc)
Upgrading to Qt 5.9.4+ fixes the problem too.