### PR TITLE
BugFix: include missing header file that is probably causing Issue #1608

### DIFF
--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -35,6 +35,7 @@
 #include <QtCore>
 #include <QDialog>
 #include <QDir>
+#include <QDoubleSpinBox>
 #include <QMap>
 #include "post_guard.h"
 


### PR DESCRIPTION
A `QDoubleSpin` box is now inserted at run-time into the Profile Preferences but without the header file it seems to be causing run-time crashes on Windows (but not other platforms?)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>