### PR TITLE
Refactor: rename the upper and lower TTextEdit pair in each TConsole

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -232,13 +232,13 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_Return:
             if (ke->modifiers() & Qt::ControlModifier) {
-                mpConsole->console2->mCursorY = mpConsole->buffer.size();
-                mpConsole->console2->hide();
+                mpConsole->mLowerPane->mCursorY = mpConsole->buffer.size();
+                mpConsole->mLowerPane->hide();
                 mpConsole->buffer.mCursorY = mpConsole->buffer.size();
-                mpConsole->console->mCursorY = mpConsole->buffer.size();
-                mpConsole->console->mIsTailMode = true;
-                mpConsole->console->updateScreenView();
-                mpConsole->console->forceUpdate();
+                mpConsole->mUpperPane->mCursorY = mpConsole->buffer.size();
+                mpConsole->mUpperPane->mIsTailMode = true;
+                mpConsole->mUpperPane->updateScreenView();
+                mpConsole->mUpperPane->forceUpdate();
                 ke->accept();
                 return true;
             } else if (ke->modifiers() & Qt::ShiftModifier) {
@@ -335,8 +335,8 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_C:
             if (ke->modifiers() & Qt::ControlModifier) {
-                if (mpConsole->console->mSelectedRegion != QRegion(0, 0, 0, 0)) {
-                    mpConsole->console->copySelectionToClipboard();
+                if (mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0)) {
+                    mpConsole->mUpperPane->copySelectionToClipboard();
                     ke->accept();
                     return true;
                 }
@@ -377,8 +377,8 @@ void TCommandLine::focusInEvent(QFocusEvent* event)
     textCursor().movePosition(QTextCursor::Start);
     textCursor().movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, mSelectedText.length());
 
-    mpConsole->console->forceUpdate();
-    mpConsole->console2->forceUpdate();
+    mpConsole->mUpperPane->forceUpdate();
+    mpConsole->mLowerPane->forceUpdate();
     QPlainTextEdit::focusInEvent(event);
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -310,18 +310,18 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     splitter->setParent(layer);
     setFocusProxy(mpCommandLine);
 
-    console = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, false);
-    console->setContentsMargins(0, 0, 0, 0);
-    console->setSizePolicy(sizePolicy3);
-    console->setFocusPolicy(Qt::NoFocus);
+    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, false);
+    mUpperPane->setContentsMargins(0, 0, 0, 0);
+    mUpperPane->setSizePolicy(sizePolicy3);
+    mUpperPane->setFocusPolicy(Qt::NoFocus);
 
-    console2 = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, true);
-    console2->setContentsMargins(0, 0, 0, 0);
-    console2->setSizePolicy(sizePolicy3);
-    console2->setFocusPolicy(Qt::NoFocus);
+    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, true);
+    mLowerPane->setContentsMargins(0, 0, 0, 0);
+    mLowerPane->setSizePolicy(sizePolicy3);
+    mLowerPane->setFocusPolicy(Qt::NoFocus);
 
-    splitter->addWidget(console);
-    splitter->addWidget(console2);
+    splitter->addWidget(mUpperPane);
+    splitter->addWidget(mLowerPane);
 
     splitter->setCollapsible(1, false);
     splitter->setCollapsible(0, false);
@@ -375,7 +375,7 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     timeStampButton->setFocusPolicy(Qt::NoFocus);
     timeStampButton->setToolTip(tr("<html><head/><body><p>Show Time Stamps.</p></body></html>"));
     timeStampButton->setIcon(QIcon(QStringLiteral(":/icons/dialog-information.png")));
-    connect(timeStampButton, SIGNAL(pressed()), console, SLOT(slot_toggleTimeStamps()));
+    connect(timeStampButton, SIGNAL(pressed()), mUpperPane, SLOT(slot_toggleTimeStamps()));
 
     auto replayButton = new QToolButton;
     replayButton->setCheckable(true);
@@ -501,20 +501,20 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     sizeList << 6 << 2;
     splitter->setSizes(sizeList);
 
-    console->show();
-    console2->show();
-    console2->hide();
+    mUpperPane->show();
+    mLowerPane->show();
+    mLowerPane->hide();
     if (mIsDebugConsole) {
         mpCommandLine->hide();
     }
 
     isUserScrollBack = false;
 
-    connect(mpScrollBar, SIGNAL(valueChanged(int)), console, SLOT(slot_scrollBarMoved(int)));
+    connect(mpScrollBar, SIGNAL(valueChanged(int)), mUpperPane, SLOT(slot_scrollBarMoved(int)));
 
     if (mIsSubConsole) {
         mpScrollBar->hide();
-        console2->hide();
+        mLowerPane->hide();
         layerCommandLine->hide();
         mpMainFrame->move(0, 0);
         mpMainDisplay->move(0, 0);
@@ -541,10 +541,10 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     mpButtonMainLayer->setMaximumWidth(400);
     setFocusPolicy(Qt::ClickFocus);
     setFocusProxy(mpCommandLine);
-    console->setFocusPolicy(Qt::ClickFocus);
-    console->setFocusProxy(mpCommandLine);
-    console2->setFocusPolicy(Qt::ClickFocus);
-    console2->setFocusProxy(mpCommandLine);
+    mUpperPane->setFocusPolicy(Qt::ClickFocus);
+    mUpperPane->setFocusProxy(mpCommandLine);
+    mLowerPane->setFocusPolicy(Qt::ClickFocus);
+    mLowerPane->setFocusProxy(mpCommandLine);
 
     buttonLayerSpacer->setAutoFillBackground(true);
     buttonLayerSpacer->setPalette(__pal);
@@ -563,7 +563,7 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
         // non-null mudlet::self() - the connect(...) will produce a debug
         // message and not make THAT connection should it indeed be null but it
         // is not fatal...
-        // So, this SHOULD be the main profile console - Slysven
+        // So, this SHOULD be the main profile mUpperPane - Slysven
         connect(mudlet::self(), SIGNAL(signal_profileMapReloadRequested(QList<QString>)), this, SLOT(slot_reloadMap(QList<QString>)), Qt::UniqueConnection);
         connect(this, SIGNAL(signal_newDataAlert(const QString&, const bool)), mudlet::self(), SLOT(slot_newDataOnHost(const QString&, const bool)), Qt::UniqueConnection);
         // For some odd reason the first seems to get connected twice - the
@@ -704,8 +704,8 @@ void TConsole::closeEvent(QCloseEvent* event)
             std::string key = objectName().toLatin1().data();
             TConsole* pC = mpHost->mpConsole;
             if (pC->mSubConsoleMap.find(key) != pC->mSubConsoleMap.end()) {
-                console->close();
-                console2->close();
+                mUpperPane->close();
+                mLowerPane->close();
 
                 pC->mSubConsoleMap.erase(key);
             }
@@ -957,14 +957,14 @@ void TConsole::changeColors()
     if (mIsDebugConsole) {
         mDisplayFont.setStyleStrategy((QFont::StyleStrategy)(QFont::NoAntialias | QFont::PreferQuality));
         mDisplayFont.setFixedPitch(true);
-        console->setFont(mDisplayFont);
-        console2->setFont(mDisplayFont);
+        mUpperPane->setFont(mDisplayFont);
+        mLowerPane->setFont(mDisplayFont);
         QPalette palette;
         palette.setColor(QPalette::Text, mFgColor);
         palette.setColor(QPalette::Highlight, QColor(55, 55, 255));
         palette.setColor(QPalette::Base, QColor(Qt::black));
-        console->setPalette(palette);
-        console2->setPalette(palette);
+        mUpperPane->setPalette(palette);
+        mLowerPane->setPalette(palette);
     } else if (mIsSubConsole) {
 #if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         mDisplayFont.setStyleStrategy((QFont::StyleStrategy)(QFont::NoAntialias | QFont::PreferQuality));
@@ -979,22 +979,22 @@ void TConsole::changeColors()
         // N/U:        int mFontHeight = QFontMetrics( mDisplayFont ).height();
         int mFontWidth = QFontMetrics(mDisplayFont).width(QChar('W'));
         qreal letterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-        console->mLetterSpacing = letterSpacing;
-        console2->mLetterSpacing = letterSpacing;
+        mUpperPane->mLetterSpacing = letterSpacing;
+        mLowerPane->mLetterSpacing = letterSpacing;
         mpHost->mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, letterSpacing);
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, console->mLetterSpacing);
+        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mUpperPane->mLetterSpacing);
 #endif
         mDisplayFont.setFixedPitch(true);
-        console->setFont(mDisplayFont);
-        console2->setFont(mDisplayFont);
+        mUpperPane->setFont(mDisplayFont);
+        mLowerPane->setFont(mDisplayFont);
         QPalette palette;
         palette.setColor(QPalette::Text, mFgColor);
         palette.setColor(QPalette::Highlight, QColor(55, 55, 255));
         palette.setColor(QPalette::Base, mBgColor);
         setPalette(palette);
         layer->setPalette(palette);
-        console->setPalette(palette);
-        console2->setPalette(palette);
+        mUpperPane->setPalette(palette);
+        mLowerPane->setPalette(palette);
     } else {
         QPalette pal;
         pal.setColor(QPalette::Text, mpHost->mCommandLineFgColor); //QColor(0,0,192));
@@ -1023,21 +1023,21 @@ void TConsole::changeColors()
         // N/U:        int mFontHeight = QFontMetrics( mpHost->mDisplayFont ).height();
         int mFontWidth = QFontMetrics(mpHost->mDisplayFont).width(QChar('W'));
         qreal letterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-        console->mLetterSpacing = letterSpacing;
-        console2->mLetterSpacing = letterSpacing;
+        mUpperPane->mLetterSpacing = letterSpacing;
+        mLowerPane->mLetterSpacing = letterSpacing;
         mpHost->mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, letterSpacing);
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, console->mLetterSpacing);
+        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mUpperPane->mLetterSpacing);
 #endif
-        console->setFont(mpHost->mDisplayFont);
-        console2->setFont(mpHost->mDisplayFont);
+        mUpperPane->setFont(mpHost->mDisplayFont);
+        mLowerPane->setFont(mpHost->mDisplayFont);
         QPalette palette;
         palette.setColor(QPalette::Text, mpHost->mFgColor);
         palette.setColor(QPalette::Highlight, QColor(55, 55, 255));
         palette.setColor(QPalette::Base, mpHost->mBgColor);
         setPalette(palette);
         layer->setPalette(palette);
-        console->setPalette(palette);
-        console2->setPalette(palette);
+        mUpperPane->setPalette(palette);
+        mLowerPane->setPalette(palette);
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;
         mpCommandLine->setFont(mpHost->mDisplayFont);
@@ -1054,8 +1054,8 @@ void TConsole::changeColors()
     palette.setColor(QPalette::Base, QColor(Qt::red));
 
     if (!mIsSubConsole) {
-        console->mWrapAt = mWrapAt;
-        console2->mWrapAt = mWrapAt;
+        mUpperPane->mWrapAt = mWrapAt;
+        mLowerPane->mWrapAt = mWrapAt;
         splitter->setPalette(palette);
     }
 
@@ -1069,14 +1069,14 @@ void TConsole::changeColors()
 void TConsole::setConsoleBgColor(int r, int g, int b)
 {
     mBgColor = QColor(r, g, b);
-    console->setConsoleBgColor(r, g, b);
+    mUpperPane->setConsoleBgColor(r, g, b);
     changeColors();
 }
 
 void TConsole::setConsoleFgColor(int r, int g, int b)
 {
     mFgColor = QColor(r, g, b);
-    console->setConsoleFgColor(r, g, b);
+    mUpperPane->setConsoleFgColor(r, g, b);
     changeColors();
 }
 
@@ -1140,8 +1140,8 @@ void TConsole::runTriggers(int line)
 
 void TConsole::finalize()
 {
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 /* ANSI color codes: sequence = "ESCAPE + [ code_1; ... ; code_n m"
@@ -1181,25 +1181,25 @@ void TConsole::finalize()
 
 void TConsole::scrollDown(int lines)
 {
-    console->scrollDown(lines);
-    if (console->isTailMode()) {
-        console2->mCursorY = buffer.lineBuffer.size(); //getLastLineNumber();
-        console2->hide();
-        console->mCursorY = buffer.lineBuffer.size(); //getLastLineNumber();
-        console->mIsTailMode = true;
-        console->updateScreenView();
-        console->forceUpdate();
+    mUpperPane->scrollDown(lines);
+    if (mUpperPane->isTailMode()) {
+        mLowerPane->mCursorY = buffer.lineBuffer.size(); //getLastLineNumber();
+        mLowerPane->hide();
+        mUpperPane->mCursorY = buffer.lineBuffer.size(); //getLastLineNumber();
+        mUpperPane->mIsTailMode = true;
+        mUpperPane->updateScreenView();
+        mUpperPane->forceUpdate();
     }
 }
 
 void TConsole::scrollUp(int lines)
 {
-    console2->mIsTailMode = true;
-    console2->mCursorY = buffer.size(); //getLastLineNumber();
-    console2->show();
-    console2->updateScreenView();
-    console2->forceUpdate();
-    console->scrollUp(lines);
+    mLowerPane->mIsTailMode = true;
+    mLowerPane->mCursorY = buffer.size(); //getLastLineNumber();
+    mLowerPane->show();
+    mLowerPane->updateScreenView();
+    mLowerPane->forceUpdate();
+    mUpperPane->scrollUp(lines);
 }
 
 void TConsole::deselect()
@@ -1280,7 +1280,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
                 buffer.insertInLine(P, text, _f);
             }
             buffer.applyLink(P, P2, text, func, hint);
-            console->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
+            mUpperPane->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
         } else if (y >= mEngineCursor) {
             if (customFormat) {
                 buffer.insertInLine(P, text, mFormatCurrent);
@@ -1312,8 +1312,8 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
                                        mFormatCurrent.bold,
                                        mFormatCurrent.italics,
                                        mFormatCurrent.underline );*/
-            console->showNewLines();
-            console2->showNewLines();
+            mUpperPane->showNewLines();
+            mLowerPane->showNewLines();
 
         } else {
             if (customFormat) {
@@ -1327,7 +1327,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
             if (text.indexOf("\n") != -1) {
                 int y_tmp = mUserCursor.y();
                 int down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
-                console->needUpdate(y_tmp, y_tmp + down + 1);
+                mUpperPane->needUpdate(y_tmp, y_tmp + down + 1);
                 int y_neu = y_tmp + down;
                 int x_adjust = text.lastIndexOf("\n");
                 int x_neu = 0;
@@ -1336,7 +1336,7 @@ void TConsole::insertLink(const QString& text, QStringList& func, QStringList& h
                 }
                 moveCursor(x_neu, y_neu);
             } else {
-                console->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
+                mUpperPane->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
                 moveCursor(mUserCursor.x() + text.size(), mUserCursor.y());
             }
         }
@@ -1364,7 +1364,7 @@ void TConsole::insertText(const QString& text, QPoint P)
         }
         if (y < mEngineCursor) {
             buffer.insertInLine(P, text, mFormatCurrent);
-            console->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
+            mUpperPane->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
         } else if (y >= mEngineCursor) {
             buffer.insertInLine(P, text, mFormatCurrent);
         }
@@ -1384,16 +1384,16 @@ void TConsole::insertText(const QString& text, QPoint P)
                           mFormatCurrent.flags & TCHAR_ITALICS,
                           mFormatCurrent.flags & TCHAR_UNDERLINE,
                           mFormatCurrent.flags & TCHAR_STRIKEOUT);
-            console->showNewLines();
-            console2->showNewLines();
+            mUpperPane->showNewLines();
+            mLowerPane->showNewLines();
         } else {
             buffer.insertInLine(mUserCursor, text, mFormatCurrent);
             if (text.indexOf("\n") != -1) {
                 int y_tmp = mUserCursor.y();
                 int down = buffer.wrapLine(mUserCursor.y(), mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
-                console->needUpdate(y_tmp, y_tmp + down + 1);
+                mUpperPane->needUpdate(y_tmp, y_tmp + down + 1);
             } else {
-                console->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
+                mUpperPane->needUpdate(mUserCursor.y(), mUserCursor.y() + 1);
             }
         }
     }
@@ -1814,12 +1814,12 @@ void TConsole::_luaWrapLine(int line)
 
 bool TConsole::setMiniConsoleFontSize(int size)
 {
-    console->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
-    console->updateScreenView();
-    console->forceUpdate();
-    console2->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
-    console2->updateScreenView();
-    console2->forceUpdate();
+    mUpperPane->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
+    mUpperPane->updateScreenView();
+    mUpperPane->forceUpdate();
+    mLowerPane->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
+    mLowerPane->updateScreenView();
+    mLowerPane->forceUpdate();
     return true;
 }
 
@@ -2067,8 +2067,8 @@ void TConsole::printCommand(QString& msg)
                 buffer.insertInLine(P, msg, format);
                 int down = buffer.wrapLine(lineBeforeNewContent, mpHost->mScreenWidth, mpHost->mWrapIndentCount, mFormatCurrent);
 
-                console->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
-                console2->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
+                mUpperPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
+                mLowerPane->needUpdate(lineBeforeNewContent, lineBeforeNewContent + 1 + down);
                 buffer.promptBuffer[lineBeforeNewContent] = false;
                 return;
             }
@@ -2130,16 +2130,16 @@ void TConsole::print(const char* txt)
                   mFormatCurrent.flags & TCHAR_ITALICS,
                   mFormatCurrent.flags & TCHAR_UNDERLINE,
                   mFormatCurrent.flags & TCHAR_STRIKEOUT);
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 void TConsole::printDebug(QColor& c, QColor& d, const QString& msg)
 {
     buffer.append(msg, 0, msg.size(), c.red(), c.green(), c.blue(), d.red(), d.green(), d.blue(), false, false, false, false);
 
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 TConsole* TConsole::createBuffer(const QString& name)
@@ -2194,8 +2194,8 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
         pC->setObjectName(name);
         pC->setFocusPolicy(Qt::NoFocus);
         pC->setUserWindow();
-        pC->console->setIsMiniConsole();
-        pC->console2->setIsMiniConsole();
+        pC->mUpperPane->setIsMiniConsole();
+        pC->mLowerPane->setIsMiniConsole();
         pC->resize(width, height);
         pC->mOldX = x;
         pC->mOldY = y;
@@ -2295,8 +2295,8 @@ bool TConsole::setBackgroundColor(const QString& name, int r, int g, int b, int 
         QPalette mainPalette;
         mainPalette.setColor(QPalette::Window, QColor(r, g, b, alpha));
         mSubConsoleMap[key]->setPalette(mainPalette);
-        mSubConsoleMap[key]->console->mBgColor = QColor(r, g, b, alpha);
-        mSubConsoleMap[key]->console2->mBgColor = QColor(r, g, b, alpha);
+        mSubConsoleMap[key]->mUpperPane->mBgColor = QColor(r, g, b, alpha);
+        mSubConsoleMap[key]->mLowerPane->mBgColor = QColor(r, g, b, alpha);
         return true;
     } else if (mLabelMap.find(key) != mLabelMap.end()) {
         QPalette mainPalette;
@@ -2342,12 +2342,12 @@ bool TConsole::showWindow(const QString& name)
 {
     std::string key = name.toLatin1().data();
     if (mSubConsoleMap.find(key) != mSubConsoleMap.end()) {
-        mSubConsoleMap[key]->console->updateScreenView();
-        mSubConsoleMap[key]->console->forceUpdate();
+        mSubConsoleMap[key]->mUpperPane->updateScreenView();
+        mSubConsoleMap[key]->mUpperPane->forceUpdate();
         mSubConsoleMap[key]->show();
 
-        mSubConsoleMap[key]->console2->updateScreenView();
-        mSubConsoleMap[key]->console2->forceUpdate();
+        mSubConsoleMap[key]->mLowerPane->updateScreenView();
+        mSubConsoleMap[key]->mLowerPane->forceUpdate();
         //mSubConsoleMap[key]->move(mSubConsoleMap[key]->mOldX, mSubConsoleMap[key]->mOldY);
         return true;
     } else if (mLabelMap.find(key) != mLabelMap.end()) {
@@ -2402,15 +2402,15 @@ void TConsole::print(const QString& msg)
                   mFormatCurrent.flags & TCHAR_ITALICS,
                   mFormatCurrent.flags & TCHAR_UNDERLINE,
                   mFormatCurrent.flags & TCHAR_STRIKEOUT);
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgColor)
 {
     buffer.append(msg, 0, msg.size(), fgColor.red(), fgColor.green(), fgColor.blue(), bgColor.red(), bgColor.green(), bgColor.blue(), false, false, false, false);
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 
@@ -2443,8 +2443,8 @@ void TConsole::printSystemMessage(const QString& msg)
                   false,
                   false,
                   false);
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 void TConsole::echoUserWindow(const QString& msg)
@@ -2466,12 +2466,12 @@ void TConsole::paste()
 {
     if (buffer.size() - 1 > mUserCursor.y()) {
         buffer.paste(mUserCursor, mClipboard);
-        console->needUpdate(mUserCursor.y(), mUserCursor.y());
+        mUpperPane->needUpdate(mUserCursor.y(), mUserCursor.y());
     } else {
         buffer.appendBuffer(mClipboard);
     }
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 void TConsole::pasteWindow(TBuffer bufferSlice)
@@ -2483,15 +2483,15 @@ void TConsole::pasteWindow(TBuffer bufferSlice)
 void TConsole::appendBuffer()
 {
     buffer.appendBuffer(mClipboard);
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 void TConsole::appendBuffer(TBuffer bufferSlice)
 {
     buffer.appendBuffer(bufferSlice);
-    console->showNewLines();
-    console2->showNewLines();
+    mUpperPane->showNewLines();
+    mLowerPane->showNewLines();
 }
 
 
@@ -2582,7 +2582,7 @@ void TConsole::slot_searchBufferUp()
         } while (begin > -1);
         if (_found) {
             scrollUp(buffer.mCursorY - i - 3);
-            console->forceUpdate();
+            mUpperPane->forceUpdate();
             mCurrentSearchResult = i;
             return;
         }
@@ -2621,7 +2621,7 @@ void TConsole::slot_searchBufferDown()
         } while (begin > -1);
         if (_found) {
             scrollUp(buffer.mCursorY - i - 3);
-            console->forceUpdate();
+            mUpperPane->forceUpdate();
             mCurrentSearchResult = i;
             return;
         }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1182,11 +1182,11 @@ void TConsole::finalize()
 void TConsole::scrollDown(int lines)
 {
     mUpperPane->scrollDown(lines);
-    if (mUpperPane->isTailMode()) {
-        mLowerPane->mCursorY = buffer.lineBuffer.size(); //getLastLineNumber();
+    if (mUpperPane->mIsTailMode) {
+        mLowerPane->mCursorY = buffer.lineBuffer.size();
         mLowerPane->hide();
-        mUpperPane->mCursorY = buffer.lineBuffer.size(); //getLastLineNumber();
-        mUpperPane->mIsTailMode = true;
+
+        mUpperPane->mCursorY = buffer.lineBuffer.size();
         mUpperPane->updateScreenView();
         mUpperPane->forceUpdate();
     }
@@ -1194,11 +1194,11 @@ void TConsole::scrollDown(int lines)
 
 void TConsole::scrollUp(int lines)
 {
-    mLowerPane->mIsTailMode = true;
-    mLowerPane->mCursorY = buffer.size(); //getLastLineNumber();
+    mLowerPane->mCursorY = buffer.size();
     mLowerPane->show();
     mLowerPane->updateScreenView();
     mLowerPane->forceUpdate();
+
     mUpperPane->scrollUp(lines);
 }
 
@@ -2428,7 +2428,6 @@ void TConsole::printSystemMessage(const QString& msg)
         bgColor = mpHost->mBgColor;
     }
 
-    //int lineBeforeNewContent = buffer.getLastLineNumber();
     QString txt = QString("System Message: ") + msg;
     buffer.append(txt,
                   0,

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -171,8 +171,8 @@ public:
 
     TBuffer buffer;
     static const QString cmLuaLineVariable;
-    TTextEdit* console;
-    TTextEdit* console2;
+    TTextEdit* mUpperPane;
+    TTextEdit* mLowerPane;
     int currentFgColorProperty;
     QToolButton* emergencyStop;
     bool isUserScrollBack;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2425,10 +2425,10 @@ int TLuaInterpreter::setFontSize(lua_State* L)
             font.setPointSize(size);
             pHost->mDisplayFont = font;
             // apply changes to main console and its while-scrolling component too.
-            mudlet::self()->mConsoleMap[pHost]->console->updateScreenView();
-            mudlet::self()->mConsoleMap[pHost]->console->forceUpdate();
-            mudlet::self()->mConsoleMap[pHost]->console2->updateScreenView();
-            mudlet::self()->mConsoleMap[pHost]->console2->forceUpdate();
+            mudlet::self()->mConsoleMap[pHost]->mUpperPane->updateScreenView();
+            mudlet::self()->mConsoleMap[pHost]->mUpperPane->forceUpdate();
+            mudlet::self()->mConsoleMap[pHost]->mLowerPane->updateScreenView();
+            mudlet::self()->mConsoleMap[pHost]->mLowerPane->forceUpdate();
             mudlet::self()->mConsoleMap[pHost]->refresh();
             lua_pushboolean(L, true);
         } else {
@@ -2712,7 +2712,7 @@ int TLuaInterpreter::clearUserWindow(lua_State* L)
     if (!lua_isstring(L, 1)) {
         Host& host = getHostFromLua(L);
         host.mpConsole->buffer.clear();
-        host.mpConsole->console->forceUpdate();
+        host.mpConsole->mUpperPane->forceUpdate();
         return 0;
     } else {
         luaSendText = lua_tostring(L, 1);
@@ -12983,7 +12983,7 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
     Host* pHost = &getHostFromLua(L);
 
     if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-        columns = pHost->mpConsole->console->getColumnCount();
+        columns = pHost->mpConsole->mUpperPane->getColumnCount();
     } else {
         columns = mudlet::self()->getColumnCount(pHost, windowName);
     }
@@ -13016,7 +13016,7 @@ int TLuaInterpreter::getRowCount(lua_State* L)
     Host* pHost = &getHostFromLua(L);
 
     if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-        rows = pHost->mpConsole->console->getRowCount();
+        rows = pHost->mpConsole->mUpperPane->getRowCount();
     } else {
         rows = mudlet::self()->getRowCount(pHost, windowName);
     }

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -76,7 +76,6 @@ public:
     int imageTopLine();
     int bufferScrollUp(int lines);
     int bufferScrollDown(int lines);
-    bool isTailMode();
     void copySelectionToClipboard();
     void setConsoleFgColor(int r, int g, int b) { mFgColor = QColor(r, g, b); }
     void setConsoleBgColor(int r, int g, int b) { mBgColor = QColor(r, g, b); }
@@ -93,6 +92,14 @@ public:
     int mFontAscent;
     int mFontDescent;
     bool mIsCommandPopup;
+    // If this flag is set it means that this instance is currently set to
+    // display the last lines in the mpBuffer associated with the mpConsole;
+    // this setting is always true for the "lower" pane and is set/reset as
+    // needed in the upper onw. Its name seems to come from the *nix tail
+    // utility which returns the end of file(s), and, if invoked with either of
+    // the -f or -F "follow" arguments continues to show new lines as they are
+    // subsequently appended to the file with old lines scrolling up the screen
+    // which is precisely what is supposed to happen when this flag is true:
     bool mIsTailMode;
     QMap<QString, QString> mPopupCommands;
     int mScrollVector;
@@ -125,7 +132,11 @@ private:
     bool mInversOn;
     bool mIsDebugConsole;
     bool mIsMiniConsole;
-    bool mIsLowerPane;
+    // Each TConsole instance uses two instances of this class, one above the
+    // other but they need to behave differently in some ways; this, now const,
+    // flag is set on creation and is used to adjust the behaviour depending on
+    // which one this instance is:
+    const bool mIsLowerPane;
     int mLastRenderBottom;
     int mLeftMargin;
     bool mMouseTracking;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -48,7 +48,7 @@ class TTextEdit : public QWidget
 
 public:
     Q_DISABLE_COPY(TTextEdit)
-    TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isDebugConsole, bool isSplitScreen);
+    TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isDebugConsole, bool isLowerPane);
     void paintEvent(QPaintEvent*) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void drawForeground(QPainter&, const QRect&);
@@ -125,7 +125,7 @@ private:
     bool mInversOn;
     bool mIsDebugConsole;
     bool mIsMiniConsole;
-    bool mIsSplitScreen;
+    bool mIsLowerPane;
     int mLastRenderBottom;
     int mLeftMargin;
     bool mMouseTracking;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -92,14 +92,11 @@ public:
     int mFontAscent;
     int mFontDescent;
     bool mIsCommandPopup;
-    // If this flag is set it means that this instance is currently set to
-    // display the last lines in the mpBuffer associated with the mpConsole;
-    // this setting is always true for the "lower" pane and is set/reset as
-    // needed in the upper onw. Its name seems to come from the *nix tail
-    // utility which returns the end of file(s), and, if invoked with either of
-    // the -f or -F "follow" arguments continues to show new lines as they are
-    // subsequently appended to the file with old lines scrolling up the screen
-    // which is precisely what is supposed to happen when this flag is true:
+    // If true, this TTextEdit is to display the last lines in
+    // mpConsole.mpBuffer. This is always true for the lower main window panel
+    // but it is RESET when the upper one is scrolled upwards. The name appears
+    // to be related to the file monitoring feature in the *nix tail command.
+    // See, e.g.: https://en.wikipedia.org/wiki/Tail_(Unix)#File_monitoring
     bool mIsTailMode;
     QMap<QString, QString> mPopupCommands;
     int mScrollVector;
@@ -133,8 +130,8 @@ private:
     bool mIsDebugConsole;
     bool mIsMiniConsole;
     // Each TConsole instance uses two instances of this class, one above the
-    // other but they need to behave differently in some ways; this, now const,
-    // flag is set on creation and is used to adjust the behaviour depending on
+    // other but they need to behave differently in some ways; this flag is set
+    // or reset on creation and is used to adjust the behaviour depending on
     // which one this instance is:
     const bool mIsLowerPane;
     int mLastRenderBottom;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1075,10 +1075,10 @@ void dlgProfilePreferences::setDisplayFont()
             mudlet::self()->mConsoleMap[pHost]->changeColors();
 
             // update the display properly when font or size selections change.
-            mudlet::self()->mConsoleMap[pHost]->console->updateScreenView();
-            mudlet::self()->mConsoleMap[pHost]->console->forceUpdate();
-            mudlet::self()->mConsoleMap[pHost]->console2->updateScreenView();
-            mudlet::self()->mConsoleMap[pHost]->console2->forceUpdate();
+            mudlet::self()->mConsoleMap[pHost]->mUpperPane->updateScreenView();
+            mudlet::self()->mConsoleMap[pHost]->mUpperPane->forceUpdate();
+            mudlet::self()->mConsoleMap[pHost]->mLowerPane->updateScreenView();
+            mudlet::self()->mConsoleMap[pHost]->mLowerPane->forceUpdate();
             mudlet::self()->mConsoleMap[pHost]->refresh();
         }
         auto config = edbeePreviewWidget->config();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -218,7 +218,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     pHB2->setSizeConstraint(QLayout::SetMaximumSize);
     mpErrorConsole = new TConsole(mpHost, false, popupArea);
     mpErrorConsole->setWrapAt(100);
-    mpErrorConsole->console->slot_toggleTimeStamps();
+    mpErrorConsole->mUpperPane->slot_toggleTimeStamps();
     mpErrorConsole->print("*** starting new session ***\n");
     pHB2->setContentsMargins(0, 0, 0, 0);
     pHB2->addWidget(mpErrorConsole);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1382,7 +1382,7 @@ int mudlet::getFontSize(Host* pHost, const QString& name)
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
 
     if (dockWindowConsoleMap.contains(name)) {
-        return dockWindowConsoleMap.value(name)->console->mDisplayFont.pointSize();
+        return dockWindowConsoleMap.value(name)->mUpperPane->mDisplayFont.pointSize();
     } else {
         return -1;
     }
@@ -1411,8 +1411,8 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         pC->layerCommandLine->hide();
         pC->mpScrollBar->hide();
         pC->setUserWindow();
-        pC->console->setIsMiniConsole();
-        pC->console2->setIsMiniConsole();
+        pC->mUpperPane->setIsMiniConsole();
+        pC->mLowerPane->setIsMiniConsole();
         dockWindowConsoleMap[name] = pC;
         addDockWidget(Qt::RightDockWidgetArea, pD);
 
@@ -1596,7 +1596,7 @@ bool mudlet::clearWindow(Host* pHost, const QString& name)
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
     if (dockWindowConsoleMap.contains(name)) {
         dockWindowConsoleMap[name]->buffer.clear();
-        dockWindowConsoleMap[name]->console->update();
+        dockWindowConsoleMap[name]->mUpperPane->update();
         return true;
     } else {
         return false;
@@ -3571,7 +3571,7 @@ int mudlet::getColumnCount(Host* pHost, QString& name)
         return -1;
     }
 
-    return dockWindowConsoleMap[name]->console->getColumnCount();
+    return dockWindowConsoleMap[name]->mUpperPane->getColumnCount();
 }
 
 int mudlet::getRowCount(Host* pHost, QString& name)
@@ -3583,7 +3583,7 @@ int mudlet::getRowCount(Host* pHost, QString& name)
         return -1;
     }
 
-    return dockWindowConsoleMap[name]->console->getRowCount();
+    return dockWindowConsoleMap[name]->mUpperPane->getRowCount();
 }
 
 // Can be called from lua sub-system OR from slot_replay(), the presence of a


### PR DESCRIPTION
It is stupid (IMHO) to call them `console` and `console2` as it means it is easy to confuse which one is which (and also confuses them with being `TConsole` instances). These renames make it altogether more easy to keep track of what each one is:
* `(TTextEdit*) TConsole::console`  ==> `TConsole::mUpperPane`
* `(TTextEdit*) TConsole::console2` ==> `TConsole::mLowerPane`
* `(bool) TTextEdit::mIsSplitScreen` ==> `TTextEdit::mIsLowerPane`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>