### PR TITLE
Fix changes in editor not saved when reloading for a new perm trigger

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6408,6 +6408,7 @@ void dlgTriggerEditor::saveOpenChanges()
 void dlgTriggerEditor::enterEvent(QEvent* pE)
 {
     if (mNeedUpdateData) {
+        saveOpenChanges();
         treeWidget_triggers->clear();
         treeWidget_aliases->clear();
         treeWidget_timers->clear();
@@ -6423,6 +6424,7 @@ void dlgTriggerEditor::enterEvent(QEvent* pE)
 void dlgTriggerEditor::focusInEvent(QFocusEvent* pE)
 {
     if (mNeedUpdateData) {
+        saveOpenChanges();
         treeWidget_triggers->clear();
         treeWidget_aliases->clear();
         treeWidget_timers->clear();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Save editor data on the other two events from Qt as well - on focus and enter. This fixes the case where if you create a new trigger, don't save it, then create a new perm trigger from Lua, and go back to the editor - your changes were lost in the reload from the focus event.
#### Motivation for adding to Mudlet
Data loss sucks.
#### Other info (issues closed, discussion etc)
Fixes #1621