### PR TITLE
Use 5.1 syntax branch for formatter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = http://github.com/edbee/edbee-lib.git
 [submodule "3rdparty/lua_code_formatter"]
 	path = 3rdparty/lcf
-	url = https://github.com/Mudlet/lua_code_formatter.git
+	url = https://github.com/martin-eden/lua_code_formatter.git
 [submodule "3rdparty/dblsqd"]
 	path = 3rdparty/dblsqd
 	url = https://bitbucket.org/pentacent/dblsqd-sdk-qt.git

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12475,7 +12475,7 @@ void TLuaInterpreter::initIndenterGlobals()
     int error = luaL_dostring(pIndenterState, R"(
       require('lcf.workshop.base')
       get_ast = request('!.lua.code.get_ast')
-      get_formatted_code = request('!.formats.lua.save')
+      get_formatted_code = request('!.lua.code.ast_as_code')
     )");
     if (error) {
         string e = "no error message available from Lua";


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This updates the lua formatter to the latest version and a branch that supports the 5.1 Syntax.

#### Motivation for adding to Mudlet
The formatter bundled with earlier Mudlet versions did not support 5.1 syntax. This was apparent in some subtle way like having a variable `goto`.

#### Other info (issues closed, discussion etc)
