### PR TITLE
Initialise restart button in the constructor

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -38,13 +38,12 @@
 //   and promptly quits. Installer updates Mudlet and launches Mudlet when its done
 // mac: handled completely outside of Mudlet by Sparkle
 
-Updater::Updater(QObject* parent, QSettings* settings) : QObject(parent), mUpdateInstalled(false)
+Updater::Updater(QObject* parent, QSettings* settings) : QObject(parent), mUpdateInstalled(false), mpInstallOrRestart(new QPushButton(tr("Update")))
 {
     Q_ASSERT_X(settings, "updater", "QSettings object is required for the updater to work");
     this->settings = settings;
 
     feed = new dblsqd::Feed(QStringLiteral("https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw"), QStringLiteral("release"));
-    installOrRestartButton = new QPushButton(tr("Update"));
 }
 
 // start the update process and figure out what needs to be done
@@ -150,8 +149,8 @@ void Updater::setupOnWindows()
 
     // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
     updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::Manual : dblsqd::UpdateDialog::OnLastWindowClosed, nullptr, settings);
-    installOrRestartButton->setText(tr("Update"));
-    updateDialog->addInstallButton(installOrRestartButton);
+    mpInstallOrRestart->setText(tr("Update"));
+    updateDialog->addInstallButton(mpInstallOrRestart);
     connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::installOrRestartClicked);
 }
 
@@ -212,8 +211,8 @@ void Updater::setupOnLinux()
 
     // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
     updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::Manual : dblsqd::UpdateDialog::OnLastWindowClosed, nullptr, settings);
-    installOrRestartButton->setText(tr("Update"));
-    updateDialog->addInstallButton(installOrRestartButton);
+    mpInstallOrRestart->setText(tr("Update"));
+    updateDialog->addInstallButton(mpInstallOrRestart);
     connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::installOrRestartClicked);
 }
 
@@ -303,8 +302,8 @@ void Updater::installOrRestartClicked(QAbstractButton* button, QString filePath)
 #elif defined(Q_OS_WIN32)
         finishSetup();
 #endif
-        installOrRestartButton->setText(tr("Restart to apply update"));
-        installOrRestartButton->setEnabled(true);
+        mpInstallOrRestart->setText(tr("Restart to apply update"));
+        mpInstallOrRestart->setEnabled(true);
     });
     watcher->setFuture(future);
 #endif // !Q_OS_MACOS

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -44,6 +44,7 @@ Updater::Updater(QObject* parent, QSettings* settings) : QObject(parent), mUpdat
     this->settings = settings;
 
     feed = new dblsqd::Feed(QStringLiteral("https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw"), QStringLiteral("release"));
+    installOrRestartButton = new QPushButton(tr("Update"));
 }
 
 // start the update process and figure out what needs to be done
@@ -149,7 +150,7 @@ void Updater::setupOnWindows()
 
     // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
     updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::Manual : dblsqd::UpdateDialog::OnLastWindowClosed, nullptr, settings);
-    installOrRestartButton = new QPushButton(tr("Update"));
+    installOrRestartButton->setText(tr("Update"));
     updateDialog->addInstallButton(installOrRestartButton);
     connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::installOrRestartClicked);
 }
@@ -211,7 +212,7 @@ void Updater::setupOnLinux()
 
     // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
     updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::Manual : dblsqd::UpdateDialog::OnLastWindowClosed, nullptr, settings);
-    installOrRestartButton = new QPushButton(tr("Update"));
+    installOrRestartButton->setText(tr("Update"));
     updateDialog->addInstallButton(installOrRestartButton);
     connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::installOrRestartClicked);
 }

--- a/src/updater.h
+++ b/src/updater.h
@@ -48,7 +48,7 @@ public:
 private:
     dblsqd::Feed* feed;
     dblsqd::UpdateDialog* updateDialog;
-    QPushButton* installOrRestartButton;
+    QPushButton* mpInstallOrRestart;
     bool mUpdateInstalled;
     QSettings* settings;
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Change `installOrRestartButton` to be initialised in the constructor.
#### Motivation for adding to Mudlet
Coverity likes it more that way and the code has less surprising member initialisations in the middle of the class.
#### Other info (issues closed, discussion etc)
Fixes Coverity 1468471.