### PR TITLE
Add setFont() to allow setting a custom font in a window

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -3,8 +3,7 @@
 set -e
 
 # we deploy only qmake and clang combination for macOS
-# unless they're broken so we have a workaround
-if [ "${Q_OR_C_MAKE}" = "cmake" ] && [ "${CC}" = "clang" ]; then
+if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "clang" ]; then
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
   cd "${TRAVIS_BUILD_DIR}/../installers/osx"

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -3,7 +3,8 @@
 set -e
 
 # we deploy only qmake and clang combination for macOS
-if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "clang" ]; then
+# unless they're broken so we have a workaround
+if [ "${Q_OR_C_MAKE}" = "cmake" ] && [ "${CC}" = "clang" ]; then
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
   cd "${TRAVIS_BUILD_DIR}/../installers/osx"

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -66,7 +66,9 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 , mCommandBgColor(Qt::black)
 , mCommandFgColor(QColor(213, 195, 0))
 , mConsoleName("main")
-, mDisplayFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal)) //mDisplayFont( QFont("Monospace", 10, QFont::Courier ) )
+, mDisplayFontName("Bitstream Vera Sans Mono")
+, mDisplayFontSize(10)
+, mDisplayFont(QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal))
 , mFgColor(Qt::black)
 , mIndentCount(0)
 , mIsDebugConsole(isDebugConsole)
@@ -86,9 +88,8 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 , mpRightToolBar(new QWidget(mpBaseHFrame))
 , mpMainDisplay(new QWidget(mpMainFrame))
 , mpMapper(nullptr)
-, mpButtonMainLayer(nullptr)
 , mpScrollBar(new QScrollBar)
-
+, mpButtonMainLayer(nullptr)
 , mRecordReplay(false)
 , mSystemMessageBgColor(mBgColor)
 , mSystemMessageFgColor(QColor(Qt::red))
@@ -1814,12 +1815,27 @@ void TConsole::_luaWrapLine(int line)
 
 bool TConsole::setMiniConsoleFontSize(int size)
 {
-    mUpperPane->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
+    mDisplayFontSize = size;
+
+    refreshMiniConsole();
+    return true;
+}
+
+void TConsole::refreshMiniConsole() const
+{
+    mUpperPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
     mUpperPane->updateScreenView();
     mUpperPane->forceUpdate();
-    mLowerPane->mDisplayFont = QFont("Bitstream Vera Sans Mono", size, QFont::Normal);
+    mLowerPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
     mLowerPane->updateScreenView();
     mLowerPane->forceUpdate();
+}
+
+bool TConsole::setMiniConsoleFont(const QString& font)
+{
+    mDisplayFontName = font;
+
+    refreshMiniConsole();
     return true;
 }
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -281,7 +281,9 @@ public slots:
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
 
+private:
     void refreshMiniConsole() const;
+
 };
 
 #endif // MUDLET_TCONSOLE_H

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -57,7 +57,7 @@ class TConsole : public QWidget
 
 public:
     Q_DISABLE_COPY(TConsole)
-    TConsole(Host*, bool isDebugConsole, QWidget* parent = 0);
+    TConsole(Host*, bool isDebugConsole, QWidget* parent = nullptr);
     void reset();
     void resetMainConsole();
     void echoUserWindow(const QString&);
@@ -140,7 +140,8 @@ public:
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
     QString getCurrentLine(std::string&);
     void selectCurrentLine(std::string&);
-    bool setMiniConsoleFontSize(int);
+    bool setMiniConsoleFontSize(int);    
+    bool setMiniConsoleFont(const QString& font);
     void setBold(bool);
     void setLink(const QString& linkText, QStringList& linkFunction, QStringList& linkHint);
     void setItalics(bool);
@@ -188,6 +189,8 @@ public:
     QString mConsoleName;
     QString mCurrentLine;
     int mDeletedLines;
+    QString mDisplayFontName;
+    int mDisplayFontSize;
     QFont mDisplayFont;
     int mEngineCursor;
     QColor mFgColor;
@@ -277,6 +280,8 @@ public slots:
     // =>"Copy Map" in another profile to inform a list of
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
+
+    void refreshMiniConsole() const;
 };
 
 #endif // MUDLET_TCONSOLE_H

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2441,6 +2441,38 @@ int TLuaInterpreter::setFont(lua_State* L)
     return 1;
 }
 
+int TLuaInterpreter::getFont(lua_State* L)
+{
+    Host* pHost = &getHostFromLua(L);
+
+    QString windowName = QStringLiteral("main");
+    QString font;
+    if (lua_gettop(L) == 1) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "getFont: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        } else {
+            windowName = QString::fromUtf8(lua_tostring(L, 1));
+
+            if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+                font = pHost->mDisplayFont.family();
+            } else {
+                font = mudlet::self()->getWindowFont(pHost, windowName);
+            }
+
+            if (font.isEmpty()) {
+                lua_pushnil(L);
+                lua_pushfstring(L, R"(window "%s" not found)", windowName.toUtf8().constData());
+                return 2;
+            }
+        }
+    } else {
+        font = pHost->mDisplayFont.family();
+    }
+
+    lua_pushstring(L, font.toUtf8().constData());
+    return 1;
+}
 
 int TLuaInterpreter::setFontSize(lua_State* L)
 {
@@ -2499,6 +2531,7 @@ int TLuaInterpreter::setFontSize(lua_State* L)
         } else {
             lua_pushnil(L);
             lua_pushfstring(L, R"(window "%s" not found)", windowName.toUtf8().constData());
+            return 2;
         }
     }
     return 1;
@@ -12052,6 +12085,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "loadWindowLayout", TLuaInterpreter::loadWindowLayout);
     lua_register(pGlobalLua, "saveWindowLayout", TLuaInterpreter::saveWindowLayout);
     lua_register(pGlobalLua, "setFont", TLuaInterpreter::setFont);
+    lua_register(pGlobalLua, "getFont", TLuaInterpreter::getFont);
     lua_register(pGlobalLua, "setFontSize", TLuaInterpreter::setFontSize);
     lua_register(pGlobalLua, "getFontSize", TLuaInterpreter::getFontSize);
     lua_register(pGlobalLua, "openUserWindow", TLuaInterpreter::openUserWindow);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2424,20 +2424,19 @@ int TLuaInterpreter::setFont(lua_State* L)
             mudlet::self()->mConsoleMap[pHost]->mLowerPane->updateScreenView();
             mudlet::self()->mConsoleMap[pHost]->mLowerPane->forceUpdate();
             mudlet::self()->mConsoleMap[pHost]->refresh();
-            lua_pushboolean(L, true);
         } else {
             lua_pushnil(L);
             lua_pushstring(L, "could not find the main window");
             return 2;
         }
     } else {
-        if (mudlet::self()->setWindowFont(pHost, windowName, font)) {
-            lua_pushboolean(L, true);
-        } else {
+        if (!mudlet::self()->setWindowFont(pHost, windowName, font)) {
             lua_pushnil(L);
             lua_pushfstring(L, R"(window "%s" not found)", windowName.toUtf8().constData());
+            return 2;
         }
     }
+    lua_pushboolean(L, true);
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2394,8 +2394,7 @@ int TLuaInterpreter::setFont(lua_State* L)
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
         if (!lua_isstring(L, ++s)) {
             lua_pushfstring(L,
-                            "setFont: bad argument #%d type (more than one argument supplied and first,\n"
-                            "window name, as string expected (omission selects \"main\" window), got %s!",
+                            "setFont: bad argument #%d type for the optional window name - expected string, got %s!",
                             s,
                             luaL_typename(L, s));
             return lua_error(L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -245,6 +245,7 @@ public:
     static int loadWindowLayout(lua_State* L);
     static int saveWindowLayout(lua_State* L);
     static int saveProfile(lua_State* L);
+    static int setFont(lua_State* L);
     static int setFontSize(lua_State* L);
     static int getFontSize(lua_State* L);
     static int openUserWindow(lua_State* L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -246,6 +246,7 @@ public:
     static int saveWindowLayout(lua_State* L);
     static int saveProfile(lua_State* L);
     static int setFont(lua_State* L);
+    static int getFont(lua_State* L);
     static int setFontSize(lua_State* L);
     static int getFontSize(lua_State* L);
     static int openUserWindow(lua_State* L);

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -26,10 +26,16 @@ function Geyser.MiniConsole:setBufferSize (linesLimit, sizeOfBatchDeletion)
   setConsoleBufferSize(self.name, linesLimit, sizeOfBatchDeletion)
 end
 
---- Sets the new font to use.
--- @param font Font family name to use.
+--- Sets the new font to use - use a monospaced font, non-monospaced fonts aren't supported by Mudlet
+-- and won't give the best results.
+-- @param font Font family name to use (see https://doc.qt.io/qt-5/qfont.html#setFamily for details)
 function Geyser.MiniConsole:setFont (font)
   setConsoleBufferSize(self.name, font)
+end
+
+--- Returns the font family in use by this miniconsole.
+function Geyser.MiniConsole:getFont()
+  return getFont(self.name)
 end
 
 --- Sets the point at which text is wrapped in this miniconsole
@@ -177,6 +183,9 @@ function Geyser.MiniConsole:new (cons, container)
   end
   if cons.scrollBar then
     me:enableScrollBar()
+  end
+  if cons.font then
+    me:setFont(cons.font)
   end
   --print("  New in " .. self.name .. " : " .. me.name)
   return me

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -30,7 +30,7 @@ end
 -- and won't give the best results.
 -- @param font Font family name to use (see https://doc.qt.io/qt-5/qfont.html#setFamily for details)
 function Geyser.MiniConsole:setFont (font)
-  setConsoleBufferSize(self.name, font)
+  setFont(self.name, font)
 end
 
 --- Returns the font family in use by this miniconsole.

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -26,6 +26,12 @@ function Geyser.MiniConsole:setBufferSize (linesLimit, sizeOfBatchDeletion)
   setConsoleBufferSize(self.name, linesLimit, sizeOfBatchDeletion)
 end
 
+--- Sets the new font to use.
+-- @param font Font family name to use.
+function Geyser.MiniConsole:setFont (font)
+  setConsoleBufferSize(self.name, font)
+end
+
 --- Sets the point at which text is wrapped in this miniconsole
 -- @param wrapAt The number of characters to start wrapping.
 function Geyser.MiniConsole:setWrap (wrapAt)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1373,6 +1373,21 @@ bool mudlet::setWindowFont(Host* pHost, const QString& window, const QString& fo
     }
 }
 
+QString mudlet::getWindowFont(Host* pHost, const QString& name)
+{
+    if (!pHost) {
+        return QString();
+    }
+
+    QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
+
+    if (dockWindowConsoleMap.contains(name)) {
+        return dockWindowConsoleMap.value(name)->mUpperPane->mDisplayFont.family();
+    } else {
+        return QString();
+    }
+}
+
 bool mudlet::setWindowFontSize(Host *pHost, const QString &name, int size)
 {
     if (!pHost) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1355,7 +1355,25 @@ void mudlet::commitLayoutUpdates()
     }
 }
 
-bool mudlet::setFontSize(Host* pHost, const QString& name, int size)
+bool mudlet::setWindowFont(Host* pHost, const QString& window, const QString& font)
+{
+    if (!pHost) {
+        return false;
+    }
+
+    QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
+
+    if (dockWindowConsoleMap.contains(window)) {
+        TConsole* pC = dockWindowConsoleMap.value(window);
+        pC->setMiniConsoleFont(font);
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool mudlet::setWindowFontSize(Host *pHost, const QString &name, int size)
 {
     if (!pHost) {
         return false;
@@ -1416,7 +1434,7 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         dockWindowConsoleMap[name] = pC;
         addDockWidget(Qt::RightDockWidgetArea, pD);
 
-        setFontSize(pHost, name, 10);
+        setWindowFontSize(pHost, name, 10);
 
         if (loadLayout && !dockWindowMap[name]->hasLayoutAlready) {
             loadWindowLayout();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -104,7 +104,8 @@ public:
     void setDockLayoutUpdated(Host*, const QString&);
     void setToolbarLayoutUpdated(Host*, TToolBar*);
     void commitLayoutUpdates();
-    bool setFontSize(Host*, const QString&, int);
+    bool setWindowFont(Host*, const QString&, const QString&);
+    bool setWindowFontSize(Host *, const QString &, int);
     int getFontSize(Host*, const QString&);
     bool openWindow(Host*, const QString&, bool loadLayout = true);
     bool createMiniConsole(Host*, const QString&, int, int, int, int);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -105,6 +105,7 @@ public:
     void setToolbarLayoutUpdated(Host*, TToolBar*);
     void commitLayoutUpdates();
     bool setWindowFont(Host*, const QString&, const QString&);
+    QString getWindowFont(Host*, const QString&);
     bool setWindowFontSize(Host *, const QString &, int);
     int getFontSize(Host*, const QString&);
     bool openWindow(Host*, const QString&, bool loadLayout = true);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add setFont() to allow setting a custom font in a window.
#### Motivation for adding to Mudlet
So UI designers can have fancy fonts in miniconsole windows.
#### Other info (issues closed, discussion etc)
