### PR TITLE
Fix getFont() to report the actual font used

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1930,9 +1930,11 @@ bool TConsole::setMiniConsoleFontSize(int size)
 void TConsole::refreshMiniConsole() const
 {
     mUpperPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
+    mUpperPane->setFont(mUpperPane->mDisplayFont);
     mUpperPane->updateScreenView();
     mUpperPane->forceUpdate();
     mLowerPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
+    mLowerPane->setFont(mLowerPane->mDisplayFont);
     mLowerPane->updateScreenView();
     mLowerPane->forceUpdate();
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2421,8 +2421,10 @@ int TLuaInterpreter::setFont(lua_State* L)
             displayFont.setFamily(font);
             pHost->mDisplayFont = displayFont;
             // apply changes to main console and its while-scrolling component too.
+            mudlet::self()->mConsoleMap[pHost]->mUpperPane->setFont(displayFont);
             mudlet::self()->mConsoleMap[pHost]->mUpperPane->updateScreenView();
             mudlet::self()->mConsoleMap[pHost]->mUpperPane->forceUpdate();
+            mudlet::self()->mConsoleMap[pHost]->mLowerPane->setFont(displayFont);
             mudlet::self()->mConsoleMap[pHost]->mLowerPane->updateScreenView();
             mudlet::self()->mConsoleMap[pHost]->mLowerPane->forceUpdate();
             mudlet::self()->mConsoleMap[pHost]->refresh();
@@ -2456,7 +2458,7 @@ int TLuaInterpreter::getFont(lua_State* L)
             windowName = QString::fromUtf8(lua_tostring(L, 1));
 
             if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-                font = pHost->mDisplayFont.family();
+                font = mudlet::self()->mConsoleMap[pHost]->mUpperPane->fontInfo().family();
             } else {
                 font = mudlet::self()->getWindowFont(pHost, windowName);
             }
@@ -2468,7 +2470,7 @@ int TLuaInterpreter::getFont(lua_State* L)
             }
         }
     } else {
-        font = pHost->mDisplayFont.family();
+        font = mudlet::self()->mConsoleMap[pHost]->mUpperPane->fontInfo().family();
     }
 
     lua_pushstring(L, font.toUtf8().constData());

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1382,7 +1382,7 @@ QString mudlet::getWindowFont(Host* pHost, const QString& name)
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
 
     if (dockWindowConsoleMap.contains(name)) {
-        return dockWindowConsoleMap.value(name)->mUpperPane->mDisplayFont.family();
+        return dockWindowConsoleMap.value(name)->mUpperPane->fontInfo().family();
     } else {
         return QString();
     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Actually set the font on the widget - we weren't before - and then use that set font in finding out which font was picked by the Qt engine.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/1647, make it possible to debug which font was actually used by the system in the end.
#### Other info (issues closed, discussion etc)
