### PR TITLE
Activate ccache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export PATH="${HOME}/latest-gcc-symlinks:$PATH"; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then source "/opt/qt${QT_VERSION}/bin/qt${QT_VERSION}-env.sh"; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then $(luarocks path); fi
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then PATH="/usr/local/opt/qt5/bin:$PATH"; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/qt5/bin:$PATH"; fi
   - ./CI/travis.before_install.sh
 install: ./CI/travis.install.sh
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
-cache: ccache
+cache:
+  - ccache
 os:
   - osx
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+cache: ccache
 os:
   - osx
   - linux
@@ -66,7 +67,7 @@ matrix:
   include:
   - os: linux
     compiler: gcc
-    env: 
+    env:
     - Q_OR_C_MAKE=cmake
     - QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
 before_install:

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-BREWS="boost cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl"
+BREWS="boost cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache"
 for i in $BREWS; do
   brew outdated | grep -q $i && brew upgrade $i
 done


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This activates `ccache` use on travis. The tool speeds up compilation by caching compilation units and only regenerating those that change.
The general use was already enabled, but it wasn't installed on macOS and the cached files were not saved between builds, Both things are changed with this PR.

#### Motivation for adding to Mudlet
Faster compilation time means less waiting for jobs to complete.
