### PR TITLE
Explicitly state build configs to decrease number of installed packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,7 @@ addons:
     - sourceline: 'ppa:beineri/opt-qt593-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
     - sourceline: 'ppa:jonathonf/php7'
-    packages:
-    - qt56base
-    - qt56multimedia
-    - qt56tools
-    - qt59base
-    - qt59multimedia
-    - qt59tools
-    - qt59gamepad
+    packages: &common-packages
     - libhunspell-dev
     - lua5.1
     - liblua5.1-0-dev
@@ -39,11 +32,7 @@ compiler:
   - gcc
   - clang
 env:
-  matrix:
-  - Q_OR_C_MAKE=cmake
-    QT_VERSION=59 # actually Qt 5.9
-  - Q_OR_C_MAKE=qmake
-    QT_VERSION=59 # actually Qt 5.9
+#  matrix:
 #  - Q_OR_C_MAKE=cmake
 #    QT_VERSION=59
 #    WITH_FONTS=NO # actually Qt 5.9, non-default without fonts
@@ -62,15 +51,68 @@ env:
 git:
   submodules: false # We selectively pull in the wanted submodules ourselves now
 matrix:
-  exclude:
-  - os: osx
-    compiler: gcc
   include:
+  - os: osx
+    compiler: clang
+    env:
+    - Q_OR_C_MAKE=qmake
+  - os: osx
+    compiler: clang
+    env:
+    - Q_OR_C_MAKE=cmake
+
+  - os: linux
+    compiler: gcc
+    env:
+    - Q_OR_C_MAKE=qmake
+    - QT_VERSION=59
+    addons:
+      apt:
+        packages: &qt59-packages
+        - *common-packages
+        - qt59base
+        - qt59multimedia
+        - qt59tools
+        - qt59gamepad
+  - os: linux
+    compiler: gcc
+    env:
+    - Q_OR_C_MAKE=cmake
+    - QT_VERSION=59
+    addons:
+      apt:
+        packages:
+        - *qt59-packages
+  - os: linux
+    compiler: clang
+    env:
+    - Q_OR_C_MAKE=qmake
+    - QT_VERSION=59
+    addons:
+      apt:
+        packages:
+        - *qt59-packages
+  - os: linux
+    compiler: clang
+    env:
+    - Q_OR_C_MAKE=cmake
+    - QT_VERSION=59
+    addons:
+      apt:
+        packages:
+        - *qt59-packages
   - os: linux
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
     - QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
+    addons:
+      apt:
+        packages: &qt56-packages
+        - *common-packages
+        - qt56base
+        - qt56multimedia
+        - qt56tools
 before_install:
   # add to the path here to pick up things as soon as its installed
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export PATH="${HOME}/latest-gcc-symlinks:$PATH"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ addons:
     - lua-filesystem
     - lua-zip
     - lua-sql-sqlite3
-compiler:
-  - gcc
-  - clang
 env:
 #  matrix:
 #  - Q_OR_C_MAKE=cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: cpp
 cache:
   - ccache
-os:
-  - osx
-  - linux
 dist: trusty
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: trusty
 sudo: false
 addons:
   apt:
-    sources:
+    sources: &add-sources
     - sourceline: 'ppa:beineri/opt-qt562-trusty'
     - sourceline: 'ppa:beineri/opt-qt593-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
@@ -68,6 +68,7 @@ matrix:
     - QT_VERSION=59
     addons:
       apt:
+        sources: *add-sources
         packages: &qt59-packages
         - *common-packages
         - qt59base
@@ -81,6 +82,7 @@ matrix:
     - QT_VERSION=59
     addons:
       apt:
+        sources: *add-sources
         packages:
         - *qt59-packages
   - os: linux
@@ -90,6 +92,7 @@ matrix:
     - QT_VERSION=59
     addons:
       apt:
+        sources: *add-sources
         packages:
         - *qt59-packages
   - os: linux
@@ -99,6 +102,7 @@ matrix:
     - QT_VERSION=59
     addons:
       apt:
+        sources: *add-sources
         packages:
         - *qt59-packages
   - os: linux
@@ -108,6 +112,7 @@ matrix:
     - QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
     addons:
       apt:
+        sources: *add-sources
         packages: &qt56-packages
         - *common-packages
         - qt56base


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This defines the build matrix for travis builds explicitly. That way we can specify, which packages to install per matrix entry and thus we don't need to install both Qt 5.6 and Qt 5.9 all the time.

#### Motivation for adding to Mudlet
Decrease build times a bit more.

#### Other info (issues closed, discussion etc)
See https://github.com/travis-ci/travis-ci/issues/3505 about the technique used.