### PR TITLE
Enhance: add option to allow all Key-bindings that match key-press to run

### DIFF
--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,7 +29,19 @@
 
 using namespace std;
 
-KeyUnit::KeyUnit(Host* pHost) : mpHost(pHost), mMaxID(0), mModuleMember()
+KeyUnit::KeyUnit(Host* pHost)
+: statsKeyTotal(0)
+, statsTempKeys(0)
+, statsActiveKeys(0)
+, statsActiveKeysMax(0)
+, statsActiveKeysMin(0)
+, statsActiveKeysAverage(0)
+, statsTempKeysCreated(0)
+, statsTempKeysKilled(0)
+, mIsToProcessAllMatches(false)
+, mpHost(pHost)
+, mMaxID(0)
+, mModuleMember(false)
 {
     setupKeyNames();
 }
@@ -60,13 +73,18 @@ void KeyUnit::uninstall(const QString& packageName)
 
 bool KeyUnit::processDataStream(int key, int modifier)
 {
+    bool isMatchFound = false;
     for (auto keyObject : mKeyRootNodeList) {
-        if (keyObject->match(key, modifier)) {
-            return true;
+        if (keyObject->match(key, modifier, mIsToProcessAllMatches)) {
+            if (!mIsToProcessAllMatches) {
+                return true;
+            } else {
+                isMatchFound = true;
+            }
         }
     }
 
-    return false;
+    return isMatchFound;
 }
 
 void KeyUnit::compileAll()

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -80,6 +81,10 @@ public:
     int statsTempKeysCreated;
     int statsTempKeysKilled;
     QList<TKey*> uninstallList;
+    // Past behaviour is to only process the first key binding that matches,
+    // ignoring any duplicates - but changing that behaviour unconditionally
+    // could break things - so only do it if this flag is set:
+    bool mIsToProcessAllMatches;
 
 private:
     KeyUnit() {}

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -71,24 +72,33 @@ void TKey::setName(const QString& name)
     mpHost->getKeyUnit()->mLookupTable.insertMulti(name, this);
 }
 
-// This method is potentially flawed in that only the first child match is ever executed...!
-bool TKey::match(int key, int modifier)
+bool TKey::match(int key, int modifier, const bool isToMatchAll)
 {
+    bool isAMatch = false;
     if (isActive()) {
         if (!isFolder()) {
             if ((mKeyCode == key) && (mKeyModifier == modifier)) {
                 execute();
-                return true;
+                if (isToMatchAll) {
+                    isAMatch = true;
+                } else {
+                    return true;
+                }
             }
         }
 
         for (auto childKey : *mpMyChildrenList) {
-            if (childKey->match(key, modifier)) {
-                return true;
+            if (childKey->match(key, modifier, isToMatchAll)) {
+                if (isToMatchAll) {
+                    isAMatch = true;
+                } else {
+                    return true;
+                }
             }
         }
     }
-    return false;
+
+    return isAMatch;
 }
 
 

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -58,16 +59,14 @@ public:
     void setCommand(QString command) { mCommand = command; }
     QString getCommand() { return mCommand; }
 
-    bool match(int, int);
+    bool match(int, int, const bool);
     bool registerKey();
 
-    //bool             serialize( QDataStream & );
-    //bool             restore( QDataStream & fs, bool );
     bool exportItem;
     bool mModuleMasterFolder;
 
 private:
-    TKey(){};
+    TKey(){}
     QString mName;
     QString mCommand;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -324,6 +324,7 @@ bool XMLexport::writeHost(Host* pHost)
     writeAttribute("USE_IRE_DRIVER_BUGFIX", pHost->mUSE_IRE_DRIVER_BUGFIX ? "yes" : "no");
     writeAttribute("mUSE_FORCE_LF_AFTER_PROMPT", pHost->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no");
     writeAttribute("mUSE_UNIX_EOL", pHost->mUSE_UNIX_EOL ? "yes" : "no");
+    writeAttribute("runAllKeyMatches", pHost->getKeyUnit()->mIsToProcessAllMatches ? "yes" : "no");
     writeAttribute("mNoAntiAlias", pHost->mNoAntiAlias ? "yes" : "no");
     writeAttribute("mEchoLuaErrors", pHost->mEchoLuaErrors ? "yes" : "no");
     // FIXME: Change to a string or integer property when possible to support more

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -777,6 +777,7 @@ void XMLimport::readHostPackage(Host* pHost)
     pHost->set_USE_IRE_DRIVER_BUGFIX(attributes().value("USE_IRE_DRIVER_BUGFIX") == "yes");
     pHost->mUSE_FORCE_LF_AFTER_PROMPT = (attributes().value("mUSE_FORCE_LF_AFTER_PROMPT") == "yes");
     pHost->mUSE_UNIX_EOL = (attributes().value("mUSE_UNIX_EOL") == "yes");
+    pHost->getKeyUnit()->mIsToProcessAllMatches = (attributes().value("runAllKeyMatches") == "yes");
     pHost->mNoAntiAlias = (attributes().value("mNoAntiAlias") == "yes");
     pHost->mEchoLuaErrors = (attributes().value("mEchoLuaErrors") == "yes");
     pHost->mIsNextLogFileInHtmlFormat = (attributes().value("mRawStreamDump") == "yes");

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -162,7 +162,12 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
                                                                      "does not have a needed glyph (a font's individual character/symbol) to represent "
                                                                      "the grapheme (what is to be represented).  Clearing this checkbox will allow "
                                                                      "the best alternative glyph from another font to be used to draw that grapheme.</p>")));
-
+    checkBox_runAllKeyBindings->setToolTip(QStringLiteral("<html><head/><body>%1</body></html>")
+                                           .arg(tr("<p>Check all Key-bindings against key-presses.</p><p><i>Versions of Mudlet prior to <b>3.9.0</b> would "
+                                                   "stop checking after the first matching combination of</i> KeyCode <i>and</i> KeyModifier <i>was found "
+                                                   "and then send the command and/or run the script of that Key-binding only.  This</i> per-profile <i>"
+                                                   "option tells Mudlet to check and run the remaining matches; but, to retain compatibility with "
+                                                   "previous versions, defaults to the <b>un</b>-checked state.</i></p>")));
 
     connect(checkBox_showSpacesAndTabs, SIGNAL(clicked(bool)), this, SLOT(slot_changeShowSpacesAndTabs(const bool)));
     connect(checkBox_showLineFeedsAndParagraphs, SIGNAL(clicked(bool)), this, SLOT(slot_changeShowLineFeedsAndParagraphs(const bool)));
@@ -421,6 +426,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     //checkBox_LF_ON_GA->setChecked( pHost->mLF_ON_GA );
     checkBox_mUSE_FORCE_LF_AFTER_PROMPT->setChecked(pHost->mUSE_FORCE_LF_AFTER_PROMPT);
     USE_UNIX_EOL->setChecked(pHost->mUSE_UNIX_EOL);
+    checkBox_runAllKeyBindings->setChecked(pHost->getKeyUnit()->mIsToProcessAllMatches);
     topBorderHeight->setValue(pHost->mBorderTopHeight);
     bottomBorderHeight->setValue(pHost->mBorderBottomHeight);
     leftBorderWidth->setValue(pHost->mBorderLeftWidth);
@@ -1857,6 +1863,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->set_USE_IRE_DRIVER_BUGFIX(checkBox_USE_IRE_DRIVER_BUGFIX->isChecked());
         pHost->mUSE_FORCE_LF_AFTER_PROMPT = checkBox_mUSE_FORCE_LF_AFTER_PROMPT->isChecked();
         pHost->mUSE_UNIX_EOL = USE_UNIX_EOL->isChecked();
+        pHost->getKeyUnit()->mIsToProcessAllMatches = checkBox_runAllKeyBindings->isChecked();
         pHost->mFORCE_NO_COMPRESSION = mFORCE_MCCP_OFF->isChecked();
         pHost->mFORCE_GA_OFF = mFORCE_GA_OFF->isChecked();
         pHost->mFORCE_SAVE_ON_EXIT = mFORCE_SAVE_ON_EXIT->isChecked();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -398,15 +398,9 @@
          <property name="title">
           <string>Input</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_5">
+         <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,1,1,1">
           <item row="0" column="0" colspan="2">
            <widget class="QCheckBox" name="USE_UNIX_EOL">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="toolTip">
              <string>use strict UNIX line endings on commands for old UNIX servers that can't handle windows line endings correctly</string>
             </property>
@@ -415,11 +409,15 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="2" colspan="2">
+           <widget class="QCheckBox" name="auto_clear_input_line_checkbox">
+            <property name="text">
+             <string>Auto clear the input line after you sent text</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0" colspan="2">
            <widget class="QCheckBox" name="show_sent_text_checkbox">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
             <property name="toolTip">
              <string>Echo the text you send in the display box</string>
             </property>
@@ -428,18 +426,18 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="3">
-           <widget class="QCheckBox" name="auto_clear_input_line_checkbox">
-            <property name="enabled">
-             <bool>true</bool>
+          <item row="1" column="2" colspan="2">
+           <widget class="QCheckBox" name="checkBox_runAllKeyBindings">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check all Key-bindings against key-presses.&lt;/p&gt;&lt;p&gt;&lt;i&gt;Versions of Mudlet prior to &lt;b&gt;3.9.0&lt;/b&gt; would stop checking after the first matching combination of&lt;/i&gt; KeyCode &lt;i&gt;and&lt;/i&gt; KeyModifier &lt;i&gt;was found and then send the command and/or run the script of that Key-binding only.  This&lt;/i&gt; per-profile &lt;i&gt;option tells Mudlet to check and run the remaining matches; but, to retain compatibility with previous versions, defaults to the &lt;b&gt;un&lt;/b&gt;-checked state.&lt;/i&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="text">
-             <string>Auto clear the input line after you sent text</string>
+             <string>Check all Key-bindings</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_18">
+          <item row="2" column="0" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_commandSeparator">
             <property name="toolTip">
              <string/>
             </property>
@@ -451,21 +449,15 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
+          <item row="2" column="1" colspan="3">
            <widget class="QLineEdit" name="command_separator_lineedit">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
             <property name="placeholderText">
              <string>Enter text to separate commands with or leave blank to disable</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_38">
-            <property name="toolTip">
-             <string/>
-            </property>
+          <item row="3" column="0" colspan="3" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_commandLineMinimumHeight">
             <property name="text">
              <string>Command line minimum height in pixels:</string>
             </property>
@@ -474,8 +466,11 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="2">
+          <item row="3" column="3">
            <widget class="QSpinBox" name="commandLineMinimumHeight">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <property name="maximum">
              <number>300</number>
             </property>


### PR DESCRIPTION
I had previously spotted that the process that checks for a key-binding match on each key-press stops after the first match is found and run. This is, IMHO, counter-intuitive given Mudlet's behaviour with other "duplicated" items which it permits to exist - i.e. two triggers set to match on the same text or two timers with the same interval; it is even more suspect when one considers that it is possible to create a temporary key-binding, which although active, may never get run if there happens to be a permanent one with the same key and modifiers combination.  Actually it is also possible that the reverse is true in that a temporary key binding - which is not visible in the GUI editor - can prevent a permanent one that is shown there from activating - with no visible indication that this is occurring!

Anyhow, this commit adds a per-profile option on the "Input Line" tab of the profile preferences dialogue to check every key-binding for a match instead of stopping on the first match.  To maintain backwards
compatibility with scripts/packages/modules that depend on the previous behaviour this option is not enabled by default.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Other info (issues closed, discussion etc)

This addresses an issue I remark upon in #1643.