### PR TITLE
Revise: update Key code to be more like other items

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -253,7 +253,6 @@ bool AliasUnit::processDataStream(const QString& data)
 void AliasUnit::stopAllTriggers()
 {
     for (auto alias : mAliasRootNodeList) {
-        QString name = alias->getName();
         alias->disableFamily();
     }
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -355,10 +355,12 @@ void Host::resetProfile()
     mudlet::self()->mTimerMap.clear();
     getTimerUnit()->removeAllTempTimers();
     getTriggerUnit()->removeAllTempTriggers();
+    getKeyUnit()->removeAllTempKeys();
 
 
     mTimerUnit.doCleanup();
     mTriggerUnit.doCleanup();
+    mKeyUnit.doCleanup();
     mpConsole->resetMainConsole();
     mEventHandlerMap.clear();
     mEventMap.clear();
@@ -373,7 +375,7 @@ void Host::resetProfile()
     getActionUnit()->compileAll();
     getKeyUnit()->compileAll();
     getScriptUnit()->compileAll();
-    //getTimerUnit()->compileAll();
+    // All the Timers are NOT compiled here;
     mResetProfile = false;
 
     mTimerUnit.reenableAllTriggers();
@@ -470,6 +472,7 @@ void Host::stopAllTriggers()
     mTriggerUnit.stopAllTriggers();
     mAliasUnit.stopAllTriggers();
     mTimerUnit.stopAllTriggers();
+    mKeyUnit.stopAllTriggers();
 }
 
 void Host::reenableAllTriggers()
@@ -477,6 +480,7 @@ void Host::reenableAllTriggers()
     mTriggerUnit.reenableAllTriggers();
     mAliasUnit.reenableAllTriggers();
     mTimerUnit.reenableAllTriggers();
+    mKeyUnit.reenableAllTriggers();
 }
 
 QPair<QString, QString> Host::getSearchEngine()

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -50,6 +50,7 @@ public:
     }
 
     TKey* getKey(int id);
+    void removeAllTempKeys();
     void compileAll();
     TKey* findKey(QString & name);
     bool enableKey(const QString& name);
@@ -67,6 +68,8 @@ public:
     bool processDataStream(int, int);
     void markCleanup( TKey * pT );
     void doCleanup();
+    void stopAllTriggers();
+    void reenableAllTriggers();
 
     QMultiMap<QString, TKey*> mLookupTable;
     std::list<TKey*> mCleanupList;

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -279,7 +279,6 @@ void TriggerUnit::compileAll()
 void TriggerUnit::stopAllTriggers()
 {
     for (auto trigger : mTriggerRootNodeList) {
-        QString name = trigger->getName();
         trigger->disableFamily();
     }
 }


### PR DESCRIPTION
This commit makes the `enableKey(<name>)` and `disable(<name>)` lua functions return `true` only if a key with the given name was found (instead of when any Key was present in the profile) - which is more like the handling for other items such as Triggers and Aliases.

It also arranges for all temporary keys to be "blown-away" when the profile is reset - which was not happening even though it does happen for other item types.

Furthermore when the "Emergency Stop" is activated it now also disables all the keys like it disables all timers/aliases/triggers.  I think this is desirable because if the user sets a binding on a normal key with no modifiers that it is impossible to type the character on that key into the profile's command line - so being able to disable the interception of the key by a temporary key (that will not show up in the editor) is just one reason to add keys to what the control does...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>