### PR TITLE
Fix crash when clicking on the X= icon in variables view

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -143,7 +143,7 @@ void TTreeWidget::getAllChildren(QTreeWidgetItem* pItem, QList<QTreeWidgetItem*>
 void TTreeWidget::mouseReleaseEvent(QMouseEvent* event)
 {
     QModelIndex indexClicked = indexAt(event->pos());
-    if (mIsVarTree && indexClicked.isValid() && mClickedItem == indexClicked) {
+    if (mIsVarTree && indexClicked.isValid() && indexClicked.row() != 0 && mClickedItem == indexClicked) {
         QRect vrect = visualRect(indexClicked);
         int itemIndentation = vrect.x() - visualRect(rootIndex()).x();
         QRect rect = QRect(header()->sectionViewportPosition(0) + itemIndentation, vrect.y(), style()->pixelMetric(QStyle::PM_IndicatorWidth), vrect.height());

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -51,8 +51,9 @@ void VarUnit::addPointer(const void* p)
 
 bool VarUnit::shouldSave(QTreeWidgetItem* p)
 {
-    TVar* var = getWVar(p);
-    if (var->getValueType() == 6 || var->isReference()) {
+    auto var = getWVar(p);
+
+    if (!var || var->getValueType() == 6 || var->isReference()) {
         return false;
     }
     return true;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Code was trying to read the Lua variable that corresponds to the list header - there is none.
#### Motivation for adding to Mudlet
Fix #1659
#### Other info (issues closed, discussion etc)
