### PR TITLE
Fix aliases to work again

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -311,6 +311,7 @@ bool TAlias::compileScript()
 {
     QString code = QStringLiteral("function Alias%1() %2\nend").arg(QString::number(mID), mScript);
     QString aliasName = QStringLiteral("Alias: %1").arg(getName());
+    mFuncName = QStringLiteral("Alias%1").arg(QString::number(mID));
     QString error;
 
     if (mpHost->mLuaInterpreter.compile(code, error, aliasName)) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix aliases to work again - re-add code that marks which Lua function an alias should call.
#### Motivation for adding to Mudlet
Mudlet is a crappy client if no aliases work, and we don't want a crappy client.
#### Other info (issues closed, discussion etc)
The lesson I've learned is to do these kinds of refactoring one smaller bit at a time.