### PR TITLE
Fix crash closing 1 tab with autosave on

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -203,7 +203,7 @@ void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileNam
 
     auto future = QtConcurrent::run(this, &XMLexport::saveXml, fileName);
     auto watcher = new QFutureWatcher<bool>;
-    QObject::connect(watcher, &QFutureWatcher<bool>::finished, [=]() { mpHost->xmlSaved(fileName); });
+    QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(fileName); });
     watcher->setFuture(future);
     saveFutures.append(future);
 }
@@ -215,7 +215,7 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
     auto future = QtConcurrent::run(this, &XMLexport::saveXml, filename_pugi_xml);
 
     auto watcher = new QFutureWatcher<bool>;
-    QObject::connect(watcher, &QFutureWatcher<bool>::finished, [=]() { mpHost->xmlSaved(QStringLiteral("profile")); });
+    QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(QStringLiteral("profile")); });
     watcher->setFuture(future);
     saveFutures.append(future);
 }
@@ -630,7 +630,7 @@ bool XMLexport::exportGenericPackage(const QString& exportFileName)
     if (writeGenericPackage(mpHost, mudletPackage)) {
         auto future = QtConcurrent::run(this, &XMLexport::saveXml, exportFileName);
         auto watcher = new QFutureWatcher<bool>;
-        QObject::connect(watcher, &QFutureWatcher<bool>::finished, [=]() { mpHost->xmlSaved(QStringLiteral("profile")); });
+        QObject::connect(watcher, &QFutureWatcher<bool>::finished, mpHost, [=]() { mpHost->xmlSaved(QStringLiteral("profile")); });
         watcher->setFuture(future);
         saveFutures.append(future);
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
While closing Mudlet when autosave on was fine, closing just 1 profile was not, since the writer would try to call a method of the host already gone.
#### Motivation for adding to Mudlet
Fix #1687.
#### Other info (issues closed, discussion etc)
Qt docs on providing the context:

> The connection will automatically disconnect if the sender or the context is destroyed. However, you should take care that any objects used within the functor are still alive when the signal is emitted.