### PR TITLE
BugFix: Core fix for macOs versions not updating "Save" on Room-Exit dialog

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -2329,6 +2329,16 @@ void dlgRoomExits::slot_checkModified()
             }
         }
     }
-    setWindowModified(isModified);
-    button_save->setEnabled(isModified);
+
+    if (isWindowModified() != isModified) {
+        // There has been a change in the "are there changes?" state
+        setWindowModified(isModified);
+        button_save->setEnabled(isModified);
+#if defined(Q_OS_MACOS) && (QT_VERSION > 0x050903)
+        // Fix: https://bugreports.qt.io/browse/QTBUG-68067 which seems to
+        // effect macOs for Qt versions somewhere after Qt 5.9.3 and which we
+        // do not have a fix version - yet!
+        button_save->repaint();
+#endif
+    }
 }


### PR DESCRIPTION
This is the central feature of the abandoned Pull-Request #1672 and will close #1665 .

However that are other things in the `dlgRoomExit` class that I think are not up to scratch (Coverity is moaning about a couple of "medium" risk items) and there could be some issues with some uses of:
`QMap<T1, TExit*>::value((T1)key)` that will cause null pointer issues in some cases (which may be what Coverity is unhappy about!)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>