### PR TITLE
Client.GUI server push version numbers are backwards

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1176,7 +1176,7 @@ void cTelnet::setGMCPVariables(const QString& msg)
         int newVersion = version.toInt();
         if (mpHost->mServerGUI_Package_version != newVersion) {
             QString _smsg = tr("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>")
-                                    .arg(QString::number(mpHost->mServerGUI_Package_version), QString::number(newVersion));
+                                    .arg(QString::number(newVersion), QString::number(mpHost->mServerGUI_Package_version));
             mpHost->mpConsole->print(_smsg.toLatin1().data());
             mpHost->uninstallPackage(mpHost->mServerGUI_Package_name, 0);
             mpHost->mServerGUI_Package_version = newVersion;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -956,7 +956,7 @@ void cTelnet::processTelnetCommand(const string& command)
                 int newVersion = version.toInt();
                 if (mpHost->mServerGUI_Package_version != newVersion) {
                     QString _smsg = tr("<The server wants to upgrade the GUI to new version '%1'. Uninstalling old version '%2'>")
-                                            .arg(QString::number(mpHost->mServerGUI_Package_version), QString::number(newVersion));
+                                            .arg(QString::number(newVersion), QString::number(mpHost->mServerGUI_Package_version));
                     mpHost->mpConsole->print(_smsg.toLatin1().data());
                     mpHost->uninstallPackage(mpHost->mServerGUI_Package_name, 0);
                     mpHost->mServerGUI_Package_version = newVersion;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

When sending a `Client.GUI` GMCP push Mudlet displays the following text while upgrading from version 6 -> 7:

```<The server wants to upgrade the GUI to new version '6'. Uninstalling old version '7'>```

#### Motivation for adding to Mudlet

This swaps the numbers to display them in the order the text expects.

#### Other info (issues closed, discussion etc)
