### PR TITLE
Improved setBackgroundColor to work with main window

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3034,7 +3034,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     int r, g, b, alpha;
 
     auto validRange = [](int number) {
-        return (number >= 0 and number <= 255) ? true : false;
+        return number >= 0 and number <= 255;
     };
 
     int s = 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3033,6 +3033,10 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     QString windowName;
     int r, g, b, alpha;
 
+    auto validRange = [](int number) {
+        return (number >= 0 and number <= 255) ? true : false;
+    };
+
     int s = 1;
     if (lua_isstring(L, s) && !lua_isnumber(L, s)) {
         windowName = QString::fromUtf8(lua_tostring(L, s));
@@ -3042,9 +3046,19 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
             return lua_error(L);
         } else {
             r = static_cast<int>(lua_tonumber(L, s));
+
+            if (!validRange(r)) {
+                lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (red value needs to be between 0-255, got %d!)", s, r);
+                return lua_error(L);
+            }
         }
     } else if (lua_isnumber(L, s)) {
         r = static_cast<int>(lua_tonumber(L, s));
+
+        if (!validRange(r)) {
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (red value needs to be between 0-255, got %d!)", s, r);
+            return lua_error(L);
+        }
     } else {
         lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (window name as string, or red value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
@@ -3055,6 +3069,11 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         return lua_error(L);
     } else {
         g = static_cast<int>(lua_tonumber(L, s));
+
+        if (!validRange(g)) {
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (green value needs to be between 0-255, got %d!)", s, g);
+            return lua_error(L);
+        }
     }
 
     if (!lua_isnumber(L, ++s)) {
@@ -3062,9 +3081,14 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         return lua_error(L);
     } else {
         b = static_cast<int>(lua_tonumber(L, s));
+
+        if (!validRange(b)) {
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (blue value needs to be between 0-255, got %d!)", s, b);
+            return lua_error(L);
+        }
     }
 
-    // if we get nothing, assuma alpha is 255. If we get a non-number value, complain.
+    // if we get nothing for the alpha value, assume it is 255. If we get a non-number value, complain.
     if (lua_gettop(L) <= 4) {
         alpha = 255;
     } else if (!lua_isnumber(L, ++s)) {
@@ -3072,6 +3096,11 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         return lua_error(L);
     } else {
         alpha = static_cast<int>(lua_tonumber(L, s));
+
+        if (!validRange(alpha)) {
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (alpha value needs to be between 0-255, got %d!)", s, alpha);
+            return lua_error(L);
+        }
     }
 
     if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3048,7 +3048,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
             r = static_cast<int>(lua_tonumber(L, s));
 
             if (!validRange(r)) {
-                lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (red value needs to be between 0-255, got %d!)", s, r);
+                lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (red value needs to be between 0-255, got %d!)", s, r);
                 return lua_error(L);
             }
         }
@@ -3056,7 +3056,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         r = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(r)) {
-            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (red value needs to be between 0-255, got %d!)", s, r);
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (red value needs to be between 0-255, got %d!)", s, r);
             return lua_error(L);
         }
     } else {
@@ -3071,7 +3071,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         g = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(g)) {
-            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (green value needs to be between 0-255, got %d!)", s, g);
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (green value needs to be between 0-255, got %d!)", s, g);
             return lua_error(L);
         }
     }
@@ -3083,7 +3083,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         b = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(b)) {
-            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (blue value needs to be between 0-255, got %d!)", s, b);
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (blue value needs to be between 0-255, got %d!)", s, b);
             return lua_error(L);
         }
     }
@@ -3098,7 +3098,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         alpha = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(alpha)) {
-            lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (alpha value needs to be between 0-255, got %d!)", s, alpha);
+            lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (alpha value needs to be between 0-255, got %d!)", s, alpha);
             return lua_error(L);
         }
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3048,16 +3048,18 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
             r = static_cast<int>(lua_tonumber(L, s));
 
             if (!validRange(r)) {
+                lua_pushnil(L);
                 lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (red value needs to be between 0-255, got %d!)", s, r);
-                return lua_error(L);
+                return 2;
             }
         }
     } else if (lua_isnumber(L, s)) {
         r = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(r)) {
+            lua_pushnil(L);
             lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (red value needs to be between 0-255, got %d!)", s, r);
-            return lua_error(L);
+            return 2;
         }
     } else {
         lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (window name as string, or red value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));
@@ -3071,8 +3073,9 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         g = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(g)) {
+            lua_pushnil(L);
             lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (green value needs to be between 0-255, got %d!)", s, g);
-            return lua_error(L);
+            return 2;
         }
     }
 
@@ -3083,8 +3086,9 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         b = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(b)) {
+            lua_pushnil(L);
             lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (blue value needs to be between 0-255, got %d!)", s, b);
-            return lua_error(L);
+            return 2;
         }
     }
 
@@ -3098,8 +3102,9 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         alpha = static_cast<int>(lua_tonumber(L, s));
 
         if (!validRange(alpha)) {
+            lua_pushnil(L);
             lua_pushfstring(L, "setBackgroundColor: bad argument #%d value (alpha value needs to be between 0-255, got %d!)", s, alpha);
-            return lua_error(L);
+            return 2;
         }
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3093,7 +3093,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
     }
 
     // if we get nothing for the alpha value, assume it is 255. If we get a non-number value, complain.
-    if (lua_gettop(L) <= 4) {
+    if (lua_gettop(L) <= s) {
         alpha = 255;
     } else if (!lua_isnumber(L, ++s)) {
         lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (optional alpha value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3105,6 +3105,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
 
     if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
         if (mudlet::self()->mConsoleMap.contains(pHost)) {
+            pHost->mBgColor.setRgb(r, g, b);
             pHost->mpConsole->setConsoleBgColor(r, g, b);
         } else {
             lua_pushnil(L);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Improved setBackgroundColour to work with main window, applied the improved error message style, and made the alpha argument optional (since it does not work on miniconsoles).
#### Motivation for adding to Mudlet
Bring it in-line with other miniconsole functions that work on the "main" window and allow https://midmud.com to set a custom background colour in their Mudlet package.
#### Other info (issues closed, discussion etc)
