### PR TITLE
Turn off scrollbar when disabled in contructor

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -183,6 +183,8 @@ function Geyser.MiniConsole:new (cons, container)
   end
   if cons.scrollBar then
     me:enableScrollBar()
+  else
+    me:disableScrollbar()
   end
   if cons.font then
     me:setFont(cons.font)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Allow turning off scrollbar when it's not needed by changing the constructor from `scrollBar = true` to `scrollBar = false` and saving the script.
#### Motivation for adding to Mudlet
Simpler development cycle.
#### Other info (issues closed, discussion etc)
