### PR TITLE
Improve load times for profiles with many packages

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -118,6 +118,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 // TODO: Implement other searchOptions:
 //, mpAction_searchWholeWords(nullptr)
 //, mpAction_searchRegExp(nullptr)
+, mCleanResetQueued(false)
 {
     // init generated dialog
     setupUi(this);
@@ -7590,6 +7591,21 @@ void dlgTriggerEditor::slot_import()
 }
 
 void dlgTriggerEditor::doCleanReset()
+{
+    if (mCleanResetQueued) {
+        return;
+    }
+
+    mCleanResetQueued = true;
+
+    QTimer::singleShot(0, [=]() {
+        mCleanResetQueued = false;
+
+        runScheduledCleanReset();
+    });
+}
+
+void dlgTriggerEditor::runScheduledCleanReset()
 {
     if (mCurrentView) {
         switch (mCurrentView) {

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -449,6 +449,10 @@ private:
 
     QAction* mProfileSaveAction;
     QAction* mProfileSaveAsAction;
+
+    // keeps track of the dialog reset being queued
+    bool mCleanResetQueued;
+    void runScheduledCleanReset();
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(dlgTriggerEditor::SearchOptions)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Improve load times for profiles with many packages by reloading the entirety of the trigger editor only once, not every single time for every single package loaded.
#### Motivation for adding to Mudlet
Faster profile load times.
#### Other info (issues closed, discussion etc)

#### Test builds
Linux: https://transfer.sh/wcDgD/Mudlet-3.9.0-testing-PR1712-751e73e-linux-x64.AppImage.tar
macOS: https://transfer.sh/YbHQ3/Mudlet-3.9.0-testing-PR1712-751e73e.dmg
Windows: https://ci.appveyor.com/api/buildjobs/1e5wu5c5k0o3y6tp/artifacts/src%2Fmudlet.zip

No need to install, just unzip Mudlet and to test this new feature. Please report back if it works or doesn't work for you :smile: 