### PR TITLE
Don't create a command line for miniconsoles

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -448,8 +448,7 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     emergencyStop->setSizePolicy(sizePolicy4);
     emergencyStop->setFocusPolicy(Qt::NoFocus);
     emergencyStop->setCheckable(true);
-    emergencyStop->setToolTip(
-            tr("<html><head/><body><p>Emergency Stop. Stops all timers and triggers.</p></body></html>"));
+    emergencyStop->setToolTip(tr("<html><head/><body><p>Emergency Stop. Stops all timers and triggers.</p></body></html>"));
     connect(emergencyStop, SIGNAL(clicked(bool)), this, SLOT(slot_stop_all_triggers(bool)));
 
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -58,6 +58,7 @@ const QString TConsole::cmLuaLineVariable("line");
 
 TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 : QWidget(parent)
+, mpCommandLine(nullptr)
 , mpHost(pH)
 , buffer(pH)
 , emergencyStop(new QToolButton)
@@ -284,10 +285,12 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     baseHFrameLayout->setMargin(0);
     centralLayout->setMargin(0);
 
-    mpCommandLine = new TCommandLine(pH, this, mpMainDisplay);
-    mpCommandLine->setContentsMargins(0, 0, 0, 0);
-    mpCommandLine->setSizePolicy(sizePolicy);
-    mpCommandLine->setFocusPolicy(Qt::StrongFocus);
+    if (!mIsDebugConsole && !mIsSubConsole) {
+        mpCommandLine = new TCommandLine(pH, this, mpMainDisplay);
+        mpCommandLine->setContentsMargins(0, 0, 0, 0);
+        mpCommandLine->setSizePolicy(sizePolicy);
+        mpCommandLine->setFocusPolicy(Qt::StrongFocus);
+    }
 
     layer = new QWidget(mpMainDisplay);
     layer->setContentsMargins(0, 0, 0, 0);
@@ -310,7 +313,9 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     splitter->setHandleWidth(3);
     splitter->setPalette(splitterPalette);
     splitter->setParent(layer);
-    setFocusProxy(mpCommandLine);
+    if (mpCommandLine) {
+        setFocusProxy(mpCommandLine);
+    }
 
     mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, false);
     mUpperPane->setContentsMargins(0, 0, 0, 0);
@@ -405,8 +410,9 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     networkLatency->setReadOnly(true);
     networkLatency->setSizePolicy(sizePolicy4);
     networkLatency->setFocusPolicy(Qt::NoFocus);
-    networkLatency->setToolTip(tr("<html><head/><body><p><i>N:</i> is the latency of the MUD server and network (aka ping, in seconds), <br><i>S:</i> is the system processing time - how long your "
-                                  "triggers took to process the last line(s).</p></body></html>"));
+    networkLatency->setToolTip(
+            tr("<html><head/><body><p><i>N:</i> is the latency of the MUD server and network (aka ping, in seconds), <br><i>S:</i> is the system processing time - how long your "
+               "triggers took to process the last line(s).</p></body></html>"));
     networkLatency->setMaximumSize(120, 30);
     networkLatency->setMinimumSize(120, 30);
     networkLatency->setAutoFillBackground(true);
@@ -442,7 +448,8 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     emergencyStop->setSizePolicy(sizePolicy4);
     emergencyStop->setFocusPolicy(Qt::NoFocus);
     emergencyStop->setCheckable(true);
-    emergencyStop->setToolTip(tr("<html><head/><body><p>Emergency Stop. Stops all timers and triggers.</p></body></html>"));
+    emergencyStop->setToolTip(
+            tr("<html><head/><body><p>Emergency Stop. Stops all timers and triggers.</p></body></html>"));
     connect(emergencyStop, SIGNAL(clicked(bool)), this, SLOT(slot_stop_all_triggers(bool)));
 
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));
@@ -479,7 +486,10 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     mpBufferSearchDown->setIcon(QIcon(QStringLiteral(":/icons/import.png")));
     connect(mpBufferSearchDown, SIGNAL(clicked()), this, SLOT(slot_searchBufferDown()));
 
-    layoutLayer2->addWidget(mpCommandLine);
+    if (mpCommandLine) {
+        layoutLayer2->addWidget(mpCommandLine);
+    }
+
     layoutLayer2->addWidget(mpButtonMainLayer);
     layoutButtonLayer->addWidget(mpBufferSearchBox, 0, 0, 0, 4);
     layoutButtonLayer->addWidget(mpBufferSearchUp, 0, 5);
@@ -506,9 +516,6 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     mUpperPane->show();
     mLowerPane->show();
     mLowerPane->hide();
-    if (mIsDebugConsole) {
-        mpCommandLine->hide();
-    }
 
     isUserScrollBack = false;
 
@@ -542,11 +549,13 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     mpButtonMainLayer->setMinimumWidth(400);
     mpButtonMainLayer->setMaximumWidth(400);
     setFocusPolicy(Qt::ClickFocus);
-    setFocusProxy(mpCommandLine);
     mUpperPane->setFocusPolicy(Qt::ClickFocus);
-    mUpperPane->setFocusProxy(mpCommandLine);
     mLowerPane->setFocusPolicy(Qt::ClickFocus);
-    mLowerPane->setFocusProxy(mpCommandLine);
+    if (mpCommandLine) {
+        setFocusProxy(mpCommandLine);
+        mUpperPane->setFocusProxy(mpCommandLine);
+        mLowerPane->setFocusProxy(mpCommandLine);
+    }
 
     buttonLayerSpacer->setAutoFillBackground(true);
     buttonLayerSpacer->setPalette(__pal);
@@ -620,7 +629,6 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     if (mIsSubConsole || mIsDebugConsole) {
         layerCommandLine->hide();
-        mpCommandLine->hide();
     } else {
         //layerCommandLine->move(0,mpMainFrame->height()-layerCommandLine->height());
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This speeds up loading of profiles that make use of miniconsoles. The major slowing factor here was creating many hunspell dictionaries.

Search and other buttons are still created, but they don't take a significant amount of time unlike hunspell creation
#### Motivation for adding to Mudlet
Faster profile load times
#### Other info (issues closed, discussion etc)
VTune showed the problem:

![selection_304](https://user-images.githubusercontent.com/110988/40598139-4ccabd98-6246-11e8-879f-c421dbe73867.png)
