### PR TITLE
Don't raise EOR Lua events just like we don't raise them for GA

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1074,8 +1074,8 @@ void cTelnet::processTelnetCommand(const string& command)
     }
     }; //end switch 1
        // raise sysTelnetEvent for all unhandled protocols
-       // EXCEPT TN_GA (performance)
-    if (command[1] != TN_GA) {
+       // EXCEPT TN_GA / TN_EOR, which come at the end of every transmission, for performance reaons
+    if (command[1] != TN_GA && command[1] != TN_EOR) {
         unsigned char type = static_cast<unsigned char>(command[1]);
         unsigned char telnetOption = static_cast<unsigned char>(command[2]);
         QString msg = command.c_str();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Don't raise EOR Lua events just like we don't raise them for GA.
#### Motivation for adding to Mudlet
Improve performance by not raising an event for every transmission.

If someone wants to trigger on the prompt, they already can using the prompt trigger.
#### Other info (issues closed, discussion etc)
I don't think anyone would have been using this obscure option and even more an obscure telnet option to do much, so I don't think this will break anything. I only found 1 script at all that makes use of `sysTelnetEvent` and [it does nothing](https://github.com/Earthcrusher/Godspeaker/blob/master/current/10-09-2017%2303-12-03.xml) with it.