### PR TITLE
Add ci retry logic

### DIFF
--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -109,8 +109,20 @@ function RunConfigure([string] $configureArguments = "--prefix=$Env:MINGW_BASE_D
 }
 
 function RunMake([string] $makefile = "Makefile"){
-  Step "Running make"
-  exec "mingw32-make" @("-f", "$makefile", "-j", $(Get-WmiObject win32_processor | Select -ExpandProperty "NumberOfLogicalProcessors"))
+  For ($retries=1; $retries -le 3; $retries++){
+    Step "Running make"
+    try{
+      exec "mingw32-make" @("-f", "$makefile", "-j", $(Get-WmiObject win32_processor | Select -ExpandProperty "NumberOfLogicalProcessors"))
+      break
+    }Catch{
+      Write-Output "Attempt $retries failed." | Tee-Object -File "$logFile" -Append
+      if ($retries -lt 3) {
+        WriteOutput "Retrying..." | Tee-Object -File "$logFile" -Append
+      }else{
+        throw $_.Exception
+      }
+    }
+  }
 }
 
 function RunMakeInstall([string] $makefile = "Makefile"){

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -7,25 +7,19 @@ fi
 set +e
 BREWS="boost cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache pugixml"
 for i in $BREWS; do
-  RETRIES=0
-  while [ ${RETRIES} -lt 3 ]; do
+  for RETRIES in $(seq 1 3); do
     brew outdated | grep -q $i && brew upgrade $i
-    STATUS=$?
-    if [ STATUS -ne 0 ]; then
-      RETRIES=$[${RETRIES}+1]
-    else
+    STATUS="$?"
+    if [ "${STATUS}" -eq 0 ]; then
       break
     fi
   done
 done
 for i in $BREWS; do
-  RETRIES=0
-  while [ ${RETRIES} -lt 3 ]; do
+  for RETRIES in $(seq 1 3); do
     brew list | grep -q $i || brew install $i
-    STATUS=$?
-    if [ STATUS -ne 0 ]; then
-      RETRIES=$[${RETRIES}+1]
-    else
+    STATUS="$?"
+    if [ "${STATUS}" -eq 0 ]; then
       break
     fi
   done

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -4,11 +4,29 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   exit
 fi
 
-set -e
+set +e
 BREWS="boost cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache pugixml"
 for i in $BREWS; do
-  brew outdated | grep -q $i && brew upgrade $i
+  RETRIES=0
+  while [ ${RETRIES} -lt 3 ]; do
+    brew outdated | grep -q $i && brew upgrade $i
+    STATUS=$?
+    if [ STATUS -ne 0 ]; then
+      RETRIES=$[${RETRIES}+1]
+    else
+      break
+    fi
+  done
 done
 for i in $BREWS; do
-  brew list | grep -q $i || brew install $i
+  RETRIES=0
+  while [ ${RETRIES} -lt 3 ]; do
+    brew list | grep -q $i || brew install $i
+    STATUS=$?
+    if [ STATUS -ne 0 ]; then
+      RETRIES=$[${RETRIES}+1]
+    else
+      break
+    fi
+  done
 done


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Our CI jobs seem to have some weak spots: macOS installation of packages fail intermittedly or the compilation of dependencies fails in Windows. The PR adds a retry logic for those cases.

#### Motivation for adding to Mudlet
Hopefully we will need to intervene less by restarting failed jobs.

#### Other info (issues closed, discussion etc)
