### PR TITLE
Modernize code (trivial constructors, no ineffective const, and a few missed for loops)

### DIFF
--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -77,7 +77,8 @@ public:
     QList<TAction*> uninstallList;
 
 private:
-    ActionUnit() {}
+    ActionUnit() = default;
+
     TAction* getActionPrivate(int id);
     void addActionRootNode(TAction* pT, int parentPosition = -1, int childPosition = -1);
     void addAction(TAction* pT);

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -81,7 +81,8 @@ public:
 
 
 private:
-    AliasUnit() {}
+    AliasUnit() = default;
+
     void initStats();
     void _assembleReport(TAlias*);
     TAlias* getAliasPrivate(int id);

--- a/src/Host.h
+++ b/src/Host.h
@@ -88,7 +88,7 @@ public:
     void               setTimeout( int seconds )        { QMutexLocker locker(& mLock); mTimeout=seconds; }
     bool               wideAmbiguousEAsianGlyphs() { QMutexLocker locker(& mLock); return mWideAmbigousWidthGlyphs; }
     // Uses PartiallyChecked to set the automatic mode, otherwise Checked/Unchecked means use wide/narrow ambiguous glyphs
-    void               setWideAmbiguousEAsianGlyphs( const Qt::CheckState state );
+    void               setWideAmbiguousEAsianGlyphs(Qt::CheckState state );
     // Is used to set preference dialog control directly:
     Qt::CheckState     getWideAmbiguousEAsianGlyphsControlState() { QMutexLocker locker(& mLock);
                                                                        return mAutoAmbigousWidthGlyphsSetting
@@ -349,7 +349,7 @@ public:
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous
     // width characters:
-    void signal_changeIsAmbigousWidthGlyphsToBeWide(const bool);
+    void signal_changeIsAmbigousWidthGlyphsToBeWide(bool);
     void profileSaveStarted();
     void profileSaveFinished();
 

--- a/src/HostManager.h
+++ b/src/HostManager.h
@@ -40,7 +40,8 @@ class TEvent;
 class HostManager
 {
 public:
-    HostManager() /* : mpActiveHost() - Not needed */ {}
+    HostManager() = default; /* : mpActiveHost() - Not needed */
+
     Host* getHost(QString hostname);
     int getHostCount();
     QStringList getHostList();

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -138,8 +138,7 @@ bool KeyUnit::disableKey(const QString& name)
 
 bool KeyUnit::killKey(QString& name)
 {
-    for (auto it = mKeyRootNodeList.begin(); it != mKeyRootNodeList.end(); it++) {
-        TKey* pChild = *it;
+    for (auto pChild : mKeyRootNodeList) {
         if (pChild->getName() == name) {
             // only temporary Keys can be killed
             if (!pChild->isTemporary()) {
@@ -371,8 +370,7 @@ void KeyUnit::initStats()
 void KeyUnit::_assembleReport(TKey* pChild)
 {
     list<TKey*>* childrenList = pChild->mpMyChildrenList;
-    for (auto it2 = childrenList->begin(); it2 != childrenList->end(); it2++) {
-        TKey* pT = *it2;
+    for (auto pT : *childrenList) {
         _assembleReport(pT);
         if (pT->isActive()) {
             statsActiveKeys++;
@@ -389,8 +387,7 @@ QString KeyUnit::assembleReport()
     statsActiveKeys = 0;
     statsKeyTotal = 0;
     statsTempKeys = 0;
-    for (auto it = mKeyRootNodeList.begin(); it != mKeyRootNodeList.end(); it++) {
-        TKey* pChild = *it;
+    for (auto pChild : mKeyRootNodeList) {
         if (pChild->isActive()) {
             statsActiveKeys++;
         }
@@ -399,8 +396,7 @@ QString KeyUnit::assembleReport()
         }
         statsKeyTotal++;
         list<TKey*>* childrenList = pChild->mpMyChildrenList;
-        for (auto it2 = childrenList->begin(); it2 != childrenList->end(); it2++) {
-            TKey* pT = *it2;
+        for (auto pT : *childrenList) {
             _assembleReport(pT);
             if (pT->isActive()) {
                 statsActiveKeys++;

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -85,7 +85,8 @@ public:
     QList<TKey*> uninstallList;
 
 private:
-    KeyUnit() {}
+    KeyUnit() = default;
+
     TKey* getKeyPrivate(int id);
     void initStats();
     void _assembleReport(TKey*);

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -43,9 +43,7 @@ LuaInterface::LuaInterface(Host* pH) : mpHost(pH), L(), depth()
     lua_atpanic(interpreter->pGlobalLua, &onPanic);
 }
 
-LuaInterface::~LuaInterface()
-{
-}
+LuaInterface::~LuaInterface() = default;
 
 int LuaInterface::onPanic(lua_State* L)
 {

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -62,7 +62,8 @@ public:
     QList<TScript*> uninstallList;
 
 private:
-    ScriptUnit() {}
+    ScriptUnit() = default;
+
     TScript* getScriptPrivate(int id);
     void addScriptRootNode(TScript* pT, int parentPosition = -1, int childPosition = -1);
     void addScript(TScript* pT);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -76,7 +76,7 @@ public:
     void createLabel(QRectF labelRect);
     // Clears cache so new symbols are built at next paintEvent():
     void flushSymbolPixmapCache() {mSymbolPixmapCache.clear();}
-    void addSymbolToPixmapCache(const QString, const bool);
+    void addSymbolToPixmapCache(QString, bool);
 
 
     TMap* mpMap;

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -135,7 +135,8 @@ public:
     bool mToolbarLastFloatingState;
 
 private:
-    TAction() {}
+    TAction() = default;
+
     QString mFuncName;
     bool mModuleMember;
     bool mDataChanged;

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -63,7 +63,8 @@ public:
     bool match(const QString& toMatch);
     bool registerAlias();
 
-    TAlias() {}
+    TAlias() = default;
+
     QString mName;
     QString mCommand;
     QString mRegexCode;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -140,7 +140,7 @@ public:
     QStringList getEndLines(int);
     void clear();
     QPoint getEndPos();
-    void translateToPlainText(std::string& s, const bool isFromServer=false);
+    void translateToPlainText(std::string& s, bool isFromServer=false);
     void append(const QString& chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID = 0);
     void appendLine(const QString& chunk, int sub_start, int sub_end, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout, int linkID = 0);
     void setWrapAt(int i) { mWrapAt = i; }
@@ -201,8 +201,8 @@ private:
     void shrinkBuffer();
     int calcWrapPos(int line, int begin, int end);
     void handleNewLine();
-    bool processUtf8Sequence(const std::string&, const bool, const size_t, size_t&, bool&);
-    bool processGBSequence(const std::string&, const bool, const bool, const size_t, size_t&, bool&);
+    bool processUtf8Sequence(const std::string&, bool, size_t, size_t&, bool&);
+    bool processGBSequence(const std::string&, bool, bool, size_t, size_t&, bool&);
 
 
     bool gotESC;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -117,12 +117,12 @@ public:
     TConsole* createBuffer(const QString& name);
     void scrollDown(int lines);
     void scrollUp(int lines);
-    void print(const QString&, const QColor fgColor, const QColor bgColor);
+    void print(const QString&, QColor fgColor, QColor bgColor);
     void print(const QString& msg);
     void print(const char*);
     void printDebug(QColor&, QColor&, const QString&);
     void printSystemMessage(const QString& msg);
-    void printOnDisplay(std::string&, const bool isFromServer = false);
+    void printOnDisplay(std::string&, bool isFromServer = false);
     void printCommand(QString&);
     bool hasSelection();
     void moveCursorEnd();
@@ -266,7 +266,7 @@ signals:
     // Raised when new data is incoming to trigger Alert handling in mudlet
     // class, second argument is true for a lower priority indication when
     // locally produced information is painted into main console
-    void signal_newDataAlert(const QString&, const bool isLowerPriorityChange = false);
+    void signal_newDataAlert(const QString&, bool isLowerPriorityChange = false);
 
 
 public slots:

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -38,9 +38,7 @@ TDebug& TDebug::operator>>(const int code)
     return *this;
 }
 
-TDebug::~TDebug()
-{
-}
+TDebug::~TDebug() = default;
 
 TDebug& TDebug::operator<<(const QString& t)
 {

--- a/src/TDebug.h
+++ b/src/TDebug.h
@@ -50,7 +50,7 @@ public:
     TDebug& operator<<(const QList<int>& list);
 
 private:
-    TDebug(){};
+    TDebug() = default;;
 };
 
 #endif // MUDLET_TDEBUG_H

--- a/src/TDebug.h
+++ b/src/TDebug.h
@@ -50,7 +50,7 @@ public:
     TDebug& operator<<(const QList<int>& list);
 
 private:
-    TDebug() = default;;
+    TDebug() = default;
 };
 
 #endif // MUDLET_TDEBUG_H

--- a/src/TDebug.h
+++ b/src/TDebug.h
@@ -39,7 +39,7 @@ class TDebug
 public:
     TDebug(QColor, QColor);
     ~TDebug();
-    TDebug& operator>>(const int);
+    TDebug& operator>>(int);
     TDebug& operator<<(const QString& t);
     TDebug& operator<<(const int& t);
     TDebug& operator<<(const QMap<QString, QString>& map);

--- a/src/TEasyButtonBar.h
+++ b/src/TEasyButtonBar.h
@@ -61,7 +61,7 @@ private:
     std::list<TFlipButton*> mButtonList;
 
 public slots:
-    void slot_pressed(const bool);
+    void slot_pressed(bool);
 };
 
 #endif // MUDLET_TEASYBUTTONBAR_H

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -67,7 +67,7 @@ public:
     bool mModuleMasterFolder;
 
 private:
-    TKey() = default;;
+    TKey() = default;
     QString mName;
     QString mCommand;
 

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -67,7 +67,7 @@ public:
     bool mModuleMasterFolder;
 
 private:
-    TKey(){};
+    TKey() = default;;
     QString mName;
     QString mCommand;
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -113,21 +113,21 @@ public:
     bool retrieveMapFileStats(QString, QString*, int*, int*, int*, int*);
     void initGraph();
     void connectExitStub(int roomId, int dirType);
-    void postMessage(const QString text);
+    void postMessage(QString text);
 
     // Used by the 2D mapper to send view center coordinates to 3D one
-    void set3DViewCenter(const int, const int, const int, const int);
+    void set3DViewCenter(int, int, int, int);
 
-    void appendRoomErrorMsg(const int, const QString, const bool isToSetFileViewingRecommended = false);
-    void appendAreaErrorMsg(const int, const QString, const bool isToSetFileViewingRecommended = false);
-    void appendErrorMsg(const QString, const bool isToSetFileViewingRecommended = false);
-    void appendErrorMsgWithNoLf(const QString, const bool isToSetFileViewingRecommended = false);
+    void appendRoomErrorMsg(int, QString, bool isToSetFileViewingRecommended = false);
+    void appendAreaErrorMsg(int, QString, bool isToSetFileViewingRecommended = false);
+    void appendErrorMsg(QString, bool isToSetFileViewingRecommended = false);
+    void appendErrorMsgWithNoLf(QString, bool isToSetFileViewingRecommended = false);
 
     // If the argument is true does not write out any thing if there is no data
     // to dump, intended to be used before an operation like a map load so that
     // any messages previously recorded are not associated with a "fresh" batch
     // from the operation.
-    void pushErrorMessagesToFile(const QString, const bool isACleanup = false);
+    void pushErrorMessagesToFile(QString, bool isACleanup = false);
 
     // Moved and revised from dlgMapper:
     void downloadMap(const QString* remoteUrl = Q_NULLPTR, const QString* localFileName = Q_NULLPTR);
@@ -140,10 +140,10 @@ public:
     bool readXmlMapFile(QFile&, QString* errMsg = Q_NULLPTR);
 
     // Use progress dialog for post-download operations.
-    void reportStringToProgressDialog(const QString);
+    void reportStringToProgressDialog(QString);
 
     // Use progress dialog for post-download operations.
-    void reportProgressToProgressDialog(const int, const int);
+    void reportProgressToProgressDialog(int, int);
 
     // Show which rooms have which symbols:
     QHash<QString, QSet<int>> roomSymbolsHash();
@@ -234,7 +234,7 @@ public slots:
 
 
 private:
-    const QString createFileHeaderLine(const QString, const QChar);
+    const QString createFileHeaderLine(QString, QChar);
 
     QStringList mStoredMessages;
 

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -78,7 +78,7 @@ public:
     const QMap<QString, int>& getExitWeights() const { return exitWeights; }
     void setExitWeight(const QString& cmd, int w);
     bool hasExitWeight(const QString& cmd);
-    const bool setDoor(const QString& cmd, const int doorStatus); //0=no door, 1=open door, 2=closed, 3=locked
+    const bool setDoor(const QString& cmd, int doorStatus); //0=no door, 1=open door, 2=closed, 3=locked
     int getDoor(const QString& cmd);
     bool hasExitStub(int direction);
     void setExitStub(int direction, bool status);
@@ -113,14 +113,14 @@ public:
     void setOut(int id) { out = id; }
     int getId() { return id; }
     int getArea() { return area; }
-    void audit(const QHash<int, int>, const QHash<int, int>);
-    void auditExits(const QHash<int, int>);
+    void audit(QHash<int, int>, QHash<int, int>);
+    void auditExits(QHash<int, int>);
     /*bool*/ void restore(QDataStream& ifs, int roomID, int version);
     void auditExit(int&,
-                   const int,
-                   const QString,
-                   const QString,
-                   const QString,
+                   int,
+                   QString,
+                   QString,
+                   QString,
                    QMap<QString, int>&,
                    QSet<int>&,
                    QSet<int>&,
@@ -129,8 +129,8 @@ public:
                    QMap<QString, QList<int>>&,
                    QMap<QString, QString>&,
                    QMap<QString, bool>&,
-                   const QHash<int, int>);
-    const QString dirCodeToDisplayName(const int dirCode);
+                   QHash<int, int>);
+    const QString dirCodeToDisplayName(int dirCode);
 
 
     int x;

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -88,7 +88,7 @@ private:
     TRoomDB() {}
     int createNewAreaID();
     bool __removeRoom(int id);
-    void setAreaRooms(const int, const QSet<int>&); // Used by XMLImport to fix rooms data after import
+    void setAreaRooms(int, const QSet<int>&); // Used by XMLImport to fix rooms data after import
 
     QHash<int, TRoom*> rooms;
     QMultiHash<int, int> entranceMap; // key is exit target, value is exit source

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -85,7 +85,8 @@ public:
 
 
 private:
-    TRoomDB() {}
+    TRoomDB() = default;
+
     int createNewAreaID();
     bool __removeRoom(int id);
     void setAreaRooms(int, const QSet<int>&); // Used by XMLImport to fix rooms data after import

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -59,7 +59,7 @@ public:
     bool mModuleMasterFolder;
 
 private:
-    TScript() = default;;
+    TScript() = default;
     QString mName;
     QString mScript;
     QString mFuncName;

--- a/src/TScript.h
+++ b/src/TScript.h
@@ -59,7 +59,7 @@ public:
     bool mModuleMasterFolder;
 
 private:
-    TScript(){};
+    TScript() = default;;
     QString mName;
     QString mScript;
     QString mFuncName;

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -48,10 +48,10 @@ public:
     bool tabUnderline(const int index) const { return indexedTabState(index, mUnderlineTabsSet); }
 
 private:
-    bool indexedTabState(const int, const QSet<QString>&) const;
+    bool indexedTabState(int, const QSet<QString>&) const;
     bool namedTabState(const QString&, const QSet<QString>&) const;
-    void setNamedTabState(const QString&, const bool, QSet<QString>&);
-    void setIndexedTabState(const int, const bool, QSet<QString>&);
+    void setNamedTabState(const QString&, bool, QSet<QString>&);
+    void setIndexedTabState(int, bool, QSet<QString>&);
 
 
     QTabBar * mpTabBar;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -118,7 +118,7 @@ public slots:
     void slot_popupMenu();
     void slot_copySelectionToClipboardHTML();
     void slot_searchSelectionOnline();
-    void slot_changeIsAmbigousWidthGlyphsToBeWide(const bool);
+    void slot_changeIsAmbigousWidthGlyphsToBeWide(bool);
 
 private:
     void initDefaultSettings();

--- a/src/TTimer.h
+++ b/src/TTimer.h
@@ -80,7 +80,7 @@ public:
     bool mModuleMasterFolder;
 
 private:
-    TTimer() = default;;
+    TTimer() = default;
     QString mName;
     QString mScript;
     QTime mTime;

--- a/src/TTimer.h
+++ b/src/TTimer.h
@@ -80,7 +80,7 @@ public:
     bool mModuleMasterFolder;
 
 private:
-    TTimer(){};
+    TTimer() = default;;
     QString mName;
     QString mScript;
     QTime mTime;

--- a/src/TToolBar.h
+++ b/src/TToolBar.h
@@ -59,7 +59,7 @@ private:
     int mItemCount;
 
 public slots:
-    void slot_pressed(const bool);
+    void slot_pressed(bool);
     void slot_topLevelChanged(bool);
     void slot_dockLocationChanged(Qt::DockWidgetArea);
 };

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -150,7 +150,8 @@ public:
     bool mRegisteredAnonymousLuaFunction;
 
 private:
-    TTrigger() {}
+    TTrigger() = default;
+
     void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList);
     void filter(std::string&, int&);
 

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -34,18 +34,18 @@ class TVar
 public:
     TVar();
     TVar(TVar*);
-    TVar(TVar*, const QString, const int, const QString, const int);
+    TVar(TVar*, QString, int, QString, int);
     void addChild(TVar*);
     void setParent(TVar*);
     void removeChild(TVar*);
-    bool setValue(const QString);
-    bool setValue(const QString, const int);
-    bool setValueType(const int);
-    bool setName(const QString);
-    bool setName(const QString, int);
-    void setNewName(const QString, int);
-    void setReference(const bool);
-    QList<TVar*> getChildren(const bool isToSort = true);
+    bool setValue(QString);
+    bool setValue(QString, int);
+    bool setValueType(int);
+    bool setName(QString);
+    bool setName(QString, int);
+    void setNewName(QString, int);
+    void setReference(bool);
+    QList<TVar*> getChildren(bool isToSort = true);
     TVar* getParent();
     QString getValue();
     QString getName();

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -71,7 +71,8 @@ public:
     QList<TTimer*> uninstallList;
 
 private:
-    TimerUnit() {}
+    TimerUnit() = default;
+
     void _assembleReport(TTimer*);
     TTimer* getTimerPrivate(int id);
     void addTimerRootNode(TTimer* pT, int parentPosition = -1, int childPosition = -1);

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -44,7 +44,7 @@ public:
     int getChildCount() const { return mpMyChildrenList->size(); }
     int getID() const { return mID; }
     void setID(const int id) { mID = id; }
-    void addChild(T* newChild, const int parentPostion = -1, const int parentPosition = -1);
+    void addChild(T* newChild, int parentPostion = -1, int parentPosition = -1);
     bool popChild(T* removeChild);
     void setParent(T* parent);
     void enableFamily();
@@ -52,15 +52,15 @@ public:
     bool isActive() const;
     bool activate();
     void deactivate();
-    bool setIsActive(const bool);
+    bool setIsActive(bool);
     bool shouldBeActive() const;
-    void setShouldBeActive(const bool b);
+    void setShouldBeActive(bool b);
     bool isTemporary() const;
-    void setTemporary(const bool state);
+    void setTemporary(bool state);
     // Returns true if all the ancesters of this node are active. If there are no ancestors it also returns true.
     bool ancestorsActive() const;
     QString& getError();
-    void setError(const QString);
+    void setError(QString);
     bool state() const;
     QString getPackageName() const { return mPackageName; }
     void setPackageName(const QString& n) { mPackageName = n; }

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -90,7 +90,8 @@ public:
     QList<TTrigger*> uninstallList;
 
 private:
-    TriggerUnit() {}
+    TriggerUnit() = default;
+
     void initStats();
     void _assembleReport(TTrigger*);
     TTrigger* getTriggerPrivate(int id);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -746,8 +746,8 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); ++it) {
-        writeTrigger(*it, xmlParent);
+    for (auto& it : *pT->mpMyChildrenList) {
+        writeTrigger(it, xmlParent);
     }
 }
 
@@ -799,8 +799,8 @@ void XMLexport::writeAlias(TAlias* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); ++it) {
-        writeAlias(*it, xmlParent);
+    for (auto& it : *pT->mpMyChildrenList) {
+        writeAlias(it, xmlParent);
     }
 }
 
@@ -869,8 +869,8 @@ void XMLexport::writeAction(TAction* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); ++it) {
-        writeAction(*it, xmlParent);
+    for (auto& it : *pT->mpMyChildrenList) {
+        writeAction(it, xmlParent);
     }
 }
 
@@ -925,8 +925,8 @@ void XMLexport::writeTimer(TTimer* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); ++it) {
-        writeTimer(*it, xmlParent);
+    for (auto& it : *pT->mpMyChildrenList) {
+        writeTimer(it, xmlParent);
     }
 }
 
@@ -980,8 +980,8 @@ void XMLexport::writeScript(TScript* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); it++) {
-        writeScript(*it, xmlParent);
+    for (auto& it : *pT->mpMyChildrenList) {
+        writeScript(it, xmlParent);
     }
 }
 
@@ -1034,8 +1034,8 @@ void XMLexport::writeKey(TKey* pT, pugi::xml_node xmlParent)
         }
     }
 
-    for (auto it = pT->mpMyChildrenList->begin(); it != pT->mpMyChildrenList->end(); ++it) {
-        writeKey(*it, xmlParent);
+    for (auto& it : *pT->mpMyChildrenList) {
+        writeKey(it, xmlParent);
     }
 }
 

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -106,7 +106,7 @@ private:
     void writeScriptPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeKeyPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeVariablePackage(Host* pHost, pugi::xml_node& mMudletPackage);
-    void inline replaceAll(std::string& source, const char from, const std::string& to);
+    void inline replaceAll(std::string& source, char from, const std::string& to);
     void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
     bool saveXml(const QString& fileName);
     pugi::xml_node writeXmlHeader();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -115,7 +115,7 @@ public:
     void setChannel102Variables(const QString&);
     bool socketOutRaw(std::string& data);
     const QString & getEncoding() const { return mEncoding; }
-    QPair<bool, QString> setEncoding(const QString &, const bool isToStore = true);
+    QPair<bool, QString> setEncoding(const QString &, bool isToStore = true);
     void postMessage(QString);
     const QStringList & getEncodingsList() const { return mAcceptableEncodings; }
     const QStringList & getFriendlyEncodingsList() const { return mFriendlyEncodings; }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -149,7 +149,8 @@ public slots:
 
 
 private:
-    cTelnet() {}
+    cTelnet() = default;
+
     void initStreamDecompressor();
     int decompressBuffer(char*& in_buffer, int& length, char* out_buffer);
     void reset();

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -42,14 +42,14 @@ signals:
     void signal_establish_connection(QString profile_name, int historyVersion);
 
 public slots:
-    void slot_update_name(const QString);
+    void slot_update_name(QString);
     void slot_save_name();
     void slot_update_url(const QString &);
-    void slot_update_port(const QString);
+    void slot_update_port(QString);
     void slot_update_login(const QString &);
     void slot_update_pass(const QString &);
     void slot_update_website(const QString &);
-    void slot_deleteprofile_check(const QString);
+    void slot_deleteprofile_check(QString);
     void slot_update_description();
 
     void slot_item_clicked(QListWidgetItem*);
@@ -64,7 +64,7 @@ public slots:
 
 private:
     void copyFolder(QString sourceFolder, QString destFolder);
-    QString getDescription(const QString& hostUrl, const quint16 port, const QString& profile_name);
+    QString getDescription(const QString& hostUrl, quint16 port, const QString& profile_name);
 
     bool validName;
     bool validUrl;

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -43,7 +43,7 @@ public:
     Q_DISABLE_COPY(dlgMapper)
     dlgMapper(QWidget*, Host*, TMap*);
     void updateAreaComboBox();
-    void setDefaultAreaShown(const bool);
+    void setDefaultAreaShown(bool);
     bool getDefaultAreaShown() { return mShowDefaultArea; }
     void resetAreaComboBoxToPlayerRoomArea();
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -114,8 +114,8 @@ public slots:
     // Log.
     void slot_setLogDir();
     void slot_resetLogDir();
-    void slot_logFileNameFormatChange(const int index);
-    void slot_changeLogFileAsHtml(const bool isHtml);
+    void slot_logFileNameFormatChange(int index);
+    void slot_changeLogFileAsHtml(bool isHtml);
 
     // Save.
     void slot_save_and_exit();
@@ -123,20 +123,20 @@ public slots:
     void hideActionLabel();
     void slot_setEncoding(const QString&);
 
-    void slot_handleHostAddition(Host*, const quint8);
+    void slot_handleHostAddition(Host*, quint8);
     void slot_handleHostDeletion(Host*);
 
 private slots:
-    void slot_changeShowSpacesAndTabs(const bool);
-    void slot_changeShowLineFeedsAndParagraphs(const bool);
+    void slot_changeShowSpacesAndTabs(bool);
+    void slot_changeShowLineFeedsAndParagraphs(bool);
     void slot_resetThemeUpdateLabel();
     void slot_script_selected(int index);
     void slot_editor_tab_selected(int tabIndex);
     void slot_theme_selected(int index);
     void slot_setMapSymbolFont(const QFont&);
-    void slot_setMapSymbolFontStrategy(const bool);
-    void slot_changeShowMenuBar(const int);
-    void slot_changeShowToolBar(const int);
+    void slot_setMapSymbolFontStrategy(bool);
+    void slot_changeShowMenuBar(int);
+    void slot_changeShowToolBar(int);
 
 private:
     void setColors();

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -258,7 +258,7 @@ public slots:
     void slot_copy_xml();
     void slot_paste_xml();
     void slot_chose_action_icon();
-    void slot_showSearchAreaResults(const bool);
+    void slot_showSearchAreaResults(bool);
     void slot_script_main_area_delete_handler();
     void slot_script_main_area_add_handler();
     void slot_script_main_area_edit_handler(QListWidgetItem*);
@@ -267,18 +267,18 @@ public slots:
     void grab_key_callback(int key, int modifier);
     void slot_profileSaveAction();
     void slot_profileSaveAsAction();
-    void slot_setToolBarIconSize(const int);
-    void slot_setTreeWidgetIconSize(const int);
+    void slot_setToolBarIconSize(int);
+    void slot_setTreeWidgetIconSize(int);
     void slot_color_trigger_fg();
     void slot_color_trigger_bg();
-    void slot_updateStatusBar(const QString statusText); // For the source code editor
+    void slot_updateStatusBar(QString statusText); // For the source code editor
     void slot_profileSaveStarted();
     void slot_profileSaveFinished();
 
 private slots:
     void slot_changeEditorTextOptions(QTextOption::Flags);
-    void slot_toggle_isPushDownButton(const int);
-    void slot_toggleSearchCaseSensitivity(const bool);
+    void slot_toggle_isPushDownButton(int);
+    void slot_toggleSearchCaseSensitivity(bool);
     void slot_clearSearchResults();
     void slot_editorContextMenu();
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -116,9 +116,7 @@ GLWidget::GLWidget(TMap* pM, QWidget* parent)
 }
 
 
-GLWidget::~GLWidget()
-{
-}
+GLWidget::~GLWidget() = default;
 
 QSize GLWidget::minimumSizeHint() const
 {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -172,8 +172,8 @@ public:
     bool isGoingDown() { return mIsGoingDown; }
     int mToolbarIconSize;
     int mEditorTreeWidgetIconSize;
-    void setToolBarIconSize(const int);
-    void setEditorTreeWidgetIconSize(const int);
+    void setToolBarIconSize(int);
+    void setEditorTreeWidgetIconSize(int);
     enum controlsVisibilityFlag {
         visibleNever = 0,
         visibleOnlyWithoutLoadedProfile = 0x1,
@@ -181,8 +181,8 @@ public:
         visibleAlways = 0x3
     };
     Q_DECLARE_FLAGS(controlsVisibility, controlsVisibilityFlag)
-    void setToolBarVisibility(const controlsVisibility);
-    void setMenuBarVisibility(const controlsVisibility);
+    void setToolBarVisibility(controlsVisibility);
+    void setMenuBarVisibility(controlsVisibility);
     void adjustToolBarVisibility();
     void adjustMenuBarVisibility();
     controlsVisibility menuBarVisibility() const { return mMenuBarVisibility; }
@@ -230,7 +230,7 @@ public:
     // and ::ShowLineAndParagraphSeparators
     // are considered/used/stored
     QTextOption::Flags mEditorTextOptions;
-    void setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const bool isLinesAndParagraphsToBeShown);
+    void setEditorTextoptions(bool isTabsAndSpacesToBeShown, bool isLinesAndParagraphsToBeShown);
     static bool loadEdbeeTheme(const QString& themeName, const QString& themeFile);
 
     // Used by a profile to tell the mudlet class
@@ -313,7 +313,7 @@ public:
         // when saving/resyncing packages/modules - ends in a '/'
         moduleBackupsPath
     };
-    static QString getMudletPath(const mudletPathType, const QString& extra1 = QString(), const QString& extra2 = QString());
+    static QString getMudletPath(mudletPathType, const QString& extra1 = QString(), const QString& extra2 = QString());
     // Used to enable "emergency" control recovery action - if Mudlet is
     // operating without either menubar or main toolbar showing.
     bool isControlsVisible() const;
@@ -366,7 +366,7 @@ public slots:
     void slot_restoreMainMenu() { setMenuBarVisibility(visibleAlways); }
     void slot_restoreMainToolBar() { setToolBarVisibility(visibleAlways); }
     void slot_handleToolbarVisibilityChanged(bool);
-    void slot_newDataOnHost(const QString&, const bool isLowerPriorityChange = false);
+    void slot_newDataOnHost(const QString&, bool isLowerPriorityChange = false);
 
 
 protected:
@@ -375,10 +375,10 @@ protected:
 signals:
     void signal_editorTextOptionsChanged(QTextOption::Flags);
     void signal_profileMapReloadRequested(QList<QString>);
-    void signal_setToolBarIconSize(const int);
-    void signal_setTreeIconSize(const int);
-    void signal_hostCreated(Host*, const quint8);
-    void signal_hostDestroyed(Host*, const quint8);
+    void signal_setToolBarIconSize(int);
+    void signal_setTreeIconSize(int);
+    void signal_hostCreated(Host*, quint8);
+    void signal_hostDestroyed(Host*, quint8);
 
 private slots:
     void slot_close_profile();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

* Removed const statements in function declaration that don't actually do anything (http://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html)
* Modernized a few missed out for loops (http://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html)
* Replaced trivial constructors with = default to allow for compiler optimisation (http://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html)
#### Motivation for adding to Mudlet
More modern code, nicer to work with! (maybe more developers?)
#### Other info (issues closed, discussion etc)
