### PR TITLE
Optimise window access in calcFontSize and fix Coverity warning

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1441,10 +1441,14 @@ QSize mudlet::calcFontSize(Host* pHost, const QString& windowName)
 
     if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
         font = pHost->mDisplayFont;
-    } else if (dockWindowConsoleMap.contains(windowName)) {
-        font = dockWindowConsoleMap.value(windowName)->mUpperPane->mDisplayFont;
     } else {
-        return QSize(-1, -1);
+        const auto window = dockWindowConsoleMap.constFind(windowName);
+        if (window != dockWindowConsoleMap.cend()) {
+            Q_ASSERT(window.value()->mUpperPane);
+            font = window.value()->mUpperPane->mDisplayFont;
+        } else {
+            return QSize(-1, -1);
+        }
     }
 
     auto fontMetrics = QFontMetrics(font);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Optimise window access in calcFontSize to look up values in the `QMap` only once, and fix the Coverity warning of a possible null deference with the assert.
#### Motivation for adding to Mudlet
Faster code, less warnings, seems good.
#### Other info (issues closed, discussion etc)
If Coverity is happy with this, I will apply the solution to other window access functions we've got.