### PR TITLE
Fixes scroll logic to update TConsoles when scrolling at the top of the Console

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -374,8 +374,8 @@ void TTextEdit::scrollUp(int lines)
     if (bufferScrollUp(lines)) {
         mIsTailMode = false;
         mScrollVector = 0;
-        update();
     }
+    update();
 }
 
 void TTextEdit::scrollDown(int lines)


### PR DESCRIPTION
Updates `TTextEdit` every scroll attempt, since `bufferScrollUp()` doesn't correctly always inform `TTextEdit::scrollUp()` when lines were actually scrolled.

#### Brief overview of PR changes/additions
Simple workaround to fix issue: https://github.com/Mudlet/Mudlet/issues/1702 where Consoles didn't properly update if you scrolled them to the very top line until you had done a TON of extra scrolling up past the top, and moved the mouse.

A proper fix would have `bufferScrollUp()` correctly returning the lines scrolled when you hit the top of the buffer, but `mCursorY` isn't being tracked correctly, which takes a good deal more reworking than is appropriate for this small fix. These issues will likely be resolved when someone fixes the scrollbar itself.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
