### PR TITLE
Include TLuaInterpreter.[h|cpp] in codeowners as special case

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,8 @@
 # But the lua interface has additional reviewers
 /src/LuaInterface.cpp           @Mudlet/core-cpp @Mudlet/lua-interface
 /src/LuaInterface.h             @Mudlet/core-cpp @Mudlet/lua-interface
+/src/TLuaInterpreter.cpp        @Mudlet/core-cpp @Mudlet/lua-interface
+/src/TLuaInterpreter.h          @Mudlet/core-cpp @Mudlet/lua-interface
 
 # The lua-interface team is also reviewing everything below the mudlet-lua
 # folder and some pre-installed packages


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This adds `TLuaInterpreter.h` and `TLuaInterpreter.cpp` as special cases for code review. Changes in both files should request automatic reviews from the lua-interface team as well.

#### Motivation for adding to Mudlet
Flagging the right people for a review without action.

#### Other info (issues closed, discussion etc)
Closes #1724 