### PR TITLE
Info message has a double `be`

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1317,7 +1317,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             postMessage(alertMsg);
             QString infoMsg = tr("[ INFO ]  - You might wish to donate THIS map file to the Mudlet Museum!\n"
                                  "There is so much data that it DOES NOT have that you could be\n"
-                                 "be better off starting again...");
+                                 "better off starting again...");
             appendErrorMsgWithNoLf(infoMsg, false);
             postMessage(infoMsg);
             canRestore = false;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
While looking at translations I noticed this English text has an error.

`you could be be better`

#### Motivation for adding to Mudlet

Simple info text clean up!

#### Other info (issues closed, discussion etc)
