### PR TITLE
BugFix: restore missing header includes in class files

### DIFF
--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2009, 2018 by Vadim Peretokin - vperetokin@gmail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@viginmedia.com          *
+ *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@viginmedia.com     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +22,12 @@
 
 #include "FontManager.h"
 #include "mudlet.h"
+
+#include "pre_guard.h"
+#include <QDir>
+#include <QFileInfo>
+#include <QDesktopServices>
+#include "post_guard.h"
 
 void FontManager::addFonts()
 {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2017 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -38,8 +38,10 @@
 
 #include "pre_guard.h"
 #include <QLineEdit>
+#include <QMessageBox>
 #include <QScrollBar>
 #include <QShortcut>
+#include <QTextCodec>
 #include "post_guard.h"
 
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -47,6 +47,7 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
+#include <QDesktopServices>
 #include <QFileDialog>
 #include "post_guard.h"
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -34,7 +34,9 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
+#include <QElapsedTimer>
 #include <QFileDialog>
+#include <QMessageBox>
 #include <QProgressDialog>
 #include "post_guard.h"
 

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -28,6 +28,10 @@
 #include "TRoomDB.h"
 #include "mudlet.h"
 
+#include "pre_guard.h"
+#include <QString>
+#include <QStringBuilder>
+#include "post_guard.h"
 
 TRoom::TRoom(TRoomDB* pRDB)
 : x(0)

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2017 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +24,10 @@
 #include "Host.h"
 #include "TArea.h"
 #include "mudlet.h"
+
+#include "pre_guard.h"
+#include <QElapsedTimer>
+#include "post_guard.h"
 
 
 TRoomDB::TRoomDB( TMap * pMap )

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -32,9 +32,11 @@
 #include "wcwidth.h"
 
 #include "pre_guard.h"
+#include <QDesktopServices>
 #include <QPainter>
 #include <QScrollBar>
 #include <QToolTip>
+#include <QTextBoundaryFinder>
 #include "post_guard.h"
 
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -30,6 +30,12 @@
 #include "VarUnit.h"
 #include "mudlet.h"
 
+#include "pre_guard.h"
+#include <QBuffer>
+#include <QtMath>
+#include "post_guard.h"
+
+
 XMLimport::XMLimport(Host* pH)
 : mpHost(pH)
 , mPackageName(QString())

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -40,6 +40,8 @@
 
 #include "pre_guard.h"
 #include <QProgressDialog>
+#include <QTextCodec>
+#include <QTextEncoder>
 #include "post_guard.h"
 
 #define DEBUG

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -3,7 +3,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,6 +29,7 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
+#include <QDesktopServices>
 #include <QScrollBar>
 #include <QShortcut>
 #include "post_guard.h"

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +24,9 @@
 
 #include "mudlet.h"
 
+#include "pre_guard.h"
+#include <QDir>
+#include "post_guard.h"
 
 dlgNotepad::dlgNotepad(Host* pH) : mpHost(pH)
 

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2017 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2015, 2017-2018 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -32,6 +33,7 @@
 #include "TTrigger.h"
 
 #include "pre_guard.h"
+#include <QDesktopServices>
 #include <QFileDialog>
 #include <QInputDialog>
 #include <zip.h>

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -41,6 +41,7 @@
 #include <QColorDialog>
 #include <QFileDialog>
 #include <QFontDialog>
+#include <QNetworkDiskCache>
 #include <QTableWidget>
 #include <QToolBar>
 #include <QUiLoader>

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2017 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Owen Davison - odavison@cs.dal.ca               *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Tom Scheper - scheper@gmail.com                 *
@@ -44,6 +44,7 @@
 #include "pre_guard.h"
 #include <QColorDialog>
 #include <QFileDialog>
+#include <QMessageBox>
 #include <QToolBar>
 #include "post_guard.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 
 #include "pre_guard.h"
 #include <QDesktopWidget>
+#include <QDir>
 #include <QPainter>
 #include <QSplashScreen>
 #include "post_guard.h"

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -53,8 +53,10 @@
 
 #include "pre_guard.h"
 #include <QtUiTools/quiloader.h>
+#include <QDesktopServices>
 #include <QDesktopWidget>
 #include <QFileDialog>
+#include <QMessageBox>
 #include <QScrollBar>
 #include <QTableWidget>
 #include <QToolBar>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
I think there may have been an issue with stale files not being removed from a cache or pre-compiled headers because since https://github.com/Mudlet/Mudlet/pull/1703 I get build fails relating to missing `#include` entries in various `.cpp` files which I think had been masked by stale files in the typical build environment when switching around the git repository - I'm guessing but perhaps the cached build header files are not cleaned out when a different branch is selected so that there are `#include` entries in the cached files that had been taken out of the actual code but not removed from the cached copy so a test build succeeds but a build on a "make clean"ed setup will fail because the cached files are purged...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Motivation for adding to Mudlet
Urgent fix for issue which arose from PR #1703 - to replicate in an existing build setup use the Qt Creator `Clean all` (or possibly run `make clean` in the build directory).  After doing this the `development` branch at commit cb0935b426b52843df657663a11287aff978b280 (which is where that PR was applied to the codebase will fail to build) whereas the immediate parent commit 1ca442ca969954ddf2261b727d0f22428c939216 will build cleanly.

#### Other info (issues closed, discussion etc)
This is urgent as the issue is breaking the development branch and tt is impossible to work on other issues using the current or other points after that PR of the `development` HEAD as a starting point.