### PR TITLE
Show render time only in debug builds

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2090,10 +2090,12 @@ void T2DMap::paintEvent(QPaintEvent* e)
             }
         }
 
+#ifdef DEBUG
         infoText.append(tr("render time: %1S mO: (%2,%3,%4)")
                         .arg(__time.nsecsElapsed() * 1.0e-9, 0, 'f', 3)
                         .arg(QString::number(mOx), QString::number(mOy), QString::number(mOz)));
-
+#endif
+    
         // Left margin for info widget:
         uint infoLeftSideAvoid = 10;
         if (mMultiSelectionListWidget.isVisible()) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2090,7 +2090,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             }
         }
 
-#ifdef DEBUG
+#ifdef QT_DEBUG
         infoText.append(tr("render time: %1S mO: (%2,%3,%4)")
                         .arg(__time.nsecsElapsed() * 1.0e-9, 0, 'f', 3)
                         .arg(QString::number(mOx), QString::number(mOy), QString::number(mOz)));


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Show render time only in debug builds
#### Motivation for adding to Mudlet
It's a very technical detail that is not useful to the usual user (it's not FPS either).
#### Other info (issues closed, discussion etc)
Prompted by discussion on Crowdin.