### PR TITLE
Cast to correct data type to avoid memory corruption

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,7 @@ init:
 - cmd: mkdir C:\src\
 environment:
   matrix:
-  - QT_BASE_DIR: C:\Qt\5.6\mingw49_32
-  - QT_BASE_DIR: C:\Qt\5.9\mingw53_32
+  - QT_BASE_DIR: C:\Qt\5.11\mingw53_32
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"
 - powershell ".\appveyor.install.ps1"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ init:
 environment:
   matrix:
   - QT_BASE_DIR: C:\Qt\5.6\mingw49_32
-#  - QT_BASE_DIR: C:\Qt\5.9\mingw53_32
+  - QT_BASE_DIR: C:\Qt\5.9\mingw53_32
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"
 - powershell ".\appveyor.install.ps1"

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -2,8 +2,8 @@ if ("$Env:APPVEYOR_REPO_NAME" -ne "Mudlet/Mudlet") {
   exit 0
 }
 
-# we deploy only QT 5.6 for windows at the moment
-if ("$Env:QT_BASE_DIR" -eq "C:\Qt\5.6\mingw49_32") {
+# we deploy only QT 5.9 for windows at the moment
+if ("$Env:QT_BASE_DIR" -eq "C:\Qt\5.9\mingw53_32") {
 
   cd "$Env:APPVEYOR_BUILD_FOLDER\src\release"
   windeployqt.exe --release mudlet.exe

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -2,60 +2,56 @@ if ("$Env:APPVEYOR_REPO_NAME" -ne "Mudlet/Mudlet") {
   exit 0
 }
 
-# we deploy only QT 5.9 for windows at the moment
-if ("$Env:QT_BASE_DIR" -eq "C:\Qt\5.9\mingw53_32") {
+cd "$Env:APPVEYOR_BUILD_FOLDER\src\release"
+windeployqt.exe --release mudlet.exe
+. "$Env:APPVEYOR_BUILD_FOLDER\CI\copy-non-qt-win-dependencies.ps1"
 
-  cd "$Env:APPVEYOR_BUILD_FOLDER\src\release"
-  windeployqt.exe --release mudlet.exe
-  . "$Env:APPVEYOR_BUILD_FOLDER\CI\copy-non-qt-win-dependencies.ps1"
-
-  Remove-Item * -include *.cpp, *.o
+Remove-Item * -include *.cpp, *.o
 
 if ("$Env:APPVEYOR_REPO_TAG" -eq "false") {
-    $DEPLOY_URL = "https://ci.appveyor.com/api/buildjobs/$Env:APPVEYOR_JOB_ID/artifacts/src%2Fmudlet.zip"
+  $DEPLOY_URL = "https://ci.appveyor.com/api/buildjobs/$Env:APPVEYOR_JOB_ID/artifacts/src%2Fmudlet.zip"
 } else {
-    git clone https://github.com/Mudlet/installers.git C:\projects\installers
-    cd C:\projects\installers\windows
-    nuget install secure-file -ExcludeVersion
-    nuget install squirrel.windows -ExcludeVersion
+  git clone https://github.com/Mudlet/installers.git C:\projects\installers
+  cd C:\projects\installers\windows
+  nuget install secure-file -ExcludeVersion
+  nuget install squirrel.windows -ExcludeVersion
 
-    # credit to http://markwal.github.io/programming/2015/07/28/squirrel-for-windows.html
-    $SQUIRRELWIN = "C:\projects\squirrel-packaging-prep"
-    $SQUIRRELWINBIN = "$SQUIRRELWIN\lib\net45\"
+  # credit to http://markwal.github.io/programming/2015/07/28/squirrel-for-windows.html
+  $SQUIRRELWIN = "C:\projects\squirrel-packaging-prep"
+  $SQUIRRELWINBIN = "$SQUIRRELWIN\lib\net45\"
 
-    if (-not $(Test-Path "$SQUIRRELWINBIN")) {
-        New-Item "$SQUIRRELWINBIN" -ItemType "directory"
-    }
-
-    # move everything into src\release\squirrel.windows\lib\net45\ as that's where Squirrel would like to see it
-    Move-Item $Env:APPVEYOR_BUILD_FOLDER\src\release\* $SQUIRRELWINBIN
-
-    nuget pack C:\projects\installers\windows\mudlet.nuspec -Version $($Env:VERSION) -BasePath $SQUIRRELWIN -OutputDirectory $SQUIRRELWIN
-    .\squirrel.windows\tools\Squirrel --releasify C:\projects\squirrel-packaging-prep\Mudlet.$($Env:VERSION).nupkg --releaseDir C:\projects\squirreloutput --loadingGif C:\projects\installers\windows\splash-installing-2x.png --no-msi --setupIcon C:\projects\installers\windows\mudlet_main_48px.ico
-    Remove-Item -Recurse -Force $Env:APPVEYOR_BUILD_FOLDER\src\release\*
-    Move-Item C:\projects\squirreloutput\* $Env:APPVEYOR_BUILD_FOLDER\src\release
-
-   <#
-    This is the shell version:
-    # add ssh-key to ssh-agent for deployment
-    # shellcheck disable=2154
-    # the two "undefined" variables are defined by travis
-    openssl aes-256-cbc -K "${encrypted_70dbe4c5e427_key}" -iv "${encrypted_70dbe4c5e427_iv}" -in "${TRAVIS_BUILD_DIR}/CI/mudlet-deploy-key.enc" -out /tmp/mudlet-deploy-key -d
-    eval "$(ssh-agent -s)"
-    chmod 600 /tmp/mudlet-deploy-key
-    ssh-add /tmp/mudlet-deploy-key
-
-    bash make-installer.sh -r "${VERSION}"
-
-    chmod +x "Mudlet.AppImage"
-
-    tar -czvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
-
-    scp -i /tmp/mudlet-deploy-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}-linux-x64.AppImage.tar" "keneanung@mudlet.org:${DEPLOY_PATH}"
-    DEPLOY_URL="http://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
-    fi #>
-
+  if (-not $(Test-Path "$SQUIRRELWINBIN")) {
+      New-Item "$SQUIRRELWINBIN" -ItemType "directory"
   }
+
+  # move everything into src\release\squirrel.windows\lib\net45\ as that's where Squirrel would like to see it
+  Move-Item $Env:APPVEYOR_BUILD_FOLDER\src\release\* $SQUIRRELWINBIN
+
+  nuget pack C:\projects\installers\windows\mudlet.nuspec -Version $($Env:VERSION) -BasePath $SQUIRRELWIN -OutputDirectory $SQUIRRELWIN
+  .\squirrel.windows\tools\Squirrel --releasify C:\projects\squirrel-packaging-prep\Mudlet.$($Env:VERSION).nupkg --releaseDir C:\projects\squirreloutput --loadingGif C:\projects\installers\windows\splash-installing-2x.png --no-msi --setupIcon C:\projects\installers\windows\mudlet_main_48px.ico
+  Remove-Item -Recurse -Force $Env:APPVEYOR_BUILD_FOLDER\src\release\*
+  Move-Item C:\projects\squirreloutput\* $Env:APPVEYOR_BUILD_FOLDER\src\release
+
+ <#
+  This is the shell version:
+  # add ssh-key to ssh-agent for deployment
+  # shellcheck disable=2154
+  # the two "undefined" variables are defined by travis
+  openssl aes-256-cbc -K "${encrypted_70dbe4c5e427_key}" -iv "${encrypted_70dbe4c5e427_iv}" -in "${TRAVIS_BUILD_DIR}/CI/mudlet-deploy-key.enc" -out /tmp/mudlet-deploy-key -d
+  eval "$(ssh-agent -s)"
+  chmod 600 /tmp/mudlet-deploy-key
+  ssh-add /tmp/mudlet-deploy-key
+
+  bash make-installer.sh -r "${VERSION}"
+
+  chmod +x "Mudlet.AppImage"
+
+  tar -czvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
+
+  scp -i /tmp/mudlet-deploy-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "Mudlet-${VERSION}-linux-x64.AppImage.tar" "keneanung@mudlet.org:${DEPLOY_PATH}"
+  DEPLOY_URL="http://www.mudlet.org/wp-content/files/Mudlet-${VERSION}-linux-x64.AppImage.tar"
+  fi #>
+
 }
 
 if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -785,7 +785,7 @@ void cTelnet::processTelnetCommand(const string& command)
 #endif
         //server wants us to enable some option
         option = command[2];
-        auto idxOption = static_cast<int>(option);
+        auto idxOption = static_cast<quint8>(option);
         if (option == static_cast<char>(69) && mpHost->mEnableMSDP) // MSDP support
         {
             qDebug() << "TELNET IAC DO MSDP";


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This fixes a memory corruption on Windows when compiling Mudlet with MinGW 5.3. It might have been a problem on other platforms as well, but it became apparent on Windows with #1176. The memory corruption is triggered in the linked issue by denying the telnet subnegotiation for ATCP. The cast from `char` to `int` lead to a change at a negative index in a bool array which happened to modify the internal state of `zlib` which in turn lead to a segfault or faulty state (which stalled).

#### Motivation for adding to Mudlet
We can switch to an updated Qt version on Windows!

#### Other info (issues closed, discussion etc)
Fixes #1176 