### PR TITLE
BugFix: Correct typo in GeyserMiniConsole.lua attempting to call disableScrollBar

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -197,7 +197,7 @@ function Geyser.MiniConsole:new (cons, container)
   if cons.scrollBar then
     me:enableScrollBar()
   else
-    me:disableScrollbar()
+    me:disableScrollBar()
   end
   if cons.font then
     me:setFont(cons.font)


### PR DESCRIPTION
Originally it was trying to call disableScrollbar instead of disableScrollBar, which naturally caused errors.