### PR TITLE
Process MUD input as it arrives rather than handling all OOB data first.

### DIFF
--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -157,7 +157,8 @@ private:
 
     void processTelnetCommand(const std::string& command);
     void sendTelnetOption(char type, char option);
-    void gotRest(std::string&);
+    void applyGAFix();
+    void gotChunk(std::string&);
     void gotPrompt(std::string&);
     void postData();
     void raiseProtocolEvent(const QString& name, const QString& protocol);


### PR DESCRIPTION
Mudlet's current method of reading input from MUDs is to build a string of in-band (IB) text, parsing and handling all out-of-band (OOB) data as this string is built.  Once complete, the in-band text is processed.  This is robust against OOB data inserted randomly into IB text as all IB text is stitched together and processed whole.

However, it has the side effect of causing all OOB events to be processed before any IB text, creating issues when MUDs use GMCP to mark up IB text with start and end tags, as described in #1745 .  This change instead processes IB and OOB chunks of text as they are received, preserving their ordering.

This was my first look at the codebase and could use a thorough review by someone who better understands A) how input is handled downstream from this code and B) the variety of input from different MUDs.  I tested this in Achaea (which needed the GA fix applied in getPrompt extended to getChunk), but that's it.