### PR TITLE
Fix compilining on Qt 5.11.x when WITH_UPDATER=NO

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -24,6 +24,7 @@
 
 
 #include "Host.h"
+#include <QRegularExpression>
 #include "TConsole.h"
 #include "TSplitter.h"
 #include "TTabBar.h"

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -49,6 +49,7 @@
 #include "pre_guard.h"
 #include <QDesktopServices>
 #include <QFileDialog>
+#include <QRegularExpression>
 #include "post_guard.h"
 
 // Provides the lua zip module for MacOs platform that does not have an easy way

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -31,6 +31,7 @@
 #include "pre_guard.h"
 #include <QString>
 #include <QStringBuilder>
+#include <QRegularExpression>
 #include "post_guard.h"
 
 TRoom::TRoom(TRoomDB* pRDB)

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -27,6 +27,7 @@
 
 #include "pre_guard.h"
 #include <QElapsedTimer>
+#include <QRegularExpression>
 #include "post_guard.h"
 
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -25,6 +25,7 @@
 
 
 #include "Host.h"
+#include <QRegularExpression>
 #include "TConsole.h"
 #include "TDebug.h"
 #include "TMatchState.h"


### PR DESCRIPTION
This is a continuation of #1612 and #1613. After latest changes introduced in Mudlet 3.10.0, WITH_UPDATER=NO makes compilation fail again if Qt is version 5.11.0 (doesn't complain on 5.10.1), and requires including <QRegularExpression> in the header of several more files.
It is most likely not all of them (which should be noted for the future), but it is a good enough fix for now.
Tested on both Qt 5.11.0 and 5.10.1.
Please review, I'm not entirely sure if the placement of said includes is correct.
Thank you. 