### PR TITLE
BugFix: correct missing indent of first line of plain text copy

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1465,6 +1465,9 @@ QString TTextEdit::getSelectedText(char newlineChar)
         if (y == mPA.y()) {
             // start from the column where the selection started
             x = mPA.x();
+            // insert the number of spaces to push the first line to the right
+            // so it lines up with the following lines
+            text.append(QStringLiteral(" ").repeated(x));
         }
         // while we are not at the end of the buffer line
         while (x < static_cast<int>(mpBuffer->buffer[y].size())) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Copying a block of text in a console where the selection does not include the *whole* of the first line causes the pasted first line content to be shifted over to the left margin.  In most situations that I can think of where only a part of the first line is copied then it makes sense to retain the layout relative to the remainder.

#### Motivation for adding to Mudlet
The padded out of a partial first line in a context menu invoked copy of text in a console was already being done for the HTML case but it was missing from the plain text form.

#### Other info (issues closed, discussion etc)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>