### PR TITLE
BugFix: ensure logging settings are saved with profile

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -360,6 +360,9 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     // future - phpBB code might be useful if it can be done.
     host.append_attribute("mRawStreamDump") = pHost->mIsNextLogFileInHtmlFormat ? "yes" : "no";
     host.append_attribute("mIsLoggingTimestamps") = pHost->mIsLoggingTimestamps ? "yes" : "no";
+    host.append_attribute("logDirectory") = pHost->mLogDir.toUtf8().constData();
+    host.append_attribute("logFileName") = pHost->mLogFileName.toUtf8().constData();
+    host.append_attribute("logFileNameFormat") = pHost->mLogFileNameFormat.toUtf8().constData();
     host.append_attribute("mAlertOnNewData") = pHost->mAlertOnNewData ? "yes" : "no";
     host.append_attribute("mFORCE_NO_COMPRESSION") = pHost->mFORCE_NO_COMPRESSION ? "yes" : "no";
     host.append_attribute("mFORCE_GA_OFF") = pHost->mFORCE_GA_OFF ? "yes" : "no";

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -789,9 +789,9 @@ void XMLimport::readHostPackage(Host* pHost)
     }
     pHost->mIsNextLogFileInHtmlFormat = (attributes().value("mRawStreamDump") == "yes");
     pHost->mIsLoggingTimestamps = (attributes().value("mIsLoggingTimestamps") == "yes");
-    pHost->mLogDir = attributes().value("mLogDir").toString();
-    pHost->mLogFileName = attributes().value("mLogFileName").toString();
-    pHost->mLogFileNameFormat = attributes().value("mLogFileNameFormat").toString();
+    pHost->mLogDir = attributes().value("logDirectory").toString();
+    pHost->mLogFileName = attributes().value("logFileName").toString();
+    pHost->mLogFileNameFormat = attributes().value("logFileNameFormat").toString();
     pHost->mAlertOnNewData = (attributes().value("mAlertOnNewData") == "yes");
     pHost->mFORCE_NO_COMPRESSION = (attributes().value("mFORCE_NO_COMPRESSION") == "yes");
     pHost->mFORCE_GA_OFF = (attributes().value("mFORCE_GA_OFF") == "yes");


### PR DESCRIPTION
It seems a clash in including two PRs lost the bit of code that was in one of them to save the settings, because the saving code was revised by the other.

This should close issue #1765 ...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>