### PR TITLE
Allow creating new maps in the map

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3880,7 +3880,7 @@ void T2DMap::slot_loadMap() {
                            tr("Load Mudlet map"),
                            mudlet::getMudletPath(mudlet::profileMapsPath, mpHost->getName()),
                            tr("Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)",
-                              "Do not change extensions (in braces) they are used programmatically!"));
+                              "Do not change extensions (in braces) as they are used programmatically"));
     if (fileName.isEmpty()) {
         return;
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2671,9 +2671,10 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             auto pArea = mpMap->mpRoomDB->getArea(mAID);
 
             if (!playerRoom || !pArea) {
-                auto createMap = new QAction("create new map", this);
+                auto createMap = new QAction(tr("create new map"), this);
+                connect(createMap, &QAction::triggered, this, &T2DMap::slot_newMap);
 
-                auto loadMap = new QAction("load map", this);
+                auto loadMap = new QAction(tr("load map"), this);
                 connect(loadMap, &QAction::triggered, this, &T2DMap::slot_loadMap);
 
                 mPopupMenu = true;
@@ -3888,6 +3889,37 @@ void T2DMap::slot_loadMap() {
         mpHost->mpConsole->importMap(fileName);
     } else {
         mpHost->mpConsole->loadMap(fileName);
+    }
+}
+
+void T2DMap::slot_newMap()
+{
+    if (!mpHost) {
+        return;
+    }
+
+    auto roomID = mpHost->mpMap->createNewRoomID();
+
+    if (!mpHost->mpMap->addRoom(roomID)) {
+        return;
+    }
+
+    mpHost->mpMap->setRoomArea(roomID, -1, false);
+    mpHost->mpMap->setRoomCoordinates(roomID, 0, 0, 0);
+    mpHost->mpMap->mMapGraphNeedsUpdate = true;
+
+    auto room = mpHost->mpMap->mpRoomDB->getRoom(roomID);
+    mpHost->mpMap->mRoomIdHash[mpHost->getName()] = roomID;
+    mpHost->mpMap->mNewMove = true;
+    if (mpHost->mpMap->mpM) {
+        mpHost->mpMap->mpM->update();
+    }
+
+    if (mpHost->mpMap->mpMapper->mp2dMap) {
+        mpHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = true;
+        mpHost->mpMap->mpMapper->mp2dMap->update();
+        mpHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = false;
+        mpHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
     }
 }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -197,6 +197,7 @@ public slots:
     void slot_customLineAddPoint();
     void slot_customLineRemovePoint();
     void slot_cancelCustomLineDialog();
+    void slot_loadMap();
 
 private:
     void resizeMultiSelectionWidget();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -198,6 +198,7 @@ public slots:
     void slot_customLineRemovePoint();
     void slot_cancelCustomLineDialog();
     void slot_loadMap();
+    void slot_newMap();
 
 private:
     void resizeMultiSelectionWidget();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1485,7 +1485,7 @@ void dlgProfilePreferences::loadMap()
                            tr("Load Mudlet map"),
                            mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()),
                            tr("Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)",
-                              "Do not change extensions (in braces) they are used programmatically!"));
+                              "Do not change extensions (in braces) as they are used programmatically"));
     if (fileName.isEmpty()) {
         return;
     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add a right-click menu that allows creation of a new map or loading of an existing one should the user have no maps available in the profile.

![peek 2018-06-17 19-57](https://user-images.githubusercontent.com/110988/41510646-aae3549e-7268-11e8-8194-63f7b886cc4f.gif)

#### Motivation for adding to Mudlet
Make the mapper a little more usable for those without a mapping script.
#### Other info (issues closed, discussion etc)
