### PR TITLE
Update strings to translate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
   - secure: VFI3UCiDrp47WTcUhsatdQvvWg+3gk00eBMZgSOXXKY5+hk+NOX7bOFcIM5t9nlZDbpHDr10SFTuUOw+PeWmLpFO06Zrjg86M9jm9WS4i8Cs9hfxoT6H4isXlR1vubX2LmNlHyzg8WtdNanlsufgecyaGksJxr7tVhG/cWyD6yo=
   - secure: XxdhHVraWpXpWo4tluD7NwJtqQT1b6LKoxX6QWKzR0fvcKgqBy2jlXMu0KVtTYtVI7M1wFdjtwSixK1UGFZyDgEYYUnDTufq7E81TWJSQ5ZhxNRaDAyO2vkLNFpH7LkwVrV/fWCPKE9t3/WiowwQnXesm9MMxAzbd2mIaeyiccY=
   - secure: mi62VU0KxOahOaYulrqDiow3SscJPug842vhnuXzfjJ5AJU5V5gAcvECL85gQIPx5W3dXoNJnHdBUi9jOhnE3tuTML67oiieoVEmZfFF2pXtnHsdFlvzFtcGcmT+cVGF7GVyItlVLa5LcLJw6SNd3C3Dhib/Lu1cb/NdsFn0sZc=
+  - secure: CaZAZW5shaYve0gauA0rdRn/Bxdf5itfAFb7FuaOHmk999AQ/aB013huCcdeeBDhon2CxQ3BRLTkRzHR00DBA7rPgR1Y/4/kHa71xisUY7CqDlHYktQI69CpqGot2Bb1eE2Rs7ZQcYKhfMbMJacE6zNBZwUq0I0OWI1Ux3PKkJs=
 git:
   submodules: false # We selectively pull in the wanted submodules ourselves now
 matrix:

--- a/CI/travis.compile.sh
+++ b/CI/travis.compile.sh
@@ -28,6 +28,7 @@ fi
 echo "Compiling using ${PROCS} cores."
 if [ "${Q_OR_C_MAKE}" = "qmake" ]; then
   qmake ${SPEC} ../src/mudlet.pro
+  lupdate -verbose -recursive ../src -ts ../translations/mudlet.ts
 else
   cmake ..
 fi

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -6,6 +6,12 @@ set -e
 if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "gcc" ]; then
 
   if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    if $(git diff --name-only | grep -q "mudlet.ts"); then
+      git config user.name "mudlet-machine-account"
+      git config user.email "39947211+mudlet-machine-account@users.noreply.github.com"
+      git commit -m "Update strings to translate [skip ci]" translations/mudlet.ts
+      git push "https://${MUDLET_MACHINE_ACCOUNT_API_KEY}@github.com/Mudlet/Mudlet.git" development
+    fi
     # instead of deployment, we upload to coverity for cron jobs
     cd build
     tar czf Mudlet.tgz cov-int


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This will try to update the strings to translate (`translations/mudlet.ts`) on a daily basis with the already existing cron job.

#### Motivation for adding to Mudlet
Automating the update of translation strings to get forward with our Mudlet 4.0 goals.

#### Other info (issues closed, discussion etc)
This is pretty hard to test, sadly. The machine account needs to bypass the branch protection of `development` as it can't simply update a different branch from travis. That's also why I chose the cron job to run the `lupdate`.