### PR TITLE
Add expiring temp triggers

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11679,6 +11679,58 @@ bool TLuaInterpreter::call_luafunction(void* pT)
 }
 
 // No documentation available in wiki - internal function
+std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
+{
+    lua_State* L = pGlobalLua;
+    lua_pushlightuserdata(L, pT);
+    lua_gettable(L, LUA_REGISTRYINDEX);
+    bool returnValue = false;
+
+    if (lua_isfunction(L, -1)) {
+        int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+        if (error != 0) {
+            int nbpossible_errors = lua_gettop(L);
+            for (int i = 1; i <= nbpossible_errors; i++) {
+                string e = "";
+                if (lua_isstring(L, i)) {
+                    e = "Lua error:";
+                    e += lua_tostring(L, i);
+                    QString _n = "error in anonymous Lua function";
+                    QString _n2 = "no debug data available";
+                    logError(e, _n, _n2);
+                    if (mudlet::debugMode) {
+                        TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running anonymous Lua function ERROR:" << e.c_str() >> 0;
+                    }
+                }
+            }
+        } else {
+            auto index = lua_gettop(L);
+            if (lua_isboolean(L, index)) {
+                returnValue = lua_toboolean(L, index);
+            }
+
+            if (mudlet::debugMode) {
+                TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK anonymous Lua function ran without errors\n" >> 0;
+            }
+        }
+        lua_pop(L, lua_gettop(L));
+        //lua_settop(L, 0);
+        if (error == 0) {
+            return make_pair(true, returnValue);
+        } else {
+            return make_pair(true, returnValue);
+        }
+    } else {
+        QString _n = "error in anonymous Lua function";
+        QString _n2 = "func reference not found by Lua, func can not be called";
+        string e = "Lua error:";
+        logError(e, _n, _n2);
+    }
+
+    return make_pair(false, false);
+}
+
+// No documentation available in wiki - internal function
 bool TLuaInterpreter::call(const QString& function, const QString& mName)
 {
     lua_State* L = pGlobalLua;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5703,7 +5703,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     int triggerID;
-    int expiryCount = -1;
+    int expirationCount = -1;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempExactMatchTrigger: bad argument #1 type (exact match pattern as string expected, got %s!)", luaL_typename(L, 1));
@@ -5712,19 +5712,19 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     QString exactMatchPattern = QString::fromUtf8(lua_tostring(L, 1));
 
     if (lua_isnumber(L, 3)) {
-        expiryCount = lua_tonumber(L, 3);
+        expirationCount = lua_tonumber(L, 3);
 
-        if (expiryCount < 1) {
+        if (expirationCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempExactMatchTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempExactMatchTrigger: bad argument #3 value (trigger expiration count must be greater than zero, got %d)", expirationCount);
             return 2;
         }
     }
 
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
+        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString::fromUtf8(lua_tostring(L, 2)), expirationCount);
     } else if (lua_isfunction(L, 2)) {
-        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString(), expiryCount);
+        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString(), expirationCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -5759,7 +5759,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
 
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #3 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -5803,7 +5803,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
         expiryCount = lua_tonumber(L, 3);
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempTrigger: bad argument #3 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -5840,7 +5840,7 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
 
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempPromptTrigger: bad argument #2 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempPromptTrigger: bad argument #2 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -5890,7 +5890,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
 
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempColorTrigger: bad argument #4 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempColorTrigger: bad argument #4 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -5938,7 +5938,7 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempLineTrigger: bad argument #4 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempLineTrigger: bad argument #4 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -6050,7 +6050,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #14 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #14 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -6303,7 +6303,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 
         if (expiryCount < 1) {
             lua_pushnil(L);
-            lua_pushfstring(L, "tempRegexTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            lua_pushfstring(L, "tempRegexTrigger: bad argument #3 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
             return 2;
         }
     }
@@ -11732,7 +11732,7 @@ bool TLuaInterpreter::call_luafunction(void* pT)
         }
     } else {
         QString _n = "error in anonymous Lua function";
-        QString _n2 = "func reference not found by Lua, func can not be called";
+        QString _n2 = "func reference not found by Lua, func cannot be called";
         string e = "Lua error:";
         logError(e, _n, _n2);
     }
@@ -11791,7 +11791,7 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
         }
     } else {
         QString _n = "error in anonymous Lua function";
-        QString _n2 = "func reference not found by Lua, func can not be called";
+        QString _n2 = "func reference not found by Lua, func cannot be called";
         string e = "Lua error:";
         logError(e, _n, _n2);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11741,9 +11741,16 @@ bool TLuaInterpreter::call_luafunction(void* pT)
 }
 
 // No documentation available in wiki - internal function
+// returns true if function ran without errors
+// as well as the boolean return value from the function
 std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
 {
     lua_State* L = pGlobalLua;
+    if (!L) {
+        qDebug() << "LUA CRITICAL ERROR: no suitable Lua execution unit found.";
+        return make_pair(false, false);
+    }
+
     lua_pushlightuserdata(L, pT);
     lua_gettable(L, LUA_REGISTRYINDEX);
     bool returnValue = false;
@@ -11780,7 +11787,7 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
         if (error == 0) {
             return make_pair(true, returnValue);
         } else {
-            return make_pair(true, returnValue);
+            return make_pair(false, returnValue);
         }
     } else {
         QString _n = "error in anonymous Lua function";
@@ -11816,7 +11823,6 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName)
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    lua_getfield(L, LUA_GLOBALSINDEX, function.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error != 0) {
         int nbpossible_errors = lua_gettop(L);
@@ -11869,7 +11875,6 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    lua_getfield(L, LUA_GLOBALSINDEX, function.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error != 0) {
         int nbpossible_errors = lua_gettop(L);
@@ -12005,7 +12010,6 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    lua_getfield(L, LUA_GLOBALSINDEX, function.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error != 0) {
         int nbpossible_errors = lua_gettop(L);
@@ -12062,7 +12066,6 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
     }
 
     lua_getglobal(L, function.toUtf8().constData());
-    lua_getfield(L, LUA_GLOBALSINDEX, function.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error != 0) {
         int nbpossible_errors = lua_gettop(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5702,6 +5702,8 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+    int triggerID;
+    int expiryCount = -1;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempExactMatchTrigger: bad argument #1 type (exact match pattern as string expected, got %s!)", luaL_typename(L, 1));
@@ -5709,11 +5711,20 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     }
     QString exactMatchPattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    int triggerID;
+    if (lua_isnumber(L, 3)) {
+        expiryCount = lua_tonumber(L, 3);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempExactMatchTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
+    }
+
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString::fromUtf8(lua_tostring(L, 2)));
+        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
     } else if (lua_isfunction(L, 2)) {
-        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString());
+        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -5734,6 +5745,8 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+    int triggerID;
+    int expiryCount = -1;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #1 type (pattern as string expected, got %s!)", luaL_typename(L, 1));
@@ -5741,11 +5754,20 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
     }
     QString pattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    int triggerID;
+        if (lua_isnumber(L, 3)) {
+        expiryCount = lua_tonumber(L, 3);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
+    }
+
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString::fromUtf8(lua_tostring(L, 2)));
+        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
     } else if (lua_isfunction(L, 2)) {
-        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString());
+        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -6267,6 +6289,8 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
+    int triggerID;
+    int expiryCount = -1;
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempRegexTrigger: bad argument #1 type (regex pattern as string expected, got %s!)", luaL_typename(L, 1));
@@ -6274,11 +6298,20 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
     }
     QString regexPattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    int triggerID;
+    if (lua_isnumber(L, 3)) {
+        expiryCount = lua_tonumber(L, 3);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempRegexTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
+    }
+
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString::fromUtf8(lua_tostring(L, 2)));
+        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
     } else if (lua_isfunction(L, 2)) {
-        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString());
+        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5779,6 +5779,11 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempTrigger: bad argument #3 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
     }
 
     if (lua_isstring(L, 2)) {
@@ -5810,6 +5815,12 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
 
     if (lua_isnumber(L, 2)) {
         expiryCount = lua_tonumber(L, 2);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempPromptTrigger: bad argument #2 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
     }
 
     if (lua_isstring(L, 1)) {
@@ -5854,6 +5865,12 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
 
     if (lua_isnumber(L, 4)) {
         expiryCount = lua_tonumber(L, 4);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempColorTrigger: bad argument #4 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
     }
 
     if (lua_isstring(L, 3)) {
@@ -5896,6 +5913,12 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
 
     if (lua_isnumber(L, 4)) {
         expiryCount = lua_tonumber(L, 4);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempLineTrigger: bad argument #4 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
     }
 
     if (lua_isstring(L, 3)) {
@@ -6002,6 +6025,12 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 
     if (lua_isnumber(L, 14)) {
         expiryCount = lua_tonumber(L, 14);
+
+        if (expiryCount < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #14 value (trigger expiry count must be greater than zero, got %d)", expiryCount);
+            return 2;
+        }
     }
 
     QString pattern = QString::fromUtf8(lua_tostring(L, 2));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5768,17 +5768,23 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
     QString substringPattern;
+    int triggerID;
+    int expiryCount = -1;
+
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "tempTrigger: bad argument #1 type (substring pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
     substringPattern = QString::fromUtf8(lua_tostring(L, 1));
 
-    int triggerID;
+    if (lua_isnumber(L, 3)) {
+        expiryCount = lua_tonumber(L, 3);
+    }
+
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString::fromUtf8(lua_tostring(L, 2)));
+        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
     } else if (lua_isfunction(L, 2)) {
-        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString());
+        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -12973,7 +12979,7 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& function)
+int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT;
     QStringList sList;
@@ -12988,6 +12994,7 @@ int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& funct
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5806,10 +5806,16 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
     int triggerID;
+    int expiryCount = -1;
+
+    if (lua_isnumber(L, 2)) {
+        expiryCount = lua_tonumber(L, 2);
+    }
+
     if (lua_isstring(L, 1)) {
-        triggerID = pLuaInterpreter->startTempPromptTrigger(QString::fromUtf8(lua_tostring(L, 1)));
+        triggerID = pLuaInterpreter->startTempPromptTrigger(QString::fromUtf8(lua_tostring(L, 1)), expiryCount);
     } else if (lua_isfunction(L, 1)) {
-        triggerID = pLuaInterpreter->startTempPromptTrigger(QString());
+        triggerID = pLuaInterpreter->startTempPromptTrigger(QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -5843,11 +5849,17 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
     }
     int backgroundColor = lua_tointeger(L, 2);
 
-    int triggerID;
+    int triggerID;    
+    int expiryCount = -1;
+
+    if (lua_isnumber(L, 4)) {
+        expiryCount = lua_tonumber(L, 4);
+    }
+
     if (lua_isstring(L, 3)) {
-        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString::fromUtf8(lua_tostring(L, 3)));
+        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString::fromUtf8(lua_tostring(L, 3)), expiryCount);
     } else if (lua_isfunction(L, 3)) {
-        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString());
+        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -5880,10 +5892,16 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
     int from = lua_tointeger(L, 1);
     int howMany = lua_tointeger(L, 2);
     int triggerID;
+    int expiryCount = -1;
+
+    if (lua_isnumber(L, 4)) {
+        expiryCount = lua_tonumber(L, 4);
+    }
+
     if (lua_isstring(L, 3)) {
-        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString::fromUtf8(lua_tostring(L, 3)));
+        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString::fromUtf8(lua_tostring(L, 3)), expiryCount);
     } else if (lua_isfunction(L, 3)) {
-        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString());
+        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString(), expiryCount);
 
         auto trigger = host.getTriggerUnit()->getTrigger(triggerID);
         trigger->mRegisteredAnonymousLuaFunction = true;
@@ -5980,6 +5998,12 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     int fireLength = lua_tonumber(L, 12);
     int lineDelta = lua_tonumber(L, 13);
 
+    int expiryCount = -1;
+
+    if (lua_isnumber(L, 14)) {
+        expiryCount = lua_tonumber(L, 14);
+    }
+
     QString pattern = QString::fromUtf8(lua_tostring(L, 2));
     QStringList regexList;
     QList<int> propertyList;
@@ -6011,6 +6035,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         pT->setSound(soundFile);
     }
     pT->setIsColorizerTrigger(highlight); //highlight
+    pT->setExpiryCount(expiryCount);
     if (highlight) {
         pT->setFgColor(hlFgColor);
         pT->setBgColor(hlBgColor);
@@ -12941,7 +12966,7 @@ int TLuaInterpreter::startTempKey(int& modifier, int& keycode, QString& function
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QString& function)
+int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT;
     QStringList sList;
@@ -12956,11 +12981,12 @@ int TLuaInterpreter::startTempExactMatchTrigger(const QString& regex, const QStr
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QString& function)
+int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT;
     QStringList sList;
@@ -12975,6 +13001,7 @@ int TLuaInterpreter::startTempBeginOfLineTrigger(const QString& regex, const QSt
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 
@@ -12999,7 +13026,7 @@ int TLuaInterpreter::startTempTrigger(const QString& regex, const QString& funct
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempPromptTrigger(const QString& function)
+int TLuaInterpreter::startTempPromptTrigger(const QString& function, int expiryCount)
 {
     TTrigger* pT;
     QStringList sList = {QString()};
@@ -13012,11 +13039,12 @@ int TLuaInterpreter::startTempPromptTrigger(const QString& function)
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempLineTrigger(int from, int howmany, const QString& function)
+int TLuaInterpreter::startTempLineTrigger(int from, int howmany, const QString& function, int expiryCount)
 {
     TTrigger* pT;
     //    QStringList sList;
@@ -13034,11 +13062,12 @@ int TLuaInterpreter::startTempLineTrigger(int from, int howmany, const QString& 
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& function)
+int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& function, int expiryCount)
 {
     TTrigger* pT;
     //    QStringList sList;
@@ -13055,11 +13084,12 @@ int TLuaInterpreter::startTempColorTrigger(int fg, int bg, const QString& functi
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& function)
+int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& function, int expiryCount)
 {
     TTrigger* pT;
     QStringList sList;
@@ -13075,6 +13105,7 @@ int TLuaInterpreter::startTempRegexTrigger(const QString& regex, const QString& 
     pT->setScript(function);
     int id = pT->getID();
     pT->setName(QString::number(id));
+    pT->setExpiryCount(expiryCount);
     return id;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -81,7 +81,8 @@ public:
     bool callMulti(const QString& function, const QString& mName);
     std::pair<bool, bool> callMultiReturnBool(const QString& function, const QString& mName);
     bool callConditionFunction(std::string& function, const QString& mName);
-    bool call_luafunction(void*);
+    bool call_luafunction(void* pT);
+    std::pair<bool, bool> callLuaFunctionReturnBool(void* pT);
     double condenseMapLoad();
     bool compile(const QString& code, QString& error, const QString& name);
     bool compileScript(const QString&);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -106,7 +106,7 @@ public:
     int startTempTimer(double, const QString&);
     int startTempAlias(const QString&, const QString&);
     int startTempKey(int&, int&, QString&);
-    int startTempTrigger(const QString&, const QString&);
+    int startTempTrigger(const QString& regex, const QString& function, int expiryCount = -1);
     int startTempBeginOfLineTrigger(const QString&, const QString&);
     int startTempExactMatchTrigger(const QString&, const QString&);
     int startTempLineTrigger(int, int, const QString&);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -107,12 +107,12 @@ public:
     int startTempAlias(const QString&, const QString&);
     int startTempKey(int&, int&, QString&);
     int startTempTrigger(const QString& regex, const QString& function, int expiryCount = -1);
-    int startTempBeginOfLineTrigger(const QString&, const QString&);
-    int startTempExactMatchTrigger(const QString&, const QString&);
-    int startTempLineTrigger(int, int, const QString&);
-    int startTempRegexTrigger(const QString&, const QString&);
-    int startTempColorTrigger(int, int, const QString&);
-    int startTempPromptTrigger(const QString& function);
+    int startTempBeginOfLineTrigger(const QString&, const QString&, int expiryCount = -1);
+    int startTempExactMatchTrigger(const QString&, const QString&, int expiryCount = -1);
+    int startTempLineTrigger(int, int, const QString&, int expiryCount = -1);
+    int startTempRegexTrigger(const QString&, const QString&, int expiryCount = -1);
+    int startTempColorTrigger(int, int, const QString&, int expiryCount = -1);
+    int startTempPromptTrigger(const QString& function, int expiryCount = -1);
     int startPermRegexTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
     int startPermSubstringTrigger(const QString& name, const QString& parent, const QStringList& regex, const QString& function);
     int startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -77,7 +77,9 @@ public:
     void initLuaGlobals();
     void initIndenterGlobals();
     bool call(const QString& function, const QString& mName);
+    std::pair<bool, bool> callReturnBool(const QString& function, const QString& mName);
     bool callMulti(const QString& function, const QString& mName);
+    std::pair<bool, bool> callMultiReturnBool(const QString& function, const QString& mName);
     bool callConditionFunction(std::string& function, const QString& mName);
     bool call_luafunction(void*);
     double condenseMapLoad();

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1010,7 +1010,7 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
                     TDebug(QColor(Qt::yellow), QColor(Qt::darkMagenta)) << tr("Trigger name=%1 expired.\n").arg(mName) >> 0;
                 }
             } else if (mudlet::debugMode) {
-                    TDebug(QColor(Qt::yellow), QColor(Qt::darkMagenta)) << tr("Trigger name=%1 has %n match(es) left.\n", "", mExpiryCount).arg(mName) >> 0;
+                    TDebug(QColor(Qt::yellow), QColor(Qt::darkMagenta)) << tr("Trigger name=%1 will fire %n more time(s).\n", "", mExpiryCount).arg(mName) >> 0;
             }
         }
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1350,7 +1350,16 @@ void TTrigger::execute()
     }
 
     if (mRegisteredAnonymousLuaFunction) {
-        mpLua->call_luafunction(this);
+        if (Q_LIKELY(mExpiryCount <= 0)) {
+            mpLua->call_luafunction(this);
+        } else {
+            // if the trigger is a temporary expiring one,
+            // don't expire if it returned true
+            auto result = mpLua->callLuaFunctionReturnBool(this);
+            if (result.second) {
+                mExpiryCount++;
+            }
+        }
         return;
     }
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1004,11 +1004,11 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
             mExpiryCount--;
 
             if (mExpiryCount == 0) {
-                if (mudlet::debugMode) {
-                    TDebug(QColor(Qt::yellow), QColor(Qt::darkMagenta)) << "trigger name=" << mName << " expired.\n" >> 0;
-                }
-
                 mpHost->getTriggerUnit()->markCleanup(this);
+
+                if (mudlet::debugMode) {
+                    TDebug(QColor(Qt::yellow), QColor(Qt::darkMagenta)) << tr("trigger name=%1 expired.\n").arg(mName) >> 0;
+                }
             } else if (mudlet::debugMode) {
                     TDebug(QColor(Qt::yellow), QColor(Qt::darkMagenta)) << tr("trigger name=%1 has %n match(es) left.\n", "", mExpiryCount).arg(mName) >> 0;
             }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1356,7 +1356,8 @@ void TTrigger::execute()
             // if the trigger is a temporary expiring one,
             // don't expire if it returned true
             auto result = mpLua->callLuaFunctionReturnBool(this);
-            if (result.second) {
+            // if the function ran okay and returned true, it wants to extend the expiry count
+            if (result.first && result.second) {
                 mExpiryCount++;
             }
         }

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -149,6 +149,9 @@ public:
     // or a function
     bool mRegisteredAnonymousLuaFunction;
 
+    int getExpiryCount() const;
+    void setExpiryCount(int expiryCount);
+
 private:
     TTrigger() = default;
 
@@ -181,6 +184,8 @@ private:
     QColor mBgColor;
     bool mIsColorizerTrigger;
     bool mModuleMember;
+    // -1: don't self-destruct, 0: delete, 1+: number of times it can still match
+    int mExpiryCount;
 };
 
 #endif // MUDLET_TTRIGGER_H

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -184,7 +184,7 @@ private:
     QColor mBgColor;
     bool mIsColorizerTrigger;
     bool mModuleMember;
-    // -1: don't self-destruct, 0: delete, 1+: number of times it can still match
+    // -1: don't self-destruct, 0: delete, 1+: number of times it can still fire
     int mExpiryCount;
 };
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Allows self-expiring temporary triggers. Adds an `expireAfter` argument to all of the functions:

```lua
tempTrigger(substring, code, expireAfter)
tempBeginOfLineTrigger(part of line, code, expireAfter)
tempColorTrigger(foregroundColor, backgroundColor, code, expireAfter)
tempComplexRegexTrigger(name, regex, code, multiline, foreground color, bg color, filter, match all, highlight foreground color, highlight background color, play sound file, fire length, line delta, expireAfter)
tempExactMatchTrigger(exact line, code, expireAfter)
tempLineTrigger(from, howMany, code, expireAfter)
tempPromptTrigger(code, expireAfter)
tempRegexTrigger(regex, code, expireAfter)
tempTrigger(substring, code, expireAfter)
```

Sample use:

```lua
-- expire after 1 prompt match
tempPromptTrigger([[echo("hey! got a prompt!\n")]], 1)

-- expire after 3 exact line matches
tempExactMatchTrigger("You see an exit west.", function() print("Got a west exit.") end, 3)
```

It also allows you to extend the lifetime of a trigger by returning true from it:

```lua
-- expire after 1 prompt match
tempPromptTrigger(function()
  echo("hey! got a prompt!\n")

  if not should_expire then
    return true
  end
end, 1)
```

#### Motivation for adding to Mudlet
Implement https://github.com/Mudlet/Mudlet/issues/476, a feature request from 2013.
#### Other info (issues closed, discussion etc)
I'm not sure if the `TLuaInterpreter::callReturnBool` copy/paste and the like is the best design to go about this.