### PR TITLE
BugFix: allow compilation for Windows builds without updater

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,6 @@ init:
 environment:
   matrix:
   - QT_BASE_DIR: C:\Qt\5.11\mingw53_32
-  - QT_BASE_DIR: C:\Qt\5.11\mingw53_32
-    WITH_UPDATER: "NO"
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"
 - powershell ".\appveyor.install.ps1"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,8 @@ init:
 environment:
   matrix:
   - QT_BASE_DIR: C:\Qt\5.11\mingw53_32
+  - QT_BASE_DIR: C:\Qt\5.11\mingw53_32
+    WITH_UPDATER: "NO"
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"
 - powershell ".\appveyor.install.ps1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ matrix:
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
+
+  - os: osx
+    osx_image: xcode8
+    compiler: clang
+    env:
     - Q_OR_C_MAKE=qmake
       WITH_UPDATER=NO
 
@@ -62,6 +67,11 @@ matrix:
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake
+
+  - os: osx
+    osx_image: xcode8
+    compiler: clang
+    env:
     - Q_OR_C_MAKE=cmake
       WITH_UPDATER=NO
 
@@ -70,6 +80,19 @@ matrix:
     env:
     - Q_OR_C_MAKE=qmake
       QT_VERSION=59
+    addons:
+      apt:
+        sources: *add-sources
+        packages: &qt59-packages
+        - *common-packages
+        - qt59base
+        - qt59multimedia
+        - qt59tools
+        - qt59gamepad
+
+  - os: linux
+    compiler: gcc
+    env:
     - Q_OR_C_MAKE=qmake
       QT_VERSION=59
       WITH_UPDATER=NO
@@ -82,11 +105,21 @@ matrix:
         - qt59multimedia
         - qt59tools
         - qt59gamepad
+
   - os: linux
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=59
+    addons:
+      apt:
+        sources: *add-sources
+        packages:
+        - *qt59-packages
+
+  - os: linux
+    compiler: gcc
+    env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=59
       WITH_UPDATER=NO
@@ -95,11 +128,21 @@ matrix:
         sources: *add-sources
         packages:
         - *qt59-packages
+
   - os: linux
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
       QT_VERSION=59
+    addons:
+      apt:
+        sources: *add-sources
+        packages:
+        - *qt59-packages
+
+  - os: linux
+    compiler: clang
+    env:
     - Q_OR_C_MAKE=qmake
       QT_VERSION=59
       WITH_UPDATER=NO
@@ -108,11 +151,21 @@ matrix:
         sources: *add-sources
         packages:
         - *qt59-packages
+
   - os: linux
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=59
+    addons:
+      apt:
+        sources: *add-sources
+        packages:
+        - *qt59-packages
+
+  - os: linux
+    compiler: clang
+    env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=59
       WITH_UPDATER=NO
@@ -121,11 +174,24 @@ matrix:
         sources: *add-sources
         packages:
         - *qt59-packages
+
   - os: linux
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
+    addons:
+      apt:
+        sources: *add-sources
+        packages: &qt56-packages
+        - *common-packages
+        - qt56base
+        - qt56multimedia
+        - qt56tools
+
+  - os: linux
+    compiler: gcc
+    env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=56
       WITH_UPDATER=NO # actually Qt 5.6, used to check minimum supported Qt works
@@ -137,6 +203,7 @@ matrix:
         - qt56base
         - qt56multimedia
         - qt56tools
+
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-; fi
   # add to the path here to pick up things as soon as its installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,17 +54,25 @@ matrix:
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
+    - Q_OR_C_MAKE=qmake
+      WITH_UPDATER=NO
+
   - os: osx
     osx_image: xcode8
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake
+    - Q_OR_C_MAKE=cmake
+      WITH_UPDATER=NO
 
   - os: linux
     compiler: gcc
     env:
     - Q_OR_C_MAKE=qmake
-    - QT_VERSION=59
+      QT_VERSION=59
+    - Q_OR_C_MAKE=qmake
+      QT_VERSION=59
+      WITH_UPDATER=NO
     addons:
       apt:
         sources: *add-sources
@@ -78,7 +86,10 @@ matrix:
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
-    - QT_VERSION=59
+      QT_VERSION=59
+    - Q_OR_C_MAKE=cmake
+      QT_VERSION=59
+      WITH_UPDATER=NO
     addons:
       apt:
         sources: *add-sources
@@ -88,7 +99,10 @@ matrix:
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
-    - QT_VERSION=59
+      QT_VERSION=59
+    - Q_OR_C_MAKE=qmake
+      QT_VERSION=59
+      WITH_UPDATER=NO
     addons:
       apt:
         sources: *add-sources
@@ -98,7 +112,10 @@ matrix:
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake
-    - QT_VERSION=59
+      QT_VERSION=59
+    - Q_OR_C_MAKE=cmake
+      QT_VERSION=59
+      WITH_UPDATER=NO
     addons:
       apt:
         sources: *add-sources
@@ -108,7 +125,10 @@ matrix:
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
-    - QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
+      QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
+    - Q_OR_C_MAKE=cmake
+      QT_VERSION=56
+      WITH_UPDATER=NO # actually Qt 5.6, used to check minimum supported Qt works
     addons:
       apt:
         sources: *add-sources

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,6 @@ addons:
     - lua-sql-sqlite3
     - libpugixml-dev
 env:
-#  matrix:
-#  - Q_OR_C_MAKE=cmake
-#    QT_VERSION=59
-#    WITH_FONTS=NO # actually Qt 5.9, non-default without fonts
-#  - Q_OR_C_MAKE=qmake
-#    QT_VERSION=59
-#    WITH_FONTS=NO # actually Qt 5.9, non-default without fonts
-#  - Q_OR_C_MAKE=cmake
-#    QT_VERSION=59
-#    WITH_UPDATER=NO # actually Qt 5.9, non-default without updater
-#  - Q_OR_C_MAKE=qmake
-#    QT_VERSION=59
-#    WITH_UPDATER=NO # actually Qt 5.9, non-default without updater
   global:
   - secure: VFI3UCiDrp47WTcUhsatdQvvWg+3gk00eBMZgSOXXKY5+hk+NOX7bOFcIM5t9nlZDbpHDr10SFTuUOw+PeWmLpFO06Zrjg86M9jm9WS4i8Cs9hfxoT6H4isXlR1vubX2LmNlHyzg8WtdNanlsufgecyaGksJxr7tVhG/cWyD6yo=
   - secure: XxdhHVraWpXpWo4tluD7NwJtqQT1b6LKoxX6QWKzR0fvcKgqBy2jlXMu0KVtTYtVI7M1wFdjtwSixK1UGFZyDgEYYUnDTufq7E81TWJSQ5ZhxNRaDAyO2vkLNFpH7LkwVrV/fWCPKE9t3/WiowwQnXesm9MMxAzbd2mIaeyiccY=
@@ -59,21 +46,7 @@ matrix:
     osx_image: xcode8
     compiler: clang
     env:
-    - Q_OR_C_MAKE=qmake
-      WITH_UPDATER=NO
-
-  - os: osx
-    osx_image: xcode8
-    compiler: clang
-    env:
     - Q_OR_C_MAKE=cmake
-
-  - os: osx
-    osx_image: xcode8
-    compiler: clang
-    env:
-    - Q_OR_C_MAKE=cmake
-      WITH_UPDATER=NO
 
   - os: linux
     compiler: gcc
@@ -93,36 +66,8 @@ matrix:
   - os: linux
     compiler: gcc
     env:
-    - Q_OR_C_MAKE=qmake
-      QT_VERSION=59
-      WITH_UPDATER=NO
-    addons:
-      apt:
-        sources: *add-sources
-        packages: &qt59-packages
-        - *common-packages
-        - qt59base
-        - qt59multimedia
-        - qt59tools
-        - qt59gamepad
-
-  - os: linux
-    compiler: gcc
-    env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=59
-    addons:
-      apt:
-        sources: *add-sources
-        packages:
-        - *qt59-packages
-
-  - os: linux
-    compiler: gcc
-    env:
-    - Q_OR_C_MAKE=cmake
-      QT_VERSION=59
-      WITH_UPDATER=NO
     addons:
       apt:
         sources: *add-sources
@@ -143,32 +88,8 @@ matrix:
   - os: linux
     compiler: clang
     env:
-    - Q_OR_C_MAKE=qmake
-      QT_VERSION=59
-      WITH_UPDATER=NO
-    addons:
-      apt:
-        sources: *add-sources
-        packages:
-        - *qt59-packages
-
-  - os: linux
-    compiler: clang
-    env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=59
-    addons:
-      apt:
-        sources: *add-sources
-        packages:
-        - *qt59-packages
-
-  - os: linux
-    compiler: clang
-    env:
-    - Q_OR_C_MAKE=cmake
-      QT_VERSION=59
-      WITH_UPDATER=NO
     addons:
       apt:
         sources: *add-sources
@@ -180,21 +101,6 @@ matrix:
     env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=56 # actually Qt 5.6, used to check minimum supported Qt works
-    addons:
-      apt:
-        sources: *add-sources
-        packages: &qt56-packages
-        - *common-packages
-        - qt56base
-        - qt56multimedia
-        - qt56tools
-
-  - os: linux
-    compiler: gcc
-    env:
-    - Q_OR_C_MAKE=cmake
-      QT_VERSION=56
-      WITH_UPDATER=NO # actually Qt 5.6, used to check minimum supported Qt works
     addons:
       apt:
         sources: *add-sources

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,9 @@
 #include "pre_guard.h"
 #include <QDesktopWidget>
 #include <QDir>
+#if defined(Q_OS_WIN32) && ! defined(INCLUDE_UPDATER)
+#include <QMessageBox>
+#endif // defined(Q_OS_WIN32) && ! defined(INCLUDE_UPDATER)
 #include <QPainter>
 #include <QSplashScreen>
 #include "post_guard.h"


### PR DESCRIPTION
`main.cpp` is missing an `#include` needed for Windows builds that would otherwise be pulled in by the updater code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>