### PR TITLE
BugFix: restore focus to main TConsole after mouse click in other ones

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2274,7 +2274,12 @@ TConsole* TConsole::createBuffer(const QString& name)
     std::string key = name.toLatin1().data();
     if (mSubConsoleMap.find(key) == mSubConsoleMap.end()) {
         auto pC = new TConsole(mpHost, false);
+        if (!pC) {
+            return nullptr;
+        }
         mSubConsoleMap[key] = pC;
+        pC->setObjectName(name);
+        pC->mConsoleName = QStringLiteral("Buffer - %1 - %2").arg(mpHost->getName(), name);
         pC->setWindowTitle(name);
         pC->setContentsMargins(0, 0, 0, 0);
         pC->hide();
@@ -2319,6 +2324,7 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
         }
         mSubConsoleMap[key] = pC;
         pC->setObjectName(name);
+        pC->mConsoleName = QStringLiteral("Miniconsole - %1 - %2").arg(mpHost->getName(), name);
         pC->setFocusPolicy(Qt::NoFocus);
         pC->setUserWindow();
         pC->mUpperPane->setIsMiniConsole();
@@ -2328,7 +2334,6 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
         pC->mOldY = y;
         pC->setContentsMargins(0, 0, 0, 0);
         pC->move(x, y);
-        std::string _n = name.toStdString();
         pC->setMiniConsoleFontSize(12);
         pC->show();
         return pC;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1517,6 +1517,25 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
         mpHost->raiseEvent(mudletEvent);
     }
+
+    if (mpHost && mpConsole != mpHost->mpConsole) {
+        // This does have a parent Host profile but it is NOT the main console
+        // for a profile instance
+
+        qDebug() << "TTextEdit::mouseReleaseEvent() INFO - considering which TConsole (and pane) is involved:" << mpConsole->mConsoleName << (mIsLowerPane ? "(lower pane)" : "(upper pane)");
+        if (mpConsole->mConsoleName.startsWith("Miniconsole - ") || mpConsole->mConsoleName.startsWith("User window - ")) {
+            qDebug() << "   This seems to be a miniConsole or a userWindow so better return the focus to the main TConsole instance...";
+            // The central debug console has a null Host::mpConsole
+            if (mpHost->mpConsole) {
+                // So return the focus to the main mpConsole - note a setFocus() call
+                // WITHOUT an argument calls the overloaded SLOT method instead:
+                mpHost->mpConsole->setFocus(Qt::OtherFocusReason);
+            }
+
+        } else {
+            qDebug() << "   This IS NOT a miniConsole or a userWindow so not adjusting the focus...";
+        }
+    }
 }
 
 void TTextEdit::showEvent(QShowEvent* event)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -205,6 +205,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     pHB2->setSizeConstraint(QLayout::SetMaximumSize);
     mpErrorConsole = new TConsole(mpHost, false, popupArea);
     mpErrorConsole->setWrapAt(100);
+    mpErrorConsole->mConsoleName = QStringLiteral("Editor error console - %1").arg(mpHost->getName());
     mpErrorConsole->mUpperPane->slot_toggleTimeStamps();
     mpErrorConsole->print("*** starting new session ***\n");
     pHB2->setContentsMargins(0, 0, 0, 0);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -338,6 +338,7 @@ mudlet::mudlet()
     mpDebugArea->setCentralWidget(mpDebugConsole);
     mpDebugArea->setWindowTitle(tr("Central Debug Console"));
     mpDebugArea->setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_debug.png")));
+    mpDebugConsole->mConsoleName = QStringLiteral("Central Debug Console");
 
     auto consoleCloser = new TConsoleMonitor(mpDebugArea);
     mpDebugArea->installEventFilter(consoleCloser);
@@ -1448,13 +1449,16 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
 
     if (!dockWindowMap.contains(name) && !dockWindowConsoleMap.contains(name)) {
         auto pD = new TDockWidget(pHost, name);
-        pD->setObjectName(QString("dockWindow_%1_%2").arg(pHost->getName(), name));
+        const QString& hostName(pHost->getName());
+        pD->setObjectName(QString("dockWindow_%1_%2").arg(hostName, name));
         pD->setContentsMargins(0, 0, 0, 0);
         pD->setFeatures(QDockWidget::AllDockWidgetFeatures);
-        pD->setWindowTitle(QString("%1 - %2").arg(name, pHost->getName()));
+        pD->setWindowTitle(tr("User Window - %1 - %2").arg(hostName, name));
         dockWindowMap[name] = pD;
         auto pC = new TConsole(pHost, false, pD);
+        pC->setFocusPolicy(Qt::NoFocus);
         pC->setContentsMargins(0, 0, 0, 0);
+        pC->mConsoleName = QStringLiteral("User window - %1 - %2").arg(hostName, name);
         pD->setWidget(pC);
         pC->show();
         pC->layerCommandLine->hide();
@@ -1502,9 +1506,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
     if (!dockWindowConsoleMap.contains(name)) {
         TConsole* pC = pHost->mpConsole->createMiniConsole(name, x, y, width, height);
         if (pC) {
-            pC->mConsoleName = name;
             dockWindowConsoleMap[name] = pC;
-            std::string _n = name.toStdString();
             pC->setMiniConsoleFontSize(12);
             return true;
         }
@@ -1547,7 +1549,6 @@ bool mudlet::createBuffer(Host* pHost, const QString& name)
     QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
     if (!dockWindowConsoleMap.contains(name)) {
         TConsole* pC = pHost->mpConsole->createBuffer(name);
-        pC->mConsoleName = name;
         if (pC) {
             dockWindowConsoleMap[name] = pC;
             return true;


### PR DESCRIPTION
This is less than perfect because it cannot totally identify what the particular `TConsole` instance is associated with - to help me to debug it I needed to add some extra code that assigns values to the `(QString) TConsole::mConsoleName` to cover the miniConsoles, buffers, user windows and Editor error window.

As well as attempting to close issue #1783 I think the addition of the `setFocusPolicy(Qt::NoFocus)` to the `mudlet::openWindow(...)` method will also cure #1769.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>