### PR TITLE
unify duplicate strings for i18n

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -124,7 +124,7 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
 
         case 7:
             if (!mpEditItem->text(7).trimmed().length()) {
-                mpEditItem->setText(7, tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (1 of 5)"));
+                mpEditItem->setText(7, tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same"));
             }
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
             //            qDebug()<<"Closed PE on item:"<<mpEditItem->text(7)<<"column:"<<mEditColumn;
@@ -238,7 +238,7 @@ void dlgRoomExits::slot_addSpecialExit()
     pI->setCheckState(6, Qt::Unchecked); //Doortype: locked
     pI->setToolTip(6,
                    QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-    pI->setText(7, tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (2 of 5)")); //Exit command
+    pI->setText(7, tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same")); //Exit command
     pI->setTextAlignment(7, Qt::AlignLeft);
     specialExits->addTopLevelItem(pI);
 }
@@ -278,7 +278,7 @@ void dlgRoomExits::save()
             door = 0;
         }
         QString value = pI->text(7);
-        if (value != tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (3 of 5)") && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) != nullptr) {
+        if (value != tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same") && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) != nullptr) {
             originalExitCmds.remove(value);
             if (pI->checkState(1) == Qt::Unchecked) {
                 value = value.prepend(QStringLiteral("0"));
@@ -2277,7 +2277,7 @@ void dlgRoomExits::slot_checkModified()
  *                   pI->text(0).toInt(),
  *                   qPrintable(pI->text(7)));
  */
-            if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (4 of 5)") || pI->text(0).toInt() <= 0)
+            if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same") || pI->text(0).toInt() <= 0)
                 continue; // Ignore new or to be deleted entries
             currentCount++;
         }
@@ -2297,7 +2297,7 @@ void dlgRoomExits::slot_checkModified()
  *                           pI->text(0).toInt(),
  *                           qPrintable(pI->text(7)));
  */
-                    if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically ensure all instances are the same, (5 of 5)") || pI->text(0).toInt() <= 0)
+                    if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same") || pI->text(0).toInt() <= 0)
                         continue; // Ignore new or to be deleted entries
                     QString currentCmd = pI->text(7);
                     TExit currentExit;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -124,7 +124,7 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
 
         case 7:
             if (!mpEditItem->text(7).trimmed().length()) {
-                mpEditItem->setText(7, tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same"));
+                mpEditItem->setText(7, tr("<command or Lua script>", "This string is also used programmatically - ensure all five instances are the same"));
             }
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
             //            qDebug()<<"Closed PE on item:"<<mpEditItem->text(7)<<"column:"<<mEditColumn;
@@ -238,7 +238,7 @@ void dlgRoomExits::slot_addSpecialExit()
     pI->setCheckState(6, Qt::Unchecked); //Doortype: locked
     pI->setToolTip(6,
                    QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-    pI->setText(7, tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same")); //Exit command
+    pI->setText(7, tr("<command or Lua script>", "This string is also used programmatically - ensure all five instances are the same")); //Exit command
     pI->setTextAlignment(7, Qt::AlignLeft);
     specialExits->addTopLevelItem(pI);
 }
@@ -278,7 +278,7 @@ void dlgRoomExits::save()
             door = 0;
         }
         QString value = pI->text(7);
-        if (value != tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same") && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) != nullptr) {
+        if (value != tr("<command or Lua script>", "This string is also used programmatically - ensure all five instances are the same") && key != 0 && mpHost->mpMap->mpRoomDB->getRoom(key) != nullptr) {
             originalExitCmds.remove(value);
             if (pI->checkState(1) == Qt::Unchecked) {
                 value = value.prepend(QStringLiteral("0"));
@@ -2277,7 +2277,7 @@ void dlgRoomExits::slot_checkModified()
  *                   pI->text(0).toInt(),
  *                   qPrintable(pI->text(7)));
  */
-            if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same") || pI->text(0).toInt() <= 0)
+            if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically - ensure all five instances are the same") || pI->text(0).toInt() <= 0)
                 continue; // Ignore new or to be deleted entries
             currentCount++;
         }
@@ -2297,7 +2297,7 @@ void dlgRoomExits::slot_checkModified()
  *                           pI->text(0).toInt(),
  *                           qPrintable(pI->text(7)));
  */
-                    if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically - ensure all instances are the same") || pI->text(0).toInt() <= 0)
+                    if (pI->text(7) == tr("<command or Lua script>", "This string is also used programmatically - ensure all five instances are the same") || pI->text(0).toInt() <= 0)
                         continue; // Ignore new or to be deleted entries
                     QString currentCmd = pI->text(7);
                     TExit currentExit;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removing the changing part like `(n of 5)` from translation comments of otherwise identical strings to archieve improved Crowdin integration.

#### Motivation for adding to Mudlet
There were comments like `This string is also used programmatically ensure all instances are the same, (1 of 5)` etc. but it seems like Crowdin can automatically ensure this. 
Compare the string in the same file with comment `This string is used in 2 places, ensure they match!` which is only listed once for translation in Crowdin, not twice, but indicates both line numbers as context:
![image](https://user-images.githubusercontent.com/117238/42607163-d2d6803a-8581-11e8-9d4a-e5d9d22aab55.png)

So to have the same effect here, we need to remove the changing part (n of 5) from source: 
![image](https://user-images.githubusercontent.com/117238/42607184-e1a6572a-8581-11e8-8bd9-17c1562af0a2.png)

Also some typographical correction to ensure understandability of the two ideas mentioned in the comment.

#### Other info (issues closed, discussion etc)
Then again, the comment is thereby obsolete and should be adjusted for more relevance to the actual contents of the string. This is left for another PR.

What is more, the surrounding < and > brackets will break Crowdin integration a bit, as Crowdin will assume this to be html code and hide it from translators. This somewhat breaks easy translatability. A possible solution may be along the same way that actual html code is handled e.g. around line 234: `QStringLiteral("<%1>").arg(tr("Text in brackets"))` Again, this is left for another PR.