### PR TITLE
Fix coverity uploads and CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ matrix:
         - qt57tools
 
 before_install:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee -a "${HOME}/ca-file.pem"; fi
   # add to the path here to pick up things as soon as its installed
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export PATH="${HOME}/latest-gcc-symlinks:$PATH"; fi
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then source "/opt/qt${QT_VERSION}/bin/qt${QT_VERSION}-env.sh"; fi

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -11,7 +11,7 @@ if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "gcc" ]; then
       git config user.name "mudlet-machine-account"
       git config user.email "39947211+mudlet-machine-account@users.noreply.github.com"
       git commit -m "Update strings to translate [skip ci]" translations/mudlet.ts
-      git push "https://${MUDLET_MACHINE_ACCOUNT_API_KEY}@github.com/Mudlet/Mudlet.git" development
+      #git push "https://${MUDLET_MACHINE_ACCOUNT_API_KEY}@github.com/Mudlet/Mudlet.git" development
     fi
     # instead of deployment, we upload to coverity for cron jobs
     cd build
@@ -23,6 +23,7 @@ if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "gcc" ]; then
       --form file=@Mudlet.tgz \
       --form version="master branch head" \
       --form description="$(git log -1|head -1)" \
+      --ca-file="${HOME}/ca-file.pem" \
       https://scan.coverity.com/builds?project=Mudlet%2FMudlet
     CURL_RESULT=$?
     echo curl returned $CURL_RESULT

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -23,7 +23,7 @@ if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "gcc" ]; then
       --form file=@Mudlet.tgz \
       --form version="master branch head" \
       --form description="$(git log -1|head -1)" \
-      --ca-file="${HOME}/ca-file.pem" \
+      --cacert="${HOME}/ca-file.pem" \
       https://scan.coverity.com/builds?project=Mudlet%2FMudlet
     CURL_RESULT=$?
     echo curl returned $CURL_RESULT


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Travis now complains when using `sudo` in container builds. This breaks CI builds.

Additionally, I deactivated the push back to github for modified translation files, which didn't work.

#### Motivation for adding to Mudlet
Fix our CI builds.