### PR TITLE
BugFix: prevent getGridMode on non-existant area from seg. faulting

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9584,7 +9584,7 @@ int TLuaInterpreter::getGridMode(lua_State* L)
     TArea* area = host.mpMap->mpRoomDB->getArea(id);
     if (!area) {
         lua_pushnil(L);
-        lua_pushfstring(L, "area %s doesn't exist", id);
+        lua_pushfstring(L, "area with id %d does not exist", id);
         return 2;
     } else {
         lua_pushboolean(L, area->gridMode);


### PR DESCRIPTION
This closes #1813.

A mistake in the string format specifier for a `lua_pushfstring` call used for an error message made that error fatal to the application rather than just the lua function involved!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>