### PR TITLE
BugFix: ensure Notepad is always saved on profile close

### DIFF
--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2016, 2018 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -225,7 +226,6 @@ public:
     QWidget* mpMainDisplay;
 
     dlgMapper* mpMapper;
-    dlgNotepad* mpNotePad;
 
     QScrollBar* mpScrollBar;
 

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -28,12 +28,24 @@
 #include <QDir>
 #include "post_guard.h"
 
-dlgNotepad::dlgNotepad(Host* pH) : mpHost(pH)
-
+dlgNotepad::dlgNotepad(Host* pH)
+: mpHost(pH)
 {
     setupUi(this);
+
+    if (mpHost) {
+        restore();
+    }
 }
 
+dlgNotepad::~dlgNotepad()
+{
+    // Safety step, just in case:
+    if (mpHost && mpHost->mpNotePad) {
+        save();
+        mpHost->mpNotePad = nullptr;
+    }
+}
 
 void dlgNotepad::save()
 {

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,6 +38,8 @@ class dlgNotepad : public QMainWindow, public Ui::notes_editor
 public:
     Q_DISABLE_COPY(dlgNotepad)
     dlgNotepad(Host*);
+    ~dlgNotepad();
+
     void save();
     void restore();
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -913,6 +913,13 @@ void mudlet::slot_close_profile_requested(int tab)
     mHostDockConsoleMap.remove(pH);
     mHostConsoleMap.remove(pH);
 
+    if (pH->mpNotePad) {
+        pH->mpNotePad->save();
+        pH->mpNotePad->setAttribute(Qt::WA_DeleteOnClose);
+        pH->mpNotePad->close();
+        pH->mpNotePad = nullptr;
+    }
+
     for (TToolBar* pTB : hostToolBarMap) {
         if (pTB) {
             pTB->setAttribute(Qt::WA_DeleteOnClose);
@@ -982,6 +989,13 @@ void mudlet::slot_close_profile()
                 }
                 mHostDockConsoleMap.remove(pH);
                 mHostConsoleMap.remove(pH);
+
+                if (pH->mpNotePad) {
+                    pH->mpNotePad->save();
+                    pH->mpNotePad->setAttribute(Qt::WA_DeleteOnClose);
+                    pH->mpNotePad->close();
+                    pH->mpNotePad = nullptr;
+                }
 
                 for (TToolBar* pTB : hostTToolBarMap) {
                     if (pTB) {
@@ -2262,6 +2276,7 @@ void mudlet::closeEvent(QCloseEvent* event)
                 pC->mpHost->mpNotePad->save();
                 pC->mpHost->mpNotePad->setAttribute(Qt::WA_DeleteOnClose);
                 pC->mpHost->mpNotePad->close();
+                pC->mpHost->mpNotePad = nullptr;
             }
 
             // close console
@@ -2298,10 +2313,12 @@ void mudlet::forceClose()
                 host->mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
                 host->mpEditorDialog->close();
             }
+
             if (host->mpNotePad) {
                 host->mpNotePad->save();
                 host->mpNotePad->setAttribute(Qt::WA_DeleteOnClose);
                 host->mpNotePad->close();
+                host->mpNotePad = nullptr;
             }
 
             if (mpIrcClientMap.contains(host)) {
@@ -2750,7 +2767,6 @@ void mudlet::slot_notes()
         QTextCharFormat format;
         format.setFont(pHost->mDisplayFont);
         pNotes->notesEdit->setCurrentCharFormat(format);
-        pNotes->restore();
         pNotes->setWindowTitle(tr("%1 - notes").arg(pHost->getName()));
         pNotes->setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_notepad.png")));
     }


### PR DESCRIPTION
I put in code to close the Notepad in two places (although only one is
in currently used code) where it was missing, and also include calls to the
loading and saving of the text contents in the constructor and destructor
respectively.

This should close Issue #1800.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>