### PR TITLE
BugFix: fix faulty log options for new profiles or old profile save files

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -77,7 +77,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mIsLoggingTimestamps(false)
 , mLogDir(QString())
 , mLogFileName(QString())
-, mLogFileNameFormat(QLatin1String("yyyy-MM-dd#hh-mm-ss"))
+, mLogFileNameFormat(QLatin1String("yyyy-MM-dd#HH-mm-ss")) // In the past we have used "yyyy-MM-dd#hh-mm-ss" but we always want a 24-hour clock
 , mResetProfile(false)
 , mScreenHeight(25)
 , mScreenWidth(90)
@@ -232,7 +232,7 @@ void Host::saveModules(int sync, bool backup)
         it.next();
         QStringList entry = it.value();
         QString filename_xml = entry[0];
-        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (1 of 6)
+        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (1 of 6)
         QString time = QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss");
         QString moduleName = it.key();
         QString zipName;
@@ -383,7 +383,7 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         directory_xml = saveFolder;
     }
 
-    // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (2 of 6)
+    // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (2 of 6)
     QString filename_xml;
     if (saveName.isEmpty()) {
         filename_xml = QStringLiteral("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));

--- a/src/Host.h
+++ b/src/Host.h
@@ -243,8 +243,9 @@ public:
     QString mLogFileName;
     // The first argument to QDateTime::toString(...) to generate a date/time
     // dependent filename unless it is empty in which case the above value is
-    // used - the previously used value of "yyyy-MM-dd#hh-mm-ss" is set as a
-    // default in the constructor:
+    // used - the previously used value of "yyyy-MM-dd#hh-mm-ss" has been
+    // changed to "yyyy-MM-dd#HH-mm-ss" and is set as a default in the
+    // constructor:
     QString mLogFileNameFormat;
 
     bool mResetProfile;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -735,7 +735,7 @@ void TConsole::closeEvent(QCloseEvent* event)
             if (mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;
                 QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
-                // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (3 of 6)
+                // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (3 of 6)
                 QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
@@ -772,7 +772,7 @@ void TConsole::closeEvent(QCloseEvent* event)
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;
                 QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
-                // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (4 of 6)
+                // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (4 of 6)
                 QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
@@ -1039,7 +1039,7 @@ void TConsole::slot_toggleReplayRecording()
     mRecordReplay = !mRecordReplay;
     if (mRecordReplay) {
         QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, profile_name);
-        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (5 of 6)
+        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (5 of 6)
         QString mLogFileName = QStringLiteral("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
         QDir dirLogFile;
         if (!dirLogFile.exists(directoryLogFile)) {
@@ -1550,7 +1550,7 @@ bool TConsole::saveMap(const QString& location)
     QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
 
     if (location.isEmpty()) {
-        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#hh-mm-ss" (6 of 6)
+        // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (6 of 6)
         filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
     } else {
         filename_map = location;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -790,8 +790,14 @@ void XMLimport::readHostPackage(Host* pHost)
     pHost->mIsNextLogFileInHtmlFormat = (attributes().value("mRawStreamDump") == "yes");
     pHost->mIsLoggingTimestamps = (attributes().value("mIsLoggingTimestamps") == "yes");
     pHost->mLogDir = attributes().value("logDirectory").toString();
-    pHost->mLogFileName = attributes().value("logFileName").toString();
-    pHost->mLogFileNameFormat = attributes().value("logFileNameFormat").toString();
+    if (attributes().hasAttribute("logFileNameFormat")) {
+        // We previously mixed "yyyy-MM-dd{#|T}hh-MM-ss" with "yyyy-MM-dd{#|T}HH-MM-ss"
+        // which is slightly different {always use 24-hour clock even if AM/PM is
+        // present (it isn't)} and that broke some code that requires an exact
+        // string to work with - now always change it to "HH":
+        pHost->mLogFileNameFormat = attributes().value("logFileNameFormat").toString().replace(QLatin1String("hh"), QLatin1String("HH"), Qt::CaseSensitive);
+        pHost->mLogFileName = attributes().value("logFileName").toString();
+    }
     pHost->mAlertOnNewData = (attributes().value("mAlertOnNewData") == "yes");
     pHost->mFORCE_NO_COMPRESSION = (attributes().value("mFORCE_NO_COMPRESSION") == "yes");
     pHost->mFORCE_GA_OFF = (attributes().value("mFORCE_GA_OFF") == "yes");


### PR DESCRIPTION
If a profile save file was from an older version it may not have an `logFileNameFormat` attribute for the `<Host>` element this would clear the `(QString) Host::mLogFileNameFormat` member away from the default coded value. This commit now only changes the setting away from the default if a setting is present in a saved file.

Additionally, the old default value for the DateTime specification string used for some log file format types did not match any of the settings in the "Profile Preference" control for this - with the result that a new profile would show **no** setting when the preferences dialog was opened. This commit updates a faulty DateTime setting by changing any "hh" read in it to "HH" which then makes the rest of the code work as intended.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>