### PR TITLE
Fix auto-save kicking in and blocking save profile as

### DIFF
--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -452,6 +452,10 @@ private:
     QAction* mProfileSaveAction;
     QAction* mProfileSaveAsAction;
 
+    // tracks the duration of the "Save Profile As" action so
+    // autosave doesn't kick in
+    bool mSavingAs;
+
     // keeps track of the dialog reset being queued
     bool mCleanResetQueued;
     void runScheduledCleanReset();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix 'save profile as' to reliably work again.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/1824.
#### Other info (issues closed, discussion etc)
Auto-save was kicking in as soon as the editor window lost focus due to the file browser dialog - and since auto-save was in the process of saving the profile already, save profile as was getting from doing the same.
