### PR TITLE
Align "no map" message in centre propely

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -618,8 +618,13 @@ void T2DMap::paintEvent(QPaintEvent* e)
     QList<int> oneWayExits;
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpHost->getName()));
     if (!pPlayerRoom) {
-        p.drawText(_w / 2, _h / 2, "No map or no valid position.");
-
+        p.save();
+        p.fillRect(0, 0, width(), height(), Qt::transparent);
+        auto font(p.font());
+        font.setPointSize(10);
+        p.setFont(font);
+        p.drawText(0, 0, _w, _h, Qt::AlignCenter | Qt::TextWordWrap, tr("No map or no valid position."));
+        p.restore();
         return;
     }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Align "no map"message in centre propely. 
#### Motivation for adding to Mudlet
Better aesthetics:

![selection_351](https://user-images.githubusercontent.com/110988/43034723-3214054c-8ce2-11e8-87b3-c8adab634c8a.png)

#### Other info (issues closed, discussion etc)
Salvaged the improvement from https://github.com/Mudlet/Mudlet/pull/1334