### PR TITLE
Create module zip if it's not already created when syncing

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -241,7 +241,7 @@ void Host::saveModules(int sync, bool backup)
             QString packagePathName = mudlet::getMudletPath(mudlet::profilePackagePath, mHostName, moduleName);
             filename_xml = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
             int err;
-            zipFile = zip_open(entry[0].toStdString().c_str(), 0, &err);
+            zipFile = zip_open(entry[0].toStdString().c_str(), ZIP_CREATE, &err);
             zipName = filename_xml;
             QDir packageDir = QDir(packagePathName);
             if (!packageDir.exists()) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Create module zip if it's not already created when syncing - this fixes a crash in the case that the original zip is no longer present.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/1834
#### Other info (issues closed, discussion etc)
