### PR TITLE
Make package manager work for paths w/ international letters

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -274,8 +274,8 @@ void dlgPackageExporter::slot_export_package()
     QDir dir(tempDir);
     QStringList contents = dir.entryList();
     for (int i = 0; i < contents.size(); i++) {
-        QString fname = contents[i];
-        if (fname == "." || fname == "..") {
+        QString moduleFile = contents[i];
+        if (moduleFile == "." || moduleFile == "..") {
             continue;
         }
         QString fullName = tempDir + "/" + contents[i];
@@ -286,7 +286,7 @@ void dlgPackageExporter::slot_export_package()
             zip_error_to_str(buf, sizeof(buf), err, errno);
             //FIXME: report error to userqDebug()<<"zip source error"<<fullName<<fname<<buf;
         }
-        err = zip_file_add(archive, fname.toStdString().c_str(), s, ZIP_FL_OVERWRITE);
+        err = zip_file_add(archive, moduleFile.toStdString().c_str(), s, ZIP_FL_OVERWRITE | ZIP_FL_ENC_UTF_8);
         if (err == -1) {
             int sep = 0;
             zip_error_get(archive, &err, &sep);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Try @SlySven's suggestion from https://github.com/Mudlet/Mudlet/pull/1832#issuecomment-407415634 and use the `ZIP_FL_ENC_UTF_8` flag when giving the zip a name.
#### Motivation for adding to Mudlet
Fix package exporter to work for Windows locations with international letters in them (https://github.com/Mudlet/Mudlet/issues/1790#issuecomment-407594287)
#### Other info (issues closed, discussion etc)
