### PR TITLE
BugFix: use Alternative OpenSSLBinary for Windows

### DIFF
--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -204,7 +204,8 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  DownloadFile "https://indy.fulgan.com/SSL/openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o-i386-win32.zip"
+  // Old source was getting intermittant: DownloadFile "https://indy.fulgan.com/SSL/openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o-i386-win32.zip"
+  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.0.2o-win32.zip" "openssl-1.0.2o-i386-win32.zip"
   ExtractZip "openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o"
   Step "installing"
   exec "XCOPY" @("/S", "/I", "/Q", "openssl-1.0.2o", "$Env:MINGW_BASE_DIR\bin")

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -204,7 +204,7 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  // Old source was getting intermittant: DownloadFile "https://indy.fulgan.com/SSL/openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o-i386-win32.zip"
+  # Old source was getting intermittant: DownloadFile "https://indy.fulgan.com/SSL/openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o-i386-win32.zip"
   DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.0.2o-win32.zip" "openssl-1.0.2o-i386-win32.zip"
   ExtractZip "openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o"
   Step "installing"

--- a/CI/appveyor.install.ps1
+++ b/CI/appveyor.install.ps1
@@ -204,7 +204,6 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  # Old source was getting intermittant: DownloadFile "https://indy.fulgan.com/SSL/openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o-i386-win32.zip"
   DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.0.2o-win32.zip" "openssl-1.0.2o-i386-win32.zip"
   ExtractZip "openssl-1.0.2o-i386-win32.zip" "openssl-1.0.2o"
   Step "installing"


### PR DESCRIPTION
The https://indy.fulgan.com site has started to not allow access to the archives for some reason - this should use a suitable alternative.

This will close #1849 if the resulting Windows CI build works for Windows users.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>