### PR TITLE
BugFix: attempt to fix UTF-8 handling of MSDP

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -73,7 +73,7 @@ public:
     ~TLuaInterpreter();
     void setMSDPTable(QString& key, const QString& string_data);
     void parseJSON(QString& key, const QString& string_data, const QString& protocol);
-    void msdp2Lua(char* src, int srclen);
+    void msdp2Lua(const char* src, size_t srclen);
     void initLuaGlobals();
     void initIndenterGlobals();
     bool call(const QString& function, const QString& mName);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -586,24 +586,24 @@ void cTelnet::processTelnetCommand(const string& command)
             break;
         }
 
-        if (option == MSDP) //MSDP support
-        {
+        if (option == OPT_MSDP) {
+            //MSDP support
             string _h;
             if (!mpHost->mEnableMSDP) {
                 _h += TN_IAC;
                 _h += TN_DONT;
-                _h += MSDP; // disable MSDP per http://tintin.sourceforge.net/msdp/
+                _h += OPT_MSDP; // disable MSDP per http://tintin.sourceforge.net/msdp/
                 socketOutRaw(_h);
                 qDebug() << "TELNET IAC DONT MSDP";
                 break;
             } else {
-                sendTelnetOption(TN_DO, 69);
+                sendTelnetOption(TN_DO, OPT_MSDP);
                 //need to send MSDP start sequence: IAC   SB MSDP MSDP_VAR "LIST" MSDP_VAL "COMMANDS" IAC SE
                 //NOTE: MSDP does not need quotes for string/vals
                 _h += TN_IAC;
                 _h += TN_SB;
-                _h += MSDP; //MSDP
-                _h += 1;    //MSDP_VAR
+                _h += OPT_MSDP; //MSDP
+                _h += 1; //MSDP_VAR
                 _h += "LIST";
                 _h += 2; //MSDP_VAL
                 _h += "COMMANDS";
@@ -747,7 +747,7 @@ void cTelnet::processTelnetCommand(const string& command)
 #ifdef DEBUG
             qDebug() << "cTelnet::processTelnetCommand() we dont accept his option because we didnt want it to be enabled";
 #endif
-            if (option == static_cast<char>(69)) // MSDP got turned off
+            if (option == static_cast<char>(OPT_MSDP)) // MSDP got turned off
             {
                 raiseProtocolEvent("sysProtocolDisabled", "MSDP");
             }
@@ -793,10 +793,10 @@ void cTelnet::processTelnetCommand(const string& command)
         //server wants us to enable some option
         option = command[2];
         auto idxOption = static_cast<quint8>(option);
-        if (option == static_cast<char>(69) && mpHost->mEnableMSDP) // MSDP support
-        {
+        if (option == static_cast<char>(OPT_MSDP) && mpHost->mEnableMSDP) {
+            // MSDP support
             qDebug() << "TELNET IAC DO MSDP";
-            sendTelnetOption(TN_WILL, 69);
+            sendTelnetOption(TN_WILL, OPT_MSDP);
 
             raiseProtocolEvent("sysProtocolEnabled", "MSDP");
             break;
@@ -874,7 +874,7 @@ void cTelnet::processTelnetCommand(const string& command)
         qDebug() << "cTelnet::processTelnetCommand() TN_DONT command=" << (quint8)command[2];
 #endif
         option = command[2];
-        if (option == static_cast<char>(69)) // MSDP got turned off
+        if (option == static_cast<char>(OPT_MSDP)) // MSDP got turned off
         {
             raiseProtocolEvent("sysProtocolDisabled", "MSDP");
         }
@@ -906,13 +906,15 @@ void cTelnet::processTelnetCommand(const string& command)
         option = command[2];
 
         // MSDP
-        if (option == static_cast<char>(69)) {
-            QString _m = command.c_str();
+        if (option == static_cast<char>(OPT_MSDP)) {
+            // Using a QByteArray means there is no consideration of encoding
+            // used - it is just bytes...
+            QByteArray _m = command.c_str();
             if (command.size() < 6) {
                 return;
             }
             _m = _m.mid(3, command.size() - 5);
-            mpHost->mLuaInterpreter.msdp2Lua(_m.toUtf8().data(), _m.length());
+            mpHost->mLuaInterpreter.msdp2Lua(_m.constData(), _m.length());
             return;
         }
         // ATCP

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -91,7 +91,6 @@ const char TN_BELL = static_cast<char>(7);
 
 const char GMCP = static_cast<char>(201);
 const char MXP = 91;
-const char MSDP = 69; // http://tintin.sourceforge.net/msdp/
 
 const char OPT_ECHO = 1;
 const char OPT_STATUS = 5;
@@ -99,6 +98,7 @@ const char OPT_TIMING_MARK = 6;
 const char OPT_TERMINAL_TYPE = 24;
 const char OPT_EOR = 25;
 const char OPT_NAWS = 31;
+const char OPT_MSDP = 69; // http://tintin.sourceforge.net/msdp/
 const char OPT_COMPRESS = 85;
 const char OPT_COMPRESS2 = 86;
 const char OPT_MSP = 90;


### PR DESCRIPTION
Correct the `cTelnet::processTelnetCommand(const string&)` to correctly measure the length of the msdp data in bytes (appropriate for UTF-8 encoded data) and not `QChar`s (appropriate for UTF-16 encoded `QStrings`) so that the correct size is passed to `(void) TLuaInterpreter::msdp2Lua(char *, int)` - this was changed to a `const char *` for the first argument to show the intent to not modify the passed array, and because it is a `const char *` it was also appropriate to change the length to the correct `size_t` type to use when indexing into it.

Revise `(void) TLuaInterpreter::msdp2Lua(const char *, size_t)` to process the supplied array as a `QByteArray` and NOT a `QString` - as it is processing a single BYTE and not a `QChar` at a time.  The conversion to a `QString` is only done when the processed data is passed to `(void) TLuaInterpreter::setMSDPTable(QString&, const QString&)` .

Some other clean up operations were done for MSDP - including unifying the mix-mash of `69` and the `const char MSDP = 69` to the consistent `const char OPT_MSDP = 69` which more closely matches other constants used for other OOB protocols in the code.

Some raw strings were revised to be placed in `QLatin1String` wrappers when used to initialise or compare against `QString` and some others removed from `QLatin1Char` wrappers when they are now added or compared to `QByteArrays`.

This should fix #1851 - but will need a decent test to check that I haven't messed up somehow - also, as `TLuaInterpreter::setMSDPTable` calls `TLuaInterpreter::parseJSON` and so does `TLuaInterpreter::setGMCPTable` it may be worthwhile checking to see that the latter still works and also handles UTF-8 data correctly...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>