### PR TITLE
BugFix: set Server Encoding correctly on auto-loading profiles

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1612,8 +1612,9 @@ void dlgConnectionProfiles::slot_connectToServer()
             slot_update_login(pHost->getLogin());
         }
 
-        QString encoding = readProfileData(profile_name, QLatin1String("encoding"));
-        pHost->mTelnet.setEncoding(encoding, false); // Only time not to save the setting
+        // This settings also need to be configured, note that the only time not to
+        // save the setting is on profile loading:
+        pHost->mTelnet.setEncoding(readProfileData(profile_name, QLatin1String("encoding")), false);
         // Needed to ensure setting is correct on start-up:
         pHost->setWideAmbiguousEAsianGlyphs(pHost->getWideAmbiguousEAsianGlyphsControlState());
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2904,6 +2904,11 @@ void mudlet::doAutoLogin(const QString& profile_name)
 
     pHost->setLogin(readProfileData(profile_name, QStringLiteral("login")));
     pHost->setPass(readProfileData(profile_name, QStringLiteral("password")));
+
+    // This settings also need to be configured, note that the only time not to
+    // save the setting is on profile loading:
+    pHost->mTelnet.setEncoding(readProfileData(profile_name, QLatin1String("encoding")), false);
+
     // For the first real host created the getHostCount() will return 2 because
     // there is already a "default_host"
     signal_hostCreated(pHost, mHostManager.getHostCount());


### PR DESCRIPTION
This closes #1861 by ensuring that a setting that must be stored in the profile home directory rather than in the save file is read when auto-loading a profile as well as when it is loaded manually.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>