### PR TITLE
Add lower() and raise() methods to appropriate Geyser objects

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -171,6 +171,14 @@ function Geyser.Container:show_impl()
   showWindow(self.name)
 end
 
+function Geyser.Container:raise ()
+	raiseWindow(self.name)
+end
+
+function Geyser.Container:lower ()
+	lowerWindow(self.name)
+end
+
 --- Moves this window according to the new x and y contraints set.
 -- @param x New x constraint to use. If nil, uses current value.
 -- @param y New y constraint to use. If nil, uses current value.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds methods for `lower()` and `raise()`, so you don't have to call them via the `lowerWindow(name)` and `raiseWindow(name)` functions.
#### Motivation for adding to Mudlet
Geyser is all about adding methods to make life easier. This is that.
#### Other info (issues closed, discussion etc)
