### PR TITLE
double width of map-version selector

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -42,7 +42,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <property name="sizePolicy">
@@ -1712,7 +1712,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="5" column="1" colspan="2">
            <widget class="QComboBox" name="comboBox_mapFileSaveFormatVersion">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -1722,7 +1722,7 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>250</width>
+              <width>500</width>
               <height>16777215</height>
              </size>
             </property>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1722,7 +1722,7 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>500</width>
+              <width>16777215</width>
               <height>16777215</height>
              </size>
             </property>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -42,7 +42,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>5</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <property name="sizePolicy">


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

Width has been doubled of the drop-down menu to select the map-format version used. This will help to effortlessly display the long texts which may be contained.

#### Motivation for adding to Mudlet

Fix #1873 

#### Other info (issues closed, discussion etc)

Before:
![image](https://user-images.githubusercontent.com/117238/43744233-6a31c870-99d9-11e8-9dd5-2117efc7c3ab.png)

After:
![image](https://user-images.githubusercontent.com/117238/43996236-9bdc6360-9dbe-11e8-946d-a16d5c3c96c0.png)