### PR TITLE
Don't autosave when the window loses focus

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6438,26 +6438,6 @@ void dlgTriggerEditor::focusOutEvent(QFocusEvent* pE)
     Q_UNUSED(pE);
 
     saveOpenChanges();
-    autoSave();
-}
-
-// this doesn't seem 100% right - I couldn't find a "window lost focus" event
-// The focusOutEvent above is not it - that is for keyboard focus
-void dlgTriggerEditor::leaveEvent(QEvent *event)
-{
-    Q_UNUSED(event);
-    if( QApplication::focusWidget() != nullptr && QApplication::focusWidget()->objectName() == "listWidgetRef" ) return;
-
-    saveOpenChanges();
-
-    // delay autosave for next event loop in case the user has pressed 'Save profile as' and
-    // the focus was lost due to a file export dialog. In this case, don't want
-    // autosave kicking in and blocking the save profile
-    QTimer::singleShot(0, this, [this]() {
-        if (!mSavingAs) {
-            autoSave();
-        }
-    });
 }
 
 void dlgTriggerEditor::changeView(int view)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -165,7 +165,6 @@ public:
     void showInfo(const QString&);
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
-    void leaveEvent(QEvent *event) override;
     void enterEvent(QEvent* pE) override;
     bool eventFilter(QObject*, QEvent* event) override;
     void children_icon_triggers(QTreeWidgetItem* pWidgetItemParent);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Only autosave on a 1min interval when the editor is open and at no other times, instead of also autosaving (and running the script) when the window loses focus.
#### Motivation for adding to Mudlet
Turns out it's a pretty annoying idea!
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/1892.