### PR TITLE
Enhance allow a profile preference dialog per host

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -67,11 +67,12 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 
     checkBox_USE_SMALL_SCREEN->setChecked(pMudlet->mEnableFullScreenMode);
 
-    // As we reflect the state of these next two checkboxes in the preview
-    // widget on another tab we have to track their changes in state and update
-    // that edbee widget straight away and as we can now have multiple profiles
-    // each with their own instance of this form open we have to update any open
-    // widgets of the same sort in use in ANY profile's editor immediately.
+    // As we demonstrate the options that these next two checkboxes control in
+    // the editor "preview" widget (on another tab) we will need to track
+    // changes and update the edbee widget straight away. As we can have
+    // multiple profiles each with a separate instance of this form open we also
+    // have to respond to changes in the settings when *another* profile saves
+    // them.
     checkBox_showSpacesAndTabs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowTabsAndSpaces);
     checkBox_showLineFeedsAndParagraphs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
 
@@ -134,10 +135,8 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
         checkbox_noAutomaticUpdates->setToolTip(tr("Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet"));
     } else {
         checkbox_noAutomaticUpdates->setChecked(!pMudlet->updater->updateAutomatically());
-        // This is also one of the group of signal/slot connections that handle
-        // updating one profile's preferences form/dialog when a different
-        // profile saves new settings that are application wide - so that this
-        // instance takes on the new settings for those controls
+        // This is the extra connect(...) relating to settings' changes saved by
+        // a different profile mentioned further down in this constructor:
         connect(pMudlet->updater, &Updater::signal_automaticUpdatesChanged, this, &dlgProfilePreferences::slot_changeAutomaticUpdates);
     }
 #else
@@ -210,10 +209,11 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     connect(comboBox_menuBarVisibility, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeShowMenuBar);
     connect(comboBox_toolBarVisibility, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeShowToolBar);
 
-    // This group of signal/slot connections handle updating one profile's
-    // preferences form/dialog when a different profile saves new settings that
-    // are application wide - so that this instance takes on the new settings
-    // for those controls:
+    // This group of signal/slot connections handle updating *this* instance of
+    // the "Profile preferences" form/dialog when a *different* profile saves
+    // new settings from it's one - there is a further connect(...) above which
+    // is also involved but it is conditional on having the updater code being
+    // included in compliation:
     connect(pMudlet, &mudlet::signal_enableFulScreenModeChanged, this, &dlgProfilePreferences::slot_changeEnableFullScreenMode);
     connect(pMudlet, &mudlet::signal_editorTextOptionsChanged, this, &dlgProfilePreferences::slot_changeEditorTextOptions);
     connect(pMudlet, &mudlet::signal_showMapAuditErrorsChanged, this, &dlgProfilePreferences::slot_changeShowMapAuditErrors);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -624,6 +624,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     // groupBox_iconsAndToolbars is NOT dependent on pHost - leave it alone
     enableHostDetails();
 
+    // Identify which Profile we are showing the settings for:
+    setWindowTitle(tr("Profile preferences - %1").arg(pHost->getName()));
+
     // CHECKME: Have moved ALL the connects, where possible, to the end so that
     // none are triggered by the setup operations...
     connect(pushButton_command_line_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setCommandLineFgColor);
@@ -857,6 +860,9 @@ void dlgProfilePreferences::clearHostDetails()
 
     mSearchEngineMap.clear();
     search_engine_combobox->clear();
+
+    // Remove the reference to the Host/profile in the title:
+    setWindowTitle(tr("Profile preferences"));
 }
 
 void dlgProfilePreferences::loadEditorTab()

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 
+#include "mudlet.h"
 #include "TAction.h"
 #include "TAlias.h"
 #include "TKey.h"
@@ -136,6 +137,14 @@ private slots:
     void slot_setMapSymbolFontStrategy(bool);
     void slot_changeShowMenuBar(int);
     void slot_changeShowToolBar(int);
+    void slot_changeEditorTextOptions(const QTextOption::Flags);
+    void slot_changeEnableFullScreenMode(const bool);
+    void slot_changeShowMapAuditErrors(const bool);
+    void slot_changeAutomaticUpdates(const bool);
+    void slot_setToolBarIconSize(const int);
+    void slot_setTreeWidgetIconSize(const int);
+    void slot_changeMenuBarVisibility(const mudlet::controlsVisibility);
+    void slot_changeToolBarVisibility(const mudlet::controlsVisibility);
 
 private:
     void setColors();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -496,7 +496,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     config->beginChanges();
     config->setThemeName(mpHost->mEditorTheme);
     config->setFont(mpHost->mDisplayFont);
-    config->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
+                                  ? edbee::TextEditorConfig::ShowWhitespaces
+                                  : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->endChanges();
 
@@ -7971,11 +7973,10 @@ void dlgTriggerEditor::slot_changeEditorTextOptions(QTextOption::Flags state)
 {
     edbee::TextEditorConfig* config = mpSourceEditorEdbee->config();
 
-    // Although this option seems to be a binary choice the Edbee editor widget
-    // needs a integer 1 to show whitespace characters and an integer 0 to hide
-    // them:
     config->beginChanges();
-    config->setShowWhitespaceMode(state & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+    config->setShowWhitespaceMode((state & QTextOption::ShowTabsAndSpaces)
+                                  ? edbee::TextEditorConfig::ShowWhitespaces
+                                  : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(state & QTextOption::ShowLineAndParagraphSeparators);
     config->endChanges();
 }
@@ -8000,7 +8001,9 @@ void dlgTriggerEditor::clearDocument(edbee::TextEditorWidget* ew, const QString&
     config->beginChanges();
     config->setThemeName(mpHost->mEditorTheme);
     config->setFont(mpHost->mDisplayFont);
-    config->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+    config->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
+                                  ? edbee::TextEditorConfig::ShowWhitespaces
+                                  : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->setSmartTab(true);
     config->setCaretBlinkRate(200);
@@ -8025,7 +8028,9 @@ void dlgTriggerEditor::setThemeAndOtherSettings(const QString& theme)
         localConfig->beginChanges();
         localConfig->setThemeName(theme);
         localConfig->setFont(mpHost->mDisplayFont);
-        localConfig->setShowWhitespaceMode(mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces ? 1 : 0);
+        localConfig->setShowWhitespaceMode((mudlet::self()->mEditorTextOptions & QTextOption::ShowTabsAndSpaces)
+                                           ? edbee::TextEditorConfig::ShowWhitespaces
+                                           : edbee::TextEditorConfig::HideWhitespaces);
         localConfig->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
         localConfig->endChanges();
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2352,7 +2352,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
 
     mShowIconsOnMenuCheckedState = static_cast<Qt::CheckState>(settings.value("showIconsInMenus", QVariant(Qt::PartiallyChecked)).toInt());
 
-    // TODO: At some point (between mudlet 4.0 and 4.1 perhaps) removal this "if" and only consider the QSetting - drop considering the sentinel file:
+    // PLACEMARKER: FULLSCREENMODECONTROLFILE_1_OF_2 At some point we might removal this "if" and only consider the QSetting - dropping consideration of the sentinel file:
     if (settings.contains(QStringLiteral("enableFullScreenMode"))) {
         // We have a setting stored for this
         mEnableFullScreenMode = settings.value(QStringLiteral("enableFullScreenMode"), QVariant(false)).toBool();
@@ -2510,7 +2510,6 @@ void mudlet::writeSettings()
     settings.setValue("reportMapIssuesToConsole", mshowMapAuditErrors);
     settings.setValue("compactInputLine", mCompactInputLine);
     settings.setValue("showIconsInMenus", mShowIconsOnMenuCheckedState);
-    // TODO: At some point (between mudlet 4.0 and 4.1 perhaps) remove writing the (old) sentinel file:
     settings.setValue("enableFullScreenMode", mEnableFullScreenMode);
 }
 
@@ -3802,7 +3801,7 @@ QStringList mudlet::getAvailableFonts()
 
 void mudlet::setEnableFullScreenMode(const bool state)
 {
-    // TODO: At some point (between mudlet 4.0 and 4.1 perhaps) removal this entire "if" and drop maintaining the sentinel file presence/absence:
+    // PLACEMARKER: FULLSCREENMODECONTROLFILE_2_OF_2 At some point we might consider removal of all but the first line of the "if" branch of code and drop maintaining the sentinel file presence/absence:
     if (state != mEnableFullScreenMode) {
         mEnableFullScreenMode = state;
         QFile file_use_smallscreen(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("mudlet_option_use_smallscreen")));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -357,10 +357,8 @@ mudlet::mudlet()
     generalRule -= QSize(30, 30);
     mpDebugArea->resize(QSize(800, 600).boundedTo(generalRule));
     mpDebugArea->hide();
-    QFont mainFont;
-    mainFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
-    QFile file_use_smallscreen(getMudletPath(mainDataItemPath, QStringLiteral("mudlet_option_use_smallscreen")));
-    if (file_use_smallscreen.exists()) {
+    QFont mainFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
+    if (mEnableFullScreenMode) {
         showFullScreen();
         QAction* actionFullScreeniew = new QAction(QIcon(QStringLiteral(":/icons/dialog-cancel.png")), tr("Toggle Full Screen View"), this);
         actionFullScreeniew->setStatusTip(tr("Toggle Full Screen View"));
@@ -475,7 +473,7 @@ mudlet::mudlet()
     // mToolbarIconSize has been set to 0 in the initialisation list but if it
     // has not been changed from that in readSettings() then set it now:
     if (!mToolbarIconSize) {
-        setToolBarIconSize(file_use_smallscreen.exists() ? 2 : 3);
+        setToolBarIconSize(mEnableFullScreenMode ? 2 : 3);
     }
 
 #if defined(QT_GAMEPAD_LIB)
@@ -2353,6 +2351,16 @@ void mudlet::readEarlySettings(const QSettings& settings)
     // as soon as possible as well!
 
     mShowIconsOnMenuCheckedState = static_cast<Qt::CheckState>(settings.value("showIconsInMenus", QVariant(Qt::PartiallyChecked)).toInt());
+
+    // TODO: At some point (between mudlet 4.0 and 4.1 perhaps) removal this "if" and only consider the QSetting - drop considering the sentinel file:
+    if (settings.contains(QStringLiteral("enableFullScreenMode"))) {
+        // We have a setting stored for this
+        mEnableFullScreenMode = settings.value(QStringLiteral("enableFullScreenMode"), QVariant(false)).toBool();
+    } else {
+        // We do not have a QSettings value stored so check for the sentinel file:
+        QFile file_use_smallscreen(getMudletPath(mainDataItemPath, QStringLiteral("mudlet_option_use_smallscreen")));
+        mEnableFullScreenMode = file_use_smallscreen.exists();
+    }
 }
 
 void mudlet::readLateSettings(const QSettings& settings)
@@ -2420,6 +2428,7 @@ void mudlet::setMenuBarVisibility(const controlsVisibility state)
     mMenuBarVisibility = state;
 
     adjustMenuBarVisibility();
+    emit signal_menuBarVisibilityChanged(state);
 }
 
 // This only adjusts the visibility as appropriate
@@ -2442,6 +2451,7 @@ void mudlet::setToolBarVisibility(const controlsVisibility state)
     mToolbarVisibility = state;
 
     adjustToolBarVisibility();
+    emit signal_toolBarVisibilityChanged(state);
 }
 
 // Override the main window context menu action to prevent the main tool bar
@@ -2500,6 +2510,8 @@ void mudlet::writeSettings()
     settings.setValue("reportMapIssuesToConsole", mshowMapAuditErrors);
     settings.setValue("compactInputLine", mCompactInputLine);
     settings.setValue("showIconsInMenus", mShowIconsOnMenuCheckedState);
+    // TODO: At some point (between mudlet 4.0 and 4.1 perhaps) remove writing the (old) sentinel file:
+    settings.setValue("enableFullScreenMode", mEnableFullScreenMode);
 }
 
 void mudlet::slot_show_connection_dialog()
@@ -3786,4 +3798,35 @@ QStringList mudlet::getAvailableFonts()
     QFontDatabase database;
 
     return database.families(QFontDatabase::Any);
+}
+
+void mudlet::setEnableFullScreenMode(const bool state)
+{
+    // TODO: At some point (between mudlet 4.0 and 4.1 perhaps) removal this entire "if" and drop maintaining the sentinel file presence/absence:
+    if (state != mEnableFullScreenMode) {
+        mEnableFullScreenMode = state;
+        QFile file_use_smallscreen(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("mudlet_option_use_smallscreen")));
+        if (state) {
+            file_use_smallscreen.open(QIODevice::WriteOnly | QIODevice::Text);
+            QTextStream out(&file_use_smallscreen);
+            Q_UNUSED(out);
+            file_use_smallscreen.close();
+        } else {
+            file_use_smallscreen.remove();
+        }
+    }
+
+    // Emit the signal whatever the stored value is - so that if there are
+    // multiple profile preference dialogs open they all update themselves:
+    emit signal_enableFulScreenModeChanged(state);
+}
+
+void mudlet::setShowMapAuditErrors(const bool state)
+{
+    if (mshowMapAuditErrors != state) {
+        mshowMapAuditErrors = state;
+
+        emit signal_showMapAuditErrorsChanged(state);
+    }
+
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -155,7 +155,6 @@ mudlet::mudlet()
 , mpAboutDlg(nullptr)
 , mpModuleDlg(nullptr)
 , mpPackageManagerDlg(nullptr)
-, mpProfilePreferencesDlg(nullptr)
 , mshowMapAuditErrors(false)
 , mTimeFormat(tr("hh:mm:ss",
                  "Formatting string for elapsed time display in replay playback - see QDateTime::toString(const QString&) for the gory details...!"))
@@ -2623,16 +2622,19 @@ void mudlet::show_options_dialog()
 {
     Host* pHost = getActiveHost();
 
-    if (!mpProfilePreferencesDlg) {
-        mpProfilePreferencesDlg = new dlgProfilePreferences(this, pHost);
-        connect(mpActionReconnect.data(), &QAction::triggered, mpProfilePreferencesDlg->need_reconnect_for_data_protocol, &QWidget::hide);
-        connect(dactionReconnect, &QAction::triggered, mpProfilePreferencesDlg->need_reconnect_for_data_protocol, &QWidget::hide);
-        connect(mpActionReconnect.data(), &QAction::triggered, mpProfilePreferencesDlg->need_reconnect_for_specialoption, &QWidget::hide);
-        connect(dactionReconnect, &QAction::triggered, mpProfilePreferencesDlg->need_reconnect_for_specialoption, &QWidget::hide);
-        mpProfilePreferencesDlg->setAttribute(Qt::WA_DeleteOnClose);
+    // value will automatically return a nullptr if there is NO entry for this
+    // Host in the QMap
+    if (!mpProfilePreferencesDlgMap.value(pHost)) {
+        mpProfilePreferencesDlgMap[pHost] = new dlgProfilePreferences(this, pHost);
+
+        connect(mpActionReconnect.data(), &QAction::triggered, mpProfilePreferencesDlgMap.value(pHost)->need_reconnect_for_data_protocol, &QWidget::hide);
+        connect(dactionReconnect, &QAction::triggered, mpProfilePreferencesDlgMap.value(pHost)->need_reconnect_for_data_protocol, &QWidget::hide);
+        connect(mpActionReconnect.data(), &QAction::triggered, mpProfilePreferencesDlgMap.value(pHost)->need_reconnect_for_specialoption, &QWidget::hide);
+        connect(dactionReconnect, &QAction::triggered, mpProfilePreferencesDlgMap.value(pHost)->need_reconnect_for_specialoption, &QWidget::hide);
+        mpProfilePreferencesDlgMap.value(pHost)->setAttribute(Qt::WA_DeleteOnClose);
     }
-    mpProfilePreferencesDlg->raise();
-    mpProfilePreferencesDlg->show();
+    mpProfilePreferencesDlgMap.value(pHost)->raise();
+    mpProfilePreferencesDlgMap.value(pHost)->show();
 }
 
 void mudlet::show_help_dialog()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2352,7 +2352,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
 
     mShowIconsOnMenuCheckedState = static_cast<Qt::CheckState>(settings.value("showIconsInMenus", QVariant(Qt::PartiallyChecked)).toInt());
 
-    // PLACEMARKER: FULLSCREENMODECONTROLFILE_1_OF_2 At some point we might removal this "if" and only consider the QSetting - dropping consideration of the sentinel file:
+    // PLACEMARKER: Full-screen mode controlled by File (1 of 2) At some point we might removal this "if" and only consider the QSetting - dropping consideration of the sentinel file:
     if (settings.contains(QStringLiteral("enableFullScreenMode"))) {
         // We have a setting stored for this
         mEnableFullScreenMode = settings.value(QStringLiteral("enableFullScreenMode"), QVariant(false)).toBool();
@@ -3801,7 +3801,7 @@ QStringList mudlet::getAvailableFonts()
 
 void mudlet::setEnableFullScreenMode(const bool state)
 {
-    // PLACEMARKER: FULLSCREENMODECONTROLFILE_2_OF_2 At some point we might consider removal of all but the first line of the "if" branch of code and drop maintaining the sentinel file presence/absence:
+    // PLACEMARKER: Full-screen mode controlled by File (2 of 2) At some point we might consider removal of all but the first line of the "if" branch of code and drop maintaining the sentinel file presence/absence:
     if (state != mEnableFullScreenMode) {
         mEnableFullScreenMode = state;
         QFile file_use_smallscreen(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("mudlet_option_use_smallscreen")));

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -348,9 +348,9 @@ public:
     void setEnableFullScreenMode(const bool);
 
     // Currently tracks the "mudlet_option_use_smallscreen" file's existance but
-    // will eventually (Mudlet 4.0?) migrate to the "EnableFullScreenMode" in
-    // the main QSetting file - there is no need to have it stored as a file now
-    // except to maintain backwards compatibility...
+    // may eventually migrate solely to the "EnableFullScreenMode" in the main
+    // QSetting file - it is only stored as a file now to maintain backwards
+    // compatibility...
     bool mEnableFullScreenMode;
 
 public slots:

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -227,7 +227,7 @@ public:
     QPointer<dlgAboutDialog> mpAboutDlg;
     QPointer<QDialog> mpModuleDlg;
     QPointer<QDialog> mpPackageManagerDlg;
-    QPointer<dlgProfilePreferences> mpProfilePreferencesDlg;
+    QMap<Host*, QPointer<dlgProfilePreferences>> mpProfilePreferencesDlgMap;
     // More modern Desktop styles no longer include icons on the buttons in
     // QDialogButtonBox buttons - but some users are using Desktops (KDE4?) that
     // does use them - use this flag to determine whether we should apply our

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -263,7 +263,7 @@ public:
     void showChangelogIfUpdated();
 
     bool showMapAuditErrors() const { return mshowMapAuditErrors; }
-    void setShowMapAuditErrors(const bool state) { mshowMapAuditErrors = state; }
+    void setShowMapAuditErrors(const bool);
     bool compactInputLine() const { return mCompactInputLine; }
     void setCompactInputLine(const bool state) { mCompactInputLine = state; }
     void createMapper(bool loadDefaultMap = true);
@@ -345,6 +345,14 @@ public:
     Updater* updater;
 #endif
 
+    void setEnableFullScreenMode(const bool);
+
+    // Currently tracks the "mudlet_option_use_smallscreen" file's existance but
+    // will eventually (Mudlet 4.0?) migrate to the "EnableFullScreenMode" in
+    // the main QSetting file - there is no need to have it stored as a file now
+    // except to maintain backwards compatibility...
+    bool mEnableFullScreenMode;
+
 public slots:
     void processEventLoopHack_timerRun();
     void slot_mapper();
@@ -401,6 +409,10 @@ signals:
     void signal_setTreeIconSize(int);
     void signal_hostCreated(Host*, quint8);
     void signal_hostDestroyed(Host*, quint8);
+    void signal_enableFulScreenModeChanged(bool);
+    void signal_showMapAuditErrorsChanged(bool);
+    void signal_menuBarVisibilityChanged(const controlsVisibility);
+    void signal_toolBarVisibilityChanged(const controlsVisibility);
 
 private slots:
     void slot_close_profile();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -66,6 +66,9 @@ void Updater::setAutomaticUpdates(const bool state)
 #else
     dblsqd::UpdateDialog::enableAutoDownload(state, settings);
 #endif
+    // The sense of this control is inverted on the dlgProfilePreferences - so
+    // must be inverted here:
+    emit signal_automaticUpdatesChanged(!state);
 }
 
 bool Updater::updateAutomatically() const

--- a/src/updater.h
+++ b/src/updater.h
@@ -76,6 +76,7 @@ private:
 
 signals:
     void updateInstalled();
+    void signal_automaticUpdatesChanged(const bool);
 
 public slots:
     void installOrRestartClicked(QAbstractButton* button, const QString& filePath);


### PR DESCRIPTION
Some time back the code-base was revised to only allow one Profile Preferences to be active at a time - this was so multiple clicks on the menu item or toolbar button did not make loads of copies of the form / dialogue.  However there are some advantages to being able to see the settings for multiple profiles side-by-side - this PR aims to provide this.

To stop the common settings being confused/getting out of sync if more than one profile is active and has the preference dialogue open, saving those setting by closing such a dialogue/form will now update the common settings currently defined for that dialogue in the other instances.

CARE SHOULD BE TAKEN THAT ANY OTHER "APPLICATION-WIDE" SETTING IS ALSO HANDLED IN THE SAME WAY SO THAT CHANGING THE SETTING AND SAVING IT FROM ONE PROFILE'S PREFERENCES DIALOGUE ARE PROPAGATED TO ANY OTHER OPEN PREFERENCE DIALOGUE.

As I worked on this synchronisation I found it was worthwhile to start the process of moving the enabling of the "Full Screen View" option from being controlled via a sentinel file kept in the Mudlet base directory into the `QSetting` system that is used for other application wide settings.  At present the existing file will also be created as needed but I would suggest that support for it is phased out between the future Mudlet 4.0 and 4.1 versions...

Also, in several places where multiple uses are made of `mudlet::self()` it seemed sensible to taking a local copy of the returned (effectively constant) pointer value (as `pMudlet`).

In passing I identified the correct `enum` values to use to control the display of "WhiteSpace" in the Edbee widgets so have replaced the values `0` and `1` with their correct symbols:
* `edbee::TextEditorConfig::ShowWhitespaces`
* `edbee::TextEditorConfig::HideWhitespaces`

instead.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>