### PR TITLE
Add getRoomHashByID()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3932,6 +3932,32 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomHashByID
+int TLuaInterpreter::getRoomHashByID(lua_State* L)
+{
+    int id;
+    if (!lua_isnumber(L, 1)) {
+        lua_pushfstring(L, "getRoomHashByID: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    } else {
+        id = lua_tonumber(L, 1);
+    }
+
+    Host& host = getHostFromLua(L);
+    QMapIterator<QString, int> it(host.mpMap->mpRoomDB->hashTable);
+
+    while (it.hasNext()) {
+        it.next();
+        if (it.value() == id) {
+            lua_pushstring(L, it.key().toUtf8().constData());
+            return 1;
+        }
+    }
+    lua_pushnil(L);
+    lua_pushfstring(L, "getRoomHashByID: Room %d not found.", id);
+    return 2;
+}
+
 int TLuaInterpreter::solveRoomCollisions(lua_State* L)
 {
     return 0;
@@ -5873,7 +5899,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
     }
     int backgroundColor = lua_tointeger(L, 2);
 
-    int triggerID;    
+    int triggerID;
     int expiryCount = -1;
 
     if (lua_isnumber(L, 4)) {
@@ -6210,7 +6236,7 @@ int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#tempButtonToolbar
 int TLuaInterpreter::tempButtonToolbar(lua_State* L)
-{ 
+{
     QString name;
     QString cmdButtonUp = "";
     QString cmdButtonDown = "";
@@ -12702,6 +12728,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "sendSocket", TLuaInterpreter::sendSocket);
     lua_register(pGlobalLua, "setRoomIDbyHash", TLuaInterpreter::setRoomIDbyHash);
     lua_register(pGlobalLua, "getRoomIDbyHash", TLuaInterpreter::getRoomIDbyHash);
+    lua_register(pGlobalLua, "getRoomHashByID", TLuaInterpreter::getRoomHashByID);
     lua_register(pGlobalLua, "addAreaName", TLuaInterpreter::addAreaName);
     lua_register(pGlobalLua, "getRoomAreaName", TLuaInterpreter::getRoomAreaName);
     lua_register(pGlobalLua, "deleteArea", TLuaInterpreter::deleteArea);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -182,6 +182,7 @@ public:
     static int getRoomAreaName(lua_State*);
     static int addAreaName(lua_State* L);
     static int getRoomIDbyHash(lua_State* L);
+    static int getRoomHashByID(lua_State* L);
     static int setRoomIDbyHash(lua_State* L);
     static int sendSocket(lua_State* L);
     static int openUrl(lua_State*);

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -316,6 +316,7 @@
   "connectExitStub": "connectExitStub(fromID, direction or toID[, optional direction])",
   "setUnderline": "setUnderline(windowName, bool)",
   "getRoomIDbyHash": "roomID = getRoomIDbyHash(hash)",
+  "getRoomHashByID": "hash = getRoomHashByID(roomId)",
   "setMergeTables": "setMergeTables(module)",
   "getLastLineNumber": "getLastLineNumber(window)",
   "addSupportedTelnetOption": "addSupportedTelnetOption(option)",


### PR DESCRIPTION
This function is reverse of getRoomIDbyHash.
It is more expensive as it iterates over all rooms.

Signed-off-by: Mateusz Kulikowski <mateusz.kulikowski@gmail.com>

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add reverse of getRoomIDbyHash()
#### Motivation for adding to Mudlet
* To ease sharing of map metadata while not sharing maps (data using hash instead of id can be easily imported to map created by someone else)
#### Other info (issues closed, discussion etc)
N/A