### PR TITLE
Add StickMUD support for MMP downloads

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1541,7 +1541,12 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             QPushButton* noButton = msgBox.addButton(tr("Start my own"), QMessageBox::ActionRole);
             msgBox.exec();
             if (msgBox.clickedButton() == yesButton) {
-                downloadMap();
+                // no https support
+                if (mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
+                    downloadMap(QStringLiteral("http://www.%1/maps/map.xml").arg(mpHost->mUrl));
+                } else {
+                    downloadMap();
+                }
             } else if (msgBox.clickedButton() == noButton) {
                 ; //No-op to avoid unused "noButton"
             }
@@ -2070,7 +2075,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
     mIsFileViewingRecommended = false;
 }
 
-void TMap::downloadMap(const QString* remoteUrl, const QString* localFileName)
+void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -2089,11 +2094,11 @@ void TMap::downloadMap(const QString* remoteUrl, const QString* localFileName)
     // We have the mutex locked - MUST unlock it when done under ALL circumstances
     QUrl url;
 
-    if (!remoteUrl || remoteUrl->isEmpty()) {
+    if (remoteUrl.isEmpty()) {
         // TODO: Provide a per profile means to specify a "user settable" default Url...
         url = QUrl::fromUserInput(QStringLiteral("https://www.%1/maps/map.xml").arg(pHost->mUrl));
     } else {
-        url = QUrl::fromUserInput(*remoteUrl);
+        url = QUrl::fromUserInput(remoteUrl);
     }
 
     if (!url.isValid()) {
@@ -2107,10 +2112,10 @@ void TMap::downloadMap(const QString* remoteUrl, const QString* localFileName)
         return;
     }
 
-    if (!localFileName || localFileName->isEmpty()) {
+    if (localFileName.isEmpty()) {
         mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, pHost->getName());
     } else {
-        mLocalMapFileName = *localFileName;
+        mLocalMapFileName = localFileName;
     }
 
     QNetworkRequest request = QNetworkRequest(url);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1534,7 +1534,8 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
         if (mpHost->mUrl.contains(QStringLiteral("achaea.com"), Qt::CaseInsensitive) || mpHost->mUrl.contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)
             || mpHost->mUrl.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
-            || mpHost->mUrl.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)) {
+            || mpHost->mUrl.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
+            || mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
             msgBox.setText(tr("No map found. Would you like to download the map or start your own?"));
             QPushButton* yesButton = msgBox.addButton(tr("Download the map"), QMessageBox::ActionRole);
             QPushButton* noButton = msgBox.addButton(tr("Start my own"), QMessageBox::ActionRole);

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -130,7 +130,7 @@ public:
     void pushErrorMessagesToFile(QString, bool isACleanup = false);
 
     // Moved and revised from dlgMapper:
-    void downloadMap(const QString* remoteUrl = Q_NULLPTR, const QString* localFileName = Q_NULLPTR);
+    void downloadMap(const QString& remoteUrl = QString(), const QString& localFileName = QString());
 
     // Also uses readXmlMapFile(...) but for local files:
     bool importMap(QFile&, QString* errMsg = Q_NULLPTR);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -398,7 +398,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     if (url.contains(QStringLiteral("achaea.com"), Qt::CaseInsensitive)
      || url.contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)
      || url.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
-     || url.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)) {
+     || url.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
+     || url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
 
         groupBox_downloadMapOptions->setVisible(true);
         connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::downloadMap);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1495,7 +1495,11 @@ void dlgProfilePreferences::downloadMap()
         mudlet::self()->createMapper(false);
     }
 
-    pHost->mpMap->downloadMap();
+    if (pHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
+        pHost->mpMap->downloadMap(QStringLiteral("http://www.%1/maps/map.xml").arg(mpHost->mUrl));
+    } else {
+        pHost->mpMap->downloadMap();
+    }
 }
 
 void dlgProfilePreferences::loadMap()


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds StickMUD as a game that supports MMP map downloads.
#### Motivation for adding to Mudlet
Easy map download when the user opens the map for the first time and re-download via settings if needed.
#### Other info (issues closed, discussion etc)
`downloadMap()` arguments changed to plain arguments from pointers for simpler use - there was no reason for them to be pointers.