### PR TITLE
Fix temporary aliases showing up in the editor after you import a package

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5777,6 +5777,10 @@ void dlgTriggerEditor::fillout_form()
     mpAliasBaseItem->setExpanded(true);
     std::list<TAlias*> baseNodeList_alias = mpHost->getAliasUnit()->getAliasRootNodeList();
     for (auto alias : baseNodeList_alias) {
+        if (alias->isTemporary()) {
+            continue;
+        }
+
         QString s = alias->getName();
         QStringList sList;
         sList << s;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix temporary aliases showing up in the alias editor after you import a package.
#### Motivation for adding to Mudlet
It's annoying.
#### Other info (issues closed, discussion etc)
