### PR TITLE
Fix Speedwalk function to recognise long directions

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -418,6 +418,10 @@ function speedwalk(dirString, backwards, delay, show)
   local walkdelay = delay
   if show ~= false then show = true end
   local walklist = {}
+  local long_dir = {north = 'n', south = 's', east = 'e', west = 'w', up = 'u', down = 'd'}
+  for k,v in pairs(long_dir) do
+    dirString = dirString:gsub(k,v)
+  end
   local reversedir = {
     n = "s",
     en = "sw",


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Change to speedwalk function to replace long form directions with short form ones so that it parses correctly.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/503
