### PR TITLE
Ascend tool-tip from filter sub-area

### DIFF
--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -1117,7 +1117,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>act as filter, i.e. only pass matches to its children to trigger on, instead of the original line from the MUD</string>
+            <string>&lt;p&gt;Only the filtered content (=capture groups) will be passed on to child triggers, not the initial line (see manual on filters)&lt;/p&gt;</string>
            </property>
            <property name="title">
             <string>filter</string>
@@ -1162,7 +1162,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Only the filtered content (=capture groups) will be passed on to child triggers, not the initial line (see manual on filters)</string>
+               <string/>
               </property>
               <property name="text">
                <string>only pass matches to children as trigger input</string>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -1161,9 +1161,6 @@
                 <height>16777215</height>
                </size>
               </property>
-              <property name="toolTip">
-               <string/>
-              </property>
               <property name="text">
                <string>only pass matches to children as trigger input</string>
               </property>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
A new and well-written tool-tip was layered above most but not all the area of an older tool-tip. The old tool-tip has now been removed and the new tool-tip made visible in the whole area.

#### Motivation for adding to Mudlet
Improve exposure of quality texts, remove duplicate information for translators

#### Other info (issues closed, discussion etc)
Address #1802 issue 13