### PR TITLE
Fix tab completion to work with non-English languages

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -701,10 +701,10 @@ void TCommandLine::handleTabCompletion(bool direction)
     }
 
     QStringList bufferList = mpHost->mpConsole->buffer.getEndLines(amount);
-    QString buffer = bufferList.join(QStringLiteral(" "));
+    QString buffer = bufferList.join(QChar::Space);
 
-    buffer.replace(QChar(0x21af), QLatin1String("\n"));
-    buffer.replace(QChar('\n'), QLatin1String(" "));
+    buffer.replace(QChar(0x21af), QChar::LineFeed);
+    buffer.replace(QChar::LineFeed, QChar::Space);
 
     QStringList wordList = buffer.split(QRegularExpression(QStringLiteral(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), QString::SkipEmptyParts);
     if (direction) {
@@ -713,7 +713,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         mTabCompletionCount--;
     }
     if (!wordList.empty()) {
-        if (mTabCompletionTyped.endsWith(QLatin1String(" "))) {
+        if (mTabCompletionTyped.endsWith(QChar::Space)) {
             return;
         }
         QString lastWord;
@@ -726,7 +726,7 @@ void TCommandLine::handleTabCompletion(bool direction)
             lastWord = QLatin1String("");
         }
 
-        QStringList filterList = wordList.filter(QRegularExpression(QStringLiteral("^") + lastWord + QStringLiteral(R"(\w+)"), QRegularExpression::CaseInsensitiveOption | QRegularExpression::UseUnicodePropertiesOption));
+        QStringList filterList = wordList.filter(QRegularExpression(QStringLiteral(R"(^%1\w+)").arg(lastWord), QRegularExpression::CaseInsensitiveOption | QRegularExpression::UseUnicodePropertiesOption));
         if (filterList.empty()) {
             return;
         }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -723,7 +723,7 @@ void TCommandLine::handleTabCompletion(bool direction)
         if (reg.captureCount() >= 1) {
             lastWord = match.captured(1);
         } else {
-            lastWord = QLatin1String("");
+            lastWord = QString();
         }
 
         QStringList filterList = wordList.filter(QRegularExpression(QStringLiteral(R"(^%1\w+)").arg(lastWord), QRegularExpression::CaseInsensitiveOption | QRegularExpression::UseUnicodePropertiesOption));

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -701,33 +701,32 @@ void TCommandLine::handleTabCompletion(bool direction)
     }
 
     QStringList bufferList = mpHost->mpConsole->buffer.getEndLines(amount);
-    QString buffer = bufferList.join(" ");
+    QString buffer = bufferList.join(QStringLiteral(" "));
 
-    buffer.replace(QChar(0x21af), "\n");
-    buffer.replace(QChar('\n'), " ");
+    buffer.replace(QChar(0x21af), QLatin1String("\n"));
+    buffer.replace(QChar('\n'), QLatin1String(" "));
 
-    QStringList wordList = buffer.split(QRegularExpression(QStringLiteral(R"(\b)")), QString::SkipEmptyParts);
+    QStringList wordList = buffer.split(QRegularExpression(QStringLiteral(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), QString::SkipEmptyParts);
     if (direction) {
         mTabCompletionCount++;
     } else {
         mTabCompletionCount--;
     }
     if (!wordList.empty()) {
-        if (mTabCompletionTyped.endsWith(" ")) {
+        if (mTabCompletionTyped.endsWith(QLatin1String(" "))) {
             return;
         }
         QString lastWord;
-        QRegularExpression reg = QRegularExpression(QStringLiteral(R"(\b(\w+)$)"));
+        QRegularExpression reg = QRegularExpression(QStringLiteral(R"(\b(\w+)$)"), QRegularExpression::UseUnicodePropertiesOption);
         QRegularExpressionMatch match = reg.match(mTabCompletionTyped);
         int typePosition = match.capturedStart();
         if (reg.captureCount() >= 1) {
             lastWord = match.captured(1);
         } else {
-            lastWord = "";
+            lastWord = QLatin1String("");
         }
 
-        QStringList filterList = wordList.filter(QRegularExpression(QStringLiteral("^") + lastWord + QStringLiteral(R"(\w+)"),
-                                                                    QRegularExpression::CaseInsensitiveOption));
+        QStringList filterList = wordList.filter(QRegularExpression(QStringLiteral("^") + lastWord + QStringLiteral(R"(\w+)"), QRegularExpression::CaseInsensitiveOption | QRegularExpression::UseUnicodePropertiesOption));
         if (filterList.empty()) {
             return;
         }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix tab completion to work with non-English languages by adding the `QRegularExpression::UseUnicodePropertiesOption` flag to regex.

![peek 2018-09-04 08-29](https://user-images.githubusercontent.com/110988/45013855-e0aff180-b01c-11e8-9542-692bee65676a.gif)

#### Motivation for adding to Mudlet
i18n
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/1934.