### PR TITLE
Attempt at raising the associated mapper window when switching tabs

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1066,6 +1066,12 @@ void mudlet::slot_tab_changed(int tabID)
         if (!mpCurrentActiveHost) {
             return;
         }
+
+        if (mpCurrentActiveHost->mpConsole->mpMapper) {
+            mpCurrentActiveHost->mpConsole->mpMapper->activateWindow();
+            mpCurrentActiveHost->mpConsole->mpMapper->raise();
+        }
+
         mpCurrentActiveHost->mpConsole->show();
         mpCurrentActiveHost->mpConsole->repaint();
         mpCurrentActiveHost->mpConsole->refresh();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet
Less annoyance in case the user is not using the embedded map but are manually stacking the map undocked map windows.
#### Other info (issues closed, discussion etc)
Address https://github.com/Mudlet/Mudlet/issues/1955 