### PR TITLE
Fix UI editor crashing when renaming variable

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -560,7 +560,7 @@ void LuaInterface::renameVar(TVar* var)
     //this assumes anything like reparenting has been done
     L = interpreter->pGlobalLua;
     QList<TVar*> vars = varOrder(var);
-    QString oldVariableDeleteCode = vars.at(0)->getName();
+    QString oldVariable = vars.at(0)->getName();
     QString newName;
     if (vars.size() > 1) {
         newName = vars[0]->getName();
@@ -568,7 +568,7 @@ void LuaInterface::renameVar(TVar* var)
     for (int i = 1; i < vars.size(); i++) {
         int kType = vars[i]->getKeyType();
         if (kType == LUA_TNUMBER) {
-            oldVariableDeleteCode.append(QStringLiteral("[%1]").arg(vars.at(i)->getName()));
+            oldVariable.append(QStringLiteral("[%1]").arg(vars.at(i)->getName()));
             if (i < vars.size() - 1) {
                 newName.append("[" + vars[i]->getName() + "]");
             }
@@ -576,18 +576,27 @@ void LuaInterface::renameVar(TVar* var)
             renameCVar(vars);
             return;
         } else {
-            oldVariableDeleteCode.append(QStringLiteral("[\"%1\"]").arg(vars.at(i)->getName()));
+            oldVariable.append(QStringLiteral("[\"%1\"]").arg(vars.at(i)->getName()));
             if (i < vars.size() - 1) {
                 newName.append(QStringLiteral("[\"%1\"]").arg(vars.at(i)->getName()));
             }
         }
     }
-    if (var->getNewKeyType() == LUA_TNUMBER) {
-        newName.append(QStringLiteral("[%1]").arg(vars.back()->getNewName()));
+
+    if (vars.size() <= 1) {
+        // this variable is at root level on _G
+        newName.append(QStringLiteral("_G[\"%1\"]").arg(vars.last()->getNewName()));
     } else {
-        newName.append(QStringLiteral("[\"%1\"]").arg(vars.back()->getNewName()));
+        // this variable is nested in a table
+        if (var->getNewKeyType() == LUA_TNUMBER) {
+            newName.append(QStringLiteral("[%1]").arg(vars.last()->getNewName()));
+        } else {
+            newName.append(QStringLiteral("[\"%1\"]").arg(vars.last()->getNewName()));
+        }
     }
-    luaL_loadstring(L, QStringLiteral("%1 = %2").arg(newName, oldVariableDeleteCode).toUtf8().constData());
+
+    auto renameCode = QStringLiteral("%1 = %2").arg(newName, oldVariable);
+    luaL_loadstring(L, renameCode.toUtf8().constData());
     int error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
         QString emsg = QString::fromUtf8(lua_tostring(L, -1));
@@ -595,7 +604,7 @@ void LuaInterface::renameVar(TVar* var)
         return;
     }
     //delete it
-    luaL_loadstring(L, oldVariableDeleteCode.append(QLatin1String(" = nil")).toUtf8().constData());
+    luaL_loadstring(L, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
     error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
         QString emsg = QString::fromUtf8(lua_tostring(L, -1));

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -157,7 +157,7 @@ int TVar::getValueType()
     return vType;
 }
 
-void TVar::setNewName(const QString n, const int t)
+void TVar::setNewName(const QString& n, const int t)
 {
     nName = n;
     nkType = t;

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -43,7 +43,7 @@ public:
     bool setValueType(int);
     bool setName(QString);
     bool setName(QString, int);
-    void setNewName(QString, int);
+    void setNewName(const QString&, int);
     void setReference(bool);
     QList<TVar*> getChildren(bool isToSort = true);
     TVar* getParent();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4459,32 +4459,32 @@ void dlgTriggerEditor::saveVar()
     if (!pItem->parent()) {
         return;
     }
-    LuaInterface* lI = mpHost->getLuaInterface();
-    VarUnit* vu = lI->getVarUnit();
-    TVar* var = vu->getWVar(pItem);
+    auto* luaInterface = mpHost->getLuaInterface();
+    auto* varUnit = luaInterface->getVarUnit();
+    TVar* variable = varUnit->getWVar(pItem);
     bool newVar = false;
-    if (!var) {
+    if (!variable) {
         newVar = true;
-        var = vu->getTVar(pItem);
+        variable = varUnit->getTVar(pItem);
     }
-    if (!var) {
+    if (!variable) {
         return;
     }
     QString newName = mpVarsMainArea->lineEdit_var_name->text();
     QString newValue = mpSourceEditorEdbeeDocument->text();
-    if (newName == "") {
+    if (newName.isEmpty()) {
         slot_var_selected(pItem);
         return;
     }
     mChangingVar = true;
     int uiNameType = mpVarsMainArea->comboBox_variable_key_type->itemData(mpVarsMainArea->comboBox_variable_key_type->currentIndex(), Qt::UserRole).toInt();
     int uiValueType = mpVarsMainArea->comboBox_variable_value_type->itemData(mpVarsMainArea->comboBox_variable_value_type->currentIndex(), Qt::UserRole).toInt();
-    if ((uiNameType == 3 || uiNameType == 4) && newVar) {
-        uiNameType = -1;
+    if ((uiNameType == LUA_TNUMBER || uiNameType == LUA_TSTRING) && newVar) {
+        uiNameType = LUA_TNONE;
     }
     //check variable recasting
     int varRecast = canRecast(pItem, uiNameType, uiValueType);
-    if ((uiNameType == -1) || (var && uiNameType != var->getKeyType())) {
+    if ((uiNameType == -1) || (variable && uiNameType != variable->getKeyType())) {
         if (QString(newName).toInt()) {
             uiNameType = LUA_TNUMBER;
         } else {
@@ -4504,37 +4504,37 @@ void dlgTriggerEditor::saveVar()
         //we sometimes get in here from new variables
         if (newVar) {
             //we're making this var
-            var = vu->getTVar(pItem);
-            if (!var) {
-                var = new TVar();
+            variable = varUnit->getTVar(pItem);
+            if (!variable) {
+                variable = new TVar();
             }
-            var->setName(newName, uiNameType);
-            var->setValue(newValue, uiValueType);
-            lI->createVar(var);
-            vu->addVariable(var);
-            vu->addTreeItem(pItem, var);
-            vu->removeTempVar(pItem);
+            variable->setName(newName, uiNameType);
+            variable->setValue(newValue, uiValueType);
+            luaInterface->createVar(variable);
+            varUnit->addVariable(variable);
+            varUnit->addTreeItem(pItem, variable);
+            varUnit->removeTempVar(pItem);
             pItem->setText(0, newName);
             mpCurrentVarItem = nullptr;
-        } else if (var) {
-            if (newName == var->getName() && (var->getValueType() == LUA_TTABLE && newValue == var->getValue())) {
+        } else if (variable) {
+            if (newName == variable->getName() && (variable->getValueType() == LUA_TTABLE && newValue == variable->getValue())) {
                 //no change made
             } else {
                 //we're trying to rename it/recast it
                 int change = 0;
-                if (newName != var->getName() || uiNameType != var->getKeyType()) {
+                if (newName != variable->getName() || uiNameType != variable->getKeyType()) {
                     //lets make sure the nametype works
-                    if (var->getKeyType() == LUA_TNUMBER && newName.toInt()) {
+                    if (variable->getKeyType() == LUA_TNUMBER && newName.toInt()) {
                         uiNameType = LUA_TNUMBER;
                     } else {
                         uiNameType = LUA_TSTRING;
                     }
                     change = change | 0x1;
                 }
-                var->setNewName(newName, uiNameType);
-                if (var->getValueType() != LUA_TTABLE && (newValue != var->getValue() || uiValueType != var->getValueType())) {
+                variable->setNewName(newName, uiNameType);
+                if (variable->getValueType() != LUA_TTABLE && (newValue != variable->getValue() || uiValueType != variable->getValueType())) {
                     //lets check again
-                    if (var->getValueType() == LUA_TTABLE) {
+                    if (variable->getValueType() == LUA_TTABLE) {
                         //HEIKO: obvious logic error used to be valueType == LUA_TABLE
                         uiValueType = LUA_TTABLE;
                     } else if (uiValueType == LUA_TNUMBER && newValue.toInt()) {
@@ -4544,33 +4544,33 @@ void dlgTriggerEditor::saveVar()
                     } else {
                         uiValueType = LUA_TSTRING; //nope, you don't agree, you lose your value
                     }
-                    var->setValue(newValue, uiValueType);
+                    variable->setValue(newValue, uiValueType);
                     change = change | 0x2;
                 }
                 if (change) {
                     if (change & 0x1 || newVar) {
-                        lI->renameVar(var);
+                        luaInterface->renameVar(variable);
                     }
-                    if ((var->getValueType() != LUA_TTABLE && change & 0x2) || newVar) {
-                        lI->setValue(var);
+                    if ((variable->getValueType() != LUA_TTABLE && change & 0x2) || newVar) {
+                        luaInterface->setValue(variable);
                     }
                     pItem->setText(0, newName);
                     mpCurrentVarItem = nullptr;
                 } else {
-                    var->clearNewName();
+                    variable->clearNewName();
                 }
             }
         }
     } else if (varRecast == 1) { //recast it
-        TVar* var = vu->getWVar(pItem);
+        TVar* var = varUnit->getWVar(pItem);
         if (newVar) {
             //we're making this var
-            var = vu->getTVar(pItem);
+            var = varUnit->getTVar(pItem);
             var->setName(newName, uiNameType);
             var->setValue(newValue, uiValueType);
-            lI->createVar(var);
-            vu->addVariable(var);
-            vu->addTreeItem(pItem, var);
+            luaInterface->createVar(var);
+            varUnit->addVariable(var);
+            varUnit->addTreeItem(pItem, var);
             pItem->setText(0, newName);
             mpCurrentVarItem = nullptr;
         } else if (var) {
@@ -4604,10 +4604,10 @@ void dlgTriggerEditor::saveVar()
             }
             if (change) {
                 if (change & 0x1 || newVar) {
-                    lI->renameVar(var);
+                    luaInterface->renameVar(var);
                 }
                 if (change & 0x2 || newVar) {
-                    lI->setValue(var);
+                    luaInterface->setValue(var);
                 }
                 pItem->setText(0, newName);
                 mpCurrentVarItem = nullptr;
@@ -4617,17 +4617,17 @@ void dlgTriggerEditor::saveVar()
     //redo this here in case we changed type
     pItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsTristate | Qt::ItemIsUserCheckable);
     pItem->setToolTip(0, "Checked variables will be saved and loaded with your profile.");
-    if (!vu->shouldSave(var)) {
+    if (!varUnit->shouldSave(variable)) {
         pItem->setFlags(pItem->flags() & ~(Qt::ItemIsDropEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsUserCheckable));
         pItem->setForeground(0, QBrush(QColor("grey")));
         pItem->setToolTip(0, "");
         pItem->setCheckState(0, Qt::Unchecked);
-    } else if (vu->isSaved(var)) {
+    } else if (varUnit->isSaved(variable)) {
         pItem->setCheckState(0, Qt::Checked);
     }
-    pItem->setData(0, Qt::UserRole, var->getValueType());
+    pItem->setData(0, Qt::UserRole, variable->getValueType());
     QIcon icon;
-    switch (var->getValueType()) {
+    switch (variable->getValueType()) {
     case 5:
         icon.addPixmap(QPixmap(QStringLiteral(":/icons/table.png")), QIcon::Normal, QIcon::Off);
         break;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix Mudlet crashing when renaming a table variable that's on the root `_G` level in the UI.
#### Motivation for adding to Mudlet
Fix #1966.
#### Other info (issues closed, discussion etc)
The code to rename a variable was incorrect and always assumed it would be nested within a table, not at `_G`, so it didn't work and failed - thus Mudlet's state tracking would get out of sync with Lua and a crash would happen later down the line.
#### Testing
https://ci.appveyor.com/api/buildjobs/qjos86ankij6077m/artifacts/src%2Fmudlet.zip - windows
https://transfer.sh/VJN0x/Mudlet-3.13.0-testing-PR1973-03ccca9.dmg - macOS
https://transfer.sh/NXRB3/Mudlet-3.13.0-testing-PR1973-03ccca9-linux-x64.AppImage.tar - linux