### PR TITLE
Allow text wrapping in HTML copy and logger

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -946,7 +946,7 @@ void TConsole::toggleLogging(bool isMessageEnabled)
                       << mpHost->mFgColor.red() << "," << mpHost->mFgColor.green() << "," << mpHost->mFgColor.blue()
                       << "); background-color:rgb("
                       << mpHost->mBgColor.red() << "," << mpHost->mBgColor.green() << "," << mpHost->mBgColor.blue() << ");}\n";
-            logStream << "        span { white-space: pre; } -->\n";
+            logStream << "        span { white-space: pre-wrap; } -->\n";
             logStream << "  </style>\n";
             logStream << "  </head>\n";
             bool isAtBody = false;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1389,7 +1389,7 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     text.append(",");
     text.append(QString::number(mpHost->mBgColor.blue()));
     text.append(");}\n");
-    text.append("        span { white-space: pre; } -->\n");
+    text.append("        span { white-space: pre-wrap; } -->\n");
     text.append("  </style>\n");
     text.append("  </head>\n");
     text.append("  <body><div>");


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Hi! This pull request modifies the HTML generation code in copying and logging to allow text wrapping.
#### Motivation for adding to Mudlet
Right now, if you open the generated HTML in a browser, you're forced to scroll horizontally if you're on a small screen. It's really inconvenient, especially for mobile users. This change makes it so long lines are wrapped while the original intent of keeping 'pre' for empty lines is still maintained.
#### Other info (issues closed, discussion etc)
I used the following resource to understand the 'white-space' CSS directive: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space

Sample:
Before: https://ada-young.appspot.com/pastebin/hBgVhr9W
After: https://ada-young.appspot.com/pastebin/sAwe0hjn
Screenshots from an iPhone X: https://imgur.com/a/RD1L7Ja