### PR TITLE
Fix GMCP parsing with embedded newlines

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1146,12 +1146,12 @@ void cTelnet::setGMCPVariables(const QString& msg)
 {
     QString var;
     QString arg;
-    var = transcodedMsg.section(QChar::Space, 0, 0);
-    arg = transcodedMsg.section(QChar::Space, 1);
+    var = msg.section(QChar::Space, 0, 0);
+    arg = msg.section(QChar::Space, 1);
 
     if (arg.isEmpty()) {
-        var = transcodedMsg.section(QChar::LineFeed, 0, 0);
-        arg = transcodedMsg.section(QChar::LineFeed, 1);
+        var = msg.section(QChar::LineFeed, 0, 0);
+        arg = msg.section(QChar::LineFeed, 1);
     }
 
     if (msg.startsWith(QStringLiteral("Client.GUI"))) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1146,12 +1146,12 @@ void cTelnet::setGMCPVariables(const QString& msg)
 {
     QString var;
     QString arg;
-    if (msg.indexOf('\n') > -1) {
-        var = msg.section(QChar::LineFeed, 0, 0);
-        arg = msg.section(QChar::LineFeed, 1);
-    } else {
-        var = msg.section(QChar::Space, 0, 0);
-        arg = msg.section(QChar::Space, 1);
+    var = transcodedMsg.section(QChar::Space, 0, 0);
+    arg = transcodedMsg.section(QChar::Space, 1);
+
+    if (arg.isEmpty()) {
+        var = transcodedMsg.section(QChar::LineFeed, 0, 0);
+        arg = transcodedMsg.section(QChar::LineFeed, 1);
     }
 
     if (msg.startsWith(QStringLiteral("Client.GUI"))) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix a newline in data throwing off the parsing of what is a GMCP key and what's the data payload.
#### Motivation for adding to Mudlet
Fix wrong code. http://www.mushclient.com/gmcp mentions also mentions that the separation is done with a space. I suspect this code was copied over from the ATCP implementation and games just didn't have a newline in their data to trigger this.

I've left the old behaviour in there as a fallback measure.
#### Other info (issues closed, discussion etc)
