### PR TITLE
Fix package exporter crashing when non-English is used

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -60,6 +60,20 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* host) :
     ui->setupUi(this);
     treeWidget = ui->treeWidget;
 
+    mpTriggers = new QTreeWidgetItem({tr("Triggers")});
+    mpAliases = new QTreeWidgetItem({tr("Aliases")});
+    mpTimers = new QTreeWidgetItem({tr("Timers")});
+    mpScripts = new QTreeWidgetItem({tr("Scripts")});
+    mpKeys = new QTreeWidgetItem({tr("Keys")});
+    mpButtons = new QTreeWidgetItem({tr("Buttons")});
+
+    treeWidget->addTopLevelItem(mpTriggers);
+    treeWidget->addTopLevelItem(mpAliases);
+    treeWidget->addTopLevelItem(mpTimers);
+    treeWidget->addTopLevelItem(mpScripts);
+    treeWidget->addTopLevelItem(mpKeys);
+    treeWidget->addTopLevelItem(mpButtons);
+
     closeButton = ui->buttonBox->addButton(QDialogButtonBox::Close);
     exportButton = new QPushButton(tr("&Export"));
 
@@ -68,17 +82,17 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* host) :
     ui->textLabel1->hide();
 
     // reset zipFile and filePath from possible previous use
-    zipFile = filePath = "";
+    zipFile = filePath = QLatin1String("");
 
-    packageName = QInputDialog::getText(nullptr, "Package name", "Package name:");
+    packageName = QInputDialog::getText(nullptr, tr("Package name"), tr("Package name:"));
     if (packageName.isEmpty()) {
         return;
     }
-    QString packagePath = QFileDialog::getExistingDirectory(nullptr, "Where do you want to save the package?", "Where do you want to save the package?");
+    QString packagePath = QFileDialog::getExistingDirectory(nullptr, tr("Where do you want to save the package?"), tr("Where do you want to save the package?"));
     if (packagePath.isEmpty()) {
         return;
     }
-    packagePath.replace(R"(\)", "/");
+    packagePath.replace(QLatin1String(R"(\)"), QLatin1String("/"));
 
     tempDir = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), QStringLiteral("tmp/%1").arg(packageName));
     QDir packageDir = QDir(tempDir);
@@ -134,8 +148,7 @@ void dlgPackageExporter::slot_export_package()
 
     XMLexport writer(mpHost);
     //write trigs
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QStringLiteral("Triggers"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpTriggers;
     QList<QTreeWidgetItem*> trigList;
     recurseTree(top, trigList);
     for (auto item : trigList) {
@@ -146,8 +159,7 @@ void dlgPackageExporter::slot_export_package()
             modTriggerMap.insert(item, triggerMap[item]);
         }
     }
-    items = treeWidget->findItems(QStringLiteral("Timers"), Qt::MatchExactly, 0);
-    top = items.first();
+    top = mpTimers;
     QList<QTreeWidgetItem*> timerList;
     recurseTree(top, timerList);
     for (auto item : timerList) {
@@ -158,8 +170,7 @@ void dlgPackageExporter::slot_export_package()
             modTimerMap.insert(item, timerMap[item]);
         }
     }
-    items = treeWidget->findItems(QStringLiteral("Aliases"), Qt::MatchExactly, 0);
-    top = items.first();
+    top = mpAliases;
     QList<QTreeWidgetItem*> aliasList;
     recurseTree(top, aliasList);
     for (auto item : qAsConst(aliasList)) {
@@ -170,8 +181,7 @@ void dlgPackageExporter::slot_export_package()
             modAliasMap.insert(item, aliasMap[item]);
         }
     }
-    items = treeWidget->findItems(QStringLiteral("Buttons"), Qt::MatchExactly, 0);
-    top = items.first();
+    top = mpButtons;
     QList<QTreeWidgetItem*> actionList;
     recurseTree(top, actionList);
     for (auto item : qAsConst(actionList)) {
@@ -182,8 +192,7 @@ void dlgPackageExporter::slot_export_package()
             modActionMap.insert(item, actionMap[item]);
         }
     }
-    items = treeWidget->findItems(QStringLiteral("Scripts"), Qt::MatchExactly, 0);
-    top = items.first();
+    top = mpScripts;
     QList<QTreeWidgetItem*> scriptList;
     recurseTree(top, scriptList);
     for (auto item : qAsConst(scriptList)) {
@@ -194,8 +203,7 @@ void dlgPackageExporter::slot_export_package()
             modScriptMap.insert(item, scriptMap[item]);
         }
     }
-    items = treeWidget->findItems(QStringLiteral("Keys"), Qt::MatchExactly, 0);
-    top = items.first();
+    top = mpKeys;
     QList<QTreeWidgetItem*> keyList;
     recurseTree(top, keyList);
     for (auto item : qAsConst(keyList)) {
@@ -347,8 +355,7 @@ void dlgPackageExporter::listTriggers()
     TriggerUnit* tu = mpHost->getTriggerUnit();
     list<TTrigger*>::const_iterator it;
     std::list<TTrigger*> tList = tu->getTriggerRootNodeList();
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QString("Triggers"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpTriggers;
     for (it = tList.begin(); it != tList.end(); it++) {
         TTrigger* pChild = *it;
         if (pChild->isTemporary()) {
@@ -393,8 +400,7 @@ void dlgPackageExporter::listAliases()
     AliasUnit* tu = mpHost->getAliasUnit();
     list<TAlias*>::const_iterator it;
     std::list<TAlias*> tList = tu->getAliasRootNodeList();
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QString("Aliases"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpAliases;
     for (it = tList.begin(); it != tList.end(); it++) {
         TAlias* pChild = *it;
         if (pChild->isTemporary()) {
@@ -436,8 +442,7 @@ void dlgPackageExporter::listScripts()
     ScriptUnit* tu = mpHost->getScriptUnit();
     list<TScript*>::const_iterator it;
     std::list<TScript*> tList = tu->getScriptRootNodeList();
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QString("Scripts"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpScripts;
     for (it = tList.begin(); it != tList.end(); it++) {
         TScript* pChild = *it;
         QStringList sl;
@@ -478,8 +483,7 @@ void dlgPackageExporter::listKeys()
     KeyUnit* tu = mpHost->getKeyUnit();
     list<TKey*>::const_iterator it;
     std::list<TKey*> tList = tu->getKeyRootNodeList();
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QString("Keys"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpKeys;
     for (it = tList.begin(); it != tList.end(); it++) {
         TKey* pChild = *it;
         if (pChild->isTemporary())
@@ -520,8 +524,7 @@ void dlgPackageExporter::listActions()
     ActionUnit* tu = mpHost->getActionUnit();
     list<TAction*>::const_iterator it;
     std::list<TAction*> tList = tu->getActionRootNodeList();
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QString("Buttons"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpButtons;
     for (it = tList.begin(); it != tList.end(); it++) {
         TAction* pChild = *it;
         QStringList sl;
@@ -563,8 +566,7 @@ void dlgPackageExporter::listTimers()
     TimerUnit* tu = mpHost->getTimerUnit();
     list<TTimer*>::const_iterator it;
     std::list<TTimer*> tList = tu->getTimerRootNodeList();
-    QList<QTreeWidgetItem*> items = treeWidget->findItems(QString("Timers"), Qt::MatchExactly, 0);
-    QTreeWidgetItem* top = items.first();
+    QTreeWidgetItem* top = mpTimers;
     for (it = tList.begin(); it != tList.end(); it++) {
         TTimer* pChild = *it;
         if (pChild->isTemporary()) {

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -82,6 +82,12 @@ private:
     QTreeWidget* treeWidget;
     QPushButton* exportButton;
     QPushButton* closeButton;
+    QTreeWidgetItem* mpTriggers;
+    QTreeWidgetItem* mpAliases;
+    QTreeWidgetItem* mpTimers;
+    QTreeWidgetItem* mpScripts;
+    QTreeWidgetItem* mpKeys;
+    QTreeWidgetItem* mpButtons;
     QString tempDir;
     QString packageName;
     QString zipFile;

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -21,36 +21,6 @@
        <string>Check items to export</string>
       </property>
      </column>
-     <item>
-      <property name="text">
-       <string>Triggers</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Aliases</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Timers</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Scripts</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Keys</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Buttons</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix package exporter crashing when non-English was used.
#### Motivation for adding to Mudlet
Necessary for 3.14 release.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2006

Because the names of items were translated now, the code couldn't find them anymore.