### PR TITLE
Fix system messages getting coloured wrong when translated

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1307,7 +1307,7 @@ void cTelnet::postMessage(QString msg)
             QString prefix = body.at(0).left(prefixLength).toUpper();
             QString firstLineTail = body.at(0).mid(prefixLength);
             body.removeFirst();
-            if (prefix.contains(QLatin1String("ERROR"))) {
+            if (prefix.contains(tr("ERROR", "Keep the capisalisation and try to keep the translated text at 7 letters max so it aligns nicely"))) {
                 mpHost->mpConsole->print(prefix, Qt::red, mpHost->mBgColor);                                  // Bright Red
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 for (quint8 _i = 0; _i < body.size(); _i++) {
@@ -1319,7 +1319,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(255, 255, 50), mpHost->mBgColor); // Bright Yellow
                 }
-            } else if (prefix.contains(QLatin1String("LUA"))) {
+            } else if (prefix.contains(tr("LUA", "Keep the capisalisation and try to keep the translated text at 7 letters max so it aligns nicely"))) {
                 mpHost->mpConsole->print(prefix, QColor(80, 160, 255), mpHost->mBgColor);                    // Light blue
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(50, 200, 50), mpHost->mBgColor); // Light green
                 for (quint8 _i = 0; _i < body.size(); _i++) {
@@ -1330,7 +1330,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(200, 50, 50), mpHost->mBgColor); // Red
                 }
-            } else if (prefix.contains(QLatin1String("WARN"))) {
+            } else if (prefix.contains(tr("WARN", "Keep the capisalisation and try to keep the translated text at 7 letters max so it aligns nicely"))) {
                 mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 150, 0), mpHost->mBgColor); // Orange
                 for (quint8 _i = 0; _i < body.size(); _i++) {
@@ -1341,7 +1341,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 150, 0), mpHost->mBgColor);
                 }
-            } else if (prefix.contains(QLatin1String("ALERT"))) {
+            } else if (prefix.contains(tr("ALERT", "Keep the capisalisation and try to keep the translated text at 7 letters max so it aligns nicely"))) {
                 mpHost->mpConsole->print(prefix, QColor(190, 100, 50), mpHost->mBgColor);                     // Orangish
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 for (quint8 _i = 0; _i < body.size(); _i++) {
@@ -1352,7 +1352,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(190, 190, 50), mpHost->mBgColor); // Yellow
                 }
-            } else if (prefix.contains(QLatin1String("INFO"))) {
+            } else if (prefix.contains(tr("INFO", "Keep the capisalisation and try to keep the translated text at 7 letters max so it aligns nicely"))) {
                 mpHost->mpConsole->print(prefix, QColor(0, 150, 190), mpHost->mBgColor);                   // Cyan
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 for (quint8 _i = 0; _i < body.size(); _i++) {
@@ -1363,7 +1363,7 @@ void cTelnet::postMessage(QString msg)
                 if (!body.empty()) {
                     mpHost->mpConsole->print(body.join('\n').append('\n'), QColor(0, 160, 0), mpHost->mBgColor); // Light Green
                 }
-            } else if (prefix.contains(QLatin1String("OK"))) {
+            } else if (prefix.contains(tr("OK", "Keep the capisalisation and try to keep the translated text at 7 letters max so it aligns nicely"))) {
                 mpHost->mpConsole->print(prefix, QColor(0, 160, 0), mpHost->mBgColor);                        // Light Green
                 mpHost->mpConsole->print(firstLineTail.append('\n'), QColor(190, 100, 50), mpHost->mBgColor); // Orangish
                 for (quint8 _i = 0; _i < body.size(); _i++) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This will attempt to match system messages for colouring purposes using their translated strings, and not the English ones.
#### Motivation for adding to Mudlet
Correct colouring for translated text.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2005. A more proper solution would be to type this in C++ and not do string matching, but that is a more extensive overhaul and we need a solution before the next release.

Note that it's not possible to test the fix just yet - we'll need to update Crowdin for the new strings, get people to translate them, and _then_ this'll work. Let's merge this in fast to give translators time to translate and for us to fix any issues that come up.