### PR TITLE
Allow enabling MMP map download via GMCP

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -494,9 +494,9 @@ void Host::setMmpMapLocation(const QString &var)
     mpMap->setMmpMapLocation(urlValue.toString());
 }
 
-QString Host::mmpMapLocation() const
+QString Host::getMmpMapLocation() const
 {
-    return mpMap->mmpMapLocation();
+    return mpMap->getMmpMapLocation();
 }
 
 // Now returns the total weight of the path

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -471,6 +471,34 @@ void Host::waitForProfileSave()
     }
 }
 
+void Host::setMmpMapLocation(const QString &var)
+{
+    auto document = QJsonDocument::fromJson(var.toUtf8());
+    if (!document.isObject()) {
+        return;
+    }
+    auto json = document.object();
+    if (json.isEmpty()) {
+        return;
+    }
+
+    auto urlValue = json.value(QStringLiteral("url"));
+    if (urlValue == QJsonValue::Undefined) {
+        return;
+    }
+    auto url = QUrl(urlValue.toString());
+    if (!url.isValid()) {
+        return;
+    }
+
+    mpMap->setMmpMapLocation(urlValue.toString());
+}
+
+QString Host::mmpMapLocation() const
+{
+    return mpMap->mmpMapLocation();
+}
+
 // Now returns the total weight of the path
 const unsigned int Host::assemblePath()
 {

--- a/src/Host.h
+++ b/src/Host.h
@@ -185,7 +185,7 @@ public:
     bool currentlySavingProfile();
     void waitForProfileSave();    
     void setMmpMapLocation(const QString& var);
-    QString mmpMapLocation() const;
+    QString getMmpMapLocation() const;
 
     cTelnet mTelnet;
     QPointer<TConsole> mpConsole;

--- a/src/Host.h
+++ b/src/Host.h
@@ -183,7 +183,9 @@ public:
     QString readProfileData(const QString &);
     void xmlSaved(const QString &xmlName);
     bool currentlySavingProfile();
-    void waitForProfileSave();
+    void waitForProfileSave();    
+    void setMmpMapLocation(const QString& var);
+    QString mmpMapLocation() const;
 
     cTelnet mTelnet;
     QPointer<TConsole> mpConsole;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1535,7 +1535,8 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         if (mpHost->mUrl.contains(QStringLiteral("achaea.com"), Qt::CaseInsensitive) || mpHost->mUrl.contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)
             || mpHost->mUrl.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
             || mpHost->mUrl.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
-            || mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
+            || mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
+            || !mmpMapLocation().isEmpty()) {
             msgBox.setText(tr("No map found. Would you like to download the map or start your own?"));
             QPushButton* yesButton = msgBox.addButton(tr("Download the map"), QMessageBox::ActionRole);
             QPushButton* noButton = msgBox.addButton(tr("Start my own"), QMessageBox::ActionRole);
@@ -2095,8 +2096,11 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     QUrl url;
 
     if (remoteUrl.isEmpty()) {
-        // TODO: Provide a per profile means to specify a "user settable" default Url...
-        url = QUrl::fromUserInput(QStringLiteral("https://www.%1/maps/map.xml").arg(pHost->mUrl));
+        if (!mmpMapLocation().isEmpty()) {
+            url = mmpMapLocation();
+        } else {
+            url = QUrl::fromUserInput(QStringLiteral("https://www.%1/maps/map.xml").arg(pHost->mUrl));
+        }
     } else {
         url = QUrl::fromUserInput(remoteUrl);
     }
@@ -2422,4 +2426,16 @@ QHash<QString, QSet<int>> TMap::roomSymbolsHash()
         }
     }
     return results;
+}
+
+void TMap::setMmpMapLocation(const QString &location)
+{
+    mMmpMapLocation = location;
+
+    qDebug() << "MMP map registered at" << mMmpMapLocation;
+}
+
+QString TMap::mmpMapLocation() const
+{
+    return mMmpMapLocation;
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2097,7 +2097,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
 
     if (remoteUrl.isEmpty()) {
         if (!mmpMapLocation().isEmpty()) {
-            url = mmpMapLocation();
+            url = QUrl::fromUserInput(mmpMapLocation());
         } else {
             url = QUrl::fromUserInput(QStringLiteral("https://www.%1/maps/map.xml").arg(pHost->mUrl));
         }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1536,7 +1536,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             || mpHost->mUrl.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
             || mpHost->mUrl.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
             || mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
-            || !mmpMapLocation().isEmpty()) {
+            || !getMmpMapLocation().isEmpty()) {
             msgBox.setText(tr("No map found. Would you like to download the map or start your own?"));
             QPushButton* yesButton = msgBox.addButton(tr("Download the map"), QMessageBox::ActionRole);
             QPushButton* noButton = msgBox.addButton(tr("Start my own"), QMessageBox::ActionRole);
@@ -2096,8 +2096,8 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     QUrl url;
 
     if (remoteUrl.isEmpty()) {
-        if (!mmpMapLocation().isEmpty()) {
-            url = QUrl::fromUserInput(mmpMapLocation());
+        if (!getMmpMapLocation().isEmpty()) {
+            url = QUrl::fromUserInput(getMmpMapLocation());
         } else {
             url = QUrl::fromUserInput(QStringLiteral("https://www.%1/maps/map.xml").arg(pHost->mUrl));
         }
@@ -2435,7 +2435,7 @@ void TMap::setMmpMapLocation(const QString &location)
     qDebug() << "MMP map registered at" << mMmpMapLocation;
 }
 
-QString TMap::mmpMapLocation() const
+QString TMap::getMmpMapLocation() const
 {
     return mMmpMapLocation;
 }

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -148,6 +148,8 @@ public:
     // Show which rooms have which symbols:
     QHash<QString, QSet<int>> roomSymbolsHash();
 
+    void setMmpMapLocation(const QString &location);
+    QString mmpMapLocation() const;
 
     TRoomDB* mpRoomDB;
     QMap<int, int> envColors;
@@ -223,6 +225,10 @@ public:
     qreal mMapSymbolFontFudgeFactor;
     // Disables font substitution if set:
     bool mIsOnlyMapSymbolFontToBeUsed;
+
+    // location of an MMP map provided by the game
+    QString mMmpMapLocation;
+
 
 
 public slots:

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -149,7 +149,7 @@ public:
     QHash<QString, QSet<int>> roomSymbolsHash();
 
     void setMmpMapLocation(const QString &location);
-    QString mmpMapLocation() const;
+    QString getMmpMapLocation() const;
 
     TRoomDB* mpRoomDB;
     QMap<int, int> envColors;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1199,6 +1199,8 @@ void cTelnet::setGMCPVariables(const QString& msg)
         connect(reply, &QNetworkReply::downloadProgress, this, &cTelnet::setDownloadProgress);
         mpProgressDialog->show();
         return;
+    } else if (msg.startsWith(QStringLiteral("Client.Map"))) {
+        mpHost->setMmpMapLocation(arg);
     }
     arg.remove('\n');
     // remove \r's from the data, as yajl doesn't like it

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -440,7 +440,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
      || url.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
      || url.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
      || url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
-     || !pHost->mmpMapLocation().isEmpty()) {
+     || !pHost->getMmpMapLocation().isEmpty()) {
         groupBox_downloadMapOptions->setVisible(true);
         connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::downloadMap);
     } else {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -439,8 +439,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
      || url.contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)
      || url.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
      || url.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
-     || url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
-
+     || url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
+     || !pHost->mmpMapLocation().isEmpty()) {
         groupBox_downloadMapOptions->setVisible(true);
         connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::downloadMap);
     } else {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Enables the following from GMCP:

```
Client.Map {
  "url": "https://...."
}
```
This allows Mudlet to know that a game supports an MMP map - it is then downloadable from settings as well as when the user opens the mapper for the first time.

This is currently in ExVenture and you can see it at https://midmud.com/ when connecting.
#### Motivation for adding to Mudlet
Remove the need to hardcode games in Mudlet that support MMP.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/1962.