### PR TITLE
Set the server-icon when the info is sent and not only on status

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1378,7 +1378,11 @@ void Host::processGMCPDiscordInfo(const QJsonObject& discordInfo)
         } else {
             hasCustomAppID = true;
             pMudlet->mDiscord.setApplicationID(this, appID.toString());
-            pMudlet->mDiscord.setLargeImage(this, QStringLiteral("server-icon"));
+            auto image = pMudlet->mDiscord.getLargeImage(this);
+
+            if (image.isEmpty() || image == QLatin1String("mudlet")) {
+                pMudlet->mDiscord.setLargeImage(this, QStringLiteral("server-icon"));
+            }
         }
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1378,6 +1378,7 @@ void Host::processGMCPDiscordInfo(const QJsonObject& discordInfo)
         } else {
             hasCustomAppID = true;
             pMudlet->mDiscord.setApplicationID(this, appID.toString());
+            pMudlet->mDiscord.setLargeImage(this, QStringLiteral("server-icon"));
         }
     }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Set the `server-icon` straight away when the custom ID is set if none is set otherwise.
#### Motivation for adding to Mudlet
This makes Mudlet behave as described in https://wiki.mudlet.org/w/Manual:Scripting#GMCP when only info is sent and no status.
#### Other info (issues closed, discussion etc)
