### PR TITLE
Don't convert forward slashes to backslashes in Windows

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5078,7 +5078,7 @@ int TLuaInterpreter::getLastLineNumber(lua_State* L)
 int TLuaInterpreter::getMudletHomeDir(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    QString nativeHomeDirectory = QDir::toNativeSeparators(mudlet::getMudletPath(mudlet::profileHomePath, host.getName()));
+    QString nativeHomeDirectory = mudlet::getMudletPath(mudlet::profileHomePath, host.getName());
     lua_pushstring(L, nativeHomeDirectory.toUtf8().constData());
     return 1;
 }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Return `/` with `getMudletHomeDir()` even on Windows.
#### Motivation for adding to Mudlet
QSS does not accept `\` as a separator on Windows, and it has been a continuous source of issues throughout the years even by most experienced developers that you need to convert the forward slashes to backslashes.
#### Other info (issues closed, discussion etc)
In theory, doing so should not break anything... that is the intention. Let's merge it early in the 3.15 development cycle to see if anything does break.