### PR TITLE
Added guard for possible null pointer deference

### DIFF
--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -341,6 +341,8 @@ void Discord::UpdatePresence()
         pDiscordPresence = mPresencePtrs.value(nullptr);
         // Reset the empty applicationID to the one that belongs to Mudlet:
         applicationID = mHostApplicationIDs.value(nullptr);
+
+        Q_ASSERT_X(pDiscordPresence, "Discord", "no Discord presence available for Mudlets default presence");
     } else {
         pDiscordPresence = mPresencePtrs.value(applicationID);
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added an assert for the unlkely case that a null pointer gets made (perhaps in the future through refactoring).
#### Motivation for adding to Mudlet
Fix possible issue.
#### Other info (issues closed, discussion etc)
Fix Coverity 1473922.

```
________________________________________________________________________________________________________
*** CID 1473922:    (FORWARD_NULL)
/home/travis/build/Mudlet/Mudlet/src/discord.cpp: 365 in Discord::UpdatePresence()()
359     
360             Discord_Initialize(applicationID.toUtf8().constData(), mpHandlers, 0);
361             mCurrentApplicationId = applicationID;
362         }
363     
364         if (pHost->mDiscordAccessFlags & Host::DiscordSetDetail) {
>>>     CID 1473922:    (FORWARD_NULL)
>>>     Passing null pointer "pDiscordPresence" to "setDetailText", which dereferences it.
365             pDiscordPresence->setDetailText(mDetailTexts.value(pHost));
366         } else {
367             pDiscordPresence->setDetailText(QString());
368         }
369     
370         if (pHost->mDiscordAccessFlags & Host::DiscordSetState) {
/home/travis/build/Mudlet/Mudlet/src/discord.cpp: 367 in Discord::UpdatePresence()()
361             mCurrentApplicationId = applicationID;
362         }
363     
364         if (pHost->mDiscordAccessFlags & Host::DiscordSetDetail) {
365             pDiscordPresence->setDetailText(mDetailTexts.value(pHost));
366         } else {
>>>     CID 1473922:    (FORWARD_NULL)
>>>     Passing null pointer "pDiscordPresence" to "setDetailText", which dereferences it.
367             pDiscordPresence->setDetailText(QString());
368         }
369     
370         if (pHost->mDiscordAccessFlags & Host::DiscordSetState) {
371             pDiscordPresence->setStateText(mStateTexts.value(pHost));
372         } else {
```