### PR TITLE
Rename Discord options to use the m prefix for consistency

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -387,9 +387,9 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mThemePreviewItemID") = QString::number(pHost->mThemePreviewItemID).toUtf8().constData();
     host.append_attribute("mThemePreviewType") = pHost->mThemePreviewType.toUtf8().constData();
     host.append_attribute("mSearchEngineName") = pHost->mSearchEngineName.toUtf8().constData();
-    host.append_attribute("DiscordAccessOptions") = QString::number(pHost->mDiscordAccessFlags).toUtf8().constData();
-    host.append_attribute("RequiredDiscordUserName") = pHost->mRequiredDiscordUserName.toUtf8().constData();
-    host.append_attribute("RequiredDiscordUserDiscriminator") = pHost->mRequiredDiscordUserDiscriminator.toUtf8().constData();
+    host.append_attribute("mDiscordAccessFlags") = QString::number(pHost->mDiscordAccessFlags).toUtf8().constData();
+    host.append_attribute("mRequiredDiscordUserName") = pHost->mRequiredDiscordUserName.toUtf8().constData();
+    host.append_attribute("mRequiredDiscordUserDiscriminator") = pHost->mRequiredDiscordUserDiscriminator.toUtf8().constData();
 
     QString ignore;
     QSetIterator<QChar> it(pHost->mDoubleClickIgnore);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -829,18 +829,18 @@ void XMLimport::readHostPackage(Host* pHost)
         pHost->mSearchEngineName = QString("Google");
     }
 
-    if (attributes().hasAttribute(QLatin1String("DiscordAccessOptions"))) {
-        pHost->mDiscordAccessFlags = static_cast<Host::DiscordOptionFlags>(attributes().value("DiscordAccessOptions").toString().toInt());
+    if (attributes().hasAttribute(QLatin1String("mDiscordAccessFlags"))) {
+        pHost->mDiscordAccessFlags = static_cast<Host::DiscordOptionFlags>(attributes().value("mDiscordAccessFlags").toString().toInt());
     }
 
-    if (attributes().hasAttribute(QLatin1String("RequiredDiscordUserName"))) {
-        pHost->mRequiredDiscordUserName = attributes().value(QLatin1String("RequiredDiscordUserName")).toString();
+    if (attributes().hasAttribute(QLatin1String("mRequiredDiscordUserName"))) {
+        pHost->mRequiredDiscordUserName = attributes().value(QLatin1String("mRequiredDiscordUserName")).toString();
     } else {
         pHost->mRequiredDiscordUserName.clear();
     }
 
-    if (attributes().hasAttribute(QLatin1String("RequiredDiscordUserDiscriminator"))) {
-        pHost->mRequiredDiscordUserDiscriminator = attributes().value(QLatin1String("RequiredDiscordUserDiscriminator")).toString();
+    if (attributes().hasAttribute(QLatin1String("mRequiredDiscordUserDiscriminator"))) {
+        pHost->mRequiredDiscordUserDiscriminator = attributes().value(QLatin1String("mRequiredDiscordUserDiscriminator")).toString();
     } else {
         pHost->mRequiredDiscordUserDiscriminator.clear();
     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Rename Discord attribute keys to be consistent with other key names - with an `m` prefix.
#### Motivation for adding to Mudlet
Consistency in key names.
#### Other info (issues closed, discussion etc)
It's not very xml-like, but inconsistency is worse.