### PR TITLE
Add message limit/auto-deletion to IRC message buffers.

### DIFF
--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -480,6 +480,7 @@ void dlgIRC::slot_onBufferAdded(IrcBuffer* buffer)
     connect(buffer, &IrcBuffer::messageReceived, this, &dlgIRC::slot_receiveMessage);
     // create a document for storing the buffer specific messages
     auto * document = new QTextDocument(buffer);
+    document->setMaximumBlockCount(300); 
     bufferTexts.insert(buffer, document);
     // create a sorted model for buffer users
     auto * userModel = new IrcUserModel(buffer);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR adds a call to `QTextDocument->setMaximumBlockCount()` to enforce automatic deletion of previously received IRC messages after a number of messages have been received.  
The Default limit is set to 300 messages per buffer.

#### Motivation for adding to Mudlet
Better memory handling is always a good thing, this may address some issues with long-term use of the embedded IRC client.

#### Other info (issues closed, discussion etc)
- This patch has yet to be tested, but may address all or part of issue #1469 

- The buffer message limit number may be desirable as an End-User configurable setting. 