### PR TITLE
GMCP: determine data separator better

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1184,10 +1184,16 @@ void cTelnet::setGMCPVariables(const QString& msg)
 {
     QString packageMessage;
     QString data;
-    packageMessage = msg.section(QChar::Space, 0, 0);
-    data = msg.section(QChar::Space, 1);
 
-    if (data.isEmpty()) {
+    int firstNewline = msg.indexOf(QChar::LineFeed);
+    int firstSpace = msg.indexOf(QChar::Space);
+
+    // if we see a space before a newline, or no newlines at all,
+    // then that's the separator for message and data
+    if (Q_LIKELY((firstSpace != -1 && firstSpace < firstNewline) || firstNewline == -1)) {
+        packageMessage = msg.section(QChar::Space, 0, 0);
+        data = msg.section(QChar::Space, 1);
+    } else {
         packageMessage = msg.section(QChar::LineFeed, 0, 0);
         data = msg.section(QChar::LineFeed, 1);
     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix data separation logic to work for the case when both newlines and spaces are present.
#### Motivation for adding to Mudlet
More robust detection.
#### Other info (issues closed, discussion etc)
Allows usecases like https://github.com/Mudlet/Mudlet/issues/2040 still to work.