### PR TITLE
BugFix: remove duplicate entries in resource file

### DIFF
--- a/src/mudlet.qrc
+++ b/src/mudlet.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file alias="materiaMagicaIcon">icons/logo_mm-120x30px-verticalBlackBgd.png</file>
+        <file alias="translation-stats.json">../translations/translated/translation-stats.json</file>
         <file>3k-mapper.xml</file>
         <file>deleteOldProfiles.xml</file>
         <file>echo.xml</file>
@@ -43,6 +44,8 @@
         <file>icons/Discord-Logo+Wordmark-Color_400x136px.png</file>
         <file>icons/Discord-Logo-Color.png</file>
         <file>icons/discord-rich-presence.png</file>
+        <file>icons/discord-rich-presence-large-icon.png</file>
+        <file>icons/discord-rich-presence-small-icon.png</file>
         <file>icons/document-decrypt.png</file>
         <file>icons/document-encrypt.png</file>
         <file>icons/document-new.png</file>
@@ -133,6 +136,7 @@
         <file>icons/searchOptions-none.png</file>
         <file>icons/searchOptions-unspecified.png</file>
         <file>icons/Slothmud.png</file>
+        <file>icons/stickmud_icon.jpg</file>
         <file>icons/system-restart.png</file>
         <file>icons/system-users.png</file>
         <file>icons/table.png</file>
@@ -156,7 +160,6 @@
         <file>Mudlet_splashscreen_main.png</file>
         <file>run-lua-code-v4.xml</file>
         <file>send-text-to-all-games.xml</file>
-        <file>send-text-to-all-games.xml</file>
         <file>ui/custom_lines.ui</file>
         <file>ui/custom_lines_properties.ui</file>
         <file>ui/delete_profile_confirmation.ui</file>
@@ -166,11 +169,5 @@
         <file>ui/package_manager.ui</file>
         <file>ui/package_manager_unpack.ui</file>
         <file>ui/set_room_area.ui</file>
-        <file>icons/discord-rich-presence-small-icon.png</file>
-        <file>icons/discord-rich-presence-large-icon.png</file>
-        <file>send-text-to-all-games.xml</file>
-        <file>lua-function-list.json</file>
-        <file alias="translation-stats.json">../translations/translated/translation-stats.json</file>
-        <file>icons/stickmud_icon.jpg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
There were some entries in `./src/mudlet.qrc` that had gotten duplicated which `qmake` moans about when it sees them - this commit sorts the entries in that XML file and removes the duplicates entries that were causing this.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>