### PR TITLE
Revise: add unlisted files to QMake project file

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1345,4 +1345,6 @@ DISTFILES += \
     ../mudlet.desktop \
     ../mudlet.png \
     ../mudlet.svg \
-    ../README.md
+    ../README.md \
+    ../translations/translated/CMakeLists.txt \
+    ../translations/translated/generate-translation-stats.lua


### PR DESCRIPTION
Added the `CMakeLists.txt` that does in CMake what `updateqm.pri` does in QMake and the `generate-translation-stats.lua` file that they *both* use: to list of files that Qt Creator "knows about" in the Mudlet project file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>