### PR TITLE
BugFix: handle Qt auto-accelerator creation on main tabBar

### DIFF
--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -33,14 +33,14 @@
 void TStyle::drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
 {
     if (element == QStyle::CE_TabBarTab) {
-        QString tabText = mpTabBar->tabText(mpTabBar->tabAt(option->rect.center()));
+        QString tabString = mpTabBar->tabData(mpTabBar->tabAt(option->rect.center())).toString();
         QFont font = widget->font();
         bool isStyleChanged = false;
-        if (mBoldTabsSet.contains(tabText)||mItalicTabsSet.contains(tabText)||mUnderlineTabsSet.contains(tabText)) {
+        if (mBoldTabsSet.contains(tabString)||mItalicTabsSet.contains(tabString)||mUnderlineTabsSet.contains(tabString)) {
             painter->save();
-            font.setBold(mBoldTabsSet.contains(tabText));
-            font.setItalic(mItalicTabsSet.contains(tabText));
-            font.setUnderline(mUnderlineTabsSet.contains(tabText));
+            font.setBold(mBoldTabsSet.contains(tabString));
+            font.setItalic(mItalicTabsSet.contains(tabString));
+            font.setUnderline(mUnderlineTabsSet.contains(tabString));
             isStyleChanged = true;
             painter->setFont(font);
         }
@@ -60,7 +60,7 @@ void TStyle::setNamedTabState(const QString& text, const bool state, QSet<QStrin
 {
     bool textIsInATab = false;
     for (int i = 0, total = mpTabBar->count(); i < total; ++i) {
-        if (mpTabBar->tabText(i) == text) {
+        if (mpTabBar->tabData(i).toString() == text) {
             textIsInATab = true;
             break;
         }
@@ -84,9 +84,9 @@ void TStyle::setIndexedTabState(const int index, const bool state, QSet<QString>
     }
 
     if (state) {
-        effect.insert(mpTabBar->tabText(index));
+        effect.insert(mpTabBar->tabData(index).toString());
     } else {
-        effect.remove(mpTabBar->tabText(index));
+        effect.remove(mpTabBar->tabData(index).toString());
     }
 }
 
@@ -94,7 +94,7 @@ bool TStyle::namedTabState(const QString& text, const QSet<QString>& effect) con
 {
     bool textIsInATab = false;
     for (int i = 0, total = mpTabBar->count(); i < total; ++i) {
-        if (mpTabBar->tabText(i) == text) {
+        if (mpTabBar->tabData(i).toString() == text) {
             textIsInATab = true;
             break;
         }
@@ -113,7 +113,7 @@ bool TStyle::indexedTabState(const int index, const QSet<QString>& effect) const
         return false;
     }
 
-    return effect.contains(mpTabBar->tabText(index));
+    return effect.contains(mpTabBar->tabData(index).toString());
 }
 
 QSize TTabBar::tabSizeHint(int index) const
@@ -121,6 +121,10 @@ QSize TTabBar::tabSizeHint(int index) const
     if (mStyle.tabBold(index)||mStyle.tabItalic(index)||mStyle.tabUnderline(index)) {
         const QSize s = QTabBar::tabSizeHint(index);
         const QFontMetrics fm(font());
+        // Note that this method must use (because it is associated with sizing
+        // the text to show) the (possibly Qt modified to include an
+        // accelarator) actual tabText and not the profile name that we have
+        // stored in the tabData:
         const int w = fm.width(tabText(index));
 
         QFont f = font();

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -34,17 +34,17 @@ public:
     ~TStyle() {}
 
     void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = Q_NULLPTR) const;
-    void setTabBold(const QString& tabText, const bool state) { setNamedTabState(tabText, state, mBoldTabsSet); }
+    void setTabBold(const QString& tabString, const bool state) { setNamedTabState(tabString, state, mBoldTabsSet); }
     void setTabBold(const int index, const bool state) { setIndexedTabState(index, state, mBoldTabsSet); }
-    void setTabItalic(const QString& tabText, const bool state) { setNamedTabState(tabText, state, mItalicTabsSet); }
+    void setTabItalic(const QString& tabString, const bool state) { setNamedTabState(tabString, state, mItalicTabsSet); }
     void setTabItalic(const int index, const bool state) { setIndexedTabState(index, state, mItalicTabsSet); }
-    void setTabUnderline(const QString& tabText, const bool state) {setNamedTabState(tabText, state, mUnderlineTabsSet); }
+    void setTabUnderline(const QString& tabString, const bool state) {setNamedTabState(tabString, state, mUnderlineTabsSet); }
     void setTabUnderline(const int index, const bool state) { setIndexedTabState(index, state, mUnderlineTabsSet); }
-    bool tabBold(const QString& tabText) const { return namedTabState(tabText, mBoldTabsSet); }
+    bool tabBold(const QString& tabString) const { return namedTabState(tabString, mBoldTabsSet); }
     bool tabBold(const int index) const { return indexedTabState(index, mBoldTabsSet); }
-    bool tabItalic(const QString& tabText) const { return namedTabState(tabText, mItalicTabsSet); }
+    bool tabItalic(const QString& tabString) const { return namedTabState(tabString, mItalicTabsSet); }
     bool tabItalic(const int index) const { return indexedTabState(index, mItalicTabsSet); }
-    bool tabUnderline(const QString& tabText) const { return namedTabState(tabText, mUnderlineTabsSet); }
+    bool tabUnderline(const QString& tabString) const { return namedTabState(tabString, mUnderlineTabsSet); }
     bool tabUnderline(const int index) const { return indexedTabState(index, mUnderlineTabsSet); }
 
 private:
@@ -72,17 +72,17 @@ public:
     ~TTabBar() {}
 
     QSize tabSizeHint(int index) const;
-    void setTabBold(const QString& tabText, const bool state) {mStyle.setTabBold(tabText, state); }
+    void setTabBold(const QString& tabString, const bool state) {mStyle.setTabBold(tabString, state); }
     void setTabBold(const int index, const bool state) {mStyle.setTabBold(index, state); }
-    void setTabItalic(const QString& tabText, const bool state) {mStyle.setTabItalic(tabText, state); }
+    void setTabItalic(const QString& tabString, const bool state) {mStyle.setTabItalic(tabString, state); }
     void setTabItalic(const int index, const bool state) {mStyle.setTabItalic(index, state); }
-    void setTabUnderline(const QString& tabText, const bool state) {mStyle.setTabUnderline(tabText, state); }
+    void setTabUnderline(const QString& tabString, const bool state) {mStyle.setTabUnderline(tabString, state); }
     void setTabUnderline(const int index, const bool state) {mStyle.setTabUnderline(index, state); }
-    bool tabBold(const QString& tabText) const {return mStyle.tabBold(tabText);}
+    bool tabBold(const QString& tabString) const {return mStyle.tabBold(tabString);}
     bool tabBold(const int index) const {return mStyle.tabBold(index);}
-    bool tabItalic(const QString& tabText) const {return mStyle.tabItalic(tabText);}
+    bool tabItalic(const QString& tabString) const {return mStyle.tabItalic(tabString);}
     bool tabItalic(const int index) const {return mStyle.tabItalic(index);}
-    bool tabUnderline(const QString& tabText) const {return mStyle.tabUnderline(tabText);}
+    bool tabUnderline(const QString& tabString) const {return mStyle.tabUnderline(tabString);}
     bool tabUnderline(const int index) const {return mStyle.tabUnderline(index);}
 
 private:


### PR DESCRIPTION
On some OS platforms (not macOs) the texts shown on the tabBar which shows when more than one profile is loaded automagically gains a unique accelerator for each different tab.  However this also modifies the text returned by `QTabBar::tabText(int)` and, at least on my FreeBSB system the displayed added underline is migrated into the text to appear as a '&' in the text.  This BREAKS our codebase as that expects the tabText to be the profile name and uses it as such.

This commit corrects that by storing and using the profile name as held in the `QTabBar` tabs' data member instead so that if the text gets changed the correct profile name is still accessible to our code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

You can see the effect of the auto-accelerators being added in the following screen-shot - note how the user windows have also gained them:

![snapshot12](https://user-images.githubusercontent.com/6163092/46981151-95323e00-d0c6-11e8-934d-2586dc16992b.png)

Even though this does mean that it is possible to switch between the separate active profiles with a direct key combination there is one horrendous flaw - it disregards any short-cuts that we have programmed in (such as `<Alt>-m` for show/hide mapper, `<Alt>-e` for show editor) and can assign the **same** key combination to a main console's tab or a user-window.

This does suggest that we will actually want to disable the automatic generation of the short-cuts - so we may instead want to just include calls to `(void) qt_set_sequence_auto_mnemonic(bool)` with a `false` argument on all but macOs platforms in suitable places.  We do not need it for Apple's devices because such short-cuts are not consistent with the way the MacOs Desktop is *apparently*... :confused: 