### PR TITLE
Fix module sync not to crash

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -278,9 +278,13 @@ void Host::slot_reloadModules()
         }
         QMap<QString, int> modulePri = otherHost->mModulePriorities;
         QMap<int, QStringList> moduleOrder;
-        for (auto it = modulePri.keyBegin(); it != modulePri.keyEnd(); ++it) {
-            moduleOrder[modulePri[*it]].append(*it);
+
+        auto modulePrioritiesIt = modulePri.constBegin();
+        while (modulePrioritiesIt != modulePri.constEnd()) {
+            moduleOrder[modulePrioritiesIt.value()].append(modulePrioritiesIt.key());
+            ++modulePrioritiesIt;
         }
+
         QMapIterator<int, QStringList> it(moduleOrder);
         while (it.hasNext()) {
             it.next();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix crash when saving profiles with synced modules. The `[]`'re were creating a new entry in the map while it was being iterated...
#### Motivation for adding to Mudlet
Fix crash.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2046.