### PR TITLE
Skip upgrading cmake installation

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -32,6 +32,9 @@ for i in $BREWS; do
   done
 done
 for i in $BREWS; do
+  if [ "${i}" = "cmake" ]; then
+    continue
+  fi
   for RETRIES in $(seq 1 3); do
     echo "Installing ${i}"
     brew list | grep -q $i || brew install $i


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
cmake is not provided as a bottle (precompiled binary) on macOS 10.11 anymore. This prolongs our CI time. Avoid upgrading it if it is already installed.

#### Motivation for adding to Mudlet
Speedier CI jobs.
