### PR TITLE
Skip lines without translation information

### DIFF
--- a/translations/translated/generate-translation-stats.lua
+++ b/translations/translated/generate-translation-stats.lua
@@ -31,9 +31,11 @@ while line <= #lines do
   local lang = currentLine:match("mudlet_([a-z]+_[A-Z]+)%.qm")
   line = line + 1
   if lang then
-    currentLine = lines[line]
-    local translated = tonumber(currentLine:match("(%d+)"))
-    line = line + 1
+    repeat
+      currentLine = lines[line]
+      local translated = tonumber(currentLine:match("(%d+)"))
+      line = line + 1
+    until translated ~= nil
     currentLine = lines[line]
     local untranslated = tonumber(currentLine:match("(%d+)"))
     line = line + 1

--- a/translations/translated/generate-translation-stats.lua
+++ b/translations/translated/generate-translation-stats.lua
@@ -31,9 +31,10 @@ while line <= #lines do
   local lang = currentLine:match("mudlet_([a-z]+_[A-Z]+)%.qm")
   line = line + 1
   if lang then
+    local translated
     repeat
       currentLine = lines[line]
-      local translated = tonumber(currentLine:match("(%d+)"))
+      translated = tonumber(currentLine:match("(%d+)"))
       line = line + 1
     until translated ~= nil
     currentLine = lines[line]


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Sometimes there are warnings or other messages which don't contain information
about the translation status. Skip them so we always have a valid number.

#### Motivation for adding to Mudlet
Don't fail anymore (like our current i18n branches do)
