### PR TITLE
Fixed showWindow and hideWindow error messages

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2879,7 +2879,7 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 {
     string luaSendText = "";
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "hideUserWindow: wrong argument type");
+        lua_pushstring(L, "hideWindow: wrong argument type");
         lua_error(L);
         return 1;
     } else {
@@ -3659,7 +3659,7 @@ int TLuaInterpreter::showUserWindow(lua_State* L)
 {
     string luaSendText = "";
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "showUserWindow: wrong argument type");
+        lua_pushstring(L, "showWindow: wrong argument type");
         lua_error(L);
         return 1;
     } else {


### PR DESCRIPTION
hideWindow and showWindow had 'hideUserWindow' and 'showUserWindow' in their error messages. This changes the error messages to match the proper name of the function. Part of Issue #2069.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
