### PR TITLE
BugFix: initialise checkBox_showIconsOnMenus in Preferences Dialogue

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -186,6 +186,14 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
                                                                                 "encodings of <b>GBK</b> or <b>GBK18030</b> and 'narrow' for all others.</li></ul></p>"
                                                                                 "<p><i>This is a temporary arrangement and will likely to change when Mudlet gains "
                                                                                 "full support for languages other than English.</i></p>"));
+    checkBox_showIconsOnMenus->setToolTip(tr("<p>Some Desktop Environments tell Qt applications like Mudlet whether they should "
+                                             "shown icons on menus, others, however do not. This control allows the user to override "
+                                             "the setting, if needed, as follows:"
+                                             "<ul><li><b>Unchecked</b> '<i>off</i>' = Prevent menus from being drawn with icons.</li>"
+                                             "<li><b>Checked</b> '<i>on</i>' = Allow menus to be drawn with icons.</li>"
+                                             "<li><b>Partly checked</b> <i>(Default) 'auto'</i> = Use the setting that the system provides.</li></ul></p>"
+                                             "<p><i>This setting is only processed when individual menus are created and changes may not "
+                                             "propogate everywhere until Mudlet is restarted.</i></p>"));
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
     connect(checkBox_showLineFeedsAndParagraphs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -80,7 +80,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     checkBox_showLineFeedsAndParagraphs->setChecked(pMudlet->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
 
     checkBox_reportMapIssuesOnScreen->setChecked(pMudlet->showMapAuditErrors());
-
+    checkBox_showIconsOnMenus->setCheckState(pMudlet->mShowIconsOnMenuCheckedState);
 
     MainIconSize->setValue(pMudlet->mToolbarIconSize);
     TEFolderIconSize->setValue(pMudlet->mEditorTreeWidgetIconSize);
@@ -209,6 +209,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     connect(pMudlet, &mudlet::signal_setTreeIconSize, this, &dlgProfilePreferences::slot_setTreeWidgetIconSize);
     connect(pMudlet, &mudlet::signal_menuBarVisibilityChanged, this, &dlgProfilePreferences::slot_changeMenuBarVisibility);
     connect(pMudlet, &mudlet::signal_toolBarVisibilityChanged, this, &dlgProfilePreferences::slot_changeToolBarVisibility);
+    connect(pMudlet, &mudlet::signal_showIconsOnMenusChanged, this, &dlgProfilePreferences::slot_changeShowIconsOnMenus);
 
     generateDiscordTooltips();
 
@@ -2210,21 +2211,9 @@ void dlgProfilePreferences::slot_save_and_exit()
     pMudlet->setEnableFullScreenMode(checkBox_USE_SMALL_SCREEN->isChecked());
     pMudlet->setEditorTextoptions(checkBox_showSpacesAndTabs->isChecked(), checkBox_showLineFeedsAndParagraphs->isChecked());
     pMudlet->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
-    pMudlet->mShowIconsOnMenuCheckedState = checkBox_showIconsOnMenus->checkState();
+    pMudlet->setShowIconsOnMenu(checkBox_showIconsOnMenus->checkState());
 
     mudlet::self()->mDiscord.UpdatePresence();
-
-    mudlet::self()->mShowIconsOnMenuCheckedState = checkBox_showIconsOnMenus->checkState();
-    switch (checkBox_showIconsOnMenus->checkState()) {
-    case Qt::Unchecked:
-        qApp->setAttribute(Qt::AA_DontShowIconsInMenus, true);
-        break;
-    case Qt::Checked:
-        qApp->setAttribute(Qt::AA_DontShowIconsInMenus, false);
-        break;
-    case Qt::PartiallyChecked:
-        qApp->setAttribute(Qt::AA_DontShowIconsInMenus, !mudlet::self()->mShowIconsOnMenuOriginally);
-    }
 
     close();
 }
@@ -3166,6 +3155,13 @@ void dlgProfilePreferences::slot_changeToolBarVisibility(const mudlet::controlsV
         if (comboBox_toolBarVisibility->currentIndex() != 2) {
             comboBox_toolBarVisibility->setCurrentIndex(2);
         }
+    }
+}
+
+void dlgProfilePreferences::slot_changeShowIconsOnMenus(const Qt::CheckState state)
+{
+    if (checkBox_showIconsOnMenus->checkState() != state) {
+        checkBox_showIconsOnMenus->setCheckState(state);
     }
 }
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -145,6 +145,7 @@ private slots:
     void slot_setTreeWidgetIconSize(const int);
     void slot_changeMenuBarVisibility(const mudlet::controlsVisibility);
     void slot_changeToolBarVisibility(const mudlet::controlsVisibility);
+    void slot_changeShowIconsOnMenus(const Qt::CheckState);
     void slot_changeGuiLanguage(const QString &language);
 
 private:

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3957,6 +3957,26 @@ void mudlet::setShowMapAuditErrors(const bool state)
 
 }
 
+void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
+{
+    if (mShowIconsOnMenuCheckedState != state) {
+        mShowIconsOnMenuCheckedState = state;
+
+        switch (state) {
+        case Qt::Unchecked:
+            qApp->setAttribute(Qt::AA_DontShowIconsInMenus, true);
+            break;
+        case Qt::Checked:
+            qApp->setAttribute(Qt::AA_DontShowIconsInMenus, false);
+            break;
+        case Qt::PartiallyChecked:
+            qApp->setAttribute(Qt::AA_DontShowIconsInMenus, !mShowIconsOnMenuOriginally);
+        }
+
+        emit signal_showIconsOnMenusChanged(state);
+    }
+}
+
 void mudlet::setInterfaceLanguage(const QString& languageCode)
 {
     mInterfaceLanguage = languageCode;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -271,6 +271,7 @@ public:
     bool compactInputLine() const { return mCompactInputLine; }
     void setCompactInputLine(const bool state) { mCompactInputLine = state; }
     void createMapper(bool loadDefaultMap = true);
+    void setShowIconsOnMenu(const Qt::CheckState);
 
     static bool unzip(const QString& archivePath, const QString& destination, const QDir& tmpDir);
 
@@ -437,6 +438,7 @@ signals:
     void signal_showMapAuditErrorsChanged(bool);
     void signal_menuBarVisibilityChanged(const controlsVisibility);
     void signal_toolBarVisibilityChanged(const controlsVisibility);
+    void signal_showIconsOnMenusChanged(const Qt::CheckState);
 
 private slots:
     void slot_close_profile();


### PR DESCRIPTION
I had previously forgotten to set the `checkBox_showIconsOnMenus` control to the current (application-wide) setting on creation of the Profile Preferences. This commit inserts the code necessary and supports updating the control in multiple profiles' preference dialogues should it be changed when one instance is saved and closed.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>