### PR TITLE
Update ctelnet.c to try to fix ANSI in GMCP

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1241,6 +1241,8 @@ void cTelnet::setGMCPVariables(const QString& msg)
         mpHost->setMmpMapLocation(data);
     }
     data.remove('\n');
+    // replace ANSI escape character with escaped version, to handle improperly passed ANSI codes
+    data.replace(QStringLiteral("\27"), QStringLiteral("\\u001B"))
     // remove \r's from the data, as yajl doesn't like it
     data.remove(QChar('\r'));
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1242,8 +1242,8 @@ void cTelnet::setGMCPVariables(const QString& msg)
     }
     data.remove('\n');
     // replace ANSI escape character with escaped version, to handle improperly passed ANSI codes
-    // testing to see why the replacement seems to not have worked.
-    data.replace(QStringLiteral("\27"), QStringLiteral("-TEST-"));
+    // trying a different way of declaring the string being searched for, to see if that is responsible for the failure
+    data.replace('\27', QStringLiteral("\\u001B"));
     // remove \r's from the data, as yajl doesn't like it
     data.remove(QChar('\r'));
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1242,7 +1242,7 @@ void cTelnet::setGMCPVariables(const QString& msg)
     }
     data.remove('\n');
     // replace ANSI escape character with escaped version, to handle improperly passed ANSI codes
-    data.replace(QStringLiteral("\27"), QStringLiteral("\\u001B"))
+    data.replace(QStringLiteral("\27"), QStringLiteral("\\u001B"));
     // remove \r's from the data, as yajl doesn't like it
     data.remove(QChar('\r'));
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1242,7 +1242,8 @@ void cTelnet::setGMCPVariables(const QString& msg)
     }
     data.remove('\n');
     // replace ANSI escape character with escaped version, to handle improperly passed ANSI codes
-    data.replace(QStringLiteral("\27"), QStringLiteral("\\u001B"));
+    // testing to see why the replacement seems to not have worked.
+    data.replace(QStringLiteral("\27"), QStringLiteral("-TEST-"));
     // remove \r's from the data, as yajl doesn't like it
     data.remove(QChar('\r'));
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1242,8 +1242,8 @@ void cTelnet::setGMCPVariables(const QString& msg)
     }
     data.remove('\n');
     // replace ANSI escape character with escaped version, to handle improperly passed ANSI codes
-    // trying a different way of declaring the string being searched for, to see if that is responsible for the failure
-    data.replace('\27', QStringLiteral("\\u001B"));
+    // trying a different way of specifying the escape character
+    data.replace(QStringLiteral("\u001B"), QStringLiteral("\\u001B"));
     // remove \r's from the data, as yajl doesn't like it
     data.remove(QChar('\r'));
 


### PR DESCRIPTION
Some games were sending ANSI codes in GMCP that weren't properly escaped, replacing '\27' with '\\u001B' to convert it to what it should be in the first place.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet
Aardwolf and some other games are passing ANSI codes in GMCP with improperly escaped ANSI escape codes, causing errors converting them from JSON. This change is intended to convert it for them.
#### Other info (issues closed, discussion etc)
