### PR TITLE
Changed Geyser.Gauge:setValue to use text label

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -57,8 +57,7 @@ function Geyser.Gauge:setValue (currentValue, maxValue, text)
   end
 
   if text then
-    self.front:echo(text)
-    self.back:echo(text)
+    self.text:echo(text)
   end
 end
 


### PR DESCRIPTION
Geyser gauges have three layers, with one specifically for the text of the gauge. Geyser.Gauge:setText and Geyser.Gauge:setColor both used the text label for text they were given, but setValue still used the old style of writing to the front and back labels. This change updates setValue to follow the new method.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
