### PR TITLE
Fixed xEcho to properly move cursor after insert

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -942,7 +942,7 @@ if rex then
             out(win, v) else out(v)
           end
           if func == 'insertText' then
-            moveCursor(window or "main", getColumnNumber() + string.len(v), getLineNumber())
+            moveCursor(win or "main", getColumnNumber() + string.len(v), getLineNumber())
           end
         else
           -- if win and fmt then setUnderline(win, true) elseif fmt then setUnderline(true) end -- not sure if underline is necessary unless asked for


### PR DESCRIPTION
xEcho was using the non-existent variable "window" in its moveCursor call, rather than the intended variable "win". Fixed.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
