### PR TITLE
Revise: properly distinguish between two pairs of two languages

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -131,10 +131,10 @@ mudlet* mudlet::self()
 void mudlet::loadLanguagesMap()
 {
     mLanguageCodeMap = {
-            {"en_US", make_pair(tr("English", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 100)},
-            {"en_GB", make_pair(tr("English (British)", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
-            {"zh_CN", make_pair(tr("Chinese", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
-            {"zh_TW", make_pair(tr("Chinese (Traditional)", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
+            {"en_US", make_pair(tr("English [American]", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 100)},
+            {"en_GB", make_pair(tr("English [British]", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
+            {"zh_CN", make_pair(tr("Chinese [Simplified]", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
+            {"zh_TW", make_pair(tr("Chinese [Traditional]", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
             {"nl_NL", make_pair(tr("Dutch", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
             {"fr_FR", make_pair(tr("French", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},
             {"de_DE", make_pair(tr("German", "Name of language. Please translate with the English description intact, like this: Nederlands (Dutch)"), 0)},


### PR DESCRIPTION
Using "English" to describe "American English" introduces some confusion when "English (British)" is also listed. Similarly calling a language "Chinese" when it actually means "Simplified Chinese" which is what is generally used in China can be confusing when Taiwan uses "Traditional Chinese" - this is actually a point of contention in that part of the World and it is not wise to mix up what each setting is supposed to mean or to imply a difference importance to different variants for the same language.

Note that I have changed to use square brackets `[`...`]` around the Country or other disambiguation term here because `(`...`)` are already used for only partially translated languages and it looks messy to use the same type of brackets twice in the same item when they imply completely different things (%-age translated and variant)!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>