### PR TITLE
Added getSelection()

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2091,6 +2091,25 @@ bool TConsole::selectSection(int from, int to)
     return true;
 }
 
+// returns whenever the selection is valid, the selection text,
+// start position, and the length of the seletion
+std::tuple<bool, QString, int, int> TConsole::getSelection()
+{
+    if (mUserCursor.y() >= static_cast<int>(buffer.buffer.size())) {
+        return make_tuple(false, QStringLiteral("the selection is no longer valid"), 0, 0);
+    }
+
+    const auto start = P_begin.x();
+    const auto length = P_end.x() - P_begin.x();
+    const auto line = buffer.line(mUserCursor.y());
+    if (line.size() < start) {
+        return make_tuple(false, QStringLiteral("the selection is no longer valid"), 0, 0);
+    }
+
+    const auto text = line.mid(start, length);
+    return make_tuple(true, text, start, length);
+}
+
 void TConsole::setLink(const QString& linkText, QStringList& linkFunction, QStringList& linkHint)
 {
     buffer.applyLink(P_begin, P_end, linkText, linkFunction, linkHint);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -108,6 +108,7 @@ public:
     void echo(const QString&);
     bool moveCursor(int x, int y);
     int select(const QString&, int numOfMatch = 1);
+    std::tuple<bool, QString, int, int> getSelection();
     void deselect();
     bool selectSection(int, int);
     void skipLine();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1638,7 +1638,7 @@ int TLuaInterpreter::getSelection(lua_State* L)
     auto& host = getHostFromLua(L);
 
     QString windowName;
-    if (lua_gettop(L) > 1) {
+    if (lua_gettop(L) > 0) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "getSelection: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1638,9 +1638,9 @@ int TLuaInterpreter::getSelection(lua_State* L)
     auto& host = getHostFromLua(L);
 
     QString windowName;
-    if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
+    if (lua_gettop(L) > 1) {
         if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "getSelection: bad argument #%1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            lua_pushfstring(L, "getSelection: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         } else {
             windowName = QString::fromUtf8(lua_tostring(L, 1));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1628,6 +1628,42 @@ int TLuaInterpreter::selectSection(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getSelection
+int TLuaInterpreter::getSelection(lua_State* L)
+{
+    bool valid;
+    QString text;
+    int start, length;
+
+    auto& host = getHostFromLua(L);
+
+    QString windowName;
+    if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "getSelection: bad argument #%1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        } else {
+            windowName = QString::fromUtf8(lua_tostring(L, 1));
+        }
+    }
+    if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+        std::tie(valid, text, start, length) = host.mpConsole->getSelection();
+    } else {
+        std::tie(valid, text, start, length) = mudlet::self()->getSelection(&host, windowName);
+    }
+
+    if (!valid) {
+        lua_pushnil(L);
+        lua_pushstring(L, text.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushstring(L, text.toUtf8().constData());
+    lua_pushnumber(L, start);
+    lua_pushnumber(L, length);
+    return 3;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#moveCursor
 int TLuaInterpreter::moveCursor(lua_State* L)
 {
@@ -1760,7 +1796,6 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
     mudlet::self()->setScrollBarVisible(&host, windowName, false);
     return 0;
 }
-
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#replace
 int TLuaInterpreter::replace(lua_State* L)
@@ -13451,6 +13486,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setDiscordParty", TLuaInterpreter::setDiscordParty);
     lua_register(pGlobalLua, "getDiscordParty", TLuaInterpreter::getDiscordParty);
     lua_register(pGlobalLua, "getPlayerRoom", TLuaInterpreter::getPlayerRoom);
+    lua_register(pGlobalLua, "getSelection", TLuaInterpreter::getSelection);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -243,6 +243,7 @@ public:
     static int selectString(lua_State* L); // Was select but I think it clashes with the Lua command with that name
     static int getMainConsoleWidth(lua_State* L);
     static int selectSection(lua_State* L);
+    static int getSelection(lua_State* L);
     static int replace(lua_State* L);
     static int deselect(lua_State* L);
     static int getRoomExits(lua_State* L);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2238,6 +2238,17 @@ int mudlet::selectSection(Host* pHost, const QString& name, int f, int t)
     }
 }
 
+std::tuple<bool, QString, int, int> mudlet::getSelection(Host* pHost, const QString& windowName)
+{
+    QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
+    const auto window = dockWindowConsoleMap.constFind(windowName);
+    if (window != dockWindowConsoleMap.cend()) {
+        return window.value()->getSelection();
+    } else {
+        return make_tuple(false, QStringLiteral(R"(window "%s" not found)").arg(windowName.toUtf8().constData()), 0, 0);
+    }
+}
+
 // Added a return value to indicate whether the given windows name was found
 bool mudlet::deselect(Host* pHost, const QString& name)
 {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -148,6 +148,7 @@ public:
     void replace(Host*, const QString& name, const QString&);
     int selectString(Host*, const QString& name, const QString& what, int);
     int selectSection(Host*, const QString& name, int, int);
+    std::tuple<bool, QString, int, int> getSelection(Host* pHost, const QString& name);
     void setBold(Host*, const QString& name, bool);
     void setLink(Host* pHost, const QString& name, const QString& linkText, QStringList& linkFunction, QStringList&);
     void setItalics(Host*, const QString& name, bool);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added `text, start, length = getSelection()`.
#### Motivation for adding to Mudlet
Knowing where the current cursor is in case it's modified by a 3rd party.
#### Other info (issues closed, discussion etc)
Addresses the need in https://github.com/Mudlet/Mudlet/issues/698.