### PR TITLE
Fix profile preferences blowing up with a long item name

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1226,6 +1226,9 @@
             <property name="editable">
              <bool>true</bool>
             </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+            </property>
            </widget>
           </item>
           <item row="2" column="0" colspan="2">


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Don't make the profile dialog too wide in case the user has a very, very long name for a trigger/alias/etc.
#### Motivation for adding to Mudlet
Better user experience.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2073.