### PR TITLE
BugFix: cure Coverity reported error

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1158,25 +1158,27 @@ void cTelnet::processTelnetCommand(const string& command)
                     if (myOptionState[i]) {
                         cmd += TN_WILL;
                         cmd += i;
-                        if (i == TN_SB) {
-                            // Handle corner case where byte value is TN_SB
+                        if (i == static_cast<unsigned char>(TN_SE)) {
+                            // Handle corner case where sub-option value is the same as TN_SE (240)
                             cmd += i;
                         }
                     }
                     if (hisOptionState[i]) {
                         cmd += TN_DO;
                         cmd += i;
-                        if (i == TN_SB) {
-                            // Handle corner case where byte value is TN_SB
+                        if (i == static_cast<unsigned char>(TN_SE)) {
+                            // Handle corner case where byte value is TN_SE
                             cmd += i;
                         }
                     }
                 }
                 cmd += TN_IAC;
                 cmd += TN_SE;
-                // This assumes that handling the status is exempt from the
-                // need to escape values that would themselves be
-                // interpreted as Telnet protocol bytes themselves -
+                // This works as handling the status is exempt from the need to
+                // escape values that would themselves be interpreted as Telnet
+                // protocol bytes themselves - except for the corner case when
+                // the sub-option is 240 as described in: RFC 859
+                // https://tools.ietf.org/html/rfc859 :
                 socketOutRaw(cmd);
             }
             break;


### PR DESCRIPTION
The code analysis that we have done by Coverity recently reported a dead (unreachable) code issue that I introduced whilst trying to "improve" the Telnet status reporting sub-option (5) - as a side effect of #1852. Basically I was comparing a `size_t` loop variable (which ran through all the values between 0 to 255 inclusive) to a `const char` which should have had the value of 240 (I also had a coding error and was using a value of 250 but the same principle applied!)  Due, I think, to the intricacies of `char` promotion to `int` a `char` value greater than 127 gets treated as a negative value (as a `signed char`) rather than the `unsigned char` I was expecting. I hope to fix that with this commit which makes the conversion go via the `unsigned char` type which should make it work...

If successful, this will close Issue #2103.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>