### PR TITLE
Revise: dead code removal for main window

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -454,55 +454,35 @@ mudlet::mudlet()
     connect(mpActionPackageManager.data(), &QAction::triggered, this, &mudlet::slot_package_manager);
     connect(mpActionModuleManager.data(), &QAction::triggered, this, &mudlet::slot_module_manager);
 
-    QAction* mactionConnect = new QAction(tr("Connect"), this);
-    QAction* mactionAlias = new QAction(tr("Aliases"), this);
-    QAction* mactionTimers = new QAction(tr("Timers"), this);
-    QAction* mactionButtons = new QAction(tr("Actions"), this);
-    QAction* mactionScripts = new QAction(tr("Scripts"), this);
-    QAction* mactionKeys = new QAction(tr("Keys"), this);
-    QAction* mactionMapper = new QAction(tr("Map"), this);
-    QAction* mactionHelp = new QAction(tr("Help"), this);
-    QAction* mactionOptions = new QAction(tr("Preferences"), this);
-    QAction* mactionMultiView = new QAction(tr("MultiView"), this);
-    QAction* mactionAbout = new QAction(tr("About"), this);
-    QAction* mactionCloseProfile = new QAction(tr("Close"), this);
+    // PLACEMARKER: Save for later restoration (1 of 2) (by adding a "Close" (profile) option to first menu on menu bar:
+    // QAction* mactionCloseProfile = new QAction(tr("Close"), this);
 
-    connect(mactionConnect, &QAction::triggered, this, &mudlet::slot_show_connection_dialog);
     connect(dactionConnect, &QAction::triggered, this, &mudlet::slot_show_connection_dialog);
     connect(dactionReconnect, &QAction::triggered, this, &mudlet::slot_reconnect);
     connect(dactionDisconnect, &QAction::triggered, this, &mudlet::slot_disconnect);
     connect(dactionNotepad, &QAction::triggered, this, &mudlet::slot_notes);
     connect(dactionReplay, &QAction::triggered, this, &mudlet::slot_replay);
 
-    connect(mactionHelp, &QAction::triggered, this, &mudlet::show_help_dialog);
     connect(dactionHelp, &QAction::triggered, this, &mudlet::show_help_dialog);
     connect(dactionVideo, &QAction::triggered, this, &mudlet::slot_show_help_dialog_video);
     connect(dactionForum, &QAction::triggered, this, &mudlet::slot_show_help_dialog_forum);
     connect(dactionIRC, &QAction::triggered, this, &mudlet::slot_irc);
-    connect(actionLive_Help_Chat, &QAction::triggered, this, &mudlet::slot_irc);
+    connect(dactionLiveHelpChat, &QAction::triggered, this, &mudlet::slot_irc);
 #if !defined(INCLUDE_UPDATER)
     dactionUpdate->setVisible(false);
 #endif
-    connect(actionPackage_manager, &QAction::triggered, this, &mudlet::slot_package_manager);
-    connect(actionPackage_Exporter, &QAction::triggered, this, &mudlet::slot_package_exporter);
-    connect(actionModule_manager, &QAction::triggered, this, &mudlet::slot_module_manager);
+    connect(dactionPackageManager, &QAction::triggered, this, &mudlet::slot_package_manager);
+    connect(dactionPackageExporter, &QAction::triggered, this, &mudlet::slot_package_exporter);
+    connect(dactionModuleManager, &QAction::triggered, this, &mudlet::slot_module_manager);
     connect(dactionMultiView, &QAction::triggered, this, &mudlet::slot_multi_view);
-    connect(mactionMultiView, &QAction::triggered, this, &mudlet::slot_multi_view);
     connect(dactionInputLine, &QAction::triggered, this, &mudlet::slot_toggle_compact_input_line);
     connect(mpActionTriggers.data(), &QAction::triggered, this, &mudlet::show_trigger_dialog);
     connect(dactionScriptEditor, &QAction::triggered, this, &mudlet::show_trigger_dialog);
-    connect(mactionMapper, &QAction::triggered, this, &mudlet::slot_mapper);
-    connect(actionShow_Map, &QAction::triggered, this, &mudlet::slot_mapper);
-    connect(mactionTimers, &QAction::triggered, this, &mudlet::show_timer_dialog);
-    connect(mactionAlias, &QAction::triggered, this, &mudlet::show_alias_dialog);
-    connect(mactionScripts, &QAction::triggered, this, &mudlet::show_script_dialog);
-    connect(mactionKeys, &QAction::triggered, this, &mudlet::show_key_dialog);
-    connect(mactionButtons, &QAction::triggered, this, &mudlet::show_action_dialog);
-    connect(mactionOptions, &QAction::triggered, this, &mudlet::show_options_dialog);
+    connect(dactionShowMap, &QAction::triggered, this, &mudlet::slot_mapper);
     connect(dactionOptions, &QAction::triggered, this, &mudlet::show_options_dialog);
-    connect(mactionAbout, &QAction::triggered, this, &mudlet::slot_show_about_dialog);
     connect(dactionAbout, &QAction::triggered, this, &mudlet::slot_show_about_dialog);
-    connect(mactionCloseProfile, &QAction::triggered, this, &mudlet::slot_close_profile);
+    // PLACEMARKER: Save for later restoration (2 of 2) (by adding a "Close" (profile) option to first menu on menu bar:
+    // connect(mactionCloseProfile, &QAction::triggered, this, &mudlet::slot_close_profile);
 
     // we historically use Alt on Windows and Linux, but that is uncomfortable on macOS
 #if defined(Q_OS_MACOS)
@@ -2827,7 +2807,7 @@ void mudlet::slot_update_shortcuts()
 
         showMapShortcut = new QShortcut(showMapKeySequence, this);
         connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
-        actionShow_Map->setShortcut(QKeySequence());
+        dactionShowMap->setShortcut(QKeySequence());
 
         inputLineShortcut = new QShortcut(inputLineKeySequence, this);
         connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_compact_input_line);
@@ -2843,11 +2823,11 @@ void mudlet::slot_update_shortcuts()
 
         packagesShortcut = new QShortcut(packagesKeySequence, this);
         connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::show_options_dialog);
-        actionPackage_manager->setShortcut(QKeySequence());
+        dactionPackageManager->setShortcut(QKeySequence());
 
         modulesShortcut = new QShortcut(packagesKeySequence, this);
         connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
-        actionModule_manager->setShortcut(QKeySequence());
+        dactionModuleManager->setShortcut(QKeySequence());
 
         multiViewShortcut = new QShortcut(multiViewKeySequence, this);
         connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_multi_view);
@@ -2869,7 +2849,7 @@ void mudlet::slot_update_shortcuts()
         dactionScriptEditor->setShortcut(triggersKeySequence);
 
         showMapShortcut.clear();
-        actionShow_Map->setShortcut(showMapKeySequence);
+        dactionShowMap->setShortcut(showMapKeySequence);
 
         inputLineShortcut.clear();
         dactionInputLine->setShortcut(inputLineKeySequence);
@@ -2881,10 +2861,10 @@ void mudlet::slot_update_shortcuts()
         dactionNotepad->setShortcut(notepadKeySequence);
 
         packagesShortcut.clear();
-        actionPackage_manager->setShortcut(packagesKeySequence);
+        dactionPackageManager->setShortcut(packagesKeySequence);
 
         modulesShortcut.clear();
-        actionModule_manager->setShortcut(modulesKeySequence);
+        dactionModuleManager->setShortcut(modulesKeySequence);
 
         multiViewShortcut.clear();
         dactionMultiView->setShortcut(multiViewKeySequence);

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -13,19 +13,6 @@
     <height>502</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Mudlet 1.0 - alpha 1</string>
-  </property>
-  <property name="windowIcon">
-   <iconset>
-    <normaloff>:/mudlet_main_16px.png</normaloff>:/mudlet_main_16px.png</iconset>
-  </property>
-  <property name="iconSize">
-   <size>
-    <width>0</width>
-    <height>0</height>
-   </size>
-  </property>
   <property name="dockOptions">
    <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks|QMainWindow::VerticalTabs</set>
   </property>
@@ -108,14 +95,14 @@
      <string>Toolbox</string>
     </property>
     <addaction name="dactionScriptEditor"/>
-    <addaction name="actionShow_Map"/>
+    <addaction name="dactionShowMap"/>
     <addaction name="dactionInputLine"/>
     <addaction name="dactionNotepad"/>
-    <addaction name="actionLive_Help_Chat"/>
-    <addaction name="actionPackage_manager"/>
+    <addaction name="dactionLiveHelpChat"/>
+    <addaction name="dactionPackageManager"/>
     <addaction name="dactionReplay"/>
-    <addaction name="actionModule_manager"/>
-    <addaction name="actionPackage_Exporter"/>
+    <addaction name="dactionModuleManager"/>
+    <addaction name="dactionPackageExporter"/>
    </widget>
    <widget class="QMenu" name="menuOptions">
     <property name="title">
@@ -159,32 +146,32 @@
    <property name="text">
     <string>Play</string>
    </property>
-   <property name="statusTip">
-    <string>configure connection details of, and make a connection to, game servers</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Configure connection details of, and make a connection to, game servers.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionDisconnect">
    <property name="text">
     <string>Disconnect</string>
    </property>
-   <property name="statusTip">
-    <string>disconnect from the current game server</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Disconnect from the current game server.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionReconnect">
    <property name="text">
     <string>Reconnect</string>
    </property>
-   <property name="statusTip">
-    <string>disconnect and then reconnect to the current game server</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Disconnect and then reconnect to the current game server.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionOptions">
    <property name="text">
     <string>Preferences</string>
    </property>
-   <property name="statusTip">
-    <string>configure setting for the Mudlet application globally and for the current profile</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Configure setting for the Mudlet application globally and for the current profile.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionScriptEditor">
@@ -192,147 +179,124 @@
     <string>Script editor</string>
    </property>
    <property name="toolTip">
-    <string>Open script editor</string>
-   </property>
-   <property name="statusTip">
-    <string>opens the Editor for the different types of things that can be scripted by the user</string>
+    <string>&lt;p&gt;Opens the Editor for the different types of things that can be scripted by the user.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionNotepad">
    <property name="text">
     <string>Notepad</string>
    </property>
-   <property name="statusTip">
-    <string>opens a free form text editor window for the active profile that is saved between sessions</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Opens a free form text editor window for the active profile that is saved between sessions.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionHelp">
    <property name="text">
     <string>API Reference</string>
    </property>
-   <property name="statusTip">
-    <string>opens the (on-line) Mudlet Wiki, at the API front page, in your system web-browser</string>
-   </property>
-  </action>
-  <action name="dactionForum_2">
-   <property name="text">
-    <string>Online forum</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Opens the (on-line) Mudlet Wiki, at the API front page, in your system web-browser.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionAbout">
    <property name="text">
     <string>About Mudlet</string>
    </property>
-   <property name="statusTip">
-    <string>inform yourself about this version of Mudlet, the people who made it and the licence under which you can share it</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Inform yourself about this version of Mudlet, the people who made it and the licence under which you can share it.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionIRC">
    <property name="text">
     <string>IRC help channel</string>
    </property>
-   <property name="statusTip">
-    <string>opens a built-in IRC chat on the #mudlet channel on Freenode IRC servers</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Opens a built-in IRC chat on the #mudlet channel on Freenode IRC servers.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionVideo">
    <property name="text">
     <string>Video tutorials</string>
    </property>
-   <property name="statusTip">
-    <string>opens an (on-line) collection of &quot;Educational Mudlet screencasts&quot; in your system web-browser</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Opens an (on-line) collection of &quot;Educational Mudlet screencasts&quot; in your system web-browser.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionReplay">
    <property name="text">
     <string>Load replay</string>
    </property>
-   <property name="statusTip">
-    <string>load a previous saved game session that can be used to test Mudlet lua systems (off-line!)</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Load a previous saved game session that can be used to test Mudlet lua systems (off-line!).&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionForum">
    <property name="text">
     <string>Online forum</string>
    </property>
-   <property name="statusTip">
-    <string>opens the (on-line) Mudlet Forum in your system web-browser</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Opens the (on-line) Mudlet Forum in your system web-browser.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionUpdate">
    <property name="text">
-    <string>Check for updates...</string>
+    <string>&lt;p&gt;Check for updates...</string>
    </property>
   </action>
-  <action name="dactionIRC_2">
-   <property name="text">
-    <string>Help chat</string>
-   </property>
-   <property name="toolTip">
-    <string>Get live help on IRC. If nobody answers right away, give it time</string>
-   </property>
-  </action>
-  <action name="actionLive_Help_Chat">
+  <action name="dactionLiveHelpChat">
    <property name="text">
     <string>Live help chat</string>
    </property>
-   <property name="statusTip">
-    <string>opens a built-in IRC chat on the #mudlet channel on Freenode IRC servers</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Opens a built-in IRC chat on the #mudlet channel on Freenode IRC servers.&lt;/p&gt;</string>
    </property>
   </action>
-  <action name="actionShow_Map">
+  <action name="dactionShowMap">
    <property name="text">
     <string>Show map</string>
    </property>
-   <property name="statusTip">
-    <string>show or hide the game map</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Show or hide the game map.&lt;/p&gt;</string>
    </property>
   </action>
-  <action name="actionPackage_manager">
+  <action name="dactionPackageManager">
    <property name="text">
     <string>Package manager</string>
    </property>
-   <property name="statusTip">
-    <string>install and remove collections of Mudlet lua items (packages)</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Install and remove collections of Mudlet lua items (packages).&lt;/p&gt;</string>
    </property>
   </action>
-  <action name="actionTest1">
-   <property name="text">
-    <string>test1</string>
-   </property>
-  </action>
-  <action name="actionAsdf">
-   <property name="text">
-    <string>asdf</string>
-   </property>
-  </action>
-  <action name="actionModule_manager">
+  <action name="dactionModuleManager">
    <property name="text">
     <string>Module manager</string>
    </property>
-   <property name="statusTip">
-    <string>install and remove (share- &amp; sync-able) collections of Mudlet lua items (modules)</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Install and remove (share- &amp; sync-able) collections of Mudlet lua items (modules).&lt;/p&gt;</string>
    </property>
   </action>
-  <action name="actionPackage_Exporter">
+  <action name="dactionPackageExporter">
    <property name="text">
     <string>Package exporter (experimental)</string>
    </property>
-   <property name="statusTip">
-    <string>gather and bundle up collections of Mudlet Lua items and other reasources into a module</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Gather and bundle up collections of Mudlet Lua items and other reasources into a module.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionMultiView">
    <property name="text">
     <string>MultiView</string>
    </property>
-   <property name="statusTip">
-    <string>share the screen area between multiple open profiles</string>
+   <property name="toolTip">
+    <string>&lt;p&gt;Share the screen area between multiple open profiles.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionInputLine">
    <property name="text">
     <string>Compact input line</string>
+   </property>
+   <property name="toolTip">
+    <string>&lt;p&gt;Hide or show the search area and the bottom buttons to the right of the input area on the input line.&lt;/p&gt;</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Some clean up work:

Remove some unused `QActions` defined in the `./ui/main_window.ui` form:
* `dactionForum_2`
* `dactionIRC_2`
* `actionTest1`
* `actionAsdf`

Removed the `windowTitle` and `windowIcon` definitions in the `main_window.ui` form as they are wrong and overwritten in the `mudlet` constructor anyway - the former would also have cropped up as a pointless `QString` to be translated.

Remove some unused `QActions` defined in the `mudlet` constructor but never placed into the application's windows:
* `mactionConnect`
* `mactionAlias`
* `mactionTimers`
* `mactionButtons`
* `mactionScripts`
* `mactionKeys`
* `mactionMapper`
* `mactionHelp`
* `mactionOptions`
* `mactionMultiView`
* `mactionAbout`

Moved the `statusTip` texts for items on the menu bar to the corresponding `toolTip` texts because we have not had a status bar for a long time and thus the texts were never shown - this did cause the replacement of one `toolTip` text (for the `QAction` to open the editor)! Also converted all `toolTip` texts in `main_window.ui` to be in a rich-text form (with initial capital letter and full stop at the end) with the addition of HTML paragraph tags to wrap the text.

A further one `mactionCloseProfile` has been left but has been commented out because I have potentially a plan to add/restore a "Close" profile action to the Game menu on the main menubar.

Some menubar `QAction`s were renamed to match the form used by others:
* `actionShow_Map`         ==> `dactionShowMap`
* `actionLive_Help_Chat`   ==> `dactionLiveHelpChat`
* `actionPackage_manager`  ==> `dactionPackageManager`
* `actionModule_manager`   ==> `dactionModuleManager`
* `actionPackage_Exporter` ==> `dactionPackageExporter`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>