### PR TITLE
Added Lua tr() function

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13504,6 +13504,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setDiscordParty", TLuaInterpreter::setDiscordParty);
     lua_register(pGlobalLua, "getDiscordParty", TLuaInterpreter::getDiscordParty);
     lua_register(pGlobalLua, "getPlayerRoom", TLuaInterpreter::getPlayerRoom);
+    lua_register(pGlobalLua, "tr", TLuaInterpreter::tr);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath
@@ -14265,6 +14266,33 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
     }
 
     lua_pushnumber(L, columns);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#tr
+int TLuaInterpreter::tr(lua_State* L)
+{
+    QString sourceText;
+    int pluralCount = -1;
+
+    if (!lua_isstring(L, 1)) {
+        lua_pushfstring(L, "tr: bad argument #1 type (text to translate as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    } else {
+        sourceText = QString::fromUtf8(lua_tostring(L, 1));
+    }
+
+    int argumentsCount = lua_gettop(L);
+    if (argumentsCount > 1) {
+        if (!lua_isnumber(L, 2)) {
+            lua_pushfstring(L, "tr: bad argument #2 type (plural count as number expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        } else {
+            pluralCount = lua_tonumber(L, 2);
+        }
+    }
+
+    lua_pushstring(L, mudlet::self()->getLuaTranslation(sourceText).toUtf8().constData());
     return 1;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -460,6 +460,7 @@ public:
     static int getDiscordParty(lua_State*);
     static int setDiscordGame(lua_State *L);
     static int getPlayerRoom(lua_State* L);
+    static int tr(lua_State *L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4048,6 +4048,16 @@ QStringList mudlet::getAvailableFonts()
     return database.families(QFontDatabase::Any);
 }
 
+QString mudlet::getLuaTranslation(const QString& sourceText)
+{
+    const auto translation = mLuaTranslations.constFind(sourceText);
+    if (translation != mLuaTranslations.cend()) {
+        return translation.value();
+    } else {
+        return sourceText;
+    }
+}
+
 std::string mudlet::replaceString(std::string subject, const std::string& search, const std::string& replace)
 {
     size_t pos = 0;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -212,6 +212,7 @@ public:
     int getColumnCount(Host* pHost, QString& name);
     int getRowCount(Host* pHost, QString& name);
     QStringList getAvailableFonts();
+    QString getLuaTranslation(const QString &sourceText);
 
     static const bool scmIsDevelopmentVersion;
     QTime mReplayTime;
@@ -580,6 +581,23 @@ private:
     QList<QPointer<QTranslator>> mTranslatorsLoadedList;
     void loadTranslationFile(const QString& translationFileName, const QString &filePath, QString &languageCode);
     void loadLanguagesMap();
+
+    // translations for the Lua tr() function
+    const QHash<QString, QString> mLuaTranslations = {
+        {"nw", QT_TRANSLATE_NOOP("Exit direction shortcode", "nw")},
+        {"n", QT_TRANSLATE_NOOP("Exit direction shortcode", "n")},
+        {"ne", QT_TRANSLATE_NOOP("Exit direction shortcode", "ne")},
+        {"up", QT_TRANSLATE_NOOP("Exit direction shortcode", "up")},
+        {"w", QT_TRANSLATE_NOOP("Exit direction shortcode", "w")},
+        {"e", QT_TRANSLATE_NOOP("Exit direction shortcode", "e")},
+        {"down", QT_TRANSLATE_NOOP("Exit direction shortcode", "down")},
+        {"sw", QT_TRANSLATE_NOOP("Exit direction shortcode", "sw")},
+        {"s", QT_TRANSLATE_NOOP("Exit direction shortcode", "s")},
+        {"se", QT_TRANSLATE_NOOP("Exit direction shortcode", "se")},
+        {"in", QT_TRANSLATE_NOOP("Exit direction shortcode", "in")},
+        {"out", QT_TRANSLATE_NOOP("Exit direction shortcode", "out")},
+    };
+
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added a Lua `tr()` function with a subset of directions available for translation into the currently-selected interface language.
#### Motivation for adding to Mudlet
So Lua scripts can have access to a few commonly-used translations.
#### Other info (issues closed, discussion etc)
Useful for i18n in https://github.com/Mudlet/Mudlet/pull/1940.