### PR TITLE
BugFix: try and get both Mac and Linux Travis CI builds working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     - sourceline: 'ppa:beineri/opt-qt571-trusty'
     - sourceline: 'ppa:beineri/opt-qt593-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
-    - sourceline: 'ppa:jonathonf/php7'
+    - sourceline: 'ppa:ondrej/php'
     packages: &common-packages
     - libhunspell-dev
     - lua5.1

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -6,7 +6,9 @@ fi
 
 set +e
 shopt -s expand_aliases
-BREWS="boost cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache pugixml luarocks"
+#Removed boost as first item as a temporary workaround to prevent trying to
+#upgrade to boost version 1.68.0 which does not seem to have been bottled yet...
+BREWS="cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache pugixml luarocks"
 for i in $BREWS; do
   if [ "${i}" = "cmake" ]; then
     continue
@@ -54,7 +56,7 @@ done
 gem update cocoapods
 
 # create an alias to avoid the need to list the lua dir all the time
-# we want to expand the subshell only once (it's only tmeporary anyways)
+# we want to expand the subshell only once (it's only temporary anyways)
 # shellcheck disable=2139
 alias luarocks-5.1="luarocks --lua-dir='$(brew --prefix lua@5.1)'"
 luarocks-5.1 --local install lua-yajl


### PR DESCRIPTION
The Personal Package Archive (on Ubuntu) called `ppa:jonathonf/php7` no longer seems to be available which has cause Linux CI builds to error out however there is a commonly used (mainline ?) alternative called `ppa:ondrej/php` which seems to do the job.

Also with recent upgrades the Mac CI builds are erroring because Boost 1.68 is being built from scratch as it is not available as a "bottled" formula on the Homebrew system - and it takes so long the install/setup process times out... However we do not need a bleeding edge Boost so it is sufficient to use the supplied CI version (which seems to be 1.60).

Also fixed a spelling mistake in a comment in the CI/travis.osx.install.sh file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>