### PR TITLE
Enhance: arrange for main menu tool tips to actually be shown to user

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -228,6 +228,12 @@ mudlet::mudlet()
     setupUi(this);
     setUnifiedTitleAndToolBarOnMac(true);
     setContentsMargins(0, 0, 0, 0);
+    menuGames->setToolTipsVisible(true);
+    menuEditor->setToolTipsVisible(true);
+    menuOptions->setToolTipsVisible(true);
+    menuHelp->setToolTipsVisible(true);
+    menuAbout->setToolTipsVisible(true);
+
     mudlet::debugMode = false;
     setAttribute(Qt::WA_DeleteOnClose);
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);


### PR DESCRIPTION
In https://github.com/Mudlet/Mudlet/pull/2110 I arranged for all the no-longer shown status tips (we discarded the status bar on the main window some time ago) to become tool tips for the main menu.  Unfortunately, I never turned on the option for those tool-tips to be shown!

This commit fixes that.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>