### PR TITLE
Keneanung migrate to mac os sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ git:
 matrix:
   include:
   - os: osx
-    osx_image: xcode8
+    osx_image: xcode9.2
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
 
   - os: osx
-    osx_image: xcode8
+    osx_image: xcode9.2
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -6,13 +6,8 @@ fi
 
 set +e
 shopt -s expand_aliases
-#Removed boost as first item as a temporary workaround to prevent trying to
-#upgrade to boost version 1.68.0 which does not seem to have been bottled yet...
-BREWS="cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache pugixml luarocks"
+BREWS="boost cmake hunspell libzip libzzip lua51 pcre pkg-config qt5 yajl ccache pugixml luarocks"
 for i in $BREWS; do
-  if [ "${i}" = "cmake" ]; then
-    continue
-  fi
   for RETRIES in $(seq 1 3); do
     echo "Upgrading ${i}"
     brew outdated | grep -q $i

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 # Should be called before PROJECT.
 cmake_minimum_required(VERSION 3.1)
 if(APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11") # Qt 5.10 with which we build on OS X only supports 10.11 and up.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12") # Qt 5.11.2 with which we build on OS X supports 10.11 and up, but some tools are not provided as bottles for that anymore.
 endif()
 
 project(mudlet)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -78,7 +78,7 @@ CONFIG += c++14
 msvc:QMAKE_CXXFLAGS += -MP
 
 # Mac specific flags.
-macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
+macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.12
 
 QT += network opengl uitools multimedia gui concurrent
 qtHaveModule(gamepad): QT += gamepad


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This migrates the travis CI build environment for macOS to Sierra (10.12).

#### Motivation for adding to Mudlet
Homebrew stopped providing bottles (precompiled binaries) for changed brews on El Capitan (10.11). That means dependencies like cmake, boost, yajl and others (probably Qt soon as well) are compiled when running `brew install` or `brew update`. Boost and Qt are large enough to make our CI builds fail during the process.

#### Other info (issues closed, discussion etc)
The update increases the minimum supported macOS version from 10.11 to 10.12 which means we could lose some users. But although there is no official support policy from Apple, the latest security update was not published for 10.11 anymore and it looks like Apple dropped the support and we should urge the users with an outdated OS version to upgrade to a newer version.