### PR TITLE
BugFix: correct presentation of texts in 2D Mapper set room weight code

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3863,9 +3863,9 @@ void T2DMap::slot_setRoomWeight()
                     itWeightsUsed.next();
                     if (itWeightsUsed.value() == weightCountsList.at(i)) {
                         if (itWeightsUsed.key() == 1) { // Indicate the "default" value which is unity weight
-                            displayStrings.append(tr("%1 {count:%2, default}").arg(itWeightsUsed.key(), itWeightsUsed.value()));
+                            displayStrings.append(tr("%1 {count:%2, default}").arg(QString::number(itWeightsUsed.key()), QString::number(itWeightsUsed.value())));
                         } else {
-                            displayStrings.append(tr("%1 {count:%2}").arg(itWeightsUsed.key(), itWeightsUsed.value()));
+                            displayStrings.append(tr("%1 {count:%2}").arg(QString::number(itWeightsUsed.key()), QString::number(itWeightsUsed.value())));
                         }
                     }
                 }


### PR DESCRIPTION
The use of `QString::arg(...)` with multiple (in these cases 2) numeric arguments was triggering an overloaded version where the second argument is a field-width rather than a second text item to display. This is fixed by either using multiple chained `arg(...)` invocations with a single value or forcing each number to be treated as a `QString` with the static `QString::number(...)` conversion method.

Before this commit:
![screenshot_20181213_200901](https://user-images.githubusercontent.com/6163092/49965050-026e1e00-ff14-11e8-8a0f-d61be6397d11.png)

Note the `%2` in the strings - and the odd dialogue width - for a choice with a *large* number rooms - it can make the dialogue *wider* that the screen can show and then only an empty middle portion with **no** visible text at all is shown...!

After this commit:
![screenshot_20181213_195513](https://user-images.githubusercontent.com/6163092/49965009-e10d3200-ff13-11e8-88b5-5b88f5e621f5.png)

Fortunately the fix is very quick and simple! :relieved: 

I count this as a **high** importance item as it does impair the UI (oversized and possibly text-less widget plonked at the top of the widget stack) for this action (modifying room weights from the 2D mapper) in some circumstances.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>