### PR TITLE
BugFix: ensure " {count:##}" is stripped from room symbol entry

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3437,7 +3437,7 @@ void T2DMap::slot_setSymbol()
                 while (itSymbolUsed.hasNext()) {
                     itSymbolUsed.next();
                     if (itSymbolUsed.value() == symbolCountsList.at(i)) {
-                        displayStrings.append(tr("%1 {count:%2}")
+                        displayStrings.append(tr("%1 {count:%2}", "Everything after the first parameter will be removed by processing it as a QRegularExpression programmatically, ensure the text, including the space after the %1 is reproduced in other text associated with this: ROOM_SYMBOL_REGULAR_EXPRESSION.")
                                               .arg(itSymbolUsed.key())
                                               .arg(QString::number(itSymbolUsed.value())));
                     }
@@ -3458,6 +3458,19 @@ void T2DMap::slot_setSymbol()
                                               true,                                                             // bool editable = true
                                               &isOk,                                                            // bool * ok = 0
                                               Qt::Dialog);
+            if (isOk && displayStrings.contains(newSymbol)) {
+                // The user has selected one of the existing items in the form
+                // "XXXX {count:##}" and we need to chop off the stuff after the
+                // "XXXX" to get what is needed:
+
+                QRegularExpression countStripper(tr("^(.*) {count:\\d+}$", "This is a QReglarExpression pattern used programmatically, ensure the text, including the space after the '(.*)` will match the previous text associated with this: ROOM_SYMBOL_REGULAR_EXPRESSION. Seek assistance from Developers, with the proposed text for use in the other place if required as functionality will be broken if this is not correct!"));
+                QRegularExpressionMatch match = countStripper.match(newSymbol);
+                if (match.hasMatch() && match.lastCapturedIndex() > 0) {
+                    // captured(0) is the whole string that matched, which is
+                    // not what we want:
+                    newSymbol = match.captured(1);
+                }
+            }
         }
 
         if (!isOk) {


### PR DESCRIPTION
When the room symbol entry dialogue is used and there are MORE THAN ONE different symbols used in the selection the user is presented with a `QComboBox` that shows all the symbols used in descending frequency order suffixed with additional text that reports exactly how many instances of each one; the current code is buggy in that it was leaving that additional text in place when one of the existing entries is chosen to be applied to ALL the selected rooms - this commit adds a fix that uses a `QRegularExpression` to retrieve only the wanted text from the `QString` returned by the `QInputDialog::getItem(...)` call.

The most frequent room symbol in this example is: `"10"` and the other is `"1"` (note that I am manually entering the room weight as a symbol in this example):
![screenshot_20181213_195614](https://user-images.githubusercontent.com/6163092/49965654-b9b76480-ff15-11e8-9075-7c5bb3bc4f98.png)

that selection causes this *symbol*  to be placed into the rooms:
![screenshot_20181213_201059](https://user-images.githubusercontent.com/6163092/49965665-be7c1880-ff15-11e8-8f75-91fa0124272f.png)

I did have to redo something whilst preparing this PR as I realised that it involves a UI text which is used programmatically - so had to make provision for the QRegularExpression to be translatable and linked to the text that is produced. Both of the texts concerned have been marked by including the text `ROOM_SYMBOL_REGULAR_EXPRESSION` in the Developers' comment that will at least be shown to translators on CrowdIn...

Marking this as **medium** because it is something that needs to (and can) be fixed but it is not fatal for the application - just a nuisance if one hits it - as I did recently.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>