### PR TITLE
Refactor: use a single enum to classify all TConsole instances

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -49,10 +49,10 @@ using namespace std;
 
 const QString TConsole::cmLuaLineVariable("line");
 
-TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
+TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 : QWidget(parent)
-, mpCommandLine(nullptr)
 , mpHost(pH)
+, mpCommandLine(nullptr)
 , buffer(pH)
 , emergencyStop(new QToolButton)
 , layerCommandLine(nullptr)
@@ -66,7 +66,6 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 , mDisplayFont(QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal))
 , mFgColor(Qt::black)
 , mIndentCount(0)
-, mIsDebugConsole(isDebugConsole)
 , mLogFileName(QString(""))
 , mLogToLogFile(false)
 , mMainFrameBottomHeight(0)
@@ -89,8 +88,6 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 , mSystemMessageBgColor(mBgColor)
 , mSystemMessageFgColor(QColor(Qt::red))
 , mTriggerEngineMode(false)
-, mUserConsole(false)
-, mWindowIsHidden(false)
 , mWrapAt(100)
 , networkLatency(new QLineEdit)
 , mUserAgreedToCloseConsole(false)
@@ -99,17 +96,18 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 , mpBufferSearchDown(new QToolButton)
 , mCurrentSearchResult(0)
 , mSearchQuery("")
+, mType(type)
 {
     auto ps = new QShortcut(this);
     ps->setKey(Qt::CTRL + Qt::Key_W);
     ps->setContext(Qt::WidgetShortcut);
 
-    if (mIsDebugConsole) {
+    if (mType & CentralDebugConsole) {
         setWindowTitle(tr("Debug Console"));
         // Probably will not show up as this is used inside a QMainWindow widget
         // which has it's own title and icon set.
+        // mIsSubConsole was left false for this
         mWrapAt = 50;
-        mIsSubConsole = false;
         mStandardFormat.bgR = mBgColor.red();
         mStandardFormat.bgG = mBgColor.green();
         mStandardFormat.bgB = mBgColor.blue();
@@ -122,21 +120,27 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
         mStandardFormat.flags &= ~(TCHAR_STRIKEOUT);
     } else {
         setWindowTitle(tr("Non Debug Console"));
-        if (parent) {
-            mIsSubConsole = true;
+        if (mType & (ErrorConsole|SubConsole|UserWindow)) {
+            // Orginally this was for TConsole instances with a parent pointer
+            // This branch for: UserWindows, SubConsole, ErrorConsole
+            // mIsSubConsole was true for these
             mpHost->mpConsole->mSubConsoleList.append(this);
             mMainFrameTopHeight = 0;
             mMainFrameBottomHeight = 0;
             mMainFrameLeftWidth = 0;
             mMainFrameRightWidth = 0;
-        } else {
-            mIsSubConsole = false;
+        } else if (mType & (MainConsole|Buffer)) {
+            // Orginally this was for TConsole instances without a parent pointer
+            // This branch for: Buffers, MainConsole
+            // mIsSubConsole was false for these
             mMainFrameTopHeight = mpHost->mBorderTopHeight;
             mMainFrameBottomHeight = mpHost->mBorderBottomHeight;
             mMainFrameLeftWidth = mpHost->mBorderLeftWidth;
             mMainFrameRightWidth = mpHost->mBorderRightWidth;
             mCommandBgColor = mpHost->mCommandBgColor;
             mCommandFgColor = mpHost->mCommandFgColor;
+        } else {
+            Q_ASSERT_X(false, "TConsole::TConsole(...)", "invalid TConsole type detected");
         }
         mStandardFormat.bgR = mpHost->mBgColor.red();
         mStandardFormat.bgG = mpHost->mBgColor.green();
@@ -278,7 +282,7 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     baseHFrameLayout->setMargin(0);
     centralLayout->setMargin(0);
 
-    if (!mIsDebugConsole && !mIsSubConsole) {
+    if (mType & (MainConsole|Buffer)) {
         mpCommandLine = new TCommandLine(pH, this, mpMainDisplay);
         mpCommandLine->setContentsMargins(0, 0, 0, 0);
         mpCommandLine->setSizePolicy(sizePolicy);
@@ -310,12 +314,12 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
         setFocusProxy(mpCommandLine);
     }
 
-    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, false);
+    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, (mType & CentralDebugConsole), false);
     mUpperPane->setContentsMargins(0, 0, 0, 0);
     mUpperPane->setSizePolicy(sizePolicy3);
     mUpperPane->setFocusPolicy(Qt::NoFocus);
 
-    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, isDebugConsole, true);
+    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, (mType & CentralDebugConsole), true);
     mLowerPane->setContentsMargins(0, 0, 0, 0);
     mLowerPane->setSizePolicy(sizePolicy3);
     mLowerPane->setFocusPolicy(Qt::NoFocus);
@@ -520,14 +524,14 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
 
     connect(mpScrollBar, &QAbstractSlider::valueChanged, mUpperPane, &TTextEdit::slot_scrollBarMoved);
 
-    if (mIsSubConsole) {
+    if (mType & (ErrorConsole|SubConsole|UserWindow)) {
         mpScrollBar->hide();
         mLowerPane->hide();
         layerCommandLine->hide();
         mpMainFrame->move(0, 0);
         mpMainDisplay->move(0, 0);
     }
-    if (mIsDebugConsole) {
+    if (mType & CentralDebugConsole) {
         layerCommandLine->hide();
     }
 
@@ -567,7 +571,7 @@ TConsole::TConsole(Host* pH, bool isDebugConsole, QWidget* parent)
     layerCommandLine->setPalette(__pal);
 
     changeColors();
-    if (!mIsSubConsole && !mIsDebugConsole) {
+    if (mType & (MainConsole|Buffer)) {
         // During first use where mIsDebugConsole IS true mudlet::self() is null
         // then - but we rely on that flag to avoid having to also test for a
         // non-null mudlet::self() - the connect(...) will produce a debug
@@ -603,7 +607,7 @@ void TConsole::setLabelStyleSheet(std::string& buf, std::string& sh)
 
 void TConsole::resizeEvent(QResizeEvent* event)
 {
-    if (!mIsDebugConsole && !mIsSubConsole) {
+    if (mType & (MainConsole|Buffer)) {
         mMainFrameTopHeight = mpHost->mBorderTopHeight;
         mMainFrameBottomHeight = mpHost->mBorderBottomHeight;
         mMainFrameLeftWidth = mpHost->mBorderLeftWidth;
@@ -613,7 +617,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int y = event->size().height();
 
 
-    if (!mIsSubConsole && !mIsDebugConsole) {
+    if (mType & (MainConsole|Buffer)) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);
@@ -626,7 +630,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
     mpMainDisplay->move(mMainFrameLeftWidth, mMainFrameTopHeight);
 
-    if (mIsSubConsole || mIsDebugConsole) {
+    if (mType & (CentralDebugConsole|ErrorConsole|SubConsole|UserWindow)) {
         layerCommandLine->hide();
     } else {
         //layerCommandLine->move(0,mpMainFrame->height()-layerCommandLine->height());
@@ -635,7 +639,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     QWidget::resizeEvent(event);
 
-    if (!mIsDebugConsole && !mIsSubConsole) {
+    if (mType & (MainConsole|Buffer)) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
         QString func = "handleWindowResizeEvent";
         QString n = "WindowResizeEvent";
@@ -656,7 +660,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
 void TConsole::refresh()
 {
-    if (!mIsDebugConsole) {
+    if (mType & (ErrorConsole|MainConsole|SubConsole|UserWindow|Buffer)) {
         mMainFrameTopHeight = mpHost->mBorderTopHeight;
         mMainFrameBottomHeight = mpHost->mBorderBottomHeight;
         mMainFrameLeftWidth = mpHost->mBorderLeftWidth;
@@ -695,7 +699,7 @@ void TConsole::refresh()
 
 void TConsole::closeEvent(QCloseEvent* event)
 {
-    if (mIsDebugConsole) {
+    if (mType & CentralDebugConsole) {
         if (mudlet::self()->isGoingDown() || mpHost->isClosingDown()) {
             event->accept();
             return;
@@ -708,7 +712,7 @@ void TConsole::closeEvent(QCloseEvent* event)
         }
     }
 
-    if (mUserConsole) {
+    if (mType & (SubConsole|UserWindow|Buffer)) {
         if (mudlet::self()->isGoingDown() || mpHost->isClosingDown()) {
             std::string key = objectName().toLatin1().data();
             TConsole* pC = mpHost->mpConsole;
@@ -820,7 +824,7 @@ int TConsole::getButtonState()
 
 void TConsole::toggleLogging(bool isMessageEnabled)
 {
-    if (mIsDebugConsole || mIsSubConsole) {
+    if (mType & (CentralDebugConsole|ErrorConsole|SubConsole|UserWindow)) {
         return;
         // We don't support logging anything other than main console (at present?)
     }
@@ -1030,7 +1034,7 @@ void TConsole::toggleLogging(bool isMessageEnabled)
 // generated for Lua user control by the Lua subsystem.
 void TConsole::slot_toggleLogging()
 {
-    if (mIsDebugConsole || mIsSubConsole) {
+    if (mType & (CentralDebugConsole|ErrorConsole|SubConsole|UserWindow)) {
         return;
         // We don't support logging anything other than main console (at present?)
     }
@@ -1040,7 +1044,7 @@ void TConsole::slot_toggleLogging()
 
 void TConsole::slot_toggleReplayRecording()
 {
-    if (mIsDebugConsole) {
+    if (mType & CentralDebugConsole) {
         return;
     }
     mRecordReplay = !mRecordReplay;
@@ -1068,7 +1072,7 @@ void TConsole::slot_toggleReplayRecording()
 void TConsole::changeColors()
 {
     mDisplayFont.setFixedPitch(true);
-    if (mIsDebugConsole) {
+    if (mType & CentralDebugConsole) {
         mDisplayFont.setStyleStrategy((QFont::StyleStrategy)(QFont::NoAntialias | QFont::PreferQuality));
         mDisplayFont.setFixedPitch(true);
         mUpperPane->setFont(mDisplayFont);
@@ -1079,7 +1083,7 @@ void TConsole::changeColors()
         palette.setColor(QPalette::Base, QColor(Qt::black));
         mUpperPane->setPalette(palette);
         mLowerPane->setPalette(palette);
-    } else if (mIsSubConsole) {
+    } else if (mType & (ErrorConsole|SubConsole|UserWindow)) {
 #if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         mDisplayFont.setStyleStrategy((QFont::StyleStrategy)(QFont::NoAntialias | QFont::PreferQuality));
         QPixmap pixmap = QPixmap(2000, 600);
@@ -1109,7 +1113,7 @@ void TConsole::changeColors()
         layer->setPalette(palette);
         mUpperPane->setPalette(palette);
         mLowerPane->setPalette(palette);
-    } else {
+    } else if (mType & (MainConsole|Buffer)) {
         QPalette pal;
         pal.setColor(QPalette::Text, mpHost->mCommandLineFgColor); //QColor(0,0,192));
         pal.setColor(QPalette::Highlight, QColor(0, 0, 192));
@@ -1161,20 +1165,22 @@ void TConsole::changeColors()
         mFormatCurrent.fgR = mpHost->mFgColor.red();
         mFormatCurrent.fgG = mpHost->mFgColor.green();
         mFormatCurrent.fgB = mpHost->mFgColor.blue();
+    } else {
+        Q_ASSERT_X(false, "TConsole::changeColors()", "invalid TConsole type detected");
     }
     QPalette palette;
     palette.setColor(QPalette::Button, QColor(Qt::blue));
     palette.setColor(QPalette::Window, QColor(Qt::green));
     palette.setColor(QPalette::Base, QColor(Qt::red));
 
-    if (!mIsSubConsole) {
+    if (mType & (CentralDebugConsole|MainConsole|Buffer)) {
         mUpperPane->mWrapAt = mWrapAt;
         mLowerPane->mWrapAt = mWrapAt;
         splitter->setPalette(palette);
     }
 
     buffer.updateColors();
-    if (!mIsDebugConsole && !mIsSubConsole) {
+    if (mType & (MainConsole|Buffer)) {
         buffer.mWrapAt = mpHost->mWrapAt;
         buffer.mWrapIndent = mpHost->mWrapIndentCount;
     }
@@ -1329,7 +1335,7 @@ void TConsole::deselect()
 
 void TConsole::showEvent(QShowEvent* event)
 {
-    if (!mIsDebugConsole && !mIsSubConsole) {
+    if (mType & (MainConsole|Buffer)) {
         if (mpHost) {
             mpHost->mTelnet.mAlertOnNewData = false;
         }
@@ -1339,7 +1345,7 @@ void TConsole::showEvent(QShowEvent* event)
 
 void TConsole::hideEvent(QHideEvent* event)
 {
-    if (!mIsDebugConsole && !mIsSubConsole) {
+    if (mType & (MainConsole|Buffer)) {
         if (mpHost) {
             if (mudlet::self()->mWindowMinimized) {
                 if (mpHost->mAlertOnNewData) {
@@ -2009,12 +2015,6 @@ bool TConsole::moveCursor(int x, int y)
     }
 }
 
-
-void TConsole::setUserWindow()
-{
-    mUserConsole = true;
-}
-
 int TConsole::select(const QString& text, int numOfMatch)
 {
     if (mUserCursor.y() < 0) {
@@ -2239,7 +2239,7 @@ void TConsole::echoLink(const QString& text, QStringList& func, QStringList& hin
     if (customFormat) {
         buffer.addLink(mTriggerEngineMode, text, func, hint, mFormatCurrent);
     } else {
-        if (!mIsSubConsole && !mIsDebugConsole) {
+        if (mType & (MainConsole|Buffer)) {
             TChar f = TChar(0, 0, 255, mpHost->mBgColor.red(), mpHost->mBgColor.green(), mpHost->mBgColor.blue(), false, false, true, false);
             buffer.addLink(mTriggerEngineMode, text, func, hint, f);
         } else {
@@ -2302,14 +2302,12 @@ TConsole* TConsole::createBuffer(const QString& name)
 {
     std::string key = name.toLatin1().data();
     if (mSubConsoleMap.find(key) == mSubConsoleMap.end()) {
-        auto pC = new TConsole(mpHost, false);
+        auto pC = new TConsole(mpHost, Buffer);
         mSubConsoleMap[key] = pC;
         pC->setWindowTitle(name);
         pC->setContentsMargins(0, 0, 0, 0);
         pC->hide();
         pC->layerCommandLine->hide();
-        //pC->mpScrollBar->hide();
-        pC->setUserWindow();
         return pC;
     } else {
         return nullptr;
@@ -2338,18 +2336,18 @@ void TConsole::resetMainConsole()
     mLabelMap.clear();
 }
 
+// This is a sub-console overlaid on to the main console
 TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int width, int height)
 {
     std::string key = name.toLatin1().data();
     if (mSubConsoleMap.find(key) == mSubConsoleMap.end()) {
-        auto pC = new TConsole(mpHost, false, mpMainFrame);
+        auto pC = new TConsole(mpHost, SubConsole, mpMainFrame);
         if (!pC) {
             return nullptr;
         }
         mSubConsoleMap[key] = pC;
         pC->setObjectName(name);
         pC->setFocusPolicy(Qt::NoFocus);
-        pC->setUserWindow();
         pC->mUpperPane->setIsMiniConsole();
         pC->mLowerPane->setIsMiniConsole();
         pC->resize(width, height);
@@ -2357,7 +2355,7 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
         pC->mOldY = y;
         pC->setContentsMargins(0, 0, 0, 0);
         pC->move(x, y);
-        std::string _n = name.toStdString();
+
         pC->setMiniConsoleFontSize(12);
         pC->show();
         return pC;
@@ -2585,7 +2583,7 @@ void TConsole::printSystemMessage(const QString& msg)
     QColor bgColor;
     QColor fgColor;
 
-    if (mIsDebugConsole) {
+    if (mType & CentralDebugConsole) {
         bgColor = mBgColor;
         fgColor = mFgColor;
     } else {

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -57,13 +57,24 @@ class TConsole : public QWidget
     Q_OBJECT
 
 public:
+    enum ConsoleTypeFlag {
+        UnknownType = 0x0, // Should not be encountered but left as a trap value
+        CentralDebugConsole = 0x1, // One of these for whole application
+        ErrorConsole = 0x2, // The bottom right corner of the Editor, one per profile
+        MainConsole = 0x4, // One per profile
+        SubConsole = 0x8, // Overlaid on top of MainConsole instance, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
+        UserWindow = 0x10, // Floatable/Dockable console, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
+        Buffer = 0x20 // Non-visible store for data that can be copied to/from other per profile TConsoles, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
+    };
+
+    Q_DECLARE_FLAGS(ConsoleType, ConsoleTypeFlag)
+
     Q_DISABLE_COPY(TConsole)
-    TConsole(Host*, bool isDebugConsole, QWidget* parent = nullptr);
+    TConsole(Host*, ConsoleType type = UnknownType, QWidget* parent = nullptr);
     void reset();
     void resetMainConsole();
     void echoUserWindow(const QString&);
     Host* getHost();
-    TCommandLine* mpCommandLine;
     void replace(const QString&);
     void insertHTML(const QString&);
     void insertText(const QString&);
@@ -81,7 +92,6 @@ public:
     void closeEvent(QCloseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void pasteWindow(TBuffer);
-    void setUserWindow();
     QStringList getLines(int from, int to);
     int getLineNumber();
     int getLineCount();
@@ -169,8 +179,11 @@ public:
     QSize getMainWindowSize() const;
 
     void toggleLogging(bool);
+    ConsoleType getType() const { return mType; }
+
 
     QPointer<Host> mpHost;
+    TCommandLine* mpCommandLine;
 
     TBuffer buffer;
     static const QString cmLuaLineVariable;
@@ -200,8 +213,6 @@ public:
     TChar mFormatSystemMessage;
 
     int mIndentCount;
-    bool mIsDebugConsole;
-    bool mIsSubConsole;
     std::map<std::string, TLabel*> mLabelMap;
     QFile mLogFile;
     QString mLogFileName;
@@ -242,7 +253,7 @@ public:
     QColor mSystemMessageBgColor;
     QColor mSystemMessageFgColor;
     bool mTriggerEngineMode;
-    bool mUserConsole;
+
     QPoint mUserCursor;
     bool mWindowIsHidden;
     int mWrapAt;
@@ -285,6 +296,10 @@ public slots:
 private:
     void refreshMiniConsole() const;
 
+
+    ConsoleType mType;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)
 
 #endif // MUDLET_TCONSOLE_H

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1061,7 +1061,7 @@ void TTextEdit::slot_popupMenu()
 
 void TTextEdit::mousePressEvent(QMouseEvent* event)
 {
-    if (!mpConsole->mIsSubConsole && !mpConsole->mIsDebugConsole) {
+    if (mpConsole->getType() & (TConsole::MainConsole|TConsole::Buffer)) {
         TEvent mudletEvent;
         mudletEvent.mArgumentList.append(QLatin1String("sysWindowMousePressEvent"));
         switch (event->button()) {
@@ -1610,7 +1610,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mCtrlSelecting = false;
     }
 
-    if (!mpConsole->mIsSubConsole && !mpConsole->mIsDebugConsole) {
+    if (mpConsole->getType() & (TConsole::MainConsole|TConsole::Buffer)) {
         TEvent mudletEvent;
         mudletEvent.mArgumentList.append(QLatin1String("sysWindowMouseReleaseEvent"));
         switch (event->button()) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -236,7 +236,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     auto pHB2 = new QHBoxLayout(popupArea);
     popupArea->setMinimumSize(200, 60);
     pHB2->setSizeConstraint(QLayout::SetMaximumSize);
-    mpErrorConsole = new TConsole(mpHost, false, popupArea);
+    mpErrorConsole = new TConsole(mpHost, TConsole::ErrorConsole, popupArea);
     mpErrorConsole->setWrapAt(100);
     mpErrorConsole->mUpperPane->slot_toggleTimeStamps();
     mpErrorConsole->print("*** starting new session ***\n");

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -405,7 +405,7 @@ mudlet::mudlet()
     // We DO NOT emit a signal_hostCreated for THIS case:
     mHostManager.addHost(defaultHost, QString(), QString(), QString());
     mpDefaultHost = mHostManager.getHost(defaultHost);
-    mpDebugConsole = new TConsole(mpDefaultHost, true);
+    mpDebugConsole = new TConsole(mpDefaultHost, TConsole::CentralDebugConsole);
     mpDebugConsole->setSizePolicy(sizePolicy);
     mpDebugConsole->setWrapAt(100);
     mpDebugArea->setCentralWidget(mpDebugConsole);
@@ -1217,7 +1217,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
         return;
     }
     pH->mLogStatus = mAutolog;
-    auto pConsole = new TConsole(pH, false);
+    auto pConsole = new TConsole(pH, TConsole::MainConsole);
     if (!pConsole) {
         return;
     }
@@ -1618,13 +1618,12 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         pD->setFeatures(QDockWidget::AllDockWidgetFeatures);
         pD->setWindowTitle(QString("%1 - %2").arg(name, pHost->getName()));
         dockWindowMap[name] = pD;
-        auto pC = new TConsole(pHost, false, pD);
+        auto pC = new TConsole(pHost, TConsole::UserWindow, pD);
         pC->setContentsMargins(0, 0, 0, 0);
         pD->setWidget(pC);
         pC->show();
         pC->layerCommandLine->hide();
         pC->mpScrollBar->hide();
-        pC->setUserWindow();
         pC->mUpperPane->setIsMiniConsole();
         pC->mLowerPane->setIsMiniConsole();
         dockWindowConsoleMap[name] = pC;


### PR DESCRIPTION
By replacing the following somewhat adhoc collection of flags it is easier to refactor code that is dependent on the particular type of `TConsole`:
* `(bool) TConsole::mIsDebugConsole`
* `(bool) TConsole::mIsSubConsole`
* `(bool) TConsole::mUserConsole` - flag for a subConsole/Buffer/UserWindow

Also removed the unused:
* `(bool) TConsole::mWindowIsHidden`

This has revealed that there are numerous cases where the `Buffer` type of `TConsole` is including code that was likely only intended for the main one for each profile...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>