### PR TITLE
Remove MMP hardcoding in favour of Client.Map

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1635,10 +1635,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
     if ((!canRestore || entries.empty()) && downloadIfNotFound) {
         QMessageBox msgBox;
 
-        if (mpHost->mUrl.contains(QStringLiteral("achaea.com"), Qt::CaseInsensitive) || mpHost->mUrl.contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)
-            || mpHost->mUrl.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
-            || mpHost->mUrl.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
-            || mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
+        if (mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
             || !getMmpMapLocation().isEmpty()) {
             msgBox.setText(tr("No map found. Would you like to download the map or start your own?"));
             QPushButton* yesButton = msgBox.addButton(tr("Download the map"), QMessageBox::ActionRole);
@@ -2239,19 +2236,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 #endif
 
-    // Unfortunately we do not seem to get a file size from the IRE servers so
-    // estimate it from current figures + 10% as of now (2016/10) - using previous
-    // 4M that was used before for other cases:
     mExpectedFileSize = 4000000;
-    if (url.toString().contains(QStringLiteral("achaea.com"), Qt::CaseInsensitive)) {
-        mExpectedFileSize = qRound(1.1f * 4706442);
-    } else if (url.toString().contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)) {
-        mExpectedFileSize = qRound(1.1f * 5695407);
-    } else if (url.toString().contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)) {
-        mExpectedFileSize = qRound(1.1f * 4997166);
-    } else if (url.toString().contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)) {
-        mExpectedFileSize = qRound(1.1f * 4842063);
-    }
 
     QString infoMsg = tr("[ INFO ]  - Map download initiated, please wait...");
     postMessage(infoMsg);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1635,19 +1635,13 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
     if ((!canRestore || entries.empty()) && downloadIfNotFound) {
         QMessageBox msgBox;
 
-        if (mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
-            || !getMmpMapLocation().isEmpty()) {
+        if (!getMmpMapLocation().isEmpty()) {
             msgBox.setText(tr("No map found. Would you like to download the map or start your own?"));
             QPushButton* yesButton = msgBox.addButton(tr("Download the map"), QMessageBox::ActionRole);
             QPushButton* noButton = msgBox.addButton(tr("Start my own"), QMessageBox::ActionRole);
             msgBox.exec();
             if (msgBox.clickedButton() == yesButton) {
-                // no https support
-                if (mpHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
-                    downloadMap(QStringLiteral("http://www.%1/maps/map.xml").arg(mpHost->mUrl));
-                } else {
-                    downloadMap();
-                }
+                downloadMap();
             } else if (msgBox.clickedButton() == noButton) {
                 ; //No-op to avoid unused "noButton"
             }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -456,12 +456,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     }
 
     const QString url(pHost->getUrl());
-    if (url.contains(QStringLiteral("achaea.com"), Qt::CaseInsensitive)
-     || url.contains(QStringLiteral("aetolia.com"), Qt::CaseInsensitive)
-     || url.contains(QStringLiteral("imperian.com"), Qt::CaseInsensitive)
-     || url.contains(QStringLiteral("lusternia.com"), Qt::CaseInsensitive)
-     || url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)
-     || !pHost->getMmpMapLocation().isEmpty()) {
+    if (url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive) || !pHost->getMmpMapLocation().isEmpty()) {
         groupBox_downloadMapOptions->setVisible(true);
         connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::downloadMap);
     } else {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -455,8 +455,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
 
-    const QString url(pHost->getUrl());
-    if (url.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive) || !pHost->getMmpMapLocation().isEmpty()) {
+    if (!pHost->getMmpMapLocation().isEmpty()) {
         groupBox_downloadMapOptions->setVisible(true);
         connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::downloadMap);
     } else {
@@ -1603,11 +1602,7 @@ void dlgProfilePreferences::downloadMap()
         mudlet::self()->createMapper(false);
     }
 
-    if (pHost->mUrl.contains(QStringLiteral("stickmud.com"), Qt::CaseInsensitive)) {
-        pHost->mpMap->downloadMap(QStringLiteral("http://www.%1/maps/map.xml").arg(mpHost->mUrl));
-    } else {
-        pHost->mpMap->downloadMap();
-    }
+    pHost->mpMap->downloadMap();
 }
 
 void dlgProfilePreferences::loadMap()


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove all games MMP map location from hardcoding since all games support [Client.Map](https://wiki.mudlet.org/w/Manual:GMCP_Extensions#Automatic_map_download) now.
#### Motivation for adding to Mudlet
Less hardcoding, less fragility!
#### Other info (issues closed, discussion etc)