### PR TITLE
Allow non-int version for gmcp.Client.GUI version (#2151)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -141,7 +141,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBubbleMode(false)
 , mShowRoomID(false)
 , mShowPanel(true)
-, mServerGUI_Package_version(-1)
+, mServerGUI_Package_version(QLatin1String("-1"))
 , mServerGUI_Package_name(QLatin1String("nothing"))
 , mAcceptServerGUI(true)
 , mCommandLineFgColor(Qt::darkGray)

--- a/src/Host.h
+++ b/src/Host.h
@@ -367,7 +367,7 @@ public:
     bool mBubbleMode;
     bool mShowRoomID;
     bool mShowPanel;
-    int mServerGUI_Package_version;
+    QString mServerGUI_Package_version;
     QString mServerGUI_Package_name;
     bool mAcceptServerGUI;
     QColor mCommandLineFgColor;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -428,7 +428,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
 
         host.append_child("url").text().set(pHost->mUrl.toUtf8().constData());
         host.append_child("serverPackageName").text().set(pHost->mServerGUI_Package_name.toUtf8().constData());
-        host.append_child("serverPackageVersion").text().set(QString::number(pHost->mServerGUI_Package_version).toUtf8().constData());
+        host.append_child("serverPackageVersion").text().set(pHost->mServerGUI_Package_version.toUtf8().constData());
         host.append_child("port").text().set(QString::number(pHost->mPort).toUtf8().constData());
         host.append_child("borderTopHeight").text().set(QString::number(pHost->mBorderTopHeight).toUtf8().constData());
         host.append_child("borderBottomHeight").text().set(QString::number(pHost->mBorderBottomHeight).toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -902,7 +902,7 @@ void XMLimport::readHostPackage(Host* pHost)
             } else if (name() == "serverPackageName") {
                 pHost->mServerGUI_Package_name = readElementText();
             } else if (name() == "serverPackageVersion") {
-                pHost->mServerGUI_Package_version = readElementText().toInt();
+                pHost->mServerGUI_Package_version = readElementText();
             } else if (name() == "port") {
                 pHost->mPort = readElementText().toInt();
             } else if (name() == "borderTopHeight") {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1071,14 +1071,13 @@ void cTelnet::processTelnetCommand(const string& command)
                 version.replace(QChar::LineFeed, QChar::Space);
                 version = version.section(QChar::Space, 0, 0);
 
-                int newVersion = version.toInt();
                 QString _smsg;
-                if (mpHost->mServerGUI_Package_version != newVersion) {
+                if (mpHost->mServerGUI_Package_version != version) {
                     postMessage(tr("[ INFO ]  - The server wants to upgrade the GUI to new version '%1'.\n"
                                    "Uninstalling old version '%2'.")
-                                .arg(QString::number(newVersion), QString::number(mpHost->mServerGUI_Package_version)));
+                                .arg(version, mpHost->mServerGUI_Package_version));
                     mpHost->uninstallPackage(mpHost->mServerGUI_Package_name, 0);
-                    mpHost->mServerGUI_Package_version = newVersion;
+                    mpHost->mServerGUI_Package_version = version;
                 }
                 QString url = msg.section(QChar::LineFeed, 1);
                 QString packageName = url.section(QLatin1Char('/'), -1);
@@ -1351,14 +1350,13 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         version.replace(QChar::LineFeed, QChar::Space);
         version = version.section(QChar::Space, 0, 0);
 
-        int newVersion = version.toInt();
         QString _smsg;
-        if (mpHost->mServerGUI_Package_version != newVersion) {
+        if (mpHost->mServerGUI_Package_version != version) {
             postMessage(tr("[ INFO ]  - The server wants to upgrade the GUI to new version '%1'.\n"
                            "Uninstalling old version '%2'.")
-                        .arg(QString::number(newVersion), QString::number(mpHost->mServerGUI_Package_version)));
+                        .arg(version, mpHost->mServerGUI_Package_version));
             mpHost->uninstallPackage(mpHost->mServerGUI_Package_name, 0);
-            mpHost->mServerGUI_Package_version = newVersion;
+            mpHost->mServerGUI_Package_version = version;
         }
         QString url = transcodedMsg.section(QChar::LineFeed, 1);
         QString packageName = url.section(QLatin1Char('/'), -1);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR solves Issue #2151 that would not allow version numbers other than integers for the Client.GUI version. The prior version was converting a string of text sent from the MUD server to the Mudlet client to an integer.  If Mudlet detected it was something other than an integer, it would default pHost->mServerGUI_Package_version to 0. To support a string representation, the following changes were made:

- modified:   ../src/Host.cpp -> pHost->mServerGUI_Package_version was int now QString
- modified:   ../src/Host.h -> pHost->mServerGUI_Package_version defaulted to -1 now QLatin1String("-1")
- modified:   ../src/XMLexport.cpp -> String no longer converted to a number
- modified:   ../src/XMLimport.cpp -> String no longer converted to a number
- modified:   ../src/ctelnet.cpp -> String no longer converted to a number

#### Motivation for adding to Mudlet

- Addressing Issue #2151 was a simpler starter opportunity to contribute to the project
- As a MUD admin, I appreciate the number of revs the UIs have and this could be of use
- As a MUD admin, I was able to test this and could verify it easily prior to the release 

#### Other info (issues closed, discussion etc)

-Tamarindo@StickMUD

Unit Test:

Login to game, mServerGUI_Package_version = "32" sent by the game

<img width="682" alt="screen shot 2018-12-26 at 10 50 49 pm" src="https://user-images.githubusercontent.com/3058178/50465429-4ece4a80-0965-11e9-98ef-ee0d94c6ad54.png">

Login to game, mServerGUI_Package_version = "32.0" sent by the game, new package downloaded.

<img width="675" alt="screen shot 2018-12-26 at 10 51 42 pm" src="https://user-images.githubusercontent.com/3058178/50465436-5988df80-0965-11e9-95f3-2d6bc636902a.png">

Login to game, mServerGUI_Package_version = "32.0" sent by the game, no package downloaded.

(tested but didn't grab a picture... this works)

Login to game, mServerGUI_Package_version = "32" sent by the game, new package downloaded.

<img width="672" alt="screen shot 2018-12-26 at 10 53 40 pm" src="https://user-images.githubusercontent.com/3058178/50465458-76251780-0965-11e9-82cc-0383e73cafe2.png">
