### PR TITLE
Adding Automatic Qt Scaling for HiDPI for Unix systems

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,10 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
+#ifdef Q_OS_UNIX
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     QScopedPointer<QCoreApplication> initApp(createApplication(argc, argv, startupAction));
     auto * app = qobject_cast<QApplication*>(initApp.data());
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This pull requests sets the autoscaling flag for Qt on Unix systems.  Mac and Windows have built-in scaling systems so the flag is gated for only Unix systems.  

#### Motivation for adding to Mudlet
On HiDPI displays on Linux/Unix systems, Mudlet will be scaled too small out of the box.  Qt offers a way to autoscale applications on systems by setting an application attribute.  See http://doc.qt.io/qt-5/highdpi.html  This pull request sets that attribute for these systems.

#### Other info (issues closed, discussion etc)
Tested against Ubuntu 18.10.  

Although this helps significantly with HiDPI, in the long term a transition away from fixed point font sizes and absolute sizing would be recommended.