### PR TITLE
Enhance: add lua getMapSelection() function {only covers rooms for now}

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -91,7 +91,7 @@ T2DMap::T2DMap(QWidget* parent)
 , mSizeLabel()
 , isCenterViewCall()
 , mDialogLock()
-, mMultiSelectionHighlightRoomId(-1)
+, mMultiSelectionHighlightRoomId(0)
 , mIsSelectionSorting(true)
 , mIsSelectionSortByNames()
 , mIsSelectionUsingNames(false)
@@ -2517,7 +2517,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             }
             switch (mMultiSelectionSet.size()) {
             case 0:
-                mMultiSelectionHighlightRoomId = -1;
+                mMultiSelectionHighlightRoomId = 0;
                 break;
             case 1:
                 mMultiSelection = false; // OK, found one room so stop
@@ -4203,7 +4203,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             }
             switch (mMultiSelectionSet.size()) {
             case 0:
-                mMultiSelectionHighlightRoomId = -1;
+                mMultiSelectionHighlightRoomId = 0;
                 break;
             case 1:
                 mMultiSelectionHighlightRoomId = mMultiSelectionSet.toList().first();
@@ -4314,7 +4314,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
 // such a room
 bool T2DMap::getCenterSelection()
 {
-    mMultiSelectionHighlightRoomId = -1;
+    mMultiSelectionHighlightRoomId = 0;
     if (mMultiSelectionSet.isEmpty()) {
         return false;
     }
@@ -4838,7 +4838,7 @@ void T2DMap::slot_roomSelectionChanged()
     }
     switch (mMultiSelectionSet.size()) {
     case 0:
-        mMultiSelectionHighlightRoomId = -1;
+        mMultiSelectionHighlightRoomId = 0;
         break;
     case 1:
         mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.constBegin());

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -70,6 +70,7 @@ public:
     // mMultiSelectionHighlightRoomId and returns a (bool) on success or failure
     // to do so.
     bool getCenterSelection();
+    int getCenterSelectedRoomId() const { return mMultiSelectionHighlightRoomId; }
 
     void setRoomSize(double);
     void setExitSize(double);
@@ -220,7 +221,8 @@ private:
     // modifications. {for slot_spread(),
     // slot_shrink(), slot_setUserData() - if ever
     // implemented, slot_setExits(),
-    // slot_movePosition(), etc.}
+    // slot_movePosition(), etc.} - previously have
+    // used -1 but is now reset to 0 if it is not valid.
     int mMultiSelectionHighlightRoomId;
 
     bool mIsSelectionSorting;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14606,15 +14606,11 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
     }
 
     lua_newtable(L);
-    lua_pushstring(L, "type");
     QList<int> selectionRoomsList = pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.toList();
     if (!selectionRoomsList.isEmpty()) {
         if (selectionRoomsList.count() > 1) {
             std::sort(selectionRoomsList.begin(), selectionRoomsList.end());
         }
-
-        lua_pushstring(L, "rooms");
-        lua_settable(L, -3);
 
         lua_pushstring(L, "center");
         lua_pushnumber(L, pHost->mpMap->mpMapper->mp2dMap->getCenterSelectedRoomId());
@@ -14628,11 +14624,6 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
             lua_settable(L, -3);
         }
 
-        lua_settable(L, -3);
-
-    } else {
-
-        lua_pushstring(L, "none");
         lua_settable(L, -3);
 
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13789,6 +13789,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getDiscordParty", TLuaInterpreter::getDiscordParty);
     lua_register(pGlobalLua, "getPlayerRoom", TLuaInterpreter::getPlayerRoom);
     lua_register(pGlobalLua, "getSelection", TLuaInterpreter::getSelection);
+    lua_register(pGlobalLua, "getMapSelection", TLuaInterpreter::getMapSelection);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath
@@ -14592,4 +14593,49 @@ int TLuaInterpreter::getRowCount(lua_State* L)
 // i.e. Unrefing tables passed into TLabel's event parameters.
 void TLuaInterpreter::freeLuaRegistryIndex(int index) {
     luaL_unref(pGlobalLua, LUA_REGISTRYINDEX, index);
+}
+
+// Documentation PENDING: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapSelection
+int TLuaInterpreter::getMapSelection(lua_State* L)
+{
+    Host* pHost = &getHostFromLua(L);
+    if (!pHost || !pHost->mpMap || !pHost->mpMap->mpMapper || !pHost->mpMap->mpMapper->mp2dMap) {
+        lua_pushnil(L);
+        lua_pushstring(L, "getMapSelection: no map present or loaded!");
+        return 2;
+    }
+
+    lua_newtable(L);
+    lua_pushstring(L, "type");
+    QList<int> selectionRoomsList = pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.toList();
+    if (!selectionRoomsList.isEmpty()) {
+        if (selectionRoomsList.count() > 1) {
+            std::sort(selectionRoomsList.begin(), selectionRoomsList.end());
+        }
+
+        lua_pushstring(L, "rooms");
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "center");
+        lua_pushnumber(L, pHost->mpMap->mpMapper->mp2dMap->getCenterSelectedRoomId());
+        lua_settable(L, -3);
+
+        lua_pushstring(L, "rooms");
+        lua_newtable(L);
+        for (int i = 0, total = selectionRoomsList.size(); i < total; ++i) {
+            lua_pushnumber(L, i + 1);
+            lua_pushnumber(L, selectionRoomsList.at(i));
+            lua_settable(L, -3);
+        }
+
+        lua_settable(L, -3);
+
+    } else {
+
+        lua_pushstring(L, "none");
+        lua_settable(L, -3);
+
+    }
+
+    return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14595,7 +14595,7 @@ void TLuaInterpreter::freeLuaRegistryIndex(int index) {
     luaL_unref(pGlobalLua, LUA_REGISTRYINDEX, index);
 }
 
-// Documentation PENDING: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapSelection
+// Documentation: https://wiki.mudlet.org/w/Manual:Mapper_Functions#getMapSelection
 int TLuaInterpreter::getMapSelection(lua_State* L)
 {
     Host* pHost = &getHostFromLua(L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -460,8 +460,9 @@ public:
     static int getDiscordSmallIconText(lua_State*);
     static int getDiscordTimeStamps(lua_State*);
     static int getDiscordParty(lua_State*);
-    static int setDiscordGame(lua_State *L);
-    static int getPlayerRoom(lua_State* L);
+    static int setDiscordGame(lua_State*);
+    static int getPlayerRoom(lua_State*);
+    static int getMapSelection(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds `getMapSelection()` to the lua API that returns a table containing the details of the currently selected items in the (2D) map. At present this is limited to rooms being selected but there is an extensible scope within the implementation to handle other things (e.g. an existing custom exit line, or a map label). 

#### Motivation for adding to Mudlet

As an aside in: https://github.com/Mudlet/Mudlet/issues/2155 I suggested that it could be useful to have a lua function that would return a list of rooms when they are selected in the (2D) mapper - this will be useful for user scripts/aliases that want to modify such a selection.

#### Other info (issues closed, discussion etc)

To allow the handling when something other than a room or rooms is selected the function actually returns an associative table which always contains the key `type` which will be `rooms` if it does contain a selection of rooms and `none` otherwise at the present. By using different values for this key It should be possible to extend this scheme as desired.

If there is a `rooms` value for the `type` then there will also be a `center` key with the room id number as the value which will be the only selected room id or that of the room that has the yellow cross-hairs in the 2D mapper; finally there will also be a key `rooms` which will contain the (sorted in ascending order) list of selected room ids.

As a zero room id is NOT a valid room number I have revised
`(int) T2DMap::mMultiSelectionHighlightRoomId` to have the `0` rather than `-1` as the sentinel value for the *no selected room* case as this is a more useful C/C++ coding style.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>