### PR TITLE
DataStamp: revise copyright strings for new year (2019)

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014, 2017-2018 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2014, 2017-2019 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
@@ -82,7 +82,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
-        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2018");
+        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2019");
         QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014, 2016-2018 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2014, 2016-2019 by Stephen Lyons                   *
  *                                            - slysven@virginmedia.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *                                                                         *
@@ -331,7 +331,7 @@ int main(int argc, char* argv[])
 
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
-        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2018");
+        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2019");
         QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Happy New Gregorian Year everyone.

This commit changes the ending year in the copyright message that appears on the splash screen as
required now that we have taken out the code that used to do it dynamically - which was frowned upon
because it breaks *[reproducible-builds](https://en.wikipedia.org/wiki/Reproducible_builds)* ...

#### Motivation for adding to Mudlet
Needed for the New Year.

#### Other info (issues closed, discussion etc)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>