### PR TITLE
BugFix: allow XMLexport to files with non-Latin1 character filenames

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2019 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,6 +37,7 @@
 
 #include "pre_guard.h"
 #include <QtConcurrent>
+#include <QFile>
 #include <fstream>
 #include <sstream>
 #include "post_guard.h"
@@ -215,26 +216,6 @@ void XMLexport::exportHost(const QString& filename_pugi_xml)
 }
 
 // credit: https://stackoverflow.com/a/29752943/72944
-void inline XMLexport::replaceAll(std::string& source, const char from, const std::string& to)
-{
-    std::string newString;
-    newString.reserve(source.length()); // avoids a few memory allocations
-
-    std::string::size_type lastPos = 0;
-    std::string::size_type findPos;
-
-    while (std::string::npos != (findPos = source.find(from, lastPos))) {
-        newString.append(source, lastPos, findPos - lastPos);
-        newString += to;
-        lastPos = findPos + 1;
-    }
-
-    // Care for the rest after last occurrence
-    newString += source.substr(lastPos);
-
-    source.swap(newString);
-}
-
 void inline XMLexport::replaceAll(std::string& source, const std::string& from, const std::string& to)
 {
     std::string newString;
@@ -262,13 +243,21 @@ void XMLexport::sanitizeForQxml(std::string& output)
 {
     QMap<std::string, std::string> replacements{
             {"&#1;", "\uFFFC\u2401"},   // SOH
+            {"&#01;", "\uFFFC\u2401"},   // SOH
             {"&#2;", "\uFFFC\u2402"},   // STX
+            {"&#02;", "\uFFFC\u2402"},   // STX
             {"&#3;", "\uFFFC\u2403"},   // ETX
+            {"&#03;", "\uFFFC\u2403"},   // ETX
             {"&#4;", "\uFFFC\u2404"},   // EOT
+            {"&#04;", "\uFFFC\u2404"},   // EOT
             {"&#5;", "\uFFFC\u2405"},   // ENQ
+            {"&#05;", "\uFFFC\u2405"},   // ENQ
             {"&#6;", "\uFFFC\u2406"},   // ACK
+            {"&#06;", "\uFFFC\u2406"},   // ACK
             {"&#7;", "\uFFFC\u2407"},   // BEL
+            {"&#07;", "\uFFFC\u2407"},   // BEL
             {"&#8;", "\uFFFC\u2408"},   // BS
+            {"&#08;", "\uFFFC\u2408"},   // BS
             {"&#11;", "\uFFFC\u240B"},  // VT
             {"&#12;", "\uFFFC\u240C"},  // FF
             {"&#14;", "\uFFFC\u240E"},  // SS
@@ -292,39 +281,75 @@ void XMLexport::sanitizeForQxml(std::string& output)
             {"&#127;", "\uFFFC\u2421"}, // DEL
     };
 
-    QMutableMapIterator<std::string, std::string> searching(replacements);
-    while (searching.hasNext()) {
-        if (output.find(searching.next().key()) == std::string::npos) {
-            searching.remove();
+    // Look for each replacement in data and if not present remove it from the
+    // list of things to replace
+    QMutableMapIterator<std::string, std::string> itReplacement(replacements);
+    while (itReplacement.hasNext()) {
+        itReplacement.next();
+        if (output.find(itReplacement.key()) == std::string::npos) {
+            itReplacement.remove();
         }
     }
 
-    QMapIterator<std::string, std::string> replacing(replacements);
-    while (replacing.hasNext()) {
-        replacing.next();
-        replaceAll(output, replacing.key(), replacing.value());
+    if (!replacements.isEmpty()) {
+        // There is at least one thing left in the QMap of replacements and we
+        // can use the same iterator if we reset it to the start of the
+        // remaining replacements:
+        itReplacement.toFront();
+        while (itReplacement.hasNext()) {
+            itReplacement.next();
+            replaceAll(output, itReplacement.key(), itReplacement.value());
+        }
     }
 }
 
 bool XMLexport::saveXml(const QString& fileName)
 {
-    std::stringstream saveStringStream(ios::out);
-    std::string output;
+    QFile file(fileName);
 
-    mExportDoc.save(saveStringStream);
-    output = saveStringStream.str();
-
-    sanitizeForQxml(output);
-
-    // only open the output file stream once we're ready to save
-    // this avoids a blank file in case serialisation crashed
-    std::ofstream saveFileStream(fileName.toUtf8().constData());
-    saveFileStream << output;
-
-    if (saveFileStream.bad()) {
+    if (!file.open(QFile::WriteOnly)) {
+        qDebug().noquote().nospace() << "XMLexport::saveXml(\"" << fileName << "\") ERROR - failed to open file, reason: " << file.errorString() << ".";
         return false;
     }
-    return true;
+
+    bool result = false;
+    if (!saveXmlFile(file)) {
+        if (file.error() != QFile::NoError) {
+            // Error reason was related to QFile:
+            qDebug().noquote().nospace() << "XMLexport::saveXml(\"" << fileName << "\") ERROR - failed to save package, reason: " << file.errorString() << ".";
+        } else {
+            // Error was due to failure in document preparation
+            qDebug().noquote().nospace() << "XMLexport::saveXml(\"" << fileName << "\") ERROR - failed to save package, reason: XML document preparation failure.";
+        }
+    }
+    file.close();
+    return result;
+}
+
+// This has been factored out to a separate method from saveXml(const QString&)
+// because there are situations where we have a QFile instance already and
+// just passing a filename and then creating another QFile instance on the
+// same file in the filesystem is less than optimum.
+// TODO: Refactor dlgTriggerEditor::slot_export() {at least} to call this method instead of saveXml(const QString&)
+bool XMLexport::saveXmlFile(QFile& file)
+{
+    std::stringstream saveStringStream(ios::out);
+    // Remember, the mExportDoc is the data in the form of a pugi::xml_document
+    // instance - the save method needs a stream that impliments the
+    // std::ostream interface into which it can push the data:
+    mExportDoc.save(saveStringStream);
+    // We need to do our own replacement of ASCII control characters that are
+    // not valid in XML verison 1.0 and that means we cannot use the pugixml
+    // file methods as it does that in a different way which is not helpful
+    // as we do not use that library for READING the XML files - so convert
+    // the data to a std::string :
+    std::string output(saveStringStream.str());
+    // Then do the control character replacement:
+    sanitizeForQxml(output);
+    // Now we can use Qt's file handling which does handle non-Latin1 named
+    // files - which MinGW's STL file handling (on Windows platform) does not:
+    file.write(output.data());
+    return file.error() == QFile::NoError;
 }
 
 QString XMLexport::saveXml()

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
  *   Copyright (C) 2017 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -32,6 +32,7 @@
 #include <pugixml.hpp>
 #include "post_guard.h"
 
+class QFile;
 class Host;
 class LuaInterface;
 class TAction;
@@ -107,9 +108,9 @@ private:
     void writeScriptPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeKeyPackage(const Host* pHost, pugi::xml_node& mMudletPackage, bool skipModuleMembers);
     void writeVariablePackage(Host* pHost, pugi::xml_node& mMudletPackage);
-    void inline replaceAll(std::string& source, char from, const std::string& to);
     void inline replaceAll(std::string& source, const std::string& from, const std::string& to);
-    bool saveXml(const QString& fileName);
+    bool saveXmlFile(QFile&);
+    bool saveXml(const QString&);
     pugi::xml_node writeXmlHeader();
     void sanitizeForQxml(std::string& output);
     QString saveXml();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2019 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Owen Davison - odavison@cs.dal.ca               *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Tom Scheper - scheper@gmail.com                 *
@@ -7263,6 +7263,8 @@ void dlgTriggerEditor::slot_export()
         QMessageBox::warning(this, tr("export package:"), tr("Cannot write file %1:\n%2.").arg(fileName, file.errorString()));
         return;
     }
+    // Should close the file that we have confirmed can be opened:
+    file.close();
 
     switch (mCurrentView) {
     case static_cast<int>(EditorViewType::cmTriggerView):


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This is a BugFix  for issue https://github.com/Mudlet/Mudlet/issues/1872 where it is reported that non-ASCII characters in the file name for items that are to exported as packages fails on Windows platforms. {An empty file with the right name is created as well as one with the expected contents but where every non-ASCII character in the file name has become Mojibake - furthermore should the same happen further up in an absolute path and file name then it is likely that erroneous path elements would be formed which due to file-system access control mechanism will either fail to be created or put the eventual XML file in a bogus location.}

#### Motivation for adding to Mudlet

This is an issue for non-English users who are likely to use characters outside of the limited range of ASCII characters in file names.

#### Other info (issues closed, discussion etc)

It transpires that the MinGW STL `std::stream` functions do not handle such characters as the Windows file i/o sub-system needs non-ASCII filenames to be supplied as a wide character array (using `wchar_t` type) but there is no requirement for that in the C++ STL specification (it is a non-standard extension in MicroSoft's MSVC library) and the third-party MinGW/MinGW64 STLs do not include it.

The workaround is to use `QFile` to provide the file handling and to push the `pugixml` document through it as a `std::string` obtained from the pugixml std::stringstream interface. We cannot use the pugixml file handling which itself does contain means to get around this awkwardness on the Windows platform because we also need to convert any ASCII control characters that are not valid in XML 1.0 in the XML data into our own custom replacements and the XML entities that pugixml uses are not compatible with the ones that we had started to use before starting to use the pugixml library;  we do not use that library to *read* the XML files (and it is not clear that it would even parse the replacement entities it uses anyway).

Whilst debugging all of this it became clear that there was a second bug in the code to replace the pugixml entities with our own replacements in that pugixml uses 2 digit numbers in the XML entities even for ASCII character codes less than 10 - but our search and replacement method was looking for single digit numbers. I have fixed the method to look for both.

Also:
`(void) XMLexport::replaceAll(std::string&, char, const std::string&)`
was not being used, instead only the method:
`(void) XMLexport::replaceAll(std::string&, const std::string, const std::string&)`
variant is active. I have thus remove the former from the application.

This will close https://github.com/Mudlet/Mudlet/issues/1872

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>


