### PR TITLE
BugFix: restore line feed effect to some debug messages on Windows platform

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -172,9 +172,21 @@ cTelnet::~cTelnet()
     }
 
     if (!messageStack.empty()) {
+#if defined (Q_OS_WIN32)
+        // Windows does not seem to accept line-feeds in these strings:
+        qWarning("cTelnet::~cTelnet() Instance being destroyed before it could display some messages,");
+        qWarning("messages are:");
+        qWarning("------------");
+#else
         qWarning("cTelnet::~cTelnet() Instance being destroyed before it could display some messages,\nmessages are:\n------------");
+#endif
         foreach (QString message, messageStack) {
+#if defined (Q_OS_WIN32)
+            qWarning("%s", qPrintable(message));
+            qWarning("------------");
+#else
             qWarning("%s\n------------", qPrintable(message));
+#endif
         }
     }
     socket.deleteLater();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Whilst working on another issue on a Windows PC I found that the printout of messages previously stacked up by `cTelnet::postMessage(QString)` but **not** displayed at the point where the class instance was being destroyed was malformed on that Windows PC in that a format string to the `qWarning(const char*, ...)` message was not respecting `\n` escapes in the format string literal.  This is a regression compared to the behaviour on my FreeBSD and GNU/Linux PCs.

#### Motivation for adding to Mudlet

To make the output from the Windows version more like that from other platform implementations.

#### Other info (issues closed, discussion etc)

It is not clear to me why this is happening but given how tricky it is to get stdout and stderr output from Mudlet to be shown on a command line it does not surprise me *that* much.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>