### PR TITLE
QPixmat dpi adjustment

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -647,8 +647,10 @@ int TTextEdit::drawGrapheme(QPainter& painter, const QPoint& cursor, const QStri
 
 void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
 {
+    qreal dpr = devicePixelRatioF();
     QPixmap screenPixmap;
-    QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth, mScreenHeight * mFontHeight);
+    QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * dpr, mScreenHeight * mFontHeight * dpr);
+    pixmap.setDevicePixelRatio(dpr);
     pixmap.fill(palette().base().color());
 
     QPainter p(&pixmap);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -714,14 +714,14 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
     if ((!noScroll) && (mScrollVector >= 0) && (mScrollVector <= mScreenHeight) && (!mForceUpdate)) {
         if (mScrollVector * mFontHeight < mScreenMap.height() && mScreenWidth * mFontWidth <= mScreenMap.width() && (mScreenHeight - mScrollVector) * mFontHeight > 0
             && (mScreenHeight - mScrollVector) * mFontHeight <= mScreenMap.height()) {
-            screenPixmap = mScreenMap.copy(0, mScrollVector * mFontHeight, mScreenWidth * mFontWidth, (mScreenHeight - mScrollVector) * mFontHeight);
+            screenPixmap = mScreenMap.copy(0, mScrollVector * mFontHeight * dpr, mScreenWidth * mFontWidth * dpr, (mScreenHeight - mScrollVector) * mFontHeight * dpr);
             p.drawPixmap(0, 0, screenPixmap);
             from = mScreenHeight - mScrollVector - 1;
         }
     } else if ((!noScroll) && (mScrollVector < 0 && mScrollVector >= ((-1) * mScreenHeight)) && (!mForceUpdate)) {
         if (abs(mScrollVector) * mFontHeight < mScreenMap.height() && mScreenWidth * mFontWidth <= mScreenMap.width() && (mScreenHeight - abs(mScrollVector)) * mFontHeight > 0
             && (mScreenHeight - abs(mScrollVector)) * mFontHeight <= mScreenMap.height()) {
-            screenPixmap = mScreenMap.copy(0, 0, mScreenWidth * mFontWidth, (mScreenHeight - abs(mScrollVector)) * mFontHeight);
+            screenPixmap = mScreenMap.copy(0, 0, mScreenWidth * mFontWidth * dpr, (mScreenHeight - abs(mScrollVector)) * mFontHeight * dpr);
             p.drawPixmap(0, abs(mScrollVector) * mFontHeight, screenPixmap);
             from = 0;
             y2 = abs(mScrollVector);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,10 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
+#ifdef Q_OS_UNIX
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     QScopedPointer<QCoreApplication> initApp(createApplication(argc, argv, startupAction));
     auto * app = qobject_cast<QApplication*>(initApp.data());
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add DPI scaling for TTextEdit

#### Motivation for adding to Mudlet
When scaled for a HiDPI screen, the font in the main windows looks pixelated as the main windows are being stretched. This adjusts the size of the main window to account for the DPI on the screen the textbox is on.

#### Other info (issues closed, discussion etc)
Resolves issue [2171](https://github.com/Mudlet/Mudlet/issues/2171).  See the issue for screenshots.

Fixes https://github.com/Mudlet/Mudlet/issues/800.