### PR TITLE
BugFix: get buttons working in menus on button toolbars

### DIFF
--- a/src/EAction.cpp
+++ b/src/EAction.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -33,7 +33,7 @@ EAction::EAction(QIcon& icon, QString& name) : QAction(icon, name, mudlet::self(
     setText(name);
     setObjectName(name);
     setIcon(icon);
-    connect(this, &EAction::triggered, this, &EAction::slot_execute);
+    connect(this, &QAction::triggered, this, &EAction::slot_execute);
 }
 
 void EAction::slot_execute(bool checked)

--- a/src/EAction.h
+++ b/src/EAction.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -42,9 +42,6 @@ public:
 
 public slots:
     void slot_execute(bool checked);
-
-signals:
-    void triggered(QAction*);
 
 public: // TODO: private:
     int mID;


### PR DESCRIPTION
A single character defect meant that the `SIGNAL` from the push-buttons on menus were not being connected to the `SLOT` that was expected to get the signal in order to perform the required behaviour.

As such the `EAction::triggered(QAction*)` signal declaration is not required and can be excised.

This will close https://github.com/Mudlet/Mudlet/issues/1914 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>