### PR TITLE
Fix clicking on miniconsoles losing focus

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2350,6 +2350,10 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
         pC->setFocusPolicy(Qt::NoFocus);
         pC->mUpperPane->setIsMiniConsole();
         pC->mLowerPane->setIsMiniConsole();
+        const auto& hostCommandLine = mpHost->mpConsole->mpCommandLine;
+        pC->setFocusProxy(hostCommandLine);
+        pC->mUpperPane->setFocusProxy(hostCommandLine);
+        pC->mLowerPane->setFocusProxy(hostCommandLine);
         pC->resize(width, height);
         pC->mOldX = x;
         pC->mOldY = y;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix clicking on a userwindow or a miniconsole losing focus from the main command line.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/1783, fix https://github.com/Mudlet/Mudlet/pull/1797, fix https://github.com/Mudlet/Mudlet/issues/1172.
#### Other info (issues closed, discussion etc)
The focus proxies we had in place got broken by d9c37bfe99a7d44f43d3a35d84db5b7fbc8fc5dd - this restores them.