### PR TITLE
Fix Mudlet to connect well again

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -356,14 +356,8 @@ void cTelnet::connectIt(const QString& address, int port)
     hostPort = port;
     QString server = tr("[ INFO ]  - Looking up the IP address of server:") + address + ":" + QString::number(port) + " ...";
     postMessage(server);
-//#if QT_VERSION >= 0x050900
-//    QHostInfo::lookupHost(address, this, &cTelnet::handle_socket_signal_hostFound);
-//#else
-    // The ability to use the overloaded forms where a functor or
-    // pointerToMember is used as the signal receiver was only introduced in
-    // Qt 5.9.0 LTS:
+    // don't use a compile-time slot for this: https://bugreports.qt.io/browse/QTBUG-67646
     QHostInfo::lookupHost(address, this, SLOT(handle_socket_signal_hostFound(QHostInfo)));
-//#endif
 }
 
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -356,14 +356,14 @@ void cTelnet::connectIt(const QString& address, int port)
     hostPort = port;
     QString server = tr("[ INFO ]  - Looking up the IP address of server:") + address + ":" + QString::number(port) + " ...";
     postMessage(server);
-#if QT_VERSION >= 0x050900
-    QHostInfo::lookupHost(address, this, &cTelnet::handle_socket_signal_hostFound);
-#else
+//#if QT_VERSION >= 0x050900
+//    QHostInfo::lookupHost(address, this, &cTelnet::handle_socket_signal_hostFound);
+//#else
     // The ability to use the overloaded forms where a functor or
     // pointerToMember is used as the signal receiver was only introduced in
     // Qt 5.9.0 LTS:
     QHostInfo::lookupHost(address, this, SLOT(handle_socket_signal_hostFound(QHostInfo)));
-#endif
+//#endif
 }
 
 
@@ -393,8 +393,6 @@ void cTelnet::slot_send_pass()
 void cTelnet::handle_socket_signal_connected()
 {
     QString msg;
-
-    qDebug() << "MODE:" << socket.mode();
 
     reset();
     setKeepAlive(socket.socketDescriptor());


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix Mudlet to connect well on the first try again.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Qt throws up this warning which seems relevant:

```
QObject: Cannot create children for a parent that is in a different thread.
(Parent is QSslSocket(0x560e5ff6b270), parent's thread is QThread(0x560e5f06f330), current thread is QThread(0x7f1bd8004a00)
```