### PR TITLE
Refactor: remove redundant external Lua module override

### DIFF
--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -91,18 +91,6 @@ end
 function handleWindowResizeEvent()
 end
 
--- override built-in createMiniConsole to allow for multiple calls
-do
-  local oldcreateMiniConsole = createMiniConsole
-
-  function createMiniConsole(name, x, y, width, height)
-    oldcreateMiniConsole(name, 0, 0, 0, 0)
-    moveWindow(name, x, y)
-    resizeWindow(name, width, height)
-  end
-end
-
-
 local packages = {
   "StringUtils.lua",
   "TableUtils.lua",


### PR DESCRIPTION
This will close https://github.com/Mudlet/Mudlet/issues/839 . This piece of Lua script has not been needed since: https://github.com/Mudlet/Mudlet/commit/b6705a1735fd275a78e000bc1299c58a548eadeb .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>