### PR TITLE
Erronoeous fixed string in MXP handler in `TBuffer::translateToPlainText(...)`

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1791,7 +1791,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     mIgnoreTag = false;
                     mSkip.clear();
                     ch = '&';
-                } else if (mSkip == "&quot;" ) {
+                } else if (mSkip == "&quot" && ch == ';' ) {
                     mIgnoreTag = false;
                     mSkip.clear();
                     ch = '"';

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1791,7 +1791,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     mIgnoreTag = false;
                     mSkip.clear();
                     ch = '&';
-                } else if (mSkip == "&quot;" && ch == ';') {
+                } else if (mSkip == "&quot;" ) {
                     mIgnoreTag = false;
                     mSkip.clear();
                     ch = '"';


### PR DESCRIPTION
erronoeous fixed string in MXP handler fixed

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
It is to fix a potentially bug in TBuffer.cpp in regards of MXP handler of a fixed string.
#### Motivation for adding to Mudlet
ez mode fix and try branching out for a seperated pull request.
#### Other info (issues closed, discussion etc)
This should close issue #2130 