### PR TITLE
extends lua functionality of exists() and isActive() for scripts

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6576,6 +6576,14 @@ int TLuaInterpreter::exists(lua_State* L)
         cnt += host.getAliasUnit()->mLookupTable.count(name);
     } else if (type == "keybind") {
         cnt += host.getKeyUnit()->mLookupTable.count(name);
+    } else if (type == "script") {
+        //Richard Moffitt: ugly hack. will fix it later for a pretty one-liner code...
+        std::list<TScript*> scripts = host.getScriptUnit()->getScriptRootNodeList();
+        for (auto script : scripts) {
+            if (!script->getScript().isEmpty()) {
+                cnt += (script->getName() == name);
+            }
+        }
     }
     lua_pushnumber(L, cnt);
     return 1;
@@ -6633,6 +6641,13 @@ int TLuaInterpreter::isActive(lua_State* L)
                 cnt++;
             }
             it1++;
+        }
+    } else if (type.compare(QLatin1String("script"), Qt::CaseInsensitive) == 0) {
+        std::list<TScript*> scripts = host.getScriptUnit()->getScriptRootNodeList();
+        for (auto script : scripts) {
+            if (script->getName() == name && script->isActive()) {
+                cnt ++;
+            }
         }
     } else {
         lua_pushnil(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6644,7 +6644,7 @@ int TLuaInterpreter::isActive(lua_State* L)
         std::list<TScript*> scripts = host.getScriptUnit()->getScriptRootNodeList();
         for (auto script : scripts) {
             if (script->getName() == name && script->isActive()) {
-                cnt ++;
+                ++cnt;
             }
         }
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6580,11 +6580,9 @@ int TLuaInterpreter::exists(lua_State* L)
         //Richard Moffitt: ugly hack. will fix it later for a pretty one-liner code...
         std::list<TScript*> scripts = host.getScriptUnit()->getScriptRootNodeList();
         for (auto script : scripts) {
-            if (!script->getScript().isEmpty()) {
-                cnt += (script->getName() == name);
+            cnt += (script->getName() == name);
             }
         }
-    }
     lua_pushnumber(L, cnt);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6577,7 +6577,6 @@ int TLuaInterpreter::exists(lua_State* L)
     } else if (type == "keybind") {
         cnt += host.getKeyUnit()->mLookupTable.count(name);
     } else if (type == "script") {
-        //Richard Moffitt: ugly hack. will fix it later for a pretty one-liner code...
         std::list<TScript*> scripts = host.getScriptUnit()->getScriptRootNodeList();
         for (auto script : scripts) {
             cnt += (script->getName() == name);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
this is for issue #683 partially. extending the isActive() and exists() functionality for scripts

#### Motivation for adding to Mudlet
It is to complete the request of issue #683. so one could execute in lua script to find them. E.g: exists("cow", "script") and/or isActive("svo", "script")

#### Other info (issues closed, discussion etc)
this partially completing the request of #683.