### PR TITLE
ensure that the MXP init state is in a open line state at start by default.

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -60,6 +60,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mDisplayFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
 , mEnableGMCP(true)
 , mEnableMSDP(false)
+, mServerMXPenabled(false)
 , mFORCE_GA_OFF(false)
 , mFORCE_NO_COMPRESSION(false)
 , mFORCE_SAVE_ON_EXIT(false)

--- a/src/Host.h
+++ b/src/Host.h
@@ -233,6 +233,7 @@ public:
     QFont mDisplayFont;
     bool mEnableGMCP;
     bool mEnableMSDP;
+    bool mServerMXPenabled;
     QTextStream mErrorLogStream;
     QMap<QString, QList<TScript*>> mEventHandlerMap;
     bool mFORCE_GA_OFF;

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -46,7 +46,7 @@
 // Define this to get qDebug() messages about the decoding of ANSI MXP sequences
 // although there is not much against this item at present {only an announcement
 // of the type (?) of an `\x1b[?z` received}:
-// #define DEBUG_MXP_PROCESSING
+//#define DEBUG_MXP_PROCESSING
 
 
 // These tables have been regenerated from examination of the Qt source code
@@ -732,7 +732,7 @@ TBuffer::TBuffer(Host* pH)
 , mWrapAt(99999999)
 , mWrapIndent(0)
 , mCursorY(0)
-, mMXP(false)
+, mMXP(true)
 , mAssemblingToken(false)
 , currentToken("")
 , openT(0)
@@ -1320,7 +1320,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 #if defined(DEBUG_MXP_PROCESSING)
                     qDebug().nospace().noquote() << "    Consider the MXP control sequence: \"" << localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str() << "\"";
 #endif
-                    if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF) {
+                    if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF && mpHost->mServerMXPenabled) {
                         mGotCSI = false;
 
                         bool isOk = false;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -903,7 +903,7 @@ void cTelnet::processTelnetCommand(const string& command)
         if (option == OPT_MXP) {
             if (!mpHost->mFORCE_MXP_NEGOTIATION_OFF) {
                 sendTelnetOption(TN_DO, OPT_MXP);
-
+                mpHost->mServerMXPenabled = true;
                 raiseProtocolEvent("sysProtocolEnabled", "MXP");
                 break;
             }
@@ -996,6 +996,7 @@ void cTelnet::processTelnetCommand(const string& command)
 
             if (option == OPT_MXP) {
                 // MXP got turned off
+                mpHost->mServerMXPenabled = false;
                 raiseProtocolEvent("sysProtocolDisabled", "MXP");
             }
 
@@ -2084,6 +2085,7 @@ void cTelnet::handle_socket_signal_readyRead()
         if (mNeedDecompression) {
             datalen = decompressBuffer(in_buffer, amount, out_buffer);
             buffer = out_buffer;
+            //qDebug() << "buffer:" << buffer;
         }
         buffer[datalen] = '\0';
         if (mpHost->mpConsole->mRecordReplay) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This change ensures that MXP will be on open line state by default initially after the completion of MXP IAC negotiation.

#### Motivation for adding to Mudlet
The motivation of this patch is to ensure that it affirms the MXP spec, and to an extent, that some servers use Evennia codebase or other will be able to display the lines as intended as it should be.

#### Other info (issues closed, discussion etc)
this should solve the issue with #2196 and evennia/evennia#1058