### PR TITLE
Added enableClickthrough and disableClickthrough

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2364,7 +2364,7 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
     }
 }
 
-TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground)
+TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough)
 {
     std::string key = name.toLatin1().data();
     if (mLabelMap.find(key) == mLabelMap.end()) {
@@ -2372,6 +2372,7 @@ TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int 
         mLabelMap[key] = pC;
         pC->setObjectName(name);
         pC->setAutoFillBackground(fillBackground);
+        pC->setClickThrough(clickThrough);
         pC->resize(width, height);
         pC->setContentsMargins(0, 0, 0, 0);
         pC->move(x, y);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -140,7 +140,8 @@ public:
     void moveCursorEnd();
     int getLastLineNumber();
     void refresh();
-    TLabel* createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground);
+    TLabel*
+    createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
     TConsole* createMiniConsole(const QString& name, int x, int y, int width, int height);
     bool createButton(const QString& name, int x, int y, int width, int height, bool fillBackground);
     bool raiseWindow(const QString& name);

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -248,3 +248,8 @@ void TLabel::releaseParams(Host* pHost, TEvent& params) {
     }
 
 }
+
+void TLabel::setClickThrough(bool clickthrough)
+{
+    setAttribute(Qt::WA_TransparentForMouseEvents, clickthrough);
+}

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -56,6 +56,7 @@ public:
     void mouseMoveEvent(QMouseEvent*) override;
     void leaveEvent(QEvent*) override;
     void enterEvent(QEvent*) override;
+    void setClickThrough(bool clickthrough);
 
     bool forwardEventToMapper(QEvent*);
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2798,7 +2798,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
         luaSendText = lua_tostring(L, 1);
     }
     int x, y, width, height;
-    bool fillBackground = false;
+    bool fillBackground, clickthrough = false;
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "createLabel: wrong argument type");
         lua_error(L);
@@ -2834,9 +2834,18 @@ int TLuaInterpreter::createLabel(lua_State* L)
     } else {
         fillBackground = lua_toboolean(L, 6);
     }
+    if (lua_gettop(L) > 6) {
+        if (!lua_isboolean(L, 7)) {
+            lua_pushstring(L, "createLabel: wrong argument type");
+            lua_error(L);
+            return 1;
+        } else {
+            clickthrough = lua_toboolean(L, 7);
+        }
+    }
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
-    lua_pushboolean(L, mudlet::self()->createLabel(&host, name, x, y, width, height, fillBackground));
+    lua_pushboolean(L, mudlet::self()->createLabel(&host, name, x, y, width, height, fillBackground, clickthrough));
     return 1;
 }
 
@@ -2928,7 +2937,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     //TODO FIXME
-    mudlet::self()->createLabel(&host, name, x, y, width, height, fillBackground);
+    mudlet::self()->createLabel(&host, name, x, y, width, height, fillBackground, false);
     return 0;
 }
 
@@ -14355,6 +14364,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getPlayerRoom", TLuaInterpreter::getPlayerRoom);
     lua_register(pGlobalLua, "getSelection", TLuaInterpreter::getSelection);
     lua_register(pGlobalLua, "getMapSelection", TLuaInterpreter::getMapSelection);
+    lua_register(pGlobalLua, "enableClickthrough", TLuaInterpreter::enableClickthrough);
+    lua_register(pGlobalLua, "disableClickthrough", TLuaInterpreter::disableClickthrough);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath
@@ -15194,4 +15205,44 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
     }
 
     return 1;
+}
+
+int TLuaInterpreter::enableClickthrough(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString windowName;
+    if (n == 1) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "enableClickthrough: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            lua_error(L);
+            return 1;
+        } else {
+            windowName = lua_tostring(L, 1);
+        }
+    }
+
+    Host& host = getHostFromLua(L);
+
+    mudlet::self()->setClickthrough(&host, windowName, true);
+    return 0;
+}
+
+int TLuaInterpreter::disableClickthrough(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString windowName;
+    if (n == 1) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "disableClickthrough: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            lua_error(L);
+            return 1;
+        } else {
+            windowName = lua_tostring(L, 1);
+        }
+    }
+
+    Host& host = getHostFromLua(L);
+
+    mudlet::self()->setClickthrough(&host, windowName, false);
+    return 0;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -369,6 +369,8 @@ public:
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);
     static int disableScrollBar(lua_State*);
+	static int enableClickthrough(lua_State* L);
+    static int disableClickthrough(lua_State* L);
     static int startLogging(lua_State* L);
     static int calcFontWidth(int size);
     static int calcFontHeight(int size);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1680,7 +1680,8 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
     return false;
 }
 
-bool mudlet::createLabel(Host* pHost, const QString& name, int x, int y, int width, int height, bool fillBg)
+bool mudlet::createLabel(Host* pHost, const QString& name, int x, int y, int width, int height, bool fillBg,
+                         bool clickthrough)
 {
     if (!pHost) {
         return false;
@@ -1690,7 +1691,7 @@ bool mudlet::createLabel(Host* pHost, const QString& name, int x, int y, int wid
     }
     QMap<QString, TLabel*>& labelMap = mHostLabelMap[pHost];
     if (!labelMap.contains(name)) {
-        TLabel* pL = pHost->mpConsole->createLabel(name, x, y, width, height, fillBg);
+        TLabel* pL = pHost->mpConsole->createLabel(name, x, y, width, height, fillBg, clickthrough);
         if (pL) {
             labelMap[name] = pL;
             return true;
@@ -4120,4 +4121,15 @@ void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
 void mudlet::setInterfaceLanguage(const QString& languageCode)
 {
     mInterfaceLanguage = languageCode;
+}
+
+bool mudlet::setClickthrough(Host* pHost, const QString& name, bool clickthrough)
+{
+    const auto& labelMap = mHostLabelMap[pHost];
+    if (labelMap.contains(name)) {
+        labelMap[name]->setClickThrough(clickthrough);
+        return true;
+    }
+
+    return false;
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -121,7 +121,8 @@ public:
     QSize calcFontSize(Host* pHost, const QString& windowName);
     bool openWindow(Host*, const QString&, bool loadLayout = true);
     bool createMiniConsole(Host*, const QString&, int, int, int, int);
-    bool createLabel(Host*, const QString&, int, int, int, int, bool);
+    bool createLabel(Host* pHost, const QString& name, int x, int y, int width, int height, bool fillBg,
+                         bool clickthrough);
     bool echoWindow(Host*, const QString&, const QString&);
     bool echoLink(Host* pHost, const QString& name, const QString& text, QStringList&, QStringList&, bool customFormat = false);
     void insertLink(Host*, const QString&, const QString&, QStringList&, QStringList&, bool customFormat = false);
@@ -200,6 +201,7 @@ public:
     bool replayStart();
     bool setConsoleBufferSize(Host* pHost, const QString& name, int x1, int y1);
     bool setScrollBarVisible(Host* pHost, const QString& name, bool isVisible);
+    bool setClickthrough(Host* pHost, const QString& name, bool clickthrough);
     void replayOver();
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds methods `enableClickthrough()` and `disableClickthrough()` for labels to make clicks 'pass through'.
#### Motivation for adding to Mudlet
So people can create labels that are just with transparent pictures on top of something else, for example.
#### Other info (issues closed, discussion etc)
Maybe these functions should work on miniconsoles as well... ?