### PR TITLE
set room area dropdown menu should be sorted by name, not by area ID. (part two...)

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4034,15 +4034,7 @@ void T2DMap::slot_setArea()
 
     QMapIterator<int, QString> it(mpMap->mpRoomDB->getAreaNamesMap());
     QStringList sortedAreaList;
-    QStringList::const_iterator constAreaIterator;
     sortedAreaList = mpMap->mpRoomDB->getAreaNamesMap().values();
-
-    while (it.hasNext()){
-        it.next();
-        if (it.key() > 0){
-            sortedAreaList += it.value();
-        }
-    }
 
     std::sort(sortedAreaList.begin(), sortedAreaList.end());
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4035,7 +4035,13 @@ void T2DMap::slot_setArea()
     QStringList sortedAreaList;
     sortedAreaList = mpMap->mpRoomDB->getAreaNamesMap().values();
 
-    std::sort(sortedAreaList.begin(), sortedAreaList.end());
+    QCollator sorter;
+    sorter.setNumericMode( true ); // Default is false
+    sorter.setCaseSensitivity( Qt::CaseInsensitive ); // Default is case sensitive
+
+    std::sort( sortedAreaList.begin(), sortedAreaList.end(), [&]( const QString& a, const QString& b ) {
+            return sorter.compare( a, b ) < 0;
+        } );
 
 
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4032,7 +4032,6 @@ void T2DMap::slot_setArea()
         return;
     }
 
-    QMapIterator<int, QString> it(mpMap->mpRoomDB->getAreaNamesMap());
     QStringList sortedAreaList;
     sortedAreaList = mpMap->mpRoomDB->getAreaNamesMap().values();
 
@@ -4042,7 +4041,7 @@ void T2DMap::slot_setArea()
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
     for (int i = 0, total = sortedAreaList.count(); i < total; ++i) {
         int areaId = areaNamesMap.key(sortedAreaList.at(i));
-        arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)), QString::number(areaId));
+        arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)));
     }
 
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4036,7 +4036,7 @@ void T2DMap::slot_setArea()
     sortedAreaList = mpMap->mpRoomDB->getAreaNamesMap().values();
 
     QCollator sorter;
-    sorter.setNumericMode( true ); // Default is false
+    sorter.setNumericMode(true);
     sorter.setCaseSensitivity(Qt::CaseInsensitive);
 
     std::sort( sortedAreaList.begin(), sortedAreaList.end(), [&]( const QString& a, const QString& b ) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4037,7 +4037,7 @@ void T2DMap::slot_setArea()
 
     QCollator sorter;
     sorter.setNumericMode( true ); // Default is false
-    sorter.setCaseSensitivity( Qt::CaseInsensitive ); // Default is case sensitive
+    sorter.setCaseSensitivity(Qt::CaseInsensitive);
 
     std::sort( sortedAreaList.begin(), sortedAreaList.end(), [&]( const QString& a, const QString& b ) {
             return sorter.compare( a, b ) < 0;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4032,7 +4032,7 @@ void T2DMap::slot_setArea()
         return;
     }
 
-    QMapIterator<int, QString> it = mpMap->mpRoomDB->getAreaNamesMap();
+    QMapIterator<int, QString> it(mpMap->mpRoomDB->getAreaNamesMap());
     QStringList sortedAreaList;
     QStringList::const_iterator constAreaIterator;
     sortedAreaList = mpMap->mpRoomDB->getAreaNamesMap().values();
@@ -4040,25 +4040,17 @@ void T2DMap::slot_setArea()
     while (it.hasNext()){
         it.next();
         if (it.key() > 0){
-            sortedAreaList += it.value().toLower();
+            sortedAreaList += it.value();
         }
     }
 
-    qSort(sortedAreaList.begin(), sortedAreaList.end());
+    std::sort(sortedAreaList.begin(), sortedAreaList.end());
 
 
-    for(constAreaIterator = sortedAreaList.constBegin(); constAreaIterator != sortedAreaList.constEnd(); ++constAreaIterator){
-        it.toFront();
-        while (it.hasNext()) {
-
-            it.next();
-            //qDebug() << it.key() << ":" << it.value();
-            int areaID = it.key();
-            if (areaID > 0 && (*constAreaIterator).constData() == it.value().toLower().constData()) {
-                arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(it.value(), QString::number(areaID)), QVariant(areaID));
-                break;
-            }
-        }
+    const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
+    for (int i = 0, total = sortedAreaList.count(); i < total; ++i) {
+        int areaId = areaNamesMap.key(sortedAreaList.at(i));
+        arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)), QString::number(areaId));
     }
 
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4032,14 +4032,36 @@ void T2DMap::slot_setArea()
         return;
     }
 
-    QMapIterator<int, QString> it(mpMap->mpRoomDB->getAreaNamesMap());
-    while (it.hasNext()) {
+    QMapIterator<int, QString> it = mpMap->mpRoomDB->getAreaNamesMap();
+    QStringList sortedAreaList;
+    QStringList::const_iterator constAreaIterator;
+    sortedAreaList = mpMap->mpRoomDB->getAreaNamesMap().values();
+
+    while (it.hasNext()){
         it.next();
-        int areaID = it.key();
-        if (areaID > 0) {
-            arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(it.value(), QString::number(areaID)), QVariant(areaID));
+        if (it.key() > 0){
+            sortedAreaList += it.value().toLower();
         }
     }
+
+    qSort(sortedAreaList.begin(), sortedAreaList.end());
+
+
+    for(constAreaIterator = sortedAreaList.constBegin(); constAreaIterator != sortedAreaList.constEnd(); ++constAreaIterator){
+        it.toFront();
+        while (it.hasNext()) {
+
+            it.next();
+            //qDebug() << it.key() << ":" << it.value();
+            int areaID = it.key();
+            if (areaID > 0 && (*constAreaIterator).constData() == it.value().toLower().constData()) {
+                arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(it.value(), QString::number(areaID)), QVariant(areaID));
+                break;
+            }
+        }
+    }
+
+
 
     if (set_room_area_dialog->exec() == QDialog::Rejected) { // Don't proceed if "cancel" was pressed
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4039,15 +4039,13 @@ void T2DMap::slot_setArea()
     sorter.setNumericMode(true);
     sorter.setCaseSensitivity(Qt::CaseInsensitive);
 
-    std::sort( sortedAreaList.begin(), sortedAreaList.end(), [&]( const QString& a, const QString& b ) {
-            return sorter.compare( a, b ) < 0;
-        } );
+    std::sort( sortedAreaList.begin(), sortedAreaList.end(), sorter);
 
 
     const QMap<int, QString>& areaNamesMap = mpMap->mpRoomDB->getAreaNamesMap();
     for (int i = 0, total = sortedAreaList.count(); i < total; ++i) {
         int areaId = areaNamesMap.key(sortedAreaList.at(i));
-        arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)));
+        arealist_combobox->addItem(QStringLiteral("%1 (%2)").arg(sortedAreaList.at(i), QString::number(areaId)), QString::number(areaId));
     }
 
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This change should cause the "Move room to other area" combobox to be in a proper A-Z order rather than to be in an area ID number order.

#### Motivation for adding to Mudlet
Ensure that others will find the area that they can move the room to other areas easily. Plus it is an easy issue to fix.

#### Other info (issues closed, discussion etc)
1)that should close #2180 and #1549
2)also, this is PR being separated from older PR #2191 (because it is on development fork which should and would screw up the future merge.
3) all feedbacks from that old PR are applied.
