### PR TITLE
Allow to tab out of game description box

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2536,6 +2536,9 @@
               <property name="readOnly">
                <bool>false</bool>
               </property>
+              <property name="tabChangesFocus">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
            </layout>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Small change will allow users to tab out of the box with game description (multi line text)

#### Motivation for adding to Mudlet
Albeit small change, this has huge implications, as some users must rely on keyboard to navigate Mudlet (e.g. visually impaired) and can't just "click" the "connect" button with mouse. Nor could they reach that button by repeatedly pressing "tabulator" on their keyboard. Therefore, they could never connect to a game and start actually using Mudlet to play a game. - Until now.

#### Other info (issues closed, discussion etc)
This is supposed to fix #2114
On the other hand, it will get harder (but not impossible) to include tabulator characters in the games' description text