### PR TITLE
Enhance: extend getLines(...) to support user created windows

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -4040,8 +4040,9 @@ bool TBuffer::moveCursor(QPoint& where)
     return true;
 }
 
-QString badLineError = QString("ERROR: invalid line number");
-
+// Needed, at least, as a filler for missing lines past end of the lineBuffer
+// requested by lua function getLines(...):
+QString badLineError = QStringLiteral("ERROR: invalid line number");
 
 QString& TBuffer::line(int n)
 {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4135,3 +4135,26 @@ bool mudlet::setClickthrough(Host* pHost, const QString& name, bool clickthrough
 
     return false;
 }
+
+QPair<bool, QStringList> mudlet::getLines(Host* pHost, const QString& windowName, const int lineFrom, const int lineTo)
+{
+    if (!pHost) {
+        QStringList failMessage;
+        failMessage << QStringLiteral("internal error: the Host class pointer was a nullptr - please report").arg(windowName);
+        return qMakePair(false, failMessage);
+    }
+
+    if (windowName.isEmpty() || windowName == QLatin1String("main")) {
+        return qMakePair(true, pHost->mpConsole->getLines(lineFrom, lineTo));
+    }
+
+    QMap<QString, TConsole*>& dockWindowConsoleMap = mHostConsoleMap[pHost];
+    const auto window = dockWindowConsoleMap.constFind(windowName);
+    if (window != dockWindowConsoleMap.cend()) {
+        return qMakePair(true, window.value()->getLines(lineFrom, lineTo));
+    } else {
+        QStringList failMessage;
+        failMessage << QStringLiteral("mini console, user window or buffer \"%1\" not found").arg(windowName);
+        return qMakePair(false, failMessage);
+    }
+}

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -358,6 +358,7 @@ public:
     void show_options_dialog(QString tab);
     void setInterfaceLanguage(const QString &languageCode);
     QList<QString> getAvailableTranslationCodes() const { return mTranslatorsMap.keys(); }
+    QPair<bool, QStringList> getLines(Host* pHost, const QString& windowName, const int lineFrom, const int lineTo);
 
 #if defined(INCLUDE_UPDATER)
     Updater* updater;


### PR DESCRIPTION
Allows a extra initial string argument as a mini-console, user window or buffer name to get the text from `TConsole` instance as well as the main profile one. To that end, the empty string and the name "main" are reserved and treated as referring to the main one.

Note that this PR ~may~ will clash with another PR I have pending: https://github.com/Mudlet/Mudlet/pull/2226

This will close Issue: https://github.com/Mudlet/Mudlet/issues/754 which was originally opened in December 2013!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>