### PR TITLE
Adding call to TriggerUnit::doCleanup() after a script save to avoid stale triggers

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4360,6 +4360,7 @@ void dlgTriggerEditor::saveScript()
     pT->setScript(script);
 
     pT->compile();
+    mpHost->getTriggerUnit()->doCleanup();
     QIcon icon;
     if (pT->isFolder()) {
         if (!pT->mPackageName.isEmpty()) {


### PR DESCRIPTION


<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds call to trigger cleanup after script save finished compiling the script. Tested working with the same scenarios it was discovered with.

#### Motivation for adding to Mudlet
Before PR, if you had the following script in a script object and saved it several times between receving lines from the MUD, all the triggers it created when saved will be triggered, then the ones marked for deletion will be cleaned up. Until the line is received, the number of tempTriggers reported in system statistics also goes up. This change prevents that.
```lua
if testtemptrigger then
    killTrigger(testtemptrigger)
end
testtemptrigger = tempRegexTrigger([[^.*$]], [[cecho(" HI I am a trigger, and I just fired!!!")]])
```

#### Other info (issues closed, discussion etc)
Discussed this issue over discord in the help and development channels, adding a quick PR.