### PR TITLE
BugFix: prevent floating user windows stealing focus

### DIFF
--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018 by Stephen Lyons                        *
+ *   Copyright (C) 2014-2016, 2018-2019 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -183,7 +183,10 @@ public:
 
 
     QPointer<Host> mpHost;
-    TCommandLine* mpCommandLine;
+    // Only assigned a value for user windows:
+    QPointer<TDockWidget> mpDockWidget;
+    // Only on a MainConsole type instance:
+    QPointer<TCommandLine> mpCommandLine;
 
     TBuffer buffer;
     static const QString cmLuaLineVariable;

--- a/src/TDockWidget.cpp
+++ b/src/TDockWidget.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
+ *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,11 +20,23 @@
 
 #include "TDockWidget.h"
 
-TDockWidget::TDockWidget(Host* pH, const QString& consoleName) : QDockWidget()
+TDockWidget::TDockWidget(Host* pH, const QString& consoleName)
+: QDockWidget()
+, widgetConsoleName(consoleName)
+, hasLayoutAlready(false)
+, mpHost(pH)
+, mpConsole(nullptr)
 {
-    mpHost = pH;
-    hasLayoutAlready = false;
-    widgetConsoleName = consoleName;
+}
+
+// This sets the mutual pointers that the TConsole and the TDockWidget now
+// have for each other as well as assigning the TConsole to be the TDockWidget's
+// widget:
+void TDockWidget::setTConsole(TConsole* pC)
+{
+    mpConsole = pC;
+    setWidget(pC);
+    pC->mpDockWidget = this;
 }
 
 void TDockWidget::closeEvent(QCloseEvent* event)

--- a/src/TDockWidget.h
+++ b/src/TDockWidget.h
@@ -2,6 +2,7 @@
 #define MUDLET_TDOCKWIDGET_H
 /***************************************************************************
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
+ *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -33,10 +34,13 @@
 // TDockWidget contains helpers for User Windows QDockWidget.
 class TDockWidget : public QDockWidget {
 public:
+    TDockWidget(Host *, const QString &);
+    void setTConsole(TConsole*);
+    TConsole* getConsole() {return mpConsole;}
+
     QString widgetConsoleName;
     bool hasLayoutAlready;
 
-    TDockWidget(Host * , const QString &);
 
 protected:
     void closeEvent(QCloseEvent *) override;
@@ -45,6 +49,7 @@ protected:
 
 private:
     QPointer<Host> mpHost;
+    QPointer<TConsole> mpConsole;
 };
 
 #endif // MUDLET_TDOCKWIDGET_H

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018 by Stephen Lyons                        *
+ *   Copyright (C) 2014-2016, 2018-2019 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
@@ -27,6 +27,7 @@
 #include "TTextEdit.h"
 
 #include "TConsole.h"
+#include "TDockWidget.h"
 #include "TEvent.h"
 #include "mudlet.h"
 #include "wcwidth.h"
@@ -1545,7 +1546,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mCtrlSelecting = false;
     }
 
-    if (mpConsole->getType() & (TConsole::MainConsole|TConsole::Buffer)) {
+    if (mpConsole->getType() == TConsole::MainConsole) {
         TEvent mudletEvent;
         mudletEvent.mArgumentList.append(QLatin1String("sysWindowMouseReleaseEvent"));
         switch (event->button()) {
@@ -1569,6 +1570,11 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
         mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
         mpHost->raiseEvent(mudletEvent);
+    } else if (mpConsole->getType() == TConsole::UserWindow && mpConsole->mpDockWidget && mpConsole->mpDockWidget->isFloating()) {
+        // Need to take an extra step to return focus to main profile TConsole's
+        // instance - using same method as TAction::execute():
+        mpHost->mpConsole->activateWindow();
+        mpHost->mpConsole->setFocus();
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2019 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
@@ -1602,16 +1602,14 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         pD->setFeatures(QDockWidget::AllDockWidgetFeatures);
         pD->setWindowTitle(tr("User window - %1 - %2").arg(pHost->getName(), name));
         pHost->mpConsole->mDockWidgetMap.insert(name, pD);
-        auto pC = new TConsole(pHost, TConsole::UserWindow, pD);
+        // It wasn't obvious but the parent passed to the TConsole constructor
+        // is sliced down to a QWidget and is NOT a TDockWidget pointer:
+        auto pC = new TConsole(pHost, TConsole::UserWindow, pD->widget());
         pC->setContentsMargins(0, 0, 0, 0);
-        pD->setWidget(pC);
+        pD->setTConsole(pC);
         pC->show();
         pC->layerCommandLine->hide();
         pC->mpScrollBar->hide();
-        const auto& hostCommandLine = pHost->mpConsole->mpCommandLine;
-        pC->setFocusProxy(hostCommandLine);
-        pC->mUpperPane->setFocusProxy(hostCommandLine);
-        pC->mLowerPane->setFocusProxy(hostCommandLine);
         pHost->mpConsole->mSubConsoleMap.insert(name, pC);
         // TODO: Allow user to specify alternate dock locations - and for it to be floating and not docked initially!
         addDockWidget(Qt::RightDockWidgetArea, pD);


### PR DESCRIPTION
Fix floating user windows stealing the focus upon being clicked by returning the focus to the main `TConsole` upon mouse button release.

Also reorganises some recent changes also associated with fixing the focus to remove some duplicated code and revises some code on the basis that ONLY the main `TConsole` has a `TCommandLine` to receive the focus...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>