### PR TITLE
Don't reset other profile's timers with resetProfile()

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -216,6 +216,12 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     if (!optin.isEmpty()) {
         mDiscordDisableServerSide = optin.toInt() == Qt::Unchecked ? true : false;
     }
+
+    if (mHostName != QStringLiteral("default_host")) {
+        Q_ASSERT_X(!mudlet::self()->mHostTimerMap.contains(this), "Host::Host(...)", "the mudlet class mHostTimerMap already contains this Host instance");
+        QMap<QTimer*, TTimer*> hostTimerMap;
+        mudlet::self()->mHostTimerMap.insert(this, hostTimerMap);
+    }
 }
 
 Host::~Host()

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -368,7 +368,7 @@ void Host::reloadModule(const QString& reloadModuleName)
 void Host::resetProfile()
 {
     getTimerUnit()->stopAllTriggers();
-    mudlet::self()->mTimerMap.clear();
+    mudlet::self()->clearHostTimerMap(this);
     getTimerUnit()->removeAllTempTimers();
     getTriggerUnit()->removeAllTempTriggers();
     getKeyUnit()->removeAllTempKeys();

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -36,10 +36,11 @@ TTimer::TTimer(TTimer* parent, Host* pHost)
 , mModuleMasterFolder(false)
 , mpHost(pHost)
 , mNeedsToBeCompiled(true)
-, mpTimer(new QTimer)
+, mpQTimer(new QTimer)
 , mModuleMember(false)
+, mKnownToBeUnregistered(false)
 {
-    mpTimer->stop();
+    mpQTimer->stop();
 }
 
 TTimer::TTimer(const QString& name, QTime time, Host* pHost)
@@ -51,21 +52,22 @@ TTimer::TTimer(const QString& name, QTime time, Host* pHost)
 , mTime(time)
 , mpHost(pHost)
 , mNeedsToBeCompiled(true)
-, mpTimer(new QTimer)
+, mpQTimer(new QTimer)
 , mModuleMember(false)
+, mKnownToBeUnregistered(false)
 {
-    mpTimer->stop();
+    mpQTimer->stop();
 }
 
 TTimer::~TTimer()
 {
-    mpTimer->stop();
+    mpQTimer->stop();
     if (!mpHost) {
         return;
     }
     mpHost->getTimerUnit()->unregisterTimer(this);
-    mudlet::self()->unregisterTimer(mpTimer);
-    mpTimer->deleteLater();
+    mudlet::self()->unregisterTimer(this);
+    mpQTimer->deleteLater();
 }
 
 bool TTimer::registerTimer()
@@ -74,7 +76,7 @@ bool TTimer::registerTimer()
         return false;
     }
     setTime(mTime);
-    mudlet::self()->registerTimer(this, mpTimer);
+    mudlet::self()->registerTimer(this);
     return mpHost->getTimerUnit()->registerTimer(this);
 }
 
@@ -93,8 +95,8 @@ void TTimer::setTime(QTime time)
 {
     QMutexLocker locker(&mLock);
     mTime = time;
-    mpTimer->setInterval(mTime.msec() + (1000 * mTime.second()) + (1000 * 60 * mTime.minute()) + (1000 * 60 * 60 * mTime.hour()));
-    mpTimer->stop();
+    mpQTimer->setInterval(mTime.msec() + (1000 * mTime.second()) + (1000 * 60 * mTime.minute()) + (1000 * 60 * 60 * mTime.hour()));
+    mpQTimer->stop();
 }
 
 // children of folder = regular timers
@@ -128,10 +130,10 @@ bool TTimer::setIsActive(bool b)
 
 void TTimer::start()
 {
-    mpTimer->setSingleShot(isTemporary());
+    mpQTimer->setSingleShot(isTemporary());
 
     if (!isFolder()) {
-        mpTimer->start();
+        mpQTimer->start();
     } else {
         stop();
     }
@@ -139,7 +141,7 @@ void TTimer::start()
 
 void TTimer::stop()
 {
-    mpTimer->stop();
+    mpQTimer->stop();
 }
 
 void TTimer::compile()
@@ -174,7 +176,7 @@ void TTimer::compileAll()
 bool TTimer::setScript(const QString& script)
 {
     mScript = script;
-    if (script == "") {
+    if (script.isEmpty()) {
         mNeedsToBeCompiled = false;
         mOK_code = true;
     } else {
@@ -186,18 +188,17 @@ bool TTimer::setScript(const QString& script)
 
 bool TTimer::compileScript()
 {
-    mFuncName = QString("Timer") + QString::number(mID);
-    QString code = QString("function ") + mFuncName + QString("()\n") + mScript + QString("\nend\n");
+    mFuncName = QStringLiteral("Timer%1").arg(mID);
+    QString code = QStringLiteral("function %1()\n%2\nend\n").arg(mFuncName, mScript);
     QString error;
-    if (mpHost->mLuaInterpreter.compile(code, error, "Timer: " + getName())) {
+    if (mpHost->mLuaInterpreter.compile(code, error, QStringLiteral("Timer: %1").arg(mName))) {
         mNeedsToBeCompiled = false;
         mOK_code = true;
-        return true;
     } else {
         mOK_code = false;
         setError(error);
-        return false;
     }
+    return mOK_code;
 }
 
 bool TTimer::checkRestart()
@@ -208,7 +209,7 @@ bool TTimer::checkRestart()
 void TTimer::execute()
 {
     if (!isActive() || isFolder()) {
-        mpTimer->stop();
+        mpQTimer->stop();
         return;
     }
 
@@ -218,7 +219,7 @@ void TTimer::execute()
         } else {
             mpHost->mLuaInterpreter.compileAndExecuteScript(mScript);
         }
-        mpTimer->stop();
+        mpQTimer->stop();
         mpHost->getTimerUnit()->markCleanup(this);
         return;
     }
@@ -249,7 +250,7 @@ void TTimer::execute()
 
         if (!mpHost->mLuaInterpreter.call(mFuncName, mName, (mTime < mpHost->mTimerDebugOutputSuppressionInterval))) {
 
-            mpTimer->stop();
+            mpQTimer->stop();
         }
     }
 }
@@ -273,11 +274,11 @@ void TTimer::enableTimer(int id)
         if (canBeUnlocked(nullptr)) {
             if (activate()) {
                 if (mScript.size() > 0) {
-                    mpTimer->start();
+                    mpQTimer->start();
                 }
             } else {
                 deactivate();
-                mpTimer->stop();
+                mpQTimer->stop();
             }
         }
     }
@@ -295,7 +296,7 @@ void TTimer::disableTimer(int id)
 {
     if (mID == id) {
         deactivate();
-        mpTimer->stop();
+        mpQTimer->stop();
     }
 
     for (auto timer : *mpMyChildrenList) {
@@ -310,11 +311,11 @@ void TTimer::enableTimer()
     if (canBeUnlocked(nullptr)) {
         if (activate()) {
             if (mScript.size() > 0) {
-                mpTimer->start();
+                mpQTimer->start();
             }
         } else {
             deactivate();
-            mpTimer->stop();
+            mpQTimer->stop();
         }
     }
     if (!isOffsetTimer()) {
@@ -329,7 +330,7 @@ void TTimer::enableTimer()
 void TTimer::disableTimer()
 {
     deactivate();
-    mpTimer->stop();
+    mpQTimer->stop();
     for (auto timer : *mpMyChildrenList) {
         timer->disableTimer();
     }
@@ -341,10 +342,10 @@ void TTimer::enableTimer(const QString& name)
     if (mName == name) {
         if (canBeUnlocked(nullptr)) {
             if (activate()) {
-                mpTimer->start();
+                mpQTimer->start();
             } else {
                 deactivate();
-                mpTimer->stop();
+                mpQTimer->stop();
             }
         }
     }
@@ -360,7 +361,7 @@ void TTimer::disableTimer(const QString& name)
 {
     if (mName == name) {
         deactivate();
-        mpTimer->stop();
+        mpQTimer->stop();
     }
 
     for (auto timer : *mpMyChildrenList) {
@@ -372,5 +373,5 @@ void TTimer::disableTimer(const QString& name)
 void TTimer::killTimer()
 {
     deactivate();
-    mpTimer->stop();
+    mpQTimer->stop();
 }

--- a/src/TTimer.h
+++ b/src/TTimer.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia,com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -73,6 +74,12 @@ public:
     void killTimer();
 
     bool isOffsetTimer();
+    QPointer<Host> getHost() { return mpHost; }
+    QTimer* getQTimer() { return mpQTimer; }
+    void setKnownUnregistered() { mKnownToBeUnregistered = true; }
+    bool knownUnregistered() { return mKnownToBeUnregistered; }
+
+
     // specifies whenever the payload is Lua code as a string
     // or a function
     bool mRegisteredAnonymousLuaFunction;
@@ -81,6 +88,7 @@ public:
 
 private:
     TTimer() = default;
+
     QString mName;
     QString mScript;
     QTime mTime;
@@ -89,9 +97,13 @@ private:
     QPointer<Host> mpHost;
     bool mNeedsToBeCompiled;
     QMutex mLock;
-    QTimer* mpTimer;
+    // Renamed to reduce confusion:
+    QTimer* mpQTimer;
     bool mModuleMember;
     //TLuaInterpreter *  mpLua;
+    // Used in XMLimport::package to mark an unused Timer that was created there
+    // and which can be removed without reporting that it was unregistered.
+    bool mKnownToBeUnregistered;
 };
 
 #endif // MUDLET_TTIMER_H

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -196,6 +196,8 @@ bool XMLimport::importPackage(QFile* pfile, QString packName, int moduleFlag, QS
             mpTimer->enableTimer(mpTimer->getID());
         } else {
             mpHost->getTimerUnit()->unregisterTimer(mpTimer);
+            // Set flag so that it can be silently deleted:
+            mpTimer->setKnownUnregistered();
             delete mpTimer;
         }
 
@@ -1229,7 +1231,7 @@ int XMLimport::readTimerGroup(TTimer* pParent)
         }
     }
 
-    mudlet::self()->registerTimer(pT, pT->mpTimer);
+    mudlet::self()->registerTimer(pT);
 
     if (!pT->mpParent && pT->shouldBeActive()) {
         pT->setIsActive(true);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1293,35 +1293,109 @@ void mudlet::addConsoleForNewHost(Host* pH)
 
 void mudlet::slot_timer_fires()
 {
-    QTimer* pQT = (QTimer*)sender();
+    auto pQT = qobject_cast<QTimer*>(sender());
     if (!pQT) {
         return;
     }
-    if (mTimerMap.contains(pQT)) {
-        TTimer* pTT = mTimerMap[pQT];
-        pTT->execute();
-        if (pTT->checkRestart()) {
-            pTT->start();
+
+    // Search through the Host instances to see which one has a QTimer that is
+    // the one that went off:
+    QMutableMapIterator<Host*, QMap<QTimer*, TTimer*>> itHostTimerMap(mHostTimerMap);
+    while (itHostTimerMap.hasNext()) {
+        itHostTimerMap.next();
+        if (itHostTimerMap.value().contains(pQT)) {
+            auto pTT = itHostTimerMap.value().value(pQT);
+            pTT->execute();
+            if (pTT->checkRestart()) {
+                pTT->start();
+            }
+
+            // Okay now we've found it we are done:
+            return;
         }
-    } else {
-        qDebug() << "MUDLET CRITICAL ERROR: Timer not registered!";
+    }
+
+    qWarning() << "mudlet::slot_timer_fires() ERROR - Timer not registered - automatically deleting it!";
+    // Clean up any bogus ones:
+    pQT->stop();
+    pQT->deleteLater();
+}
+
+// This is called by the TTimer destructor:
+void mudlet::unregisterTimer(TTimer* pTT)
+{
+    if (Q_UNLIKELY(!pTT)) {
+        return;
+    }
+
+    auto pQT = pTT->getQTimer();
+    auto pHost = pTT->getHost();
+    if (Q_UNLIKELY(!pQT||!pHost)) {
+        return;
+    }
+
+    if (mHostTimerMap.contains(pHost)) {
+        if (mHostTimerMap.value(pHost).contains(pQT)) {
+            // Be paranoid - ensure that the timer does not fire again:
+            pTT->stop();
+
+//            qDebug().nospace().noquote() << "mudlet::unregisterTimer(...) INFO - unregistering a Timer \"" << pTT->getName() << "\" for profile \"" << pHost->getName() << "\".";
+            mHostTimerMap[pHost].remove(pQT);
+        }
+        if (mHostTimerMap.value(pHost).isEmpty()) {
+            mHostTimerMap.remove(pHost);
+        }
+    }
+
+    // This message (and it's previous form:
+    // "MUDLET CRITICAL ERROR: trying to unregister Timer but it is not
+    // registered!") were somewhat bogus because such an unregestered Timer is
+    // created every time that XMLimport::importPackage is run and the package
+    // does not contain any Timer items.
+    if (!pTT->knownUnregistered()) {
+        qWarning() << "mudlet::unregisterTimer(...) ERROR - trying to unregister TTimer  \"" << pTT->getName() << "\" for profile \"" << pHost->getName() << "\" but it is not registered.";
     }
 }
 
-void mudlet::unregisterTimer(QTimer* pQT)
+void mudlet::registerTimer(TTimer* pTT)
 {
-    if (mTimerMap.contains(pQT)) {
-        mTimerMap.remove(pQT);
-    } else {
-        qDebug() << "MUDLET CRITICAL ERROR: trying to unregister Timer but it is not registered!";
+    auto pQT = pTT->getQTimer();
+    if (Q_UNLIKELY(!pTT || !pQT)) {
+        qWarning() << "mudlet::registerTimer(...) ERROR - TTimer or QTimer pointer was a nullpt, aborting!";
     }
-}
 
-void mudlet::registerTimer(TTimer* pTT, QTimer* pQT)
-{
-    if (!mTimerMap.contains(pQT)) {
-        mTimerMap[pQT] = pTT;
+    auto pHost = pTT->getHost();
+    if (Q_UNLIKELY(!pHost)) {
+        qWarning() << "mudlet::registerTimer(...) ERROR - TTimer pointed to had a Host nullpt, aborting!";
+        return;
+    }
+
+    if (!mHostTimerMap.contains(pHost)) {
+        QMap <QTimer*, TTimer*> newTimerMap;
+        mHostTimerMap.insert(pHost, newTimerMap);
+    }
+
+    if (!mHostTimerMap.value(pHost).contains(pQT)) {
+        mHostTimerMap[pHost][pQT] = pTT;
         connect(pQT, &QTimer::timeout, this, &mudlet::slot_timer_fires);
+//        qDebug().nospace().noquote() << "mudlet::registerTimer(...) INFO - registering a Timer \"" << pTT->getName() << "\" for profile \"" << pHost->getName() << "\".";
+    } else {
+        qWarning() << "mudlet::registerTimer(...) ERROR - QTimer is already registered for Host \"" << pHost->getName() << "\", not registering again!";
+    }
+}
+
+void mudlet::clearHostTimerMap(Host* pHost)
+{
+    if (Q_UNLIKELY(!pHost)) {
+        return;
+    }
+
+    if (Q_LIKELY(mHostTimerMap.contains(pHost))) {
+        QMap<QTimer*, TTimer*> hostTimerMap = mHostTimerMap.take(pHost);
+
+// This will silence a warning whilst the following line is commented out:
+        Q_UNUSED(hostTimerMap);
+//        qDebug().nospace().noquote() << "mudlet::clearHostTimerMap(...) INFO - removed QTimer<==>TTimer map, containing " << hostTimerMap.size() << " entries, for profile \"" << pHost->getName() << "\".";
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1334,22 +1334,18 @@ void mudlet::unregisterTimer(TTimer* pTT)
         return;
     }
 
-    if (mHostTimerMap.contains(pHost)) {
-        if (mHostTimerMap.value(pHost).contains(pQT)) {
-            // Be paranoid - ensure that the timer does not fire again:
-            pTT->stop();
+    Q_ASSERT_X(mHostTimerMap.contains(pHost), "mudlet::unregisterTimer(...)", "the mHostTimerMap does not contain the Host instance that the TTimer seems to belong to");
+    if (mHostTimerMap.value(pHost).contains(pQT)) {
+        // Be paranoid - ensure that the timer does not fire again:
+        pTT->stop();
 
 //            qDebug().nospace().noquote() << "mudlet::unregisterTimer(...) INFO - unregistering a Timer \"" << pTT->getName() << "\" for profile \"" << pHost->getName() << "\".";
-            mHostTimerMap[pHost].remove(pQT);
-        }
-        if (mHostTimerMap.value(pHost).isEmpty()) {
-            mHostTimerMap.remove(pHost);
-        }
+        mHostTimerMap[pHost].remove(pQT);
     }
 
     // This message (and it's previous form:
     // "MUDLET CRITICAL ERROR: trying to unregister Timer but it is not
-    // registered!") were somewhat bogus because such an unregestered Timer is
+    // registered!") were somewhat bogus because such an unregistered Timer is
     // created every time that XMLimport::importPackage is run and the package
     // does not contain any Timer items.
     if (!pTT->knownUnregistered()) {
@@ -1370,10 +1366,7 @@ void mudlet::registerTimer(TTimer* pTT)
         return;
     }
 
-    if (!mHostTimerMap.contains(pHost)) {
-        QMap <QTimer*, TTimer*> newTimerMap;
-        mHostTimerMap.insert(pHost, newTimerMap);
-    }
+    Q_ASSERT_X(mHostTimerMap.contains(pHost), "mudlet::registerTimer(...)", "the mHostTimerMap does not contain the Host instance that the TTimer seems to belong to");
 
     if (!mHostTimerMap.value(pHost).contains(pQT)) {
         mHostTimerMap[pHost][pQT] = pTT;
@@ -1390,13 +1383,12 @@ void mudlet::clearHostTimerMap(Host* pHost)
         return;
     }
 
-    if (Q_LIKELY(mHostTimerMap.contains(pHost))) {
-        QMap<QTimer*, TTimer*> hostTimerMap = mHostTimerMap.take(pHost);
+    Q_ASSERT_X(mHostTimerMap.contains(pHost), "mudlet::clearHostTimerMap(...)", "the mHostTimerMap does not contain the Host instance that the TTimer seems to belong to");
+    QMap<QTimer*, TTimer*> hostTimerMap = mHostTimerMap.take(pHost);
 
-// This will silence a warning whilst the following line is commented out:
-        Q_UNUSED(hostTimerMap);
-//        qDebug().nospace().noquote() << "mudlet::clearHostTimerMap(...) INFO - removed QTimer<==>TTimer map, containing " << hostTimerMap.size() << " entries, for profile \"" << pHost->getName() << "\".";
-    }
+// This will silence a warning whilst the line following it is commented out:
+    Q_UNUSED(hostTimerMap);
+//  qDebug().nospace().noquote() << "mudlet::clearHostTimerMap(...) INFO - removed QTimer<==>TTimer map, containing " << hostTimerMap.size() << " entries, for profile \"" << pHost->getName() << "\".";
 }
 
 void mudlet::disableToolbarButtons()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1300,7 +1300,7 @@ void mudlet::slot_timer_fires()
 
     // Search through the Host instances to see which one has a QTimer that is
     // the one that went off:
-    QMutableMapIterator<Host*, QMap<QTimer*, TTimer*>> itHostTimerMap(mHostTimerMap);
+    QMapIterator<Host*, QMap<QTimer*, TTimer*>> itHostTimerMap(mHostTimerMap);
     while (itHostTimerMap.hasNext()) {
         itHostTimerMap.next();
         if (itHostTimerMap.value().contains(pQT)) {
@@ -1358,6 +1358,7 @@ void mudlet::registerTimer(TTimer* pTT)
     auto pQT = pTT->getQTimer();
     if (Q_UNLIKELY(!pTT || !pQT)) {
         qWarning() << "mudlet::registerTimer(...) ERROR - TTimer or QTimer pointer was a nullpt, aborting!";
+        return;
     }
 
     auto pHost = pTT->getHost();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -107,8 +107,9 @@ public:
     void disableToolbarButtons();
     void enableToolbarButtons();
     Host* getActiveHost();
-    void registerTimer(TTimer*, QTimer*);
-    void unregisterTimer(QTimer*);
+    void registerTimer(TTimer*);
+    void unregisterTimer(TTimer*);
+    void clearHostTimerMap(Host*);
     void forceClose();
     bool saveWindowLayout();
     bool loadWindowLayout();
@@ -216,7 +217,8 @@ public:
     QTime mReplayTime;
     int mReplaySpeed;
     QToolBar* mpMainToolBar;
-    QMap<QTimer*, TTimer*> mTimerMap;
+    // Was mTimerMap shared between all Host instances:
+    QMap<Host*, QMap<QTimer*, TTimer*>> mHostTimerMap;
     QMap<Host*, QPointer<dlgIRC>> mpIrcClientMap;
     QString version;
     QPointer<Host> mpCurrentActiveHost;


### PR DESCRIPTION
This will split up the `QMap` in the `mudlet` class that contains all the `QTimer` & `TTimer` paired up in the `TTimer` class so that when a `Host` instance runs its `resetProfile()` method only the QTimers that are associated with the TTimers in THAT profile get removed from the `mudlet` map.  Previously all of them were nuked in that table.

Cleaned up the `TTimer` class - renamed the `(QTimer*) mpTimer` to be called `mpQTimer` because in some places we refer to instances of this class with a `mpTimer` member variable and sometimes we want to access the `QTimer` within and using the same name can lead to confusion.

This also lead me to discover that there was no need to include the latter in the arguments to `mudlet::registerTimer(...)` as it is already available from the previous argument.

I also found out one cause of *bogus* "MUDLET CRITICAL ERROR: trying to unregister Timer but it is not registered!" messages in that a TTimer is created as a root item for `TTimer` items every time
`XMLimport::importPackage(...)` is run and it is delete at the end if the package does not import any timer items. I have added a flag that can be set in that method so that the (revised) error message is not produced in *that* case.

This should cure/close https://github.com/Mudlet/Mudlet/issues/2204 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>