### PR TITLE
Remove colours from trigger patterns

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4719,11 +4719,6 @@ void dlgTriggerEditor::saveKey()
     }
 }
 
-QString dlgTriggerEditor::itemTypeStyleSheet(const int type)
-{
-    return QString();
-}
-
 void dlgTriggerEditor::setupPatternControls(const int type, dlgTriggerPatternEdit* pItem)
 {
     switch (type) {
@@ -4868,10 +4863,6 @@ void dlgTriggerEditor::slot_setupPatternControls(int type)
             pPatternItem->lineEdit_pattern->clear();
         }
     }
-    // Now sets both foreground and the opposite color background to avoid text
-    // being lost with a dark desktop environment or hopefully not being
-    // readable by those with partial color blindness.
-    pPatternItem->lineEdit_pattern->setStyleSheet(itemTypeStyleSheet(type));
 }
 
 void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4721,25 +4721,7 @@ void dlgTriggerEditor::saveKey()
 
 QString dlgTriggerEditor::itemTypeStyleSheet(const int type)
 {
-    switch (type) {
-    case REGEX_PERL:                    return QLatin1String("QLineEdit { background-color: #FFFF00; color: #0000FF; }");
-    case REGEX_BEGIN_OF_LINE_SUBSTRING: return QLatin1String("QLineEdit { background-color: #00FFFF; color: #FF0000; }");
-    case REGEX_EXACT_MATCH:             return QLatin1String("QLineEdit { background-color: #FF00FF; color: #00FF00; }");
-    case REGEX_LUA_CODE:                return QLatin1String("QLineEdit { background-color: #FF0000; color: #00FFFF; }");
-    case REGEX_LINE_SPACER:             return QLatin1String("QLineEdit { background-color: #00FF00; color: #FF00FF; }");
-    case REGEX_COLOR_PATTERN: // Text is never shown so the style is not changed
-        [[clang::fallthrough]];
-    case REGEX_PROMPT: // Text is never shown so the style is not changed
-        [[clang::fallthrough]];
-    case REGEX_SUBSTRING:
-        // The substring one is used by default so has to use the default style
-        // so as not to paint the empty items differently to ones that have
-        // been used in other triggers and never changed
-        [[clang::fallthrough]];
-    default:
-        return QString();
-    }
-
+    return QString();
 }
 
 void dlgTriggerEditor::setupPatternControls(const int type, dlgTriggerPatternEdit* pItem)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -396,8 +396,6 @@ private:
     void clearEditorNotification() const;
     void runScheduledCleanReset();
     void autoSave();
-    // Helper to color the text in (and possible the control value) that the pattern area:
-    QString itemTypeStyleSheet(const int);
     void setupPatternControls(const int type, dlgTriggerPatternEdit* pItem);
 
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -418,7 +418,6 @@ private:
     QTreeWidgetItem* mpCurrentTriggerItem;
     QTreeWidgetItem* mpCurrentAliasItem;
     QTreeWidgetItem* mpCurrentVarItem;
-// Not used:    QLineEdit* mpCursorPositionIndicator;
 
     int mCurrentView;
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Removes all colours from trigger patterns - we used to have foreground colours but that caused issued on dark themes. The addition of background colours looks pretty bad, so might as well remove the colours altogether - in theory this should now work on a dark theme.
#### Motivation for adding to Mudlet
Better support for dark themes while not turning the triggers area into a kaleidoscope! 
#### Other info (issues closed, discussion etc)
We might be able to reinstate the foreground colours only if https://stackoverflow.com/a/15520024/72944 works, perhaps? Otherwise, we can see if we get any feedback on the foreground colour removal. If nobody misses it, then it wasn't useful at all.