### PR TITLE
Moving-a-Key-into-a-subfolder fix.

### DIFF
--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -181,7 +181,7 @@ void KeyUnit::removeAllTempKeys()
     }
 }
 
-void KeyUnit::addKeyRootNode(TKey* pT, int parentPosition, int childPosition)
+void KeyUnit::addKeyRootNode(TKey* pT, int parentPosition, int childPosition, bool moveKey)
 {
     if (!pT) {
         return;
@@ -204,7 +204,7 @@ void KeyUnit::addKeyRootNode(TKey* pT, int parentPosition, int childPosition)
         }
     }
 
-    if (mKeyMap.find(pT->getID()) == mKeyMap.end()) {
+    if (!moveKey) {
         mKeyMap.insert(pT->getID(), pT);
     }
 }
@@ -221,17 +221,15 @@ void KeyUnit::reParentKey(int childID, int oldParentID, int newParentID, int par
     }
     if (pOldParent) {
         pOldParent->popChild(pChild);
-    }
-    if (!pOldParent) {
-        // CHECKME: TriggerUnit copy of this code uses mXxxxxRootNodeList.remove(pChild) - which is best?
-        removeKeyRootNode(pChild);
+    } else {
+        mKeyRootNodeList.remove(pChild);
     }
     if (pNewParent) {
         pNewParent->addChild(pChild, parentPosition, childPosition);
         pChild->setParent(pNewParent);
     } else {
         pChild->Tree<TKey>::setParent(nullptr);
-        addKeyRootNode(pChild, parentPosition, childPosition);
+        addKeyRootNode(pChild, parentPosition, childPosition, true);
     }
 }
 

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -95,7 +95,7 @@ private:
     TKey* getKeyPrivate(int id);
     void initStats();
     void _assembleReport(TKey*);
-    void addKeyRootNode(TKey* pT, int parentPosition = -1, int childPosition = -1);
+    void addKeyRootNode(TKey* pT, int parentPosition = -1, int childPosition = -1, bool moveKey = false);
     void addKey(TKey* pT);
     void removeKeyRootNode(TKey* pT);
     void removeKey(TKey*);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Some fixes go into place to ensure that it won't cause a move of a key to a subfolder to malfunctioning that would cause a displacement of naming, unable to delete or modify a key.
#### Motivation for adding to Mudlet
I find it interesting that moving triggers into folder won't cause a problem but keys would. so it gives me a good guess where and why it won't work.
#### Other info (issues closed, discussion etc)
it should resolve #2253 .