### PR TITLE
BugFix: fix updater problems on Linux and Windows OSes

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -478,7 +478,11 @@ mudlet::mudlet()
     connect(dactionIRC, &QAction::triggered, this, &mudlet::slot_irc);
     connect(dactionLiveHelpChat, &QAction::triggered, this, &mudlet::slot_irc);
 #if !defined(INCLUDE_UPDATER)
+    // Hide the update menu item if the code is not included
     dactionUpdate->setVisible(false);
+#else
+    // Also, only show it if this is a release version
+    dactionUpdate->setVisible(!scmIsDevelopmentVersion);
 #endif
     connect(dactionPackageManager, &QAction::triggered, this, &mudlet::slot_package_manager);
     connect(dactionPackageExporter, &QAction::triggered, this, &mudlet::slot_package_exporter);
@@ -3994,7 +3998,11 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
 #if defined(INCLUDE_UPDATER)
 void mudlet::checkUpdatesOnStart()
 {
-    updater->checkUpdatesOnStart();
+    if (!scmIsDevelopmentVersion) {
+        // Only try and create an updater (which checks for updates online) if
+        // this is a release version:
+        updater->checkUpdatesOnStart();
+    }
 }
 
 void mudlet::slot_check_manual_update()

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -152,7 +152,7 @@ void Updater::setupOnWindows()
     });
 
     // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
-    updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::Manual : dblsqd::UpdateDialog::OnLastWindowClosed, nullptr, settings);
+    updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::OnLastWindowClosed : dblsqd::UpdateDialog::Manual, nullptr, settings);
     mpInstallOrRestart->setText(tr("Update"));
     updateDialog->addInstallButton(mpInstallOrRestart);
     connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::installOrRestartClicked);

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -214,7 +214,7 @@ void Updater::setupOnLinux()
     });
 
     // finally, create the dblsqd objects. Constructing the UpdateDialog triggers the update check
-    updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::Manual : dblsqd::UpdateDialog::OnLastWindowClosed, nullptr, settings);
+    updateDialog = new dblsqd::UpdateDialog(feed, updateAutomatically() ? dblsqd::UpdateDialog::OnLastWindowClosed : dblsqd::UpdateDialog::Manual, nullptr, settings);
     mpInstallOrRestart->setText(tr("Update"));
     updateDialog->addInstallButton(mpInstallOrRestart);
     connect(updateDialog, &dblsqd::UpdateDialog::installButtonClicked, this, &Updater::installOrRestartClicked);


### PR DESCRIPTION
Also stops it running on development version when it is supposed to be permanently disabled but was still putting up the change-log when the main application ended.

There is similar code in the `Update::setupOnWndows()` method and I do wonder whether it may also be the cause of: https://github.com/Mudlet/Mudlet/issues/1823 in the Windows version?

I also found two other things needed to keep the updater sedated for development versions of the code:
- hide the Update option from the "About" sub-menu
- Prevent the setup of the UpdateDialog on start up as that initiates the on-line search for updates - which is pointless in the development version case.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>