### PR TITLE
Fix notification image size in security preferences

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -56,6 +56,20 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 {
     // init generated dialog
     setupUi(this);
+ 
+    QPixmap holdPixmap;
+
+    holdPixmap = *(this->notificationAreaIconLabelWarning->pixmap());
+    holdPixmap.setDevicePixelRatio(5.3);
+    this->notificationAreaIconLabelWarning->setPixmap(holdPixmap);
+
+    holdPixmap = *(this->notificationAreaIconLabelError->pixmap());
+    holdPixmap.setDevicePixelRatio(5.3);
+    this->notificationAreaIconLabelError->setPixmap(holdPixmap);
+
+    holdPixmap = *(this->notificationAreaIconLabelInformation->pixmap());
+    holdPixmap.setDevicePixelRatio(5.3);
+    this->notificationAreaIconLabelInformation->setPixmap(holdPixmap);
 
     // The groupBox_debug is no longer empty, (it contains
     // checkBox_showIconsOnMenus) so can no longer be "hidden until needed"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Info, Error and Warning images are now shown much bigger, after the image files got increased resolution

#### Motivation for adding to Mudlet
Image taking up too much space:
![image](https://user-images.githubusercontent.com/117238/52091824-00404b80-25b6-11e9-8d35-0ecc8e26e078.png)


#### Other info (issues closed, discussion etc)
Trying fix from #2231 here as well