### PR TITLE
BugFix: ensure command line spell checker handles non-Latin1 characters

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1657,3 +1657,17 @@ bool Host::discordUserIdMatch(const QString& userName, const QString& userDiscri
         return true;
     }
 }
+
+void Host::setSpellDic(const QString& newDict)
+{
+    QMutexLocker locker(& mLock);
+    bool isChanged = false;
+    if (!newDict.isEmpty() && mSpellDic != newDict) {
+        mSpellDic = newDict;
+        isChanged = true;
+    }
+    locker.unlock();
+    if (isChanged) {
+        emit signal_changeSpellDict(mSpellDic);
+    }
+}

--- a/src/Host.h
+++ b/src/Host.h
@@ -118,6 +118,8 @@ public:
     bool               getMayRedefineColors() { QMutexLocker locker(& mLock); return mServerMayRedefineColors; }
     void               setDiscordApplicationID(const QString& s);
     const QString&     getDiscordApplicationID();
+    void               setSpellDic(const QString&);
+    const QString&     getSpellDic() { QMutexLocker locker(& mLock); return mSpellDic; }
 
     void closingDown();
     bool isClosingDown();
@@ -373,7 +375,6 @@ public:
     QColor mBgColor_2;
     bool mMapStrongHighlight;
     QStringList mGMCP_merge_table_keys;
-    QString mSpellDic;
     bool mLogStatus;
     bool mEnableSpellCheck;
     QStringList mInstalledPackages;
@@ -419,6 +420,7 @@ signals:
     void signal_changeIsAmbigousWidthGlyphsToBeWide(bool);
     void profileSaveStarted();
     void profileSaveFinished();
+    void signal_changeSpellDict(const QString&);
 
 private slots:
     void slot_reloadModules();
@@ -507,6 +509,10 @@ private:
     // 16 basic colors (and OSC "R\" to reset them).
     bool mServerMayRedefineColors;
 
+    // Was public but hidden to prevent it being changed without going through
+    // the process to signal to existing uses that they need to change
+    // dictionaries:
+    QString mSpellDic;
     void processGMCPDiscordStatus(const QJsonObject& discordInfo);
     void processGMCPDiscordInfo(const QJsonObject& discordInfo);
     void updateModuleZips() const;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2018-2019 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,51 +35,23 @@
 TCommandLine::TCommandLine(Host* pHost, TConsole* pConsole, QWidget* parent)
 : QPlainTextEdit(parent)
 , mpHost(pHost)
+, mpKeyUnit(pHost->getKeyUnit())
 , mpConsole(pConsole)
-, mSelectedText()
-, mSelectionStart(0)
-, mTabCompletion()
 , mTabCompletionCount()
 , mAutoCompletionCount()
 , mUserKeptOnTyping()
+, mHistoryBuffer()
+, mSelectionStart(0)
+, mpHunspell(nullptr)
 , mHunspellSuggestionNumber()
 , mpHunspellSuggestionList()
 {
-    QString path;
-    // This is duplicated (and should be the same as) the code in:
-    // (void) dlgProfilePreferences::initWithHost(Host*)
-#if defined(Q_OS_MACOS)
-    path = QStringLiteral("%1/../Resources/").arg(QCoreApplication::applicationDirPath());
-#elif defined(Q_OS_FREEBSD)
-    if (QFile::exists(QStringLiteral("/usr/local/share/hunspell/%1.aff").arg(pHost->mSpellDic))) {
-        path = QLatin1String("/usr/local/share/hunspell/");
-    } else if (QFile::exists(QStringLiteral("/usr/share/hunspell/%1.aff").arg(pHost->mSpellDic))) {
-        path = QLatin1String("/usr/share/hunspell/");
-    } else {
-        path = QLatin1String("./");
-    }
-#elif defined(Q_OS_LINUX)
-    if (QFile::exists(QStringLiteral("/usr/share/hunspell/%1.aff").arg(pHost->mSpellDic))) {
-        path = QLatin1String("/usr/share/hunspell/");
-    } else {
-        path = QLatin1String("./");
-    }
-#else
-    // Probably Windows!
-    path = "./";
-#endif
+    slot_changeSpellDict(mpHost->getSpellDic());
 
-    QString spell_aff = QStringLiteral("%1%2.aff").arg(path, pHost->mSpellDic);
-    QString spell_dic = QStringLiteral("%1%2.dic").arg(path, pHost->mSpellDic);
-    // The man page for hunspell advises Utf8 encoding of the pathFileNames for
-    // use on Windows platforms which can have non ASCII characters...
-    mpHunspell = Hunspell_create(spell_aff.toUtf8().constData(), spell_dic.toUtf8().constData());
-    mpKeyUnit = mpHost->getKeyUnit();
     setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);
 
-    QFont font = mpHost->mDisplayFont;
-    setFont(font);
+    setFont(mpHost->mDisplayFont);
 
     mRegularPalette.setColor(QPalette::Text, mpHost->mCommandLineFgColor); //QColor(0,0,192));
     mRegularPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
@@ -88,23 +60,16 @@ TCommandLine::TCommandLine(Host* pHost, TConsole* pConsole, QWidget* parent)
 
     setPalette(mRegularPalette);
 
-    mTabCompletionPalette.setColor(QPalette::Text, QColor(0, 0, 192));
-    mTabCompletionPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
-    mTabCompletionPalette.setColor(QPalette::HighlightedText, QColor(Qt::white));
-    mTabCompletionPalette.setColor(QPalette::Base, QColor(235, 255, 235));
-
-    mAutoCompletionPalette.setColor(QPalette::Text, QColor(0, 0, 192));
-    mAutoCompletionPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
-    mAutoCompletionPalette.setColor(QPalette::HighlightedText, QColor(Qt::white));
-    mAutoCompletionPalette.setColor(QPalette::Base, QColor(255, 235, 235));
-
-
-    mHistoryBuffer = 0;
-    mAutoCompletion = false;
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setCenterOnScroll(false);
     setWordWrapMode(QTextOption::WrapAnywhere);
     setContentsMargins(0, 0, 0, 0);
+
+    // We do NOT want the standard context menu to happen as we generate it
+    // ourself:
+    setContextMenuPolicy(Qt::PreventContextMenu);
+
+    connect(mpHost, &Host::signal_changeSpellDict, this, &TCommandLine::slot_changeSpellDict);
 }
 
 TCommandLine::~TCommandLine()
@@ -165,7 +130,6 @@ bool TCommandLine::event(QEvent* event)
                 mTabCompletionCount = -1;
                 mAutoCompletionCount = -1;
                 mTabCompletionTyped.clear();
-                mAutoCompletionTyped.clear();
                 if (mpHost->mAutoClearCommandLineAfterSend) {
                     mHistoryBuffer = -1;
                 } else {
@@ -225,18 +189,19 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
+            }
+
+            if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 handleTabCompletion(true);
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers
-                // other than just the Ctrl one
-                // CHECKME: What about system foreground application switching?
-                return processPotentialKeyBinding(ke);
-
             }
+
+            // Process as a possible key binding if there are ANY modifiers
+            // other than just the Ctrl one
+            // CHECKME: What about system foreground application switching?
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_unknown:
             qWarning() << "ERROR: key unknown!";
@@ -253,7 +218,6 @@ bool TCommandLine::event(QEvent* event)
 
                 if (mTabCompletionTyped.size() >= 1) {
                     mTabCompletionTyped.chop(1);
-                    mAutoCompletionTyped.chop(1);
                 }
                 mTabCompletionCount = -1;
                 mAutoCompletionCount = -1;
@@ -263,12 +227,10 @@ bool TCommandLine::event(QEvent* event)
                 adjustHeight();
 
                 return true;
-            } else {
-                // Process as a possible key binding if there are ANY modifiers
-                // other than <CTRL> and/or <SHIFT>
-                return processPotentialKeyBinding(ke);
-
             }
+            // Process as a possible key binding if there are ANY modifiers
+            // other than <CTRL> and/or <SHIFT>
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_Delete:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
@@ -280,10 +242,8 @@ bool TCommandLine::event(QEvent* event)
 
                 if (mTabCompletionTyped.size() >= 1) {
                     mTabCompletionTyped.chop(1);
-                    mAutoCompletionTyped.chop(1);
                 } else {
                     mTabCompletionTyped.clear();
-                    mAutoCompletionTyped.clear();
                     mUserKeptOnTyping = false;
                 }
                 mAutoCompletionCount = -1;
@@ -293,11 +253,9 @@ bool TCommandLine::event(QEvent* event)
                 adjustHeight();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers
-                return processPotentialKeyBinding(ke);
-
             }
+            // Process as a possible key binding if there are ANY modifiers
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_Return: // This is the main one (not the keypad)
             if ((ke->modifiers() & allModifiers) == Qt::ControlModifier) {
@@ -312,16 +270,19 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else if ((ke->modifiers() & allModifiers) == Qt::ShiftModifier) {
+            }
+
+            if ((ke->modifiers() & allModifiers) == Qt::ShiftModifier) {
                 textCursor().insertBlock();
                 ke->accept();
                 return true;
 
-            } else if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
+            }
+
+            if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 // Do the normal return key stuff only if NO modifiers are used:
                 enterCommand(ke);
                 mAutoCompletionCount = -1;
-                mAutoCompletionTyped.clear();
                 mLastCompletion.clear();
                 mTabCompletionTyped.clear();
                 mUserKeptOnTyping = false;
@@ -336,12 +297,11 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                // other than just the Shift or just the Control modifiers
-                return processPotentialKeyBinding(ke);
-
             }
+
+            // Process as a possible key binding if there are ANY modifiers,
+            // other than just the Shift or just the Control modifiers
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_Enter:
             // This is usually the Keypad one, so may come with
@@ -355,7 +315,6 @@ bool TCommandLine::event(QEvent* event)
                 mAutoCompletionCount = -1;
                 mLastCompletion.clear();
                 mTabCompletionTyped.clear();
-                mAutoCompletionTyped.clear();
                 mUserKeptOnTyping = false;
                 if (mpHost->mAutoClearCommandLineAfterSend) {
                     clear();
@@ -367,12 +326,10 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                // other than just the Keypad modifier
-                return processPotentialKeyBinding(ke);
-
             }
+            // Process as a possible key binding if there are ANY modifiers,
+            // other than just the Keypad modifier
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_Down:
 #if defined(Q_OS_MACOS)
@@ -385,11 +342,12 @@ bool TCommandLine::event(QEvent* event)
                 moveCursor(QTextCursor::Down, QTextCursor::MoveAnchor);
                 ke->accept();
                 return true;
+            }
 
 #if defined(Q_OS_MACOS)
-            } else if ((ke->modifiers() & allModifiers) == Qt::KeypadModifier) {
+            if ((ke->modifiers() & allModifiers) == Qt::KeypadModifier) {
 #else
-            } else if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
+            if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
 #endif
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
@@ -397,13 +355,11 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                // other than just the Control modifier (or keypad modifier on
-                // macOs)
-                return processPotentialKeyBinding(ke);
-
             }
+            // Process as a possible key binding if there are ANY modifiers,
+            // other than just the Control modifier (or keypad modifier on
+            // macOs)
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_Up:
 #if defined(Q_OS_MACOS)
@@ -417,10 +373,12 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
+            }
+
 #if defined(Q_OS_MACOS)
-            } else if ((ke->modifiers() & allModifiers) == Qt::KeypadModifier) {
+            if ((ke->modifiers() & allModifiers) == Qt::KeypadModifier) {
 #else
-            } else if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
+            if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
 #endif
                 // If EXACTLY Up is pressed without modifiers (special case for
                 // macOs - also sets KeyPad modifier)
@@ -428,22 +386,18 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                // other than just the Control modifier (or keypad modifier on
-                // macOs)
-                return processPotentialKeyBinding(ke);
-
             }
+
+            // Process as a possible key binding if there are ANY modifiers,
+            // other than just the Control modifier (or keypad modifier on
+            // macOs)
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_Escape:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 // Escape from tab completion mode if used with NO modifiers
                 selectAll();
-                mAutoCompletion = false;
-                mTabCompletion = false;
                 mTabCompletionTyped.clear();
-                mAutoCompletionTyped.clear();
                 mUserKeptOnTyping = false;
                 mTabCompletionCount = -1;
                 mAutoCompletionCount = -1;
@@ -456,11 +410,10 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                return processPotentialKeyBinding(ke);
-
             }
+
+            // Process as a possible key binding if there are ANY modifiers,
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_PageUp:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
@@ -468,11 +421,10 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                return processPotentialKeyBinding(ke);
-
             }
+
+            // Process as a possible key binding if there are ANY modifiers,
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_PageDown:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
@@ -480,11 +432,10 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                return processPotentialKeyBinding(ke);
-
             }
+
+            // Process as a possible key binding if there are ANY modifiers,
+            return processPotentialKeyBinding(ke);
 
         case Qt::Key_C:
             if (((ke->modifiers() & allModifiers) == Qt::ControlModifier)
@@ -496,28 +447,27 @@ bool TCommandLine::event(QEvent* event)
                 ke->accept();
                 return true;
 
-            } else {
-                // Process as a possible key binding if there are ANY modifiers,
-                if (processPotentialKeyBinding(ke)) {
-                    return true;
-
-                } else {
-                    processNormalKey(event);
-                    return false;
-
-                }
             }
+
+            // Process as a possible key binding if there are ANY modifiers,
+            if (processPotentialKeyBinding(ke)) {
+                return true;
+
+            }
+
+            processNormalKey(event);
+            return false;
 
         default:
             // Process as a possible key binding if there are ANY modifiers,
             if (processPotentialKeyBinding(ke)) {
                 return true;
 
-            } else {
-                processNormalKey(event);
-                return false;
-
             }
+
+            processNormalKey(event);
+            return false;
+
         }
     }
 
@@ -580,19 +530,29 @@ void TCommandLine::spellCheck()
 
     QTextCursor oldCursor = textCursor();
     QTextCharFormat f;
-    auto cred = QColor(Qt::red);
-    f.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
-    f.setUnderlineColor(cred);
     QTextCursor c = textCursor();
     c.select(QTextCursor::WordUnderCursor);
-
-    if (!Hunspell_spell(mpHunspell, c.selectedText().toLatin1().data())) {
-        f.setFontUnderline(true);
-        c.setCharFormat(f);
-    } else {
+    QByteArray encodedText = mpHunspellCodec->fromUnicode(c.selectedText());
+    // By including the hunspell C++ header before the C one we get access to
+    // some possible useful #define constants, however HUNSPELL_OK_WARN did
+    // not seem to be associated with "bad" (obsence?) words as originally
+    // thought:
+    int spellCheckResult = Hunspell_spell(mpHunspell, encodedText.constData());
+    if (spellCheckResult == HUNSPELL_OK) {
+        // Word is spelt correctly
         f.setFontUnderline(false);
-        c.setCharFormat(f);
+    } else if (spellCheckResult == HUNSPELL_OK_WARN) {
+        // Word is wrong somehow - but in what manner is not clear at present:
+        f.setUnderlineStyle(QTextCharFormat::DashDotLine);
+        f.setUnderlineColor(Qt::blue);
+        f.setFontUnderline(true);
+    } else {
+        // Word is misspelt
+        f.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
+        f.setUnderlineColor(Qt::red);
+        f.setFontUnderline(true);
     }
+    c.setCharFormat(f);
     setTextCursor(c);
     f.setFontUnderline(false);
     oldCursor.setCharFormat(f);
@@ -617,40 +577,78 @@ void TCommandLine::slot_popupMenu()
 
 void TCommandLine::mousePressEvent(QMouseEvent* event)
 {
+
     if (event->button() == Qt::RightButton) {
+        auto popup = createStandardContextMenu(event->globalPos());
         QTextCursor c = cursorForPosition(event->pos());
         c.select(QTextCursor::WordUnderCursor);
-
-        if (!Hunspell_spell(mpHunspell, c.selectedText().toLatin1().data())) {
+        QByteArray encodedText = mpHunspellCodec->fromUnicode(c.selectedText());
+        int spellCheckResult = Hunspell_spell(mpHunspell, encodedText.constData());
+        if (!spellCheckResult) {
+            // The word is NOT in the dictionary:
             char** sl;
-            mHunspellSuggestionNumber = Hunspell_suggest(mpHunspell, &sl, c.selectedText().toLatin1().data());
-            auto popup = new QMenu(this);
-            for (int i = 0; i < mHunspellSuggestionNumber; i++) {
-                QAction* pA;
-                pA = popup->addAction(sl[i]);
-                connect(pA, &QAction::triggered, this, &TCommandLine::slot_popupMenu);
-            }
-            mpHunspellSuggestionList = sl;
-            mPopupPosition = event->pos();
-            popup->popup(event->globalPos());
-        }
+            auto separator = popup->actions().first();
+            separator = popup->insertSeparator(separator);
+            // separator is now the QAction of, indeed is, a separator:
+            QList<QAction*> spellings;
 
+            // The return value is the count of suggestions:
+            mHunspellSuggestionNumber = Hunspell_suggest(mpHunspell, &sl, encodedText.constData());
+            if (mHunspellSuggestionNumber) {
+                for (int i = 0; i < mHunspellSuggestionNumber; ++i) {
+                    auto pA = new QAction(mpHunspellCodec->toUnicode(sl[i]));
+                    connect(pA, &QAction::triggered, this, &TCommandLine::slot_popupMenu);
+                    spellings << pA;
+                }
+
+            } else {
+                auto pA = new QAction(tr("no suggestions",
+                                         // Intentional comment
+                                         "used when the command spelling checker has no words to suggest"));
+                pA->setEnabled(false);
+                spellings << pA;
+            }
+
+            mpHunspellSuggestionList = sl;
+            popup->insertActions(separator, spellings);
+        } else if (spellCheckResult == HUNSPELL_OK_WARN) {
+            // Word is spelt correctly but for some reason Hunspell says it is
+            // wrong in some way:
+            auto separator = popup->actions().first();
+            separator = popup->insertSeparator(separator);
+            auto pA = new QAction(tr("word is not okay",
+                                     // Intentional comment
+                                     "Used when the command spelling checker reports that a word is spelt correctly "
+                                     "but it is unhappy about it, the coder thought that it meant it was obscene or "
+                                     "otherwise unsafe to use but testing has not proved that to be the case; "
+                                     "nevertheless the Hunspell checker has gone to the extent of reporting that "
+                                     "there is a problem with this word - we just do not know what that is!"));
+            pA->setEnabled(false);
+            pA->setIcon(QIcon(QStringLiteral(":/icons/dialog-warning.png")));
+            popup->insertAction(separator, pA);
+        }
+        // else the word is in the dictionary - in either case show the context
+        // menu - either the one with the prefixed spellings, the warning or
+        // the standard one:
+
+        mPopupPosition = event->pos();
+        popup->popup(event->globalPos());
         event->accept();
         return;
     }
+
+    // Process any other possible mousePressEvent
     QPlainTextEdit::mousePressEvent(event);
 }
 
 void TCommandLine::enterCommand(QKeyEvent* event)
 {
     QString _t = toPlainText();
-    mAutoCompletion = false;
-    mTabCompletion = false;
     mTabCompletionCount = -1;
     mAutoCompletionCount = -1;
-    mTabCompletionTyped = "";
+    mTabCompletionTyped.clear();
 
-    QStringList _l = _t.split("\n");
+    QStringList _l = _t.split(QChar::LineFeed);
     for (int i = 0; i < _l.size(); i++) {
         mpHost->send(_l[i]);
     }
@@ -722,7 +720,7 @@ void TCommandLine::handleTabCompletion(bool direction)
             return;
         }
         int offset = 0;
-        for (;;) {
+        forever {
             QString tmp = filterList.back();
             filterList.removeAll(tmp);
             filterList.insert(offset, tmp);
@@ -835,5 +833,46 @@ void TCommandLine::historyUp(QKeyEvent* event)
     } else {
         mAutoCompletionCount++;
         handleAutoCompletion();
+    }
+}
+
+void TCommandLine::slot_changeSpellDict(const QString& newDict)
+{
+    // This is duplicated (and should be the same as) the code in:
+    // (void) dlgProfilePreferences::initWithHost(Host*)
+    QString path;
+#if defined(Q_OS_MACOS)
+    path = QStringLiteral("%1/../Resources/").arg(QCoreApplication::applicationDirPath());
+#elif defined(Q_OS_FREEBSD)
+    if (QFile::exists(QStringLiteral("/usr/local/share/hunspell/%1.aff").arg(newDict))) {
+        path = QLatin1String("/usr/local/share/hunspell/");
+    } else if (QFile::exists(QStringLiteral("/usr/share/hunspell/%1.aff").arg(newDict))) {
+        path = QLatin1String("/usr/share/hunspell/");
+    } else {
+        path = QLatin1String("./");
+    }
+#elif defined(Q_OS_LINUX)
+    if (QFile::exists(QStringLiteral("/usr/share/hunspell/%1.aff").arg(newDict))) {
+        path = QLatin1String("/usr/share/hunspell/");
+    } else {
+        path = QLatin1String("./");
+    }
+#else
+    // Probably Windows!
+    path = "./";
+#endif
+
+    QString spell_aff = QStringLiteral("%1%2.aff").arg(path, newDict);
+    QString spell_dic = QStringLiteral("%1%2.dic").arg(path, newDict);
+    // The man page for hunspell advises Utf8 encoding of the pathFileNames for
+    // use on Windows platforms which can have non ASCII characters...
+    if (mpHunspell) {
+        Hunspell_destroy(mpHunspell);
+    }
+    mpHunspell = Hunspell_create(spell_aff.toUtf8().constData(), spell_dic.toUtf8().constData());
+    if (mpHunspell) {
+        mHunspellCodecName = QByteArray(Hunspell_get_dic_encoding(mpHunspell));
+        qDebug().noquote().nospace() << "TCommandLine::slot_changeSpellDict(\"" << newDict << "\") INFO - Hunspell dictionary loaded, it uses a \"" << Hunspell_get_dic_encoding(mpHunspell) << "\" encoding...";
+        mpHunspellCodec = QTextCodec::codecForName(mHunspellCodecName);
     }
 }

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2018-2019 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,14 +29,15 @@
 #include <QPointer>
 #include <QString>
 #include <QStringList>
+#include <QTextDecoder>
 #include "post_guard.h"
 
+#include <hunspell/hunspell.hxx>
 #include <hunspell/hunspell.h>
 
 class TConsole;
 class KeyUnit;
 class Host;
-class TConsole;
 
 
 class TCommandLine : public QPlainTextEdit //QLineEdit
@@ -49,49 +50,52 @@ public:
     ~TCommandLine();
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
+
+
     QPalette mRegularPalette;
 
+
 private:
-    QString mLastCompletion;
+    bool event(QEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
     void handleAutoCompletion();
     void spellCheck();
-    void handleTabCompletion(bool direction);
-    void historyUp(QKeyEvent* event);
-    void historyDown(QKeyEvent* event);
-    bool event(QEvent* event) override;
-    void enterCommand(QKeyEvent* event);
+    void handleTabCompletion(bool);
+    void historyUp(QKeyEvent*);
+    void historyDown(QKeyEvent*);
+    void enterCommand(QKeyEvent*);
     void adjustHeight();
-    void mousePressEvent(QMouseEvent* event) override;
     void processNormalKey(QEvent*);
     bool processPotentialKeyBinding(QKeyEvent*);
 
-    int mHistoryBuffer;
-    QStringList mHistoryList;
-    QMap<QString, int> mHistoryMap;
-    bool mAutoCompletion;
-    bool mTabCompletion;
+
     QPointer<Host> mpHost;
+    KeyUnit* mpKeyUnit;
+    TConsole* mpConsole;
+    QString mLastCompletion;
     int mTabCompletionCount;
     int mAutoCompletionCount;
     QString mTabCompletionTyped;
-    QString mAutoCompletionTyped;
     bool mUserKeptOnTyping;
-
-    QPalette mTabCompletionPalette;
-    QPalette mAutoCompletionPalette;
-    KeyUnit* mpKeyUnit;
-    TConsole* mpConsole;
-    QString mSelectedText;
-    int mSelectionStart;
-    QString mTabCompletionOld;
-    Hunhandle* mpHunspell;
-    QPoint mPopupPosition;
-    int mHunspellSuggestionNumber;
-    char** mpHunspellSuggestionList;
 
 
 public slots:
     void slot_popupMenu();
+    void slot_changeSpellDict(const QString&);
+
+
+private:
+    int mHistoryBuffer;
+    QStringList mHistoryList;
+    QString mSelectedText;
+    int mSelectionStart;
+    QString mTabCompletionOld;
+    QPoint mPopupPosition;
+    Hunhandle* mpHunspell;
+    QByteArray mHunspellCodecName;
+    QTextCodec* mpHunspellCodec;
+    int mHunspellSuggestionNumber;
+    char** mpHunspellSuggestionList;
 };
 
 #endif // MUDLET_TCOMMANDLINE_H

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2090,7 +2090,7 @@ void dlgProfilePreferences::slot_save_and_exit()
     Host* pHost = mpHost;
     if (pHost) {
         if (dictList->currentItem()) {
-            pHost->mSpellDic = dictList->currentItem()->text();
+            pHost->setSpellDic(dictList->currentItem()->text());
         }
 
         pHost->mEnableSpellCheck = enableSpellCheck->isChecked();


### PR DESCRIPTION
Using `QString::toLatin1()` when transferring text to and from the Hunspell library will miss-encode any characters that are not in the ISO 8859-1 (Latin 1) character set and will not work if used with languages that use characters outside of that set.

The existing code only installed the user selected dictionary for spell-checking in the constructor of the `TCommandLine` class instances which meant that changes with the profile active did not take effect until the next profile load - which is less user friendly than changing it when requested. This commit corrects that problem.

At the moment there is (or should be?) only one `TCommandLine` per profile - for the Main Console.  I have chosen to use the signal/slot method for the `Host` class to inform the rest of the profile that the dictionary has been changed. This is so it can be extensible in the future if https://github.com/Mudlet/Mudlet/issues/1897 is implemented, so that we could:
1. centralise access to a profile dictionary
2. provide a custom dictionary for each profile
3. give Lua API access to both a custom and indeed the selected dictionary

although we will probably want to consider moving the code accessing the Hunspell library to the main profile `TConsole` class.

I have also added a qDebug() line to report on the loading of a dictionary, during development of this PR the output from this showed me that each dictionary could have a different character encoding and that it was essential to use the indicated one when transferred text into and out of the Hunspell library.

~Further exploration of that library also revealed that there was an extra return value from the `Hunspell_spell(...)` call. It is necessary to include both the C and the C++ header file for it to be available. This value indicated that the word was spelt correctly but there was some problem with
it.  I originally thought that it was a marker for obscene words and decided to include handling that in the spell-checker. However testing revealed that that did not appear to be the case.  The exact meaning of the `HUNSPELL_OK_WARN` value is not currently clear to me, but since they make the information available I decided to use it.  Should a word be flagged in that way it will be underlined in a blue dash-dot line (to distinguish it from the wavy red line that is used for misspelled words).~ *Update: Removed in later commit.*

Remove useless cruft from class:
* `(bool) TCommandLine::mAutoCompletion`
* `(QPalette) TCommandLine::mAutoCompletionPalette`
* `(QString) TCommandLine::mAutoCompletionTyped`
* `(QMap<QString, int>) TCommandLine::mHistoryMap`
* `(QString) TCommandLine::mLastCompletion`
* `(bool) TCommandLine::mTabCompletion`
* `(QPalette) TCommandLine::mTabCompletionPalette`

Cleaned up initialisation list.

Improve the context menu action so that the spelling suggestions are presented on top of the normal context menu rather than separately as (before).

Fixup some CLazy `else-after-return` code style warnings.

The context menu spelling checker will now report `"no suggestions"` rather than producing no information at all if it cannot find a suggestion which helps to make it different from the case where the word is correctly spelled.

Replace one use of `for (;;)` with the more obvious `forever`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>