### PR TITLE
Remove scaling attribute

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,10 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
+#ifdef Q_OS_UNIX
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     QScopedPointer<QCoreApplication> initApp(createApplication(argc, argv, startupAction));
     auto * app = qobject_cast<QApplication*>(initApp.data());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,10 +188,6 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
-#ifdef Q_OS_UNIX
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
     QScopedPointer<QCoreApplication> initApp(createApplication(argc, argv, startupAction));
     auto * app = qobject_cast<QApplication*>(initApp.data());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #endif // defined(Q_OS_WIN32) && ! defined(INCLUDE_UPDATER)
 #include <QPainter>
 #include <QSplashScreen>
+#include <QScreen>
 #include "post_guard.h"
 
 
@@ -188,12 +189,15 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
-#ifdef Q_OS_UNIX
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
     QScopedPointer<QCoreApplication> initApp(createApplication(argc, argv, startupAction));
     auto * app = qobject_cast<QApplication*>(initApp.data());
+
+#ifdef Q_OS_UNIX
+    auto dpi = app->primaryScreen()->devicePixelRatio();
+    if (dpi > 1) {
+        QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    }
+#endif
 
     // Non-GUI actions --help and --version as suggested by GNU coding standards,
     // section 4.7: http://www.gnu.org/prep/standards/standards.html#Command_002dLine-Interfaces

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,8 +193,8 @@ int main(int argc, char* argv[])
     auto * app = qobject_cast<QApplication*>(initApp.data());
 
 #ifdef Q_OS_UNIX
-    auto dpi = app->primaryScreen()->devicePixelRatio();
-    if (dpi > 1) {
+    auto dpi = app->primaryScreen()->physicalDotsPerInch();
+    if (dpi > 200) {
         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     }
 #endif


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove the Unix-only call to enable scaling.
#### Motivation for adding to Mudlet
I'm not entirely sure what it helps with, but I am sure that it causes an issue for any Qt version under 5.12: https://github.com/Mudlet/Mudlet/issues/2246
#### Other info (issues closed, discussion etc)
