### PR TITLE
Fix Mudlet freezing on Windows when securely-connected host is closed

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -368,6 +368,12 @@ void cTelnet::disconnect()
 
 }
 
+void cTelnet::abortConnection()
+{
+    mDontReconnect = true;
+    socket.abort();
+}
+
 void cTelnet::handle_socket_signal_error()
 {
     QString err = tr("[ ERROR ] - TCP/IP socket ERROR:") % socket.errorString();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -131,6 +131,7 @@ public:
     ~cTelnet();
     void connectIt(const QString& address, int port);
     void disconnect();
+    void abortConnection();
     bool sendData(QString& data);
     void setATCPVariables(const QByteArray&);
     void setGMCPVariables(const QByteArray&);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1019,7 +1019,15 @@ void mudlet::slot_close_profile_requested(int tab)
     pH->closingDown();
 
     // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
+#if defined (Q_OS_WIN32)
+    if (pH->mSslTsl) {
+        pH->mTelnet.abortConnection();
+    } else {
+        pH->mTelnet.disconnect();
+    }
+#else
     pH->mTelnet.disconnect();
+#endif
 
     pH->stopAllTriggers();
     pH->mpEditorDialog->close();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix Mudlet freezing when host that has an open secure connection is closed on Windows.
#### Motivation for adding to Mudlet
Pretty bad to have Mudlet freeze at all!
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2272.