### PR TITLE
BugFix: repair loss of trigger colorization

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8239,7 +8239,7 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
             case 9: // RRRGGGBBB
                 [[clang::fallthrough]];
             case 12: // RRRRGGGGBBBB
-                return QColor(match.captured(1));
+                return QColor(match.captured(1).prepend(QLatin1Char('#')));
 
             default:
             // case 8: // AARRGGBB - Invalid here
@@ -8273,7 +8273,7 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
             case 9: // RRRGGGBBB
                 [[clang::fallthrough]];
             case 12: // RRRRGGGGBBBB
-                return QColor(match.captured(1));
+                return QColor(match.captured(1).prepend(QLatin1Char('#')));
 
             default:
             // case 8: // AARRGGBB - Invalid here


### PR DESCRIPTION
The code was incorrectly using the string that had been parsed from the style-sheet used to set the colours of some push buttons with the result that it was returning the invalid colour `QColor(0,0,0,0)`. 

This was because the `QColor` constructor needs the `#` prefix when parsing a hex colour code like `#RGB` or `#RRGGBB` or `#RRRGGGBBB` where the letters represent the parts of a 3, 6, 9, 12  (or 8) digit hex numbers.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>