### PR TITLE
Only enable HiDPI on Linux on Qt 5.12+

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,7 +188,9 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
-#ifdef Q_OS_UNIX
+    // due to a Qt bug, this only safely works for both non- and HiDPI displays on 5.12+
+    // 5.6 - 5.11 make the application blow up in size on non-HiDPI displays
+#if defined (Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Only enable HiDPI on Linux on Qt 5.12+ where it's safe. Qt versions 5.6 - 5.11 make the application blow up twice in size on normal displays.
#### Motivation for adding to Mudlet
Most people don't have a a HiDPI display, so it's better to have it working for the majority.
#### Other info (issues closed, discussion etc)
Workaround https://github.com/Mudlet/Mudlet/issues/2246.