### PR TITLE
(release-3.17) BugFix: 2D mapper custom line creation

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4721,8 +4721,8 @@ void T2DMap::slot_cancelCustomLineDialog()
 
 void T2DMap::slot_setCustomLine2()
 {
-    auto* button = qobject_cast<QPushButton*>(sender());
-    if (!button) {
+    auto pButton = qobject_cast<QPushButton*>(sender());
+    if (!pButton) {
         if (mpCustomLinesDialog) {
             mpCustomLinesDialog->reject();
         } else {
@@ -4735,58 +4735,145 @@ void T2DMap::slot_setCustomLine2()
         }
         return;
     }
-    QString exit = button->text();
+
     mpCustomLinesDialog->hide(); // Hide but don't delete until done the custom line
-    mCustomLinesRoomExit = exit;
+
     mDialogLock = false;
     TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
     if (!room) {
         return;
     }
-    if (exit == QLatin1String("nw")) {
+    // The button texts are going to be subject to translation so we need to go
+    // for their addresses instead:
+    QString exitKey = QLatin1String("nw");
+    bool isFound = false;
+    if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
         mCustomLinesRoomTo = room->getNorthwest(); // mCustomLinesRoomTo - wasn't being set!
-    } else if (exit == QLatin1String("n")) {
-        mCustomLinesRoomTo = room->getNorth();
-    } else if (exit == QLatin1String("ne")) {
-        mCustomLinesRoomTo = room->getNortheast();
-    } else if (exit == QLatin1String("up")) {
-        mCustomLinesRoomTo = room->getUp();
-    } else if (exit == QLatin1String("w")) {
-        mCustomLinesRoomTo = room->getWest();
-    } else if (exit == QLatin1String("e")) {
-        mCustomLinesRoomTo = room->getEast();
-    } else if (exit == QLatin1String("down")) {
-        mCustomLinesRoomTo = room->getDown();
-    } else if (exit == QLatin1String("sw")) {
-        mCustomLinesRoomTo = room->getSouthwest();
-    } else if (exit == QLatin1String("s")) {
-        mCustomLinesRoomTo = room->getSouth();
-    } else if (exit == QLatin1String("se")) {
-        mCustomLinesRoomTo = room->getSoutheast();
-    } else if (exit == QLatin1String("in")) {
-        mCustomLinesRoomTo = room->getIn();
-    } else if (exit == QLatin1String("out")) {
-        mCustomLinesRoomTo = room->getOut();
-    } else {
-        qWarning(R"(T2DMap::slot_setCustomLine2(): unable to identify exit "%s"to use!)", qPrintable(exit));
+        mCustomLinesRoomExit = exitKey;
+        isFound = true;
+    }
+
+    if (!isFound) {
+        // NOTE: A previous (larger instance PR #1810) which was cherry-picked for the PR that made this change had "nw" instead of "n" here, when resolving a merge of the two choose the "n" version!
+        exitKey = QLatin1String("n");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("ne");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("up");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("w");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("e");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("down");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("sw");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("s");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("se");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("in");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        exitKey = QLatin1String("out");
+        if (pButton == mpCustomLinesDialog->findChild<QPushButton*>(exitKey)) {
+            mCustomLinesRoomTo = room->getNorth();
+            mCustomLinesRoomExit = exitKey;
+            isFound = true;
+        }
+    }
+
+    if (!isFound) {
+        qWarning() << "T2DMap::slot_setCustomLine2() ERROR - unable to identify exit to use for the button with text:" << pButton->text() << "!)";
         return;
     }
+
     QList<QPointF> list;
-    room->customLines[exit] = list;
+    room->customLines[exitKey] = list;
     //    qDebug("T2DMap::slot_setCustomLine2() NORMAL EXIT: %s", qPrintable(exit));
-    room->customLinesColor[exit] = mCurrentLineColor;
+    room->customLinesColor[exitKey] = mCurrentLineColor;
     /*
      *    qDebug("   COLOR(r,g,b): %i,%i,%i",
      *            mCurrentLineColor.red(),
      *            mCurrentLineColor.green(),
      *            mCurrentLineColor.blue() );
      */
-    room->customLinesStyle[exit] = mCurrentLineStyle;
+    room->customLinesStyle[exitKey] = mCurrentLineStyle;
     //    qDebug("   LINE STYLE: %d", mCurrentLineStyle);
-    room->customLinesArrow[exit] = mCurrentLineArrow;
+    room->customLinesArrow[exitKey] = mCurrentLineArrow;
     //    qDebug("   ARROW: %s", mCurrentLineArrow ? "Yes" : "No");
 
-    mHelpMsg = tr("Left-click to add point, right-click to undo/change/finish...");
+    mHelpMsg = tr("Left-click to add point, right-click to undo/change/finish...", "2D Mapper big, bottom of screen help message");
     // This message was previously being put up AFTER first click to set first segment was made....
     update();
 }
@@ -4820,7 +4907,7 @@ void T2DMap::slot_setCustomLine2B(QTreeWidgetItem* special_exit, int column)
     //    qDebug("   LINE STYLE: %d", mCurrentLineStyle);
     room->customLinesArrow[exit] = mCurrentLineArrow;
     //    qDebug("   ARROW: %s", mCurrentLineArrow ? "Yes" : "No");
-    mHelpMsg = tr("Left-click to add point, right-click to undo/change/finish...");
+    mHelpMsg = tr("Left-click to add point, right-click to undo/change/finish...", "2D Mapper big, bottom of screen help message");
     // This message was previously being put up AFTER first click to set first segment was made....
     update();
 }


### PR DESCRIPTION
With the introduction of translations AND also after the conversion of the internal exit direction keys for normal exits in the `TRoom` data structures for custom exit lines, in: https://github.com/Mudlet/Mudlet/pull/2106 (which was included in Mudlet 3.16.0) it has not possible to create new custom exit lines without encountering a bug that means the lines are drawn in black and do not show up whilst drawing, the properties dialogue also has no idea of the destination room and there are other oddities.

This commit contains an extract from: https://github.com/Mudlet/Mudlet/pull/1810 that was pending and had the fix for this problem

Note that this does not fix the lua `getCustomLines(...)` function which, since 3.16.0 has also been using lower case keys to return the normal exit direction custom exit line details rather than the UPPER CASE that was used before.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>