### PR TITLE
Avoid unnecessary allocations with midRef in TBuffer

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2899,14 +2899,14 @@ void TBuffer::decodeOSC(const QString& sequence)
                 // Uses mid(...) rather than at(...) because we want the return to
                 // be a (single character) QString and not a QChar so we can use
                 // QString::toUInt(...):
-                quint8 colorNumber = sequence.mid(1,1).toUInt(&isOk, 16);
+                quint8 colorNumber = sequence.midRef(1,1).toUInt(&isOk, 16);
                 quint8 rr = 0;
                 if (isOk) {
-                    rr = sequence.mid(2, 2).toUInt(&isOk, 16);
+                    rr = sequence.midRef(2, 2).toUInt(&isOk, 16);
                 }
                 quint8 gg = 0;
                 if (isOk) {
-                    gg = sequence.mid(4, 2).toUInt(&isOk, 16);
+                    gg = sequence.midRef(4, 2).toUInt(&isOk, 16);
                 }
                 quint8 bb = 0;
                 if (isOk) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Use QString.midRef() instead of QString.mid()
#### Motivation for adding to Mudlet
Trivial performance improvement
#### Other info (issues closed, discussion etc)
https://github.com/KDE/clazy/blob/master/docs/checks/README-qstring-ref.md