### PR TITLE
Ignore empty Discord inviteurl from GMCP

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1435,7 +1435,7 @@ void Host::processGMCPDiscordInfo(const QJsonObject& discordInfo)
     bool hasInvite = false;
     auto inviteUrl = discordInfo.value(QStringLiteral("inviteurl"));
     // Will be of form: "https://discord.gg/#####"
-    if (inviteUrl != QJsonValue::Undefined) {
+    if (inviteUrl != QJsonValue::Undefined && !inviteUrl.toString().isEmpty()) {
         hasInvite = true;
     }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Some games are sending `"inviteurl": ""` in what is probably a misunderstanding that the key is optional - ignore it for further purposes.
#### Motivation for adding to Mudlet
Not much right now since we don't display the invite url anywhere, but when we do, it'll be nice not to have to work around it!
#### Other info (issues closed, discussion etc)
