### PR TITLE
Don't go out of our way to mask the game name for Discord

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1408,10 +1408,6 @@ QColor Host::getAnsiColor(const int ansiCode, const bool isBackground) const
 // Telnet sub-option comes in and starts with "External.Discord.(Status|Info)"
 void Host::processDiscordGMCP(const QString& packageMessage, const QString& data)
 {
-    if (mDiscordDisableServerSide) {
-        return;
-    }
-
     auto document = QJsonDocument::fromJson(data.toUtf8());
     if (!document.isObject()) {
         return;
@@ -1476,6 +1472,10 @@ void Host::processGMCPDiscordInfo(const QJsonObject& discordInfo)
 
 void Host::processGMCPDiscordStatus(const QJsonObject& discordInfo)
 {
+    if (mDiscordDisableServerSide) {
+        return;
+    }
+
     auto pMudlet = mudlet::self();
     auto gameName = discordInfo.value(QStringLiteral("game"));
     if (gameName != QJsonValue::Undefined) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -327,7 +327,7 @@ QPair<bool, QString> cTelnet::setEncoding(const QString& newEncoding, const bool
 void cTelnet::requestDiscordInfo()
 {
     mudlet* pMudlet = mudlet::self();
-    if (pMudlet->mDiscord.libraryLoaded() && !mpHost->mDiscordDisableServerSide) {
+    if (pMudlet->mDiscord.libraryLoaded()) {
         string data;
         data = TN_IAC;
         data += TN_SB;
@@ -992,7 +992,7 @@ void cTelnet::processTelnetCommand(const string& command)
             output += TN_SE;
             socketOutRaw(output);
 
-            if (mudlet::self()->mDiscord.libraryLoaded() && !mpHost->mDiscordDisableServerSide) {
+            if (mudlet::self()->mDiscord.libraryLoaded()) {
                 output = TN_IAC;
                 output += TN_SB;
                 output += OPT_GMCP;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
If the user has an enabled "show current game" option in Discord:

![image](https://user-images.githubusercontent.com/110988/52250503-8fbc6600-28f8-11e9-8643-b22534e05939.png)

Don't go out of our way to mask the actual game name with "Mudlet" like it is currently happening:
![image](https://user-images.githubusercontent.com/110988/52250626-00fc1900-28f9-11e9-901c-27ddd962c5d6.png)

And show the actual game name instead (without revealing any information about the player!)

![image](https://user-images.githubusercontent.com/110988/52250560-b7133300-28f8-11e9-826f-38fdddd63b79.png)

This change does not affect the Discord opt-in because it does not have the possibility of leaking data (such as character names), the game name is hardcoded by the developers for everybody equally.
#### Motivation for adding to Mudlet
The idea of Discord integration was to actually show the game name + give the ability for game admins and players to show more data. The feature was built with very good privacy controls and is opt-in. I think we went overhead with masking things though - nothing wrong with showing the current game if the user has **already** enabled it in Discord.
#### Other info (issues closed, discussion etc)
Putting this PR out early in the release cycle so we can test the waters with our users. I think it makes sense and it's an improvement to Mudlet, players, and game admins - hope others see it this way too.