### PR TITLE
Fix getColumnNumber("main")

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1579,7 +1579,7 @@ int TLuaInterpreter::getColumnNumber(lua_State* L)
         }
         int result = 0;
         if (windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-            lua_pushnumber(L, host.mpConsole->getColumnNumber());
+            result = host.mpConsole->getColumnNumber();
         } else {
             result = mudlet::self()->getColumnNumber(&host, windowName);
         }


### PR DESCRIPTION
…by calling to getColumnNumber(win).

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This ensures that calling to GetColumnNumber(windowName) on the mudlet side will properly return the result for Xecho function on the Lua side.
#### Motivation for adding to Mudlet
I find it curious that moveCursor is not the main cause of misalignment rather, it is getColumnNumber that failed to return the result. so in this fix, it should now correctly return the result as intended.
#### Other info (issues closed, discussion etc)
this should resolve #2316 and #743
