### PR TITLE
Fixed speedwalk with translations

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -2761,7 +2761,7 @@ function map.speedwalk(roomID, walkPath, walkDirs)
     until k &gt; #walkDirs
     if map.configs.use_translation then
         for k, v in ipairs(walkDirs) do
-            walkDirs[k] = map.configs.lang_dirs[v]
+            walkDirs[k] = map.configs.lang_dirs[v] or v
         end
     end
     -- perform walk


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The speedwalk function was removing commands for which there wasn't a translation, causing problems for non-standard commands. Looking at the existing code, it appears that door handling as it is won't work properly with translations, but I'll come back for that later.

#### Motivation for adding to Mudlet
Someone was having trouble using speedwalk through portals, and debugging revealed this as the root cause.

#### Other info (issues closed, discussion etc)
