### PR TITLE
event handler to properly function by re-append after deletion for a registered event handler 

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6957,7 +6957,7 @@ void dlgTriggerEditor::slot_script_main_area_delete_handler()
 
 void dlgTriggerEditor::slot_script_main_area_add_handler()
 {
-    auto createItemList = [&] () {
+    auto addEventHandler = [&] () {
         auto pItem = new QListWidgetItem;
         pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
         mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
@@ -6967,17 +6967,17 @@ void dlgTriggerEditor::slot_script_main_area_add_handler()
     if (mIsScriptsMainAreaEditHandler) {
         if (!mpScriptsMainAreaEditHandlerItem) {
             mIsScriptsMainAreaEditHandler = false;
-            createItemList();
+            addEventHandler();
         } else {
             QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
             if (!pItem) {
-                createItemList();
+                addEventHandler();
             }
         }
         mIsScriptsMainAreaEditHandler = false;
         mpScriptsMainAreaEditHandlerItem = nullptr;
     } else {
-        createItemList();
+        addEventHandler();
     }
     mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6957,11 +6957,10 @@ void dlgTriggerEditor::slot_script_main_area_delete_handler()
 
 void dlgTriggerEditor::slot_script_main_area_add_handler()
 {
-    auto createItemList = [=] () {
+    auto createItemList = [&] () {
         auto pItem = new QListWidgetItem;
         pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
         mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
-        //return pItem;
     };
 
     mpScriptsMainArea->trimEventHandlerName();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6966,7 +6966,7 @@ void dlgTriggerEditor::slot_script_main_area_add_handler()
         }
         QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
         if (!pItem) {
-            return;
+            goto LAZY; //why we have to be this lazy too?
         }
         pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
         mIsScriptsMainAreaEditHandler = false;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6957,25 +6957,28 @@ void dlgTriggerEditor::slot_script_main_area_delete_handler()
 
 void dlgTriggerEditor::slot_script_main_area_add_handler()
 {
+    auto createItemList = [](auto * mpScriptsMainArea) {
+        auto pItem = new QListWidgetItem;
+        pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
+        mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
+        return pItem;
+    };
+
     mpScriptsMainArea->trimEventHandlerName();
     if (mIsScriptsMainAreaEditHandler) {
         if (!mpScriptsMainAreaEditHandlerItem) {
             mIsScriptsMainAreaEditHandler = false;
-            goto LAZY;
+            auto pItem = createItemList(mpScriptsMainArea);
             return;
         }
         QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
         if (!pItem) {
-            goto LAZY; //why we have to be this lazy too?
+            auto pItem = createItemList(mpScriptsMainArea);
         }
-        pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
         mIsScriptsMainAreaEditHandler = false;
         mpScriptsMainAreaEditHandlerItem = nullptr;
     } else {
-    LAZY:
-        auto pItem = new QListWidgetItem;
-        pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
-        mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
+        auto pItem = createItemList(mpScriptsMainArea);
     }
     mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6957,28 +6957,28 @@ void dlgTriggerEditor::slot_script_main_area_delete_handler()
 
 void dlgTriggerEditor::slot_script_main_area_add_handler()
 {
-    auto createItemList = [](auto * mpScriptsMainArea) {
+    auto createItemList = [=] () {
         auto pItem = new QListWidgetItem;
         pItem->setText(mpScriptsMainArea->lineEdit_script_event_handler_entry->text());
         mpScriptsMainArea->listWidget_script_registered_event_handlers->addItem(pItem);
-        return pItem;
+        //return pItem;
     };
 
     mpScriptsMainArea->trimEventHandlerName();
     if (mIsScriptsMainAreaEditHandler) {
         if (!mpScriptsMainAreaEditHandlerItem) {
             mIsScriptsMainAreaEditHandler = false;
-            auto pItem = createItemList(mpScriptsMainArea);
+            createItemList();
             return;
         }
         QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
         if (!pItem) {
-            auto pItem = createItemList(mpScriptsMainArea);
+          createItemList();
         }
         mIsScriptsMainAreaEditHandler = false;
         mpScriptsMainAreaEditHandlerItem = nullptr;
     } else {
-        auto pItem = createItemList(mpScriptsMainArea);
+        createItemList();
     }
     mpScriptsMainArea->lineEdit_script_event_handler_entry->clear();
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6968,11 +6968,11 @@ void dlgTriggerEditor::slot_script_main_area_add_handler()
         if (!mpScriptsMainAreaEditHandlerItem) {
             mIsScriptsMainAreaEditHandler = false;
             createItemList();
-            return;
-        }
-        QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
-        if (!pItem) {
-          createItemList();
+        } else {
+            QListWidgetItem* pItem = mpScriptsMainArea->listWidget_script_registered_event_handlers->currentItem();
+            if (!pItem) {
+                createItemList();
+            }
         }
         mIsScriptsMainAreaEditHandler = false;
         mpScriptsMainAreaEditHandlerItem = nullptr;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
previously, it is not possible to append after list don't have any event handlers in them(by deleting them). This change in this PR will recreate a list after the previous list is completely cleared for an event handler. 
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
this resolve #2320 