### PR TITLE
Limit macOS workaround for 3D mapper to known bad Qt versions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@ QCoreApplication* createApplication(int& argc, char* argv[], unsigned int& actio
     if ((action) & (1 | 2)) {
         return new QCoreApplication(argc, argv);
     } else {
-#if defined(Q_OS_MACOS)
+#if defined(Q_OS_MACOS) && (QT_VERSION < QT_VERSION_CHECK(5, 12, 0))
         // Workaround for horrible mac rendering issues once the mapper widget
         // is open - see https://bugreports.qt.io/browse/QTBUG-41257
         QApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove the workaround for the toolbar going black when the 3D mapper is opened on macOS since https://bugreports.qt.io/browse/QTBUG-41257 is now fixed.
#### Motivation for adding to Mudlet
We can delete the code when we deprecate support for 5.12 (way later) and it might have a positive side-effect to disable it now.
#### Other info (issues closed, discussion etc)
