### PR TITLE
Align Mac shortcuts for profiles&modules manager

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -506,8 +506,8 @@ mudlet::mudlet()
     inputLineKeySequence = QKeySequence(Qt::CTRL | Qt::Key_L);
     optionsKeySequence = QKeySequence(Qt::CTRL | Qt::Key_P);
     notepadKeySequence = QKeySequence(Qt::CTRL | Qt::Key_N);
-    packagesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_I);
-    modulesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_O);
+    packagesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_O);
+    modulesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_I);
     multiViewKeySequence = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_V);
     connectKeySequence = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_C);
     disconnectKeySequence = QKeySequence(Qt::CTRL | Qt::Key_D);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Mac now uses same keyboard shortcuts as all other OS

#### Motivation for adding to Mudlet
Before this, Mac users had mixed up O and I keys

#### Other info (issues closed, discussion etc)
Fix #2323