### PR TITLE
Get command separator

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -56,7 +56,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBorderRightWidth(0)
 , mBorderTopHeight(0)
 , mCommandLineFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
-, mCommandSeparator(QLatin1String(";;"))
+, mCommandSeparator(QLatin1String(";"))
 , mDisplayFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
 , mEnableGMCP(true)
 , mEnableMSDP(false)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -56,7 +56,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBorderRightWidth(0)
 , mBorderTopHeight(0)
 , mCommandLineFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
-, mCommandSeparator(QLatin1String(";"))
+, mCommandSeparator(QLatin1String(";;"))
 , mDisplayFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
 , mEnableGMCP(true)
 , mEnableMSDP(false)

--- a/src/Host.h
+++ b/src/Host.h
@@ -88,6 +88,7 @@ public:
 
 
     QString            getName()                        { QMutexLocker locker(& mLock); return mHostName; }
+    QString            getCommandSeparator()            { QMutexLocker locker(& mLock); return mCommandSeparator; }
     void               setName(const QString& s )       { QMutexLocker locker(& mLock); mHostName = s; }
     QString            getUrl()                         { QMutexLocker locker(& mLock); return mUrl; }
     void               setUrl(const QString& s )        { QMutexLocker locker(& mLock); mUrl = s; }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -473,6 +473,14 @@ int TLuaInterpreter::getProfileName(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions:getCommandSeparator
+int TLuaInterpreter::getCommandSeparator(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    lua_pushstring(L, host.getCommandSeparator().toUtf8().constData());
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#raiseGlobalEvent
 int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
 {
@@ -14643,6 +14651,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "clearMapUserDataItem", TLuaInterpreter::clearMapUserDataItem);
     lua_register(pGlobalLua, "setDefaultAreaVisible", TLuaInterpreter::setDefaultAreaVisible);
     lua_register(pGlobalLua, "getProfileName", TLuaInterpreter::getProfileName);
+    lua_register(pGlobalLua, "getCommandSeparator", TLuaInterpreter::getCommandSeparator);
     lua_register(pGlobalLua, "raiseGlobalEvent", TLuaInterpreter::raiseGlobalEvent);
     lua_register(pGlobalLua, "saveProfile", TLuaInterpreter::saveProfile);
 #ifdef QT_TEXTTOSPEECH_LIB

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -473,7 +473,7 @@ int TLuaInterpreter::getProfileName(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions:getCommandSeparator
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCommandSeparator
 int TLuaInterpreter::getCommandSeparator(lua_State* L)
 {
     Host& host = getHostFromLua(L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -435,6 +435,7 @@ public:
     static int clearMapUserDataItem(lua_State*);
     static int setDefaultAreaVisible(lua_State*);
     static int getProfileName(lua_State*);
+    static int getCommandSeparator(lua_State*);
     static int raiseGlobalEvent(lua_State*);
     static int setServerEncoding(lua_State*);
     static int getServerEncoding(lua_State*);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Changing the default command separator from ';' to ';;' and adding getCommandSeparator functions to support dynamically making use of the command separator.

#### Motivation for adding to Mudlet
The command separator has long been a point of discussion in Mudlet. The default of ';' causes issues when someone uses it as grammatical punctionation, sometimes sending folks to support to figure out why their sentences keep getting broken up. It's also parsed by send() and similar functions to split a command into multiples. This causes problems if you use send() with the command separator in lieu of sendAll(), or if you use expandAlias() with the command separator in your script and wish to distribute it. Despite some of these things being poor practice, we can't ignore that they are and have been used. This change allows use to move new profiles to a default that is less likely to trip a user up during normal speech, as well as give script writers a tool to make use of the command separator without worrying about the user changing it and breaking their script.

#### Other info (issues closed, discussion etc)
Older PR that didn't get finished (read: I dropped the ball on months ago) and was based on a much older branch: https://github.com/Mudlet/Mudlet/pull/1866
Resolves issue https://github.com/Mudlet/Mudlet/issues/1139