### PR TITLE
Reopen/show User Window should cause console to appear in a dock widget.

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1643,6 +1643,8 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         // Lets confirm this:
         Q_ASSERT_X(pC->getType()==TConsole::UserWindow, "mudlet::openWindow(...)", "An existing TConsole was expected to be marked as a User Window type but it isn't");
         pD->update();
+        //do not change the ->show() order! Otherwise, it will automatically minimize the floating/dock window(!!)
+        pC->show();
         pD->show();
         pC->showWindow(name);
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This PR should ensure that the Console will show itself, then the dock widget reappears on the screen.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
resolve #2333