### PR TITLE
Enable HiDPI for Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #endif // defined(Q_OS_WIN32) && ! defined(INCLUDE_UPDATER)
 #include <QPainter>
 #include <QSplashScreen>
+#include <QScreen>
 #include "post_guard.h"
 
 
@@ -188,9 +189,24 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
+#if defined(Q_OS_UNIX) && (QT_VERSION < QT_VERSION_CHECK(5, 12, 0))
+    bool enableHighDpiScaling = false;
+
+    {
+        // it's not possible to get any screen information before a QApplication
+        // is created, and it's also not possible to set the HiDPI option after its been
+        // created. Hence, create a fake one to get screen info.
+        QApplication fakeApp(argc, argv);
+        qDebug() << "desktop DPI: " << fakeApp.desktop()->screen()->devicePixelRatio();
+        if (fakeApp.desktop()->screen()->devicePixelRatio() > 1) {
+            enableHighDpiScaling = true;
+        }
+    }
+
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, enableHighDpiScaling);
+
     // due to a Qt bug, this only safely works for both non- and HiDPI displays on 5.12+
-    // 5.6 - 5.11 make the application blow up in size on non-HiDPI displays
-#if defined (Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+#elif defined(Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
     spDebugConsole = nullptr;
     unsigned int startupAction = 0;
 
-#if defined(Q_OS_UNIX) && (QT_VERSION < QT_VERSION_CHECK(5, 12, 0))
+#if defined(Q_OS_LINUX) && (QT_VERSION < QT_VERSION_CHECK(5, 12, 0))
     bool enableHighDpiScaling = false;
 
     {
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, enableHighDpiScaling);
 
     // due to a Qt bug, this only safely works for both non- and HiDPI displays on 5.12+
-#elif defined(Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+#elif defined(Q_OS_LINUX) && (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added a workaround to detect screen size and selectively enable HiDPI on Linux.
#### Motivation for adding to Mudlet
So Linux HiDPI users get a crisp Mudlet, while low-res users don't get a huge Mudlet.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2292.