### PR TITLE
Fix copy/paste trigger bug in background colour matching

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -664,8 +664,8 @@ bool TTrigger::match_color_pattern(int line, int regexNumber)
         // Ideally we should base the matching on only the ANSI code but not
         // all parts of the text come from the Server and can be determined to
         // have come from a decoded ANSI code number:
-        if (  ((pCT->ansiFg == scmIgnored)||((pCT->ansiFg == scmDefault) && mpHost->mpConsole->mFgColor == (*it).foreground())||(pCT->mFgColor == (*it).foreground()))
-            &&((pCT->ansiBg == scmIgnored)||((pCT->ansiBg == scmDefault) && mpHost->mpConsole->mBgColor == (*it).foreground())||(pCT->mBgColor == (*it).background()))) {
+        if (((pCT->ansiFg == scmIgnored)||((pCT->ansiFg == scmDefault) && mpHost->mpConsole->mFgColor == (*it).foreground())||(pCT->mFgColor == (*it).foreground()))
+            &&((pCT->ansiBg == scmIgnored)||((pCT->ansiBg == scmDefault) && mpHost->mpConsole->mBgColor == (*it).background())||(pCT->mBgColor == (*it).background()))) {
 
             if (matchBegin == -1) {
                 matchBegin = pos;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Not 100% sure what case this will fail to work on... why isn't the last `(pCT->mBgColor == (*it).background())` condition enough?
#### Motivation for adding to Mudlet
Less warnings in Coverity.
#### Other info (issues closed, discussion etc)
Thanks to Coverity for finding the issue.