### PR TITLE
Refactor: provide mProfileName to cTelnet, TConsole and TMap classes

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -42,7 +42,7 @@
 #include "post_guard.h"
 
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
-: mTelnet(this)
+: mTelnet(this, hostname)
 , mpConsole(nullptr)
 , mLuaInterpreter(this, id)
 , commandLineMinimumHeight(30)
@@ -70,7 +70,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mLF_ON_GA(true)
 , mNoAntiAlias(false)
 , mpEditorDialog(nullptr)
-, mpMap(new TMap(this))
+, mpMap(new TMap(this, hostname))
 , mpNotePad(nullptr)
 , mPrintCommand(true)
 , mIsRemoteEchoingActive(false)
@@ -1669,5 +1669,29 @@ void Host::setSpellDic(const QString& newDict)
     locker.unlock();
     if (isChanged) {
         emit signal_changeSpellDict(mSpellDic);
+    }
+}
+
+// This does not take care of any QMaps or other containers that the mudlet
+// and HostManager classes have that use the name of this profile as a key,
+// however it should ensure that other classes get updated:
+void Host::setName(const QString& newName)
+{
+    int currentPlayerRoom;
+    if (mpMap) {
+        currentPlayerRoom = mpMap->mRoomIdHash.take(mHostName);
+    }
+
+    QMutexLocker locker(& mLock);
+    mHostName = newName;
+    locker.unlock();
+
+    mTelnet.mProfileName = newName;
+    if (mpMap) {
+        mpMap->mProfileName = newName;
+        mpMap->mRoomIdHash.insert(newName, currentPlayerRoom);
+    }
+    if (mpConsole) {
+        mpConsole->setProfileName(newName);
     }
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -89,7 +89,7 @@ public:
 
     QString            getName()                        { QMutexLocker locker(& mLock); return mHostName; }
     QString            getCommandSeparator()            { QMutexLocker locker(& mLock); return mCommandSeparator; }
-    void               setName(const QString& s )       { QMutexLocker locker(& mLock); mHostName = s; }
+    void               setName(const QString& s );
     QString            getUrl()                         { QMutexLocker locker(& mLock); return mUrl; }
     void               setUrl(const QString& s )        { QMutexLocker locker(& mLock); mUrl = s; }
     QString            getUserDefinedName()             { QMutexLocker locker(& mLock); return mUserDefinedName; }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -326,7 +326,7 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
         return;
     }
 
-    int playerRoomId = mpMap->mRoomIdHash.value(pHost->getName());
+    int playerRoomId = mpMap->mRoomIdHash.value(mpMap->mProfileName);
     TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(playerRoomId);
     int playerAreaID = -2; // Cannot be valid (but -1 can be)!
     if (pPlayerRoom) {
@@ -666,7 +666,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     QList<int> exitList;
     QList<int> oneWayExits;
-    TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpHost->getName()));
+    TRoom* pPlayerRoom = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpMap->mProfileName));
     if (!pPlayerRoom) {
         painter.save();
         painter.fillRect(0, 0, width(), height(), Qt::transparent);
@@ -680,7 +680,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
     int ox;
     int oy;
-    if (mRoomID != mpMap->mRoomIdHash.value(mpHost->getName()) && mShiftMode) {
+    if (mRoomID != mpMap->mRoomIdHash.value(mpMap->mProfileName) && mShiftMode) {
         mShiftMode = false;
     }
     TArea* playerArea;
@@ -696,7 +696,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         if (!mpMap->mpRoomDB->getArea(playerAreaID)) {
             return;
         }
-        mRoomID = mpMap->mRoomIdHash.value(mpHost->getName());
+        mRoomID = mpMap->mRoomIdHash.value(mpMap->mProfileName);
         playerRoom = mpMap->mpRoomDB->getRoom(mRoomID);
         if (!playerRoom) {
             return;
@@ -1535,7 +1535,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                 mTarget = currentAreaRoom;
                 if (mpMap->mpRoomDB->getRoom(mTarget)) {
                     mpMap->mTargetID = mTarget;
-                    if (mpMap->findPath(mpMap->mRoomIdHash.value(mpHost->getName()), mpMap->mTargetID)) {
+                    if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID)) {
                         mpHost->startSpeedWalk();
                     } else {
                         QString msg = tr("Mapper: Cannot find a path to this room using known exits.\n");
@@ -1633,7 +1633,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                 painter.setPen(roomIdPen);
             }
 
-            if (mShiftMode && currentAreaRoom == mpMap->mRoomIdHash.value(mpHost->getName())) {
+            if (mShiftMode && currentAreaRoom == mpMap->mRoomIdHash.value(mpMap->mProfileName)) {
                 float roomRadius = (1.2 * mRoomWidth) / 2;
                 QPointF roomCenter = QPointF(rx, ry);
                 QRadialGradient gradient(roomCenter, roomRadius);
@@ -1885,7 +1885,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                     mTarget = it.key();
                     if (mpMap->mpRoomDB->getRoom(mTarget)) {
                         mpMap->mTargetID = mTarget;
-                        if (mpMap->findPath(mpMap->mRoomIdHash.value(mpHost->getName()), mpMap->mTargetID)) {
+                        if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID)) {
                             mpHost->startSpeedWalk();
                         } else {
                             QString msg = tr("Mapper: Cannot find a path to this room using known exits.\n");
@@ -1926,7 +1926,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                     mTarget = it.key();
                     if (mpMap->mpRoomDB->getRoom(mTarget)) {
                         mpMap->mTargetID = mTarget;
-                        if (mpMap->findPath(mpMap->mRoomIdHash.value(mpHost->getName()), mpMap->mTargetID)) {
+                        if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID)) {
                             mpMap->mpHost->startSpeedWalk();
                         } else {
                             QString msg = tr("Mapper: Cannot find a path to this room using known exits.\n");
@@ -2743,7 +2743,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
         }
 
         if (!mLabelHighlighted && mCustomLineSelectedRoom == 0) {
-            auto playerRoom = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpHost->getName()));
+            auto playerRoom = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpMap->mProfileName));
             auto pArea = mpMap->mpRoomDB->getArea(mAreaID);
 
             if (!playerRoom || !pArea) {
@@ -3329,7 +3329,7 @@ void T2DMap::slot_setPlayerLocation()
     int _newRoomId = *(mMultiSelectionSet.constBegin());
     if (mpMap->mpRoomDB->getRoom(_newRoomId)) {
         // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
-        mpMap->mRoomIdHash[mpHost->getName()] = _newRoomId;
+        mpMap->mRoomIdHash[mpMap->mProfileName] = _newRoomId;
         mpMap->mNewMove = true;
         TEvent manualSetEvent;
         manualSetEvent.mArgumentList.append(QLatin1String("sysManualLocationSetEvent"));
@@ -4089,7 +4089,7 @@ void T2DMap::slot_loadMap() {
     QString fileName = QFileDialog::getOpenFileName(
                            this,
                            tr("Load Mudlet map"),
-                           mudlet::getMudletPath(mudlet::profileMapsPath, mpHost->getName()),
+                           mudlet::getMudletPath(mudlet::profileMapsPath, mpMap->mProfileName),
                            tr("Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)",
                               // Intentional comment to separate arguments
                               "Do not change extensions (in braces) or the ;;s as they are used programmatically"));
@@ -4120,8 +4120,7 @@ void T2DMap::slot_newMap()
     mpHost->mpMap->setRoomCoordinates(roomID, 0, 0, 0);
     mpHost->mpMap->mMapGraphNeedsUpdate = true;
 
-    auto room = mpHost->mpMap->mpRoomDB->getRoom(roomID);
-    mpHost->mpMap->mRoomIdHash[mpHost->getName()] = roomID;
+    mpHost->mpMap->mRoomIdHash[mpMap->mProfileName] = roomID;
     mpHost->mpMap->mNewMove = true;
     if (mpHost->mpMap->mpM) {
         mpHost->mpMap->mpM->update();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -90,6 +90,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mSystemMessageFgColor(QColor(Qt::red))
 , mTriggerEngineMode(false)
 , mWrapAt(100)
+, mProfileName(mpHost ? mpHost->getName() : QStringLiteral("debug console"))
 , networkLatency(new QLineEdit)
 , mIsPromptLine(false)
 , mUserAgreedToCloseConsole(false)
@@ -137,11 +138,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         mStandardFormat.setTextFormat(mpHost->mFgColor, mpHost->mBgColor, TChar::None);
     }
     setContentsMargins(0, 0, 0, 0);
-    if (mpHost) {
-        profile_name = mpHost->getName();
-    } else {
-        profile_name = "debug console";
-    }
     mFormatSystemMessage.setBackground(mBgColor);
     mFormatSystemMessage.setForeground(Qt::red);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -731,7 +727,7 @@ void TConsole::closeEvent(QCloseEvent* event)
         }
     }
 
-    if (profile_name != "default_host") {
+    if (mProfileName != QLatin1String("default_host")) {
         TEvent conCloseEvent;
         conCloseEvent.mArgumentList.append(QLatin1String("sysExitEvent"));
         conCloseEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -744,9 +740,9 @@ void TConsole::closeEvent(QCloseEvent* event)
 
             if (mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;
-                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
+                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
                 // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (3 of 6)
-                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
+                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
                 }
@@ -762,9 +758,9 @@ void TConsole::closeEvent(QCloseEvent* event)
         }
     }
 
-    if (profile_name != "default_host" && !mUserAgreedToCloseConsole) {
+    if (mProfileName != "default_host" && !mUserAgreedToCloseConsole) {
     ASK:
-        int choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(profile_name), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+        int choice = QMessageBox::question(this, tr("Save profile?"), tr("Do you want to save the profile %1?").arg(mProfileName), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
         if (choice == QMessageBox::Cancel) {
             event->setAccepted(false);
             event->ignore();
@@ -781,9 +777,9 @@ void TConsole::closeEvent(QCloseEvent* event)
                 goto ASK;
             } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB->size() > 0) {
                 QDir dir_map;
-                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
+                QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
                 // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (4 of 6)
-                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
+                QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("dd-MM-yyyy#hh-mm-ss"));
                 if (!dir_map.exists(directory_map)) {
                     dir_map.mkpath(directory_map);
                 }
@@ -841,7 +837,7 @@ void TConsole::toggleLogging(bool isMessageEnabled)
         QString logFileName;
         // If no log directory is set, default to Mudlet's replay and log files path
         if (mpHost->mLogDir == nullptr || mpHost->mLogDir.isEmpty()) {
-            directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, profile_name);
+            directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
         } else {
             directoryLogFile = mpHost->mLogDir;
         }
@@ -942,7 +938,7 @@ void TConsole::toggleLogging(bool isMessageEnabled)
             // switches away from the ASCII default
             logStream << "  <meta name='generator' content='" << tr("Mudlet MUD Client version: %1%2").arg(APP_VERSION, APP_BUILD) << "'>\n";
             // Nice to identify what made the file!
-            logStream << "  <title>" << tr("Mudlet, log from %1 profile").arg(profile_name) << "</title>\n";
+            logStream << "  <title>" << tr("Mudlet, log from %1 profile").arg(mProfileName) << "</title>\n";
             // Web-page title
             logStream << "  <style type='text/css'>\n";
             logStream << "   <!-- body { font-family: '" << fontsList.join("', '") << "'; font-size: 100%; line-height: 1.125em; white-space: nowrap; color:rgb("
@@ -1048,7 +1044,7 @@ void TConsole::slot_toggleReplayRecording()
     }
     mRecordReplay = !mRecordReplay;
     if (mRecordReplay) {
-        QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, profile_name);
+        QString directoryLogFile = mudlet::getMudletPath(mudlet::profileReplayAndLogFilesPath, mProfileName);
         // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (5 of 6)
         QString mLogFileName = QStringLiteral("%1/%2.dat").arg(directoryLogFile, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
         QDir dirLogFile;
@@ -1234,7 +1230,7 @@ void TConsole::printOnDisplay(std::string& incomingSocketData, const bool isFrom
     // method is only used on the "main" console so no need to filter depending
     // on TConsole types:
 
-    emit signal_newDataAlert(mpHost->getName());
+    emit signal_newDataAlert(mProfileName);
 }
 
 void TConsole::runTriggers(int line)
@@ -1495,11 +1491,11 @@ bool TConsole::saveMap(const QString& location, int saveVersion)
 {
     QDir dir_map;
     QString filename_map;
-    QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, profile_name);
+    QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
 
     if (location.isEmpty()) {
         // CHECKME: Consider changing datetime spec to more "sortable" "yyyy-MM-dd#HH-mm-ss" (6 of 6)
-        filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, profile_name, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
+        filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(QStringLiteral("dd-MM-yyyy#hh-mm-ss")));
     } else {
         filename_map = location;
     }
@@ -1616,7 +1612,7 @@ bool TConsole::importMap(const QString& location, QString* errMsg)
     if (!fileInfo.filePath().isEmpty()) {
         if (fileInfo.isRelative()) {
             // Resolve the name relative to the profile home directory:
-            filePathNameString = QDir::cleanPath(mudlet::getMudletPath(mudlet::profileDataItemPath, pHost->getName(), fileInfo.filePath()));
+            filePathNameString = QDir::cleanPath(mudlet::getMudletPath(mudlet::profileDataItemPath, mProfileName, fileInfo.filePath()));
         } else {
             if (fileInfo.exists()) {
                 filePathNameString = fileInfo.canonicalFilePath(); // Cannot use cannonical path if file doesn't exist!
@@ -2576,9 +2572,8 @@ void TConsole::slot_reloadMap(QList<QString> profilesList)
         return;
     }
 
-    QString ourName = pHost->getName();
-    if (!profilesList.contains(ourName)) {
-        qDebug() << "TConsole::slot_reloadMap(" << profilesList << ") request received but we:" << ourName << "are not mentioned - so we are ignoring it...!";
+    if (!profilesList.contains(mProfileName)) {
+        qDebug() << "TConsole::slot_reloadMap(" << profilesList << ") request received but we:" << mProfileName << "are not mentioned - so we are ignoring it...!";
         return;
     }
 
@@ -2593,4 +2588,16 @@ void TConsole::slot_reloadMap(QList<QString> profilesList)
     }
 
     pHost->postMessage(outcomeMsg);
+}
+
+void TConsole::setProfileName(const QString& newName)
+{
+    mProfileName = newName;
+    if (mType != MainConsole) {
+        return;
+    }
+
+    for (auto pC : mSubConsoleMap) {
+        pC->setProfileName(newName);
+    }
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -180,6 +180,7 @@ public:
 
     void toggleLogging(bool);
     ConsoleType getType() const { return mType; }
+    void setProfileName(const QString&);
 
 
     QPointer<Host> mpHost;
@@ -261,7 +262,7 @@ public:
     QLineEdit* networkLatency;
     QPoint P_begin;
     QPoint P_end;
-    QString profile_name;
+    QString mProfileName;
     TSplitter* splitter;
     bool mIsPromptLine;
     QToolButton* logButton;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -40,9 +40,10 @@
 #include <QProgressDialog>
 #include "post_guard.h"
 
-TMap::TMap(Host* pH)
+TMap::TMap(Host* pH, const QString& profileName)
 : mpRoomDB(new TRoomDB(this))
 , mpHost(pH)
+, mProfileName(profileName)
 , m2DPanMode(false)
 , mLeftDown(false)
 , mRightDown(false)
@@ -584,7 +585,7 @@ QList<int> TMap::detectRoomCollisions(int id)
 bool TMap::gotoRoom(int r)
 {
     mTargetID = r;
-    return findPath(mRoomIdHash.value(mpHost->getName()), r);
+    return findPath(mRoomIdHash.value(mProfileName), r);
 }
 
 // As can be seen this only sets the target and start point for a path find
@@ -1182,7 +1183,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         // location
         ofs << mRoomIdHash;
     } else {
-        ofs << mRoomIdHash.value(mpHost->getName());
+        ofs << mRoomIdHash.value(mProfileName);
     }
 
     ofs << mapLabels.size(); //anzahl der areas
@@ -1384,7 +1385,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
 
 bool TMap::restore(QString location, bool downloadIfNotFound)
 {
-    qDebug() << "TMap::restore(" << location << ") INFO: restoring map of Profile:" << mpHost->getName() << " URL:" << mpHost->getUrl();
+    qDebug() << "TMap::restore(" << location << ") INFO: restoring map of Profile:" << mProfileName << " URL:" << mpHost->getUrl();
 
     QElapsedTimer _time;
     _time.start();
@@ -1392,7 +1393,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
     QStringList entries;
 
     if (location.isEmpty()) {
-        folder = mudlet::getMudletPath(mudlet::profileMapsPath, mpHost->getName());
+        folder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
         QDir dir(folder);
         dir.setSorting(QDir::Time);
         entries = dir.entryList(QDir::Files, QDir::Time);
@@ -1566,7 +1567,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         } else if (mVersion >= 12) {
             int oldRoomId;
             ifs >> oldRoomId;
-            mRoomIdHash[mpHost->getName()] = oldRoomId;
+            mRoomIdHash[mProfileName] = oldRoomId;
         }
 
         if (mVersion >= 11) {
@@ -2169,7 +2170,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "\"%1\"\n"
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
-                    .arg(mudlet::getMudletPath(mudlet::profileLogErrorsFilePath, mpHost->getName()), title));
+                    .arg(mudlet::getMudletPath(mudlet::profileLogErrorsFilePath, mProfileName), title));
     } else if (mIsFileViewingRecommended && mudlet::self()->showMapAuditErrors()) {
         postMessage(tr("[ INFO ]  - The equivalent to the above information about that last map\n"
                        "operation has been saved for review as the most recent report in\n"
@@ -2177,7 +2178,7 @@ void TMap::pushErrorMessagesToFile(const QString title, const bool isACleanup)
                        "\"%1\"\n"
                        "- look for the (last) report with the title:\n"
                        "\"%2\".")
-                    .arg(mudlet::getMudletPath(mudlet::profileLogErrorsFilePath, mpHost->getName()), title));
+                    .arg(mudlet::getMudletPath(mudlet::profileLogErrorsFilePath, mProfileName), title));
     }
 
     mIsFileViewingRecommended = false;
@@ -2224,7 +2225,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     if (localFileName.isEmpty()) {
-        mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, pHost->getName());
+        mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, mProfileName);
     } else {
         mLocalMapFileName = localFileName;
     }
@@ -2253,7 +2254,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     mpNetworkReply = mpNetworkAccessManager->get(QNetworkRequest(QUrl(url)));
     // Using zero for both min and max values should cause the bar to oscillate
     // until the first update
-    mpProgressDialog = new QProgressDialog(tr("Downloading XML map file for use in %1...").arg(pHost->getName()), tr("Abort"), 0, 0);
+    mpProgressDialog = new QProgressDialog(tr("Downloading XML map file for use in %1...").arg(mProfileName), tr("Abort"), 0, 0);
     mpProgressDialog->setWindowTitle(tr("Map download"));
     mpProgressDialog->setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_map_download.png")));
     mpProgressDialog->setMinimumWidth(300);
@@ -2313,7 +2314,7 @@ bool TMap::readXmlMapFile(QFile& file, QString* errMsg)
         // This is the local import case - which has not got a progress dialog
         // until now:
         isLocalImport = true;
-        mpProgressDialog = new QProgressDialog(tr("Importing XML map file for use in %1...").arg(pHost->getName()), QString(), 0, 0);
+        mpProgressDialog = new QProgressDialog(tr("Importing XML map file for use in %1...").arg(mProfileName), QString(), 0, 0);
         mpProgressDialog->setWindowTitle(tr("Map import"));
         mpProgressDialog->setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_map_download.png")));
         mpProgressDialog->setMinimumWidth(300);

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018 by Stephen Lyons                        *
+ *   Copyright (C) 2014-2016, 2018-2019 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -82,7 +82,7 @@ class TMap : public QObject
 
 public:
     Q_DISABLE_COPY(TMap)
-    TMap(Host*);
+    TMap(Host*, const QString&);
     ~TMap();
     void mapClear();
     int createMapLabelID(int area);
@@ -154,6 +154,7 @@ public:
     TRoomDB* mpRoomDB;
     QMap<int, int> envColors;
     QPointer<Host> mpHost;
+    QString mProfileName;
 
     // Was a single int mRoomId but that breaks things when maps are
     // copied/shared between profiles - so now we track the profile name

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2019 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -284,7 +284,7 @@ bool TRoomDB::__removeRoom(int id)
 bool TRoomDB::removeRoom(int id)
 {
     if (rooms.contains(id) && id > 0) {
-        if (mpMap->mRoomIdHash.value(mpMap->mpHost->getName()) == id) {
+        if (mpMap->mRoomIdHash.value(mpMap->mProfileName) == id) {
             // Now we store mRoomId for each profile, we must remove any where
             // this room was used
             QList<QString> profilesWithUserInThisRoom = mpMap->mRoomIdHash.keys(id);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -58,7 +58,7 @@ QDataStream replayStream;
 QFile replayFile;
 
 
-cTelnet::cTelnet(Host* pH)
+cTelnet::cTelnet(Host* pH, const QString& profileName)
 : mResponseProcessed(true)
 , networkLatency()
 , mAlertOnNewData(true)
@@ -74,6 +74,7 @@ cTelnet::cTelnet(Host* pH)
 , mMCCP_version_1(false)
 , mMCCP_version_2(false)
 , mpProgressDialog()
+, mProfileName(profileName)
 , hostPort()
 , networkLatencyMin()
 , networkLatencyMax()
@@ -128,7 +129,7 @@ cTelnet::cTelnet(Host* pH)
 
     // initialize the socket after the Host initialisation is complete so we can access mSslTsl
     QTimer::singleShot(0, this, [this]() {
-        qDebug() << mpHost->getName();
+        qDebug() << mProfileName;
         if (mpHost->mSslTsl) {
             connect(&socket, &QSslSocket::encrypted, this, &cTelnet::handle_socket_signal_connected);
         } else {
@@ -1345,7 +1346,7 @@ void cTelnet::processTelnetCommand(const string& command)
                     return;
                 }
 
-                mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), fileName);
+                mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mProfileName, fileName);
 
                 QNetworkReply* reply = mpDownloader->get(QNetworkRequest(QUrl(url)));
                 mpProgressDialog = new QProgressDialog(tr("downloading game GUI from server"), tr("Cancel", "Cancel download of GUI package from Server"), 0, 4000000, mpHost->mpConsole);
@@ -1550,7 +1551,7 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
     mpHost->mLuaInterpreter.setAtcpTable(var, arg);
     if (var.startsWith(QLatin1String("RoomNum"))) {
         if (mpHost->mpMap) {
-            mpHost->mpMap->mRoomIdHash[mpHost->getName()] = arg.toInt();
+            mpHost->mpMap->mRoomIdHash[mProfileName] = arg.toInt();
             if (mpHost->mpMap->mpM && mpHost->mpMap->mpMapper && mpHost->mpMap->mpMapper->mp2dMap) {
                 mpHost->mpMap->mpM->update();
                 mpHost->mpMap->mpMapper->mp2dMap->update();
@@ -1624,7 +1625,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
             return;
         }
 
-        mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), fileName);
+        mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mProfileName, fileName);
 
         QNetworkReply* reply = mpDownloader->get(QNetworkRequest(QUrl(url)));
         mpProgressDialog = new QProgressDialog(tr("downloading game GUI from server"), tr("Cancel", "Cancel download of GUI package from Server"), 0, 4000000, mpHost->mpConsole);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2014-2015 by Florian Scheel - keneanung@googlemail.com  *
- *   Copyright (C) 2015, 2017-2018 by Stephen Lyons                        *
+ *   Copyright (C) 2015, 2017-2019 by Stephen Lyons                        *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -127,7 +127,7 @@ class cTelnet : public QObject
 
 public:
     Q_DISABLE_COPY(cTelnet)
-    cTelnet(Host* pH);
+    cTelnet(Host* pH, const QString&);
     ~cTelnet();
     void connectIt(const QString& address, int port);
     void disconnect();
@@ -182,6 +182,8 @@ public:
     QNetworkAccessManager* mpDownloader;
     QProgressDialog* mpProgressDialog;
     QString mServerPackage;
+    QString mProfileName;
+
 
 public slots:
     void setDownloadProgress(qint64, qint64);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -136,7 +136,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     mpMap->customEnvColors[271] = mpHost->mLightWhite_2;
     mpMap->customEnvColors[272] = mpHost->mLightBlack_2;
     if (mpHost) {
-        qDebug()<<"dlgMapper::dlgMapper(...) INFO constructor called, mpHost->getName(): " << mpHost->getName();
+        qDebug()<<"dlgMapper::dlgMapper(...) INFO constructor called, mpMap->mProfileName: " << mpMap->mProfileName;
         mp2dMap->init();
     } else {
         qDebug()<<"dlgMapper::dlgMapper(...) INFO constructor called, mpHost is null";
@@ -223,7 +223,7 @@ void dlgMapper::choseRoom(QListWidgetItem* pT)
         if (pR->name == txt) {
             qDebug() << "found room id=" << i;
             mpMap->mTargetID = i;
-            if (!mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mpHost->getName()), i)) {
+            if (!mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), i)) {
                 mpHost->mpConsole->printSystemMessage(tr("Cannot find a path to this room.\n"));
             } else {
                 mpMap->mpHost->startSpeedWalk();
@@ -314,7 +314,7 @@ void dlgMapper::resetAreaComboBoxToPlayerRoomArea()
         return;
     }
 
-    TRoom* pR = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(pHost->getName()));
+    TRoom* pR = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpMap->mProfileName));
     if (pR) {
         int playerRoomArea = pR->getArea();
         TArea* pA = mpMap->mpRoomDB->getArea(playerRoomArea);

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014, 2016 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2014, 2016, 2019 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -358,13 +359,13 @@ void GLWidget::paintGL()
         return;
     }
     float px, py, pz;
-    if (mRID != mpMap->mRoomIdHash.value(mpMap->mpHost->getName()) && mShiftMode) {
+    if (mRID != mpMap->mRoomIdHash.value(mpMap->mProfileName) && mShiftMode) {
         mShiftMode = false;
     }
 
     int ox, oy, oz;
     if (!mShiftMode) {
-        mRID = mpMap->mRoomIdHash.value(mpMap->mpHost->getName());
+        mRID = mpMap->mRoomIdHash.value(mpMap->mProfileName);
         TRoom* pRID = mpMap->mpRoomDB->getRoom(mRID);
         if (!pRID) {
             glClearDepth(1.0);
@@ -2191,7 +2192,7 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         updateGL();
         if (mpMap->mpRoomDB->getRoom(mTarget)) {
             mpMap->mTargetID = mTarget;
-            if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mpHost->getName()), mpMap->mTargetID)) {
+            if (mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), mpMap->mTargetID)) {
                 mpMap->mpHost->startSpeedWalk();
             }
             //            else


### PR DESCRIPTION
This will enable them to establish the identity of their related `Host` instance without the need to call `Host::getName()` which involves a mutex in the latter class. This makes things a bit faster and less likely to cause deadlocks in odd places and does make things simpler for some other related classes.

The `Host::setName(const QString&)` method has been revised to ensure that changes are passed across to the other three classes on change. This will close https://github.com/Mudlet/Mudlet/issues/2357 - with the exception that changing the name of the profile whilst it is active will need some further jiggery-pokery in the HostManager and mudlet classes.

This came about as I was investigating https://github.com/Mudlet/Mudlet/issues/2288 but it became something that could be sorted out separately but might help in the overall process of fixing that.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>