### PR TITLE
Draft: move trigger type QComboBox to LHS of trigger item

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -613,20 +613,62 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     lay1->setContentsMargins(0, 0, 0, 0);
     lay1->setSpacing(0);
     mpScrollArea->setWidget(HpatternList);
+
+    QPixmap pixMap_subString(256, 256);
+    pixMap_subString.fill(Qt::black);
+    QIcon icon_subString(pixMap_subString);
+
+    QPixmap pixMap_perl_regex(256, 256);
+    pixMap_perl_regex.fill(Qt::blue);
+    QIcon icon_perl_regex(pixMap_perl_regex);
+
+    QPixmap pixMap_begin_of_line_substring(256, 256);
+    pixMap_begin_of_line_substring.fill(Qt::red);
+    QIcon icon_begin_of_line_substring(pixMap_begin_of_line_substring);
+
+    QPixmap pixMap_exact_match(256,256);
+    pixMap_exact_match.fill(Qt::green);
+    QIcon icon_exact_match(pixMap_exact_match);
+
+    QPixmap pixMap_lua_function(256, 256);
+    pixMap_lua_function.fill(Qt::cyan);
+    QIcon icon_lua_function(pixMap_lua_function);
+
+    QPixmap pixMap_line_spacer(256, 256);
+    pixMap_line_spacer.fill(Qt::magenta);
+    QIcon icon_line_spacer(pixMap_line_spacer);
+
+    QPixmap pixMap_color_trigger(256, 256);
+    pixMap_color_trigger.fill(Qt::lightGray);
+    QIcon icon_color_trigger(pixMap_color_trigger);
+
+    QPixmap pixMap_prompt(256, 256);
+    pixMap_prompt.fill(Qt::yellow);
+    QIcon icon_prompt(pixMap_prompt);
+
+    QStringList patternList;
+    patternList << tr("substring")
+                << tr("perl regex")
+                << tr("begin of line substring")
+                << tr("exact match")
+                << tr("lua function")
+                << tr("line spacer")
+                << tr("color trigger")
+                << tr("prompt");
+
     for (int i = 0; i < 50; i++) {
         auto pItem = new dlgTriggerPatternEdit(HpatternList);
-        QStringList _patternList;
-        _patternList << "substring"
-                     << "perl regex"
-                     << "begin of line substring"
-                     << "exact match"
-                     << "Lua function"
-                     << "line spacer"
-                     << "color trigger"
-                     << "prompt";
         QComboBox* pBox = pItem->comboBox_patternType;
-        pBox->addItems(_patternList);
+        pBox->addItems(patternList);
         pBox->setItemData(0, QVariant(i));
+        pBox->setItemIcon(0, icon_subString);
+        pBox->setItemIcon(1, icon_perl_regex);
+        pBox->setItemIcon(2, icon_begin_of_line_substring);
+        pBox->setItemIcon(3, icon_exact_match);
+        pBox->setItemIcon(4, icon_lua_function);
+        pBox->setItemIcon(5, icon_line_spacer);
+        pBox->setItemIcon(6, icon_color_trigger);
+        pBox->setItemIcon(7, icon_prompt);
         connect(pBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_setupPatternControls);
         connect(pItem->pushButton_fgColor, &QAbstractButton::pressed, this, &dlgTriggerEditor::slot_color_trigger_fg);
         connect(pItem->pushButton_bgColor, &QAbstractButton::pressed, this, &dlgTriggerEditor::slot_color_trigger_bg);
@@ -4910,12 +4952,20 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
             }
             // Use operator[] so we have write access to the array/list member:
             dlgTriggerPatternEdit* pPatternItem = mTriggerPatternEdit[i];
-            pPatternItem->comboBox_patternType->setCurrentIndex(propertyList.at(i));
-            setupPatternControls(propertyList.at(i), pPatternItem);
-            if (propertyList.at(i) == REGEX_PROMPT ) {
+            int pType = propertyList.at(i);
+            if (!pType) {
+                // If the control is for the default (0) case nudge the setting
+                // up and down so that it copies the coloure icon for the
+                // subString type across into the QLineEdit:
+                pPatternItem->comboBox_patternType->setCurrentIndex(1);
+                setupPatternControls(1, pPatternItem);
+            }
+            pPatternItem->comboBox_patternType->setCurrentIndex(pType);
+            setupPatternControls(pType, pPatternItem);
+            if (pType == REGEX_PROMPT ) {
                 pPatternItem->lineEdit_pattern->clear();
 
-            } else if (propertyList.at(i) == REGEX_COLOR_PATTERN) {
+            } else if (pType == REGEX_COLOR_PATTERN) {
                 pPatternItem->lineEdit_pattern->setText(patternList.at(i));
                 if (pT->mColorPatternList.at(i)) {
                     if (pT->mColorPatternList.at(i)->ansiFg == TTrigger::scmIgnored) {
@@ -4973,6 +5023,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
             mTriggerPatternEdit[i]->pushButton_fgColor->hide();
             mTriggerPatternEdit[i]->pushButton_bgColor->hide();
             mTriggerPatternEdit[i]->pushButton_prompt->hide();
+            // Nudge the type up and down so that the appropriate (coloured) icon is copied across to the QLineEdit:
+            mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(1);
             mTriggerPatternEdit[i]->comboBox_patternType->setCurrentIndex(0);
         }
         // Scroll to the last used pattern:

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,9 +22,24 @@
 
 #include "dlgTriggerPatternEdit.h"
 
+#include "pre_guard.h"
+#include <QAction>
+#include "post_guard.h"
 
-dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pF) : QWidget(pF), mRow()
+dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pF)
+: QWidget(pF)
+, mRow()
 {
     // init generated dialog
     setupUi(this);
+
+    mAction_typeIndication = new QAction(this);
+    lineEdit_pattern->addAction(mAction_typeIndication, QLineEdit::TrailingPosition);
+
+    connect(comboBox_patternType, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged);
+}
+
+void dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged(const int index)
+{
+    mAction_typeIndication->setIcon(comboBox_patternType->itemIcon(index));
 }

--- a/src/dlgTriggerPatternEdit.h
+++ b/src/dlgTriggerPatternEdit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,6 +27,7 @@
 #include "ui_trigger_pattern_edit.h"
 #include "post_guard.h"
 
+class QAction;
 
 class dlgTriggerPatternEdit : public QWidget, public Ui::trigger_pattern_edit
 {
@@ -35,8 +37,15 @@ public:
     Q_DISABLE_COPY(dlgTriggerPatternEdit)
     dlgTriggerPatternEdit(QWidget*);
 
-//private:
     int mRow;
+
+
+public slots:
+    void slot_triggerTypeComboBoxChanged(const int);
+
+
+private:
+    QAction* mAction_typeIndication;
 };
 
 #endif // MUDLET_DLGTRIGGERPATTERNEDIT_H

--- a/src/ui/trigger_pattern_edit.ui
+++ b/src/ui/trigger_pattern_edit.ui
@@ -73,6 +73,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QComboBox" name="comboBox_patternType">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>33</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QPushButton" name="pushButton_fgColor">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -149,16 +159,6 @@
    </item>
    <item>
     <widget class="QLineEdit" name="lineEdit_pattern">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>33</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QComboBox" name="comboBox_patternType">
      <property name="maximumSize">
       <size>
        <width>16777215</width>


### PR DESCRIPTION
This is a reworking of #2361 to provide an alternative format with the QComboBox moved to the LHS.

We recently removed the foreground colour coding of text entered into the trigger item text line because it could render some types unreadable with some themes/styling.  That was not universally popular because the colour was also a sub-conscious reminder to some users as to the item type.

This PR adds a coloured icon to the trigger type selection `QComboBox` but - given that it is a little way from the point at which any text is entered I have also arranged for the coloured (they could also be pictorial icons if someone wanted to design a set) icons to be duplicated at the start of the `QLineEdit` where the text is entered.

The colours largely duplicate the colours previously used for those with text entry and I have chosen a pair of contrasting colours for the two (colour and prompt) triggers that do not show the text entry widget.

This also properly wraps the trigger type texts in `tr(`...`)` so they will finally be included in the translation process - from which they were previously not!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>