### PR TITLE
Bugfix: fix header includes for compilation on FreeBSD

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -50,6 +50,7 @@
 #include <QTextOption>
 #include <QTime>
 #include <QTimer>
+#include <QToolButton>
 #include "edbee/models/textautocompleteprovider.h"
 #include <QShortcut>
 #include <QKeySequence>


### PR DESCRIPTION
it seems that the absence of the updater code (presumably) causes a needed `#include` to be missing from a well used header file causing compilation to fail.

Thinking about it - this has come about because of the enhancement of the "About" button on the main toolbar which has indeed been changed from a `QPushButton` to a `QToolButton` to enable it to have an instant popup when a menu is added to it on other OSes when an update is spotted for users who have set their Mudlet to NOT automatically update.  Obviously that is not applicable for this OS so it would not be surprising if the missing header was included from, say, `./3rdparty/dblsqd/update_dialog.h` which is not retrieved on a platform without the updater functionality...

Whilst it is not likely that anyone else in the project core can verify this, I guess it is not too controversial to prevent approval if I just say that this one liner fixes it for me...?

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>