### PR TITLE
Bug fix freeze when closing self signed certificates on linux

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -225,7 +225,6 @@ Host::~Host()
     }
     mIsGoingDown = true;
     mIsClosingDown = true;
-    mTelnet.disconnect();
     mErrorLogStream.flush();
     mErrorLogFile.close();
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5264,7 +5264,7 @@ int TLuaInterpreter::getMudletLuaDefaultPaths(lua_State* L)
 int TLuaInterpreter::disconnect(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    host.mTelnet.disconnect();
+    host.mTelnet.disconnectIt();
     return 0;
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -370,7 +370,7 @@ void cTelnet::connectIt(const QString& address, int port)
 }
 
 
-void cTelnet::disconnect()
+void cTelnet::disconnectIt()
 {
     mDontReconnect = true;
     socket.disconnectFromHost();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -130,7 +130,7 @@ public:
     cTelnet(Host* pH);
     ~cTelnet();
     void connectIt(const QString& address, int port);
-    void disconnect();
+    void disconnectIt();
     void abortConnection();
     bool sendData(QString& data);
     void setATCPVariables(const QByteArray&);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -166,10 +166,10 @@ public:
     bool isATCPEnabled() const { return enableATCP; }
     bool isGMCPEnabled() const { return enableGMCP; }
     bool isChannel102Enabled() const { return enableChannel102; }
-
     void requestDiscordInfo();
-
     QString decodeOption(const unsigned char) const;
+    QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
+
 
     QMap<int, bool> supportedTelnetOptions;
     bool mResponseProcessed;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1032,10 +1032,10 @@ void mudlet::slot_close_profile_requested(int tab)
     if (pH->mSslTsl) {
         pH->mTelnet.abortConnection();
     } else {
-        pH->mTelnet.disconnect();
+        pH->mTelnet.disconnectIt();
     }
 #else
-    pH->mTelnet.disconnect();
+    pH->mTelnet.disconnectIt();
 #endif
 
     pH->stopAllTriggers();
@@ -1112,7 +1112,7 @@ void mudlet::slot_close_profile()
                 pH->closingDown();
 
                 // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
-                pH->mTelnet.disconnect();
+                pH->mTelnet.disconnectIt();
 
                 mpCurrentActiveHost->mpEditorDialog->close();
                 for (auto consoleName : hostConsoleMap.keys()) {
@@ -2477,7 +2477,7 @@ void mudlet::closeEvent(QCloseEvent* event)
     foreach (TConsole* pC, mConsoleMap) {
         if (pC->mpHost->getName() != QStringLiteral("default_host")) {
             // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
-            pC->mpHost->mTelnet.disconnect();
+            pC->mpHost->mTelnet.disconnectIt();
 
             // close script-editor
             if (pC->mpHost->mpEditorDialog) {
@@ -2519,7 +2519,7 @@ void mudlet::forceClose()
         console->mUserAgreedToCloseConsole = true;
 
         if (host->getName() != QStringLiteral("default_host")) {
-            host->mTelnet.disconnect();
+            host->mTelnet.disconnectIt();
             // close script-editor
             if (host->mpEditorDialog) {
                 host->mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -3131,7 +3131,7 @@ void mudlet::slot_disconnect()
     if (!pHost) {
         return;
     }
-    pHost->mTelnet.disconnect();
+    pHost->mTelnet.disconnectIt();
 }
 
 void mudlet::slot_replay()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1072,6 +1072,11 @@ void mudlet::slot_close_profile_requested(int tab)
         mpIrcClientMap[pH]->deleteLater();
     }
 
+    // Wait for disconnection to complete
+    while (pH->mTelnet.getConnectionState() != QAbstractSocket::UnconnectedState) {
+        QApplication::processEvents();
+    }
+
     mConsoleMap[pH]->close();
     if (mTabMap.contains(pH->getName())) {
         mpTabBar->removeTab(tab);
@@ -1098,6 +1103,7 @@ void mudlet::slot_close_profile_requested(int tab)
     }
 }
 
+// Not currently used - may not be properly functional anymore!
 void mudlet::slot_close_profile()
 {
     if (mpCurrentActiveHost) {
@@ -1145,6 +1151,11 @@ void mudlet::slot_close_profile()
                 if (mpIrcClientMap.contains(pH)) {
                     mpIrcClientMap[pH]->setAttribute(Qt::WA_DeleteOnClose);
                     mpIrcClientMap[pH]->deleteLater();
+                }
+
+                // Wait for disconnection to complete
+                while (pH->mTelnet.getConnectionState() != QAbstractSocket::UnconnectedState) {
+                    QApplication::processEvents();
                 }
 
                 mConsoleMap[pH]->close();
@@ -2491,6 +2502,11 @@ void mudlet::closeEvent(QCloseEvent* event)
                 pC->mpHost->mpNotePad = nullptr;
             }
 
+            // Wait for disconnection to complete
+            while (pC->mpHost->mTelnet.getConnectionState() != QAbstractSocket::UnconnectedState) {
+                QApplication::processEvents();
+            }
+
             // close console
             pC->close();
         }
@@ -2535,6 +2551,11 @@ void mudlet::forceClose()
 
             if (mpIrcClientMap.contains(host)) {
                 mpIrcClientMap.value(host)->close();
+            }
+
+            // Wait for disconnection to complete
+            while (host->mTelnet.getConnectionState() != QAbstractSocket::UnconnectedState) {
+                QApplication::processEvents();
             }
         }
 


### PR DESCRIPTION
The cause of Issue #2288 "Mudlet freezes when closing secure profile with self-signed certificates on Linux" seems to be because there is an asynchronous signal from the network thread that arrive when there is not enough of the profile left to handle it.

Putting a call to the `cTelnet` method `disconnectIt()` {was called `disconnect()` see below} in the `Host` destructor is the primary suspect in this case!

This PR seems to fix the issue by not allowing the profile to be closed until it is known to be disconnected from the game server.

it also renames `(void) cTelnet::disconnect()` to `(void) cTelnet::disconnectIt()` this is so that it does not hide the non-static `QObject::disconnect(...)` call with three arguments which are all defaulted (although that does have a `bool` return type).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>