### PR TITLE
BugFix: missing header for non-updater platform builds

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -43,6 +43,7 @@
 #include <QScrollBar>
 #include <QTextBoundaryFinder>
 #include <QToolTip>
+#include <QVersionNumber>
 #include "post_guard.h"
 #include <chrono>
 


### PR DESCRIPTION
As FreeBSD does not include the updater code it is missing a needed header associated with handling `QVersionNumber`s - probably this header is a requirement for the updater code and since I recently added code that uses that class I had not spotted that the include was being provided indirectly rather than explicitly at the top of the implementation file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>