### PR TITLE
Fix punctuation being put on a line of their own when wrapped

### DIFF
--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -252,7 +252,7 @@ public:
 
 private:
     void shrinkBuffer();
-    int calcWrapPos(int line, int begin, int end);
+    int calculateWrapPosition(int lineNumber, int begin, int end);
     void handleNewLine();
     bool processUtf8Sequence(const std::string&, bool, size_t, size_t&, bool&);
     bool processGBSequence(const std::string&, bool, bool, size_t, size_t&, bool&);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix cases like this:

`Here is a line from a MUD. It has some words and then some more words and then word wrap
.`

So they are this:

`Here is a line from a MUD. It has some words and then some more words and then word
wrap.`

#### Motivation for adding to Mudlet
Happy @Eraene.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/1928.