### PR TITLE
Remove unused SSL-status boolean from ctelnet

### DIFF
--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -237,7 +237,6 @@ private:
     QTextEncoder* outgoingDataEncoder;
     QString hostName;
     int hostPort;
-    bool hostSslTsl;
     double networkLatencyMin;
     double networkLatencyMax;
     bool mWaitingForResponse;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove unused boolean from the `ctelnet` class which was added during SSL work.
#### Motivation for adding to Mudlet
Less Coverity complaints.
#### Other info (issues closed, discussion etc)
