### PR TITLE
Update: include some files in qmake project that were missing [skip CI]

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -607,7 +607,9 @@ HEADERS += \
     VarUnit.h \
     XMLexport.h \
     XMLimport.h \
-    widechar_width.h
+    widechar_width.h \
+    ../3rdparty/discord/rpc/include/discord_register.h \
+    ../3rdparty/discord/rpc/include/discord_rpc.h
 
 
 # This is for compiled UI files, not those used at runtime through the resource file.
@@ -1384,4 +1386,14 @@ DISTFILES += \
     ../mudlet.svg \
     ../README.md \
     ../translations/translated/CMakeLists.txt \
-    ../translations/translated/generate-translation-stats.lua
+    ../translations/translated/generate-translation-stats.lua \
+    ../COMMITMENT \
+    ../.crowdin.yml \
+    ../.gitignore \
+    ../.gitmodules \
+    ../translations/translated/updateqm.pri \
+    ../CI/mudlet-deploy-key.enc \
+    ../CI/copy-non-qt-win-dependencies.ps1 \
+    ../CI/mudlet-deploy-key-windows.ppk \
+    ../CI/qt-silent-install.qs \
+    ../CI/travis.compile.sh


### PR DESCRIPTION
They were thus missing from the view within the Qt Creator IDE:
* ../3rdparty/discord/rpc/include/discord_register.h
* ../3rdparty/discord/rpc/include/discord_rpc.h
* ../.crowdin.yml
* ../.gitignore
* ../.gitmodules
* ../COMMITMENT
* ../translations/translated/updateqm.pri
* ../CI/mudlet-deploy-key.enc
* ../CI/copy-non-qt-win-dependencies.ps1
* ../CI/mudlet-deploy-key-windows.ppk
* ../CI/qt-silent-install.qs
* ../CI/travis.compile.sh

There is no change to the code so it is not going to be helpful to run the CI processes - but it does mean that merging may have to be done by @vadi2 to force it past the requirement to have CI passes.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>