### PR TITLE
Refactor: rationalise TLuaInterpreter access to TConsoles (Part 01)

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1966,7 +1966,7 @@ QPair<int, QString> TConsole::select(const QString& text, const int numOfMatch)
                 P_end.setY(0);
                 return qMakePair(-1,
                                  QStringLiteral("there is not %1 of the text \"%2\" in the selected line")
-                                         .arg(QString::number(numOfMatch), numOfMatch > 1 ? QStringLiteral("%1 instances").arg(numOfMatch) : QStringLiteral("an instance"), text));
+                                         .arg(numOfMatch > 1 ? QStringLiteral("%1 instances").arg(numOfMatch) : QStringLiteral("an instance"), text));
             }
         }
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1941,16 +1941,17 @@ bool TConsole::moveCursor(int x, int y)
 QPair<int, QString> TConsole::select(const QString& text, const int numOfMatch)
 {
     if (mUserCursor.y() < 0) {
-        return qMakePair(-2, QStringLiteral("unable to select anything, the current line is set to be before the first one"));
+        return qMakePair(-1, QStringLiteral("invalid current line (%1), it is less than the first one in the buffer (0)").arg(QString::number(mUserCursor.y())));
     }
     if (mUserCursor.y() >= buffer.size()) {
-        return qMakePair(-2, QStringLiteral("unable to select anything, the current line is set to be after the last one"));
+        return qMakePair(-1, QStringLiteral("invalid current line (%1), it is greater than the last one in the buffer (%2)").arg(QString::number(mUserCursor.y()), QString::number(buffer.size() - 1)));
     }
 
     if (mudlet::debugMode) {
-        TDebug(QColor(Qt::darkMagenta), QColor(Qt::black)) << QStringLiteral("\nline under current user cursor: ") >> 0;
-        TDebug(QColor(Qt::red), QColor(Qt::black)) << QStringLiteral("%1#:").arg(mUserCursor.y()) >> 0;
-        TDebug(QColor(Qt::gray), QColor(Qt::black)) << QStringLiteral("%1\n").arg(buffer.line(mUserCursor.y())) >> 0;
+        TDebug(QColor(Qt::darkMagenta), QColor(Qt::black)) << QStringLiteral("\nLine under current user cursor: ") >> 0;
+        TDebug(QColor(Qt::red), QColor(Qt::black)) << QStringLiteral("#%1:\n\"").arg(mUserCursor.y()) >> 0;
+        TDebug(QColor(Qt::gray), QColor(Qt::black)) << QStringLiteral("%1").arg(buffer.line(mUserCursor.y())) >> 0;
+        TDebug(QColor(Qt::red), QColor(Qt::black)) << QStringLiteral("\"\n") >> 0;
     }
 
     int begin = -1;
@@ -1978,11 +1979,10 @@ QPair<int, QString> TConsole::select(const QString& text, const int numOfMatch)
     P_end.setY(mUserCursor.y());
 
     if (mudlet::debugMode) {
-        TDebug(QColor(Qt::darkRed), QColor(Qt::black)) << QStringLiteral("P_begin(%1/%2), P_end(%3/%4) selectedText:\n\"%5\"\n")
+        TDebug(QColor(Qt::darkRed), QColor(Qt::black)) << QStringLiteral("P_begin(%1/%2), P_end(%3/%2) selectedText:\n\"%4\"\n")
                                                                   .arg(QString::number(P_begin.x()),
                                                                        QString::number(P_begin.y()),
                                                                        QString::number(P_end.x()),
-                                                                       QString::number(P_end.y()),
                                                                        buffer.line(mUserCursor.y()).mid(P_begin.x(), P_end.x() - P_begin.x()))
                 >> 0;
     }
@@ -2000,7 +2000,7 @@ QPair<int, QString> TConsole::select(const QString& name, const QString& text, c
         return pC->select(text, numOfMatch);
     }
 
-    return qMakePair(-2, QStringLiteral("window \"%s\" not found").arg(name));
+    return qMakePair(-1, QStringLiteral("window \"%s\" not found").arg(name));
 }
 
 bool TConsole::selectSection(int from, int to)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -122,7 +122,8 @@ public:
 
     void echo(const QString&);
     bool moveCursor(int x, int y);
-    int select(const QString&, int numOfMatch = 1);
+    QPair<int, QString> select(const QString& text, const int numOfMatch);
+    QPair<int, QString> select(const QString& name, const QString& text, const int numOfMatch = 1);
     std::tuple<bool, QString, int, int> getSelection();
     void deselect();
     bool selectSection(int, int);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -571,8 +571,8 @@ int TLuaInterpreter::selectString(lua_State* L)
 
     searchText = QString::fromUtf8(lua_tostring(L, s));
     if (searchText.isEmpty()) {
-        lua_pushnil(L);
-        lua_pushstring(L, "an empty string is not selectable");
+        lua_pushnumber(L, -1);
+        lua_pushstring(L, "it is not possible to select an empty string");
         return 2;
     }
 
@@ -585,13 +585,12 @@ int TLuaInterpreter::selectString(lua_State* L)
     numOfMatch = lua_tointeger(L, s);
 
     QPair<int, QString> result = host.mpConsole->select(windowName, searchText, numOfMatch);
-    if (result.first == -2) {
-        lua_pushnil(L);
+    lua_pushnumber(L, result.first);
+    if (result.first == -1) {
         lua_pushstring(L, result.second.toUtf8().constData());
         return 2;
     }
 
-    lua_pushnumber(L, result.first);
     return 1;
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2538,20 +2538,6 @@ void mudlet::setBgColor(Host* pHost, const QString& name, int r, int g, int b)
     }
 }
 
-int mudlet::selectString(Host* pHost, const QString& name, const QString& text, int num)
-{
-    if (!pHost || !pHost->mpConsole) {
-        return -1;
-    }
-
-    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        return pC->select(text, num);
-    } else {
-        return -1;
-    }
-}
-
 int mudlet::selectSection(Host* pHost, const QString& name, int f, int t)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -157,7 +157,6 @@ public:
     void deleteLine(Host*, const QString& name);
     bool insertText(Host*, const QString& windowName, const QString&);
     void replace(Host*, const QString& name, const QString&);
-    int selectString(Host*, const QString& name, const QString& what, int);
     int selectSection(Host*, const QString& name, int, int);
     void setLink(Host* pHost, const QString& name, QStringList& linkFunction, QStringList&);
     std::tuple<bool, QString, int, int> getSelection(Host* pHost, const QString& name);


### PR DESCRIPTION
This revises the lua `selectString(...)` function. As well as selecting the given instance of the given text in the given window (which is the main profile `TConsole` if the name is omitted or is the empty string) it also returns the first character position in the relevant line in the buffer or -1 if the text does not occur the requested number of times in the (previously) selected line.

There are a couple of other error conditions that can also return an error (if the selected line is outside of the range of lines within the buffer) as they are run-time they will now cause a nil plus error message - as will trying to select an empty string.

I18n note: the character position is still the index into the `QChar`s that make up the UTF-16 encoded representation of the string - this is demonstrably WRONG for anything other than ASCII text... especially because we use UTF-8 in the lua subsystem!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>