### PR TITLE
Revise: remove colour palettes from editor search area

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -471,7 +471,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar->addAction(mProfileSaveAsAction);
     toolBar->addAction(mProfileSaveAction);
 
-    connect(button_displayAllVariables, &QAbstractButton::toggled, this, &dlgTriggerEditor::slot_toggleHiddenVariables);
+    connect(checkBox_displayAllVariables, &QAbstractButton::toggled, this, &dlgTriggerEditor::slot_toggleHiddenVariables);
 
     connect(mpVarsMainArea->checkBox_variable_hidden, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_toggleHiddenVar);
 
@@ -6574,7 +6574,7 @@ void dlgTriggerEditor::changeView(int view)
     mpKeysMainArea->hide();
     mpVarsMainArea->hide();
     // hiding this for some reason shifts focus to the search box
-    button_displayAllVariables->hide();
+    checkBox_displayAllVariables->hide();
 
     clearEditorNotification();
     treeWidget_triggers->hide();
@@ -6685,8 +6685,8 @@ void dlgTriggerEditor::slot_show_vars()
     repopulateVars();
     mpCurrentVarItem = nullptr;
     mpSourceEditorArea->show();
-    button_displayAllVariables->show();
-    button_displayAllVariables->setChecked(showHiddenVars);
+    checkBox_displayAllVariables->show();
+    checkBox_displayAllVariables->setChecked(showHiddenVars);
     QTreeWidgetItem* pI = treeWidget_variables->topLevelItem(0);
     if (pI) {
         if (pI->childCount() > 0) {
@@ -6711,8 +6711,8 @@ void dlgTriggerEditor::show_vars()
     changeView(static_cast<int>(EditorViewType::cmVarsView));
     mpCurrentVarItem = nullptr;
     mpSourceEditorArea->show();
-    button_displayAllVariables->show();
-    button_displayAllVariables->setChecked(showHiddenVars);
+    checkBox_displayAllVariables->show();
+    checkBox_displayAllVariables->setChecked(showHiddenVars);
     QTreeWidgetItem* pI = treeWidget_variables->topLevelItem(0);
     if (pI) {
         if (pI->childCount() > 0) {
@@ -7502,7 +7502,7 @@ void dlgTriggerEditor::slot_paste_xml()
         selectTriggerByID(importedItemID);
         treeWidget_triggers->setAnimated(animated);
 
-        // set the focus because hiding button_displayAllVariables in changeView
+        // set the focus because hiding checkBox_displayAllVariables in changeView
         // changes the focus to the search box for some reason. This thus breaks
         // successive pastes because you'll now be pasting into the search box
         treeWidget_triggers->setFocus();

--- a/src/ui/trigger_editor.ui
+++ b/src/ui/trigger_editor.ui
@@ -93,7 +93,7 @@
        <property name="lineWidth">
         <number>1</number>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <layout class="QVBoxLayout" name="verticalLayout_frame_left" stretch="2,2,2,2,2,2,2,0,0,1">
         <property name="spacing">
          <number>1</number>
         </property>
@@ -430,258 +430,103 @@
           </column>
          </widget>
         </item>
-        <item>
-         <widget class="QFrame" name="frame_">
-          <layout class="QGridLayout" name="gridLayout_display_hidden_variables">
-           <property name="leftMargin">
-            <number>8</number>
-           </property>
-           <property name="topMargin">
-            <number>3</number>
-           </property>
-           <property name="rightMargin">
-            <number>8</number>
-           </property>
-           <property name="bottomMargin">
-            <number>3</number>
-           </property>
-           <item row="0" column="0" alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-            <widget class="QCheckBox" name="button_displayAllVariables">
-             <property name="text">
-              <string>Show normally hidden variables</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
+        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+         <widget class="QCheckBox" name="checkBox_displayAllVariables">
+          <property name="text">
+           <string>Show normally hidden variables</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
          </widget>
         </item>
         <item>
-         <widget class="QWidget" name="widget_searchArea" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout_6">
-           <property name="spacing">
-            <number>0</number>
-           </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
+         <widget class="QWidget" name="widget_searchTerm" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_searchTerm" stretch="0,0,0">
            <property name="topMargin">
             <number>0</number>
            </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
            <property name="bottomMargin">
-            <number>0</number>
+            <number>3</number>
            </property>
            <item>
-            <widget class="QWidget" name="widget_searchAreaTop" native="true">
+            <widget class="QLabel" name="label_searchTerm">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="palette">
-              <palette>
-               <active>
-                <colorrole role="Base">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>255</green>
-                   <blue>255</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-                <colorrole role="Window">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>234</green>
-                   <blue>218</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </active>
-               <inactive>
-                <colorrole role="Base">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>255</green>
-                   <blue>255</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-                <colorrole role="Window">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>234</green>
-                   <blue>218</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </inactive>
-               <disabled>
-                <colorrole role="Base">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>234</green>
-                   <blue>218</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-                <colorrole role="Window">
-                 <brush brushstyle="SolidPattern">
-                  <color alpha="255">
-                   <red>255</red>
-                   <green>234</green>
-                   <blue>218</blue>
-                  </color>
-                 </brush>
-                </colorrole>
-               </disabled>
-              </palette>
+             <property name="text">
+              <string>Search:</string>
              </property>
-             <property name="autoFillBackground">
-              <bool>true</bool>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
-             <layout class="QHBoxLayout" name="horizontalLayout_5">
-              <property name="spacing">
-               <number>0</number>
-              </property>
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QWidget" name="widget_searchTerm" native="true">
-                <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-                 <property name="leftMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>3</number>
-                 </property>
-                 <property name="horizontalSpacing">
-                  <number>5</number>
-                 </property>
-                 <item row="0" column="0" alignment="Qt::AlignRight|Qt::AlignVCenter">
-                  <widget class="QLabel" name="label_searchTerm">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Search:</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1" alignment="Qt::AlignVCenter">
-                  <widget class="QComboBox" name="comboBox_searchTerms">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="editable">
-                    <bool>true</bool>
-                   </property>
-                   <property name="insertPolicy">
-                    <enum>QComboBox::InsertAtTop</enum>
-                   </property>
-                   <property name="duplicatesEnabled">
-                    <bool>true</bool>
-                   </property>
-                   <property name="frame">
-                    <bool>false</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="2" alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-                  <widget class="QToolButton" name="button_toggleSearchAreaResults">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="minimumSize">
-                    <size>
-                     <width>16</width>
-                     <height>16</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>32</width>
-                     <height>32</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>&lt;p&gt;Toggles the display of the search results area.&lt;/p&gt;</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="iconSize">
-                    <size>
-                     <width>16</width>
-                     <height>16</height>
-                    </size>
-                   </property>
-                   <property name="checkable">
-                    <bool>true</bool>
-                   </property>
-                   <property name="arrowType">
-                    <enum>Qt::NoArrow</enum>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-             </layout>
             </widget>
            </item>
            <item>
-            <widget class="QTreeWidget" name="treeWidget_searchResults">
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
+            <widget class="QComboBox" name="comboBox_searchTerms">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <property name="midLineWidth">
-              <number>4</number>
+             <property name="minimumSize">
+              <size>
+               <width>180</width>
+               <height>28</height>
+              </size>
              </property>
-             <property name="alternatingRowColors">
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+             <property name="insertPolicy">
+              <enum>QComboBox::InsertAtTop</enum>
+             </property>
+             <property name="duplicatesEnabled">
+              <bool>true</bool>
+             </property>
+             <property name="frame">
               <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="button_toggleSearchAreaResults">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>16</width>
+               <height>16</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>32</width>
+               <height>32</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>&lt;p&gt;Toggles the display of the search results area.&lt;/p&gt;</string>
+             </property>
+             <property name="text">
+              <string/>
              </property>
              <property name="iconSize">
               <size>
@@ -689,54 +534,93 @@
                <height>16</height>
               </size>
              </property>
-             <property name="textElideMode">
-              <enum>Qt::ElideRight</enum>
-             </property>
-             <property name="rootIsDecorated">
+             <property name="checkable">
               <bool>true</bool>
              </property>
-             <property name="uniformRowHeights">
-              <bool>true</bool>
+             <property name="arrowType">
+              <enum>Qt::NoArrow</enum>
              </property>
-             <property name="sortingEnabled">
-              <bool>true</bool>
-             </property>
-             <property name="animated">
-              <bool>true</bool>
-             </property>
-             <property name="headerHidden">
-              <bool>false</bool>
-             </property>
-             <property name="columnCount">
-              <number>3</number>
-             </property>
-             <attribute name="headerVisible">
-              <bool>true</bool>
-             </attribute>
-             <attribute name="headerDefaultSectionSize">
-              <number>80</number>
-             </attribute>
-             <attribute name="headerMinimumSectionSize">
-              <number>20</number>
-             </attribute>
-             <column>
-              <property name="text">
-               <string>1</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string notr="true">2</string>
-              </property>
-             </column>
-             <column>
-              <property name="text">
-               <string notr="true">3</string>
-              </property>
-             </column>
             </widget>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTreeWidget" name="treeWidget_searchResults">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="midLineWidth">
+           <number>4</number>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QAbstractScrollArea::AdjustToContents</enum>
+          </property>
+          <property name="alternatingRowColors">
+           <bool>false</bool>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>16</width>
+            <height>16</height>
+           </size>
+          </property>
+          <property name="textElideMode">
+           <enum>Qt::ElideRight</enum>
+          </property>
+          <property name="rootIsDecorated">
+           <bool>true</bool>
+          </property>
+          <property name="uniformRowHeights">
+           <bool>true</bool>
+          </property>
+          <property name="sortingEnabled">
+           <bool>true</bool>
+          </property>
+          <property name="animated">
+           <bool>true</bool>
+          </property>
+          <property name="headerHidden">
+           <bool>false</bool>
+          </property>
+          <property name="columnCount">
+           <number>4</number>
+          </property>
+          <attribute name="headerVisible">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="headerDefaultSectionSize">
+           <number>80</number>
+          </attribute>
+          <attribute name="headerMinimumSectionSize">
+           <number>20</number>
+          </attribute>
+          <column>
+           <property name="text">
+            <string>1</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string notr="true">2</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string notr="true">3</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string notr="true">4</string>
+           </property>
+          </column>
          </widget>
         </item>
        </layout>
@@ -746,9 +630,10 @@
        <zorder>treeWidget_actions</zorder>
        <zorder>treeWidget_scripts</zorder>
        <zorder>treeWidget_triggers</zorder>
-       <zorder>widget_searchArea</zorder>
        <zorder>treeWidget_variables</zorder>
-       <zorder>frame_</zorder>
+       <zorder>treeWidget_searchResults</zorder>
+       <zorder>checkBox_displayAllVariables</zorder>
+       <zorder>widget_searchTerm</zorder>
       </widget>
       <widget class="QFrame" name="frame_right">
        <property name="sizePolicy">


### PR DESCRIPTION
The palette settings there do not work well when using a dark theme, removing the previous palette details does not seem to have any other side effects.

At the same time I have also renamed the editor control:
* `(QCheckBox*) dlgTriggerEditor::button_displayAllVariables` ==> `dlgTriggerEditor::checkBox_displayAllVariables`
because it *is* a `QCheckBox` and not the `QPushButton` it once was!

I also managed to simplify the widget structure on the left side of the editor - by removing some container widgets - this should make the layout work better in extreme cases or if some text elements change their needed sizes when the GUI language is changed.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>