### PR TITLE
Remove unnecessary if check in ctelnet decompression

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2244,48 +2244,46 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                     command = "";
                     iac = false;
                 } else if (insb) {
-                    if (!mNeedDecompression) {
-                        // IAC SB COMPRESS WILL SE for MCCP v1 (unterminated invalid telnet sequence)
-                        // IAC SB COMPRESS2 IAC SE for MCCP v2
-                        if ((mMCCP_version_1 || mMCCP_version_2) && (!mNeedDecompression)) {
-                            char _ch = buffer[i];
-                            if ((_ch == OPT_COMPRESS) || (_ch == OPT_COMPRESS2)) {
-                                bool _compress = false;
-                                if ((i > 1) && (i + 2 < datalen)) {
-                                    qDebug() << "checking mccp start seq...";
-                                    if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_WILL) && (buffer[i + 2] == TN_SE)) {
-                                        qDebug() << "MCCP version 1 starting sequence";
-                                        _compress = true;
-                                    }
-                                    if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_IAC) && (buffer[i + 2] == TN_SE)) {
-                                        qDebug() << "MCCP version 2 starting sequence";
-                                        _compress = true;
-                                    }
-                                    qDebug() << (int)buffer[i - 2] << "," << (int)buffer[i - 1] << "," << (int)buffer[i] << "," << (int)buffer[i + 1] << "," << (int)buffer[i + 2];
+                    // IAC SB COMPRESS WILL SE for MCCP v1 (unterminated invalid telnet sequence)
+                    // IAC SB COMPRESS2 IAC SE for MCCP v2
+                    if ((mMCCP_version_1 || mMCCP_version_2) && (!mNeedDecompression)) {
+                        char _ch = buffer[i];
+                        if ((_ch == OPT_COMPRESS) || (_ch == OPT_COMPRESS2)) {
+                            bool _compress = false;
+                            if ((i > 1) && (i + 2 < datalen)) {
+                                qDebug() << "checking mccp start seq...";
+                                if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_WILL) && (buffer[i + 2] == TN_SE)) {
+                                    qDebug() << "MCCP version 1 starting sequence";
+                                    _compress = true;
                                 }
-                                if (_compress) {
-                                    mNeedDecompression = true;
-                                    // from this position in stream onwards, data will be compressed by zlib
-                                    gotRest(cleandata);
-                                    cleandata = "";
-                                    initStreamDecompressor();
-                                    buffer += i + 3; //bugfix: BenH
-                                    int restLength = datalen - i - 3;
-                                    if (restLength > 0) {
-                                        datalen = decompressBuffer(buffer, restLength, out_buffer);
-                                        buffer = out_buffer;
-                                        i = -1; // start processing buffer from the beginning.
-                                    } else {
-                                        datalen = 0;
-                                        i = -1; // end the loop, this will make i and datalen the same.
-                                    }
-                                    //bugfix: BenH
-                                    iac = false;
-                                    insb = false;
-                                    command = "";
-                                    ////////////////
-                                    goto MAIN_LOOP_END;
+                                if ((buffer[i - 2] == TN_IAC) && (buffer[i - 1] == TN_SB) && (buffer[i + 1] == TN_IAC) && (buffer[i + 2] == TN_SE)) {
+                                    qDebug() << "MCCP version 2 starting sequence";
+                                    _compress = true;
                                 }
+                                qDebug() << (int)buffer[i - 2] << "," << (int)buffer[i - 1] << "," << (int)buffer[i] << "," << (int)buffer[i + 1] << "," << (int)buffer[i + 2];
+                            }
+                            if (_compress) {
+                                mNeedDecompression = true;
+                                // from this position in stream onwards, data will be compressed by zlib
+                                gotRest(cleandata);
+                                cleandata = "";
+                                initStreamDecompressor();
+                                buffer += i + 3; //bugfix: BenH
+                                int restLength = datalen - i - 3;
+                                if (restLength > 0) {
+                                    datalen = decompressBuffer(buffer, restLength, out_buffer);
+                                    buffer = out_buffer;
+                                    i = -1; // start processing buffer from the beginning.
+                                } else {
+                                    datalen = 0;
+                                    i = -1; // end the loop, this will make i and datalen the same.
+                                }
+                                //bugfix: BenH
+                                iac = false;
+                                insb = false;
+                                command = "";
+                                ////////////////
+                                goto MAIN_LOOP_END;
                             }
                         }
                     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove the single `if (!mNeedDecompression) {` check on top because we already check it a few lines after.
#### Motivation for adding to Mudlet
Less confusing code.
#### Other info (issues closed, discussion etc)
Diff looks absolutely horrible...