### PR TITLE
Default-initialise Mudlet event objects before use

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -399,7 +399,7 @@ void Host::resetProfile()
 
     mTimerUnit.reenableAllTriggers();
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     raiseEvent(event);
@@ -747,7 +747,7 @@ void Host::raiseEvent(const TEvent& pE)
 
 void Host::postIrcMessage(const QString& a, const QString& b, const QString& c)
 {
-    TEvent event;
+    TEvent event {};
     event.mArgumentList << QLatin1String("sysIrcMessage");
     event.mArgumentList << a << b << c;
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING << ARGUMENT_TYPE_STRING;
@@ -995,14 +995,14 @@ bool Host::installPackage(const QString& fileName, int module)
     // raise 2 events - a generic one and a more detailed one to serve both
     // a simple need ("I just want the install event") and a more specific need
     // ("I specifically need to know when the module was synced")
-    TEvent genericInstallEvent;
+    TEvent genericInstallEvent {};
     genericInstallEvent.mArgumentList.append(QLatin1String("sysInstall"));
     genericInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     genericInstallEvent.mArgumentList.append(packageName);
     genericInstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     raiseEvent(genericInstallEvent);
 
-    TEvent detailedInstallEvent;
+    TEvent detailedInstallEvent {};
     switch (module) {
     case 0:
         detailedInstallEvent.mArgumentList.append(QLatin1String("sysInstallPackage"));
@@ -1075,14 +1075,14 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     // raise 2 events - a generic one and a more detailed one to serve both
     // a simple need ("I just want the uninstall event") and a more specific need
     // ("I specifically need to know when the module was uninstalled via Lua")
-    TEvent genericUninstallEvent;
+    TEvent genericUninstallEvent {};
     genericUninstallEvent.mArgumentList.append(QLatin1String("sysUninstall"));
     genericUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     genericUninstallEvent.mArgumentList.append(packageName);
     genericUninstallEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     raiseEvent(genericUninstallEvent);
 
-    TEvent detailedUninstallEvent;
+    TEvent detailedUninstallEvent {};
     switch (module) {
     case 0:
         detailedUninstallEvent.mArgumentList.append(QLatin1String("sysUninstallPackage"));

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3331,7 +3331,7 @@ void T2DMap::slot_setPlayerLocation()
         // No need to check it is a DIFFERENT room - that is taken care of by en/dis-abling the control
         mpMap->mRoomIdHash[mpMap->mProfileName] = _newRoomId;
         mpMap->mNewMove = true;
-        TEvent manualSetEvent;
+        TEvent manualSetEvent {};
         manualSetEvent.mArgumentList.append(QLatin1String("sysManualLocationSetEvent"));
         manualSetEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         manualSetEvent.mArgumentList.append(QString::number(_newRoomId));
@@ -3343,7 +3343,7 @@ void T2DMap::slot_setPlayerLocation()
 
 void T2DMap::slot_userAction(QString uniqueName)
 {
-    TEvent event;
+    TEvent event {};
     QStringList userEvent = mUserActions[uniqueName];
     event.mArgumentList.append(userEvent[0]);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -649,7 +649,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
         QString n = "WindowResizeEvent";
         pLua->call(func, n);
 
-        TEvent mudletEvent;
+        TEvent mudletEvent {};
         mudletEvent.mArgumentList.append(QLatin1String("sysWindowResizeEvent"));
         mudletEvent.mArgumentList.append(QString::number(x - mMainFrameLeftWidth - mMainFrameRightWidth));
         mudletEvent.mArgumentList.append(QString::number(y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height()));
@@ -757,7 +757,7 @@ void TConsole::closeEvent(QCloseEvent* event)
     }
 
     if (mProfileName != QLatin1String("default_host")) {
-        TEvent conCloseEvent;
+        TEvent conCloseEvent {};
         conCloseEvent.mArgumentList.append(QLatin1String("sysExitEvent"));
         conCloseEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent(conCloseEvent);
@@ -2216,7 +2216,7 @@ void TConsole::createMapper(int x, int y, int width, int height)
 
         mpHost->mpMap->pushErrorMessagesToFile(tr("Loading map(2) at %1 report").arg(now.toString(Qt::ISODate)), true);
 
-        TEvent mapOpenEvent;
+        TEvent mapOpenEvent {};
         mapOpenEvent.mArgumentList.append(QLatin1String("mapOpenEvent"));
         mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent(mapOpenEvent);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -149,7 +149,7 @@ void TLuaInterpreter::slot_replyFinished(QNetworkReply* reply)
     }
 
     QString localFileName = downloadMap.value(reply);
-    TEvent event;
+    TEvent event {};
     if (reply->error() != QNetworkReply::NoError) {
         event.mArgumentList << QLatin1String("sysDownloadError");
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -412,7 +412,7 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
 {
     Host& host = getHostFromLua(L);
 
-    TEvent event;
+    TEvent event {};
 
     int n = lua_gettop(L);
     // We go from the top of the stack down, because luaL_ref will
@@ -494,7 +494,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
         return 1;
     }
 
-    TEvent event;
+    TEvent event {};
 
     for (int i = 1; i <= n; ++i) {
         // The sending profile of the event does not receive the event if
@@ -3478,7 +3478,7 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         lua_remove(L, 1);
     }
 
-    TEvent event;
+    TEvent event {};
     int n = lua_gettop(L);
     // Iterate from the top down thru the stack because luaL_ref requires
     // the object (table or function in our case) to be on top
@@ -12447,7 +12447,7 @@ int TLuaInterpreter::ttsSetRate(lua_State* L)
 
     speechUnit->setRate(rate);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("ttsRateChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(rate));
@@ -12482,7 +12482,7 @@ int TLuaInterpreter::ttsSetPitch(lua_State* L)
 
     speechUnit->setPitch(pitch);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("ttsPitchChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(pitch));
@@ -12517,7 +12517,7 @@ int TLuaInterpreter::ttsSetVolume(lua_State* L)
 
     speechUnit->setVolume(volume);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("ttsVolumeChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(volume));
@@ -12605,7 +12605,7 @@ int TLuaInterpreter::ttsSetVoiceByName(lua_State* L)
             speechUnit->setVoice(voice);
             lua_pushboolean(L, true);
 
-            TEvent event;
+            TEvent event {};
             event.mArgumentList.append(QLatin1String("ttsVoiceChanged"));
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             event.mArgumentList.append(voice.name());
@@ -12645,7 +12645,7 @@ int TLuaInterpreter::ttsSetVoiceByIndex(lua_State* L)
 
     speechUnit->setVoice(speechVoices.at(index));
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("ttsVoiceChanged"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(speechVoices[index].name());
@@ -12661,7 +12661,7 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
 {
     if (state != speechState) {
         speechState = state;
-        TEvent event;
+        TEvent event {};
         switch (state) {
         case QTextToSpeech::Paused:
             event.mArgumentList.append(QLatin1String("ttsSpeechPaused"));
@@ -12738,7 +12738,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
 
     speechQueue.insert(index, inputText);
 
-    TEvent event;
+    TEvent event {};
     Host& host = getHostFromLua(L);
     event.mArgumentList.append(QLatin1String("ttsSpeechQueued"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -13255,7 +13255,7 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
     lua_rawset(L, -3);
     lua_pop(L, 1);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(var);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(arg);
@@ -13391,7 +13391,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
     }
 
     for (int k = 0, total = tokenList.size(); k < total; ++k) {
-        TEvent event;
+        TEvent event {};
         token.append(".");
         token.append(tokenList[k]);
         event.mArgumentList.append(token);
@@ -13559,7 +13559,7 @@ void TLuaInterpreter::setChannel102Table(int& var, int& arg)
     lua_rawset(L, -3);
     lua_pop(L, 1);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("channel102Message"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(var));

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2450,7 +2450,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
                     // direct importation of a local copy of a map file.
 
                     if (readXmlMapFile(file)) {
-                        TEvent mapDownloadEvent;
+                        TEvent mapDownloadEvent {};
                         mapDownloadEvent.mArgumentList.append(QLatin1String("sysMapDownloadEvent"));
                         mapDownloadEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
                         pHost->raiseEvent(mapDownloadEvent);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1014,7 +1014,7 @@ void TTextEdit::slot_popupMenu()
 void TTextEdit::mousePressEvent(QMouseEvent* event)
 {
     if (mpConsole->getType() & (TConsole::MainConsole|TConsole::Buffer)) {
-        TEvent mudletEvent;
+        TEvent mudletEvent {};
         mudletEvent.mArgumentList.append(QLatin1String("sysWindowMousePressEvent"));
         switch (event->button()) {
         case Qt::LeftButton:
@@ -1574,7 +1574,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
     }
 
     if (mpConsole->getType() == TConsole::MainConsole) {
-        TEvent mudletEvent;
+        TEvent mudletEvent {};
         mudletEvent.mArgumentList.append(QLatin1String("sysWindowMouseReleaseEvent"));
         switch (event->button()) {
         case Qt::LeftButton:

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -426,7 +426,7 @@ void cTelnet::handle_socket_signal_connected()
 
     emit signal_connected(mpHost);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QStringLiteral("sysConnectionEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     mpHost->raiseEvent(event);
@@ -435,7 +435,7 @@ void cTelnet::handle_socket_signal_connected()
 void cTelnet::handle_socket_signal_disconnected()
 {
     QString msg;
-    TEvent event;
+    TEvent event {};
     QString reason;
     QString spacer = "    ";
     bool sslerr = false;
@@ -560,7 +560,7 @@ bool cTelnet::sendData(QString& data)
 {
     data.remove(QChar::LineFeed);
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QStringLiteral("sysDataSendRequest"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(data);
@@ -1476,7 +1476,7 @@ void cTelnet::processTelnetCommand(const string& command)
             msg = msg.mid(3, command.size() - 5);
         }
 
-        TEvent event;
+        TEvent event {};
         event.mArgumentList.append(QStringLiteral("sysTelnetEvent"));
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         event.mArgumentList.append(QString::number(type));
@@ -2356,7 +2356,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
 
 void cTelnet::raiseProtocolEvent(const QString& name, const QString& protocol)
 {
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(name);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(protocol);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3305,7 +3305,7 @@ void mudlet::createMapper(bool loadDefaultMap)
     loadWindowLayout();
 
     check_for_mappingscript();
-    TEvent mapOpenEvent;
+    TEvent mapOpenEvent {};
     mapOpenEvent.mArgumentList.append(QLatin1String("mapOpenEvent"));
     mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     pHost->raiseEvent(mapOpenEvent);
@@ -3631,7 +3631,7 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, int historyVer
 
     packagesToInstallList.clear();
 
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     pHost->raiseEvent(event);
@@ -3907,7 +3907,7 @@ void mudlet::playSound(const QString& s, int soundVolume)
 
     connect(pPlayer, &QMediaPlayer::stateChanged, [=](QMediaPlayer::State state) {
         if (state == QMediaPlayer::StoppedState) {
-            TEvent soundFinished;
+            TEvent soundFinished {};
             soundFinished.mArgumentList.append("sysSoundFinished");
             soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             soundFinished.mArgumentList.append(pPlayer->media().canonicalUrl().fileName());
@@ -4103,7 +4103,7 @@ void mudlet::slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButto
     if (!pH) {
         return;
     }
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysGamepadButtonPress"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(deviceId));
@@ -4121,7 +4121,7 @@ void mudlet::slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadBut
     if (!pH) {
         return;
     }
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysGamepadButtonRelease"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(deviceId));
@@ -4137,7 +4137,7 @@ void mudlet::slot_gamepadConnected(int deviceId)
     if (!pH) {
         return;
     }
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysGamepadConnected"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(deviceId));
@@ -4151,7 +4151,7 @@ void mudlet::slot_gamepadDisconnected(int deviceId)
     if (!pH) {
         return;
     }
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysGamepadDisconnected"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(deviceId));
@@ -4165,7 +4165,7 @@ void mudlet::slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis ax
     if (!pH) {
         return;
     }
-    TEvent event;
+    TEvent event {};
     event.mArgumentList.append(QLatin1String("sysGamepadAxisMove"));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(deviceId));


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Default-initialise Mudlet event objects before use
#### Motivation for adding to Mudlet
Less static analyser warnings? Possibly less side-effects too.
#### Other info (issues closed, discussion etc)
