### PR TITLE
Enhance: add Event when application Style-sheet set

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5144,7 +5144,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
     int n = lua_gettop(L);
     if (n) {
         if (!lua_isstring(L, ++s)) {
-            lua_pushfstring(L, "setAppStyleSheet: bad argument #%d type (style sheet as string expected {may be omitted to remove existing stylesheet}, got %s!)", s, luaL_typename(L, s));
+            lua_pushfstring(L, "setAppStyleSheet: bad argument #%d type (style sheet as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
         styleSheet = QString::fromUtf8(lua_tostring(L, s));
@@ -5167,7 +5167,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
     event.mArgumentList.append(host.getName());
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     qApp->setStyleSheet(styleSheet);
-    mudlet::self()->getHostManager().postInterHostEvent(NULL, event, true);
+    mudlet::self()->getHostManager().postInterHostEvent(nullptr, event, true);
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5138,12 +5138,38 @@ int TLuaInterpreter::echoUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setAppStyleSheet
 int TLuaInterpreter::setAppStyleSheet(lua_State* L)
 {
-    if (lua_isstring(L, 1)) {
-        string stylesheet = lua_tostring(L, 1);
-        qApp->setStyleSheet(stylesheet.c_str());
+    QString styleSheet;
+    QString tag;
+    int s = 0;
+    int n = lua_gettop(L);
+    if (n) {
+        if (!lua_isstring(L, ++s)) {
+            lua_pushfstring(L, "setAppStyleSheet: bad argument #%d type (style sheet as string expected {may be omitted to remove existing stylesheet}, got %s!)", s, luaL_typename(L, s));
+            return lua_error(L);
+        }
+        styleSheet = QString::fromUtf8(lua_tostring(L, s));
     }
 
-    return 0;
+    if (n > 1) {
+        if (!lua_isstring(L, ++s)) {
+            lua_pushfstring(L, "setAppStyleSheet: bad argument #%d type (tag as string is optional, got %s!)", s, luaL_typename(L, s));
+            return lua_error(L);
+        }
+        tag = QString::fromUtf8(lua_tostring(L, s));
+    }
+
+    Host& host = getHostFromLua(L);
+    TEvent event;
+    event.mArgumentList.append(QLatin1String("sysAppStyleSheetChange"));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(tag);
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(host.getName());
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    qApp->setStyleSheet(styleSheet);
+    mudlet::self()->getHostManager().postInterHostEvent(NULL, event, true);
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // this was an internal only function used by the package system, but it was


### PR DESCRIPTION
Using the Lua function `setAppStyleSheet` will likely wipe out any local changes that Geyser and user scripts have made to things like labels (and gauges that are based upon them).  It is essential therefore for those to be aware that this has happened - so this PR provides a "sysAppStyleSheetChange" event that will be sent to ALL profiles when it is called from one of them. To allow individual bits of code to trace the origin of the call (in case it was responsible for it and must therefore not respond to it in the same way) an optional second (string) argument to the setAppStyleSheet call will propagate into the event passed by the system as a second argument (will be an empty string if omitted) and the source of the event (the profile name) will be included as a third argument.

At this time I am also producing another PR that will involve the Mudlet application itself applying an application style sheet - so that that can be accommodates I will arrange for it too to produce this event type when it acts - in this case the second argument will likely be one of `mudlet-theme-dark` or `mudlet-theme-light` and the third will be `system`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>