### PR TITLE
BugFix: error in recent PR to properly clear mudlet class Hosts' timers map

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -230,6 +230,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
 Host::~Host()
 {
+    mudlet::self()->removeHostTimerMap(this);
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1663,11 +1663,22 @@ void mudlet::clearHostTimerMap(Host* pHost)
     }
 
     Q_ASSERT_X(mHostTimerMap.contains(pHost), "mudlet::clearHostTimerMap(...)", "the mHostTimerMap does not contain the Host instance that the TTimer seems to belong to");
-    QMap<QTimer*, TTimer*> hostTimerMap = mHostTimerMap.take(pHost);
+    auto hostTimerMap = mHostTimerMap.value(pHost);
+//    qDebug().nospace().noquote() << "mudlet::clearHostTimerMap(...) INFO - clearing QTimer<==>TTimer map, containing " << hostTimerMap.size() << " entries, for profile \"" << pHost->getName() << "\".";
+    // Remove all the timers register for that host in it's QMap- BUT DON'T
+    // remove the container itself - as we may be resetting the profile not
+    // closing it:
+    for (auto timer : hostTimerMap) {
+        delete timer;
+    }
+}
 
-// This will silence a warning whilst the line following it is commented out:
-    Q_UNUSED(hostTimerMap);
-//  qDebug().nospace().noquote() << "mudlet::clearHostTimerMap(...) INFO - removed QTimer<==>TTimer map, containing " << hostTimerMap.size() << " entries, for profile \"" << pHost->getName() << "\".";
+// Like the above but also removes the Host's QMap<QTimer*, TTimer*> entry
+// in the mudlet::mHostTimerMap map:
+void mudlet::removeHostTimerMap(Host* pHost)
+{
+    clearHostTimerMap(pHost);
+    mHostTimerMap.remove(pHost);
 }
 
 void mudlet::disableToolbarButtons()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -116,6 +116,7 @@ public:
     void registerTimer(TTimer*);
     void unregisterTimer(TTimer*);
     void clearHostTimerMap(Host*);
+    void removeHostTimerMap(Host*);
     void forceClose();
     bool saveWindowLayout();
     bool loadWindowLayout();


### PR DESCRIPTION
This should close https://github.com/Mudlet/Mudlet/issues/2471 which was introduced by the PR "Don't reset other profile's timers with resetProfile()" https://github.com/Mudlet/Mudlet/pull/2257 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>