### PR TITLE
Enhance: New parameter nestflyout=true, use with nestable=true...

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -410,7 +410,7 @@ end
 --- Internal function when a parent nest element is clicked
 --- to lay out the nested elements within
 -- @param label The name of the label to use
-function doNestClick(label)
+function doNestShow(label)
   Geyser.Label:displayNest(label)
 end
 
@@ -465,13 +465,12 @@ function Geyser.Label:new (cons, container)
 
   -- Set up mouse hover as the callback if we have one
   if cons.nestflyout then
-    --echo("setting hover to doNestClick")
-    setLabelOnEnter(me.name, "doNestClick", me.name)
+    setLabelOnEnter(me.name, "doNestShow", me.name)
   end
   -- Set up the callback if we have one
   if cons.nestable then
-    --echo("setting callback to doNestClick")
-    setLabelClickCallback(me.name, "doNestClick", me.name)
+    --echo("setting callback to doNestShow")
+    setLabelClickCallback(me.name, "doNestShow", me.name)
   end
   if me.clickCallback then
     if type(me.clickArgs) == "string" or type(me.clickArgs) == "number" then

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -463,6 +463,11 @@ function Geyser.Label:new (cons, container)
   Geyser.Color.applyColors(me)
   me:echo()
 
+  -- Set up mouse hover as the callback if we have one
+  if cons.nestflyout then
+    --echo("setting hover to doNestClick")
+    setLabelOnEnter(me.name, "doNestClick", me.name)
+  end
   -- Set up the callback if we have one
   if cons.nestable then
     --echo("setting callback to doNestClick")

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -469,7 +469,6 @@ function Geyser.Label:new (cons, container)
   end
   -- Set up the callback if we have one
   if cons.nestable then
-    --echo("setting callback to doNestShow")
     setLabelClickCallback(me.name, "doNestShow", me.name)
   end
   if me.clickCallback then

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -464,11 +464,7 @@ function Geyser.Label:new (cons, container)
   me:echo()
 
   -- Set up mouse hover as the callback if we have one
-<<<<<<< HEAD
   if cons.nestflyout then
-=======
-  if cons.nestflyout and cons.nestable then
->>>>>>> 49a48e45fb7d43967e99ac7a53129b5fc9f58536
     --echo("setting hover to doNestClick")
     setLabelOnEnter(me.name, "doNestClick", me.name)
   end


### PR DESCRIPTION
…to allow the parent label to be hovered over instead of clicked to open the children flyout labels.

#### Brief overview of PR changes/additions
Allows a Geyser flyout menu to open on hover instead of left click when nestflyout=true is set as a parameter.

You can compare this behavior to the previous behavior by using the demo listed on the wiki:
https://wiki.mudlet.org/w/Manual:Geyser#Flyout_Labels

All you have to do is change the example **mainlabel** to also include the parameter nestflyout=true

`mainlabel = Geyser.Label:new({name="testa", x=0,y=0,height=50,width=300, nestable=true, nestflyout=true, message="<center>Hover Here to see FLY-OUT LABELS!</center>"})`

#### Motivation for adding to Mudlet
I added this because I wanted a way to open the menu on hover instead of left click.
