### PR TITLE
M multi selection list widget

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -134,7 +134,7 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.setColumnCount(2);
     mMultiSelectionListWidget.hideColumn(1);
     QStringList headerLabels;
-    headerLabels << tr("Room Id") << tr("Room Name");
+    headerLabels << tr("Id") << tr("Name");
     mMultiSelectionListWidget.setHeaderLabels(headerLabels);
     mMultiSelectionListWidget.setToolTip(tr("<p>Click on a line to select or deselect that room number (with the given name if the "
                                                  "rooms are named) to add or remove the room from the selection.  Click on the "
@@ -5019,10 +5019,8 @@ void T2DMap::resizeMultiSelectionWidget()
 {
     int newWidth;
     if (mIsSelectionUsingNames) {
-        if (width() <= 300) { // 0 - 300 => 0 - 200
-            newWidth = 2 * width() / 3;
-        } else if (width() <= 600) { // 300 - 600 => 200 - 300
-            newWidth = 100 + width() / 3;
+        if (width() <= 999) { // 0 - 300 => 0 - 200
+            newWidth = 160;
         } else { // 600+ => 300
             newWidth = 300;
         }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5021,7 +5021,7 @@ void T2DMap::resizeMultiSelectionWidget()
     if (mIsSelectionUsingNames) {
         if (width() <= 999) { // 0 - 300 => 0 - 200
             newWidth = 160;
-        } else { // 600+ => 300
+        } else { // 999+ => 300
             newWidth = 300;
         }
     } else {

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -410,7 +410,7 @@ end
 --- Internal function when a parent nest element is clicked
 --- to lay out the nested elements within
 -- @param label The name of the label to use
-function doNestClick(label)
+function doNestShow(label)
   Geyser.Label:displayNest(label)
 end
 
@@ -465,13 +465,12 @@ function Geyser.Label:new (cons, container)
 
   -- Set up mouse hover as the callback if we have one
   if cons.nestflyout then
-    --echo("setting hover to doNestClick")
-    setLabelOnEnter(me.name, "doNestClick", me.name)
+    setLabelOnEnter(me.name, "doNestShow", me.name)
   end
   -- Set up the callback if we have one
   if cons.nestable then
-    --echo("setting callback to doNestClick")
-    setLabelClickCallback(me.name, "doNestClick", me.name)
+    --echo("setting callback to doNestShow")
+    setLabelClickCallback(me.name, "doNestShow", me.name)
   end
   if me.clickCallback then
     if type(me.clickArgs) == "string" or type(me.clickArgs) == "number" then

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -463,6 +463,11 @@ function Geyser.Label:new (cons, container)
   Geyser.Color.applyColors(me)
   me:echo()
 
+  -- Set up mouse hover as the callback if we have one
+  if cons.nestflyout then
+    --echo("setting hover to doNestClick")
+    setLabelOnEnter(me.name, "doNestClick", me.name)
+  end
   -- Set up the callback if we have one
   if cons.nestable then
     --echo("setting callback to doNestClick")

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -469,7 +469,6 @@ function Geyser.Label:new (cons, container)
   end
   -- Set up the callback if we have one
   if cons.nestable then
-    --echo("setting callback to doNestShow")
     setLabelClickCallback(me.name, "doNestShow", me.name)
   end
   if me.clickCallback then

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -464,11 +464,7 @@ function Geyser.Label:new (cons, container)
   me:echo()
 
   -- Set up mouse hover as the callback if we have one
-<<<<<<< HEAD
   if cons.nestflyout then
-=======
-  if cons.nestflyout and cons.nestable then
->>>>>>> 49a48e45fb7d43967e99ac7a53129b5fc9f58536
     --echo("setting hover to doNestClick")
     setLabelOnEnter(me.name, "doNestClick", me.name)
   end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This makes the popup list widget for multiple selected rooms more compact when the size of the mapper is less than 999pixels wide, going from 300 pixels wide to 160. This makes working with the mapper much easier.

#### Motivation for adding to Mudlet
Mapping areas and being infuriated while trying to move rooms around while that popup list is visible.