### PR TITLE
Enhance: Compact View for multiSelectionRoomName, next have full room…

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5022,7 +5022,7 @@ void T2DMap::resizeMultiSelectionWidget()
         if (width() <= 750) {
             newWidth = 160;
         } else if (width() <= 890) { // 750-890 => 160-300
-            newWidth = width()-750;
+            newWidth = 160+width()-750;
         } else { // 890+ => 300
             newWidth = 300;
         }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -134,7 +134,7 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.setColumnCount(2);
     mMultiSelectionListWidget.hideColumn(1);
     QStringList headerLabels;
-    headerLabels << tr("Room Id") << tr("Room Name");
+    headerLabels << tr("Id") << tr("Name");
     mMultiSelectionListWidget.setHeaderLabels(headerLabels);
     mMultiSelectionListWidget.setToolTip(tr("<p>Click on a line to select or deselect that room number (with the given name if the "
                                                  "rooms are named) to add or remove the room from the selection.  Click on the "
@@ -5019,11 +5019,11 @@ void T2DMap::resizeMultiSelectionWidget()
 {
     int newWidth;
     if (mIsSelectionUsingNames) {
-        if (width() <= 300) { // 0 - 300 => 0 - 200
-            newWidth = 2 * width() / 3;
-        } else if (width() <= 600) { // 300 - 600 => 200 - 300
-            newWidth = 100 + width() / 3;
-        } else { // 600+ => 300
+        if (width() <= 750) {
+            newWidth = 160;
+        } else if (width() <= 890) { // 750-890 => 160-300
+            newWidth = width()-750;
+        } else { // 890+ => 300
             newWidth = 300;
         }
     } else {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -134,7 +134,7 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.setColumnCount(2);
     mMultiSelectionListWidget.hideColumn(1);
     QStringList headerLabels;
-    headerLabels << tr("Id") << tr("Name");
+    headerLabels << tr("ID", "Room ID in the mapper widget") << tr("Name", "Room name in the mapper widget");
     mMultiSelectionListWidget.setHeaderLabels(headerLabels);
     mMultiSelectionListWidget.setToolTip(tr("<p>Click on a line to select or deselect that room number (with the given name if the "
                                                  "rooms are named) to add or remove the room from the selection.  Click on the "


### PR DESCRIPTION
… name shown in tooltip on mouse hover.

#### Brief overview of PR changes/additions
This shortens the room id header field which frees up a bit of space and also changes the points at which the popup list grows in size from 750-890 it will scale from 160-300 wide as the map window is resized.

#### Motivation for adding to Mudlet
Because I was trying to map all the Areas in my Mud, and with a Map window size of about 600 the popup window was at about 300 wide, thats half my available mapper view. It was nearly impossible to efficiently move rooms around while mapping.