### PR TITLE
Remove "no user dictionary" item

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -448,21 +448,13 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     pHost->getUserDictionaryOptions(useUserDictionary, mUseSharedDictionary);
     // Always set the true radio button first - avoids any problems with
     // exclusivity of radio buttons:
-// DISABLED: - Prevent "None" option for user dictionary
-//    if (useUserDictionary) {
-        if (mUseSharedDictionary) {
-            radioButton_userDictionary_common->setChecked(true);
-            radioButton_userDictionary_profile->setChecked(false);
-        } else {
-            radioButton_userDictionary_profile->setChecked(true);
-            radioButton_userDictionary_common->setChecked(false);
-        }
-        radioButton_userDictionary_none->setChecked(false);
-//    } else {
-//        radioButton_userDictionary_none->setChecked(true);
-//        radioButton_userDictionary_profile->setChecked(false);
-//        radioButton_userDictionary_common->setChecked(false);
-//    }
+    if (mUseSharedDictionary) {
+        radioButton_userDictionary_common->setChecked(true);
+        radioButton_userDictionary_profile->setChecked(false);
+    } else {
+        radioButton_userDictionary_profile->setChecked(true);
+        radioButton_userDictionary_common->setChecked(false);
+    }
     checkBox_echoLuaErrors->setChecked(pHost->mEchoLuaErrors);
     checkBox_useWideAmbiguousEastAsianGlyphs->setCheckState(pHost->getWideAmbiguousEAsianGlyphsControlState());
 
@@ -2167,11 +2159,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         }
 
         pHost->mEnableSpellCheck = checkBox_spellCheck->isChecked();
-// DISABLED: - Prevent "None" option for user dictionary
-//        if (radioButton_userDictionary_none->isChecked()) {
-            // Disable using which ever dictionary was previously in use:
-//            pHost->setUserDictionaryOptions(false, mUseSharedDictionary);
-/*        } else */ if (radioButton_userDictionary_common->isChecked()) {
+        if (radioButton_userDictionary_common->isChecked()) {
             pHost->setUserDictionaryOptions(true, true);
         } else {
             pHost->setUserDictionaryOptions(true, false);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -58,9 +58,6 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     // init generated dialog
     setupUi(this);
 
-// DISABLED: - Prevent "None" option for user dictionary
-    radioButton_userDictionary_none->hide();
-
     QPixmap holdPixmap;
 
     holdPixmap = *(this->notificationAreaIconLabelWarning->pixmap());

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -577,19 +577,6 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_userDictionary">
              <item>
-              <widget class="QRadioButton" name="radioButton_userDictionary_none">
-               <property name="toolTip">
-                <string>&lt;p&gt;A user dictionary will not be used on the main console command line. Lua commands that target a user dictionary will return &lt;tt&gt;nil&lt;/t&gt; and &lt;i&gt;an error message&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;It will still, however, be possible to access the main dictionary selected above.&lt;/p&gt;</string>
-               </property>
-               <property name="text">
-                <string>None</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
               <widget class="QRadioButton" name="radioButton_userDictionary_profile">
                <property name="toolTip">
                 <string>&lt;p&gt;A user dictionary specific to this profile will be available. This will be on the command line (words which are in it will appear with a dashed cyan underline) and in the lua sub-system.&lt;/p&gt;</string>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
radioButton_userDictionary_none is not used at all, was left over from prototype

#### Motivation for adding to Mudlet
We should not confuse translators

#### Other info (issues closed, discussion etc)
Fix #2436 