### PR TITLE
Revert "Don't reset other profile's timers with resetProfile() (#2257)"

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -220,12 +220,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     if (!optin.isEmpty()) {
         mDiscordDisableServerSide = optin.toInt() == Qt::Unchecked ? true : false;
     }
-
-    if (mHostName != QStringLiteral("default_host")) {
-        Q_ASSERT_X(!mudlet::self()->mHostTimerMap.contains(this), "Host::Host(...)", "the mudlet class mHostTimerMap already contains this Host instance");
-        QMap<QTimer*, TTimer*> hostTimerMap;
-        mudlet::self()->mHostTimerMap.insert(this, hostTimerMap);
-    }
 }
 
 Host::~Host()
@@ -377,7 +371,7 @@ void Host::reloadModule(const QString& reloadModuleName)
 void Host::resetProfile()
 {
     getTimerUnit()->stopAllTriggers();
-    mudlet::self()->clearHostTimerMap(this);
+    mudlet::self()->mTimerMap.clear();
     getTimerUnit()->removeAllTempTimers();
     getTriggerUnit()->removeAllTempTriggers();
     getKeyUnit()->removeAllTempKeys();

--- a/src/TTimer.h
+++ b/src/TTimer.h
@@ -4,7 +4,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia,com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -74,12 +73,6 @@ public:
     void killTimer();
 
     bool isOffsetTimer();
-    QPointer<Host> getHost() { return mpHost; }
-    QTimer* getQTimer() { return mpQTimer; }
-    void setKnownUnregistered() { mKnownToBeUnregistered = true; }
-    bool knownUnregistered() { return mKnownToBeUnregistered; }
-
-
     // specifies whenever the payload is Lua code as a string
     // or a function
     bool mRegisteredAnonymousLuaFunction;
@@ -88,7 +81,6 @@ public:
 
 private:
     TTimer() = default;
-
     QString mName;
     QString mScript;
     QTime mTime;
@@ -97,13 +89,9 @@ private:
     QPointer<Host> mpHost;
     bool mNeedsToBeCompiled;
     QMutex mLock;
-    // Renamed to reduce confusion:
-    QTimer* mpQTimer;
+    QTimer* mpTimer;
     bool mModuleMember;
     //TLuaInterpreter *  mpLua;
-    // Used in XMLimport::package to mark an unused Timer that was created there
-    // and which can be removed without reporting that it was unregistered.
-    bool mKnownToBeUnregistered;
 };
 
 #endif // MUDLET_TTIMER_H

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -197,8 +197,6 @@ bool XMLimport::importPackage(QFile* pfile, QString packName, int moduleFlag, QS
             mpTimer->enableTimer(mpTimer->getID());
         } else {
             mpHost->getTimerUnit()->unregisterTimer(mpTimer);
-            // Set flag so that it can be silently deleted:
-            mpTimer->setKnownUnregistered();
             delete mpTimer;
         }
 
@@ -1235,7 +1233,7 @@ int XMLimport::readTimerGroup(TTimer* pParent)
         }
     }
 
-    mudlet::self()->registerTimer(pT);
+    mudlet::self()->registerTimer(pT, pT->mpTimer);
 
     if (!pT->mpParent && pT->shouldBeActive()) {
         pT->setIsActive(true);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -113,9 +113,8 @@ public:
     void disableToolbarButtons();
     void enableToolbarButtons();
     Host* getActiveHost();
-    void registerTimer(TTimer*);
-    void unregisterTimer(TTimer*);
-    void clearHostTimerMap(Host*);
+    void registerTimer(TTimer*, QTimer*);
+    void unregisterTimer(QTimer*);
     void forceClose();
     bool saveWindowLayout();
     bool loadWindowLayout();
@@ -223,8 +222,7 @@ public:
     QTime mReplayTime;
     int mReplaySpeed;
     QToolBar* mpMainToolBar;
-    // Was mTimerMap shared between all Host instances:
-    QMap<Host*, QMap<QTimer*, TTimer*>> mHostTimerMap;
+    QMap<QTimer*, TTimer*> mTimerMap;
     QMap<Host*, QPointer<dlgIRC>> mpIrcClientMap;
     QString version;
     QPointer<Host> mpCurrentActiveHost;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This reverts commit 8a32c0b411a307f8d22867209cfb4f0614686f4b.
#### Motivation for adding to Mudlet
The improvement fixes a small problem that our users aren't really aware of, but it also introduces a bigger problem - Mudlet will crash in a timer after `resetProfile()` is used. We already have a fix for that in https://github.com/Mudlet/Mudlet/pull/2480, but the fix involves completely reworking how timers function - so it is not very safe to put in right before release.
#### Other info (issues closed, discussion etc)
Let's go back to how things were in 3.18 and make all of the changes for 3.20 just to reduce the risk of things going really bad, and us having more stress before&after release attempting to make things good.