### PR TITLE
Enhance: draw RoomId numbers better in 2D Mapper

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -806,8 +806,10 @@ void T2DMap::paintEvent(QPaintEvent* e)
             roomTestRect = QRectF(0, 0, static_cast<qreal>(mRoomWidth) * rSize, static_cast<qreal>(mRoomHeight) * rSize);
         }
         static quint8 roomVnumMargin = 10;
-        roomVNumFont.setUnderline(true);
-        roomVNumFont.setOverline(true);
+        // Peer review has suggested that under/overlining the room id numbers
+        // is not helpful after all:
+        // roomVNumFont.setUnderline(true);
+        // roomVNumFont.setOverline(true);
         roomVNumFont.setBold(true);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         // QFont::PreferNoShaping is only available in Qt 5.10 or later

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -617,15 +617,14 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const bool gridMode)
  * Helper used to size fonts establishes the font size to use to draw the given
  * sample text centralized inside the given boundary (or rather the boundary
  * reduced by the margin (0-40) as a percentage). This margin is defaulted to
- * 20%.
+ * 10%.
  */
 bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect, const QString & text, const quint8 percentageMargin )
 {
     QFont _font = font;
 
-    if (percentageMargin > 80) {
-        qWarning() << "T2DMap::sizeFontToFitTextInRect(...) percentage margin" << percentageMargin << "exceeded maximum (40%) !";
-        return false;
+    if (percentageMargin > 40) {
+        qWarning() << "T2DMap::sizeFontToFitTextInRect(...) percentage margin" << percentageMargin << "exceeded recommended maximum (40%) !";
     }
     if (text.isEmpty()) {
         qWarning() << "T2DMap::sizeFontToFitTextInRect(...) called with no sample text!";
@@ -666,10 +665,10 @@ bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect,
 
     if (isSizeTooSmall) {
         return false;
-    } else {
-        font.setPointSizeF(fontSize);
-        return true;
     }
+
+    font.setPointSizeF(fontSize);
+    return true;
 }
 
 // Revised to use a QCache to hold QPixmap * to generated images for room symbols
@@ -806,12 +805,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
         } else {
             roomTestRect = QRectF(0, 0, static_cast<qreal>(mRoomWidth) * rSize, static_cast<qreal>(mRoomHeight) * rSize);
         }
-        QFont roomVNumFont = mpMap->mMapSymbolFont;
         static quint8 roomVnumMargin = 10;
         roomVNumFont.setUnderline(true);
         roomVNumFont.setOverline(true);
         roomVNumFont.setBold(true);
-#if QT_VERSION >= 0x050a00
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         // QFont::PreferNoShaping is only available in Qt 5.10 or later
         // QFont::PreferOutline will help to select a font that will scale to any
         // size - which is important for good rendering over a range of sizes
@@ -1722,17 +1720,15 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
             if (mShowRoomID && isFontBigEnoughToShowRoomVnum) {
                 painter.save();
-                QPen roomIdPen = painter.pen();
                 QColor roomIdColor;
-                if (roomColor.red() + roomColor.green() + roomColor.blue() > 200) {
+                if (roomColor.lightness() > 127) {
                     roomIdColor = QColor(Qt::black);
                 } else {
                     roomIdColor = QColor(Qt::white);
                 }
-                painter.setFont(roomVNumFont);
                 painter.setPen(QPen(roomIdColor));
-                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QString::number(currentAreaRoom));
-                painter.setPen(roomIdPen);
+                painter.setFont(roomVNumFont);
+                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QStringLiteral("%1").arg(currentAreaRoom, mMaxRoomIdDigits, 10, QLatin1Char('0')));
                 painter.restore();
             }
 

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016, 2018 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2016, 2018-2019 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -209,6 +210,7 @@ private:
     void resizeMultiSelectionWidget();
     std::pair<int, int> getMousePosition();
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
+    bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8);
 
     bool mDialogLock;
 
@@ -240,7 +242,12 @@ private:
     QFont mMapSymbolFont;
 
     QPointer<QAction> mpCreateRoomAction;
-
+    // Calculated near the top of the paintEvent() and is used in a couple of
+    // places where we need to pad roomIds to the same widths, it also affects
+    // the font size used to show roomId numbers (longer numbers need a smaller
+    // font to fit - as the numbers are NOW scaled to fit inside the room symbol
+    // - and they are suppressed if they would be too small.);
+    quint8 mMaxRoomIdDigits;
 
 private slots:
     void slot_createRoom();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -210,7 +210,7 @@ private:
     void resizeMultiSelectionWidget();
     std::pair<int, int> getMousePosition();
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);
-    bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8);
+    bool sizeFontToFitTextInRect(QFont&, const QRectF&, const QString&, const quint8 percentageMargin = 10);
 
     bool mDialogLock;
 


### PR DESCRIPTION
Whilst trying to locate my prototype code for `Z-exit lines` for the 2D Mapper I found this code that I had put to one side and which can go in as an enhancement - it scales the text used for the room numbers so that they fit better into the space available for them...

They now are scaled so that they fit the room symbol square - and are suppressed if they are too small to show.  Importantly this is done on the length of the longest number found in the area so that there will not be truncation - either they will all fit or none will. Also, leading zeros are used so that they are all the same size...

To distinguish between roomId and any user defined symbols for a room that might just be a series of numbers, the room Id numbers are also drawn in bold and with both an under- and an over-line.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>