### PR TITLE
Enhance: add getTextFormat() function to Lua API

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1841,6 +1841,31 @@ std::list<int> TConsole::getBgColor(std::string& buf)
     return {};
 }
 
+QPair<quint8, TChar> TConsole::getTextAttributes() const
+{
+    int x = P_begin.x();
+    int y = P_begin.y();
+    if (y < 0 || x < 0 || y >= static_cast<int>(buffer.buffer.size()) || x >= (static_cast<int>(buffer.buffer.at(y).size()) - 1)) {
+        return qMakePair(2, TChar());
+    }
+
+    return qMakePair(0, buffer.buffer.at(y).at(x));
+}
+
+QPair<quint8, TChar> TConsole::getTextAttributes(const QString& name) const
+{
+    if (name.isEmpty() || name == QLatin1String("main")) {
+        return getTextAttributes();
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (pC) {
+        return pC->getTextAttributes();
+    }
+
+    return qMakePair(1, TChar());
+}
+
 void TConsole::luaWrapLine(std::string& buf, int line)
 {
     QString key = QString::fromUtf8(buf.c_str());

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -204,6 +204,13 @@ public:
     QSet<QString> getWordSet() const;
     void setProfileName(const QString&);
     bool isUsingSharedDictionary() const { return mUseSharedDictionary; }
+    // In the next pair of functions the first element in the return is an
+    // error code:
+    // 0 = Okay
+    // 1 = Window not found
+    // 2 = Selection not valid
+    QPair<quint8, TChar> getTextAttributes() const;
+    QPair<quint8, TChar> getTextAttributes(const QString&) const;
 
 
     QPointer<Host> mpHost;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -860,6 +860,94 @@ int TLuaInterpreter::getBgColor(lua_State* L)
     return result.size();
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getFgColor
+int TLuaInterpreter::getTextFormat(lua_State* L)
+{
+    QString windowName = QStringLiteral("main");
+    if (lua_gettop(L)) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "getTextFormat: bad argument #1 type (window name as string is optional, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
+        windowName = lua_tostring(L, 1);
+    }
+
+    Host& host = getHostFromLua(L);
+    QPair<quint8, TChar> result = host.mpConsole->getTextAttributes(windowName);
+    if (result.first == 1) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "window \"%s\" not found", windowName.toUtf8().constData());
+        return 2;
+    }
+
+    if (result.first == 2) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "current selection invalid in window \"%s\"", windowName.toUtf8().constData());
+        return 2;
+    }
+
+    lua_newtable(L);
+
+    TChar::AttributeFlags format = result.second.allDisplayAttributes();
+    lua_pushstring(L, "bold");
+    lua_pushboolean(L, format & TChar::Bold);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "italic");
+    lua_pushboolean(L, format & TChar::Italic);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "overline");
+    lua_pushboolean(L, format & TChar::Overline);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "reverse");
+    lua_pushboolean(L, format & TChar::Reverse);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "strikeout");
+    lua_pushboolean(L, format & TChar::StrikeOut);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "underline");
+    lua_pushboolean(L, format & TChar::Underline);
+    lua_settable(L, -3);
+
+    QColor foreground(result.second.foreground());
+    lua_pushstring(L, "foreground");
+    lua_newtable(L);
+    lua_pushnumber(L, 1);
+    lua_pushnumber(L, foreground.red());
+    lua_settable(L, -3);
+
+    lua_pushnumber(L, 2);
+    lua_pushnumber(L, foreground.green());
+    lua_settable(L, -3);
+
+    lua_pushnumber(L, 3);
+    lua_pushnumber(L, foreground.blue());
+    lua_settable(L, -3);
+    lua_settable(L, -3);
+
+    QColor background(result.second.background());
+    lua_pushstring(L, "background");
+    lua_newtable(L);
+    lua_pushnumber(L, 1);
+    lua_pushnumber(L, background.red());
+    lua_settable(L, -3);
+
+    lua_pushnumber(L, 2);
+    lua_pushnumber(L, background.green());
+    lua_settable(L, -3);
+
+    lua_pushnumber(L, 3);
+    lua_pushnumber(L, background.blue());
+    lua_settable(L, -3);
+    lua_settable(L, -3);
+
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#wrapLine
 int TLuaInterpreter::wrapLine(lua_State* L)
 {
@@ -14740,6 +14828,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "spellCheckWord", TLuaInterpreter::spellCheckWord);
     lua_register(pGlobalLua, "spellSuggestWord", TLuaInterpreter::spellSuggestWord);
     lua_register(pGlobalLua, "getDictionaryWordList", TLuaInterpreter::getDictionaryWordList);
+    lua_register(pGlobalLua, "getTextFormat", TLuaInterpreter::getTextFormat);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -498,6 +498,7 @@ public:
     static int spellCheckWord(lua_State*);
     static int spellSuggestWord(lua_State*);
     static int getDictionaryWordList(lua_State*);
+    static int getTextFormat(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 


### PR DESCRIPTION
Returns a table containing text attribute names and their values; booleans for: bold, italics, underline, overline, strikeout, and reverse and colour triplet tables for fore- and back-ground colours.

In the future I anticipate adding in the ANSI colour codes (0 to 255) used to produce the fore- and back-ground colours for text from the MUD - with some other special codes for certain other classes of text generated within the Mudlet application...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>