### PR TITLE
Fix db:add() when adding timestamp fieldsUpdate DB.lua

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -360,11 +360,11 @@ function db:_sql_values(values)
       s = "'" .. v:gsub("'", "''") .. "'"
     elseif t == "nil" then
       s = "NULL"
-    elseif t == "table" and t._timestamp ~= nil then
-      if not t._timestamp then
+    elseif t == "table" and v._timestamp ~= nil then
+      if not v._timestamp then
         return "NULL"
       else
-        s = "datetime('" .. t._timestamp .. "', 'unixepoch')"
+        s = "datetime('" .. v._timestamp .. "', 'unixepoch')"
       end
     else
       s = tostring(v)


### PR DESCRIPTION
i have a database like this:
```lua
local mydb = db:create("combat_log", {
    kills = {
        killtime = db:Timestamp("CURRENT_TIMESTAMP"),
        name = "",
        shortname = "",
        location = "",
        x = 0,
        y = 0,
        duration = 0,
        ep = 0,
        player = "",
    },
})
```
and i have a trigger on kill with code like this:
```lua
local kill = {
	killtime={_timestamp=os.time(os.date("!*t"))},
	name=matches[2],
	shortname=game.gegnerName,
	location=ort,
	x=x, y=y,
	duration=game.fightTime,
	player=playerName
}
--db.debug_sql = true
local succ, msg = db:add(mydb.kills, kill)
if not succ then
	cecho("\n<red>"..msg.."<reset>\n")
end
```
and a trigger for EP (which come in on a short delay after the kill) with code like this:
```lua
local mydb = db:get_database("combat_log")
local results = db:fetch_sql(mydb.kills, "SELECT * FROM kills ORDER BY _row_id DESC")[1]
results.ep = matches[2]
results.killtime._timestamp = os.time(os.date("!*t"))
db:update(mydb.kills, results)
```
to update the last kill entry and add the EP for this kill.

I had to provide the timestamp to the database because the underlying sqlite engine adds a timestamp that is 1 hour in the future (integer unix epoch) on my system. i don't know why. (unix epoch timestamp is independent from timezones) so as a workaround i had to provide the timestamp on db:add() and db:update()

i than realised that this works on db:update() but throws "LuaSQL: near "table": syntax error".
as i turned on db.debug_sql i could see that the db functions converted it to a sql INSERT command with the VALUES.
in the generated VALUES list for the timestamp column there was not the time value (included in datetime('xxxxxx')) but there was the word "table" (in quotes) and a table reference (in hex if i remember right).

so i started to look into the source of DB.lua and found this little bug.
in the code the type variable t is used instead of the value variable v.
I changed that in my local copy, restarted mudlet and the db:add() function runs correctly.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

*Edited by @ SlySven to add code formatting to make it readable!* :grinning: