### PR TITLE
Revise: avoid changing the objectName of toolbars/docked windows on layout + add titles to toolbars

### DIFF
--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -418,3 +418,16 @@ void TAction::insertActions(TEasyButtonBar* pT, QMenu* menu)
     Q_ASSERT_X(menu, "TAction::insertActions( TEasyButtonBar *, QMenu * )", "method called with a NULL QMenu pointer!");
     menu->addAction(action);
 }
+
+void TAction::setName(const QString& name)
+{
+    if (name != mName) {
+        setDataChanged();
+        mName = name;
+        if (mpToolBar) {
+            // Need to revise the objectName and displayed name in the titlebar
+            // if floating and the main window context menu:
+            mpToolBar->setName(name);
+        }
+    }
+}

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -53,7 +53,7 @@ public:
     TAction(const QString& name, Host* pHost);
     void compileAll();
     QString getName() { return mName; }
-    void setName(const QString& name) { if(name != mName) { setDataChanged(); mName = name; } }
+    void setName(const QString& name);
     void setButtonColor(QColor c) { if(c != mButtonColor) { setDataChanged(); mButtonColor = c; } }
     QColor getButtonColor() { return mButtonColor; }
     void setButtonRotation(int r) { if(r != mButtonRotation) { setDataChanged(); mButtonRotation = r; } }

--- a/src/TEasyButtonBar.cpp
+++ b/src/TEasyButtonBar.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,14 +36,13 @@ TEasyButtonBar::TEasyButtonBar(TAction* pA, QString name, QWidget* pW)
 : QWidget( pW )
 , mpTAction( pA )
 , mVerticalOrientation( false )
-, mpWidget( new QWidget )
-, mName( name )
+, mpWidget( new QWidget(this) )
 , mRecordMove( false )
 , mpLayout( nullptr )
 , mItemCount( 0 )
-, mpBar( pW )
 {
     mButtonList.clear();
+    auto hostName(pA->mpHost->getName());
     auto layout = new QVBoxLayout;
     setLayout(layout);
     layout->setContentsMargins(0, 0, 0, 0);
@@ -67,6 +66,10 @@ TEasyButtonBar::TEasyButtonBar(TAction* pA, QString name, QWidget* pW)
     }
     setStyleSheet(mpTAction->css);
     mpWidget->setStyleSheet(mpTAction->css);
+    setObjectName(QStringLiteral("easyButtonBar_%1_%2").arg(hostName, name));
+    mpWidget->setObjectName(QStringLiteral("easyButtonBar_Widget_%1_%2").arg(hostName, name));
+    // It is not entirely clear if this is ever visible:
+    setWindowTitle(tr("Easybutton Bar - %1 - %2").arg(hostName, name));
 }
 
 void TEasyButtonBar::addButton(TFlipButton* pB)
@@ -191,8 +194,12 @@ void TEasyButtonBar::clear()
         disconnect(flipButton, &QAbstractButton::clicked, this, &TEasyButtonBar::slot_pressed);
     }
     mButtonList.clear();
+    // Transfer the object name to the new instance:
+    auto widgetObjectName(mpWidget->objectName());
+    mpWidget->setObjectName(QString());
     mpWidget->deleteLater();
     mpWidget = pW;
+    mpWidget->setObjectName(widgetObjectName);
 
     if (!mpTAction->mUseCustomLayout) {
         mpLayout = new QGridLayout;

--- a/src/TEasyButtonBar.h
+++ b/src/TEasyButtonBar.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -47,21 +47,20 @@ public:
     void setHorizontalOrientation() { mVerticalOrientation = false; }
     void clear();
     void finalize();
-    TAction* mpTAction;
     void recordMove() { mRecordMove = true; }
+
+    TAction* mpTAction;
+
+public slots:
+    void slot_pressed(bool);
 
 private:
     bool mVerticalOrientation;
     QWidget* mpWidget;
-    QString mName;
     bool mRecordMove;
     QGridLayout* mpLayout;
     int mItemCount;
-    QWidget* mpBar;
     std::list<TFlipButton*> mButtonList;
-
-public slots:
-    void slot_pressed(bool);
 };
 
 #endif // MUDLET_TEASYBUTTONBAR_H

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,14 +35,14 @@ TToolBar::TToolBar(TAction* pA, const QString& name, QWidget* pW)
 , mpTAction( pA )
 , mVerticalOrientation( false )
 , mpWidget( new QWidget( this ) )
-, mName( name )
 , mRecordMove( false )
 , mpLayout( nullptr )
 , mItemCount( 0 )
 {
     setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     setWidget(mpWidget);
-    setObjectName(QString("dockToolBar_%1").arg(name));
+    // Needs a unique name across application so needs the Host name as well:
+    setName(name);
 
     connect(this, &QDockWidget::dockLocationChanged, this, &TToolBar::slot_dockLocationChanged);
     connect(this, &QDockWidget::topLevelChanged, this, &TToolBar::slot_topLevelChanged);
@@ -52,11 +52,8 @@ TToolBar::TToolBar(TAction* pA, const QString& name, QWidget* pW)
         setContentsMargins(0, 0, 0, 0);
         mpLayout->setContentsMargins(0, 0, 0, 0);
         mpLayout->setSpacing(0);
-        QSizePolicy sizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-        mpWidget->setSizePolicy(sizePolicy);
+        mpWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     }
-    auto test = new QWidget;
-    setTitleBarWidget(test);
     setStyleSheet(mpTAction->css);
     mpWidget->setStyleSheet(mpTAction->css);
 }
@@ -66,6 +63,16 @@ void TToolBar::resizeEvent(QResizeEvent* e)
     if (!mudlet::self()->mIsLoadingLayout) {
         mudlet::self()->setToolbarLayoutUpdated(mpTAction->mpHost, this);
     }
+}
+
+void TToolBar::setName(const QString& name)
+{
+    mName = name;
+    QString hostName(mpTAction->mpHost->getName());
+    setObjectName(QStringLiteral("dockToolBar_%1_%2").arg(hostName, name));
+    // Actually put something in as the title so that the main window context
+    // menu no longer has empty entries which are disabled:
+    setWindowTitle(tr("Toolbar - %1 - %2").arg(hostName, name));
 }
 
 void TToolBar::moveEvent(QMoveEvent* e)
@@ -224,10 +231,8 @@ void TToolBar::clear()
     } else {
         mpLayout = nullptr;
     }
-    auto test = new QWidget;
     setStyleSheet(mpTAction->css);
     mpWidget->setStyleSheet(mpTAction->css);
-    setTitleBarWidget(test);
 
     mudlet::self()->removeDockWidget(this);
 }

--- a/src/TToolBar.h
+++ b/src/TToolBar.h
@@ -46,9 +46,11 @@ public:
     void setHorizontalOrientation() { mVerticalOrientation = false; }
     void clear();
     void finalize();
-    TAction* mpTAction;
     void recordMove() { mRecordMove = true; }
-    QString getName() { return mName; }
+    QString getName() const { return mName; }
+    void setName(const QString&);
+
+    TAction* mpTAction;
 
 private:
     bool mVerticalOrientation;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1750,16 +1750,16 @@ void mudlet::setDockLayoutUpdated(Host* pHost, const QString& name)
 
 void mudlet::setToolbarLayoutUpdated(Host* pHost, TToolBar* pTB)
 {
-    if (!pHost || !pTB) {
+    if (!pHost) {
         return;
     }
 
     // Using the operator[] will instantiate an empty QList<TToolBar*> if there
     // is not already one in existance for that pHost:
-    QList<TToolBar*>& mToolbarLayoutUpdateMap = mHostToolbarLayoutChangeMap[pHost];
-    if (!mToolbarLayoutUpdateMap.contains(pTB)) {
+    QList<TToolBar*>& toolbarLayoutUpdateMap = mHostToolbarLayoutChangeMap[pHost];
+    if (!toolbarLayoutUpdateMap.contains(pTB)) {
         pTB->setProperty("layoutChanged", QVariant(true));
-        mToolbarLayoutUpdateMap.append(pTB);
+        toolbarLayoutUpdateMap.append(pTB);
         mHasSavedLayout = false;
     }
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1882,6 +1882,7 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         return false;
     }
 
+    auto hostName(pHost->getName());
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     auto pD = pHost->mpConsole->mDockWidgetMap.value(name);
 
@@ -1889,10 +1890,10 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         // The name is not used in either the QMaps of all user created TConsole
         // or TDockWidget instances - so we can make a NEW one:
         auto pD = new TDockWidget(pHost, name);
-        pD->setObjectName(QString("dockWindow_%1_%2").arg(pHost->getName(), name));
+        pD->setObjectName(QString("dockWindow_%1_%2").arg(hostName, name));
         pD->setContentsMargins(0, 0, 0, 0);
         pD->setFeatures(QDockWidget::AllDockWidgetFeatures);
-        pD->setWindowTitle(tr("User window - %1 - %2").arg(pHost->getName(), name));
+        pD->setWindowTitle(tr("User window - %1 - %2").arg(hostName, name));
         pHost->mpConsole->mDockWidgetMap.insert(name, pD);
         // It wasn't obvious but the parent passed to the TConsole constructor
         // is sliced down to a QWidget and is NOT a TDockWidget pointer:
@@ -3289,8 +3290,9 @@ void mudlet::createMapper(bool loadDefaultMap)
         return;
     }
 
-    pHost->mpDockableMapWidget = new QDockWidget(tr("Map - %1").arg(pHost->getName()));
-    pHost->mpDockableMapWidget->setObjectName(QString("dockMap_%1").arg(pHost->getName()));
+    auto hostName(pHost->getName());
+    pHost->mpDockableMapWidget = new QDockWidget(tr("Map - %1").arg(hostName));
+    pHost->mpDockableMapWidget->setObjectName(QString("dockMap_%1").arg(hostName));
     pHost->mpMap->mpMapper = new dlgMapper(pHost->mpDockableMapWidget, pHost, pHost->mpMap.data()); //FIXME: mpHost definieren
     pHost->mpMap->mpM = pHost->mpMap->mpMapper->glWidget;
     pHost->mpDockableMapWidget->setWidget(pHost->mpMap->mpMapper);


### PR DESCRIPTION
The `objectName` is used to identify the item in the opaque data that is saved to preserve the size and position these items - so changing it is probably not a good idea.

This PR instead sets and modifies a (dynamic) property "layoutChanged" on each item instead.

It also revises the code used to reset the property on each item when the state details are saved, the replacement code is a bit clearer IMHO as it uses the Qt Java style iterators rather than the STL ones.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>