### PR TITLE
Remove -lglut for Windows linking

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -290,7 +290,6 @@ unix:!macx {
         -lz \                   # for ctelnet.cpp
         -lyajl \
         -lopengl32 \
-        -lglut \
         -lglu32 \
         -lpugixml \
         -lWs2_32 \


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove `-lglut` from being linked to Windows binaries.
#### Motivation for adding to Mudlet
It does not seem it is actually necessary! Everything (including 3D mapper) works fine without it.
#### Other info (issues closed, discussion etc)
