### PR TITLE
Increase cache timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: cpp
 cache:
   timeout: 600
   ccache: true
+  directories:
+    - $HOME/Library/Caches/Homebrew
 dist: xenial
 sudo: false
 addons:
@@ -117,7 +119,8 @@ matrix:
         - qt57base
         - qt57multimedia
         - qt57tools
-
+before_cache:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee -a "${HOME}/ca-file.pem"; fi
   # add to the path here to pick up things as soon as its installed

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 cache:
-  - ccache
+  timeout: 600
+  ccache: true
 dist: xenial
 sudo: false
 addons:


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Our macOS builds seem to be unable to upload their cache as they run into timeouts. We set the timeout to 10 minutes in the hopes to be able to upload the initial cache in that time and subsequent caches don't need as much time.

#### Motivation for adding to Mudlet
Speed up our macOS builds eventually.

#### Other info (issues closed, discussion etc)
