### PR TITLE
BugFix: save & load custom line colors in map format version less than 20

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1316,7 +1316,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
 
             QMap<QString, QList<int>> oldLinesColorData;
             QMapIterator<QString, QColor> itCustomLineColor(pR->customLinesColor);
-            while (itCustomLine.hasNext()) {
+            while (itCustomLineColor.hasNext()) {
                 itCustomLineColor.next();
                 QString direction(itCustomLineColor.key());
                 QList<int> colorComponents;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -844,7 +844,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             QMap<QString, QList<int>> oldLinesColorData;
             ifs >> oldLinesColorData;
             QMapIterator<QString, QList<int>> itCustomLineColor(oldLinesColorData);
-            while (itCustomLine.hasNext()) {
+            while (itCustomLineColor.hasNext()) {
                 itCustomLineColor.next();
                 QString direction(itCustomLineColor.key());
                 if (direction == QLatin1String("N") || direction == QLatin1String("E") || direction == QLatin1String("S") || direction == QLatin1String("W") || direction == QLatin1String("UP")


### PR DESCRIPTION
This will close https://github.com/Mudlet/Mudlet/issues/2558 .

The bug was made in https://github.com/Mudlet/Mudlet/pull/2106/ which has been present since before Mudlet 2.16.0 was released·

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>