### PR TITLE
Split and renamed TRoomDB hashTable.

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4195,15 +4195,15 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 {
     int id;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setRoomIDbyHash: wrong argument type");
+        lua_pushfstring(L, "setRoomIDbyHash: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
         id = lua_tonumber(L, 1);
     }
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "getRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)",
-              luaL_typename(L, 1));
+        lua_pushfstring(L, "setRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)",
+              luaL_typename(L, 2));
         lua_error(L);
         return 1;
     }
@@ -4255,7 +4255,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
         return 1;
     }
     lua_pushnil(L);
-    lua_pushfstring(L, "No hash for room %d.", id);
+    lua_pushfstring(L, "no hash for room %d.", id);
     return 2;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4201,47 +4201,38 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
     } else {
         id = lua_tonumber(L, 1);
     }
-    string hash;
     if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "setRoomIDbyHash: wrong argument type");
+        lua_pushfstring(L, "getRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)",
+              luaL_typename(L, 1));
         lua_error(L);
         return 1;
-    } else {
-        hash = lua_tostring(L, 2);
     }
+    QString hash = QString::fromUtf8(lua_tostring(L, 2));
     Host& host = getHostFromLua(L);
-    QString hashStr = QString(hash.c_str());
     if ( host.mpMap->mpRoomDB->roomIDToHash.contains(id) ){
        host.mpMap->mpRoomDB->hashToRoomID.remove( host.mpMap->mpRoomDB->roomIDToHash[id] );
     }
-    if ( host.mpMap->mpRoomDB->hashToRoomID.contains(hashStr) ){
-       host.mpMap->mpRoomDB->roomIDToHash.remove( host.mpMap->mpRoomDB->hashToRoomID[hashStr] );
+    if ( host.mpMap->mpRoomDB->hashToRoomID.contains(hash) ){
+       host.mpMap->mpRoomDB->roomIDToHash.remove( host.mpMap->mpRoomDB->hashToRoomID[hash] );
     }
-    host.mpMap->mpRoomDB->hashToRoomID[hashStr] = id;
-    host.mpMap->mpRoomDB->roomIDToHash[id] = hashStr;
+    host.mpMap->mpRoomDB->hashToRoomID[hash] = id;
+    host.mpMap->mpRoomDB->roomIDToHash[id] = hash;
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomIDbyHash
 int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 {
-    string hash;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "getRoomIDbyHash() wrong argument type");
+        lua_pushfstring(L, "getRoomIDbyHash: bad argument #1 type (hash as string expected, got %s)",
+              luaL_typename(L, 1));
         lua_error(L);
         return 1;
-    } else {
-        hash = lua_tostring(L, 1);
     }
+    QString hash = QString::fromUtf8(lua_tostring(L, 1));
     Host& host = getHostFromLua(L);
-    int retID = -1;
-    QString _hash = hash.c_str();
-    if (host.mpMap->mpRoomDB->hashToRoomID.contains(_hash)) {
-        retID = host.mpMap->mpRoomDB->hashToRoomID[_hash];
-        lua_pushnumber(L, retID);
-    } else {
-        lua_pushnumber(L, -1);
-    }
+    int retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
+    lua_pushnumber(L, retID);
 
     return 1;
 }
@@ -4264,8 +4255,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
         return 1;
     }
     lua_pushnil(L);
-    // This is sloppy: it might exist but not be hashed.
-    lua_pushfstring(L, "room %d doesn't exist", id);
+    lua_pushfstring(L, "No hash for room %d.", id);
     return 2;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4200,17 +4200,16 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
     }
     id = lua_tonumber(L, 1);
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "setRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)",
-              luaL_typename(L, 2));
+        lua_pushfstring(L, "setRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)", luaL_typename(L, 2));
         return lua_error(L);
     }
     QString hash = QString::fromUtf8(lua_tostring(L, 2));
     Host& host = getHostFromLua(L);
-    if ( host.mpMap->mpRoomDB->roomIDToHash.contains(id) ){
-       host.mpMap->mpRoomDB->hashToRoomID.remove( host.mpMap->mpRoomDB->roomIDToHash[id] );
+    if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
+        host.mpMap->mpRoomDB->hashToRoomID.remove(host.mpMap->mpRoomDB->roomIDToHash[id]);
     }
-    if ( host.mpMap->mpRoomDB->hashToRoomID.contains(hash) ){
-       host.mpMap->mpRoomDB->roomIDToHash.remove( host.mpMap->mpRoomDB->hashToRoomID[hash] );
+    if (host.mpMap->mpRoomDB->hashToRoomID.contains(hash)) {
+        host.mpMap->mpRoomDB->roomIDToHash.remove(host.mpMap->mpRoomDB->hashToRoomID[hash]);
     }
     host.mpMap->mpRoomDB->hashToRoomID[hash] = id;
     host.mpMap->mpRoomDB->roomIDToHash[id] = hash;
@@ -4221,8 +4220,7 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
 int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "getRoomIDbyHash: bad argument #1 type (hash as string expected, got %s)",
-              luaL_typename(L, 1));
+        lua_pushfstring(L, "getRoomIDbyHash: bad argument #1 type (hash as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
     QString hash = QString::fromUtf8(lua_tostring(L, 1));
@@ -4244,7 +4242,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
     id = lua_tonumber(L, 1);
 
     Host& host = getHostFromLua(L);
-    if ( host.mpMap->mpRoomDB->roomIDToHash.contains(id) ){
+    if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         QString retHash = host.mpMap->mpRoomDB->roomIDToHash[id];
         lua_pushstring(L, retHash.toUtf8().constData());
         return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4210,7 +4210,15 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
         hash = lua_tostring(L, 2);
     }
     Host& host = getHostFromLua(L);
-    host.mpMap->mpRoomDB->hashTable[QString(hash.c_str())] = id;
+    QString hashStr = QString(hash.c_str());
+    if ( host.mpMap->mpRoomDB->roomIDToHash.contains(id) ){
+       host.mpMap->mpRoomDB->hashToRoomID.remove( host.mpMap->mpRoomDB->roomIDToHash[id] );
+    }
+    if ( host.mpMap->mpRoomDB->hashToRoomID.contains(hashStr) ){
+       host.mpMap->mpRoomDB->roomIDToHash.remove( host.mpMap->mpRoomDB->hashToRoomID[hashStr] );
+    }
+    host.mpMap->mpRoomDB->hashToRoomID[hashStr] = id;
+    host.mpMap->mpRoomDB->roomIDToHash[id] = hashStr;
     return 0;
 }
 
@@ -4228,8 +4236,8 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
     Host& host = getHostFromLua(L);
     int retID = -1;
     QString _hash = hash.c_str();
-    if (host.mpMap->mpRoomDB->hashTable.contains(_hash)) {
-        retID = host.mpMap->mpRoomDB->hashTable[_hash];
+    if (host.mpMap->mpRoomDB->hashToRoomID.contains(_hash)) {
+        retID = host.mpMap->mpRoomDB->hashToRoomID[_hash];
         lua_pushnumber(L, retID);
     } else {
         lua_pushnumber(L, -1);
@@ -4250,16 +4258,13 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
     }
 
     Host& host = getHostFromLua(L);
-    QMapIterator<QString, int> it(host.mpMap->mpRoomDB->hashTable);
-
-    while (it.hasNext()) {
-        it.next();
-        if (it.value() == id) {
-            lua_pushstring(L, it.key().toUtf8().constData());
-            return 1;
-        }
+    if ( host.mpMap->mpRoomDB->roomIDToHash.contains(id) ){
+        QString retHash = host.mpMap->mpRoomDB->roomIDToHash[id];
+        lua_pushstring(L, retHash.toUtf8().constData());
+        return 1;
     }
     lua_pushnil(L);
+    // This is sloppy: it might exist but not be hashed.
     lua_pushfstring(L, "room %d doesn't exist", id);
     return 2;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4196,16 +4196,13 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
     int id;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setRoomIDbyHash: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
-    } else {
-        id = lua_tonumber(L, 1);
+        return lua_error(L);
     }
+    id = lua_tonumber(L, 1);
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)",
               luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString hash = QString::fromUtf8(lua_tostring(L, 2));
     Host& host = getHostFromLua(L);
@@ -4226,8 +4223,7 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getRoomIDbyHash: bad argument #1 type (hash as string expected, got %s)",
               luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString hash = QString::fromUtf8(lua_tostring(L, 1));
     Host& host = getHostFromLua(L);
@@ -4244,9 +4240,8 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getRoomHashByID: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        id = lua_tonumber(L, 1);
     }
+    id = lua_tonumber(L, 1);
 
     Host& host = getHostFromLua(L);
     if ( host.mpMap->mpRoomDB->roomIDToHash.contains(id) ){
@@ -4255,7 +4250,7 @@ int TLuaInterpreter::getRoomHashByID(lua_State* L)
         return 1;
     }
     lua_pushnil(L);
-    lua_pushfstring(L, "no hash for room %d.", id);
+    lua_pushfstring(L, "no hash for room %d", id);
     return 2;
 }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1461,8 +1461,8 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         if (mVersion >= 7) {
             ifs >> mpRoomDB->hashToRoomID;
             QMap<QString, int>::const_iterator i;
-            for( i = mpRoomDB->hashToRoomID.constBegin(); i != mpRoomDB->hashToRoomID.constEnd(); ++i ){
-               mpRoomDB->roomIDToHash.insert( i.value(), i.key() );
+            for (i = mpRoomDB->hashToRoomID.constBegin(); i != mpRoomDB->hashToRoomID.constEnd(); ++i) {
+                mpRoomDB->roomIDToHash.insert(i.value(), i.key());
             }
         }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1067,7 +1067,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
     ofs << envColors;
     ofs << mpRoomDB->getAreaNamesMap();
     ofs << customEnvColors;
-    ofs << mpRoomDB->hashTable;
+    ofs << mpRoomDB->hashToRoomID;
     if (mSaveVersion >= 17) {
         if (mSaveVersion < 19) {
             // Save the data in the map user data for older versions
@@ -1459,7 +1459,11 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             ifs >> customEnvColors;
         }
         if (mVersion >= 7) {
-            ifs >> mpRoomDB->hashTable;
+            ifs >> mpRoomDB->hashToRoomID;
+            QMap<QString, int>::const_iterator i;
+            for( i = mpRoomDB->hashToRoomID.constBegin(); i != mpRoomDB->hashToRoomID.constEnd(); ++i ){
+               mpRoomDB->roomIDToHash.insert( i.value(), i.key() );
+            }
         }
 
         if (mVersion >= 17) {
@@ -1759,7 +1763,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
 
     if (otherProfileVersion >= 7) {
-        // hashTable
+        // hashToRoomID
         QHash<QString, int> _dummyQHashQStringInt;
         ifs >> _dummyQHashQStringInt;
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1764,8 +1764,8 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
 
     if (otherProfileVersion >= 7) {
         // hashToRoomID
-        QHash<QString, int> _dummyQHashQStringInt;
-        ifs >> _dummyQHashQStringInt;
+        QMap<QString, int> _dummyQMapQStringInt;
+        ifs >> _dummyQMapQStringInt;
     }
 
     if (otherProfileVersion >= 17) {

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -255,13 +255,10 @@ bool TRoomDB::__removeRoom(int id)
             ++i;
         }
         rooms.remove(id);
-        // FIXME: make hashTable a bimap
-        QList<QString> keyList = hashTable.keys();
-        QList<int> valueList = hashTable.values();
-        for (int i = 0; i < valueList.size(); i++) {
-            if (valueList[i] == id) {
-                hashTable.remove(keyList[i]);
-            }
+        if ( roomIDToHash.contains(id) ) {
+            QString hash = roomIDToHash[id];
+            roomIDToHash.remove(id);
+            hashToRoomID.remove(hash);
         }
         int areaID = pR->getArea();
         TArea* pA = getArea(areaID);
@@ -1079,7 +1076,8 @@ void TRoomDB::clearMapDB()
     rooms.clear(); // Prevents any further use of TRoomDB::getRoom(int) !!!
     entranceMap.clear();
     areaNamesMap.clear();
-    hashTable.clear();
+    hashToRoomID.clear();
+    roomIDToHash.clear();
     for (auto room : rPtrL) {
         delete room; // Uses the internally held value of the room Id
                      // (TRoom::id) to call TRoomDB::__removeRoom(id)

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -255,7 +255,7 @@ bool TRoomDB::__removeRoom(int id)
             ++i;
         }
         rooms.remove(id);
-        if ( roomIDToHash.contains(id) ) {
+        if (roomIDToHash.contains(id)) {
             QString hash = roomIDToHash[id];
             roomIDToHash.remove(id);
             hashToRoomID.remove(hash);

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -80,8 +80,14 @@ public:
     void restoreSingleRoom(int, TRoom*);
     const QString getDefaultAreaName() { return mDefaultAreaName; }
 
-
-    QMap<QString, int> hashTable;
+    // This is for muds that provide hashes to rooms instead of IDs.
+    // If it exists, we delete the info when deleting a room.
+    // But we rely on the user to add the data, don't do any checking,
+    // and it isn't audited.
+    // It should be a QHash, but changing it would break loading from files
+    // saved under the old version.
+    QMap<QString, int> hashToRoomID;
+    QMap<int, QString> roomIDToHash;
 
 
 private:


### PR DESCRIPTION
This will speed up roomID to hash lookups, as well as room
deletions. Added logic to keep them in sync and avoid duplicates.

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Split and renamed TRoomDB hashTable.

#### Motivation for adding to Mudlet
Speed up roomID to hash lookup, and also deletion by roomID.

#### Other info (issues closed, discussion etc)
