### PR TITLE
Refactor: improve handling of show/hiding some trigger editor controls

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8393,7 +8393,8 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
         if (mpTriggersMainArea->toolButton_toggleExtraControls->isChecked()) {
             // The extra controls are visible in the triggersMainArea
             bottomWidgetHeight = mpTriggersMainArea->widget_bottom->height();
-            if ((mpTriggersMainArea->widget_left->height()) <= (mpTriggersMainArea->widget_right->minimumSizeHint().height() + hysteresis)) {
+            if ((mpTriggersMainArea->widget_left->height()) <= (mpTriggersMainArea->widget_right->minimumSizeHint().height() + hysteresis)
+                || mpTriggersMainArea->widget_verticalSpacer_right->height() == 0) {
                 // And it is not tall enough to show the right hand side - so
                 // hide them:
                 slot_showAllTriggerControls(false);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -700,6 +700,11 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         pItem->label_patternNumber->setText(QString::number(i+1));
         pItem->label_patternNumber->show();
     }
+    // force the minimum size of the scroll area for the trigger items to be one
+    // and a half trigger item widgets:
+    int triggerWidgetItemMinHeight = qRound(mTriggerPatternEdit.at(0)->minimumSizeHint().height() * 1.5);
+    mpScrollArea->setMinimumHeight(triggerWidgetItemMinHeight);
+
     showHiddenVars = false;
     widget_searchTerm->updateGeometry();
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8366,26 +8366,23 @@ void dlgTriggerEditor::slot_showAllTriggerControls(const bool isShown)
 
 void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
 {
-    // Change these from const to static to enable interactive adjustment whilst
-    // running in a debugging environment:
-    const uint threshold = 335;
-    const uint hysteresis = 20;
-    QList<int> partsSizes = splitter_right->sizes();
-    // qDebug().noquote().nospace() << "dlgTriggerEditor::slot_rightSplitterMoved(...) INFO - splitters are now: " << partsSizes;
-    if (partsSizes.at(1) > 10) {
+    const int hysteresis = 5;
+    if (mpTriggersMainArea->isVisible()) {
         // The triggersMainArea is visible
-        if (partsSizes.at(1) > (threshold + hysteresis)) {
-            // And it is more than an upper limit high
-            if (!mpTriggersMainArea->toolButton_toggleExtraControls->isChecked()) {
-                // And the extra controls are not visible - so show them
-                slot_showAllTriggerControls(true);
+        if (mpTriggersMainArea->toolButton_toggleExtraControls->isChecked()) {
+            // And the extra controls are visible in the triggersMainArea:
+            if ((mpTriggersMainArea->scrollArea->height() + mpTriggersMainArea->widget_bottom->height()) <= mpTriggersMainArea->widget_right->minimumSizeHint().height()) {
+                // And it is not tall enough to show the right hand side - so
+                // hide them:
+                slot_showAllTriggerControls(false);
             }
 
-        } else if (partsSizes.at(1) < (threshold - hysteresis)) {
-            // And it is less than a lower limit high
-            if (mpTriggersMainArea->toolButton_toggleExtraControls->isChecked()) {
-                // And the extra controls are visible - so hide them
-                slot_showAllTriggerControls(false);
+        } else {
+            // And the extra controls are NOT visible
+            if (mpTriggersMainArea->scrollArea->height() > (mpTriggersMainArea->widget_right->minimumSizeHint().height() + hysteresis)) {
+                // And it is tall enough to show the right hand side completely
+                // so show them:
+                slot_showAllTriggerControls(true);
             }
         }
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8371,12 +8371,29 @@ void dlgTriggerEditor::slot_showAllTriggerControls(const bool isShown)
 
 void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
 {
-    const int hysteresis = 5;
+    /*
+     * With all widgets shown:              With some hidden:
+     *  +--------------------------------+   +--------------------------------+
+     *  | name / control toggle /command |   | name / control toggle /command |
+     *--+----------------------+---------+ --+----------------------+---------+
+     *  |+--------------------+|         |   |+------------------------------+|
+     *w_||                    ||         |   ||                              ||
+     *il||    scroll area     || widget  |   ||         scroll area          ||
+     *de||                    || _right  |   ||                              ||
+     *gf|+--------------------+|         |   |+------------------------------+|
+     *et|+--------------------+|         | --+--------------------------------+
+     *t ||   widget_bottom    ||         |
+     *=>|+--------------------+|         |
+     *--+----------------------+---------+
+     */
+    const int hysteresis = 10;
+    static int bottomWidgetHeight = 0;
     if (mpTriggersMainArea->isVisible()) {
         // The triggersMainArea is visible
         if (mpTriggersMainArea->toolButton_toggleExtraControls->isChecked()) {
-            // And the extra controls are visible in the triggersMainArea:
-            if ((mpTriggersMainArea->scrollArea->height() + mpTriggersMainArea->widget_bottom->height()) <= mpTriggersMainArea->widget_right->minimumSizeHint().height()) {
+            // The extra controls are visible in the triggersMainArea
+            bottomWidgetHeight = mpTriggersMainArea->widget_bottom->height();
+            if ((mpTriggersMainArea->widget_left->height()) <= (mpTriggersMainArea->widget_right->minimumSizeHint().height() + hysteresis)) {
                 // And it is not tall enough to show the right hand side - so
                 // hide them:
                 slot_showAllTriggerControls(false);
@@ -8384,7 +8401,7 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
 
         } else {
             // And the extra controls are NOT visible
-            if (mpTriggersMainArea->scrollArea->height() > (mpTriggersMainArea->widget_right->minimumSizeHint().height() + hysteresis)) {
+            if ((mpTriggersMainArea->widget_left->height() - bottomWidgetHeight) > mpTriggersMainArea->widget_right->minimumSizeHint().height() - hysteresis) {
                 // And it is tall enough to show the right hand side completely
                 // so show them:
                 slot_showAllTriggerControls(true);

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -55,12 +55,6 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>51</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Name:</string>
         </property>
@@ -74,12 +68,6 @@
       </item>
       <item>
        <widget class="QLineEdit" name="lineEdit_trigger_name">
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="toolTip">
          <string>&lt;p&gt;Choose a good, (ideally, though it need not be, unique) name for your trigger or trigger group. This will be displayed in the trigger tree.&lt;/p&gt;</string>
         </property>
@@ -126,12 +114,6 @@
       </item>
       <item>
        <widget class="QLineEdit" name="lineEdit_trigger_command">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
         <property name="toolTip">
          <string>&lt;p&gt;Type in one or more commands you want the trigger to send directly to the game if it fires. (Optional)&lt;/p&gt;&lt;p&gt;To send more complex commands, that could depend on or need to modifies variables within this profile a Lua script should be entered &lt;i&gt;instead&lt;/i&gt; in the editor area below.  Anything entered here is, literally, just sent to the game server.&lt;/p&gt;&lt;p&gt;It is permissable to use both this &lt;i&gt;and&lt;/i&gt; a Lua script - this will be sent &lt;b&gt;before&lt;/b&gt; the script is run.&lt;/p&gt;</string>
         </property>
@@ -206,12 +188,6 @@
              <height>48</height>
             </size>
            </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
            <property name="toolTip">
             <string>&lt;p&gt;The trigger will only fire if &lt;u&gt;all&lt;/u&gt; conditions on the list have been met within the specified line delta, and captures will be saved in &lt;tt&gt;multimatches&lt;/tt&gt; instead of &lt;tt&gt;matches&lt;/tt&gt;.&lt;/p&gt;
 &lt;p&gt;If this option is &lt;b&gt;not&lt;/b&gt; set the trigger will fire if &lt;u&gt;any&lt;/u&gt; condition on the list have been met.&lt;/p&gt;</string>
@@ -258,12 +234,6 @@
                 <height>21</height>
                </size>
               </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
               <property name="toolTip">
                <string>&lt;p&gt;Within how many lines must all condition be true to fire the trigger?&lt;/p&gt;</string>
               </property>
@@ -277,12 +247,6 @@
          </item>
          <item alignment="Qt::AlignTop">
           <widget class="QGroupBox" name="groupBox_filterTrigger">
-           <property name="baseSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
            <property name="autoFillBackground">
             <bool>true</bool>
            </property>
@@ -324,18 +288,6 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
               </property>
               <property name="text">
                <string>Do not pass whole line to children.</string>
@@ -395,24 +347,6 @@
             </property>
             <item alignment="Qt::AlignTop">
              <widget class="QLabel" name="label_perlSlashGOption">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
               <property name="text">
                <string>Match all occurences of the pattern in the line.</string>
               </property>
@@ -468,12 +402,6 @@
       </property>
       <item alignment="Qt::AlignTop">
        <widget class="QGroupBox" name="groupBox_stayOpen">
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="toolTip">
          <string>&lt;p&gt;Keep firing the script for this many more lines, after the trigger or chain has matched.&lt;/p&gt;</string>
         </property>
@@ -538,12 +466,6 @@
       </item>
       <item alignment="Qt::AlignTop">
        <widget class="QGroupBox" name="groupBox_soundTrigger">
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="toolTip">
          <string>&lt;p&gt;Play a sound file if the trigger fires.&lt;/p&gt;</string>
         </property>
@@ -727,12 +649,6 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
            <property name="text">
             <string>Background</string>
            </property>
@@ -745,12 +661,6 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
            </property>
            <property name="text">
             <string>Foreground</string>


### PR DESCRIPTION
This attempts to make the code that shows/hides the controls to the right and bottom of the `triggers_main_area` form/dialogue not depend on hard coded settings but rather on the actual space that various widgets claim they need to be shown correctly (and not to show them if there is not enough).

This should help to address: https://github.com/Mudlet/Mudlet/issues/2548 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>