### PR TITLE
Revise: pad RoomId numbers with spaces on 2D map

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1734,7 +1734,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
                 }
                 painter.setPen(QPen(roomIdColor));
                 painter.setFont(roomVNumFont);
-                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QStringLiteral("%1").arg(currentAreaRoom, mMaxRoomIdDigits, 10, QLatin1Char('0')));
+                // U+2007 is Unicode codepoint for "Figure Space" - the width of
+                // a numeric digit:
+                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QStringLiteral("%1").arg(currentAreaRoom, mMaxRoomIdDigits, 10, QChar(0x2007)));
                 painter.restore();
             }
 


### PR DESCRIPTION
As requested in the issue below this converts the room Id numbers when shown in the 2D Mapper to be padded with leading spaces rather than leading zeroes.

Note that the numbers are shown only when the longest (most digits) Room Id number for the displayed area can be displayed at a readable size - otherwise the mapper switches back to displaying room *symbols* if they will fit inside the room rectangle/circle.

I believe this closes https://github.com/Mudlet/Mudlet/issues/2560 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>