### PR TITLE
Proposed mxp fix

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1309,13 +1309,13 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                         QString _tp = currentToken.substr(currentToken.find_first_of(' ')).c_str();
                         _tn = _tp.section(' ', 1, 1).toUpper();
                         _tp = _tp.section(' ', 2).toUpper();
-                        if ((_tp.indexOf("SEND") != -1)) {
+                        if ((_tp.indexOf("<SEND") != -1)) {
                             QString _t2 = _tp;
                             int pRef = _t2.indexOf("HREF=");
                             bool _got_ref = false;
                             // wenn kein href angegeben ist, dann gilt das 1. parameter als href
                             if (pRef == -1) {
-                                pRef = _t2.indexOf("SEND ");
+                                pRef = _t2.indexOf("<SEND ") + 1;
                             } else {
                                 _got_ref = true;
                             }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -122,6 +122,14 @@ struct TMxpElement
     QString hint;
 };
 
+enum TMXPMode
+{
+    MXP_MODE_OPEN,
+    MXP_MODE_SECURE,
+    MXP_MODE_LOCKED,
+    MXP_MODE_TEMP_SECURE
+};
+
 class TBuffer
 {
     // need to use tr() on encoding names in csmEncodingTable
@@ -232,6 +240,8 @@ public:
 
     // State of MXP systen:
     bool mMXP;
+    TMXPMode mMXP_MODE;
+    TMXPMode mMXP_DEFAULT;
 
     bool mAssemblingToken;
     std::string currentToken;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

- Change MXP state from being "on/off" to support the line / default modes from the MXP standard
- MXP mode resets to current default mode on newline (but not on <br> tags)
- Slight tweak to <SEND> tag detection by including the opening < in the substring match

#### Motivation for adding to Mudlet

Improve MXP support by allowing use of locked mode (to print from the mud without needing to escape < as &lt; etc) and temp secure mode before each tag.  (Muds can work around Mudlet's limitations by manually resetting to locked mode immediately after each opening / closing tag but it's nicer to obey the temporary mode).

#### Other info (issues closed, discussion etc)

Ideally OPEN and SECURE mode would be different (it still allows all tags regardless of if it is in open or secure mode)