### PR TITLE
Fixed: impossible to add special exit to room 1.

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -629,7 +629,7 @@ void TRoom::setSpecialExit(int to, const QString& cmd)
     // Have definitely removed the existing case of this command
     // Now add it to map if wanted
 
-    if (to > 1) {
+    if (to > 0) {
         if (_prefix.isEmpty()) {
             _prefix = '0';
         }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fixed off-by-1 error in setSpecialExit

#### Motivation for adding to Mudlet
It is now possible to have a special exit that goes to room 1

#### Other info (issues closed, discussion etc)
attached test code. run before and after to see difference

[testSexit1.txt](https://github.com/Mudlet/Mudlet/files/3228671/testSexit1.txt)

**NOTE** This is a new version of #2575 which I messed up... I'm very sorry @LiamLeFey @vadi2 