### PR TITLE
Add support for opening a profile offline

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -36,7 +36,7 @@
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 : QDialog( parent )
 , mProfileList( QStringList() )
-, load_button( Q_NULLPTR )
+, offline_button( Q_NULLPTR )
 , connect_button( Q_NULLPTR )
 , delete_profile_lineedit( Q_NULLPTR )
 , delete_button( Q_NULLPTR )
@@ -68,7 +68,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     QAbstractButton* abort = dialog_buttonbox->button(QDialogButtonBox::Cancel);
     connect_button = dialog_buttonbox->addButton(tr("Connect"), QDialogButtonBox::AcceptRole);
-    load_button = dialog_buttonbox->addButton(tr("Load"), QDialogButtonBox::AcceptRole);
+    offline_button = dialog_buttonbox->addButton(tr("Offline"), QDialogButtonBox::AcceptRole);
 
     // Test and set if needed mudlet::mIsIconShownOnDialogButtonBoxes - if there
     // is already a Qt provided icon on a predefined button, this is probably
@@ -110,7 +110,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
         QIcon icon_new(QIcon::fromTheme(QStringLiteral("document-new"), QIcon(QStringLiteral(":/icons/document-new.png"))));
         QIcon icon_connect(QIcon::fromTheme(QStringLiteral("dialog-ok-apply"), QIcon(QStringLiteral(":/icons/dialog-ok-apply.png"))));
 
-        load_button->setIcon(QIcon(QStringLiteral(":/icons/mudlet_editor.png")));
+        offline_button->setIcon(QIcon(QStringLiteral(":/icons/mudlet_editor.png")));
         connect_button->setIcon(QIcon(QStringLiteral(":/icons/preferences-web-browser-cache.png")));
         new_profile_button->setIcon(icon_new);
         copy_profile_button->setIcon(QIcon::fromTheme(QStringLiteral("edit-copy"), QIcon(QStringLiteral(":/icons/edit-copy.png"))));
@@ -131,7 +131,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
         Q_ASSERT_X(!cursor.isNull(), "dlgConnectionProfiles::dlgConnectionProfiles(...)",
                    "CONNECT_PROFILE_ICON text marker not found in welcome_message text for when icons are shown on dialogue buttons");
         cursor.removeSelectedText();
-        QImage image_load(QPixmap(icon_connect.pixmap(load_button->iconSize())).toImage());
+        QImage image_load(QPixmap(icon_connect.pixmap(offline_button->iconSize())).toImage());
         cursor.insertImage(image_load);
         cursor.clearSelection();
         QImage image_connect(QPixmap(icon_connect.pixmap(connect_button->iconSize())).toImage());
@@ -143,7 +143,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     }
     welcome_message->setDocument(pWelcome_document);
 
-    connect(load_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_load);
+    connect(offline_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_load);
     connect(connect_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::accept);
     connect(abort, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_cancel);
     connect(new_profile_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_addProfile);
@@ -259,7 +259,7 @@ void dlgConnectionProfiles::slot_update_url(const QString& url)
 {
     if (url.isEmpty()) {
         validUrl = false;
-        load_button->setDisabled(true);
+        offline_button->setDisabled(true);
         connect_button->setDisabled(true);
         return;
     }
@@ -327,8 +327,8 @@ void dlgConnectionProfiles::slot_update_port(const QString& ignoreBlank)
 
     if (ignoreBlank.isEmpty()) {
         validPort = false;
-        if (load_button) {
-            load_button->setDisabled(true);
+        if (offline_button) {
+            offline_button->setDisabled(true);
         }
         if (connect_button) {
             connect_button->setDisabled(true);
@@ -532,7 +532,7 @@ void dlgConnectionProfiles::slot_addProfile()
     validName = false;
     validUrl = false;
     validPort = false;
-    load_button->setDisabled(true);
+    offline_button->setDisabled(true);
     connect_button->setDisabled(true);
 }
 
@@ -1916,9 +1916,9 @@ bool dlgConnectionProfiles::validateProfile()
             validPort = true;
             validUrl = true;
 
-            if (load_button) {
-                load_button->setEnabled(true);
-                load_button->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Load profile without connecting.")));
+            if (offline_button) {
+                offline_button->setEnabled(true);
+                offline_button->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Load profile without connecting.")));
             }
             if (connect_button) {
                 connect_button->setEnabled(true);
@@ -1930,9 +1930,9 @@ bool dlgConnectionProfiles::validateProfile()
         } else {
             notificationArea->show();
             notificationAreaMessageBox->show();
-            if (load_button) {
-                load_button->setDisabled(true);
-                load_button->setToolTip(
+            if (offline_button) {
+                offline_button->setDisabled(true);
+                offline_button->setToolTip(
                         QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Please set a valid profile name, game server address and the game port before connecting.")));
             }
             if (connect_button) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -36,6 +36,7 @@
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 : QDialog( parent )
 , mProfileList( QStringList() )
+, load_button( Q_NULLPTR )
 , connect_button( Q_NULLPTR )
 , delete_profile_lineedit( Q_NULLPTR )
 , delete_button( Q_NULLPTR )
@@ -67,6 +68,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     QAbstractButton* abort = dialog_buttonbox->button(QDialogButtonBox::Cancel);
     connect_button = dialog_buttonbox->addButton(tr("Connect"), QDialogButtonBox::AcceptRole);
+    load_button = dialog_buttonbox->addButton(tr("Load"), QDialogButtonBox::AcceptRole);
 
     // Test and set if needed mudlet::mIsIconShownOnDialogButtonBoxes - if there
     // is already a Qt provided icon on a predefined button, this is probably
@@ -108,6 +110,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
         QIcon icon_new(QIcon::fromTheme(QStringLiteral("document-new"), QIcon(QStringLiteral(":/icons/document-new.png"))));
         QIcon icon_connect(QIcon::fromTheme(QStringLiteral("dialog-ok-apply"), QIcon(QStringLiteral(":/icons/dialog-ok-apply.png"))));
 
+        load_button->setIcon(QIcon(QStringLiteral(":/icons/mudlet_editor.png")));
         connect_button->setIcon(QIcon(QStringLiteral(":/icons/preferences-web-browser-cache.png")));
         new_profile_button->setIcon(icon_new);
         copy_profile_button->setIcon(QIcon::fromTheme(QStringLiteral("edit-copy"), QIcon(QStringLiteral(":/icons/edit-copy.png"))));
@@ -128,6 +131,9 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
         Q_ASSERT_X(!cursor.isNull(), "dlgConnectionProfiles::dlgConnectionProfiles(...)",
                    "CONNECT_PROFILE_ICON text marker not found in welcome_message text for when icons are shown on dialogue buttons");
         cursor.removeSelectedText();
+        QImage image_load(QPixmap(icon_connect.pixmap(load_button->iconSize())).toImage());
+        cursor.insertImage(image_load);
+        cursor.clearSelection();
         QImage image_connect(QPixmap(icon_connect.pixmap(connect_button->iconSize())).toImage());
         cursor.insertImage(image_connect);
         cursor.clearSelection();
@@ -137,6 +143,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     }
     welcome_message->setDocument(pWelcome_document);
 
+    connect(load_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_load);
     connect(connect_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::accept);
     connect(abort, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_cancel);
     connect(new_profile_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_addProfile);
@@ -252,6 +259,7 @@ void dlgConnectionProfiles::slot_update_url(const QString& url)
 {
     if (url.isEmpty()) {
         validUrl = false;
+        load_button->setDisabled(true);
         connect_button->setDisabled(true);
         return;
     }
@@ -319,6 +327,9 @@ void dlgConnectionProfiles::slot_update_port(const QString& ignoreBlank)
 
     if (ignoreBlank.isEmpty()) {
         validPort = false;
+        if (load_button) {
+            load_button->setDisabled(true);
+        }
         if (connect_button) {
             connect_button->setDisabled(true);
         }
@@ -521,6 +532,7 @@ void dlgConnectionProfiles::slot_addProfile()
     validName = false;
     validUrl = false;
     validPort = false;
+    load_button->setDisabled(true);
     connect_button->setDisabled(true);
 }
 
@@ -1670,7 +1682,16 @@ void dlgConnectionProfiles::slot_copy_profile()
     discord_optin_checkBox->setChecked(false);
 }
 
+void dlgConnectionProfiles::slot_load()
+{
+    loadProfile(false);
+    QDialog::accept();
+}
 void dlgConnectionProfiles::slot_connectToServer()
+{
+    loadProfile(true);
+}
+void dlgConnectionProfiles::loadProfile(bool alsoConnect)
 {
     QString profile_name = profile_name_entry->text().trimmed();
 
@@ -1681,7 +1702,9 @@ void dlgConnectionProfiles::slot_connectToServer()
     HostManager & hostManager = mudlet::self()->getHostManager();
     Host* pHost = hostManager.getHost(profile_name);
     if (pHost) {
-        pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
+        if (alsoConnect) {
+            pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
+        }
         QDialog::accept();
         return;
     }
@@ -1773,7 +1796,7 @@ void dlgConnectionProfiles::slot_connectToServer()
     }
 
     emit mudlet::self()->signal_hostCreated(pHost, hostManager.getHostCount());
-    emit signal_establish_connection(profile_name, 0);
+    emit signal_load_profile(profile_name, 0, alsoConnect);
 }
 
 bool dlgConnectionProfiles::validateProfile()
@@ -1893,6 +1916,10 @@ bool dlgConnectionProfiles::validateProfile()
             validPort = true;
             validUrl = true;
 
+            if (load_button) {
+                load_button->setEnabled(true);
+                load_button->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Load profile without connecting.")));
+            }
             if (connect_button) {
                 connect_button->setEnabled(true);
                 connect_button->setToolTip(QString());
@@ -1903,6 +1930,11 @@ bool dlgConnectionProfiles::validateProfile()
         } else {
             notificationArea->show();
             notificationAreaMessageBox->show();
+            if (load_button) {
+                load_button->setDisabled(true);
+                load_button->setToolTip(
+                        QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Please set a valid profile name, game server address and the game port before connecting.")));
+            }
             if (connect_button) {
                 connect_button->setDisabled(true);
                 connect_button->setToolTip(

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1918,7 +1918,7 @@ bool dlgConnectionProfiles::validateProfile()
 
             if (offline_button) {
                 offline_button->setEnabled(true);
-                offline_button->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Load profile without connecting.")));
+                offline_button->setToolTip(tr("<p>Load profile without connecting.</p>"));
             }
             if (connect_button) {
                 connect_button->setEnabled(true);
@@ -1932,13 +1932,11 @@ bool dlgConnectionProfiles::validateProfile()
             notificationAreaMessageBox->show();
             if (offline_button) {
                 offline_button->setDisabled(true);
-                offline_button->setToolTip(
-                        QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Please set a valid profile name, game server address and the game port before connecting.")));
+                offline_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before loading.</p>"));
             }
             if (connect_button) {
                 connect_button->setDisabled(true);
-                connect_button->setToolTip(
-                        QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(tr("Please set a valid profile name, game server address and the game port before connecting.")));
+                connect_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before connecting.</p>"));
             }
             return false;
         }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -39,7 +39,7 @@ public:
     void accept() override;
 
 signals:
-    void signal_establish_connection(QString profile_name, int historyVersion);
+    void signal_load_profile(QString profile_name, int historyVersion, bool alsoConnect);
 
 public slots:
     void slot_update_name(const QString&);
@@ -62,6 +62,7 @@ public slots:
     void slot_update_autoreconnect(int state);
     void slot_update_discord_optin(int state);
     void slot_connectToServer();
+    void slot_load();
     void slot_cancel();
     void slot_copy_profile();
 
@@ -71,6 +72,7 @@ private:
     bool validateConnect();
     void updateDiscordStatus();
     bool validateProfile();
+    void loadProfile(bool alsoConnect);
 
     bool validName;
     bool validUrl;
@@ -81,6 +83,7 @@ private:
     QPalette mOKPalette;
     QPalette mErrorPalette;
     QPalette mReadOnlyPalette;
+    QPushButton* load_button;
     QPushButton* connect_button;
     QLineEdit* delete_profile_lineedit;
     QPushButton* delete_button;

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -83,7 +83,7 @@ private:
     QPalette mOKPalette;
     QPalette mErrorPalette;
     QPalette mReadOnlyPalette;
-    QPushButton* load_button;
+    QPushButton* offline_button;
     QPushButton* connect_button;
     QLineEdit* delete_profile_lineedit;
     QPushButton* delete_button;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3660,6 +3660,9 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, int historyVer
     tempHostQueue.enqueue(pHost);
     if (connect) {
         pHost->connectToServer();
+    } else {
+        QString infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
+        pHost->postMessage(infoMsg);
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3025,7 +3025,7 @@ void mudlet::writeSettings()
 void mudlet::slot_show_connection_dialog()
 {
     auto pDlg = new dlgConnectionProfiles(this);
-    connect(pDlg, &dlgConnectionProfiles::signal_establish_connection, this, &mudlet::slot_connection_dlg_finished);
+    connect(pDlg, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connection_dlg_finished);
     pDlg->fillout_form();
 
     connect(pDlg, &QDialog::accepted, this, [=]() { enableToolbarButtons(); });
@@ -3537,7 +3537,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     // For the first real host created the getHostCount() will return 2 because
     // there is already a "default_host"
     signal_hostCreated(pHost, mHostManager.getHostCount());
-    slot_connection_dlg_finished(profile_name, 0);
+    slot_connection_dlg_finished(profile_name, 0, true);
     enableToolbarButtons();
 }
 
@@ -3603,7 +3603,7 @@ void mudlet::hideMudletsVariables(Host* pHost)
     }
 }
 
-void mudlet::slot_connection_dlg_finished(const QString& profile, int historyVersion)
+void mudlet::slot_connection_dlg_finished(const QString& profile, int historyVersion, bool connect)
 {
     Host* pHost = getHostManager().getHost(profile);
     if (!pHost) {
@@ -3658,7 +3658,9 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, int historyVer
 
     tempHostQueue.enqueue(pHost);
     tempHostQueue.enqueue(pHost);
-    pHost->connectToServer();
+    if (connect) {
+        pHost->connectToServer();
+    }
 }
 
 void mudlet::slot_multi_view()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3537,7 +3537,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     // For the first real host created the getHostCount() will return 2 because
     // there is already a "default_host"
     signal_hostCreated(pHost, mHostManager.getHostCount());
-    slot_connection_dlg_finished(profile_name, 0, true);
+    slot_connection_dlg_finished(profile_name, true);
     enableToolbarButtons();
 }
 
@@ -3603,7 +3603,7 @@ void mudlet::hideMudletsVariables(Host* pHost)
     }
 }
 
-void mudlet::slot_connection_dlg_finished(const QString& profile, int historyVersion, bool connect)
+void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
 {
     Host* pHost = getHostManager().getHost(profile);
     if (!pHost) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -436,7 +436,7 @@ public slots:
     void slot_module_clicked(QTableWidgetItem*);
     void slot_module_changed(QTableWidgetItem*);
     void slot_multi_view();
-    void slot_connection_dlg_finished(const QString& profile, int historyVersion, bool connectOnLoad);
+    void slot_connection_dlg_finished(const QString& profile, bool connectOnLoad);
     void slot_timer_fires();
     void slot_send_login();
     void slot_send_pass();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -436,7 +436,7 @@ public slots:
     void slot_module_clicked(QTableWidgetItem*);
     void slot_module_changed(QTableWidgetItem*);
     void slot_multi_view();
-    void slot_connection_dlg_finished(const QString& profile, int historyVersion);
+    void slot_connection_dlg_finished(const QString& profile, int historyVersion, bool connectOnLoad);
     void slot_timer_fires();
     void slot_send_login();
     void slot_send_pass();


### PR DESCRIPTION
 <!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Added Load button to profile selection dialog, which loads profile but does not connect.

#### Motivation for adding to Mudlet
Issue #700 
And I wanted it.

#### Other info (issues closed, discussion etc)
