### PR TITLE
Fix player's current map location changing when renaming to same Host

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1739,20 +1739,25 @@ void Host::setName(const QString& newName)
         return;
     }
 
-    int currentPlayerRoom;
+    int currentPlayerRoom = 0;
     if (mpMap) {
         currentPlayerRoom = mpMap->mRoomIdHash.take(mHostName);
     }
 
     QMutexLocker locker(& mLock);
+    // Now we have the exclusive lock on this class's protected members
     mHostName = newName;
+    // We have made the change to the protected aspects of this class so can unlock the mutex locker and proceed:
     locker.unlock();
 
     mTelnet.mProfileName = newName;
     if (mpMap) {
         mpMap->mProfileName = newName;
-        mpMap->mRoomIdHash.insert(newName, currentPlayerRoom);
+        if (currentPlayerRoom) {
+            mpMap->mRoomIdHash.insert(newName, currentPlayerRoom);
+        }
     }
+
     if (mpConsole) {
         mpConsole->setProfileName(newName);
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1735,21 +1735,17 @@ void Host::setUserDictionaryOptions(const bool _useDictionary, const bool useSha
 // however it should ensure that other classes get updated:
 void Host::setName(const QString& newName)
 {
+    if (mHostName == newName) {
+        return;
+    }
+
     int currentPlayerRoom;
     if (mpMap) {
         currentPlayerRoom = mpMap->mRoomIdHash.take(mHostName);
     }
 
     QMutexLocker locker(& mLock);
-    if (mHostName == newName) {
-        // Oh, it hasn't changed after all so put the player room back and bail
-        // out:
-        mpMap->mRoomIdHash.insert(newName, currentPlayerRoom);
-        return;
-    }
-
     mHostName = newName;
-    // We have made the change so can unlock the mutex locker and procede:
     locker.unlock();
 
     mTelnet.mProfileName = newName;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix the following problem:

```
*** CID 1479659:  Uninitialized variables  (UNINIT)
/home/travis/build/Mudlet/Mudlet/src/Host.cpp: 1747 in Host::setName(const QString &)()
1741         }
1742     
1743         QMutexLocker locker(& mLock);
1744         if (mHostName == newName) {
1745             // Oh, it hasn't changed after all so put the player room back and bail
1746             // out:
>>>     CID 1479659:  Uninitialized variables  (UNINIT)
>>>     Using uninitialized value "currentPlayerRoom" when calling "insert".
1747             mpMap->mRoomIdHash.insert(newName, currentPlayerRoom);
1748             return;
1749         }
1750     
1751         mHostName = newName;
1752         // We have made the change so can unlock the mutex locker and procede:
```
#### Motivation for adding to Mudlet
Don't have weird teleportation if you say "ok" when not having changed the players location (I assume).
#### Other info (issues closed, discussion etc)
Reword the code to be simpler - if the name is the same, don't do anything at all, instead of taking things out and putting them back in.