### PR TITLE
Fix use of unintialised slice.mEchoText when using copy()

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -750,6 +750,7 @@ TBuffer::TBuffer(Host* pH)
 , lastloggedToLine(0)
 , mEncoding()
 , mMainIncomingCodec(nullptr)
+, mEchoingText(false)
 {
     clear();
 
@@ -3051,8 +3052,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         // The ternary operator is used here to set/reset only the TChar::Echo bit in the flags:
         TChar c(format.mFgColor,
                 format.mBgColor,
-                (mEchoText
-                 ? (TChar::Echo | (format.mFlags & TChar::TestMask))
+                (mEchoingText ? (TChar::Echo | (format.mFlags & TChar::TestMask))
                  : (format.mFlags & TChar::TestMask)));
         newLine.push_back(c);
         buffer.push_back(newLine);
@@ -3125,8 +3125,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, TChar form
         lineBuffer.back().append(text.at(i));
         TChar c(format.mFgColor,
                 format.mBgColor,
-                (mEchoText
-                 ? (TChar::Echo | (format.mFlags & TChar::TestMask))
+                (mEchoingText ? (TChar::Echo | (format.mFlags & TChar::TestMask))
                  : (format.mFlags & TChar::TestMask)),
                 linkID);
         buffer.back().push_back(c);
@@ -3148,7 +3147,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
     int last = buffer.size() - 1;
     if (last < 0) {
         std::deque<TChar> newLine;
-        TChar c(fgColor, bgColor, (mEchoText ? (TChar::Echo | flags) : flags));
+        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
@@ -3217,7 +3216,7 @@ void TBuffer::append(const QString& text, int sub_start, int sub_end, const QCol
             }
         }
         lineBuffer.back().append(text.at(i));
-        TChar c(fgColor, bgColor, (mEchoText ? (TChar::Echo | flags) : flags), linkID);
+        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
             timeBuffer.back() = QTime::currentTime().toString(QStringLiteral("hh:mm:ss.zzz   "));
@@ -3240,7 +3239,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
     if (Q_UNLIKELY(lastLine < 0)) {
         // There are NO lines in the buffer - so initialize with a new empty line
         std::deque<TChar> newLine;
-        TChar c(fgColor, bgColor, (mEchoText ? (TChar::Echo | flags) : flags));
+        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags));
         newLine.push_back(c);
         buffer.push_back(newLine);
         lineBuffer.push_back(QString());
@@ -3262,7 +3261,7 @@ void TBuffer::appendLine(const QString& text, const int sub_start, const int sub
 
     for (int i = sub_start; i <= (sub_start + lineEndPos); i++) {
         lineBuffer.back().append(text.at(i));
-        TChar c(fgColor, bgColor, (mEchoText ? (TChar::Echo | flags) : flags), linkID);
+        TChar c(fgColor, bgColor, (mEchoingText ? (TChar::Echo | flags) : flags), linkID);
         buffer.back().push_back(c);
         if (firstChar) {
             timeBuffer.back() = (QTime::currentTime()).toString("hh:mm:ss.zzz") + "   ";

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -716,6 +716,7 @@ TBuffer::TBuffer(Host* pH)
 , mParsingVar(false)
 , mOpenMainQuote()
 , mMXP_SEND_NO_REF_MODE(false)
+, mEchoingText(false)
 , mGotESC(false)
 , mGotCSI(false)
 , mGotOSC(false)
@@ -750,7 +751,6 @@ TBuffer::TBuffer(Host* pH)
 , lastloggedToLine(0)
 , mEncoding()
 , mMainIncomingCodec(nullptr)
-, mEchoingText(false)
 {
     clear();
 

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -257,7 +257,7 @@ public:
     char mOpenMainQuote;
     bool mMXP_SEND_NO_REF_MODE;
     std::string mAssembleRef;
-    bool mEchoText;
+    bool mEchoingText;
 
 
 private:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10874,9 +10874,9 @@ int TLuaInterpreter::Echo(lua_State* L)
     }
 
     if (consoleName.isEmpty()) {
-        host.mpConsole->buffer.mEchoText = true;
+        host.mpConsole->buffer.mEchoingText = true;
         host.mpConsole->echo(displayText);
-        host.mpConsole->buffer.mEchoText = false;
+        host.mpConsole->buffer.mEchoingText = false;
         // Writing to the main window must always succeed, but for consistent
         // results, we now return a true for that
         lua_pushboolean(L, true);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix use of unintialised slice.mEchoText when using copy() and rename to something more friendly - "if em echoing text then" reads better than "if em echo text then".
#### Motivation for adding to Mudlet
Less Coverity issues.
#### Other info (issues closed, discussion etc)
