### PR TITLE
Revise: do not pad RoomId numbers with zeros on 2D map

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1734,7 +1734,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
                 }
                 painter.setPen(QPen(roomIdColor));
                 painter.setFont(roomVNumFont);
-                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QStringLiteral("%1").arg(currentAreaRoom, mMaxRoomIdDigits, 10, QLatin1Char('0')));
+                // U+2007 is Unicode codepoint for "Figure Space" - the width of
+                // a numeric digit:
+                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QStringLiteral("%1").arg(currentAreaRoom, mMaxRoomIdDigits, 10, QChar(0x2007)));
                 painter.restore();
             }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -806,10 +806,6 @@ void T2DMap::paintEvent(QPaintEvent* e)
             roomTestRect = QRectF(0, 0, static_cast<qreal>(mRoomWidth) * rSize, static_cast<qreal>(mRoomHeight) * rSize);
         }
         static quint8 roomVnumMargin = 10;
-        // Peer review has suggested that under/overlining the room id numbers
-        // is not helpful after all:
-        // roomVNumFont.setUnderline(true);
-        // roomVNumFont.setOverline(true);
         roomVNumFont.setBold(true);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
         // QFont::PreferNoShaping is only available in Qt 5.10 or later
@@ -1734,9 +1730,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
                 }
                 painter.setPen(QPen(roomIdColor));
                 painter.setFont(roomVNumFont);
-                // U+2007 is Unicode codepoint for "Figure Space" - the width of
-                // a numeric digit:
-                painter.drawText(roomRectangle, Qt::AlignHCenter | Qt::AlignVCenter, QStringLiteral("%1").arg(currentAreaRoom, mMaxRoomIdDigits, 10, QChar(0x2007)));
+                painter.drawText(roomRectangle, Qt::AlignCenter, QString::number(currentAreaRoom));
                 painter.restore();
             }
 


### PR DESCRIPTION
As requested in the issue below this converts the room Id numbers when
shown in the 2D Mapper to be padded with leading spaces rather than leading
zeroes.

Note that the numbers are shown only when the longest (most digits) Room
Id number for the displayed area can be displayed at a readable size -
otherwise the mapper switches back to displaying room *symbols* if they
will fit inside the room rectangle/circle.

This closes https://github.com/Mudlet/Mudlet/issues/2560 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
