### PR TITLE
BugFix: ensure user windows closure when profile is closed if multi-playing

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -718,9 +718,11 @@ void TConsole::closeEvent(QCloseEvent* event)
 
     if (mType & (SubConsole|Buffer)) {
         if (mudlet::self()->isGoingDown() || mpHost->isClosingDown()) {
-            QString key = objectName();
-            auto pC = mpHost->mpConsole->mSubConsoleMap.take(key);
+            auto pC = mpHost->mpConsole->mSubConsoleMap.take(mConsoleName);
             if (pC) {
+                // As it happens pC will be identical to 'this' it is just that
+                // we will have removed it from the main TConsole's
+                // mSubConsoleMap:
                 mUpperPane->close();
                 mLowerPane->close();
             }
@@ -736,10 +738,12 @@ void TConsole::closeEvent(QCloseEvent* event)
 
     if (mType == UserWindow) {
         if (mudlet::self()->isGoingDown() || mpHost->isClosingDown()) {
-            QString key = objectName();
-            auto pC = mpHost->mpConsole->mSubConsoleMap.take(key);
-            auto pD = mpHost->mpConsole->mDockWidgetMap.take(key);
+            auto pC = mpHost->mpConsole->mSubConsoleMap.take(mConsoleName);
+            auto pD = mpHost->mpConsole->mDockWidgetMap.take(mConsoleName);
             if (pC) {
+                // As it happens pC will be identical to 'this' it is just that
+                // we will have removed it from the main TConsole's
+                // mSubConsoleMap:
                 mUpperPane->close();
                 mLowerPane->close();
             }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -140,7 +140,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     // system message area
     mpSystemMessageArea = new dlgSystemMessageArea(this);
-    mpSystemMessageArea->setObjectName("mpSystemMessageArea");
+    mpSystemMessageArea->setObjectName(QStringLiteral("mpSystemMessageArea"));
     splitter_right->addWidget(mpSystemMessageArea);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, mpSystemMessageArea, &QWidget::hide);
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -495,7 +495,7 @@ mudlet::mudlet()
     setWindowTitle(version);
     setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_main_48px.png")));
     mpMainToolBar = new QToolBar(this);
-    mpMainToolBar->setObjectName("mpMainToolBar");
+    mpMainToolBar->setObjectName(QStringLiteral("mpMainToolBar"));
     mpMainToolBar->setWindowTitle(tr("Main Toolbar"));
     addToolBar(mpMainToolBar);
     mpMainToolBar->setMovable(false);
@@ -1889,15 +1889,19 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
     if (!pC && !pD) {
         // The name is not used in either the QMaps of all user created TConsole
         // or TDockWidget instances - so we can make a NEW one:
-        auto pD = new TDockWidget(pHost, name);
-        pD->setObjectName(QString("dockWindow_%1_%2").arg(hostName, name));
+        pD = new TDockWidget(pHost, name);
+        pD->setObjectName(QStringLiteral("dockWindow_%1_%2").arg(hostName, name));
         pD->setContentsMargins(0, 0, 0, 0);
         pD->setFeatures(QDockWidget::AllDockWidgetFeatures);
         pD->setWindowTitle(tr("User window - %1 - %2").arg(hostName, name));
         pHost->mpConsole->mDockWidgetMap.insert(name, pD);
         // It wasn't obvious but the parent passed to the TConsole constructor
         // is sliced down to a QWidget and is NOT a TDockWidget pointer:
-        auto pC = new TConsole(pHost, TConsole::UserWindow, pD->widget());
+        pC = new TConsole(pHost, TConsole::UserWindow, pD->widget());
+        pC->setObjectName(QStringLiteral("dockWindowConsole_%1_%2").arg(hostName, name));
+        // Without this the TConsole instance inside the TDockWidget will be
+        // left being called the default value of "main":
+        pC->mConsoleName = name;
         pC->setContentsMargins(0, 0, 0, 0);
         pD->setTConsole(pC);
         pC->show();
@@ -3292,7 +3296,7 @@ void mudlet::createMapper(bool loadDefaultMap)
 
     auto hostName(pHost->getName());
     pHost->mpDockableMapWidget = new QDockWidget(tr("Map - %1").arg(hostName));
-    pHost->mpDockableMapWidget->setObjectName(QString("dockMap_%1").arg(hostName));
+    pHost->mpDockableMapWidget->setObjectName(QStringLiteral("dockMap_%1").arg(hostName));
     pHost->mpMap->mpMapper = new dlgMapper(pHost->mpDockableMapWidget, pHost, pHost->mpMap.data()); //FIXME: mpHost definieren
     pHost->mpMap->mpM = pHost->mpMap->mpMapper->glWidget;
     pHost->mpDockableMapWidget->setWidget(pHost->mpMap->mpMapper);


### PR DESCRIPTION
The previous code in `(void) TConsole::closeEvent(QCloseEvent*)` assumed the `TConsole` for a user window's `objectName` was what was used as a key in the profile's main `TConsole`'s `<QString, TConsole*> mSubConsoleMap` and `<QString, TDockWidget*> mDockWidgetMap`.

In fact for user windows the object name was never set for the `TConsole` and it would not be a good thing to have both the `TDockWidget` and the `TConsole` have the same `objectName` anyhow.  To further confuse things, the process of constructing the `TConsole` for a user window did not set a `(QString) mConsoleName` so the default of `"main"` was set for that member.

This PR revises the design so that the `TConsole::closeEvent` DOES find the wanted item in the main `TConsole`'s `mSubConsoleMap` and `mDockWidgetMap` so that the `(TTextEdit*) mUpperPane` and `mLowerPane` DO get the `close()` method called on them - and there is no error message: `"TConsole::closeEvent(QCloseEvent*) INFO - closing a UserWindow but the TDockWidget pointer was not found to be removed..."` produced for every user window that is closed when a profile is ended but the Mudlet application continues to run when multi-playing...

Also:
* A shadowed pair of `TDockWidget` and `TConsole` pointers are no longer created in `(bool) mudlet::openWindow(...)` by spurious uses of `auto` (when there are already a pair of `pD` and `pC` in existence).
* Some uses of raw strings or `QString` constructions for `objectName` are cleaned up to use `QStringLiteral` constructions instead.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>