### PR TITLE
Fix room deletion crashing in a rare case on Windows

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -207,7 +207,7 @@ bool TRoomDB::__removeRoom(int id)
         // iterator is active on - see "Implicit sharing iterator problem" in
         // "Container Class | Qt 5.x Core" - this is now avoid by taking a deep
         // copy and iterating through that instead whilst modifying the original
-        while (i != entranceMap.cend() && i.key() == id) {
+        while (i != _entranceMap.cend() && i.key() == id) {
             if (i.value() == id || (mpTempRoomDeletionSet && mpTempRoomDeletionSet->size() > 1 && mpTempRoomDeletionSet->contains(i.value()))) {
                 ++i;
                 continue; // Bypass rooms we know are also to be deleted


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Try out fix as suggested in https://github.com/Mudlet/Mudlet/issues/2557#issuecomment-498848656.
#### Motivation for adding to Mudlet
Fix crash.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2557.