### PR TITLE
Trim settings tooltip for 'show map errors' even more

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1823,7 +1823,7 @@
           <item row="1" column="2">
            <widget class="QCheckBox" name="checkBox_reportMapIssuesOnScreen">
             <property name="toolTip">
-             <string>&lt;p&gt;Mudlet now does some sanity checking and repairing to clean up issues that may have arisen in previous version due to faulty code or badly documented commands. However if significant problems are found the report can be quite extensive, in particular for larger maps. In order to reduce the amount of on-screen messages this option (if not set) will cause most of the text to not be displayed - except for a suggestion to review the report file.&lt;/i&gt;&lt;/p&gt;</string>
+             <string>&lt;p&gt;Mudlet now does some sanity checking and repairing to clean up issues that may have arisen in previous version due to faulty code or badly documented commands. However if significant problems are found the report can be quite extensive, in particular for larger maps.&lt;/p&gt;&lt;p&gt;Unless this option is set, Mudlet will reduce the amount of on-screen messages by hiding many texts and showing a suggestion to review the report file instead.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Report map issues on screen</string>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Trim tooltip text. Remove obsolete HTML. Split text in two paragraphs.

#### Motivation for adding to Mudlet
Improve readability.

#### Other info (issues closed, discussion etc)
Fix #2601