### PR TITLE
Enhance: allow more than one room ID to have same hash value

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -184,6 +184,7 @@ public:
     static int getRoomAreaName(lua_State*);
     static int addAreaName(lua_State* L);
     static int getRoomIDbyHash(lua_State* L);
+    static int getRoomIDsbyHash(lua_State* L);
     static int getRoomHashByID(lua_State* L);
     static int setRoomIDbyHash(lua_State* L);
     static int sendSocket(lua_State* L);

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -159,6 +159,7 @@ public:
     float highlightRadius;
     bool rendered;
     QMap<QString, int> doors; //0=no door 1=open 2=closed 3=locked
+    QString mHash;
 
 
 private:

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -255,10 +255,9 @@ bool TRoomDB::__removeRoom(int id)
             ++i;
         }
         rooms.remove(id);
-        if (roomIDToHash.contains(id)) {
-            QString hash = roomIDToHash[id];
-            roomIDToHash.remove(id);
-            hashToRoomID.remove(hash);
+        // Always remove any matching hashToRoomID entries
+        if (!pR->mHash.isEmpty()) {
+            hashToRoomID.remove(pR->mHash, id);
         }
         int areaID = pR->getArea();
         TArea* pA = getArea(areaID);
@@ -1077,7 +1076,6 @@ void TRoomDB::clearMapDB()
     entranceMap.clear();
     areaNamesMap.clear();
     hashToRoomID.clear();
-    roomIDToHash.clear();
     for (auto room : rPtrL) {
         delete room; // Uses the internally held value of the room Id
                      // (TRoom::id) to call TRoomDB::__removeRoom(id)

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -80,14 +80,15 @@ public:
     void restoreSingleRoom(int, TRoom*);
     const QString getDefaultAreaName() { return mDefaultAreaName; }
 
-    // This is for muds that provide hashes to rooms instead of IDs.
+    // This is for muds that provide hashes to rooms instead of IDs, and
+    // latterly for the user to produce their own indexing/hashing schemes.
     // If it exists, we delete the info when deleting a room.
-    // But we rely on the user to add the data, don't do any checking,
-    // and it isn't audited.
-    // It should be a QHash, but changing it would break loading from files
-    // saved under the old version.
-    QMap<QString, int> hashToRoomID;
-    QMap<int, QString> roomIDToHash;
+    // We rely on the user to add the data, and do limited checking.
+    // For map file formats prior to 21 it was a QMap and NOT a "multi" one,
+    // this was changed to allow the Hash table to allow be used for locally
+    // generated hashes (e.g. derived from the room description) which may
+    // produce collisions:
+    QMultiHash<QString, int> hashToRoomID;
 
 
 private:


### PR DESCRIPTION
This PR revises the ability to have a hash (arbitrary `QString`) to represent a room number so that the same hash can refer to more than a single room.

The code is refactored in such a way that it should behave in a backwards compatible manner - i.e. existing packages or scripts should not see any difference if they invoke the existing functions in the way they have up to the present. However, if a script or package checks and confirms the existence of the new function `getRoomIDsbyHash` (note the extra 's') then it can know that it can invoke the extended functionality of both that function (which returns a table of ALL the rooms with a hash that matches) and also:
+ supply an optional `false` third argument to `setRoomIDbyHash` to cause it to return a nil + error message should the same hash be supplied for more than one room id - the previous code would silently forget about the
previous room id against that hash and only remember the last one stored.
+ supply an optional `true` second argument to `getRoomIDbyHash` to cause it to return a nil + error message should there be more (or less) than one room id stored for the given hash string.  Previous code would return `-1`
if no room was found and only the last room id stored with that hash if there was more than one - which is what will happen without that optional argument being present and true.

Also, `setRoomIDbyHash` can now clear a hash for a room id by supplying an empty string as the hash. This does mean that no room can have a hash that is an empty string...

This PR also revises the Mudlet binary Map Format to version 21. This is necessary and required to retain the `QMultiHash<QString, int>` entity that now contains the hash to room Id table. This is incompatible with previous
map formats so the map saving code will now warn if a previous format is used AND there are MULTIPLE ROOMS with the SAME hash. This will not occur for the prior usage of the hash feature so existing packages/scripts should not be affected however users that do create hashing schemes (like I have been doing using WoTMUD's room descriptions) will need to set their map format control to 21 to prevent data loss (or warnings about it) if they do have hash collisions.

This PR was prompted by another recent one: https://github.com/Mudlet/Mudlet/pull/2570 by @LiamLeFey and, as it happens does actually rip out some of his code to do things in a different way - instead of keeping a central `QMap<int, QString> TRoomDB::roomIDToHash` to provid the reverse lookup of room id to hash - the hash value is stored directly within the `TRoom` instances themselves.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>