### PR TITLE
Parametrize texts for Lua modules

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14916,7 +14916,8 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+            "%1 is the name of the module.")
             .arg(QStringLiteral("rex_pcre"));
         mpHost->postMessage(msg);
     }
@@ -14935,7 +14936,8 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+            "%1 is the name of the module.")
             .arg(QStringLiteral("zip"));
         mpHost->postMessage(msg);
     }
@@ -14955,7 +14957,8 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+            "%1 is the name of the module.")
             .arg(QStringLiteral("lfs"));
         mpHost->postMessage(msg);
     }
@@ -14976,7 +14979,8 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+            "%1 is the name of the module.")
             .arg(QStringLiteral("sqlite3"));
         mpHost->postMessage(msg);
     }
@@ -14996,7 +15000,8 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+            "%1 is the name of the module.")
             .arg(QStringLiteral("utf8"));
         mpHost->postMessage(msg);
     }
@@ -15016,7 +15021,8 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+            "%1 is the name of the module.")
             .arg(QStringLiteral("yajl"));
         mpHost->postMessage(msg);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14908,12 +14908,16 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module rex_pcre.\n"
-                         "Some functions may not be available.\n");
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+            "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+            .arg(QStringLiteral("rex_pcre"))
+            .arg(QStringLiteral("\n%1\n"))
+            .arg(tr("Some functions may not be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module rex_pcre loaded.");
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+            .arg(QStringLiteral("rex_pcre"));
         mpHost->postMessage(msg);
     }
 
@@ -14924,11 +14928,15 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module zip.\n");
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+            "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+            .arg(QStringLiteral("zip"))
+            .arg(QString());
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module zip loaded.");
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+            .arg(QStringLiteral("zip"));
         mpHost->postMessage(msg);
     }
 
@@ -14939,12 +14947,16 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module lfs (Lua File System).\n"
-                         "Probably will not be able to access Mudlet Lua code.\n");
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+            "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+            .arg(QStringLiteral("lfs (Lua File System)"))
+            .arg(QStringLiteral("\n%1\n"))
+            .arg(tr("Probably will not be able to access Mudlet Lua code."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module lfs loaded.");
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+            .arg(QStringLiteral("lfs"));
         mpHost->postMessage(msg);
     }
 
@@ -14955,15 +14967,19 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module luasql.sqlite3.\n"
-                         "Database support will not be available.\n");
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+    "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+    .arg(QStringLiteral("luasql.sqlite3"))
+    .arg(QStringLiteral("\n%1\n"))
+    .arg(tr("Database support will not be available."));
+
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module sqlite3 loaded.");
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+            .arg(QStringLiteral("sqlite3"));
         mpHost->postMessage(msg);
     }
-
 
     error = luaL_dostring(pGlobalLua, R"(utf8 = require "lua-utf8")");
     if (error != 0) {
@@ -14972,15 +14988,18 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module utf8.\n"
-                         "utf8.* Lua functions won't be available.\n");
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+            "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+            .arg(QStringLiteral("utf8"))
+            .arg(QStringLiteral("\n%1\n"))
+            .arg(tr("utf8.* Lua functions won't be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module utf8 loaded.");
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+            .arg(QStringLiteral("utf8"));
         mpHost->postMessage(msg);
     }
-
 
     error = luaL_dostring(pGlobalLua, R"(yajl = require "yajl")");
     if (error != 0) {
@@ -14989,12 +15008,16 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module yajl.\n"
-                         "yajl.* Lua functions won't be available.\n");
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+            "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+            .arg(QStringLiteral("yajl"))
+            .arg(QStringLiteral("\n%1\n"))
+            .arg(tr("yajl.* Lua functions won't be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module yajl loaded.");
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.")
+            .arg(QStringLiteral("yajl"));
         mpHost->postMessage(msg);
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14910,8 +14910,8 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-            .arg(QStringLiteral("rex_pcre"))
-            .arg(QStringLiteral("\n%1\n"))
+            .arg(QStringLiteral("rex_pcre"),
+                 QStringLiteral("\n%1\n"))
             .arg(tr("Some functions may not be available."));
         msg.append(e);
         mpHost->postMessage(msg);
@@ -14971,10 +14971,10 @@ void TLuaInterpreter::initLuaGlobals()
             e += lua_tostring(pGlobalLua, -1);
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
-    "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-    .arg(QLatin1String("luasql.sqlite3"),
-         QLatin1String("\n%1\n"))
-    .arg(tr("Database support will not be available."));
+            "%1 is the name of the module. %2 can be an additional message about the expected effect.")
+            .arg(QLatin1String("luasql.sqlite3"),
+                 QLatin1String("\n%1\n"))
+            .arg(tr("Database support will not be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14931,14 +14931,14 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-            .arg(QStringLiteral("zip"))
-            .arg(QString());
+            .arg(QLatin1String("zip"),
+                 QString());
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
         QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
             "%1 is the name of the module.")
-            .arg(QStringLiteral("zip"));
+            .arg(QLatin1String("zip"));
         mpHost->postMessage(msg);
     }
 
@@ -14951,15 +14951,15 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-            .arg(QStringLiteral("lfs (Lua File System)"))
-            .arg(QStringLiteral("\n%1\n"))
+            .arg(QLatin1String("lfs (Lua File System)"),
+                 QLatin1String("\n%1\n"))
             .arg(tr("Probably will not be able to access Mudlet Lua code."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
         QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
             "%1 is the name of the module.")
-            .arg(QStringLiteral("lfs"));
+            .arg(QLatin1String("lfs"));
         mpHost->postMessage(msg);
     }
 
@@ -14972,16 +14972,15 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
     "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-    .arg(QStringLiteral("luasql.sqlite3"))
-    .arg(QStringLiteral("\n%1\n"))
+    .arg(QLatin1String("luasql.sqlite3"),
+         QLatin1String("\n%1\n"))
     .arg(tr("Database support will not be available."));
-
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
         QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
             "%1 is the name of the module.")
-            .arg(QStringLiteral("sqlite3"));
+            .arg(QLatin1String("sqlite3"));
         mpHost->postMessage(msg);
     }
 
@@ -14994,15 +14993,15 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-            .arg(QStringLiteral("utf8"))
-            .arg(QStringLiteral("\n%1\n"))
+            .arg(QLatin1String("utf8"),
+                 QLatin1String("\n%1\n"))
             .arg(tr("utf8.* Lua functions won't be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
         QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
             "%1 is the name of the module.")
-            .arg(QStringLiteral("utf8"));
+            .arg(QLatin1String("utf8"));
         mpHost->postMessage(msg);
     }
 
@@ -15015,15 +15014,15 @@ void TLuaInterpreter::initLuaGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
-            .arg(QStringLiteral("yajl"))
-            .arg(QStringLiteral("\n%1\n"))
+            .arg(QLatin1String("yajl"),
+                 QLatin1String("\n%1\n"))
             .arg(tr("yajl.* Lua functions won't be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
         QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
             "%1 is the name of the module.")
-            .arg(QStringLiteral("yajl"));
+            .arg(QLatin1String("yajl"));
         mpHost->postMessage(msg);
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Texts shown when required Lua modules are loaded now parameters for the name of module and an optional more detailed error message.

#### Motivation for adding to Mudlet
Combine multiple very alike texts into one, so translators have less work.

#### Other info (issues closed, discussion etc)
Found issue during translation here: https://crowdin.com/translate/mudlet/137/en-de#89862

This whole section seems very repetitive. 
Maybe make another issue to create a function for this?