### PR TITLE
Keep "New alias" if no regex exists

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4082,7 +4082,7 @@ void dlgTriggerEditor::saveAlias()
     mpAliasMainArea->trimName();
     QString name = mpAliasMainArea->lineEdit_alias_name->text();
     QString regex = mpAliasMainArea->lineEdit_alias_pattern->text();
-    if ((name.size() < 1) || (name == "New Alias")) {
+    if (!regex.isEmpty() && ((name.isEmpty()) || (name == "New Alias"))) {
         name = regex;
     }
     QString substitution = mpAliasMainArea->lineEdit_alias_command->text();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
"New alias" should not loose their name while they are still new

#### Motivation for adding to Mudlet
Less empty named items

#### Other info (issues closed, discussion etc)
Fix #2637 