### PR TITLE
Add seperator to editor window

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -504,6 +504,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar2->addAction(viewKeysAction);
     toolBar2->addAction(viewVarsAction);
     toolBar2->addAction(viewActionAction);
+
+    toolBar2->addSeparator();
+    
     toolBar2->addAction(viewErrorsAction);
     toolBar2->addAction(viewStatsAction);
     toolBar2->addAction(showDebugAreaAction);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Emphazise special actions at the end of the toolbar

#### Motivation for adding to Mudlet
The first buttons let you view and edit created items (and groups) in this very editor window.
The last three buttons are different:
* Error - superimpose error pane in editor window
* Statistics - display numbers in main window (maybe move this elsewhere eventually?)
* Debug - open a new debug window with precious information

#### Other info (issues closed, discussion etc)
Top toolbar has some seperators between different items.
Green line indicates the new seperator on left hand toolbar.
![image](https://user-images.githubusercontent.com/117238/59887717-b8835a80-93c4-11e9-81ea-b99f3e051853.png)