### PR TITLE
Generalize travis deployment jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
+      DEPLOY=deploy
 
   - os: osx
     osx_image: xcode9.2
@@ -78,6 +79,7 @@ matrix:
     env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=512
+      DEPLOY=deploy
     addons:
       apt:
         sources: *add-sources

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
     env:
     - Q_OR_C_MAKE=qmake
       QT_VERSION=512
+      DEPLOY=deploy
     addons:
       apt:
         sources: *add-sources
@@ -79,7 +80,6 @@ matrix:
     env:
     - Q_OR_C_MAKE=cmake
       QT_VERSION=512
-      DEPLOY=deploy
     addons:
       apt:
         sources: *add-sources

--- a/CI/travis.compile.sh
+++ b/CI/travis.compile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 compile_line=()
 if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-  if [ "${CC}" = "clang" ] || [ "${Q_OR_C_MAKE}" = "cmake" ] || [ "${QT_VERSION}" = "56" ]; then
+  if [ "${DEPLOY}" != "deploy" ] || [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     echo Job not executed under cron run
     exit 0
   fi

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-# we deploy only qmake and gcc combination for linux
-if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "gcc" ]; then
+# we deploy only certain builds
+if [ "${DEPLOY}" = "deploy" ]; then
 
   if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     if $(git diff --name-only | grep -q "mudlet.ts"); then

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -7,8 +7,8 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
   exit
 fi
 
-# we deploy only qmake and clang combination for macOS
-if [ "${Q_OR_C_MAKE}" = "qmake" ] && [ "${CC}" = "clang" ]; then
+# we deploy only certain builds
+if [ "${DEPLOY}" = "deploy" ]; then
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
   cd "${TRAVIS_BUILD_DIR}/../installers/osx"

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -16,7 +16,7 @@ fi
 VERSION=""
 
 if [ "${Q_OR_C_MAKE}" = "cmake" ]; then
-  VERSION=$(perl -lne 'print $1 if /^SET\(APP_VERSION (.+)\)/' < "${TRAVIS_BUILD_DIR}/CMakeLists.txt")
+  VERSION=$(perl -lne 'print $1 if /^set\(APP_VERSION (.+)\)/' < "${TRAVIS_BUILD_DIR}/CMakeLists.txt")
 elif [ "${Q_OR_C_MAKE}" = "qmake" ]; then
   VERSION=$(perl -lne 'print $1 if /^VERSION = (.+)/' < "${TRAVIS_BUILD_DIR}/src/mudlet.pro")
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 # file, which is NOW called: ./src/mudlet.pro
 set(APP_VERSION 3.21.0)
 if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD} STREQUAL "")
-  SET(APP_BUILD $ENV{MUDLET_VERSION_BUILD})
+  set(APP_BUILD $ENV{MUDLET_VERSION_BUILD})
 else()
   set(APP_BUILD "-dev")
 endif()


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This will make it a bit easier to determine the travis builds that are deployed as travis will list the environment variables in the job view. Additionally, deployed builds are less hard coded and we can generalize the deployment bot, see Mudlet/deployment-link-probot#11

#### Motivation for adding to Mudlet
A bit more info at a glance and less hardcoding.

#### Other info (issues closed, discussion etc)
Closes #2600