### PR TITLE
Remove double-declaration in createMiniConsole

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1949,7 +1949,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
 
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (!pC) {
-        TConsole* pC = pHost->mpConsole->createMiniConsole(name, x, y, width, height);
+        pC = pHost->mpConsole->createMiniConsole(name, x, y, width, height);
         if (pC) {
             pC->setMiniConsoleFontSize(12);
             return true;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove double-declaration in createMiniConsole - `pC` is declared just a few lines above.
#### Motivation for adding to Mudlet
Better code.
#### Other info (issues closed, discussion etc)
