### PR TITLE
Added translatable directions and a function for scripters to use

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15056,7 +15056,7 @@ void TLuaInterpreter::setupLanguageData()
     lua_setfield(L, -2, "n");
     lua_pushstring(L, QCoreApplication::translate("directions", "east", "Entering this direction will move the player in the game").toUtf8().constData());
     lua_setfield(L, -2, "east");
-    lua_pushstring(L, QCoreApplication::translate("directions", "s", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_pushstring(L, QCoreApplication::translate("directions", "e", "Entering this direction will move the player in the game").toUtf8().constData());
     lua_setfield(L, -2, "s");
     lua_pushstring(L, QCoreApplication::translate("directions", "south", "Entering this direction will move the player in the game").toUtf8().constData());
     lua_setfield(L, -2, "south");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -47,6 +47,7 @@
 
 #include "pre_guard.h"
 #include <QCollator>
+#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QVector>
@@ -14905,7 +14906,7 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2",
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
             .arg(QStringLiteral("rex_pcre"),
                  QStringLiteral("\n%1\n"))
@@ -14913,7 +14914,7 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.",
             "%1 is the name of the module.")
             .arg(QStringLiteral("rex_pcre"));
         mpHost->postMessage(msg);
@@ -14926,14 +14927,14 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2",
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
             .arg(QLatin1String("zip"),
                  QString());
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.",
             "%1 is the name of the module.")
             .arg(QLatin1String("zip"));
         mpHost->postMessage(msg);
@@ -14946,7 +14947,7 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2",
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
             .arg(QLatin1String("lfs (Lua File System)"),
                  QLatin1String("\n%1\n"))
@@ -14954,7 +14955,7 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.",
             "%1 is the name of the module.")
             .arg(QLatin1String("lfs"));
         mpHost->postMessage(msg);
@@ -14967,7 +14968,7 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2",
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
             .arg(QLatin1String("luasql.sqlite3"),
                  QLatin1String("\n%1\n"))
@@ -14975,7 +14976,7 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.",
             "%1 is the name of the module.")
             .arg(QLatin1String("sqlite3"));
         mpHost->postMessage(msg);
@@ -14988,7 +14989,7 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2",
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
             .arg(QLatin1String("utf8"),
                  QLatin1String("\n%1\n"))
@@ -14996,7 +14997,7 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.",
             "%1 is the name of the module.")
             .arg(QLatin1String("utf8"));
         mpHost->postMessage(msg);
@@ -15009,7 +15010,7 @@ void TLuaInterpreter::initLuaGlobals()
             e = tr("Lua error:");
             e += lua_tostring(pGlobalLua, -1);
         }
-        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2", 
+        QString msg = tr("[ ERROR ] - Cannot find Lua module %1.%2",
             "%1 is the name of the module. %2 can be an additional message about the expected effect.")
             .arg(QLatin1String("yajl"),
                  QLatin1String("\n%1\n"))
@@ -15017,7 +15018,7 @@ void TLuaInterpreter::initLuaGlobals()
         msg.append(e);
         mpHost->postMessage(msg);
     } else {
-        QString msg = tr("[  OK  ]  - Lua module %1 loaded.", 
+        QString msg = tr("[  OK  ]  - Lua module %1 loaded.",
             "%1 is the name of the module.")
             .arg(QLatin1String("yajl"));
         mpHost->postMessage(msg);
@@ -15033,6 +15034,80 @@ void TLuaInterpreter::initLuaGlobals()
     lua_pop(pGlobalLua, lua_gettop(pGlobalLua));
 
     //FIXME make function call in destructor lua_close(L);
+}
+
+// No documentation available in wiki - internal function
+// Creates a 'mudlet.translations' table with directions
+void TLuaInterpreter::setupLanguageData()
+{
+    lua_State* L = pGlobalLua;
+
+    // 'mudlet' global table
+    lua_createtable(L, 0, 1);
+    // language-specific table
+    lua_createtable(L, 0, 1);
+    // language-specific directions table
+    lua_createtable(L, 0, 24);
+
+    // this cannot be generated programmatically since lupdate needs the explicit string at extraction time
+    lua_pushstring(L, QCoreApplication::translate("directions", "north", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "north");
+    lua_pushstring(L, QCoreApplication::translate("directions", "n", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "n");
+    lua_pushstring(L, QCoreApplication::translate("directions", "east", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "east");
+    lua_pushstring(L, QCoreApplication::translate("directions", "s", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "s");
+    lua_pushstring(L, QCoreApplication::translate("directions", "south", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "south");
+    lua_pushstring(L, QCoreApplication::translate("directions", "s", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "s");
+    lua_pushstring(L, QCoreApplication::translate("directions", "west", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "west");
+    lua_pushstring(L, QCoreApplication::translate("directions", "w", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "w");
+    lua_pushstring(L, QCoreApplication::translate("directions", "northeast", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "northeast");
+    lua_pushstring(L, QCoreApplication::translate("directions", "ne", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "ne");
+    lua_pushstring(L, QCoreApplication::translate("directions", "southeast", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "southeast");
+    lua_pushstring(L, QCoreApplication::translate("directions", "se", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "se");
+    lua_pushstring(L, QCoreApplication::translate("directions", "southwest", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "southwest");
+    lua_pushstring(L, QCoreApplication::translate("directions", "sw", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "sw");
+    lua_pushstring(L, QCoreApplication::translate("directions", "northwest", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "northwest");
+    lua_pushstring(L, QCoreApplication::translate("directions", "nw", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "nw");
+    lua_pushstring(L, QCoreApplication::translate("directions", "in", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "in");
+    lua_pushstring(L, QCoreApplication::translate("directions", "i", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "i");
+    lua_pushstring(L, QCoreApplication::translate("directions", "out", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "out");
+    lua_pushstring(L, QCoreApplication::translate("directions", "o", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "o");
+    lua_pushstring(L, QCoreApplication::translate("directions", "up", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "up");
+    lua_pushstring(L, QCoreApplication::translate("directions", "u", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "u");
+    lua_pushstring(L, QCoreApplication::translate("directions", "down", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "down");
+    lua_pushstring(L, QCoreApplication::translate("directions", "d", "Entering this direction will move the player in the game").toUtf8().constData());
+    lua_setfield(L, -2, "d");
+
+    // finalize language-specific directions table
+    lua_setfield(L, -2, mudlet::self()->mInterfaceLanguage.toUtf8().constData());
+
+    lua_pushstring(L, mudlet::self()->mInterfaceLanguage.toUtf8().constData());
+    lua_setfield(L, -2, "interfacelanguage");
+
+    lua_setfield(L, -2, "translations");
+    lua_setglobal(L, "mudlet");
+    lua_pop(L, lua_gettop(L));
 }
 
 // No documentation available in wiki - internal function
@@ -15123,6 +15198,8 @@ void TLuaInterpreter::initIndenterGlobals()
 // No documentation available in wiki - internal function
 void TLuaInterpreter::loadGlobal()
 {
+    setupLanguageData();
+
 #if defined(Q_OS_MACOS)
     // Load relatively to MacOS inside Resources when we're in a .app bundle,
     // as mudlet-lua always gets copied in by the build script into the bundle

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -515,6 +515,7 @@ private:
     QByteArray encodeBytes(const char*);
     void setMatches(lua_State* L);
     static std::pair<bool, QString> discordApiEnabled(lua_State* L, bool writeAccess = false);
+    void setupLanguageData();
 
     QNetworkAccessManager* mpFileDownloader;
 

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -904,3 +904,21 @@ creplaceLine = function(str)
 	replace("")
 	cinsertText(str)
 end
+
+function translateTable(data, language)
+  language = language or mudlet.translations.interfacelanguage
+  assert(type(data) == "table", string.format("translateTable: bad argument #1 type (input as table expected, got %s!)", type(data)))
+
+  local t, translations = {}, mudlet.translations[language]
+
+  if not translations then
+    return nil, language.." doesn't have any translations for it"
+  end
+
+  for i = 1, #data do
+    local key = data[i]
+    t[#t+1] = translations[key]
+  end
+
+  return t
+end


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This creates a key-value "mudlet.translations._language_" table as well as a "mudlet.translations.interfacelanguage" key. The table will hold the translations of normal directions and the key holds the current interface language.

Note that due to limitations in Qt, only one language is ever populated at a time: the current interface language. You cannot load translations from other languages other than the one you're using, not without a lot of work. This means that a Spanish person playing a German game that only accepts German directions for input won't be able to use Mudlets speedwalking - but since we've been stuck on this very rare usecase for the last year without any progress, I think it's an acceptable compromise.

I've added a companion function `translateTable()` which given a table and an optional language string will translate directions. This means script writers, if they want to get directions translated, simply need to add:

```lua
speedWalkDir = translateTable(speedWalkDir)
```

After the `getPath()` function and they'll have the localised directions.

We have to merge this PR first, re-run `ludpate`, and translate strings in Crowdin before we can test that this works for real.
#### Motivation for adding to Mudlet
One more step towards 4.0 and finally a PR that's relevant to i18n! I feel we are getting off track a bit...
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2692