### PR TITLE
Remove self-test profile from release build

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1497,6 +1497,7 @@ void dlgConnectionProfiles::fillout_form()
         }
     }
 
+#if defined(QT_DEBUG)
     mudServer = QStringLiteral("Mudlet self-test");
     if (!deletedDefaultMuds.contains(mudServer) && !mProfileList.contains(mudServer)) {
         for (int i = mProfileList.size() - 1; i >= 0; --i) {
@@ -1506,6 +1507,7 @@ void dlgConnectionProfiles::fillout_form()
             }
         }
     }
+#endif
 
     for (int i = 0; i < mProfileList.size(); i++) {
         QString s = mProfileList.at(i);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove self-test profile from release build
#### Motivation for adding to Mudlet
We don't have adequate documentation to introduce this feature to the users yet - so let's keep it for developers in 3.22 and hopefully present it publicly in the next release after.
#### Other info (issues closed, discussion etc)
Just announcing a feature when there's no documentation for it or examples to copy from isn't very good.