### PR TITLE
Fix translateTable() losing non-translatable text

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -917,7 +917,7 @@ function translateTable(data, language)
 
   for i = 1, #data do
     local key = data[i]
-    t[#t+1] = translations[key]
+    t[#t+1] = translations[key] or key
   end
 
   return t

--- a/translations/mudlet.ts
+++ b/translations/mudlet.ts
@@ -4661,12 +4661,12 @@ Count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1877"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1879"/>
         <source>You have to enter a number. Other characters are not permitted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1866"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1868"/>
         <source>This profile name is already in use.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4717,61 +4717,61 @@ Count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1854"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1856"/>
         <source>The %1 character is not permitted. Use one of the following:
 &quot;%2&quot;.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1887"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1953"/>
+        <source>&lt;p&gt;Load profile without connecting.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1967"/>
+        <source>&lt;p&gt;Please set a valid profile name, game server address and the game port before loading.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1971"/>
+        <source>&lt;p&gt;Please set a valid profile name, game server address and the game port before connecting.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1897"/>
+        <source>Mudlet is not configured for secure connections.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1889"/>
         <source>Port number must be above zero and below 65535.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1951"/>
-        <source>&lt;p&gt;Load profile without connecting.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1965"/>
-        <source>&lt;p&gt;Please set a valid profile name, game server address and the game port before loading.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1969"/>
-        <source>&lt;p&gt;Please set a valid profile name, game server address and the game port before connecting.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1895"/>
-        <source>Mudlet is not configured for secure connections.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1898"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1900"/>
         <source>Mudlet is not configured for secure connections.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1907"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1909"/>
         <source>Mudlet can not load support for secure connections.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1921"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1923"/>
         <source>Please enter the URL or IP address of the Game server.
 
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dlgConnectionProfiles.cpp" line="1930"/>
+        <location filename="../src/dlgConnectionProfiles.cpp" line="1932"/>
         <source>SSL connections require the URL of the Game server.
 
 %1</source>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
`translateTable()` would only keep texts it knew about:

```
lua mmp.speedWalkDir
{
  "nw",
  "nw",
  "nw",
  "n",
  "n",
  "enter grate",
  "n",
  "ne",
  "ne",
  "up"
}
lua translateTable(mmp.speedWalkDir)
{
  "сз",
  "сз",
  "сз",
  "с",
  "с",
  "с",
  "св",
  "св",
  "вверх"
}
```

With this fix:

```
lua translateTable(mmp.speedWalkDir)
{
  "сз",
  "сз",
  "сз",
  "с",
  "с",
  "enter grate",
  "с",
  "св",
  "св",
  "вверх"
}
```
#### Motivation for adding to Mudlet
Fix discovered bug while testing and documenting the function.
#### Other info (issues closed, discussion etc)
