### PR TITLE
Revert "Change default command separator to ;; (#1866)"

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -57,7 +57,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mBorderRightWidth(0)
 , mBorderTopHeight(0)
 , mCommandLineFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
-, mCommandSeparator(QLatin1String(";;"))
+, mCommandSeparator(QLatin1String(";"))
 , mDisplayFont(QFont("Bitstream Vera Sans Mono", 10, QFont::Normal))
 , mEnableGMCP(true)
 , mEnableMSDP(false)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This reverts commit fb8e276379d279bdeeb28e0a3690b56aeb6b9d55.
#### Motivation for adding to Mudlet
We're going to be stressing out a lot of people by making them update their packages ASAP for the new Mudlet.
#### Other info (issues closed, discussion etc)
We'll announce that we're changing it next release in first week of August 2019 instead.

Also mention that `getCommandSeparator()` exists and players can always adjust the command separator to what they'd like.