### PR TITLE
Speed up Windows Appveyor builds by 2x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ artifacts:
   name: mudlet
 
 cache:
-  - '%MINGW_BASE_DIR%'
+  - '%MINGW_BASE_DIR%' -> CI\appveyor.install.ps1
 
 notifications:
 - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ artifacts:
   name: mudlet
 
 cache:
-  - '%MINGW_BASE_DIR%' -> CI\appveyor.install.ps1
+  - '%MINGW_BASE_DIR% -> CI\appveyor.install.ps1'
 
 notifications:
 - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,9 @@ artifacts:
 - path: src\release
   name: mudlet
 
+cache:
+  - '%MINGW_BASE_DIR%'
+
 notifications:
 - provider: Webhook
   url: https://webhooks.gitter.im/e/2d6f7bea328a9dd60769


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add Appveyor caching of 3rd party dependencies.
#### Motivation for adding to Mudlet
It takes a really long while to compile the same version of 3rd party libraries every time :(

And Appveyor only does it one build at a time for the entire project...
#### Other info (issues closed, discussion etc)
Typical Appveyor build takes 14-16 min, with the cache: half a 7-8min.

![image](https://user-images.githubusercontent.com/110988/60687722-ab7c6600-9eb0-11e9-8eb0-bb46aaa2ac2a.png)

Look for the nice `Cache 'C:\Qt\Tools\mingw730_32' - Restored` line at the top of the logs :grinning: 