### PR TITLE
Don't make super-advanced CLI arguments translatable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,46 +227,46 @@ int main(int argc, char* argv[])
                                                      "less likely to be useful for normal use of this application:\n")
                  .arg(QLatin1String(APP_TARGET));
         // From documentation and from http://qt-project.org/doc/qt-5/qapplication.html:
-        texts << QCoreApplication::translate("main", "       --dograb        ignore any implicit or explicit -nograb.\n"
-                                                     "                       --dograb wins over --nograb even when --nograb is last on\n"
-                                                     "                       the command line.\n");
+        texts << QStringLiteral("       --dograb        ignore any implicit or explicit -nograb.\n"
+                                "                       --dograb wins over --nograb even when --nograb is last on\n"
+                                "                       the command line.\n");
 #if defined(Q_OS_LINUX)
         // Need to split these into actually seperate strings, as Crowdin translation would not split strings on #if otherwise.
-        texts << QCoreApplication::translate("main", "       --nograb        the application should never grab the mouse or the\n"
-                                                     "                       keyboard. This option is set by default when Mudlet is\n"
-                                                     "                       running in the gdb debugger under Linux.\n");
+        texts << QStringLiteral("       --nograb        the application should never grab the mouse or the\n"
+                                "                       keyboard. This option is set by default when Mudlet is\n"
+                                "                       running in the gdb debugger under Linux.\n");
 #else // ! defined(Q_OS_LINUX)
-        texts << QCoreApplication::translate("main", "       --nograb        the application should never grab the mouse or the\n"
-                                                     "                       keyboard.\n");
+        texts << QStringLiteral("       --nograb        the application should never grab the mouse or the\n"
+                                "                       keyboard.\n");
 #endif // ! defined(Q_OS_LINUX)
-        texts << QCoreApplication::translate("main", "       --reverse       sets the application's layout direction to right to left.\n"
-                                                     "       --style= style  sets the application GUI style. Possible values depend on\n"
-                                                     "                       your system configuration. If Qt was compiled with\n"
-                                                     "                       additional styles or has additional styles as plugins\n"
-                                                     "                       these will be available to the -style command line\n"
-                                                     "                       option. You can also set the style for all Qt\n"
-                                                     "                       applications by setting the QT_STYLE_OVERRIDE environment\n"
-                                                     "                       variable.\n"
-                                                     "       --style style   is the same as listed above.\n"
-                                                     "       --stylesheet= stylesheet  sets the application styleSheet.\n"
-                                                     "                       The value must be a path to a file that contains the\n"
-                                                     "                       Style Sheet. Note: Relative URLs in the Style Sheet file\n"
-                                                     "                       are relative to the Style Sheet file's path.\n"
-                                                     "       --stylesheet stylesheet  is the same as listed above.\n");
+        texts << QStringLiteral("       --reverse       sets the application's layout direction to right to left.\n"
+                                "       --style= style  sets the application GUI style. Possible values depend on\n"
+                                "                       your system configuration. If Qt was compiled with\n"
+                                "                       additional styles or has additional styles as plugins\n"
+                                "                       these will be available to the -style command line\n"
+                                "                       option. You can also set the style for all Qt\n"
+                                "                       applications by setting the QT_STYLE_OVERRIDE environment\n"
+                                "                       variable.\n"
+                                "       --style style   is the same as listed above.\n"
+                                "       --stylesheet= stylesheet  sets the application styleSheet.\n"
+                                "                       The value must be a path to a file that contains the\n"
+                                "                       Style Sheet. Note: Relative URLs in the Style Sheet file\n"
+                                "                       are relative to the Style Sheet file's path.\n"
+                                "       --stylesheet stylesheet  is the same as listed above.\n");
 // Not sure about MacOS case as that does not use X
 #if defined(Q_OS_UNIX) && (! defined(Q_OS_MACOS))
-        texts << QCoreApplication::translate("main", "       --sync          forces the X server to perform each X client request\n"
-                                                     "                       immediately and not use buffer optimization. It makes the\n"
-                                                     "                       program easier to debug and often much slower. The --sync\n"
-                                                     "                       option is only valid for the X11 version of Qt.\n");
+        texts << QStringLiteral("       --sync          forces the X server to perform each X client request\n"
+                                "                       immediately and not use buffer optimization. It makes the\n"
+                                "                       program easier to debug and often much slower. The --sync\n"
+                                "                       option is only valid for the X11 version of Qt.\n");
 #endif // defined(Q_OS_UNIX) and not defined(Q_OS_MACOS)
-        texts << QCoreApplication::translate("main", "       --widgetcount   prints debug message at the end about number of widgets\n"
-                                                     "                       left undestroyed and maximum number of widgets existing\n"
-                                                     "                       at the same time.\n"
-                                                     "       --qmljsdebugger=1234[,block]  activates the QML/JS debugger with a\n"
-                                                     "                       specified port. The number is the port value and block is\n"
-                                                     "                       optional and will make the application wait until a\n"
-                                                     "                       debugger connects to it.\n\n");
+        texts << QStringLiteral("       --widgetcount   prints debug message at the end about number of widgets\n"
+                                "                       left undestroyed and maximum number of widgets existing\n"
+                                "                       at the same time.\n"
+                                "       --qmljsdebugger=1234[,block]  activates the QML/JS debugger with a\n"
+                                "                       specified port. The number is the port value and block is\n"
+                                "                       optional and will make the application wait until a\n"
+                                "                       debugger connects to it.\n\n");
         texts << QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues\n");
         texts << QCoreApplication::translate("main", "Project home page: http://www.mudlet.org/\n");
         std::cout << texts.join(QString()).toStdString();
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
     QString splash_message;
     if (show_splash) {
         splash_message.append(QLatin1String("\n\n"));
-        splash_message.append(QCoreApplication::translate("main", 
+        splash_message.append(QCoreApplication::translate("main",
                               "Mudlet comes with\n"
                               "ABSOLUTELY NO WARRANTY!\n"
                               "This is free software, and you are\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,7 +231,6 @@ int main(int argc, char* argv[])
                                 "                       --dograb wins over --nograb even when --nograb is last on\n"
                                 "                       the command line.\n");
 #if defined(Q_OS_LINUX)
-        // Need to split these into actually seperate strings, as Crowdin translation would not split strings on #if otherwise.
         texts << QStringLiteral("       --nograb        the application should never grab the mouse or the\n"
                                 "                       keyboard. This option is set by default when Mudlet is\n"
                                 "                       running in the gdb debugger under Linux.\n");


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Don't make the super-advanced Qt CLI arguments translatable.
#### Motivation for adding to Mudlet
It's a lot, a lot of burden on translators to translate this amount of very technical text and keep the correct formatting for very little to none benefit.

The only people who'd seriously consider using these arguments would also have a decent grasp of English to understand the text.
#### Other info (issues closed, discussion etc)
