### PR TITLE
Change macOS deploy CMake & have qmake run daily only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
     - Q_OR_C_MAKE=qmake
 
   - os: osx
+    if: type != cron
     osx_image: xcode9.2
     compiler: clang
     env:
@@ -77,6 +78,7 @@ matrix:
         - qt512speech
 
   - os: linux
+    if: type != cron
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
@@ -88,6 +90,7 @@ matrix:
         - *qt512-packages
 
   - os: linux
+    if: type != cron
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
@@ -99,6 +102,7 @@ matrix:
         - *qt512-packages
 
   - os: linux
+    if: type != cron
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake
@@ -110,6 +114,7 @@ matrix:
         - *qt512-packages
 
   - os: linux
+    if: type != cron
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,18 @@ git:
 matrix:
   include:
   - os: osx
+    if: type = cron
     osx_image: xcode9.2
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
-      DEPLOY=deploy
 
   - os: osx
     osx_image: xcode9.2
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake
+      DEPLOY=deploy
 
   - os: linux
     compiler: gcc
@@ -121,6 +122,7 @@ matrix:
         - qt57base
         - qt57multimedia
         - qt57tools
+
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 before_install:

--- a/CI/travis.compile.sh
+++ b/CI/travis.compile.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 compile_line=()
-if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-  if [ "${DEPLOY}" != "deploy" ] || [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-    echo Job not executed under cron run
-    exit 0
-  fi
+if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] && [ "${TRAVIS_OS_NAME}" = "linux" ]; then
   export CCACHE_DISABLE=1
   compile_line+=(cov-build --dir cov-int)
 fi

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-  echo Job not executed under cron run
-  exit
-fi
-
 # we deploy only certain builds
 if [ "${DEPLOY}" = "deploy" ]; then
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-  echo Job not executed under cron run
-  exit
-fi
 
 set +e
 shopt -s expand_aliases


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Change macOS deploy CMake & have qmake run daily only
#### Motivation for adding to Mudlet
macOS builds are very limited compared to Linux ones and they take significantly more time - they are a serious bottleneck in the process when you're actively submitting many PRs.
#### Other info (issues closed, discussion etc)
