### PR TITLE
Temporarily disable automerge check on status

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -63,10 +63,10 @@ workflow "automerge pull requests on reviews" {
   resolves = ["automerge"]
 }
 
-workflow "automerge pull requests on status updates" {
-  on = "status"
-  resolves = ["automerge"]
-}
+# workflow "automerge pull requests on status updates" {
+#   on = "status"
+#   resolves = ["automerge"]
+# }
 
 action "automerge" {
   uses = "pascalgn/automerge-action@master"


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Temporarily disable automerge check on status, since Travis tends to spam us with a lot of events, as @keneanung has figured out.
#### Motivation for adding to Mudlet
Don't have up to 50 'automerge cancelled' spams in checks.
