### PR TITLE
Prevent deleting the default area

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7939,6 +7939,11 @@ int TLuaInterpreter::deleteArea(lua_State* L)
                             "area name).",
                             name.toUtf8().constData());
             return 2;
+        } else if (name==host.mpMap->mpRoomDB->getDefaultAreaName()) {
+            lua_pushnil(L);
+            lua_pushfstring(L,
+                            "deleteArea: bad argument #1 value (you can't delete the default area).");
+            return 2;
         }
     } else {
         lua_pushfstring(L,

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7939,7 +7939,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
                             "area name).",
                             name.toUtf8().constData());
             return 2;
-        } else if (name==host.mpMap->mpRoomDB->getDefaultAreaName()) {
+        } else if (name == host.mpMap->mpRoomDB->getDefaultAreaName()) {
             lua_pushnil(L);
             lua_pushfstring(L,
                             "deleteArea: bad argument #1 value (you can't delete the default area).");


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Simple check if the area name given to `deleteArea()` is actually same as `host.mpMap->mpRoomDB->getDefaultAreaName`

#### Motivation for adding to Mudlet
Deleting the default area would create all kind of problems when you continue mapping later.

#### Other info (issues closed, discussion etc)
This should fix #2728