### PR TITLE
Fix permGroup for triggers to make a folder

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -140,7 +140,7 @@ local group_creation_functions = {
     return not (permTimer(name, parent, 0, "") == -1)
   end,
   trigger = function(name, parent)
-    return not (permSubstringTrigger(name, parent, { "" }, "") == -1)
+    return not (permSubstringTrigger(name, parent, {}, "") == -1)
   end,
   alias = function(name, parent)
     return not (permAlias(name, parent, "", "") == -1)


### PR DESCRIPTION
permSubstringTrigger() creates a trigger group only if it is passed an empty set of patterns, but we passed it a set with one empty pattern instead by accident.

#### Brief overview of PR changes/additions
Fix permGroup() to pass an empty set rather than a set containing a single empty string. 
#### Motivation for adding to Mudlet
Have to pass the empty set in order to actually have Mudlet create a group/folder. With the empty string inside it, it was creating an actual substring trigger.
#### Other info (issues closed, discussion etc)
We found and discussed this in discord but then the fix never quite made it into a PR. 