### PR TITLE
Fix broken io.lines() after Windows utf8 override

### DIFF
--- a/src/mudlet-lua/lua/utf8_filenames.lua
+++ b/src/mudlet-lua/lua/utf8_filenames.lua
@@ -245,8 +245,10 @@ local function modify_lua_functions(all_compressed_mappings)
          function io.lines(filename, ...)
             if filename then
                filename = convert_from_utf8(filename)
+               return orig_io_lines(filename, ...)
+            else
+               return orig_io_lines()
             end
-            return orig_io_lines(filename, ...)
          end
 
          local orig_dofile = dofile


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix broken io.lines() after Windows utf8 override
#### Motivation for adding to Mudlet
Emergency hotfix.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2741.

There's a difference between `callfunction(nil)` and `callfunction()` as far as the Lua C API is concerned and this is one of those cases :(