### PR TITLE
Update rest of Lua IO functions to have same behaviour when called without arguments

### DIFF
--- a/src/mudlet-lua/lua/utf8_filenames.lua
+++ b/src/mudlet-lua/lua/utf8_filenames.lua
@@ -224,8 +224,10 @@ local function modify_lua_functions(all_compressed_mappings)
          function os.execute(command)
             if command then
                command = convert_from_utf8(command)
+               return orig_os_execute(command)
+            else
+               return orig_os_execute()
             end
-            return orig_os_execute(command)
          end
 
          local orig_io_open = io.open
@@ -256,8 +258,10 @@ local function modify_lua_functions(all_compressed_mappings)
          function dofile(filename)
             if filename then
                filename = convert_from_utf8(filename)
+               return orig_dofile(filename)
+            else
+               return orig_dofile()
             end
-            return orig_dofile(filename)
          end
 
          local orig_loadfile = loadfile
@@ -265,8 +269,10 @@ local function modify_lua_functions(all_compressed_mappings)
          function loadfile(filename, ...)
             if filename then
                filename = convert_from_utf8(filename)
+               return orig_loadfile(filename, ...)
+            else
+               return orig_loadfile()
             end
-            return orig_loadfile(filename, ...)
          end
 
          local orig_require = require


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Update rest of Lua IO functions to have same behaviour when called without arguments

Most of them read from STDIN, which is not relevant in the context of Mudlet, but it's good to have the functions behave in the same way across all platforms either way.
#### Motivation for adding to Mudlet
Consitency
#### Other info (issues closed, discussion etc)
See https://github.com/Mudlet/Mudlet/pull/2756 for the original important fix