### PR TITLE
Update default MinGW path to 7.x

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -280,7 +280,7 @@ unix:!macx {
 } else:win32 {
     MINGW_BASE_DIR = $$(MINGW_BASE_DIR)
     isEmpty(MINGW_BASE_DIR) {
-        MINGW_BASE_DIR = "C:\\Qt\\Tools\\mingw530_32"
+        MINGW_BASE_DIR = "C:\\Qt\\Tools\\mingw730_32"
     }
     LIBS +=  \
         -llua51 \


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Update default MinGW path to 7.x, since that's what we use now.
#### Motivation for adding to Mudlet
Fix a potential issue.
#### Other info (issues closed, discussion etc)
Perhaps this is why stand-alone Qt Creator builds are failing yet the windows SDK setup script works fine.
