### PR TITLE
macOS CI: cache 'brew update' to remove 5min from every build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 # Credit https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9
 # Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find . \! -regex ".+\.git.+" -delete; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee -a "${HOME}/ca-file.pem"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   ccache: true
   directories:
     - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
 dist: xenial
 sudo: false
 addons:
@@ -146,6 +147,12 @@ script:
 after_success:
   - cd "${TRAVIS_BUILD_DIR}"
   - bash CI/travis.after_success.sh
+
+before_cache:
+# Credit https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9
+# Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find . \! -regex ".+\.git.+" -delete; fi
+
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,10 @@ matrix:
         - qt57tools
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
+# Credit https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9
+# Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find . \! -regex ".+\.git.+" -delete; fi
+
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee -a "${HOME}/ca-file.pem"; fi
   # add to the path here to pick up things as soon as its installed
@@ -147,11 +151,6 @@ script:
 after_success:
   - cd "${TRAVIS_BUILD_DIR}"
   - bash CI/travis.after_success.sh
-
-before_cache:
-# Credit https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9
-# Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find . \! -regex ".+\.git.+" -delete; fi
 
 notifications:
   webhooks:


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Cache `brew update` per instructions on https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9 from the Homebrew maintainer.
#### Motivation for adding to Mudlet
Remove 5min from every macOS build, which we seem to be especially limited on. Some PRs can take 2h to build because of how delayed our macOS backlog is.
#### Other info (issues closed, discussion etc)
Before

![Selection_166](https://user-images.githubusercontent.com/110988/61169028-23086000-a557-11e9-867b-eb3ae735dbb8.png)

After

![Selection_165](https://user-images.githubusercontent.com/110988/61169017-fc4a2980-a556-11e9-91b6-96d536c3e147.png)


