### PR TITLE
Debug: add debug output line for (partly) working codebase branch

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -868,6 +868,7 @@ void mudlet::loadTranslationFile(const QString& fileName, const QString& filePat
     QPointer<QTranslator> pMudletTranslator = new QTranslator();
     auto translatorList = mTranslatorsMap.value(languageCode);
 
+qDebug().nospace().noquote() << "TRANSLATOR (MUDLET {WORKS}/QT {FAILS}, SCAN & LOAD) DEBUG: load(...) called with arguments, 1: \"" << fileName << "\", 2: \"" << filePath << "\"";
     if (pMudletTranslator->load(fileName, filePath)) {
         translatorList.append(pMudletTranslator);
 


### PR DESCRIPTION
THIS IS NOT TO BE ADDED INTO CODEBASE - it is purely to aid in the debugging of https://github.com/Mudlet/Mudlet/pull/2729 which is not finding the Mudlet translation files embedded in the resource file when built as a Linux CI AppImage...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>