### PR TITLE
Toggle "About" icon text display

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2945,12 +2945,16 @@ void mudlet::setToolBarIconSize(const int s)
     if (mToolbarIconSize > 2) {
         mpMainToolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
         mpButtonDiscord->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-        mpButtonAbout->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+        if (!mpButtonAbout.isNull()) {
+            mpButtonAbout->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+        }
         mpButtonPackageManagers->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     } else {
         mpMainToolBar->setToolButtonStyle(Qt::ToolButtonIconOnly);
         mpButtonDiscord->setToolButtonStyle(Qt::ToolButtonIconOnly);
-        mpButtonAbout->setToolButtonStyle(Qt::ToolButtonIconOnly);
+        if (!mpButtonAbout.isNull()) {
+            mpButtonAbout->setToolButtonStyle(Qt::ToolButtonIconOnly);
+        }
         mpButtonPackageManagers->setToolButtonStyle(Qt::ToolButtonIconOnly);
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2930,9 +2930,11 @@ void mudlet::setToolBarIconSize(const int s)
     if (mToolbarIconSize > 2) {
         mpMainToolBar->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
         mpButtonDiscord->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+        mpButtonAbout->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     } else {
         mpMainToolBar->setToolButtonStyle(Qt::ToolButtonIconOnly);
         mpButtonDiscord->setToolButtonStyle(Qt::ToolButtonIconOnly);
+        mpButtonAbout->setToolButtonStyle(Qt::ToolButtonIconOnly);
     }
 
     if (mpToolBarReplay) {

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -147,7 +147,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 3.22.1
+VERSION = 3.0
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment
@@ -157,7 +157,7 @@ BUILD = $$(MUDLET_VERSION_BUILD)
 isEmpty( BUILD ) {
 # Leave the value of the following empty for a release build
 # i.e. the line should be "BUILD =" without quotes
-   BUILD = "-dev"
+   BUILD = 
 }
 
 # Changing BUILD and VERSION values affects: ctelnet.cpp, main.cpp, mudlet.cpp

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -147,7 +147,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 3.0
+VERSION = 3.10
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment
@@ -157,7 +157,7 @@ BUILD = $$(MUDLET_VERSION_BUILD)
 isEmpty( BUILD ) {
 # Leave the value of the following empty for a release build
 # i.e. the line should be "BUILD =" without quotes
-   BUILD = ""
+   BUILD = 
 }
 
 # Changing BUILD and VERSION values affects: ctelnet.cpp, main.cpp, mudlet.cpp

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -147,7 +147,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 3.10
+VERSION = "3.10.0"
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -157,7 +157,7 @@ BUILD = $$(MUDLET_VERSION_BUILD)
 isEmpty( BUILD ) {
 # Leave the value of the following empty for a release build
 # i.e. the line should be "BUILD =" without quotes
-   BUILD = 
+   BUILD = ""
 }
 
 # Changing BUILD and VERSION values affects: ctelnet.cpp, main.cpp, mudlet.cpp

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -147,7 +147,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = "3.10.0"
+VERSION = 3.21.1
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment
@@ -157,7 +157,7 @@ BUILD = $$(MUDLET_VERSION_BUILD)
 isEmpty( BUILD ) {
 # Leave the value of the following empty for a release build
 # i.e. the line should be "BUILD =" without quotes
-   BUILD = ""
+   BUILD = "-dev"
 }
 
 # Changing BUILD and VERSION values affects: ctelnet.cpp, main.cpp, mudlet.cpp

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -147,7 +147,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 3.21.1
+VERSION = 3.22.1
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Toggle display of text beneath "About" icon as expected

#### Motivation for adding to Mudlet
Show text only if players want to see text

#### Other info (issues closed, discussion etc)
Fix #2746