### PR TITLE
Add 'Copy profile (settings only)' button

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1761,7 +1761,6 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
     profiles_tree_widget->setCurrentItem(pItem);
     profiles_tree_widget->setItemSelected(pItem, true);
 
-    qDebug() << "new profile name" << profile_name;
     profile_name_entry->setText(profile_name);
     profile_name_entry->setFocus();
     profile_name_entry->selectAll();

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -91,7 +91,6 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     auto pWelcome_document = new QTextDocument(this);
 
-
     auto copyProfile = new QAction(tr("Copy"), this);
     copyProfile->setObjectName(QStringLiteral("copyProfile"));
     auto copyProfileSettings = new QAction(tr("Copy profile (settings only)"), this);
@@ -1911,7 +1910,6 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
-    qDebug() << entries;
     bool needsGenericPackagesInstall = false;
     mudlet::self()->hideMudletsVariables(pHost);
     if (entries.isEmpty()) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -93,7 +93,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     auto copyProfile = new QAction(tr("Copy"), this);
     copyProfile->setObjectName(QStringLiteral("copyProfile"));
-    auto copyProfileSettings = new QAction(tr("Copy profile (settings only)"), this);
+    auto copyProfileSettings = new QAction(tr("Copy settings only"), this);
     copyProfileSettings->setObjectName(QStringLiteral("copyProfileSettingsOnly"));
 
     copy_profile_toolbutton->addAction(copyProfile);
@@ -1671,46 +1671,12 @@ void dlgConnectionProfiles::slot_cancel()
 
 void dlgConnectionProfiles::slot_copy_profile()
 {
-    QString profile_name = profile_name_entry->text().trimmed();
-    QString oldname = profile_name;
-
-    if (profile_name.isEmpty()) {
+    QString profile_name;
+    QString oldname;
+    QListWidgetItem* pItem;
+    if (!copyProfileWidget(profile_name, oldname, pItem)) {
         return;
     }
-
-    // prepend n+1 to end of the profile name
-    if (profile_name.at(profile_name.size() - 1).isDigit()) {
-        int i = 1;
-        do {
-            profile_name = profile_name.left(profile_name.size() - 1) + QString::number(profile_name.at(profile_name.size() - 1).digitValue() + i++);
-        } while (mProfileList.contains(profile_name));
-    } else {
-        int i = 1;
-        QString profile_name2;
-        do {
-            profile_name2 = profile_name + QString::number(i++);
-        } while (mProfileList.contains(profile_name2));
-        profile_name = profile_name2;
-    }
-
-    auto pItem = new QListWidgetItem(profile_name);
-    if (!pItem) {
-        return;
-    }
-
-    // add the new widget in
-    profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
-    profiles_tree_widget->addItem(pItem);
-    profiles_tree_widget->setItemSelected(profiles_tree_widget->currentItem(), false); // Unselect previous item
-    profiles_tree_widget->setCurrentItem(pItem);
-    profiles_tree_widget->setItemSelected(pItem, true);
-
-    profile_name_entry->setText(profile_name);
-    profile_name_entry->setFocus();
-    profile_name_entry->selectAll();
-    profile_name_entry->setReadOnly(false);
-    host_name_entry->setReadOnly(false);
-    port_entry->setReadOnly(false);
 
     // copy the folder on-disk
     QDir dir(mudlet::getMudletPath(mudlet::profileHomePath, oldname));
@@ -1730,46 +1696,12 @@ void dlgConnectionProfiles::slot_copy_profile()
 
 void dlgConnectionProfiles::slot_copy_profilesettings_only()
 {
-    QString profile_name = profile_name_entry->text().trimmed();
-    QString oldname = profile_name;
-
-    if (profile_name.isEmpty()) {
+    QString profile_name;
+    QString oldname;
+    QListWidgetItem* pItem;
+    if (!copyProfileWidget(profile_name, oldname, pItem)) {
         return;
     }
-
-    // prepend n+1 to end of the profile name
-    if (profile_name.at(profile_name.size() - 1).isDigit()) {
-        int i = 1;
-        do {
-            profile_name = profile_name.left(profile_name.size() - 1) + QString::number(profile_name.at(profile_name.size() - 1).digitValue() + i++);
-        } while (mProfileList.contains(profile_name));
-    } else {
-        int i = 1;
-        QString profile_name2;
-        do {
-            profile_name2 = profile_name + QString::number(i++);
-        } while (mProfileList.contains(profile_name2));
-        profile_name = profile_name2;
-    }
-
-    auto pItem = new QListWidgetItem(profile_name);
-    if (!pItem) {
-        return;
-    }
-
-    // add the new widget in
-    profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
-    profiles_tree_widget->addItem(pItem);
-    profiles_tree_widget->setItemSelected(profiles_tree_widget->currentItem(), false); // Unselect previous item
-    profiles_tree_widget->setCurrentItem(pItem);
-    profiles_tree_widget->setItemSelected(pItem, true);
-
-    profile_name_entry->setText(profile_name);
-    profile_name_entry->setFocus();
-    profile_name_entry->selectAll();
-    profile_name_entry->setReadOnly(false);
-    host_name_entry->setReadOnly(false);
-    port_entry->setReadOnly(false);
 
     QDir newProfileDir(mudlet::getMudletPath(mudlet::profileHomePath, profile_name));
     newProfileDir.mkpath(newProfileDir.path());
@@ -1792,6 +1724,50 @@ void dlgConnectionProfiles::slot_copy_profilesettings_only()
     // one may have had it enabled does not mean we can assume the new one would
     // want it set:
     discord_optin_checkBox->setChecked(false);
+}
+
+bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& oldname, QListWidgetItem*& pItem) const
+{
+    profile_name= profile_name_entry->text().trimmed();
+    oldname= profile_name;
+    pItem= new QListWidgetItem(profile_name);
+    if (profile_name.isEmpty()) {
+        return false;
+    }
+
+    // prepend n+1 to end of the profile name
+    if (profile_name.at(profile_name.size() - 1).isDigit()) {
+        int i = 1;
+        do {
+            profile_name = profile_name.left(profile_name.size() - 1) + QString::number(profile_name.at(profile_name.size() - 1).digitValue() + i++);
+        } while (mProfileList.contains(profile_name));
+    } else {
+        int i = 1;
+        QString profile_name2;
+        do {
+            profile_name2 = profile_name + QString::number(i++);
+        } while (mProfileList.contains(profile_name2));
+        profile_name = profile_name2;
+    }
+    if (!pItem) {
+        return false;
+    }
+
+    // add the new widget in
+    profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
+    profiles_tree_widget->addItem(pItem);
+    profiles_tree_widget->setItemSelected(profiles_tree_widget->currentItem(), false); // Unselect previous item
+    profiles_tree_widget->setCurrentItem(pItem);
+    profiles_tree_widget->setItemSelected(pItem, true);
+
+    profile_name_entry->setText(profile_name);
+    profile_name_entry->setFocus();
+    profile_name_entry->selectAll();
+    profile_name_entry->setReadOnly(false);
+    host_name_entry->setReadOnly(false);
+    port_entry->setReadOnly(false);
+
+    return true;
 }
 
 void dlgConnectionProfiles::copyProfileSettingsOnly(const QString& oldname, const QString& newname)
@@ -1842,10 +1818,8 @@ bool dlgConnectionProfiles::extractSettingsFromProfile(pugi::xml_document& newPr
     const auto hostPackageResults = oldProfile.select_nodes("/MudletPackage/HostPackage");
     pugi::xml_node hostPackage = hostPackageResults.first().node();
     auto host = hostPackage.child("Host");
-    hostPackage.print(std::cout, "  ", pugi::format_default);
     host.remove_child("mInstalledPackages");
     host.remove_child("mInstalledModules");
-    hostPackage.print(std::cout, "  ", pugi::format_default);
 
     // copy in the /Mudlet/HostPackage
     mudletPackage.append_copy(hostPackage);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1787,8 +1787,6 @@ void dlgConnectionProfiles::copyProfileSettingsOnly(const QString& oldname, cons
     if (extractSettingsFromProfile(newProfileXml, copySettingsFromFile)) {
         saveProfileCopy(newProfiledir, newProfileXml);
     }
-
-    return;
 }
 
 bool dlgConnectionProfiles::extractSettingsFromProfile(pugi::xml_document& newProfile, const QString& copySettingsFrom)

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1728,9 +1728,9 @@ void dlgConnectionProfiles::slot_copy_profilesettings_only()
 
 bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& oldname, QListWidgetItem*& pItem) const
 {
-    profile_name= profile_name_entry->text().trimmed();
-    oldname= profile_name;
-    pItem= new QListWidgetItem(profile_name);
+    profile_name = profile_name_entry->text().trimmed();
+    oldname = profile_name;
+    pItem = new QListWidgetItem(profile_name);
     if (profile_name.isEmpty()) {
         return false;
     }
@@ -1760,6 +1760,7 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
     profiles_tree_widget->setCurrentItem(pItem);
     profiles_tree_widget->setItemSelected(pItem, true);
 
+    qDebug() << "new profile name" << profile_name;
     profile_name_entry->setText(profile_name);
     profile_name_entry->setFocus();
     profile_name_entry->selectAll();
@@ -1838,7 +1839,6 @@ void dlgConnectionProfiles::saveProfileCopy(const QDir& newProfiledir, const pug
     std::stringstream saveStringStream(std::ios::out);
     newProfileXml.save(saveStringStream);
     std::string output(saveStringStream.str());
-    std::cout << output;
     file.write(output.data());
     file.close();
 }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1730,7 +1730,6 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
 {
     profile_name = profile_name_entry->text().trimmed();
     oldname = profile_name;
-    pItem = new QListWidgetItem(profile_name);
     if (profile_name.isEmpty()) {
         return false;
     }
@@ -1749,6 +1748,8 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
         } while (mProfileList.contains(profile_name2));
         profile_name = profile_name2;
     }
+
+    pItem = new QListWidgetItem(profile_name);
     if (!pItem) {
         return false;
     }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -24,6 +24,8 @@
 
 #include "pre_guard.h"
 #include "ui_connection_profiles.h"
+#include "QDir"
+#include <pugixml.hpp>
 #include "post_guard.h"
 
 class dlgConnectionProfiles : public QDialog, public Ui::connection_profiles
@@ -74,6 +76,9 @@ private:
     void updateDiscordStatus();
     bool validateProfile();
     void loadProfile(bool alsoConnect);
+    void copyProfileSettingsOnly(const QString& oldname, const QString& newname);
+    bool extractSettingsFromProfile(pugi::xml_document& newProfile, const QString& copySettingsFrom);
+    void saveProfileCopy(const QDir& newProfiledir, const pugi::xml_document& newProfileXml) const;
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -65,6 +65,7 @@ public slots:
     void slot_load();
     void slot_cancel();
     void slot_copy_profile();
+    void slot_copy_profilesettings_only();
 
 private:
     void copyFolder(const QString& sourceFolder, const QString& destFolder);

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -79,6 +79,7 @@ private:
     void copyProfileSettingsOnly(const QString& oldname, const QString& newname);
     bool extractSettingsFromProfile(pugi::xml_document& newProfile, const QString& copySettingsFrom);
     void saveProfileCopy(const QDir& newProfiledir, const pugi::xml_document& newProfileXml) const;
+    bool copyProfileWidget(QString& profile_name, QString& oldname, QListWidgetItem*& pItem) const;
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -373,15 +373,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -519,15 +510,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -659,15 +641,6 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -849,15 +822,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -995,15 +959,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -1135,15 +1090,6 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -1325,15 +1271,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -1471,15 +1408,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -1611,15 +1539,6 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -1801,15 +1720,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -1947,15 +1857,6 @@
                    </color>
                   </brush>
                  </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -2087,15 +1988,6 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                   </color>
-                  </brush>
-                 </colorrole>
-                 <colorrole role="PlaceholderText">
-                  <brush brushstyle="NoBrush">
-                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2216,25 +2216,6 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="copy_profile_button">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Copy</string>
-              </property>
-             </widget>
-            </item>
-            <item>
              <widget class="QPushButton" name="new_profile_button">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>760</width>
-    <height>671</height>
+    <height>682</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -373,6 +373,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -510,6 +519,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -641,6 +659,15 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -822,6 +849,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -959,6 +995,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -1090,6 +1135,15 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -1271,6 +1325,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -1408,6 +1471,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </inactive>
                 <disabled>
                  <colorrole role="WindowText">
@@ -1539,6 +1611,15 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -1720,6 +1801,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </active>
                 <inactive>
                  <colorrole role="WindowText">
@@ -1851,6 +1941,15 @@
                  <colorrole role="ToolTipText">
                   <brush brushstyle="SolidPattern">
                    <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
                     <red>0</red>
                     <green>0</green>
                     <blue>0</blue>
@@ -1994,6 +2093,15 @@
                    </color>
                   </brush>
                  </colorrole>
+                 <colorrole role="PlaceholderText">
+                  <brush brushstyle="NoBrush">
+                   <color alpha="128">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </brush>
+                 </colorrole>
                 </disabled>
                </palette>
               </property>
@@ -2080,14 +2188,30 @@
                 <height>25</height>
                </size>
               </property>
-              <property name="maximumSize">
+              <property name="text">
+               <string>Remove</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QToolButton" name="copy_profile_toolbutton">
+              <property name="minimumSize">
                <size>
-                <width>16777215</width>
-                <height>16777215</height>
+                <width>0</width>
+                <height>25</height>
                </size>
               </property>
               <property name="text">
-               <string>Remove</string>
+               <string>Copy</string>
+              </property>
+              <property name="popupMode">
+               <enum>QToolButton::MenuButtonPopup</enum>
+              </property>
+              <property name="toolButtonStyle">
+               <enum>Qt::ToolButtonFollowStyle</enum>
+              </property>
+              <property name="autoRaise">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -2103,12 +2227,6 @@
                <size>
                 <width>0</width>
                 <height>25</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
                </size>
               </property>
               <property name="text">
@@ -2128,12 +2246,6 @@
                <size>
                 <width>0</width>
                 <height>25</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
                </size>
               </property>
               <property name="text">
@@ -2533,11 +2645,11 @@
               <property name="toolTip">
                <string>Game description</string>
               </property>
-              <property name="readOnly">
-               <bool>false</bool>
-              </property>
               <property name="tabChangesFocus">
                <bool>true</bool>
+              </property>
+              <property name="readOnly">
+               <bool>false</bool>
               </property>
              </widget>
             </item>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2173,9 +2173,6 @@
             </item>
             <item>
              <widget class="QPushButton" name="remove_profile_button">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -2195,6 +2192,12 @@
             </item>
             <item>
              <widget class="QToolButton" name="copy_profile_toolbutton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>0</width>
@@ -2209,9 +2212,6 @@
               </property>
               <property name="toolButtonStyle">
                <enum>Qt::ToolButtonFollowStyle</enum>
-              </property>
-              <property name="autoRaise">
-               <bool>true</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add a new button to copy profile's settings only. 

![image](https://user-images.githubusercontent.com/110988/61224178-65c86480-a71e-11e9-88ad-f554ccd0334f.png)


#### Motivation for adding to Mudlet
This is great for copying colour schemes and settings such as the command separator, while not having the rest of the scripts that come with the profile.

It's a simpler solution to the default command separator preference we have: people can choose to create a copy of an existing profile instead of having to change the command separator every single time.

It's also a simpler solution to keep colour schemed organised: don't have to create, name them, manage them - just copy from the profile you like.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2737.