### PR TITLE
Don't show both menubar and toolbar by default: they duplicate each other

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -450,7 +450,7 @@ mudlet::mudlet()
 , mCopyAsImageTimeout{3}
 , mUsingMudletDictionaries(false)
 , mIsGoingDown(false)
-, mMenuBarVisibility(visibleAlways)
+, mMenuBarVisibility(visibleNever)
 , mToolbarVisibility(visibleAlways)
 , mpActionReplaySpeedDown(nullptr)
 , mpActionReplaySpeedUp(nullptr)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2985,12 +2985,15 @@ void mudlet::adjustMenuBarVisibility()
 {
     // Are there any profiles loaded - note that the dummy "default_host" counts
     // as the first one
+    qDebug() <<"adjustMenuBarVisibility():" << mMenuBarVisibility;
     if ((mHostManager.getHostCount() < 2 && mMenuBarVisibility & visibleAlways)
       ||(mMenuBarVisibility & visibleMaskNormally)) {
 
         menuBar()->show();
+        qDebug() << "showing menubar";
     } else {
         menuBar()->hide();
+        qDebug() << "hiding menubar";
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -467,6 +467,7 @@ mudlet::mudlet()
                  "Formatting string for elapsed time display in replay playback - see QDateTime::toString(const QString&) for the gory details...!"))
 , mHunspell_sharedDictionary(nullptr)
 {
+    qDebug() << "mudlet constructor start:" << mMenuBarVisibility;
     mShowIconsOnMenuOriginally = !qApp->testAttribute(Qt::AA_DontShowIconsInMenus);
     mpSettings = getQSettings();
     readEarlySettings(*mpSettings);
@@ -847,6 +848,8 @@ mudlet::mudlet()
     // load bundled fonts
     mFontManager.addFonts();
     loadLanguagesMap();
+
+    qDebug() << "mudlet constructor end:" << mMenuBarVisibility;
 }
 
 QSettings* mudlet::getQSettings()
@@ -2975,6 +2978,7 @@ void mudlet::setEditorTreeWidgetIconSize(const int s)
 void mudlet::setMenuBarVisibility(const controlsVisibility state)
 {
     mMenuBarVisibility = state;
+    qDebug() << "setMenuBarVisibility()" << mMenuBarVisibility;
 
     adjustMenuBarVisibility();
     emit signal_menuBarVisibilityChanged(state);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -832,6 +832,8 @@ mudlet::mudlet()
         setToolBarIconSize(mEnableFullScreenMode ? 2 : 3);
     }
 
+    adjustMenuBarVisibility();
+
 #if defined(QT_GAMEPAD_LIB)
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonPressEvent, this, &mudlet::slot_gamepadButtonPress);
     connect(QGamepadManager::instance(), &QGamepadManager::gamepadButtonReleaseEvent, this, &mudlet::slot_gamepadButtonRelease);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2923,8 +2923,8 @@ void mudlet::readLateSettings(const QSettings& settings)
     // although we provide a backwards compatible value
     // of: (bool) showXXXXBar = (XXXXBarVisibilty != visibleNever) for, until,
     // it is suggested Mudlet 4.x:
-    setMenuBarVisibility(static_cast<controlsVisibilityFlag>(settings.value("menuBarVisibility", static_cast<int>(visibleAlways)).toInt()));
-    setToolBarVisibility(static_cast<controlsVisibilityFlag>(settings.value("toolBarVisibility", static_cast<int>(visibleAlways)).toInt()));
+    setMenuBarVisibility(static_cast<controlsVisibilityFlag>(settings.value("menuBarVisibility", static_cast<int>(mMenuBarVisibility)).toInt()));
+    setToolBarVisibility(static_cast<controlsVisibilityFlag>(settings.value("toolBarVisibility", static_cast<int>(mToolbarVisibility)).toInt()));
     mEditorTextOptions = static_cast<QTextOption::Flags>(settings.value("editorTextOptions", QVariant(0)).toInt());
 
     mshowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -467,7 +467,6 @@ mudlet::mudlet()
                  "Formatting string for elapsed time display in replay playback - see QDateTime::toString(const QString&) for the gory details...!"))
 , mHunspell_sharedDictionary(nullptr)
 {
-    qDebug() << "mudlet constructor start:" << mMenuBarVisibility;
     mShowIconsOnMenuOriginally = !qApp->testAttribute(Qt::AA_DontShowIconsInMenus);
     mpSettings = getQSettings();
     readEarlySettings(*mpSettings);
@@ -848,8 +847,6 @@ mudlet::mudlet()
     // load bundled fonts
     mFontManager.addFonts();
     loadLanguagesMap();
-
-    qDebug() << "mudlet constructor end:" << mMenuBarVisibility;
 }
 
 QSettings* mudlet::getQSettings()
@@ -2978,7 +2975,6 @@ void mudlet::setEditorTreeWidgetIconSize(const int s)
 void mudlet::setMenuBarVisibility(const controlsVisibility state)
 {
     mMenuBarVisibility = state;
-    qDebug() << "setMenuBarVisibility()" << mMenuBarVisibility;
 
     adjustMenuBarVisibility();
     emit signal_menuBarVisibilityChanged(state);
@@ -2989,15 +2985,12 @@ void mudlet::adjustMenuBarVisibility()
 {
     // Are there any profiles loaded - note that the dummy "default_host" counts
     // as the first one
-    qDebug() <<"adjustMenuBarVisibility():" << mMenuBarVisibility;
     if ((mHostManager.getHostCount() < 2 && mMenuBarVisibility & visibleAlways)
       ||(mMenuBarVisibility & visibleMaskNormally)) {
 
         menuBar()->show();
-        qDebug() << "showing menubar";
     } else {
         menuBar()->hide();
-        qDebug() << "hiding menubar";
     }
 }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

![image](https://user-images.githubusercontent.com/110988/61267690-24c16600-a799-11e9-9121-e33d35c60277.png)

#### Motivation for adding to Mudlet
Look at most screenshots from Windows in Discord - everyone has both the toolbar and menubar enabled...
#### Other info (issues closed, discussion etc)
