### PR TITLE
Fix feedTriggers to work no matter what server encoding is set to

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1584,7 +1584,14 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         text = lua_tostring(L, 1);
     }
 
+    QString previousEncoding = host.mTelnet.getEncoding();
+    if (previousEncoding.isEmpty()) {
+        previousEncoding = QStringLiteral("ASCII");
+    }
+    // ensure encoding is utf-8 because that is what the Lua subsystem works with
+    host.mTelnet.setEncoding(QStringLiteral("UTF-8"));
     host.mpConsole->printOnDisplay(text);
+    host.mTelnet.setEncoding(previousEncoding);
     return 0;
 }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Test with: `lua feedTriggers("Ты слышишь скрип мачт и крики чаек.\n")` and encoding set to `KOI8-R (Cyrillic)` for example, which is a very real scenario when playing a Russian game. You'll get this jibberish because feedTriggers is trying to interpret the utf-8 encoded text from Lua as `KOI8-R`:

![image](https://user-images.githubusercontent.com/110988/61373887-4c98f280-a89b-11e9-8cb1-e855ddf415f2.png)

With this fix, input into feedTriggers is independent on the server encoding as it ought to be.

#### Motivation for adding to Mudlet
i18n goals.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/1946