### PR TITLE
Add icon and icon theme support in Linux AppImage

### DIFF
--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -27,7 +27,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
     exit
   fi
 
-  git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
+  git clone -b add-icon-theme-support https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
   cd "${TRAVIS_BUILD_DIR}/../installers/generic-linux"
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This will hopefully restore the more native look'n'feel of the Mudlet AppImage on Linux systems by integrating with the theme better.
#### Motivation for adding to Mudlet
Better integration with the users desktop.
#### Other info (issues closed, discussion etc)
See new note over at https://github.com/probonopd/linuxdeployqt/blob/master/README.md#adding-icon-and-icon-theme-support.