### PR TITLE
Revert "macOS CI: cache 'brew update'"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   ccache: true
   directories:
     - $HOME/Library/Caches/Homebrew
-    - /usr/local/Homebrew
 dist: xenial
 sudo: false
 addons:
@@ -124,10 +123,6 @@ matrix:
         - qt57tools
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
-# Credit https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9
-# Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
-
 before_install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee -a "${HOME}/ca-file.pem"; fi
   # add to the path here to pick up things as soon as its installed
@@ -151,7 +146,6 @@ script:
 after_success:
   - cd "${TRAVIS_BUILD_DIR}"
   - bash CI/travis.after_success.sh
-
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This reverts commit a86b9d6021c892cd546e978e4a8202c66a182d0a.
#### Motivation for adding to Mudlet
This broke macOS binary builds, because `brew` is deleted by the time we need it for the packager.
#### Other info (issues closed, discussion etc)
Will be reinstated as part of https://github.com/Mudlet/Mudlet/pull/2781.