### PR TITLE
Improve cTelnet::setEncoding argument naming

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1589,7 +1589,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         previousEncoding = QStringLiteral("ASCII");
     }
     // ensure encoding is utf-8 because that is what the Lua subsystem works with
-    host.mTelnet.setEncoding(QStringLiteral("UTF-8"));
+    host.mTelnet.setEncoding(QStringLiteral("UTF-8"), false);
     host.mpConsole->printOnDisplay(text);
     host.mTelnet.setEncoding(previousEncoding);
     return 0;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -288,13 +288,12 @@ const QString& cTelnet::getFriendlyEncoding()
     return mFriendlyEncodings.at(index);
 }
 
-// Need to set the encoding at the start but it does not need to be written out
-// then. Return values are for Lua subsystem...!
 // newEncoding must be EITHER: one of the FIXED non-translatable values in
 // cTelnet::csmAcceptableEncodings
 // OR "ASCII"
 // OR an empty string (which means the same as the ASCII).
-QPair<bool, QString> cTelnet::setEncoding(const QString& newEncoding, const bool isToStore)
+// saveValue: if true, record this setting, otherwise it is ephemereal for this session
+QPair<bool, QString> cTelnet::setEncoding(const QString& newEncoding, const bool saveValue)
 {
     QString reportedEncoding = newEncoding;
     if (newEncoding.isEmpty() || newEncoding == QLatin1String("ASCII")) {
@@ -305,7 +304,7 @@ QPair<bool, QString> cTelnet::setEncoding(const QString& newEncoding, const bool
             // incoming OOB in TLuaInterpreter::encodeBytes(...)
             // output in cTelnet::sendData(...)
             mEncoding.clear();
-            if (isToStore) {
+            if (saveValue) {
                 mpHost->writeProfileData(QStringLiteral("encoding"), reportedEncoding);
             }
         }
@@ -317,7 +316,7 @@ QPair<bool, QString> cTelnet::setEncoding(const QString& newEncoding, const bool
                                  % QLatin1String(R"(".)"));
     } else if (mEncoding != newEncoding) {
         encodingChanged(newEncoding);
-        if (isToStore) {
+        if (saveValue) {
             mpHost->writeProfileData(QStringLiteral("encoding"), mEncoding);
         }
     }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -149,7 +149,7 @@ public:
     void setChannel102Variables(const QString&);
     bool socketOutRaw(std::string& data);
     const QString & getEncoding() const { return mEncoding; }
-    QPair<bool, QString> setEncoding(const QString &, bool isToStore = true);
+    QPair<bool, QString> setEncoding(const QString &, bool saveValue = true);
     void postMessage(QString);
     const QStringList & getEncodingsList() const { return mAcceptableEncodings; }
     const QStringList & getFriendlyEncodingsList() const { return mFriendlyEncodings; }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Improve cTelnet::setEncoding argument naming
#### Motivation for adding to Mudlet
Less confusing codebase with no names like `isToStore`!
#### Other info (issues closed, discussion etc)
See https://github.com/Mudlet/Mudlet/pull/2791