### PR TITLE
Refactor & upgrade setBorder* & add getBorder*

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3204,7 +3204,7 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::setBorderSize(int size, int position, bool updateEvent = true)
+void TLuaInterpreter::setBorderSize(lua_State L*, int size, int position, bool updateEvent = true)
 {
     Host& host = getHostFromLua(L);
     // position: 0 = top, 1 = right, 2 = bottom, 3 = left
@@ -3259,10 +3259,10 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
     } else {
         sizeLeft = lua_tonumber(L, 4);
     }
-    setBorderSize(sizeTop, 0, false);
-    setBorderSize(sizeRight, 1, false);
-    setBorderSize(sizeBottom, 2, false);
-    setBorderSize(sizeLeft, 3, true); // only now send update event
+    setBorderSize(L, sizeTop, 0, false);
+    setBorderSize(L, sizeRight, 1, false);
+    setBorderSize(L, sizeBottom, 2, false);
+    setBorderSize(L, sizeLeft, 3, true); // only now send update event
     return 0;
 }
 
@@ -3277,7 +3277,7 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
     } else {
         size = lua_tonumber(L, 1);
     }
-    setBorderSize(size, 0);
+    setBorderSize(L, size, 0);
     return 0;
 }
 
@@ -3292,7 +3292,7 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
     } else {
         size = lua_tonumber(L, 1);
     }
-    setBorderSize(size, 1);
+    setBorderSize(L, size, 1);
     return 0;
 }
 
@@ -3307,7 +3307,7 @@ int TLuaInterpreter::setBorderBottom(lua_State* L)
     } else {
         size = lua_tonumber(L, 1);
     }
-    setBorderSize(size, 2);
+    setBorderSize(L, size, 2);
     return 0;
 }
 
@@ -3322,7 +3322,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
     } else {
         size = lua_tonumber(L, 1);
     }
-    setBorderSize(size, 3);
+    setBorderSize(L, size, 3);
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3331,7 +3331,7 @@ int TLuaInterpreter::getBorderTop(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.mBorderTopHeight);
-    return 0;
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderLeft
@@ -3339,7 +3339,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.mBorderLeftWidth);
-    return 0;
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderBottom
@@ -3347,7 +3347,7 @@ int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.mBorderBottomHeight);
-    return 0;
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderRight
@@ -3355,7 +3355,7 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     lua_pushnumber(L, host.mBorderRightWidth);
-    return 0;
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderSizes

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3204,7 +3204,7 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool updateEvent = true)
+void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool updateEvent)
 {
     Host& host = getHostFromLua(L);
     // position: 0 = top, 1 = right, 2 = bottom, 3 = left
@@ -3214,7 +3214,7 @@ void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool u
         case 2: host.mBorderBottomHeight = size; break;
         case 3: host.mBorderLeftWidth = size; break;
     }
-    if updateEvent {
+    if (updateEvent) {
         int x, y;
         x = host.mpConsole->width();
         y = host.mpConsole->height();
@@ -3330,7 +3330,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderTop(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.mBorderTopWidth);
+    lua_pushnumber(L, host.mBorderTopHeight);
     return 0;
 }
 
@@ -3346,7 +3346,7 @@ int TLuaInterpreter::getBorderLeft(lua_State* L)
 int TLuaInterpreter::getBorderBottom(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    lua_pushnumber(L, host.mBorderBottomWidth);
+    lua_pushnumber(L, host.mBorderBottomHeight);
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3222,6 +3222,48 @@ void TLuaInterpreter::setBorderSize(int size, int position)
     QApplication::sendEvent(host.mpConsole, &event);
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderSizes
+int TLuaInterpreter::setBorderSizes(lua_State* L)
+{
+    int sizeTop;
+    if (!lua_isnumber(L, 1)) {
+        lua_pushstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_error(L);
+        return 1;
+    } else {
+        sizeTop = lua_tonumber(L, 1);
+    }
+    int sizeRight;
+    if (!lua_isnumber(L, 2)) {
+        lua_pushstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
+        lua_error(L);
+        return 1;
+    } else {
+        sizeRight = lua_tonumber(L, 2);
+    }
+    int sizeBottom;
+    if (!lua_isnumber(L, 3)) {
+        lua_pushstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
+        lua_error(L);
+        return 1;
+    } else {
+        sizeBottom = lua_tonumber(L, 3);
+    }
+    int sizeLeft;
+    if (!lua_isnumber(L, 4)) {
+        lua_pushstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
+        lua_error(L);
+        return 1;
+    } else {
+        sizeLeft = lua_tonumber(L, 4);
+    }
+    setBorderSize(sizeTop, 0, false);
+    setBorderSize(sizeRight, 1, false);
+    setBorderSize(sizeBottom, 2, false);
+    setBorderSize(sizeLeft, 3, true); // only now send update event
+    return 0;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderTop
 int TLuaInterpreter::setBorderTop(lua_State* L)
 {
@@ -14625,10 +14667,11 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "isAnsiBgColor", TLuaInterpreter::isAnsiBgColor);
     lua_register(pGlobalLua, "stopSounds", TLuaInterpreter::stopSounds);
     lua_register(pGlobalLua, "playSoundFile", TLuaInterpreter::playSoundFile);
+    lua_register(pGlobalLua, "setBorderSizes", TLuaInterpreter::setBorderSizes);
     lua_register(pGlobalLua, "setBorderTop", TLuaInterpreter::setBorderTop);
+    lua_register(pGlobalLua, "setBorderRight", TLuaInterpreter::setBorderRight);
     lua_register(pGlobalLua, "setBorderBottom", TLuaInterpreter::setBorderBottom);
     lua_register(pGlobalLua, "setBorderLeft", TLuaInterpreter::setBorderLeft);
-    lua_register(pGlobalLua, "setBorderRight", TLuaInterpreter::setBorderRight);
     lua_register(pGlobalLua, "setBorderColor", TLuaInterpreter::setBorderColor);
     lua_register(pGlobalLua, "setConsoleBufferSize", TLuaInterpreter::setConsoleBufferSize);
     lua_register(pGlobalLua, "enableScrollBar", TLuaInterpreter::enableScrollBar);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3204,7 +3204,7 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::setBorderSize(lua_State L*, int size, int position, bool updateEvent = true)
+void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool updateEvent = true)
 {
     Host& host = getHostFromLua(L);
     // position: 0 = top, 1 = right, 2 = bottom, 3 = left

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3227,7 +3227,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
     int sizeTop;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3235,7 +3235,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
     }
     int sizeRight;
     if (!lua_isnumber(L, 2)) {
-        lua_pushstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
+        lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
         lua_error(L);
         return 1;
     } else {
@@ -3243,7 +3243,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
     }
     int sizeBottom;
     if (!lua_isnumber(L, 3)) {
-        lua_pushstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
+        lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
         lua_error(L);
         return 1;
     } else {
@@ -3251,7 +3251,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
     }
     int sizeLeft;
     if (!lua_isnumber(L, 4)) {
-        lua_pushstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
+        lua_pushfstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
         lua_error(L);
         return 1;
     } else {
@@ -3269,7 +3269,7 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
 {
     int size;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderTop: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "setBorderTop: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3284,7 +3284,7 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
 {
     int size;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderRight: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "setBorderRight: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3299,7 +3299,7 @@ int TLuaInterpreter::setBorderBottom(lua_State* L)
 {
     int size;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderBottom: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "setBorderBottom: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3314,7 +3314,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
 {
     int size;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderLeft: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "setBorderLeft: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3227,26 +3227,88 @@ void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool u
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderSizes
 int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
-    if (!lua_isnumber(L, 1)) {
-        lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
-        return lua_error(L);
-    } 
-    int sizeTop = lua_tonumber(L, 1);
-    if (!lua_isnumber(L, 2)) {
-        lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
-    } 
-    int sizeRight = lua_tonumber(L, 2);
-    if (!lua_isnumber(L, 3)) {
-        lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
-        return lua_error(L);
-    } 
-    int sizeBottom = lua_tonumber(L, 3);
-    if (!lua_isnumber(L, 4)) {
-        lua_pushfstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
-        return lua_error(L);
-    } 
-    int sizeLeft = lua_tonumber(L, 4);
+    int numberOfArguments = lua_gettop(L);
+    switch(numberOfArguments) {
+        case 0: {
+            int sizeTop = 0;
+            int sizeRight = 0;
+            int sizeBottom = 0;
+            int sizeLeft = 0;
+            break;
+        }
+        case 1: {
+            if (!lua_isnumber(L, 1)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+                return lua_error(L);
+            } 
+            int sizeTop = lua_tonumber(L, 1);
+            int sizeRight = lua_tonumber(L, 1);
+            int sizeBottom = lua_tonumber(L, 1);
+            int sizeLeft = lua_tonumber(L, 1);
+            break;
+        }
+        case 2: {
+            if (!lua_isnumber(L, 1)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new heights size as number expected, got %s!)", luaL_typename(L, 1));
+                return lua_error(L);
+            } 
+            int sizeTop = lua_tonumber(L, 1);
+            int sizeBottom = lua_tonumber(L, 1);
+            if (!lua_isnumber(L, 2)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new widths size as number expected, got %s!)", luaL_typename(L, 2));
+                return lua_error(L);
+            } 
+            int sizeRight = lua_tonumber(L, 2);
+            int sizeLeft = lua_tonumber(L, 2);
+            break;
+        }
+        case 3: {
+            if (!lua_isnumber(L, 1)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
+                return lua_error(L);
+            } 
+            int sizeTop = lua_tonumber(L, 1);
+            if (!lua_isnumber(L, 2)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new widths size as number expected, got %s!)", luaL_typename(L, 2));
+                return lua_error(L);
+            } 
+            int sizeRight = lua_tonumber(L, 2);
+            int sizeLeft = lua_tonumber(L, 2);
+            if (!lua_isnumber(L, 3)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
+                return lua_error(L);
+            } 
+            int sizeBottom = lua_tonumber(L, 3);
+            break;
+        }
+        case 4: {
+            if (!lua_isnumber(L, 1)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
+                return lua_error(L);
+            } 
+            int sizeTop = lua_tonumber(L, 1);
+            if (!lua_isnumber(L, 2)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
+                return lua_error(L);
+            } 
+            int sizeRight = lua_tonumber(L, 2);
+            if (!lua_isnumber(L, 3)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
+                return lua_error(L);
+            } 
+            int sizeBottom = lua_tonumber(L, 3);
+            if (!lua_isnumber(L, 4)) {
+                lua_pushfstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
+                return lua_error(L);
+            } 
+            int sizeLeft = lua_tonumber(L, 4);
+            break;
+        }
+        default: {
+            lua_pushfstring(L, "setBorderSizes: wrong number of arguments (0-4 expected, got %d!)", numberOfArguments);
+            return lua_error(L);
+        }
+    }
     setBorderSize(L, sizeTop, 0, false);
     setBorderSize(L, sizeRight, 1, false);
     setBorderSize(L, sizeBottom, 2, false);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3204,7 +3204,7 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::setBorderSize(int size, int position)
+void TLuaInterpreter::setBorderSize(int size, int position, bool updateEvent = true)
 {
     Host& host = getHostFromLua(L);
     // position: 0 = top, 1 = right, 2 = bottom, 3 = left
@@ -3214,12 +3214,14 @@ void TLuaInterpreter::setBorderSize(int size, int position)
         case 2: host.mBorderBottomHeight = size; break;
         case 3: host.mBorderLeftWidth = size; break;
     }
-    int x, y;
-    x = host.mpConsole->width();
-    y = host.mpConsole->height();
-    QSize s = QSize(x, y);
-    QResizeEvent event(s, s);
-    QApplication::sendEvent(host.mpConsole, &event);
+    if updateEvent {
+        int x, y;
+        x = host.mpConsole->width();
+        y = host.mpConsole->height();
+        QSize s = QSize(x, y);
+        QResizeEvent event(s, s);
+        QApplication::sendEvent(host.mpConsole, &event);
+    }
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderSizes

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3228,23 +3228,21 @@ void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool u
 int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
     int numberOfArguments = lua_gettop(L);
+    int sizeTop = 0;
+    int sizeRight = 0;
+    int sizeBottom = 0;
+    int sizeLeft = 0;
     switch(numberOfArguments) {
-        case 0: {
-            int sizeTop = 0;
-            int sizeRight = 0;
-            int sizeBottom = 0;
-            int sizeLeft = 0;
-            break;
-        }
+        case 0: break;
         case 1: {
             if (!lua_isnumber(L, 1)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
                 return lua_error(L);
             } 
-            int sizeTop = lua_tonumber(L, 1);
-            int sizeRight = lua_tonumber(L, 1);
-            int sizeBottom = lua_tonumber(L, 1);
-            int sizeLeft = lua_tonumber(L, 1);
+            sizeTop = lua_tonumber(L, 1);
+            sizeRight = lua_tonumber(L, 1);
+            sizeBottom = lua_tonumber(L, 1);
+            sizeLeft = lua_tonumber(L, 1);
             break;
         }
         case 2: {
@@ -3252,14 +3250,14 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
                 lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new heights size as number expected, got %s!)", luaL_typename(L, 1));
                 return lua_error(L);
             } 
-            int sizeTop = lua_tonumber(L, 1);
-            int sizeBottom = lua_tonumber(L, 1);
             if (!lua_isnumber(L, 2)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new widths size as number expected, got %s!)", luaL_typename(L, 2));
                 return lua_error(L);
             } 
-            int sizeRight = lua_tonumber(L, 2);
-            int sizeLeft = lua_tonumber(L, 2);
+            sizeTop = lua_tonumber(L, 1);
+            sizeRight = lua_tonumber(L, 2);
+            sizeBottom = lua_tonumber(L, 1);
+            sizeLeft = lua_tonumber(L, 2);
             break;
         }
         case 3: {
@@ -3267,18 +3265,18 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
                 lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
                 return lua_error(L);
             } 
-            int sizeTop = lua_tonumber(L, 1);
             if (!lua_isnumber(L, 2)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new widths size as number expected, got %s!)", luaL_typename(L, 2));
                 return lua_error(L);
             } 
-            int sizeRight = lua_tonumber(L, 2);
-            int sizeLeft = lua_tonumber(L, 2);
             if (!lua_isnumber(L, 3)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
                 return lua_error(L);
             } 
-            int sizeBottom = lua_tonumber(L, 3);
+            sizeTop = lua_tonumber(L, 1);
+            sizeRight = lua_tonumber(L, 2);
+            sizeBottom = lua_tonumber(L, 3);
+            sizeLeft = lua_tonumber(L, 2);
             break;
         }
         case 4: {
@@ -3286,22 +3284,22 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
                 lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
                 return lua_error(L);
             } 
-            int sizeTop = lua_tonumber(L, 1);
             if (!lua_isnumber(L, 2)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
                 return lua_error(L);
             } 
-            int sizeRight = lua_tonumber(L, 2);
             if (!lua_isnumber(L, 3)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
                 return lua_error(L);
             } 
-            int sizeBottom = lua_tonumber(L, 3);
             if (!lua_isnumber(L, 4)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
                 return lua_error(L);
             } 
-            int sizeLeft = lua_tonumber(L, 4);
+            sizeTop = lua_tonumber(L, 1);
+            sizeRight = lua_tonumber(L, 2);
+            sizeBottom = lua_tonumber(L, 3);
+            sizeLeft = lua_tonumber(L, 4);
             break;
         }
         default: {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3204,17 +3204,16 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool updateEvent)
+void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool resizeMudlet)
 {
     Host& host = getHostFromLua(L);
-    // position: 0 = top, 1 = right, 2 = bottom, 3 = left
     switch(position) {
-        case 0: host.mBorderTopHeight = size; break;
-        case 1: host.mBorderRightWidth = size; break;
-        case 2: host.mBorderBottomHeight = size; break;
-        case 3: host.mBorderLeftWidth = size; break;
+        case Qt::TopSection: host.mBorderTopHeight = size; break;
+        case Qt::RightSection: host.mBorderRightWidth = size; break;
+        case Qt::BottomSection: host.mBorderBottomHeight = size; break;
+        case Qt::LeftSection: host.mBorderLeftWidth = size; break;
     }
-    if (updateEvent) {
+    if (resizeMudlet) {
         int x, y;
         x = host.mpConsole->width();
         y = host.mpConsole->height();
@@ -3247,11 +3246,11 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
         }
         case 2: {
             if (!lua_isnumber(L, 1)) {
-                lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new heights size as number expected, got %s!)", luaL_typename(L, 1));
+                lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new height as number expected, got %s!)", luaL_typename(L, 1));
                 return lua_error(L);
             } 
             if (!lua_isnumber(L, 2)) {
-                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new widths size as number expected, got %s!)", luaL_typename(L, 2));
+                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new width as number expected, got %s!)", luaL_typename(L, 2));
                 return lua_error(L);
             } 
             sizeTop = lua_tonumber(L, 1);
@@ -3266,7 +3265,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
                 return lua_error(L);
             } 
             if (!lua_isnumber(L, 2)) {
-                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new widths size as number expected, got %s!)", luaL_typename(L, 2));
+                lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new width as number expected, got %s!)", luaL_typename(L, 2));
                 return lua_error(L);
             } 
             if (!lua_isnumber(L, 3)) {
@@ -3279,7 +3278,7 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
             sizeLeft = lua_tonumber(L, 2);
             break;
         }
-        case 4: {
+        default: {
             if (!lua_isnumber(L, 1)) {
                 lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
                 return lua_error(L);
@@ -3302,15 +3301,11 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
             sizeLeft = lua_tonumber(L, 4);
             break;
         }
-        default: {
-            lua_pushfstring(L, "setBorderSizes: wrong number of arguments (0-4 expected, got %d!)", numberOfArguments);
-            return lua_error(L);
-        }
     }
-    setBorderSize(L, sizeTop, 0, false);
-    setBorderSize(L, sizeRight, 1, false);
-    setBorderSize(L, sizeBottom, 2, false);
-    setBorderSize(L, sizeLeft, 3, true); // only now send update event
+    setBorderSize(L, sizeTop, Qt::TopSection, false);
+    setBorderSize(L, sizeRight, Qt::RightSection, false);
+    setBorderSize(L, sizeBottom, Qt::BottomSection, false);
+    setBorderSize(L, sizeLeft, Qt::LeftSection, true); // only now send update event to resize Mudlet window
     return 0;
 }
 
@@ -3322,7 +3317,7 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
         return lua_error(L);
     } 
     int size = lua_tonumber(L, 1);
-    setBorderSize(L, size, 0);
+    setBorderSize(L, size, Qt::TopSection);
     return 0;
 }
 
@@ -3334,7 +3329,7 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
         return lua_error(L);
     } 
     int size = lua_tonumber(L, 1);
-    setBorderSize(L, size, 1);
+    setBorderSize(L, size, Qt::RightSection);
     return 0;
 }
 
@@ -3346,7 +3341,7 @@ int TLuaInterpreter::setBorderBottom(lua_State* L)
         return lua_error(L);
     } 
     int size = lua_tonumber(L, 1);
-    setBorderSize(L, size, 2);
+    setBorderSize(L, size, Qt::BottomSection);
     return 0;
 }
 
@@ -3358,7 +3353,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
         return lua_error(L);
     } 
     int size = lua_tonumber(L, 1);
-    setBorderSize(L, size, 3);
+    setBorderSize(L, size, Qt::LeftSection);
     return 0;
 }
 
@@ -3398,7 +3393,6 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
 int TLuaInterpreter::getBorderSizes(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    int n = lua_gettop(L);
     lua_createtable(L, 0, 4);
     lua_pushinteger(L, host.mBorderTopHeight);
     lua_setfield(L, -2, "top");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3203,91 +3203,82 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderTop
-int TLuaInterpreter::setBorderTop(lua_State* L)
+// No documentation available in wiki - internal function
+void TLuaInterpreter::setBorderSize(int size, int position)
 {
-    int x1;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderTop: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        x1 = lua_tonumber(L, 1);
-    }
     Host& host = getHostFromLua(L);
-    host.mBorderTopHeight = x1;
+    // position: 0 = top, 1 = right, 2 = bottom, 3 = left
+    switch(position) {
+        case 0: host.mBorderTopHeight = size; break;
+        case 1: host.mBorderRightWidth = size; break;
+        case 2: host.mBorderBottomHeight = size; break;
+        case 3: host.mBorderLeftWidth = size; break;
+    }
     int x, y;
     x = host.mpConsole->width();
     y = host.mpConsole->height();
     QSize s = QSize(x, y);
     QResizeEvent event(s, s);
     QApplication::sendEvent(host.mpConsole, &event);
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderTop
+int TLuaInterpreter::setBorderTop(lua_State* L)
+{
+    int size;
+    if (!lua_isnumber(L, 1)) {
+        lua_pushstring(L, "setBorderTop: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_error(L);
+        return 1;
+    } else {
+        size = lua_tonumber(L, 1);
+    }
+    setBorderSize(size, 0);
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderRight
+int TLuaInterpreter::setBorderRight(lua_State* L)
+{
+    int size;
+    if (!lua_isnumber(L, 1)) {
+        lua_pushstring(L, "setBorderRight: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
+        lua_error(L);
+        return 1;
+    } else {
+        size = lua_tonumber(L, 1);
+    }
+    setBorderSize(size, 1);
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderBottom
 int TLuaInterpreter::setBorderBottom(lua_State* L)
 {
-    int x1;
+    int size;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderBottom: wrong argument type");
+        lua_pushstring(L, "setBorderBottom: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
-        x1 = lua_tonumber(L, 1);
+        size = lua_tonumber(L, 1);
     }
-    Host& host = getHostFromLua(L);
-    host.mBorderBottomHeight = x1;
-    int x, y;
-    x = host.mpConsole->width();
-    y = host.mpConsole->height();
-    QSize s = QSize(x, y);
-    QResizeEvent event(s, s);
-    QApplication::sendEvent(host.mpConsole, &event);
+    setBorderSize(size, 2);
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderBottom
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderLeft
 int TLuaInterpreter::setBorderLeft(lua_State* L)
 {
-    int x1;
+    int size;
     if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderLeft: wrong argument type");
+        lua_pushstring(L, "setBorderLeft: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
-        x1 = lua_tonumber(L, 1);
+        size = lua_tonumber(L, 1);
     }
-    Host& host = getHostFromLua(L);
-    host.mBorderLeftWidth = x1;
-    int x, y;
-    x = host.mpConsole->width();
-    y = host.mpConsole->height();
-    QSize s = QSize(x, y);
-    QResizeEvent event(s, s);
-    QApplication::sendEvent(host.mpConsole, &event);
-    return 0;
-}
-
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderBottom
-int TLuaInterpreter::setBorderRight(lua_State* L)
-{
-    int x1;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "setBorderRight: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        x1 = lua_tonumber(L, 1);
-    }
-    Host& host = getHostFromLua(L);
-    host.mBorderRightWidth = x1;
-    int x, y;
-    x = host.mpConsole->width();
-    y = host.mpConsole->height();
-    QSize s = QSize(x, y);
-    QResizeEvent event(s, s);
-    QApplication::sendEvent(host.mpConsole, &event);
+    setBorderSize(size, 3);
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3326,6 +3326,38 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderTop
+int TLuaInterpreter::getBorderTop(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    lua_pushnumber(L, host.mBorderTopWidth);
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderLeft
+int TLuaInterpreter::getBorderLeft(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    lua_pushnumber(L, host.mBorderLeftWidth);
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderBottom
+int TLuaInterpreter::getBorderBottom(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    lua_pushnumber(L, host.mBorderBottomWidth);
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderRight
+int TLuaInterpreter::getBorderRight(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    lua_pushnumber(L, host.mBorderRightWidth);
+    return 0;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resizeWindow -- not resizeUserWindow - compare initLuaGlobals()
 int TLuaInterpreter::resizeWindow(lua_State* L)
 {
@@ -14675,6 +14707,10 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setBorderBottom", TLuaInterpreter::setBorderBottom);
     lua_register(pGlobalLua, "setBorderLeft", TLuaInterpreter::setBorderLeft);
     lua_register(pGlobalLua, "setBorderColor", TLuaInterpreter::setBorderColor);
+    lua_register(pGlobalLua, "getBorderTop", TLuaInterpreter::getBorderTop);
+    lua_register(pGlobalLua, "getBorderRight", TLuaInterpreter::getBorderRight);
+    lua_register(pGlobalLua, "getBorderBottom", TLuaInterpreter::getBorderBottom);
+    lua_register(pGlobalLua, "getBorderLeft", TLuaInterpreter::getBorderLeft);
     lua_register(pGlobalLua, "setConsoleBufferSize", TLuaInterpreter::setConsoleBufferSize);
     lua_register(pGlobalLua, "enableScrollBar", TLuaInterpreter::enableScrollBar);
     lua_register(pGlobalLua, "disableScrollBar", TLuaInterpreter::disableScrollBar);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14728,6 +14728,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getBorderRight", TLuaInterpreter::getBorderRight);
     lua_register(pGlobalLua, "getBorderBottom", TLuaInterpreter::getBorderBottom);
     lua_register(pGlobalLua, "getBorderLeft", TLuaInterpreter::getBorderLeft);
+    lua_register(pGlobalLua, "getBorderSizes", TLuaInterpreter::getBorderSizes);
     lua_register(pGlobalLua, "setConsoleBufferSize", TLuaInterpreter::setConsoleBufferSize);
     lua_register(pGlobalLua, "enableScrollBar", TLuaInterpreter::enableScrollBar);
     lua_register(pGlobalLua, "disableScrollBar", TLuaInterpreter::disableScrollBar);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3358,6 +3358,23 @@ int TLuaInterpreter::getBorderRight(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderSizes
+int TLuaInterpreter::getBorderSizes(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    int n = lua_gettop(L);
+    lua_createtable(L, 0, 4);
+    lua_pushinteger(L, host.mBorderTopHeight);
+    lua_setfield(L, -2, "top");
+    lua_pushinteger(L, host.mBorderRightWidth);
+    lua_setfield(L, -2, "right");
+    lua_pushinteger(L, host.mBorderBottomHeight);
+    lua_setfield(L, -2, "bottom");
+    lua_pushinteger(L, host.mBorderLeftWidth);
+    lua_setfield(L, -2, "left");
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resizeWindow -- not resizeUserWindow - compare initLuaGlobals()
 int TLuaInterpreter::resizeWindow(lua_State* L)
 {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2196,14 +2196,14 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
         return 1;
     }
     if (!pR->exitStubs.contains(dirType)) {
-        lua_pushstring(L, "connectExitStubs: ExitStub doesn't exist");
+        lua_pushstring(L, "connectExitStub: ExitStub doesn't exist");
         lua_error(L);
         return 1;
     }
     if (roomsGiven) {
         TRoom* pR_to = host.mpMap->mpRoomDB->getRoom(toRoom);
         if (!pR_to) {
-            lua_pushstring(L, "connectExitStubs: toRoom doesn't exist");
+            lua_pushstring(L, "connectExitStub: toRoom doesn't exist");
             lua_error(L);
             return 1;
         }
@@ -2211,7 +2211,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
         lua_pushboolean(L, host.mpMap->setExit(roomId, toRoom, dirType));
     } else {
         if (!pR->exitStubs.contains(dirType)) {
-            lua_pushstring(L, "connectExitStubs: ExitStub doesn't exist");
+            lua_pushstring(L, "connectExitStub: ExitStub doesn't exist");
             lua_error(L);
             return 1;
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3227,38 +3227,26 @@ void TLuaInterpreter::setBorderSize(lua_State* L, int size, int position, bool u
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderSizes
 int TLuaInterpreter::setBorderSizes(lua_State* L)
 {
-    int sizeTop;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderSizes: bad argument #1 value (new top size as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
-    } else {
-        sizeTop = lua_tonumber(L, 1);
-    }
-    int sizeRight;
+        return lua_error(L);
+    } 
+    int sizeTop = lua_tonumber(L, 1);
     if (!lua_isnumber(L, 2)) {
         lua_pushfstring(L, "setBorderSizes: bad argument #2 value (new right size as number expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
-    } else {
-        sizeRight = lua_tonumber(L, 2);
-    }
-    int sizeBottom;
+        return lua_error(L);
+    } 
+    int sizeRight = lua_tonumber(L, 2);
     if (!lua_isnumber(L, 3)) {
         lua_pushfstring(L, "setBorderSizes: bad argument #3 value (new bottom size as number expected, got %s!)", luaL_typename(L, 3));
-        lua_error(L);
-        return 1;
-    } else {
-        sizeBottom = lua_tonumber(L, 3);
-    }
-    int sizeLeft;
+        return lua_error(L);
+    } 
+    int sizeBottom = lua_tonumber(L, 3);
     if (!lua_isnumber(L, 4)) {
         lua_pushfstring(L, "setBorderSizes: bad argument #4 value (new left size as number expected, got %s!)", luaL_typename(L, 4));
-        lua_error(L);
-        return 1;
-    } else {
-        sizeLeft = lua_tonumber(L, 4);
-    }
+        return lua_error(L);
+    } 
+    int sizeLeft = lua_tonumber(L, 4);
     setBorderSize(L, sizeTop, 0, false);
     setBorderSize(L, sizeRight, 1, false);
     setBorderSize(L, sizeBottom, 2, false);
@@ -3272,8 +3260,7 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
     int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderTop: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         size = lua_tonumber(L, 1);
     }
@@ -3287,8 +3274,7 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
     int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderRight: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         size = lua_tonumber(L, 1);
     }
@@ -3302,8 +3288,7 @@ int TLuaInterpreter::setBorderBottom(lua_State* L)
     int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderBottom: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         size = lua_tonumber(L, 1);
     }
@@ -3317,8 +3302,7 @@ int TLuaInterpreter::setBorderLeft(lua_State* L)
     int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderLeft: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         size = lua_tonumber(L, 1);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3319,13 +3319,11 @@ int TLuaInterpreter::setBorderSizes(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderTop
 int TLuaInterpreter::setBorderTop(lua_State* L)
 {
-    int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderTop: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        size = lua_tonumber(L, 1);
-    }
+    } 
+    int size = lua_tonumber(L, 1);
     setBorderSize(L, size, 0);
     return 0;
 }
@@ -3333,13 +3331,11 @@ int TLuaInterpreter::setBorderTop(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderRight
 int TLuaInterpreter::setBorderRight(lua_State* L)
 {
-    int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderRight: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        size = lua_tonumber(L, 1);
-    }
+    } 
+    int size = lua_tonumber(L, 1);
     setBorderSize(L, size, 1);
     return 0;
 }
@@ -3347,13 +3343,11 @@ int TLuaInterpreter::setBorderRight(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderBottom
 int TLuaInterpreter::setBorderBottom(lua_State* L)
 {
-    int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderBottom: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        size = lua_tonumber(L, 1);
-    }
+    } 
+    int size = lua_tonumber(L, 1);
     setBorderSize(L, size, 2);
     return 0;
 }
@@ -3361,13 +3355,11 @@ int TLuaInterpreter::setBorderBottom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderLeft
 int TLuaInterpreter::setBorderLeft(lua_State* L)
 {
-    int size;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setBorderLeft: bad argument #1 value (new size as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        size = lua_tonumber(L, 1);
-    }
+    } 
+    int size = lua_tonumber(L, 1);
     setBorderSize(L, size, 3);
     return 0;
 }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -361,6 +361,7 @@ public:
     static int isAnsiBgColor(lua_State*);
     static int stopSounds(lua_State*);
     static int playSoundFile(lua_State*);
+    static void setBorderSize(lua_State*);
     static int setBorderTop(lua_State*);
     static int setBorderBottom(lua_State*);
     static int setBorderLeft(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -372,7 +372,7 @@ public:
     static int getBorderBottom(lua_State*);
     static int getBorderLeft(lua_State*);
     static int getBorderRight(lua_State*);
-    static int getBorderSizes(lua_State* L)
+    static int getBorderSizes(lua_State* L);
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);
     static int disableScrollBar(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -361,7 +361,7 @@ public:
     static int isAnsiBgColor(lua_State*);
     static int stopSounds(lua_State*);
     static int playSoundFile(lua_State*);
-    static void setBorderSize(lua_State*);
+    static void setBorderSize(int size, int position, bool updateEvent = true);
     static int setBorderSizes(lua_State*);
     static int setBorderTop(lua_State*);
     static int setBorderBottom(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -368,6 +368,10 @@ public:
     static int setBorderLeft(lua_State*);
     static int setBorderRight(lua_State*);
     static int setBorderColor(lua_State*);
+    static int getBorderTop(lua_State*);
+    static int getBorderBottom(lua_State*);
+    static int getBorderLeft(lua_State*);
+    static int getBorderRight(lua_State*);
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);
     static int disableScrollBar(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -361,7 +361,7 @@ public:
     static int isAnsiBgColor(lua_State*);
     static int stopSounds(lua_State*);
     static int playSoundFile(lua_State*);
-    static void setBorderSize(int size, int position, bool updateEvent = true);
+    static void setBorderSize(lua_State* L, int size, int position, bool updateEvent = true);
     static int setBorderSizes(lua_State*);
     static int setBorderTop(lua_State*);
     static int setBorderBottom(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -361,7 +361,7 @@ public:
     static int isAnsiBgColor(lua_State*);
     static int stopSounds(lua_State*);
     static int playSoundFile(lua_State*);
-    static void setBorderSize(lua_State* L, int size, int position, bool updateEvent = true);
+    static void setBorderSize(lua_State*, int, int, bool resizeMudlet = true);
     static int setBorderSizes(lua_State*);
     static int setBorderTop(lua_State*);
     static int setBorderBottom(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -372,6 +372,7 @@ public:
     static int getBorderBottom(lua_State*);
     static int getBorderLeft(lua_State*);
     static int getBorderRight(lua_State*);
+    static int getBorderSizes(lua_State* L)
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);
     static int disableScrollBar(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -362,6 +362,7 @@ public:
     static int stopSounds(lua_State*);
     static int playSoundFile(lua_State*);
     static void setBorderSize(lua_State*);
+    static int setBorderSizes(lua_State*);
     static int setBorderTop(lua_State*);
     static int setBorderBottom(lua_State*);
     static int setBorderLeft(lua_State*);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
* Review found mostly identical code in all 4 border functions
* Duplicate code moved to new joint setBorderSize function
* Error messages have been upgraded to be more helpful
* Erroneous links to documentation have been corrected
* Renamed ambiguous variable names from `x1` to `size`
* Added a new [setBorderSizes](https://wiki.mudlet.org/w/Manual:Lua_Functions#setBorderSizes) function:
  - setBorderSizes()
  - setBorderSizes(size)
  - setBorderSizes(heights, widths)
  - setBorderSizes(top, widths, bottom)
  - setBorderSizes(top, right, bottom, left)
* Added the originally requested functions
    * [getBorderTop](https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderTop)
    * [getBorderRight](https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderRight)
    * [getBorderBottom](https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderBottom)
    * [getBorderLeft](https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderLeft)
* Testing a new idea by SlySven to add a joint [getBorderSizes](https://wiki.mudlet.org/w/Manual:Lua_Functions#getBorderSizes) as discussed in issue #2783
* [x] better shield getBorderSizes, e.g. against wrong number of arguments
* [x] document these functions in wiki
* [x] look into [using enums](https://github.com/Mudlet/Mudlet/pull/2809#issuecomment-513214272) instead of mere integers

#### Motivation for adding to Mudlet
Make border handling easier

#### Other info (issues closed, discussion etc)
Fix #2783
