### PR TITLE
Show full path to sound file instead of explanatory tooltip

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5035,6 +5035,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
         mpTriggersMainArea->spinBox_lineMargin->setValue(pT->getConditionLineDelta());
         mpTriggersMainArea->spinBox_stayOpen->setValue(pT->mStayOpen);
         mpTriggersMainArea->groupBox_soundTrigger->setChecked(pT->mSoundTrigger);
+        mpTriggersMainArea->lineEdit_soundFile->setToolTip(pT->mSoundFile);
         mpTriggersMainArea->lineEdit_soundFile->setText(pT->mSoundFile);
         mpTriggersMainArea->lineEdit_soundFile->setCursorPosition(mpTriggersMainArea->lineEdit_soundFile->text().length());
         mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(!mpTriggersMainArea->lineEdit_soundFile->text().isEmpty());
@@ -7957,6 +7958,7 @@ void dlgTriggerEditor::slot_soundTrigger()
                                                        "This the list of file extensions that are considered for sounds from triggers, the terms inside of the '('...')' and the \";;\" are used programmatically and should not be changed."));
     if (!fileName.isEmpty()) {
         // This will only be executed if the user did not press cancel
+        mpTriggersMainArea->lineEdit_soundFile->setToolTip(fileName);
         mpTriggersMainArea->lineEdit_soundFile->setText(fileName);
         mpTriggersMainArea->lineEdit_soundFile->setCursorPosition(mpTriggersMainArea->lineEdit_soundFile->text().length());
         mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(!mpTriggersMainArea->lineEdit_soundFile->text().isEmpty());

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>690</width>
+    <width>692</width>
     <height>270</height>
    </rect>
   </property>
@@ -247,11 +247,11 @@
          </item>
          <item alignment="Qt::AlignTop">
           <widget class="QGroupBox" name="groupBox_filterTrigger">
-           <property name="autoFillBackground">
-            <bool>true</bool>
-           </property>
            <property name="toolTip">
             <string>&lt;p&gt;When checked, only the filtered content (=capture groups) will be passed on to child triggers, not the initial line (see manual on filters).&lt;/p&gt;</string>
+           </property>
+           <property name="autoFillBackground">
+            <bool>true</bool>
            </property>
            <property name="title">
             <string>only pass matches</string>
@@ -311,11 +311,11 @@
          </item>
          <item alignment="Qt::AlignTop">
           <widget class="QGroupBox" name="groupBox_perlSlashGOption">
-           <property name="autoFillBackground">
-            <bool>true</bool>
-           </property>
            <property name="toolTip">
             <string>&lt;p&gt;Choose this option if you want to include all possible matches of the pattern in the line.&lt;/p&gt;&lt;p&gt;Without this option, the pattern matching will stop after the first successful match.&lt;/p&gt;</string>
+           </property>
+           <property name="autoFillBackground">
+            <bool>true</bool>
            </property>
            <property name="title">
             <string>match all</string>
@@ -537,9 +537,6 @@
            <property name="focusPolicy">
             <enum>Qt::NoFocus</enum>
            </property>
-           <property name="toolTip">
-            <string comment="This is the tooltip for the QLineEdit that shows - but does not permit changing - the sound file used for a trigger." extracomment="Please ensure that the text used for &quot;Choose file ,,,&quot; here is the same as is used for the button that it refers to.">&lt;p&gt;This displays the file selected to play when the trigger fires. To change this used the &lt;i&gt;Choose file...&lt;/i&gt; button or to remove it use the clear button.&lt;/p&gt;</string>
-           </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -607,11 +604,11 @@
       </item>
       <item alignment="Qt::AlignTop">
        <widget class="QGroupBox" name="groupBox_triggerColorizer">
-        <property name="autoFillBackground">
-         <bool>true</bool>
-        </property>
         <property name="toolTip">
          <string>&lt;p&gt;Enable this to highlight the matching text by changing the fore and background colors to the ones selected here.&lt;/p&gt;</string>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
         </property>
         <property name="title">
          <string>highlight</string>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -537,6 +537,9 @@
            <property name="focusPolicy">
             <enum>Qt::NoFocus</enum>
            </property>
+           <property name="toolTip">
+            <string comment="This is the tooltip for the QLineEdit that shows - but does not permit changing - the sound file used for a trigger.">&lt;p&gt;Sound file to play when the trigger fires.&lt;/p&gt;</string>
+           </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Before:
![image](https://user-images.githubusercontent.com/110988/61561311-ee246d80-aa6e-11e9-97a6-8ba43f77e460.png)

You can't see the full path to the sound file and the tooltip isn't particularly enlightening in telling the player that they can select `Choose file` to choose a sound file!

After:
![image](https://user-images.githubusercontent.com/110988/61561342-03999780-aa6f-11e9-9cfe-e2a4471aac15.png)

Full location to the sound file so you can tell exactly where it came from.
#### Motivation for adding to Mudlet
Better usability.