### PR TITLE
Reset sound location tooltip when sound is removed

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5035,7 +5035,9 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
         mpTriggersMainArea->spinBox_lineMargin->setValue(pT->getConditionLineDelta());
         mpTriggersMainArea->spinBox_stayOpen->setValue(pT->mStayOpen);
         mpTriggersMainArea->groupBox_soundTrigger->setChecked(pT->mSoundTrigger);
-        mpTriggersMainArea->lineEdit_soundFile->setToolTip(pT->mSoundFile);
+        if (!pT->mSoundFile.isEmpty()) {
+            mpTriggersMainArea->lineEdit_soundFile->setToolTip(pT->mSoundFile);
+        }
         mpTriggersMainArea->lineEdit_soundFile->setText(pT->mSoundFile);
         mpTriggersMainArea->lineEdit_soundFile->setCursorPosition(mpTriggersMainArea->lineEdit_soundFile->text().length());
         mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(!mpTriggersMainArea->lineEdit_soundFile->text().isEmpty());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8407,6 +8407,7 @@ void dlgTriggerEditor::slot_clearSoundFile()
 {
     mpTriggersMainArea->lineEdit_soundFile->clear();
     mpTriggersMainArea->toolButton_clearSoundFile->setEnabled(false);
+    mpTriggersMainArea->lineEdit_soundFile->setToolTip(tr("<p>Sound file to play when the trigger fires.</p>"));
 }
 
 void dlgTriggerEditor::slot_showAllTriggerControls(const bool isShown)

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -560,7 +560,7 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>&lt;p&gt;Click to remove a sound file set for this trigger.&lt;/p&gt;</string>
+            <string>&lt;p&gt;Click to remove the sound file set for this trigger.&lt;/p&gt;</string>
            </property>
            <property name="icon">
             <iconset resource="../mudlet.qrc">


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Reset sound location tooltip when sound is removed
#### Motivation for adding to Mudlet
Fix oversight from previous PR.
#### Other info (issues closed, discussion etc)
Note that there is no issue with the tooltip when there is no sound set:

![image](https://user-images.githubusercontent.com/110988/61586036-d6caaa80-ab6a-11e9-8805-888c90b9d0cc.png)
