### PR TITLE
Link to -lstdc++ as we need to in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -504,6 +504,7 @@ target_link_libraries(mudlet
     ${PUGIXML_LIBRARIES}
     communi
     edbee-lib
+    -lstdc++
 )
 
 if(Qt5TextToSpeech_FOUND)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Link to -lstdc++ as we need to in CMake
#### Motivation for adding to Mudlet
Apparently we were getting away with not being explicit before for clang, but can't now:

```
[100%] Linking CXX executable mudlet
/usr/bin/ld: CMakeFiles/mudlet.dir/ctelnet.cpp.o: undefined reference to symbol '_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEaSEPKc@@GLIBCXX_3.4.21'
//usr/lib/x86_64-linux-gnu/libstdc++.so.6: error adding symbols: DSO missing from command line
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
#### Other info (issues closed, discussion etc)
