### PR TITLE
Add a repeating option to tempTimer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -504,7 +504,6 @@ target_link_libraries(mudlet
     ${PUGIXML_LIBRARIES}
     communi
     edbee-lib
-    -lstdc++
 )
 
 if(Qt5TextToSpeech_FOUND)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6179,6 +6179,7 @@ int TLuaInterpreter::getMousePosition(lua_State* L)
 int TLuaInterpreter::tempTimer(lua_State* L)
 {
     double time;
+    bool repeating;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "tempTimer: bad argument #1 type (time in seconds as {maybe decimal} number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
@@ -6190,7 +6191,11 @@ int TLuaInterpreter::tempTimer(lua_State* L)
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     if (lua_isfunction(L, 2)) {
-        QPair<int, QString> result = pLuaInterpreter->startTempTimer(time, QString());
+        if (lua_isboolean(L, 3)) {
+            repeating = lua_toboolean(L, 3);
+        }
+
+        QPair<int, QString> result = pLuaInterpreter->startTempTimer(time, QString(), repeating);
         if (result.first == -1) {
             lua_pushnumber(L, -1);
             lua_pushstring(L, result.second.toUtf8().constData());
@@ -6211,8 +6216,11 @@ int TLuaInterpreter::tempTimer(lua_State* L)
         return lua_error(L);
     }
     QString luaCode = QString::fromUtf8(lua_tostring(L, 2));
+    if (lua_isboolean(L, 3)) {
+        repeating = lua_toboolean(L, 3);
+    }
 
-    QPair<int, QString> result = pLuaInterpreter->startTempTimer(time, luaCode);
+    QPair<int, QString> result = pLuaInterpreter->startTempTimer(time, luaCode, repeating);
     lua_pushnumber(L, result.first);
     if (result.first == -1) {
         lua_pushstring(L, result.second.toUtf8().constData());
@@ -15349,10 +15357,10 @@ QPair<int, QString> TLuaInterpreter::startPermTimer(const QString& name, const Q
 }
 
 // No documentation available in wiki - internal function
-QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QString& function)
+QPair<int, QString> TLuaInterpreter::startTempTimer(double timeout, const QString& function, const bool repeating)
 {
     QTime time = QTime(0,0,0,0).addMSecs(qRound(timeout * 1000));
-    TTimer* pT = new TTimer(QStringLiteral("newTempTimerWithoutAnId"), time, mpHost);
+    auto* pT = new TTimer(QStringLiteral("newTempTimerWithoutAnId"), time, mpHost, repeating);
     pT->setTime(time);
     pT->setIsFolder(false);
     pT->setTemporary(true);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -108,7 +108,7 @@ public:
     static int dirToNumber(lua_State*, int);
 
 
-    QPair<int, QString> startTempTimer(double, const QString&);
+    QPair<int, QString> startTempTimer(double timeout, const QString& function, const bool repeating = false);
     int startTempAlias(const QString&, const QString&);
     int startTempKey(int&, int&, QString&);
     int startTempTrigger(const QString& regex, const QString& function, int expiryCount = -1);

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -49,7 +49,7 @@ TTimer::TTimer(TTimer* parent, Host* pHost)
     mpQTimer->setProperty(scmProperty_TTimerId, 0);
 }
 
-TTimer::TTimer(const QString& name, QTime time, Host* pHost)
+TTimer::TTimer(const QString& name, QTime time, Host* pHost, bool repeating)
 : Tree<TTimer>(nullptr)
 , mRegisteredAnonymousLuaFunction(false)
 , exportItem(true)
@@ -65,6 +65,7 @@ TTimer::TTimer(const QString& name, QTime time, Host* pHost)
     mpQTimer->setProperty(scmProperty_HostName, mpHost->getName());
     mpHost->getTimerUnit()->mQTimerSet.insert(mpQTimer);
     mpQTimer->setProperty(scmProperty_TTimerId, 0);
+    mRepeating = repeating;
 }
 
 TTimer::~TTimer()
@@ -200,7 +201,7 @@ bool TTimer::compileScript()
 
 bool TTimer::checkRestart()
 {
-    return (!isTemporary() && !isOffsetTimer() && isActive() && !isFolder());
+    return ((!isTemporary() || mRepeating) && !isOffsetTimer() && isActive() && !isFolder());
 }
 
 void TTimer::execute()

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -127,6 +127,7 @@ bool TTimer::setIsActive(bool b)
 
 void TTimer::start()
 {
+    // temporary repeating timers are still singleshot not to change the design too much
     mpQTimer->setSingleShot(isTemporary());
 
     if (!isFolder()) {
@@ -217,8 +218,11 @@ void TTimer::execute()
         } else {
             mpHost->mLuaInterpreter.compileAndExecuteScript(mScript);
         }
-        mpQTimer->stop();
-        mpHost->getTimerUnit()->markCleanup(this);
+
+        if (!mRepeating) {
+            mpQTimer->stop();
+            mpHost->getTimerUnit()->markCleanup(this);
+        }
         return;
     }
 

--- a/src/TTimer.h
+++ b/src/TTimer.h
@@ -45,7 +45,7 @@ class TTimer : public Tree<TTimer>
 public:
     ~TTimer();
     TTimer(TTimer* parent, Host* pHost);
-    TTimer(const QString& name, QTime time, Host* pHost);
+    TTimer(const QString& name, QTime time, Host* pHost, bool repeating = false);
     void compileAll();
     QString& getName() { return mName; }
     void setName(const QString& name);
@@ -77,7 +77,7 @@ public:
     QTimer* getQTimer() { return mpQTimer; }
     // Override the Tree version as we need to insert the id number as a
     // property into the QTimer that mpQTimer points to as well:
-    void setID(const int);
+    void setID(int) override;
 
 
     // specifies whenever the payload is Lua code as a string
@@ -101,6 +101,8 @@ private:
     QMutex mLock;
     QTimer* mpQTimer;
     bool mModuleMember;
+    // temporary timers are single-shot by default, unless repeating is set
+    bool mRepeating;
 };
 
 #endif // MUDLET_TTIMER_H

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -44,7 +44,7 @@ public:
     bool hasChildren() const { return (!mpMyChildrenList->empty()); }
     int getChildCount() const { return mpMyChildrenList->size(); }
     int getID() const { return mID; }
-    void setID(const int id) { mID = id; }
+    virtual void setID(const int id) { mID = id; }
     void addChild(T* newChild, int parentPostion = -1, int parentPosition = -1);
     bool popChild(T* removeChild);
     void setParent(T* parent);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Now can do `tempTimer(1, function() print"yes" end, true)` to get the temp timer to repeat until killed.
#### Motivation for adding to Mudlet
Easier porting of MUSHclient scripts to Mudlet.
#### Other info (issues closed, discussion etc)
