### PR TITLE
Make reconnect() and Reconnect button respect custom connectToServer()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5445,7 +5445,7 @@ int TLuaInterpreter::disconnect(lua_State* L)
 int TLuaInterpreter::reconnect(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    host.mTelnet.connectIt(host.getUrl(), host.getPort());
+    host.mTelnet.reconnect();
     return 0;
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -298,7 +298,7 @@ QPair<bool, QString> cTelnet::setEncoding(const QString& newEncoding, const bool
     if (newEncoding.isEmpty() || newEncoding == QLatin1String("ASCII")) {
         reportedEncoding = QStringLiteral("ASCII");
         if (!mEncoding.isEmpty()) {
-            // This will disable trancoding on:
+            // This will disable transcoding on:
             // input in TBuffer::translateToPlainText(...)
             // incoming OOB in TLuaInterpreter::encodeBytes(...)
             // output in cTelnet::sendData(...)
@@ -367,6 +367,10 @@ void cTelnet::connectIt(const QString& address, int port)
     QHostInfo::lookupHost(address, this, SLOT(handle_socket_signal_hostFound(QHostInfo)));
 }
 
+void cTelnet::reconnect()
+{
+    connectIt(hostName, hostPort);
+}
 
 void cTelnet::disconnectIt()
 {

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -130,6 +130,7 @@ public:
     cTelnet(Host* pH, const QString&);
     ~cTelnet();
     void connectIt(const QString& address, int port);
+    void reconnect();
     void disconnectIt();
     void abortConnection();
     bool sendData(QString& data);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3532,7 +3532,7 @@ void mudlet::slot_reconnect()
     if (!pHost) {
         return;
     }
-    pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
+    pHost->mTelnet.reconnect();
 }
 
 void mudlet::slot_disconnect()


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
`reconnect()` and the Reconnect button work fine for reconnecting, however if you connected to an entirely different profile using `connectToServer()` and decided not to save the new parameters, reconnecting would still connect to the profile's address and port, instead of the custom one. If you saved the values, then it would connect just fine.

This makes the behaviour be more intuitive, reconnect always reconnects to whatever you were connected to last.
#### Motivation for adding to Mudlet
More intuitive behaviour as one would expect.
#### Other info (issues closed, discussion etc)
