### PR TITLE
BugFix: render tabs correctly

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -64,6 +64,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 , mpScrollBar(nullptr)
 , mWideAmbigousWidthGlyphs(pH->wideAmbiguousEAsianGlyphs())
 , mUseOldUnicode8(false)
+, mTabStopwidth(8)
 {
     mLastClickTimer.start();
     if (pC->getType() != TConsole::CentralDebugConsole) {
@@ -500,7 +501,7 @@ int TTextEdit::drawGrapheme(QPainter& painter, const QPoint& cursor, const QStri
     uint unicode = getGraphemeBaseCharacter(grapheme);
     int charWidth;
     if (unicode == '\t') {
-        charWidth = column / 8 * 8 + 8;
+        charWidth = mTabStopwidth - (column % mTabStopwidth);
     } else {
         charWidth = getGraphemeWidth(unicode);
     }

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -166,8 +166,11 @@ private:
     // Set in constructor for run-time Qt versions less than 5.11 which only
     // supports up to Unicode 8.0:
     bool mUseOldUnicode8;
-    // How many "normal" width "characters" are each tab stop apart:
-    unsigned int mTabStopwidth;
+    // How many "normal" width "characters" are each tab stop apart, whilst
+    // there is no current mechanism to adjust this, sensible values will
+    // probably be 1 (so that a tab is just treated as a space), 2, 4 and 8,
+    // in the past it was typically 8 and this is what we'll use at present:
+    int mTabStopwidth;
 };
 
 #endif // MUDLET_TTEXTEDIT_H

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -166,6 +166,8 @@ private:
     // Set in constructor for run-time Qt versions less than 5.11 which only
     // supports up to Unicode 8.0:
     bool mUseOldUnicode8;
+    // How many "normal" width "characters" are each tab stop apart:
+    unsigned int mTabStopwidth;
 };
 
 #endif // MUDLET_TTEXTEDIT_H


### PR DESCRIPTION
This will close https://github.com/Mudlet/Mudlet/issues/2797.

The setting is for tabs every 8 normal width characters - this could be made adjustable for each `TTextEdit` class instance but that is left for as a future coding option if needed.

Closes https://github.com/Mudlet/Mudlet/issues/2039.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>