### PR TITLE
Faster profile load: don't load formatter until needed

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -394,7 +394,6 @@ void Host::resetProfile_phase2()
     mEventMap.clear();
     mLuaInterpreter.initLuaGlobals();
     mLuaInterpreter.loadGlobal();
-    mLuaInterpreter.initIndenterGlobals();
     mBlockScriptCompile = false;
 
     getTriggerUnit()->compileAll();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -101,7 +101,6 @@ QString speechCurrent;
 TLuaInterpreter::TLuaInterpreter(Host* pH, int id) : mpHost(pH), mHostID(id), purgeTimer(this)
 {
     pGlobalLua = nullptr;
-    pIndenterState.reset();
 
     connect(&purgeTimer, &QTimer::timeout, this, &TLuaInterpreter::slotPurge);
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -101,6 +101,7 @@ QString speechCurrent;
 TLuaInterpreter::TLuaInterpreter(Host* pH, int id) : mpHost(pH), mHostID(id), purgeTimer(this)
 {
     pGlobalLua = nullptr;
+    pIndenterState.reset();
 
     connect(&purgeTimer, &QTimer::timeout, this, &TLuaInterpreter::slotPurge);
 
@@ -108,7 +109,6 @@ TLuaInterpreter::TLuaInterpreter(Host* pH, int id) : mpHost(pH), mHostID(id), pu
     connect(mpFileDownloader, &QNetworkAccessManager::finished, this, &TLuaInterpreter::slot_replyFinished);
 
     initLuaGlobals();
-    initIndenterGlobals();
 
     purgeTimer.start(2000);
 }
@@ -13193,7 +13193,12 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
     if (code.isEmpty()) {
         return code;
     }
-    lua_State* L = pIndenterState;
+
+    if (!pIndenterState) {
+        initIndenterGlobals();
+    }
+
+    lua_State* L = pIndenterState.get();
     if (!L) {
         qDebug() << "LUA CRITICAL ERROR: no suitable Lua execution unit found.";
         return code;
@@ -15150,58 +15155,60 @@ void TLuaInterpreter::initIndenterGlobals()
 {
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 
-    pIndenterState = newstate();
-    storeHostInLua(pIndenterState, mpHost);
+    Q_ASSERT_X(!pIndenterState, "TLuaInterpreter::initIndenterGlobals()", "Indenter state is already initialized - re-initializing it is very expensive!");
 
-    luaL_openlibs(pIndenterState);
+    pIndenterState.reset(newstate());
+    storeHostInLua(pIndenterState.get(), mpHost);
 
-    lua_pushstring(pIndenterState, "SESSION");
-    lua_pushnumber(pIndenterState, mHostID);
-    lua_settable(pIndenterState, LUA_GLOBALSINDEX);
+    luaL_openlibs(pIndenterState.get());
 
-    lua_pushstring(pIndenterState, "SCRIPT_NAME");
-    lua_pushstring(pIndenterState, "Lua Indenter Interpreter");
-    lua_settable(pIndenterState, LUA_GLOBALSINDEX);
+    lua_pushstring(pIndenterState.get(), "SESSION");
+    lua_pushnumber(pIndenterState.get(), mHostID);
+    lua_settable(pIndenterState.get(), LUA_GLOBALSINDEX);
 
-    lua_pushstring(pIndenterState, "SCRIPT_ID");
-    lua_pushnumber(pIndenterState, -2); // ID 2 is used to indicate that this is the indenter Lua interpreter
-    lua_settable(pIndenterState, LUA_GLOBALSINDEX);
-    lua_register(pIndenterState, "echo", TLuaInterpreter::Echo);
-    lua_register(pIndenterState, "tempTimer", TLuaInterpreter::tempTimer);
-    lua_register(pIndenterState, "send", TLuaInterpreter::sendRaw);
-    lua_register(pIndenterState, "debugc", TLuaInterpreter::debug);
+    lua_pushstring(pIndenterState.get(), "SCRIPT_NAME");
+    lua_pushstring(pIndenterState.get(), "Lua Indenter Interpreter");
+    lua_settable(pIndenterState.get(), LUA_GLOBALSINDEX);
+
+    lua_pushstring(pIndenterState.get(), "SCRIPT_ID");
+    lua_pushnumber(pIndenterState.get(), -2); // ID 2 is used to indicate that this is the indenter Lua interpreter
+    lua_settable(pIndenterState.get(), LUA_GLOBALSINDEX);
+    lua_register(pIndenterState.get(), "echo", TLuaInterpreter::Echo);
+    lua_register(pIndenterState.get(), "tempTimer", TLuaInterpreter::tempTimer);
+    lua_register(pIndenterState.get(), "send", TLuaInterpreter::sendRaw);
+    lua_register(pIndenterState.get(), "debugc", TLuaInterpreter::debug);
     // PLACEMARKER: End of indenter Lua interpreter functions registration
 
 
 
 #if defined(Q_OS_MACOS)
         //macOS app bundle would like the search path to also be set to the current binary directory
-        luaL_dostring(pIndenterState, QStringLiteral("package.cpath = package.cpath .. ';%1/?.so'")
+        luaL_dostring(pIndenterState.get(), QStringLiteral("package.cpath = package.cpath .. ';%1/?.so'")
                       .arg(QCoreApplication::applicationDirPath())
                       .toUtf8().constData());
-        luaL_dostring(pIndenterState, QStringLiteral("package.path = package.path .. ';%1/?.lua'")
+        luaL_dostring(pIndenterState.get(), QStringLiteral("package.path = package.path .. ';%1/?.lua'")
                       .arg(QCoreApplication::applicationDirPath())
                       .toUtf8().constData());
 
 #elif defined(Q_OS_UNIX)
     // Need to tweak the lua path for the installed *nix case and AppImage builds as well as
     // to allow running from a shadow build directory (both qmake and cmake).
-    luaL_dostring(pIndenterState, QStringLiteral("package.path = '" LUA_DEFAULT_PATH "/?.lua;%1/?.lua;%1/../3rdparty/?.lua;%1/../../3rdparty/?.lua;' .. package.path")
+    luaL_dostring(pIndenterState.get(), QStringLiteral("package.path = '" LUA_DEFAULT_PATH "/?.lua;%1/?.lua;%1/../3rdparty/?.lua;%1/../../3rdparty/?.lua;' .. package.path")
                   .arg(QCoreApplication::applicationDirPath())
                   .toUtf8().constData());
 
-    luaL_dostring(pIndenterState, "package.path = package.path");
+    luaL_dostring(pIndenterState.get(), "package.path = package.path");
 
     // if using LuaJIT, adjust the cpath to look in /usr/lib as well - it doesn't by default
-    luaL_dostring(pIndenterState, "if jit then package.cpath = package.cpath .. ';/usr/lib/lua/5.1/?.so;/usr/lib/x86_64-linux-gnu/lua/5.1/?.so' end");
+    luaL_dostring(pIndenterState.get(), "if jit then package.cpath = package.cpath .. ';/usr/lib/lua/5.1/?.so;/usr/lib/x86_64-linux-gnu/lua/5.1/?.so' end");
 
     //AppInstaller on Linux would like the search path to also be set to the current binary directory
-    luaL_dostring(pIndenterState, QStringLiteral("package.cpath = package.cpath .. ';%1/lib/?.so'")
+    luaL_dostring(pIndenterState.get(), QStringLiteral("package.cpath = package.cpath .. ';%1/lib/?.so'")
                   .arg(QCoreApplication::applicationDirPath())
                   .toUtf8().constData());
 #elif defined(Q_OS_WIN32)
     // For Qt Creator builds, add search paths one and two levels up from here, then a 3rdparty directory:
-    luaL_dostring(pIndenterState,
+    luaL_dostring(pIndenterState.get(),
                   QStringLiteral("package.path = [[%1\\?.lua;%2\\..\\3rdparty\\?.lua;%2\\..\\..\\3rdparty\\?.lua;]] .. package.path")
                           .arg(QByteArray(LUA_DEFAULT_PATH), QDir::toNativeSeparators(QCoreApplication::applicationDirPath()))
                           .toUtf8().constData());
@@ -15209,7 +15216,7 @@ void TLuaInterpreter::initIndenterGlobals()
     qDebug() << "up to dostring "
               << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() << "ms.\n";
 
-    int error = luaL_dostring(pIndenterState, R"(
+    int error = luaL_dostring(pIndenterState.get(), R"(
       require('lcf.workshop.base')
       get_ast = request('!.lua.code.get_ast')
       get_formatted_code = request('!.lua.code.ast_as_code')
@@ -15218,9 +15225,9 @@ void TLuaInterpreter::initIndenterGlobals()
               << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() << "ms.\n";
     if (error) {
         QString e = tr("no error message available from Lua");
-        if (lua_isstring(pIndenterState, -1)) {
+        if (lua_isstring(pIndenterState.get(), -1)) {
             e = tr("Lua error:");
-            e += lua_tostring(pIndenterState, -1);
+            e += lua_tostring(pIndenterState.get(), -1);
         }
         QString msg = tr("[ ERROR ] - Cannot load code formatter, indenting functionality won't be available.\n");
         msg.append(e);
@@ -15230,7 +15237,7 @@ void TLuaInterpreter::initIndenterGlobals()
         mpHost->postMessage(msg);
     }
 
-    lua_pop(pIndenterState, lua_gettop(pIndenterState));
+    lua_pop(pIndenterState.get(), lua_gettop(pIndenterState.get()));
 }
 
 // No documentation available in wiki - internal function

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15153,8 +15153,6 @@ void TLuaInterpreter::setupLanguageData()
 // and we don't want to tie ourselves to it by exposing them for scripting.
 void TLuaInterpreter::initIndenterGlobals()
 {
-    std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-
     Q_ASSERT_X(!pIndenterState, "TLuaInterpreter::initIndenterGlobals()", "Indenter state is already initialized - re-initializing it is very expensive!");
 
     pIndenterState.reset(newstate());
@@ -15213,16 +15211,12 @@ void TLuaInterpreter::initIndenterGlobals()
                           .arg(QByteArray(LUA_DEFAULT_PATH), QDir::toNativeSeparators(QCoreApplication::applicationDirPath()))
                           .toUtf8().constData());
 #endif
-    qDebug() << "up to dostring "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() << "ms.\n";
 
     int error = luaL_dostring(pIndenterState.get(), R"(
       require('lcf.workshop.base')
       get_ast = request('!.lua.code.get_ast')
       get_formatted_code = request('!.lua.code.ast_as_code')
     )");
-    qDebug() << "right after dostring "
-              << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() << "ms.\n";
     if (error) {
         QString e = tr("no error message available from Lua");
         if (lua_isstring(pIndenterState.get(), -1)) {
@@ -15231,9 +15225,6 @@ void TLuaInterpreter::initIndenterGlobals()
         }
         QString msg = tr("[ ERROR ] - Cannot load code formatter, indenting functionality won't be available.\n");
         msg.append(e);
-        mpHost->postMessage(msg);
-    } else {
-        QString msg = tr("[  OK  ]  - Lua code formatter loaded.");
         mpHost->postMessage(msg);
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5701,7 +5701,7 @@ int TLuaInterpreter::setItalics(lua_State* L)
     }
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setOverline 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setOverline
 int TLuaInterpreter::setOverline(lua_State* L)
 {
     Host& host = getHostFromLua(L);
@@ -15148,6 +15148,8 @@ void TLuaInterpreter::setupLanguageData()
 // and we don't want to tie ourselves to it by exposing them for scripting.
 void TLuaInterpreter::initIndenterGlobals()
 {
+    std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
+
     pIndenterState = newstate();
     storeHostInLua(pIndenterState, mpHost);
 
@@ -15204,12 +15206,16 @@ void TLuaInterpreter::initIndenterGlobals()
                           .arg(QByteArray(LUA_DEFAULT_PATH), QDir::toNativeSeparators(QCoreApplication::applicationDirPath()))
                           .toUtf8().constData());
 #endif
+    qDebug() << "up to dostring "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() << "ms.\n";
 
     int error = luaL_dostring(pIndenterState, R"(
       require('lcf.workshop.base')
       get_ast = request('!.lua.code.get_ast')
       get_formatted_code = request('!.lua.code.ast_as_code')
     )");
+    qDebug() << "right after dostring "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() << "ms.\n";
     if (error) {
         QString e = tr("no error message available from Lua");
         if (lua_isstring(pIndenterState, -1)) {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -48,6 +48,7 @@ extern "C" {
 
 #include <list>
 #include <string>
+#include <memory>
 
 
 class Host;
@@ -532,7 +533,14 @@ private:
     QMap<QNetworkReply*, QString> downloadMap;
 
     lua_State* pGlobalLua;
-    lua_State* pIndenterState;
+
+    struct lua_state_deleter {
+      void operator()(lua_State* ptr) const noexcept {
+        lua_close(ptr);
+      }
+    };
+
+    std::unique_ptr<lua_State, lua_state_deleter> state;
 
     QPointer<Host> mpHost;
     int mHostID;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -540,7 +540,7 @@ private:
       }
     };
 
-    std::unique_ptr<lua_State, lua_state_deleter> state;
+    std::unique_ptr<lua_State, lua_state_deleter> pIndenterState;
 
     QPointer<Host> mpHost;
     int mHostID;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Faster profile load: don't load formatter until needed. Once needed, it's loaded on demand and the user doesn't notice because it is fairly fast (60-200ms)
#### Motivation for adding to Mudlet
Shave off 60-200ms from Mudlet's profile load, and also use less memory! It is very possible that a player will never need to format code during their playing session.

![perf data - Hotspot_250](https://user-images.githubusercontent.com/110988/61814057-80e65300-ae47-11e9-85e1-9d62247c978b.png)

#### Other info (issues closed, discussion etc)
... I also fixed a memory leak! We were never calling `lua_close()` on `pIndenterState` like we do on `pGlobalLua` :open_mouth: 

This is why `std::unique_ptr` is good. It'll take care of this for us automatically :)

Detected with the wonderful [hotspot](https://github.com/KDAB/hotspot) tool.