### PR TITLE
Fix reconnect after offline profile load

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -375,7 +375,13 @@ void cTelnet::connectIt(const QString& address, int port)
 
 void cTelnet::reconnect()
 {
-    connectIt(hostName, hostPort);
+    // if we've connected offline and wish to reconnect, the last
+    // connection parameters aren't yet set
+    if (hostName.isEmpty() && hostPort == 0) {
+        connectIt(mpHost->getUrl(), mpHost->getPort());
+    } else {
+        connectIt(hostName, hostPort);
+    }
 }
 
 void cTelnet::disconnectIt()


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
When I made 'reconnect' connect to the last parameters connect() from Lua was called with, instead of the profile's address/host, I broke offline+reconnect case: because you haven't connected to anything yet...

Simple fix, if last parameters aren't known, fallback to the profile's.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
This fixes what @maiyannah ran into.