### PR TITLE
Bugfix: add missing header for FreeBSD

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -58,6 +58,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QNetworkDiskCache>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QTableWidget>


### PR DESCRIPTION
Probably because of the slightly different includes for FreeBSD (maybe because it does not include any updater code) I need to add an additional `#include` in order to get Mudlet to compile for me.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>