### PR TITLE
Remove duplicate mAutoReconnect attribute

### DIFF
--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -424,7 +424,6 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mProxyPassword") = pHost->mProxyPassword.toUtf8().constData();
     host.append_attribute("mAutoReconnect") = pHost->mAutoReconnect ? "yes" : "no";
     host.append_attribute("mSslTsl") = pHost->mSslTsl ? "yes" : "no";
-    host.append_attribute("mAutoReconnect") = pHost->mAutoReconnect ? "yes" : "no";
     host.append_attribute("mSslIgnoreExpired") = pHost->mSslIgnoreExpired ? "yes" : "no";
     host.append_attribute("mSslIgnoreSelfSigned") = pHost->mSslIgnoreSelfSigned ? "yes" : "no";
     host.append_attribute("mSslIgnoreAll") = pHost->mSslIgnoreAll ? "yes" : "no";


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove duplicate mAutoReconnect attribute, which is illegal in XML and breaks profile loading.
#### Motivation for adding to Mudlet
Fix profile loading to work.
#### Other info (issues closed, discussion etc)
Broken by the recent proxy saving.