### PR TITLE
Remove unnecessary boost/random.hpp

### DIFF
--- a/src/TAstar.h
+++ b/src/TAstar.h
@@ -29,7 +29,6 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/astar_search.hpp>
 #include <boost/graph/graphviz.hpp>
-#include <boost/random.hpp>
 #include "post_guard.h"
 #endif
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -53,8 +53,6 @@ GLWidget::GLWidget(QWidget *parent)
     : QGLWidget(QGLFormat(QGL::SampleBuffers), parent)
 , mShowInfo()
 , dehnung()
-, rotTri()
-, rotQuad()
 , mTarget()
 {
     mpMap = nullptr;
@@ -96,8 +94,6 @@ GLWidget::GLWidget(TMap* pM, QWidget* parent)
 , dehnung()
 , mShowTopLevels()
 , mShowBottomLevels()
-, rotTri()
-, rotQuad()
 , mScale()
 , mTarget()
 {
@@ -2128,10 +2124,6 @@ void GLWidget::paintGL()
 
         zPlane += 1.0;
     }
-    //   qDebug()<<"FINAL: mQuads.size()="<<mQuads.size()<<"area.size()="<<pArea->rooms.size()<<" quads="<<quads<<" verts="<<verts;
-    //    qDebug()<<"mScale="<<mScale<<" 1/mScale="<<1/mScale<<" env="<<env;
-    //    cout<<"dif r="<<diffuseLight[0]<<" g="<<diffuseLight[1]<<" b="<<diffuseLight[2]<<endl;
-    //    cout << "xRot:"<<xRot<<" yRot:"<<yRot<<" zRot:"<<zRot<<endl;
     glFlush();
 }
 
@@ -2168,7 +2160,6 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
         gluPerspective(60 * mScale, (GLfloat)width() / (GLfloat)height(), 0.0001, 10000.0);
         glMatrixMode(GL_MODELVIEW);
 
-        mQuads.clear();
         mTarget = -22;
         selectionMode = true;
         paintGL();

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -112,15 +112,10 @@ private:
     float dehnung;
     int mShowTopLevels;
     int mShowBottomLevels;
-    QPoint lastPos;
-    QColor qtGreen;
-    QColor qtPurple;
 
-    GLfloat rotTri, rotQuad;
     float mScale;
     int mTarget;
     QPointer<Host> mpHost;
-    QMap<int, int> mQuads;
 };
 
 #endif // MUDLET_GLWIDGET_H


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove unnecessary and outdated boost random which is not needed for compilation.
#### Motivation for adding to Mudlet
Fix `error: no member named 'bind2nd' in namespace 'std'` on a strict compiler that removes `std` functions gone in C++17.
#### Other info (issues closed, discussion etc)
