### PR TITLE
BugFix: add missing headers for FreeBSD (2)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -39,6 +39,7 @@
 
 #include "pre_guard.h"
 #include <QtUiTools>
+#include <QNetworkProxy>
 #include <zip.h>
 #include <memory>
 #include "post_guard.h"

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1768,7 +1768,8 @@ void Host::setName(const QString& newName)
     mTimerUnit.changeHostName(newName);
 }
 
-void Host::updateProxySettings(QNetworkAccessManager* manager) {
+void Host::updateProxySettings(QNetworkAccessManager* manager)
+{
     if (mUseProxy && !mProxyAddress.isEmpty() && mProxyPort != 0) {
         auto& proxy = getConnectionProxy();
         manager->setProxy(*proxy);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -39,6 +39,7 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
+#include <QNetworkProxy>
 #include <QProgressDialog>
 #include <QTextCodec>
 #include <QSslError>


### PR DESCRIPTION
Recent code to support the use of proxys uses classes that do not have some needed `#ìnclude`s to work on FreeBSD which has some slightly different header files usage compared to the standard OS triumverate of Windows/Linux/macOs.

I also spotted a miss-placed opening brace in a recently added method associated with the new ~~poxy~~ *proxy* code. :grin:

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>