### PR TITLE
Downgrade to GCC 7 for official builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ addons:
     - libzip-dev
     - libpulse-dev
     - libyajl-dev
-    - gcc-9
-    - g++-9
+    - gcc-7
+    - g++-7
     - luarocks
     - lua-rex-pcre
     - lua-filesystem

--- a/CI/travis.linux.install.sh
+++ b/CI/travis.linux.install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 mkdir -p "${HOME}/latest-gcc-symlinks"
-ln -s /usr/bin/g++-9 "${HOME}/latest-gcc-symlinks/g++"
-ln -s /usr/bin/gcc-9 "${HOME}/latest-gcc-symlinks/gcc"
+ln -s /usr/bin/g++-7 "${HOME}/latest-gcc-symlinks/g++"
+ln -s /usr/bin/gcc-7 "${HOME}/latest-gcc-symlinks/gcc"
 
 # lua-utf8 is not in the repositories...
 luarocks install --local luautf8


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Downgrade to GCC 7 for official builds
#### Motivation for adding to Mudlet
Better compatibility with Linux releases.
#### Other info (issues closed, discussion etc)
I forgot that compatibility for older distros is against using a newer compiler... which is a pretty annoying limitation.