### PR TITLE
Fix macOS crash when saving settings in testing/development builds

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2398,7 +2398,9 @@ void dlgProfilePreferences::slot_save_and_exit()
     }
 
 #if defined(INCLUDE_UPDATER)
-    pMudlet->updater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
+    if (!mudlet::scmIsDevelopmentVersion) {
+        pMudlet->updater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
+    }
 #endif
 
     pMudlet->setToolBarIconSize(MainIconSize->value());


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix macOS crash when saving settings because the Sparkle updater is not initialised in development builds.
#### Other info (issues closed, discussion etc)
Caused by 861c4af22b70de2790b3cde6231005c83e3244c9 which stopped `updater->checkUpdatesOnStart();` from being run; that method created the Sparkle updater object. 