### PR TITLE
Fix Patreon link in Supporters tab to open browser

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -950,4 +950,5 @@ void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
 
     supportersDocument->setHtml(QStringLiteral("<html>%1<body>%2</body></html>").arg(htmlHead, supporters_text));
     textBrowser_supporters->setDocument(supportersDocument.get());
+    textBrowser_supporters->setOpenExternalLinks(true);
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Patreon link will now be opened in system's standard browser.

#### Motivation for adding to Mudlet
Until now, clicking that link would try (and fail) to open the link internally. 
Thus showing a blank page with no way visible to go back to the supporters list.

#### Other info (issues closed, discussion etc)
Discussed in discord, fix #2920