### PR TITLE
Fix incorrect explanation for mMaxRoomIdDigits

### DIFF
--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -244,7 +244,7 @@ private:
     QFont mMapSymbolFont;
 
     QPointer<QAction> mpCreateRoomAction;
-    // in the players current area, how many digits the biggest room number?
+    // in the players current area, how many digits does the biggest room number have?
     quint8 mMaxRoomIdDigits;
 
 private slots:

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -244,11 +244,7 @@ private:
     QFont mMapSymbolFont;
 
     QPointer<QAction> mpCreateRoomAction;
-    // Calculated near the top of the paintEvent() and is used in a couple of
-    // places where we need to pad roomIds to the same widths, it also affects
-    // the font size used to show roomId numbers (longer numbers need a smaller
-    // font to fit - as the numbers are NOW scaled to fit inside the room symbol
-    // - and they are suppressed if they would be too small.);
+    // in the players current area, how many digits the biggest room number?
     quint8 mMaxRoomIdDigits;
 
 private slots:


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
The comment despite being 5 lines long does not actually explain what value this field holds! It is also wrong: this field is only ever used once.
#### Motivation for adding to Mudlet
More intuitive development, spend less time hunting down things based on wrong information.
#### Other info (issues closed, discussion etc)
I spent 10 minutes double-checking all of the code because of it...

This is why I don't like such long narrative in comments - it forces me to read the comment, it forces me to double-check the code because the comment could be wrong (and in this case, it is), and then I have to spend time reconciling the two and finding out the truth.

I prefer when things are a lot simpler: the comment explains what this field does, and the code explains how this field is used.