### PR TITLE
Delete unused autosave debug statement

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -475,7 +475,6 @@ std::tuple<bool, QString, QString> Host::saveProfileAs(const QString& file)
 
 void Host::xmlSaved(const QString& xmlName)
 {
-    qDebug() << "saved" << xmlName;
     if (writers.contains(xmlName)) {
         auto writer = writers.take(xmlName);
         delete writer;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Delete unused autosave debug statement
#### Motivation for adding to Mudlet
Less spam in stdout.
#### Other info (issues closed, discussion etc)
No longer needed as autosave has been working fine for a long while.