### PR TITLE
Fixes widechar table lookup

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -289,12 +289,12 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     splitter->setPalette(splitterPalette);
     splitter->setParent(layer);
 
-    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, false, QFontMetrics(mpHost->mDisplayFont));
+    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, false);
     mUpperPane->setContentsMargins(0, 0, 0, 0);
     mUpperPane->setSizePolicy(sizePolicy3);
     mUpperPane->setFocusPolicy(Qt::NoFocus);
 
-    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, true, QFontMetrics(mpHost->mDisplayFont));
+    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, true);
     mLowerPane->setContentsMargins(0, 0, 0, 0);
     mLowerPane->setSizePolicy(sizePolicy3);
     mLowerPane->setFocusPolicy(Qt::NoFocus);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -289,12 +289,12 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     splitter->setPalette(splitterPalette);
     splitter->setParent(layer);
 
-    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, false);
+    mUpperPane = new TTextEdit(this, splitter, &buffer, mpHost, false, QFontMetrics(mpHost->mDisplayFont));
     mUpperPane->setContentsMargins(0, 0, 0, 0);
     mUpperPane->setSizePolicy(sizePolicy3);
     mUpperPane->setFocusPolicy(Qt::NoFocus);
 
-    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, true);
+    mLowerPane = new TTextEdit(this, splitter, &buffer, mpHost, true, QFontMetrics(mpHost->mDisplayFont));
     mLowerPane->setContentsMargins(0, 0, 0, 0);
     mLowerPane->setSizePolicy(sizePolicy3);
     mLowerPane->setFocusPolicy(Qt::NoFocus);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -985,16 +985,9 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber) co
 {
     int characterIndex = -1;
     if (lineNumber < mpBuffer->lineBuffer.size()) {
-        int characterWidth = 1;
         int currentX = 0;
         for (const auto character : mpBuffer->lineBuffer.at(lineNumber)) {
-            const uint unicode = getGraphemeBaseCharacter(character);
-            if (unicode == '\t') {
-                characterWidth = 8;
-            } else {
-                characterWidth = getGraphemeWidth(unicode);
-            }
-            currentX += characterWidth * mFontWidth;
+            currentX += mFontMetrics.horizontalAdvance(character);
             characterIndex++;
             if (currentX >= mouseX) {
                 if (mShowTimeStamps) {

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -52,7 +52,7 @@ class TTextEdit : public QWidget
 
 public:
     Q_DISABLE_COPY(TTextEdit)
-    TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isLowerPane);
+    TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isLowerPane, QFontMetrics fontMetrics);
     void paintEvent(QPaintEvent*) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void drawForeground(QPainter&, const QRect&);
@@ -133,6 +133,7 @@ private:
     int convertMouseXToBufferX(const int mouseX, const int lineNumber) const;
     int getGraphemeWidth(uint unicode) const;
 
+    QFontMetrics mFontMetrics;
     int mFontHeight;
     int mFontWidth;
     bool mForceUpdate;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -52,7 +52,7 @@ class TTextEdit : public QWidget
 
 public:
     Q_DISABLE_COPY(TTextEdit)
-    TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isLowerPane, QFontMetrics fontMetrics);
+    TTextEdit(TConsole*, QWidget*, TBuffer* pB, Host* pH, bool isLowerPane/*, QFontMetrics fontMetrics*/);
     void paintEvent(QPaintEvent*) override;
     void contextMenuEvent(QContextMenuEvent* event) override;
     void drawForeground(QPainter&, const QRect&);
@@ -133,7 +133,7 @@ private:
     int convertMouseXToBufferX(const int mouseX, const int lineNumber) const;
     int getGraphemeWidth(uint unicode) const;
 
-    QFontMetrics mFontMetrics;
+    QFontMetrics* mFontMetrics;
     int mFontHeight;
     int mFontWidth;
     bool mForceUpdate;

--- a/src/widechar_width.h
+++ b/src/widechar_width.h
@@ -30,8 +30,8 @@ enum {
 
 /* An inclusive range of characters. */
 struct widechar_range {
-  int32_t lo;
-  int32_t hi;
+  unsigned int lo;
+  unsigned int hi;
 };
 
 /* Simple ASCII characters - used a lot, so we check them first. */
@@ -506,14 +506,14 @@ static const struct widechar_range widechar_widened_table[] = {
 };
 
 template<typename Collection>
-bool widechar_in_table(const Collection &arr, int32_t c) {
+bool widechar_in_table(const Collection &arr, unsigned int c) {
     auto where = std::lower_bound(std::begin(arr), std::end(arr), c,
-        [](widechar_range p, wchar_t c) { return p.hi < c; });
+        [](widechar_range p, unsigned int c) {return p.hi < c; });
     return where != std::end(arr) && where->lo <= c;
 }
 
 /* Return the width of character c, or a special negative value. */
-int widechar_wcwidth(wchar_t c) {
+int widechar_wcwidth(unsigned int c) {
     if (widechar_in_table(widechar_ascii_table, c))
         return 1;
     if (widechar_in_table(widechar_private_table, c))


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Related to issue #2379
Rendering width of characters in TConsole was wrong for some glyphs because the lookup algorithm of unicode ranges was faulty (it converted unsigned ints to signed ints). This patch fixes the algorithm.

#### Motivation for adding to Mudlet
Some wide characters (like emojis) were interpreted as single-width instead of double-width.

Output before the patch:
![a](https://user-images.githubusercontent.com/43037977/62531311-7910b080-b842-11e9-8af2-a7d15f1fbbc5.png)

Output after the patch:
![b](https://user-images.githubusercontent.com/43037977/62531160-30f18e00-b842-11e9-9638-86244c7ad5ae.png)
