### PR TITLE
Raise minimum to Qt 5.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ sudo: false
 addons:
   apt:
     sources: &add-sources
-    - sourceline: 'ppa:beineri/opt-qt571-xenial'
+    - sourceline: 'ppa:beineri/opt-qt-5.11.3-xenial'
     - sourceline: 'ppa:beineri/opt-qt-5.12.3-xenial'
     - sourceline: 'ppa:ondrej/php' # more-or-less up to date libzip
-    - sourceline: 'ppa:ubuntu-toolchain-r/test' # gcc 9
+    - sourceline: 'ppa:ubuntu-toolchain-r/test' # gcc 7
     packages: &common-packages
     - libhunspell-dev
     - lua5.1
@@ -115,15 +115,15 @@ matrix:
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
-    - QT_VERSION=57 # actually Qt 5.7, used to check minimum supported Qt works
+    - QT_VERSION=511 # actually Qt 5.11, used to check minimum supported Qt works
     addons:
       apt:
         sources: *add-sources
-        packages: &qt57-packages
+        packages: &qt511-packages
         - *common-packages
-        - qt57base
-        - qt57multimedia
-        - qt57tools
+        - qt511base
+        - qt511multimedia
+        - qt511tools
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 before_install:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -334,25 +334,12 @@ if((APPLE) AND (PKG_CONFIG_FOUND))
   endif()
 endif()
 
-find_package(Qt5 5.7 REQUIRED COMPONENTS Core Multimedia Network OpenGL UiTools Widgets Concurrent)
-
-# This is not present before Qt 5.7:
+find_package(Qt5 5.11 REQUIRED COMPONENTS Core Multimedia Network OpenGL UiTools Widgets Concurrent)
 find_package(Qt5 COMPONENTS Gamepad QUIET)
-
-# This is not present before Qt 5.9:
 find_package(Qt5 COMPONENTS TextToSpeech QUIET)
 
-if (Qt5Core_VERSION VERSION_LESS 5.7)
-  message(FATAL_ERROR "Mudlet requires Qt 5.7 or later, yours is ${Qt5Core_VERSION}")
-elif(Qt5Core_VERSION VERSION_LESS 5.9)
-  # Qt Gamepad was a Technology Preview in 5.7
-  # Qt Gamepad was a Technology Preview 2 in 5.8
-  # Qt Speech (or at least the TTS part) was a Technology Preview in 5.8
-  message(WARNING "Qt version: ${Qt5Core_VERSION} - Gamepad and TextToSpeech may not be supported, as officially they requires 5.9 and 5.10 respectively")
-elif(Qt5Core_VERSION VERSION_LESS 5.10)
-  # Qt Speech (or at least the TTS part) was a Technology Preview 2 in 5.9, now supported on Mingw
-  # Qt Gamepad was officially released in 5.9
-  message(WARNING "Qt version: ${Qt5Core_VERSION} - TextToSpeech may not be supported, officially it requires 5.10")
+if (Qt5Core_VERSION VERSION_LESS 5.11)
+  message(FATAL_ERROR "Mudlet requires Qt 5.11 or later, yours is ${Qt5Core_VERSION}")
 else()
   # Qt Speech (or at least the TTS part) was officially release in 5.10
   message(STATUS "Qt version: ${Qt5Core_VERSION}")

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -34,8 +34,8 @@
 #                                                                          #
 ############################################################################
 
-lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_VERSION, 7)) {
-    error("Mudlet requires Qt 5.7 or later")
+lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_VERSION, 11)) {
+    error("Mudlet requires Qt 5.11 or later")
 }
 
 # Including IRC Library


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Now that Qt 5.11 is available in Debian stable, we can raise the minimum Qt version supported.
#### Motivation for adding to Mudlet
New classes and functions available for usage, no more having to remove `<colorrole role="PlaceholderText">` and so on.
#### Other info (issues closed, discussion etc)
Needed by https://github.com/Mudlet/Mudlet/pull/2943.