### PR TITLE
Add feature: Ctrl+# tab switching between profiles

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -106,7 +106,7 @@ bool TCommandLine::event(QEvent* event)
 {
     const Qt::KeyboardModifiers allModifiers = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier;
     if (event->type() == QEvent::KeyPress) {
-        auto * ke = dynamic_cast<QKeyEvent*>(event);
+        auto* ke = dynamic_cast<QKeyEvent*>(event);
 
         // Shortcut for keypad keys
         if ((ke->modifiers() & Qt::KeypadModifier) && mpKeyUnit->processDataStream(ke->key(), (int)ke->modifiers())) {
@@ -466,15 +466,68 @@ bool TCommandLine::event(QEvent* event)
                 return true;
 
             } else if (keybindingMatched(ke)) {
-                // Process as a possible key binding if there are ANY modifiers,
+                // Process as a possible key binding if there are ANY modifiers
                 return true;
             } else {
                 processNormalKey(event);
                 return false;
             }
+        case Qt::Key_1:
+            if (handleCtrlTabChange(ke, 1)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_2:
+            if (handleCtrlTabChange(ke, 2)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_3:
+            if (handleCtrlTabChange(ke, 3)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_4:
+            if (handleCtrlTabChange(ke, 4)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_5:
+            if (handleCtrlTabChange(ke, 5)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_6:
+            if (handleCtrlTabChange(ke, 6)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_7:
+            if (handleCtrlTabChange(ke, 7)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_8:
+            if (handleCtrlTabChange(ke, 8)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_9:
+            if (handleCtrlTabChange(ke, 9)) {
+                return true;
+            }
+            break;
 
         default:
-            // Process as a possible key binding if there are ANY modifiers,
+            // Process as a possible key binding if there are ANY modifiers
             if (keybindingMatched(ke)) {
                 return true;
 
@@ -482,7 +535,6 @@ bool TCommandLine::event(QEvent* event)
 
             processNormalKey(event);
             return false;
-
         }
     }
 
@@ -1033,6 +1085,23 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     }
     c.setCharFormat(f);
     setTextCursor(c);
+}
+
+bool TCommandLine::handleCtrlTabChange(QKeyEvent* key, int tabNumber)
+{
+    const Qt::KeyboardModifiers allModifiers = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier;
+
+    if ((key->modifiers() & allModifiers) == Qt::ControlModifier) {
+        // let user-defined Ctrl+# keys match first - and only if the user hasn't created
+        // then we fallback to tab switching
+        if (!keybindingMatched(key) && mudlet::self()->mpTabBar->count() >= (tabNumber)) {
+            mudlet::self()->mpTabBar->setCurrentIndex(tabNumber - 1);
+            key->accept();
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void TCommandLine::recheckWholeLine()

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -96,6 +96,7 @@ private:
     char** mpSystemSuggestionsList;
     char** mpUserSuggestionsList;
     void spellCheckWord(QTextCursor& c);
+    bool handleCtrlTabChange(QKeyEvent* key, int tabNumber);
 };
 
 #endif // MUDLET_TCOMMANDLINE_H


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This makes is so you can use Ctrl+1 to select the first open profile, Ctrl+2 the second open profile and so on.

This is specicially designed in a way that if the player has already defined Ctrl+1, Ctrl+# as a custom keybinding - that will still work and take priority over this new keybinding; thus this won't break any profiles and annoy players.
#### Motivation for adding to Mudlet
User interest.
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/2424.