### PR TITLE
Fix proxy settings screen for when no profiles are loaded

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -841,11 +841,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         ssl_issued_label->setText(cert.subjectInfo(QSslCertificate::CommonName).join(","));
         ssl_expires_label->setText(cert.expiryDate().toString(Qt::LocalDate));
         ssl_serial_label->setText(QString::fromStdString(cert.serialNumber().toStdString()));
-        checkBox_self_signed->setStyleSheet("");
-        checkBox_expired->setStyleSheet("");
-        ssl_issuer_label->setStyleSheet("");
-        ssl_expires_label->setStyleSheet("");
-        checkBox_ssl->setStyleSheet("");
+        checkBox_self_signed->setStyleSheet(QString());
+        checkBox_expired->setStyleSheet(QString());
+        ssl_issuer_label->setStyleSheet(QString());
+        ssl_expires_label->setStyleSheet(QString());
+        checkBox_ssl->setStyleSheet(QString());
 
         if (!pHost->mTelnet.getSslErrors().empty()) {
             // handle ssl errors
@@ -900,6 +900,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_expired->setChecked(pHost->mSslIgnoreExpired);
     checkBox_ignore_all->setChecked(pHost->mSslIgnoreAll);
 
+    groupBox_proxy->setEnabled(true);
     groupBox_proxy->setChecked(pHost->mUseProxy);
     lineEdit_proxyAddress->setText(pHost->mProxyAddress);
     if (pHost->mProxyPort != 0) {
@@ -1167,6 +1168,8 @@ void dlgProfilePreferences::clearHostDetails()
     checkBox_discordServerAccessToTimerInfo->setChecked(false);
     lineEdit_discordUserName->clear();
     lineEdit_discordUserDiscriminator->clear();
+
+    groupBox_proxy->setDisabled(true);
 
     // Remove the reference to the Host/profile in the title:
     setWindowTitle(tr("Profile preferences"));

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -4856,6 +4856,9 @@
          <property name="checkable">
           <bool>true</bool>
          </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
          <layout class="QGridLayout" name="gridLayout_groupBox_proxy">
           <item row="0" column="0">
            <widget class="QLineEdit" name="lineEdit_proxyAddress">


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix proxy settings screen for when no profiles are loaded: don't make it so people can enable/disable it when there are no profiles open.
#### Motivation for adding to Mudlet
Better user experience.
#### Other info (issues closed, discussion etc)
