### PR TITLE
Fix userwindows not going away on profile close

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -495,7 +495,6 @@ signals:
 
 
 private slots:
-    void slot_close_profile();
     void slot_tab_changed(int);
     void show_help_dialog();
     void slot_show_connection_dialog();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix userwindows not going away on profile close - the console they were belonging to was getting removed, but not the dock widget the console was in.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2916.