### PR TITLE
Don't include TLS code in ctelnet when it's not available

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -128,16 +128,18 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
 
     // initialize the socket after the Host initialisation is complete so we can access mSslTsl
     QTimer::singleShot(0, this, [this]() {
+#if !defined(QT_NO_SSL)
         if (mpHost->mSslTsl) {
             connect(&socket, &QSslSocket::encrypted, this, &cTelnet::handle_socket_signal_connected);
         } else {
             connect(&socket, &QAbstractSocket::connected, this, &cTelnet::handle_socket_signal_connected);
         }
+        connect(&socket, qOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &cTelnet::handle_socket_signal_sslError);
+#else
+        connect(&socket, &QAbstractSocket::connected, this, &cTelnet::handle_socket_signal_connected);
+#endif
         connect(&socket, &QAbstractSocket::disconnected, this, &cTelnet::handle_socket_signal_disconnected);
         connect(&socket, &QIODevice::readyRead, this, &cTelnet::handle_socket_signal_readyRead);
-#if !defined(QT_NO_SSL)
-        connect(&socket, qOverload<const QList<QSslError>&>(&QSslSocket::sslErrors), this, &cTelnet::handle_socket_signal_sslError);
-#endif
     });
 
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
`QSslSocket::encrypted` was being connected to when it's not actually available :open_mouth: 
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Good thing we can find these things at compile-time thanks to the Qt 5!