### PR TITLE
Fix Coverity TTimer mRepeating initialiser warning

### DIFF
--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -39,6 +39,7 @@ TTimer::TTimer(TTimer* parent, Host* pHost)
 , mNeedsToBeCompiled(true)
 , mpQTimer(new QTimer)
 , mModuleMember(false)
+, mRepeating(false)
 {
     mpQTimer->stop();
     mpQTimer->setProperty(scmProperty_HostName, mpHost->getName());


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix Coverity TTimer mRepeating initialiser warning. This constructor isn't used so it didn't have a practical effect.
#### Motivation for adding to Mudlet
Less warnings! :)
#### Other info (issues closed, discussion etc)
CID 1415062.