### PR TITLE
Fix updateDialog uninitialised in constructor

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -37,7 +37,10 @@
 //   and promptly quits. Installer updates Mudlet and launches Mudlet when its done
 // mac: handled completely outside of Mudlet by Sparkle
 
-Updater::Updater(QObject* parent, QSettings* settings) : QObject(parent), mUpdateInstalled(false), mpInstallOrRestart(new QPushButton(tr("Update")))
+Updater::Updater(QObject* parent, QSettings* settings) : QObject(parent)
+, mUpdateInstalled(false)
+, mpInstallOrRestart(new QPushButton(tr("Update")))
+, updateDialog(nullptr)
 {
     Q_ASSERT_X(settings, "updater", "QSettings object is required for the updater to work");
     this->settings = settings;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix updateDialog uninitialised in constructor. Should be `nullptr` as creating it triggers an update check - so it is done at a later point.
#### Motivation for adding to Mudlet
Less warnings
#### Other info (issues closed, discussion etc)
CID 1415098.