### PR TITLE
Handle possible crash if we give an invalid roomID to getRoom()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4852,6 +4852,10 @@ int TLuaInterpreter::searchRoom(lua_State* L)
         if (!roomIdsFound.isEmpty()) {
             for (int i : roomIdsFound) {
                 TRoom* pR = host.mpMap->mpRoomDB->getRoom(i);
+                if (!pR) {
+                    continue;
+                }
+
                 QString name = pR->name;
                 int roomID = pR->getId();
                 lua_pushnumber(L, roomID);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Handle possible crash if we give an invalid roomID to getRoom() while searching for rooms.
#### Motivation for adding to Mudlet
Fix possible crash.
#### Other info (issues closed, discussion etc)
CID 1415023.