### PR TITLE
Make translation stats be optional at build time

### DIFF
--- a/translations/translated/generate-translation-stats.lua
+++ b/translations/translated/generate-translation-stats.lua
@@ -1,5 +1,13 @@
-local yajl = require 'yajl'
-assert(yajl, "yajl is not available (luarocks install lua-yajl)")
+local status, result = pcall(require, 'yajl')
+if not status then
+  print("warning: lua-yajl not available - translation statistics in settings won't be shown.")
+  io.output("translation-stats.json")
+  io.write("{}")
+
+  return
+end
+
+local yajl = result
 
 -- see if the file exists
 function file_exists(file)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Make translation stats be optional at build time - because all they do is provide information for the gold star and translation %'s in Mudlet. Not having these stats is absolutely fine for Mudlet:

![Workspace 1_413](https://user-images.githubusercontent.com/110988/63006176-47b96580-be7e-11e9-9ca9-0b4c949cc40d.png)

Of course official builds and all releases should have them - but in case the file can't be generated, it should not be a build-breaking issue.

It recently came up as an issue in building Mudlet for on Windows, Raspberry Pi, and it's an issue for analysis checkers like [LGTM](https://lgtm.com/projects/g/Mudlet/Mudlet/logs/languages/lang:cpp).
#### Motivation for adding to Mudlet
Less pain when building Mudlet.
#### Other info (issues closed, discussion etc)
