### PR TITLE
Fix LGTM updater class warnings

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include "pre_guard.h"
+#include <QPushButton>
 #include <QtConcurrent>
 #include "post_guard.h"
 
@@ -46,6 +47,10 @@ Updater::Updater(QObject* parent, QSettings* settings) : QObject(parent)
     this->settings = settings;
 
     feed = new dblsqd::Feed(QStringLiteral("https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw"), QStringLiteral("release"));
+}
+Updater::~Updater()
+{
+    delete (feed);
 }
 
 // start the update process and figure out what needs to be done
@@ -250,14 +255,13 @@ void Updater::untarOnLinux(const QString& fileName)
 
 void Updater::updateBinaryOnLinux()
 {
-    // FIXME don't hardcode name in case we want to change it
     QFileInfo unzippedBinary(QStandardPaths::writableLocation(QStandardPaths::TempLocation) + "/" + unzippedBinaryName);
     auto systemEnvironment = QProcessEnvironment::systemEnvironment();
     auto appimageLocation = systemEnvironment.contains(QStringLiteral("APPIMAGE")) ?
                 systemEnvironment.value(QStringLiteral("APPIMAGE"), QString()) :
                 QCoreApplication::applicationFilePath();
 
-    QString installedBinaryPath(appimageLocation);
+    const QString& installedBinaryPath(appimageLocation);
 
     auto executablePermissions = unzippedBinary.permissions();
     executablePermissions |= QFileDevice::ExeOwner | QFileDevice::ExeUser;
@@ -283,7 +287,7 @@ void Updater::installOrRestartClicked(QAbstractButton* button, const QString& fi
 {
     Q_UNUSED(button)
 
-    // moc, when used with cmake on macos bugs out if the entire function declaration and definition is entirely
+    // moc, when used with cmake on macOS bugs out if the entire function declaration and definition is entirely
     // commented out so we leave a stub in
 #if !defined(Q_OS_MACOS)
 

--- a/src/updater.h
+++ b/src/updater.h
@@ -42,6 +42,7 @@ class Updater : public QObject
 public:
     Q_DISABLE_COPY(Updater)
     explicit Updater(QObject* parent = nullptr, QSettings* settings = nullptr);
+    virtual ~Updater();
     void checkUpdatesOnStart();
     void manuallyCheckUpdates();
     void showChangelog() const;
@@ -89,7 +90,6 @@ public slots:
 #if defined(Q_OS_LINUX)
     // might want to make these private
     void updateBinaryOnLinux();
-    virtual ~Updater();
 #endif
 };
 

--- a/src/updater.h
+++ b/src/updater.h
@@ -89,6 +89,7 @@ public slots:
 #if defined(Q_OS_LINUX)
     // might want to make these private
     void updateBinaryOnLinux();
+    virtual ~Updater();
 #endif
 };
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix LGTM updater class warnings. The destructor is a trivial thing but good to have anyway.
#### Motivation for adding to Mudlet
Less warnings!
#### Other info (issues closed, discussion etc)
See https://lgtm.com/projects/g/Mudlet/Mudlet/latest/files/src/updater.cpp?sort=name&dir=ASC&mode=list#V48