### PR TITLE
Change "Script Editor" menu entry to respect current view selection

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6684,6 +6684,25 @@ void dlgTriggerEditor::slot_show_timers()
     }
 }
 
+void dlgTriggerEditor::slot_show_current()
+{
+    if (mCurrentView != EditorViewType::cmUnknownView) return;
+
+    changeView(EditorViewType::cmTriggerView);
+    QTreeWidgetItem* pI = treeWidget_triggers->topLevelItem(0);
+    if (!pI || pI == treeWidget_triggers->currentItem() || !pI->childCount()) {
+        // There is no root item, we are on the root item or there are no other
+        // items - so show the help message:
+        mpTriggersMainArea->hide();
+        mpSourceEditorArea->hide();
+        showInfo(msgInfoAddTrigger);
+    } else {
+        mpTriggersMainArea->show();
+        mpSourceEditorArea->show();
+        slot_trigger_selected(treeWidget_triggers->currentItem());
+    }
+}
+
 void dlgTriggerEditor::slot_show_triggers()
 {
     changeView(EditorViewType::cmTriggerView);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6686,7 +6686,9 @@ void dlgTriggerEditor::slot_show_timers()
 
 void dlgTriggerEditor::slot_show_current()
 {
-    if (mCurrentView != EditorViewType::cmUnknownView) return;
+    if (mCurrentView != EditorViewType::cmUnknownView) {
+        return;
+    }
 
     changeView(EditorViewType::cmTriggerView);
     QTreeWidgetItem* pI = treeWidget_triggers->topLevelItem(0);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -226,6 +226,7 @@ public slots:
     void slot_import();
     void slot_viewStatsAction();
     void slot_debug_mode();
+    void slot_show_current();
     void slot_show_timers();
     void slot_show_triggers();
     void slot_show_scripts();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3089,6 +3089,7 @@ void mudlet::show_editor_dialog()
     pEditor->slot_show_current();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_trigger_dialog()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -495,7 +495,7 @@ mudlet::mudlet()
     connect(dactionMultiView, &QAction::triggered, this, &mudlet::slot_multi_view);
     connect(dactionInputLine, &QAction::triggered, this, &mudlet::slot_toggle_compact_input_line);
     connect(mpActionTriggers.data(), &QAction::triggered, this, &mudlet::show_trigger_dialog);
-    connect(dactionScriptEditor, &QAction::triggered, this, &mudlet::show_trigger_dialog);
+    connect(dactionScriptEditor, &QAction::triggered, this, &mudlet::show_editor_dialog);
     connect(dactionShowMap, &QAction::triggered, this, &mudlet::slot_mapper);
     connect(dactionOptions, &QAction::triggered, this, &mudlet::slot_show_options_dialog);
     connect(dactionAbout, &QAction::triggered, this, &mudlet::slot_show_about_dialog);
@@ -3076,6 +3076,21 @@ void mudlet::slot_show_connection_dialog()
     pDlg->show();
 }
 
+void mudlet::show_editor_dialog()
+{
+    Host* pHost = getActiveHost();
+    if (!pHost) {
+        return;
+    }
+    dlgTriggerEditor* pEditor = pHost->mpEditorDialog;
+    if (!pEditor) {
+        return;
+    }
+    pEditor->slot_show_current();
+    pEditor->raise();
+    pEditor->showNormal();
+}
+
 void mudlet::show_trigger_dialog()
 {
     Host* pHost = getActiveHost();
@@ -3206,7 +3221,7 @@ void mudlet::slot_update_shortcuts()
 {
     if (mpMainToolBar->isVisible()) {
         triggersShortcut = new QShortcut(triggersKeySequence, this);
-        connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_trigger_dialog);
+        connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_editor_dialog);
         dactionScriptEditor->setShortcut(QKeySequence());
 
         showMapShortcut = new QShortcut(showMapKeySequence, this);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -498,6 +498,7 @@ private slots:
     void slot_tab_changed(int);
     void show_help_dialog();
     void slot_show_connection_dialog();
+    void show_editor_dialog();
     void show_trigger_dialog();
     void show_alias_dialog();
     void show_script_dialog();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Currently, the "Script Editor" menu item(which is what Alt+E activates) forces your window to the Trigger View, even if the window is already open. This PR changes the behavior of that menu item to respect whatever view is already open, or was open last time the editor was up.

#### Motivation for adding to Mudlet
A very common workflow with any script editor is hopping back and forth between the editor window and whatever the script is running in, testing changes that you make repeatedly until you get a result you like. While this can be done with Alt+Tab, I think it would be valuable to have a means of reliably getting to the editor in one key-combination, rather than having to rely on the editor being the last thing you Alt+Tabbed to, or visually confirming as you tab through whatever other windows you've interacted with since then.

#### Other info (issues closed, discussion etc)
I'm also planning a PR to add an Alt+E shortcut to the editor that activates the primary Mudlet window and brings focus to the input line, to make this iterative process faster and simpler, and to reduce the need to use the mouse.
