### PR TITLE
Fix error/info block sizing in trigger editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -175,6 +175,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // system message area
     mpSystemMessageArea = new dlgSystemMessageArea(this);
     mpSystemMessageArea->setObjectName(QStringLiteral("mpSystemMessageArea"));
+    mpSystemMessageArea->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     splitter_right->addWidget(mpSystemMessageArea);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, mpSystemMessageArea, &QWidget::hide);
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes error/info block sizing in the trigger editor so that it does NOT expand to take up extra space.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Regression that occurred with 4.0