### PR TITLE
Move info block to the bottom of the trigger editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -175,7 +175,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     // system message area
     mpSystemMessageArea = new dlgSystemMessageArea(this);
     mpSystemMessageArea->setObjectName(QStringLiteral("mpSystemMessageArea"));
-    splitter_right->addWidget(mpSystemMessageArea);
+    //splitter_right->addWidget(mpSystemMessageArea);
+    mpSystemMessageArea->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, mpSystemMessageArea, &QWidget::hide);
 
     // main areas
@@ -265,6 +266,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpSourceEditorEdbee->textEditorComponent()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mpSourceEditorEdbee->textEditorComponent(), &QWidget::customContextMenuRequested, this, &dlgTriggerEditor::slot_editorContextMenu);
 
+    splitter_right->addWidget(mpSystemMessageArea);
+
     // option areas
     mpErrorConsole = new TConsole(mpHost, TConsole::ErrorConsole, this);
     mpErrorConsole->setWrapAt(100);
@@ -274,23 +277,23 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     splitter_right->addWidget(mpErrorConsole);
 
-    splitter_right->setStretchFactor(0, 0); // mpSystemMessageArea
+    splitter_right->setStretchFactor(0, 1); // mpTriggersMainArea
     splitter_right->setCollapsible(0, false);
-    splitter_right->setStretchFactor(1, 1); // mpTriggersMainArea
+    splitter_right->setStretchFactor(1, 1); // mpTimersMainArea
     splitter_right->setCollapsible(1, false);
-    splitter_right->setStretchFactor(2, 1); // mpTimersMainArea
+    splitter_right->setStretchFactor(2, 1); // mpAliasMainArea
     splitter_right->setCollapsible(2, false);
-    splitter_right->setStretchFactor(3, 1); // mpAliasMainArea
+    splitter_right->setStretchFactor(3, 1); // mpActionsMainArea
     splitter_right->setCollapsible(3, false);
-    splitter_right->setStretchFactor(4, 1); // mpActionsMainArea
+    splitter_right->setStretchFactor(4, 1); // mpKeysMainArea
     splitter_right->setCollapsible(4, false);
-    splitter_right->setStretchFactor(5, 1); // mpKeysMainArea
+    splitter_right->setStretchFactor(5, 1); // mpVarsMainArea
     splitter_right->setCollapsible(5, false);
-    splitter_right->setStretchFactor(6, 1); // mpVarsMainArea
+    splitter_right->setStretchFactor(6, 1); // mpScriptsMainArea
     splitter_right->setCollapsible(6, false);
-    splitter_right->setStretchFactor(7, 1); // mpScriptsMainArea
+    splitter_right->setStretchFactor(7, 3); // mpSourceEditorArea
     splitter_right->setCollapsible(7, false);
-    splitter_right->setStretchFactor(8, 3); // mpSourceEditorArea
+    splitter_right->setStretchFactor(8, 0); // mpSystemMessageArea
     splitter_right->setCollapsible(8, false);
     splitter_right->setStretchFactor(9, 1); // mpErrorConsole
     splitter_right->setCollapsible(9, false);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Moves the info block to the bottom of the editor(although still above the dedicated Errors console).

#### Motivation for adding to Mudlet
If a bug gets introduced by changes to your trigger/alias/script/etc, when you save the script, it's going to get marked as bugged, and the error/info block is going to show up to indicate what you did wrong.

Currently, that block gets inserted above the rest of the trigger editor(apart from the menu. This displaces every input box in the editor, which causes you to have to adjust where you're clicking. Then, when the bug is resolved, the widgets all make another shift. It seems to be that moving the majority of the widgets in that dialog box over and over when someone's working on some code is counter-productive, especially in that you have to get used to two separate positions of widgets, which gets alternated repeatedly.

In moving the block to the bottom of the window(but still above the error console), you're keeping the block still very visible and prominent, but it no longer displaces the widgets around it, leaving all the fields where you're used to them being.

This proposed change bring Mudlet's IDE in line with the majority of IDE's that I've used, where the code is at the top, and errors all get displayed at the bottom. This behavior exists in many other kinds of applications as well, with OS consoles and shells being another prime example. Regarding the visibility of this, I think that the combination of the block at the bottom of the screen and the bug icon on the trigger itself make it very apparent when something is wrong with a script. And since the majority of the written languages used with Mudlet are written left-to-right, top-to-bottom, it makes sense that a user will look below their script, intuitively, to find error information.

#### Other info (issues closed, discussion etc)
This PR also includes the fix to the block's sizing, because you might not necessarily be able to get a good feel for it to determine if you think it's a positive change or not if a bug is causing your design to work in a manner that is NOT how you intend.