### PR TITLE
Add new shortcut to the trigger editor 

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -504,6 +504,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     showDebugAreaAction->setStatusTip(tr("Shows/Hides the separate Central Debug Console - when being displayed the system will be slower."));
     connect(showDebugAreaAction, &QAction::triggered, this, &dlgTriggerEditor::slot_debug_mode);
 
+    QShortcut *activateMainWindowAction = new QShortcut(QKeySequence((Qt::ALT | Qt::Key_E)), this);
+    QObject::connect(activateMainWindowAction, &QShortcut::activated, this, &dlgTriggerEditor::slot_activateMainWindow);
+
     toolBar = new QToolBar();
     toolBar2 = new QToolBar();
 
@@ -7078,6 +7081,12 @@ void dlgTriggerEditor::slot_debug_mode()
     mudlet::mpDebugArea->setVisible(!mudlet::debugMode);
     mudlet::debugMode = !mudlet::debugMode;
     mudlet::mpDebugArea->setWindowTitle("Central Debug Console");
+}
+
+void dlgTriggerEditor::slot_activateMainWindow()
+{
+    mudlet::self()->activateWindow();
+    mpHost->mpConsole->setFocus();
 }
 
 void dlgTriggerEditor::exportTrigger(const QString& fileName)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -232,6 +232,7 @@ public slots:
     void slot_show_aliases();
     void slot_show_actions();
     void slot_show_keys();
+    void slot_activateMainWindow();
     void slot_tree_selection_changed();
     void slot_trigger_selected(QTreeWidgetItem* pItem);
     void slot_timer_selected(QTreeWidgetItem* pItem);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a new shortcut of Alt+E to the trigger editor. When activated, it brings the Main Window to the front, activates it, and gives focus to the input widget, so you can hit Alt+E and immediately get back to typing in the main console.

#### Motivation for adding to Mudlet
If you use Mudlet a lot, and you are actively creating new triggers/aliases/etc, you're likely jumping between the main window and the trigger editor quite a lot. Having a single shortcut that toggles between the two means less fumbling around grabbing the mouse, and no accidentally Ctrl+Tabbing to the wrong window.

This PR, along with a few others, intends to bring Mudlet closer to being navigable entirely without needing to use the mouse.

#### Other info (issues closed, discussion etc)
