### PR TITLE
Fix toolbar buttons that open editor to activate editor as well

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3086,6 +3086,7 @@ void mudlet::show_trigger_dialog()
     pEditor->slot_show_triggers();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_alias_dialog()
@@ -3101,6 +3102,7 @@ void mudlet::show_alias_dialog()
     pEditor->slot_show_aliases();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_timer_dialog()
@@ -3116,6 +3118,7 @@ void mudlet::show_timer_dialog()
     pEditor->slot_show_timers();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_script_dialog()
@@ -3131,6 +3134,7 @@ void mudlet::show_script_dialog()
     pEditor->slot_show_scripts();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_key_dialog()
@@ -3146,6 +3150,7 @@ void mudlet::show_key_dialog()
     pEditor->slot_show_keys();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_variable_dialog()
@@ -3161,6 +3166,7 @@ void mudlet::show_variable_dialog()
     pEditor->slot_show_vars();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 void mudlet::show_action_dialog()
@@ -3176,6 +3182,7 @@ void mudlet::show_action_dialog()
     pEditor->slot_show_actions();
     pEditor->raise();
     pEditor->showNormal();
+    pEditor->activateWindow();
 }
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a call to `activateWindow()` to all the toolbar Triggers/Aliases/Etc buttons. Currently, they raise the window and show it, but don't activate it, meaning that keyboard presses still go to the main window.

#### Motivation for adding to Mudlet
It's obviously not intentional that those actions don't also activate the window.

#### Other info (issues closed, discussion etc)
