### PR TITLE
Fix use of incorrect function const and add a few missing ones

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -535,7 +535,7 @@ QString Host::getMmpMapLocation() const
 }
 
 // Now returns the total weight of the path
-const unsigned int Host::assemblePath()
+unsigned int Host::assemblePath()
 {
     unsigned int totalWeight = 0;
     QStringList pathList;
@@ -559,7 +559,7 @@ const unsigned int Host::assemblePath()
     return totalWeight;
 }
 
-const bool Host::checkForMappingScript()
+bool Host::checkForMappingScript()
 {
     // the mapper script reminder is only shown once
     // because it is too difficult and error prone (->proper script sequence)

--- a/src/Host.h
+++ b/src/Host.h
@@ -126,8 +126,8 @@ public:
 
     void closingDown();
     bool isClosingDown();
-    const unsigned int assemblePath();
-    const bool checkForMappingScript();
+    unsigned int assemblePath();
+    bool checkForMappingScript();
 
     TriggerUnit* getTriggerUnit() { return &mTriggerUnit; }
     TimerUnit* getTimerUnit() { return &mTimerUnit; }

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -198,12 +198,11 @@ void TRoom::setExitWeight(const QString& cmd, int w)
     }
 }
 
-// Declared in header but was missing!
 // Uses lower case initials: n,ne,e,se,s,sw,w,nw
 //
 // also: up, down, in, out or any unprefixed special exit command
 // all of which can be stored but aren't (yet?) showable on the 2D mapper
-const bool TRoom::setDoor(const QString& cmd, const int doorStatus)
+bool TRoom::setDoor(const QString& cmd, const int doorStatus)
 {
     if (doorStatus > 0 && doorStatus <= 3) {
         if (doors.value(cmd, 0) != doorStatus) {

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -78,7 +78,7 @@ public:
     const QMap<QString, int>& getExitWeights() const { return exitWeights; }
     void setExitWeight(const QString& cmd, int w);
     bool hasExitWeight(const QString& cmd);
-    const bool setDoor(const QString& cmd, int doorStatus); //0=no door, 1=open door, 2=closed, 3=locked
+    bool setDoor(const QString& cmd, int doorStatus); //0=no door, 1=open door, 2=closed, 3=locked
     int getDoor(const QString& cmd);
     bool hasExitStub(int direction);
     void setExitStub(int direction, bool status);

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -418,7 +418,7 @@ void TRoomDB::buildAreas()
 }
 
 
-const QList<TRoom*> TRoomDB::getRoomPtrList()
+const QList<TRoom*> TRoomDB::getRoomPtrList() const
 {
     return rooms.values();
 }
@@ -558,7 +558,7 @@ bool TRoomDB::addArea(int id, QString name)
     }
 }
 
-const QList<TArea*> TRoomDB::getAreaPtrList()
+const QList<TArea*> TRoomDB::getAreaPtrList() const
 {
     return areas.values();
 }

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -56,8 +56,8 @@ public:
     int addArea(QString name);
     bool addArea(int id, QString name);
     bool setAreaName(int areaID, QString name);
-    const QList<TRoom*> getRoomPtrList();
-    const QList<TArea*> getAreaPtrList();
+    const QList<TRoom*> getRoomPtrList() const;
+    const QList<TArea*> getAreaPtrList() const;
     const QHash<int, TRoom*>& getRoomMap() const { return rooms; }
     const QMap<int, TArea*>& getAreaMap() const { return areas; }
     QList<int> getRoomIDList();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -286,7 +286,7 @@ QString cTelnet::errorString()
 }
 
 // returns the human-friendly one ("ISO 8859-5 (Cyrillic)") given a computer encoding name ("ISO 8859-5")
-const QString& cTelnet::getFriendlyEncoding()
+const QString& cTelnet::getFriendlyEncoding() const
 {
     int index = mAcceptableEncodings.indexOf(mEncoding);
     return mFriendlyEncodings.at(index);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -154,7 +154,7 @@ public:
     const QStringList & getEncodingsList() const { return mAcceptableEncodings; }
     const QStringList & getFriendlyEncodingsList() const { return mFriendlyEncodings; }
     const QString& getComputerEncoding(const QString& encoding);
-    const QString& getFriendlyEncoding();
+    const QString& getFriendlyEncoding() const;
     QAbstractSocket::SocketError error();
     QString errorString();
 #if !defined(QT_NO_SSL)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
From LGTM:

> A 'const' modifier on a member function return type is useless. It is usually a typo or misunderstanding, since the syntax for a 'const' function is 'int foo() const', not 'const int foo()'.

That's exactly what happened here (misunderstanding).
#### Motivation for adding to Mudlet
_actually_ mark readonly functions as readonly.
#### Other info (issues closed, discussion etc)
Fixes this LGTM query: https://lgtm.com/query/1192113587356471581/