### PR TITLE
BugFix: correct PR#2976

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4842,6 +4842,9 @@ int TLuaInterpreter::searchRoom(lua_State* L)
         lua_newtable(L);
         QList<int> roomIdsFound;
         for (auto pR : roomList) {
+            if (!pR) {
+                continue;
+            }
             if (exactMatch) {
                 if (pR->name.compare(room, caseSensitive ? Qt::CaseSensitive : Qt::CaseInsensitive) == 0) {
                     roomIdsFound.append(pR->getId());
@@ -4855,10 +4858,6 @@ int TLuaInterpreter::searchRoom(lua_State* L)
         if (!roomIdsFound.isEmpty()) {
             for (int i : roomIdsFound) {
                 TRoom* pR = host.mpMap->mpRoomDB->getRoom(i);
-                if (!pR) {
-                    continue;
-                }
-
                 QString name = pR->name;
                 int roomID = pR->getId();
                 lua_pushnumber(L, roomID);


### PR DESCRIPTION
#2976 did a reasonable check for a non-null `TRoom` pointer but it was being performed in the wrong place. This commit moves the test to a better place (before it is first dereferenced) in the `TLuaInterpreter::searchRoom(...)` method.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>