### PR TITLE
Revert: PR #2975

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -451,14 +451,10 @@ void T2DMap::slot_switchArea(const QString& newAreaName)
                         }
                     }
 
-                    if (closestCenterRoom) {
-                        mOx = closestCenterRoom->x;
-                        // Map y coordinates are reversed on 2D map!
-                        mOy = -closestCenterRoom->y;
-                        mOz = closestCenterRoom->z;
-                    } else {
-                        mOx = mOy = mOz = 0;
-                    }
+                    mOx = closestCenterRoom->x;
+                    // Map y coordinates are reversed on 2D map!
+                    mOy = -closestCenterRoom->y;
+                    mOz = closestCenterRoom->z;
                 }
 
                 if (!validRoomFound) {


### PR DESCRIPTION
That PR #2975 was unnecessary as there is no need to validate the `TRoom` pointers for the set of rooms in the `(QSet<int>) roomsToConsider` as they were previously checked for validity before being added to that set in the code around line 415 within the same method in:
`(void) T2DMap::slot_switchArea(const QString&)`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>