### PR TITLE
Implement JSON for Client.GUI (Issue #2875)

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1650,8 +1650,6 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
             if (url.isEmpty()) {
                 return;
             }
-
-            qDebug() << "DEBUG: Client.GUI RAW version<" << version << "> and url<" << url << ">";
         } else {
             // This is JSON
             auto json = document.object();
@@ -1675,8 +1673,6 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
             } else {
                 return;
             }
-
-            qDebug() << "DEBUG: Client.GUI JSON version<" << version << "> and url<" << url << ">";
         }
 
         QString packageName = url.section(QLatin1Char('/'), -1);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1617,11 +1617,6 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
     }
 
     if (transcodedMsg.startsWith(QStringLiteral("Client.GUI"))) {
-        // Parse a message containing the current "version" and
-        // "url" of where to find the current version of the client's
-        // Graphical User Interface (GUI).
-
-        // Do we accept GUI downloads from the server?
         if (!mpHost->mAcceptServerGUI) {
             return;
         }
@@ -1634,7 +1629,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         //
         // If the data does not parse as JSON, we'll try Raw telnet.
 
-        QString version;        
+        QString version;
         bool hasVersion = false;
         QString url;
         bool hasUrl = false;
@@ -1644,8 +1639,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         if (!document.isObject()) {
             // This is raw telnet, not JSON
             version = transcodedMsg.section(QChar::LineFeed, 0);
-            // Cannot use QLatin1String(...) as that is only introduced in Qt 5.11:
-            version.remove(QStringLiteral("Client.GUI "));
+            version.remove(QLatin1String("Client.GUI "));
             version.replace(QChar::LineFeed, QChar::Space);
             version = version.section(QChar::Space, 0, 0);
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1624,7 +1624,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         // Mudlet supports two formats for parsing data associated with
         // Client.GUI package:
         //
-        // JSON:       Client.GUI = {"version" = "39", "url" = "https://www.example.com/example.mpackage"}
+        // JSON:       Client.GUI {"version": "39", "url": "https://www.example.com/example.mpackage"}
         // Raw Telnet: Client.GUI <version>\n<url>
         //
         // If the data does not parse as JSON, we'll try Raw telnet.


### PR DESCRIPTION
#### Brief overview of PR changes/additions
**cTelnet::setGMCPVariables** function of **ctelnet.cpp**:
- Now also parses JSON for Client.GUI for example
```json
Client.GUI = {
    "version" = "39",
    "url" = "https://www.stickmud.com/mudwww/StickMUDv39.mpackage"
}
```
- Continues to parse raw telnet messages for example
```
Client.GUI 39\nhttps://www.stickmud.com/mudwww/StickMUDv39.mpackage
```

#### Motivation for adding to Mudlet
- Standardizes format to JSON that is used with other GMCP messages 

#### Other info (issues closed, discussion etc)
This will close Add JSON-friendly version of Client.GUI syntax, closes #2875  

#### How to Test
_Note: StickMUD GUI in Windows Mudlet <= 4.0.3 is vulnerable to the Mapper Window sizing issue_

**JSON**
- Shutdown Mudlet
- Delete your StickMUD profile from the backend via CLI
- Start Mudlet
- Pick StickMUD inside Mudlet, login as `vadi` (others could be setup, send me a name before creating the character)
- Debug statement will confirm this hits the JSON block of code
- GUI and Map will download from the server as you follow the prompts
- Optional: When you move one room the map will update

**Raw Telnet**
- Shutdown Mudlet
- Delete your StickMUD profile from the backend via CLI
- Start Mudlet
- Pick StickMUD inside Mudlet, login as a new player other than `vadi` (make a new character)
- Debug statement will confirm this hits the RAW block of code
- GUI and Map will download from the server as you follow the prompts
- Optional: When you move one room the map will update

#### Cleanup
You may want to eliminate the debug statements.  They only appear once per session.