### PR TITLE
Adding function Geyser.calcSizeForFont 

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -239,21 +239,3 @@ function Geyser.MiniConsole:new (cons, container)
   --print("  New in " .. self.name .. " : " .. me.name)
   return me
 end
-_fontConsole = _fontConsole or Geyser.MiniConsole:new({x=o,y=o,height=0,width=0})
-_fontConsole:hide()
-
-function Geyser.calcSizeForFont(fontName, fontSize)
-  local fontNameType = type(fontName)
-	local fontSizeType = type(fontSize)
-	local af = getAvailableFonts()
-  if fontNameType ~= "string" then
-	  error("Geyser.calcSizeForFont(fontName, fontSize): Argument Error: fontName as string expected, got " .. fontNameType)
-	elseif fontSizeType ~= "number" then
-	  error("Geyser.calcSizeForFont(fontName, fontSize): Argument Error: fontSize as number expect, got " .. fontSizeType)
-	elseif not table.contains(af, fontName) then
-	  error("Geyser.calcSizeForFont(fontNAme, fontSize): " .. fontName .. " is not available on this machine. Please check getAvailableFonts() for options.")
-	end
-	_fontConsole:setFont(fontName)
-	_fontConsole:setFontSize(fontSize)
-	return _fontConsole:calcFontSize()
-end

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -239,3 +239,21 @@ function Geyser.MiniConsole:new (cons, container)
   --print("  New in " .. self.name .. " : " .. me.name)
   return me
 end
+_fontConsole = _fontConsole or Geyser.MiniConsole:new({x=o,y=o,height=0,width=0})
+_fontConsole:hide()
+
+function Geyser.calcSizeForFont(fontName, fontSize)
+  local fontNameType = type(fontName)
+	local fontSizeType = type(fontSize)
+	local af = getAvailableFonts()
+  if fontNameType ~= "string" then
+	  error("Geyser.calcSizeForFont(fontName, fontSize): Argument Error: fontName as string expected, got " .. fontNameType)
+	elseif fontSizeType ~= "number" then
+	  error("Geyser.calcSizeForFont(fontName, fontSize): Argument Error: fontSize as number expect, got " .. fontSizeType)
+	elseif not table.contains(af, fontName) then
+	  error("Geyser.calcSizeForFont(fontNAme, fontSize): " .. fontName .. " is not available on this machine. Please check getAvailableFonts() for options.")
+	end
+	_fontConsole:setFont(fontName)
+	_fontConsole:setFontSize(fontSize)
+	return _fontConsole:calcFontSize()
+end

--- a/src/mudlet-lua/lua/geyser/GeyserUtil.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUtil.lua
@@ -58,3 +58,23 @@ function Geyser.copyTable (table)
   end
   return copy
 end
+
+createMiniConsole("__Geyser__Fontconsole",0,0,0,0)
+hideWindow("__Geyser__Fontconsole")
+
+function Geyser.calcSizeForFont(fontName, fontSize)
+  local fcn = "__Geyser__Fontconsole"
+  local fontNameType = type(fontName)
+	local fontSizeType = type(fontSize)
+	local af = getAvailableFonts()
+  if fontNameType ~= "string" then
+	  error("Geyser.calcSizeForFont(fontName, fontSize): Argument Error: fontName as string expected, got " .. fontNameType)
+	elseif fontSizeType ~= "number" then
+	  error("Geyser.calcSizeForFont(fontName, fontSize): Argument Error: fontSize as number expect, got " .. fontSizeType)
+	elseif not table.contains(af, fontName) then
+	  error("Geyser.calcSizeForFont(fontNAme, fontSize): " .. fontName .. " is not available on this machine. Please check getAvailableFonts() for options.")
+  end
+  setFont(fcn, fontName)
+  setMiniConsoleFontSize(fcn, fontSize)
+	return calcFontSize(fcn)
+end


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
There is currently not an easy way to get the font size for a font by name and font size. You can get the font size by setting a miniconsole to that font and size and then running calcFontSize("nameOfMiniconsole") but that's more than a bit clunky. This add a Geyser utility function, Geyser.calcSizeForFont(fontName, fontSize) which does the mucking about in hyperspace against a hidden label and then returns the value for the user.

#### Motivation for adding to Mudlet
Came up in discord, and I felt like this was an easy enough way to offer a solution using existing tools. 

#### Other info (issues closed, discussion etc)
I struggle with what to call this, but this was the best I could come up with.