### PR TITLE
Use correct commit SHA1 for Windows builds

### DIFF
--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -3,7 +3,7 @@ cd $Env:APPVEYOR_BUILD_FOLDER
 if ($Env:APPVEYOR_REPO_TAG -eq "false") {
   $Env:MUDLET_VERSION_BUILD = "-testing"
   if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
-      $Script:Commit = git rev-parse --short $Env:APPVEYOR_REPO_COMMIT
+      $Script:Commit = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER-$Commit"
   } else {
     $Script:Commit = git rev-parse --short HEAD


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Currently, testing builds on Windows use a bogus commit ID. This should fix the result.

#### Motivation for adding to Mudlet
Correct commit SHA-1 ids to cause less confusion.

#### Other info (issues closed, discussion etc)
Discussion on Discord a while ago and can also be seen on make.mudlet.org/snapshots