### PR TITLE
Support left and right alignments in format strings for Geyser label echos

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -35,6 +35,7 @@ function Geyser.Label:echo(message, color, format)
   self.fgColor = color
 
   local fs = ""
+  local alignment = ""
   -- check for formatting commands
   if format then
     if string.find(format, "b") then
@@ -44,7 +45,14 @@ function Geyser.Label:echo(message, color, format)
       message = "<i>" .. message .. "</i>"
     end
     if string.find(format, "c") then
-      message = "<center>" .. message .. "</center>"
+      alignment = "center"
+    elseif string.find(format, "l") then
+      alignment = "left"
+    elseif string.find(format, "r") then
+      alignment = "right"
+    end
+    if alignment ~= "" then
+      alignment = string.format([[align="%s" ]], alignment)
     end
     if string.find(format, "u") then
       message = "<u>" .. message .. "</u>"
@@ -55,7 +63,7 @@ function Geyser.Label:echo(message, color, format)
     end
     fs = "font-size: " .. fs .. "pt; "
   end
-  message = [[<div style="color: ]] .. Geyser.Color.hex(self.fgColor) .. "; " .. fs ..
+  message = [[<div ]] .. alignment .. [[ style="color: ]] .. Geyser.Color.hex(self.fgColor) .. "; " .. fs ..
   [[">]] .. message .. [[</div>]]
   echo(self.name, message)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -23,9 +23,7 @@ Geyser.Label.numChildren = 0
 -- specified will use the last set value.
 -- @param message The message to print. Can contain html formatting.
 -- @param color The color to use.
--- @param format A format list to use. 'c' - center, 'b' - bold, 'i' - italics,
---               'u' - underline, '##' - font size.  For example, "cb18"
---               specifies center bold 18pt font be used.  Order doesn't matter.
+-- @param format A format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, '##' - font size.  For example, "cb18" specifies center bold 18pt font be used.  Order doesn't matter.
 function Geyser.Label:echo(message, color, format)
   message = message or self.message
   self.message = message


### PR DESCRIPTION

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

Currently, Mudlet supports Geyser.Label:echo("message", "optional color", "optional format") and stores the color and format for future use. In the final argument for format, we accept 'c' for center but had no equivalent for 'left' or 'right. This shifts to using the align= in the div tag for text alignment rather than the `<center></center>` tags it was using before, allowing us to easily add support for 'l' and 'r' as left and right alignments.

#### Motivation for adding to Mudlet

Someone asked about using 'l' and 'r' for left and right formatting in Geyser.Label:echo() and I was as surprised as they were it wasn't there.

#### Other info (issues closed, discussion etc)
