### PR TITLE
BugFix: restore 3D mapper to FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,22 +109,16 @@ endif()
 
 # Set the environment variable WITH_3DMAPPER=NO to disable the built-in 3D mapper
 set(3DMAPPER_TEST $ENV{WITH_3DMAPPER})
-if((CMAKE_SYSTEM_NAME STREQUAL "Linux") OR (CMAKE_SYSTEM_NAME STREQUAL "Windows") OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-  # We are on one of the supported platforms
-  if(DEFINED 3DMAPPER_TEST)
-    string(TOUPPER ${3DMAPPER_TEST} 3DMAPPER_TEST)
-    if(3DMAPPER_TEST STREQUAL "NO")
-      option(USE_3DMAPPER "Include 3D mapper" OFF)
-    else()
-      option(USE_3DMAPPER "Include 3D mapper" ON)
-    endif()
+if(DEFINED 3DMAPPER_TEST)
+  string(TOUPPER ${3DMAPPER_TEST} 3DMAPPER_TEST)
+  if(3DMAPPER_TEST STREQUAL "NO")
+    option(USE_3DMAPPER "Include 3D mapper" OFF)
   else()
-    # An environmental variable not detected, apply platform default of "yes, include the updater"
     option(USE_3DMAPPER "Include 3D mapper" ON)
   endif()
 else()
-  # Option not available for other platforms
-  set(USE_3DMAPPER NO)
+  # An environmental variable not detected, apply platform default of "yes, include the 3D mapper"
+  option(USE_3DMAPPER "Include 3D mapper" ON)
 endif()
 
 # Set the environment variable WITH_FONTS=NO to disable including built-in fonts

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -42,6 +42,8 @@
 #endif
 
 #include "pre_guard.h"
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QNetworkProxy>
 #include <QProgressDialog>
 #include <QTextCodec>

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -180,11 +180,9 @@ linux|macx|win32 {
 # To remove the 3D mapper, set the environment WITH_3DMAPPER variable to "NO"
 # ie: export WITH_3DMAPPER="NO" qmake
 #
-linux|macx|win32 {
-    3DMAPPER_TEST = $$upper($$(WITH_3DMAPPER))
-    isEmpty( 3DMAPPER_TEST ) | !equals(3DMAPPER_TEST, "NO" ) {
-       DEFINES += INCLUDE_3DMAPPER
-    }
+3DMAPPER_TEST = $$upper($$(WITH_3DMAPPER))
+isEmpty( 3DMAPPER_TEST ) | !equals(3DMAPPER_TEST, "NO" ) {
+    DEFINES += INCLUDE_3DMAPPER
 }
 
 ###################### Platform Specific Paths and related #####################
@@ -638,28 +636,23 @@ linux|macx|win32 {
     }
 }
 
-linux|macx|win32 {
-    contains( DEFINES, INCLUDE_3DMAPPER ) {
-        HEADERS += glwidget.h
-        SOURCES += glwidget.cpp
-        QT += opengl
 
-        win32 {
-            LIBS += -lopengl32 \
-                    -lglu32
-        }
+contains( DEFINES, INCLUDE_3DMAPPER ) {
+    HEADERS += glwidget.h
+    SOURCES += glwidget.cpp
+    QT += opengl
 
-        !build_pass{
-            message("The 3D mapper code is included in this configuration")
-        }
-    } else {
-        !build_pass{
-            message("The 3D mapper code is excluded from this configuration")
-        }
+    win32 {
+        LIBS += -lopengl32 \
+                -lglu32
+    }
+
+    !build_pass{
+        message("The 3D mapper code is included in this configuration")
     }
 } else {
     !build_pass{
-        message("The 3D mapper code is excluded as OpenGL 1.5 might not be available on this platform")
+        message("The 3D mapper code is excluded from this configuration")
     }
 }
 


### PR DESCRIPTION
The code that made the inclusion of the 3D mapper dependent on the OS being Linux, Windows or macOs was misguided as the issue that was to be solved was that Raspberry Pis do not have hardware that can support the ancient *direct* dialect of OpenGL (pre-1.5) that we use.

{They support the OpenGLES form which is a reduced functionality OpenGL for embedded devices but which started off at a level comparable to OpenGL 2.0} These later versions only use the *indirect* form which is expressed in OpenGL ShaderLanguage a.k.a. GLSL.}

It is erroneous to depend on the OS being just those three because the primary OS used with the Raspberry Pi - called Raspbian - is itself a version of Linux - specifically Debian, which has been compiled with some additional support for the Arm 7 hard-fp (with floating-point support in the processor core hardware) and the external hardware that the units posses.

This commit removes the OS dependent tests from the QMake and CMake project files but leaves the handling of the `WITH_3DMAPPER` environmental variable which needs to be set to `NO` for the Raspberry Pi and theoretically any other system which does not have support for the old OpenGL used in the 3d Mapper display.

Also, it also adds in the two JSON related headers needed in `ctelnet.cpp` that I have already found necessary in another PR. This is possibly because I tend to build with another environmental variable `WITH_UPDATER` defined to the value `NO` as well - although on the FreeBSD platform that is implicit.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>