### PR TITLE
Adding format option 's' for geyser labels to add strikethrough

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -23,7 +23,7 @@ Geyser.Label.numChildren = 0
 -- specified will use the last set value.
 -- @param message The message to print. Can contain html formatting.
 -- @param color The color to use.
--- @param format A format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, '##' - font size.  For example, "cb18" specifies center bold 18pt font be used.  Order doesn't matter.
+-- @param format A format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, 's' - strikethrough,  '##' - font size.  For example, "cb18" specifies center bold 18pt font be used.  Order doesn't matter.
 function Geyser.Label:echo(message, color, format)
   message = message or self.message
   self.message = message
@@ -54,6 +54,9 @@ function Geyser.Label:echo(message, color, format)
     end
     if string.find(format, "u") then
       message = "<u>" .. message .. "</u>"
+    end
+    if string.find(format, 's') then
+      message = "<s>" .. message .. "</s>"
     end
     fs = string.gmatch(format, "%d+")()
     if not fs then


### PR DESCRIPTION


<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds 's' format option to Geyser labels for strikethrough
#### Motivation for adding to Mudlet
I had someone ask about strikethrough and realized Geyser didn't have a format option for it. So here it is.
#### Other info (issues closed, discussion etc)
