### PR TITLE
Store character's login passwords securely

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "3rdparty/sparkle-glue"]
 	path = 3rdparty/sparkle-glue
 	url = https://github.com/Mudlet/mixing-cocoa-and-qt.git
+[submodule "3rdparty/qtkeychain"]
+	path = 3rdparty/qtkeychain
+	url = https://github.com/frankosterfeld/qtkeychain.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ addons:
     - mesa-common-dev
     - libglu1-mesa-dev
     - fcitx-frontend-qt5
+    - libsecret-1-dev
 env:
   global:
   - secure: VFI3UCiDrp47WTcUhsatdQvvWg+3gk00eBMZgSOXXKY5+hk+NOX7bOFcIM5t9nlZDbpHDr10SFTuUOw+PeWmLpFO06Zrjg86M9jm9WS4i8Cs9hfxoT6H4isXlR1vubX2LmNlHyzg8WtdNanlsufgecyaGksJxr7tVhG/cWyD6yo=

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ elseif()
 endif()
 
 if(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/qtkeychain/CMakeLists.txt")
+  add_definitions(-DQTKEYCHAIN_NO_EXPORT)
   add_subdirectory(3rdparty/qtkeychain)
 elseif()
   message(FATAL_ERROR "Cannot locate QtKeychain submodule source code, build abandoned!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,18 @@ if(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/edbee-lib/CMakeLists.txt")
   endif()
 endif()
 
+if(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/qtkeychain/CMakeLists.txt")
+  message(STATUS "git submodule for required QtKeychain missing from source code, will attempt to get it...")
+  execute_process(COMMAND git submodule update --init 3rdparty/qtkeychain
+          TIMEOUT 30
+          WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY}
+          OUTPUT_VARIABLE output_text
+          ERROR_VARIABLE error_text)
+  if(output_text OR error_text)
+    message(STATUS ${output_text} ${error_text})
+  endif()
+endif()
+
 if(NOT EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/lcf/lcf-scm-1.rockspec")
   message(STATUS "git submodule for required lua code formatter source code missing, will attempt to get it...")
   execute_process(COMMAND git submodule update --init 3rdparty/lcf
@@ -210,6 +222,12 @@ if(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/edbee-lib/CMakeLists.txt")
   add_subdirectory(3rdparty/edbee-lib/edbee-lib)
 elseif()
   message(FATAL_ERROR "Cannot locate edbee-lib editor widget submodule source code, build abandoned!")
+endif()
+
+if(EXISTS "${CMAKE_HOME_DIRECTORY}/3rdparty/qtkeychain/CMakeLists.txt")
+  add_subdirectory(3rdparty/qtkeychain)
+elseif()
+  message(FATAL_ERROR "Cannot locate QtKeychain submodule source code, build abandoned!")
 endif()
 
 file(GLOB_RECURSE lua_files RELATIVE "${CMAKE_HOME_DIRECTORY}/src/mudlet-lua/lua/" "${CMAKE_HOME_DIRECTORY}/src/mudlet-lua/lua/*.lua")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,7 +212,6 @@ if(USE_UPDATER)
   list(APPEND mudlet_MOC_HDRS updater.h)
 endif(USE_UPDATER)
 
-
 if(USE_3DMAPPER)
   list(APPEND mudlet_SRCS glwidget.cpp)
   list(APPEND mudlet_MOC_HDRS glwidget.h)
@@ -504,6 +503,7 @@ target_link_libraries(mudlet
     ${PUGIXML_LIBRARIES}
     communi
     edbee-lib
+    qt5keychain
 )
 
 if(Qt5TextToSpeech_FOUND)

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -805,11 +805,14 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
     QString DiscordHeader(tr("<h2><u>Discord - Rich Presence - RPC library</u></h2>"
                              "<h3>Copyright © 2017 Discord, Inc.</h3>"));
 
+    QString QtKeyChainHeader(tr("<h2><u>QtKeyChain - Platform-independent Qt API for storing passwords securely</u></h2>"
+                                 "<h3>Copyright © 2011-2019 Frank Osterfeld &lt;frank.osterfeld@gmail.com&gt;.</h3>"));
+
     // Now start to assemble the fragments above:
     QStringList license_3rdParty_texts;
     license_3rdParty_texts.append(QStringLiteral("<html>%1<body>%2<hr>")
                                           .arg(htmlHead,                       //  1 - Html Header
-                                               thirdPartiesHeader)); //  2 - Introductory header - translatable
+                                               thirdPartiesHeader));           //  2 - Introductory header - translatable
 
     license_3rdParty_texts.append(QStringLiteral("%3%4%5<hr>")
                                           .arg(communiHeader,                  //  3 - Communi (IRC) header - translatable
@@ -823,16 +826,16 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
                                           .arg(luaHeader,                      //  6 - lua header - translatable
                                                MIT_Body,                       //  7 - lua body MIT - not translatable
                                                luaYajlHeader,                  //  8 - lua_yajl header - translatable
-                                               MIT_Body));    //  9 - lua_yajl body MIT - not translatable
+                                               MIT_Body));                     //  9 - lua_yajl body MIT - not translatable
 #if defined(Q_OS_MACOS) || defined(DEBUG_SHOWALL)
     license_3rdParty_texts.append(QStringLiteral("%10%11<hr>")
-                                          .arg(luaZipHeader, // 10 - macOS luazip header - translatable
-                                               MIT_Body));   // 11 - macOS luazip body MIT - not translatable
+                                          .arg(luaZipHeader,                   // 10 - macOS luazip header - translatable
+                                               MIT_Body));                     // 11 - macOS luazip body MIT - not translatable
 #endif
 
     license_3rdParty_texts.append(QStringLiteral("%12%13")
                                           .arg(edbeeHeader,                    // 12 - edbee header - translatable
-                                               MIT_Body));  // 13 - edbee body MIT - not translatable
+                                               MIT_Body));                     // 13 - edbee body MIT - not translatable
 
     license_3rdParty_texts.append(QStringLiteral("<hr width=\"50%\">%14"
                                                  "%15%16<hr width=\"33%\">"
@@ -861,13 +864,13 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 #if defined(INCLUDE_UPDATER) || defined(DEBUG_SHOWALL)
     license_3rdParty_texts.append(QStringLiteral("<hr>%23%24")
                                           .arg(DblsqdHeader,                   // 23 - dblsqd Header - translatable
-                                               APACHE2_Body)); // 24 - dblsqd body APACHE2 - not translatable
+                                               APACHE2_Body));                 // 24 - dblsqd body APACHE2 - not translatable
 #if defined(Q_OS_MACOS) || defined(DEBUG_SHOWALL)
     license_3rdParty_texts.append(QStringLiteral("<hr width=\"50%\">%25%26<hr width=\"33%\">%27%28<hr width=\"33%\">%29%30")
-                                          .arg(SparkleHeader,         // 25 - Sparkle header - translatable
-                                               MIT_Body,              // 26 - Sparkle body MIT - not translatable
-                                               Sparkle3rdPartyHeader, // 27 - Sparkle 3rd Party headers - translatable
-                                               BSD2Clause_Body        // 28 - Sparkle 3rd Party body BSD2 ("AUTHOR") - not translatable
+                                          .arg(SparkleHeader,                  // 25 - Sparkle header - translatable
+                                               MIT_Body,                       // 26 - Sparkle body MIT - not translatable
+                                               Sparkle3rdPartyHeader,          // 27 - Sparkle 3rd Party headers - translatable
+                                               BSD2Clause_Body                 // 28 - Sparkle 3rd Party body BSD2 ("AUTHOR") - not translatable
                                                        .arg(QLatin1String("AUTHOR"), QLatin1String("AUTHOR")),
                                                SparkleGlueHeader, // 29 - Sparkle glue header - translatable
                                                BSD2Clause_Body    // 30 - Sparkle glue body BSD2 ("COPYRIGHT HOLDERS AND/OR CONTRIBUTORS") - not translatable
@@ -877,17 +880,23 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 
 #if defined(INCLUDE_FONTS) || defined(DEBUG_SHOWALL)
     license_3rdParty_texts.append(QStringLiteral("<hr>%31")
-                                  .arg(UbuntuFontText));               // 31 - Ubuntu Font Text - not translatable
+                                  .arg(UbuntuFontText));                       // 31 - Ubuntu Font Text - not translatable
     license_3rdParty_texts.append(QStringLiteral("<hr>%32")
-                                  .arg(SILOpenFontText));              // 32 - SIL Open Font Text - not translatable
+                                  .arg(SILOpenFontText));                      // 32 - SIL Open Font Text - not translatable
 
 #endif
 
     license_3rdParty_texts.append(QStringLiteral("<hr><br>"
                                                  "<center><img src=\":/icons/Discord-Logo+Wordmark-Color_400x136px.png\"/></center><br>"
                                                  "%33%34")
-                                  .arg(DiscordHeader,                  // 33 - Discord header - translatable
-                                       MIT_Body));                     // 34 - Discord body MIT - not translatable
+                                  .arg(DiscordHeader,                          // 33 - Discord header - translatable
+                                       MIT_Body));                             // 34 - Discord body MIT - not translatable
+
+    license_3rdParty_texts.append(QStringLiteral("<hr><br>"
+                                                 "%35%36")
+                                  .arg(QtKeyChainHeader,                       // 35 - QtKeyChain header - translatable
+                                       BSD2Clause_Body                         // 36 - QtKeyChain body BSD2 ("AUTHOR") - not translatable
+                                       .arg(QLatin1String("AUTHOR"), QLatin1String("AUTHOR"))));
 
     license_3rdParty_texts.append(QStringLiteral("</body></html>"));
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1748,7 +1748,6 @@ void dlgConnectionProfiles::setSecuredPassword(const QString &profile, L callbac
             }
         } else {
             auto readJob = static_cast<QKeychain::ReadPasswordJob*>(job);
-            qDebug() << profile << "password is" << readJob->textData();
             callback(readJob->textData());
         }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -33,7 +33,7 @@
 #include <QtUiTools>
 #include <QSettings>
 #include <sstream>
-#include <qtkeychain/keychain.h>
+#include <../3rdparty/qtkeychain/keychain.h>
 #include "post_guard.h"
 
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1739,8 +1739,11 @@ void dlgConnectionProfiles::setSecuredPassword(const QString &profile, L callbac
     job->setKey(profile);
 
     connect(job, &QKeychain::ReadPasswordJob::finished, this, [=](QKeychain::Job* job) {
-        if (job->error() && job->errorString() != QStringLiteral("No match")) {
-            qDebug() << "dlgConnectionProfiles::setSecuredPassword ERROR: couldn't retrieve secure password for" << profile << ", error is:" << job->errorString();
+        if (job->error()) {
+            const auto error = job->errorString();
+            if (error != QStringLiteral("Entry not found") && error != QStringLiteral("No match")) {
+            qDebug() << "dlgConnectionProfiles::setSecuredPassword ERROR: couldn't retrieve secure password for" << profile << ", error is:" << error;
+            }
         } else {
             auto readJob = static_cast<QKeychain::ReadPasswordJob*>(job);
             qDebug() << profile << "password is" << readJob->textData();

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -977,7 +977,7 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
     port_entry->setText(host_port);
 
     val = readProfileData(profile, QStringLiteral("password"));
-//    character_password_entry->setText(val);
+    character_password_entry->setText(QString());
     setSecuredPassword(profile);
 
     val = readProfileData(profile, QStringLiteral("login"));

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -26,7 +26,7 @@
 #include "ui_connection_profiles.h"
 #include "QDir"
 #include <pugixml.hpp>
-#include <qtkeychain/keychain.h>
+#include <../3rdparty/qtkeychain/keychain.h>
 #include "post_guard.h"
 
 class dlgConnectionProfiles : public QDialog, public Ui::connection_profiles

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -87,8 +87,10 @@ private:
     void generateCustomProfile(const QFont& font, int i, const QString& profileName) const;
     void setCustomIcon(const QString& profileName, QListWidgetItem* profile) const;
     template <typename L>
-    void setSecuredPassword(const QString& profile, L callback);
+    void loadSecuredPassword(const QString& profile, L callback);
     void migrateSecuredPassword(const QString& oldProfile, const QString& newProfile);
+    void writeSecurePassword(const QString& profile, const QString& pass) const;
+    void deleteSecurePassword(const QString& profile) const;
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has
@@ -113,7 +115,8 @@ private slots:
     void slot_profile_menu(QPoint pos);
     void slot_set_custom_icon();
     void slot_reset_custom_icon();
-    void slot_password_saved(QKeychain::Job *job);
+    void slot_password_saved(QKeychain::Job* job);
+    void slot_password_deleted(QKeychain::Job* job);
 };
 
 

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -26,6 +26,7 @@
 #include "ui_connection_profiles.h"
 #include "QDir"
 #include <pugixml.hpp>
+#include <qtkeychain/keychain.h>
 #include "post_guard.h"
 
 class dlgConnectionProfiles : public QDialog, public Ui::connection_profiles
@@ -85,6 +86,7 @@ private:
     void loadCustomProfile(const QFont& font, const QString& profileName) const;
     void generateCustomProfile(const QFont& font, int i, const QString& profileName) const;
     void setCustomIcon(const QString& profileName, QListWidgetItem* profile) const;
+    void setSecuredPassword(const QString& profile);
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has
@@ -109,6 +111,7 @@ private slots:
     void slot_profile_menu(QPoint pos);
     void slot_set_custom_icon();
     void slot_reset_custom_icon();
+    void slot_password_saved(QKeychain::Job *job);
 };
 
 

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -86,7 +86,9 @@ private:
     void loadCustomProfile(const QFont& font, const QString& profileName) const;
     void generateCustomProfile(const QFont& font, int i, const QString& profileName) const;
     void setCustomIcon(const QString& profileName, QListWidgetItem* profile) const;
-    void setSecuredPassword(const QString& profile);
+    template <typename L>
+    void setSecuredPassword(const QString& profile, L callback);
+    void migrateSecuredPassword(const QString& oldProfile, const QString& newProfile);
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,6 +508,8 @@ int main(int argc, char* argv[])
 
     mudlet::self()->show();
 
+    mudlet::self()->migratePasswordsToSecureStorage();
+
     mudlet::self()->startAutoLogin();
 
 #if defined(INCLUDE_UPDATER)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4745,6 +4745,24 @@ void mudlet::setEnableFullScreenMode(const bool state)
     emit signal_enableFulScreenModeChanged(state);
 }
 
+
+void mudlet::migratePasswordsToSecureStorage()
+{
+    static bool migrating = false;
+    if (migrating) {
+        return;
+    }
+
+    QStringList profiles = QDir(mudlet::getMudletPath(mudlet::profilesPath))
+                                   .entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+
+    for (const auto& entry : profiles) {
+        qDebug() << "profile" << entry;
+    }
+
+    emit signal_passwordMigrationCompleted();
+}
+
 void mudlet::setShowMapAuditErrors(const bool state)
 {
     if (mshowMapAuditErrors != state) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4783,10 +4783,6 @@ void mudlet::slot_password_saved(QKeychain::Job *job)
 {
     if (job->error()) {
         qWarning() << "mudlet::slot_password_saved ERROR: couldn't migrate for" << job->property("profile") << "; error was:" << job->errorString();
-    } else {
-        const auto& profile = job->property("profile").toString();
-
-        deleteProfileData(profile, QStringLiteral("password"));
     }
 
     job->deleteLater();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -380,6 +380,7 @@ public:
     QList<QString> getAvailableTranslationCodes() const { return mTranslationsMap.keys(); }
     QPair<bool, QStringList> getLines(Host* pHost, const QString& windowName, const int lineFrom, const int lineTo);
     void setEnableFullScreenMode(const bool);
+    void migratePasswordsToSecureStorage();
 
     // Both of these revises the contents of the .aff file: the first will
     // handle a .dic file that has been updated externally/manually (to add
@@ -493,6 +494,7 @@ signals:
     void signal_toolBarVisibilityChanged(const controlsVisibility);
     void signal_showIconsOnMenusChanged(const Qt::CheckState);
     void signal_guiLanguageChanged(const QString&);
+    void signal_passwordMigrationCompleted();
 
 
 private slots:

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -53,6 +53,7 @@
 #include <QTimer>
 #include <QToolButton>
 #include "edbee/models/textautocompleteprovider.h"
+#include <../3rdparty/qtkeychain/keychain.h>
 #include <QShortcut>
 #include <QKeySequence>
 #ifdef QT_GAMEPAD_LIB
@@ -164,6 +165,7 @@ public:
     void setFgColor(Host*, const QString& name, int, int, int);
     void setBgColor(Host*, const QString& name, int, int, int);
     QString readProfileData(const QString& profile, const QString& item);
+    void deleteProfileData(const QString &profile, const QString &item);
     bool setWindowWrap(Host* pHost, const QString& name, int& wrap);
     bool setWindowWrapIndent(Host* pHost, const QString& name, int& wrap);
     bool copy(Host* pHost, const QString& name);
@@ -431,7 +433,6 @@ public:
     // the system
     bool mUsingMudletDictionaries;
 
-
 public slots:
     void processEventLoopHack_timerRun();
     void slot_mapper();
@@ -494,7 +495,6 @@ signals:
     void signal_toolBarVisibilityChanged(const controlsVisibility);
     void signal_showIconsOnMenusChanged(const Qt::CheckState);
     void signal_guiLanguageChanged(const QString&);
-    void signal_passwordMigrationCompleted();
 
 
 private slots:
@@ -524,6 +524,7 @@ private slots:
     void slot_updateAvailable(const int);
 #endif
     void slot_toggle_compact_input_line();
+    void slot_password_saved(QKeychain::Job *job);
 
 private:
     void initEdbee();

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -354,10 +354,13 @@ win32 {
         # PowerShell - for cmd.exe the nearest equivalent is '&'
         system("cd $${PWD}\.. & git submodule update --init 3rdparty/edbee-lib")
     }
-
     !exists("$${PWD}/../3rdparty/lcf/lcf-scm-1.rockspec") {
         message("git submodule for required lua code formatter source code missing, executing 'git submodule update --init' to get it...")
         system("cd $${PWD}\.. & git submodule update --init 3rdparty/lcf")
+    }
+    !exists("$${PWD}/../3rdparty/qtkeychain/keychain.h") {
+        message("git submodule for required QtKeychain source code missing, executing 'git submodule update --init' to get it...")
+        system("cd $${PWD}\.. & git submodule update --init 3rdparty/qtkeychain")
     }
 } else {
     !exists("$${PWD}/../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri") {
@@ -367,6 +370,10 @@ win32 {
     !exists("$${PWD}/../3rdparty/lcf/lcf-scm-1.rockspec") {
         message("git submodule for required lua code formatter source code missing, executing 'git submodule update --init' to get it...")
         system("cd $${PWD}/.. ; git submodule update --init 3rdparty/lcf")
+    }
+    !exists("$${PWD}/../3rdparty/qtkeychain/keychain.h") {
+        message("git submodule for required QtKeychain source code missing, executing 'git submodule update --init' to get it...")
+        system("cd $${PWD}/.. ; git submodule update --init 3rdparty/qtkeychain")
     }
 }
 
@@ -404,6 +411,12 @@ exists("$${PWD}/../3rdparty/edbee-lib/edbee-lib/edbee-lib.pri") {
 
 !exists("$${PWD}/../3rdparty/lcf/lcf-scm-1.rockspec") {
     error("Cannot locate lua code formatter submodule source code, build abandoned!")
+}
+
+exists("$${PWD}/../3rdparty/qtkeychain/qt5keychain.pri") {
+    include("$${PWD}/../3rdparty/qtkeychain/qt5keychain.pri")
+} else {
+    error("Cannot locate QtKeychain submodule source code, build abandoned!")
 }
 
 contains( DEFINES, INCLUDE_UPDATER ) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Store character's login passwords securely (the ones in the connection screen).
#### Motivation for adding to Mudlet
While it's very unlikely that a hacker who gets access to someone's machine will specifically go after their MUD characters password - there are many more valuable things to go after - it's still a good idea!

#### How can I tell if it works?
1. the password field in Mudlets connection window should still have your password
1. the `password` file in your profile's directory should be gone
1. your OS's credential manager should list the passwords instead:

![image](https://user-images.githubusercontent.com/110988/63772050-9a603c00-c8d8-11e9-95a5-44b1cae8565e.png)


#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/1917.

Note that once you use this test version of Mudlet which migrates passwords to secure storage - normal Mudlet which doesn't have support for secured passwords, obviously, won't be able to read them. Keep this in mind: if you notice your password has "disappeared", you probably used this test version which secured your password and now you're back on the normal version which can't access it.