### PR TITLE
Add postHTTP(), putHTTP(), deleteHTTP() to interact with online services

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14668,6 +14668,11 @@ int TLuaInterpreter::putHTTP(lua_State* L)
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->put(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
+
+    if (mudlet::debugMode) {
+        TDebug(QColor(Qt::white), QColor(Qt::blue)) << "putHTTP: script is uploading data to " << reply->url().toString() << "\n" >> 0;
+    }
+
     lua_pushboolean(L, true);
     lua_pushstring(L, reply->url().toString().toUtf8().constData()); // Returns the Url that was ACTUALLY used
     return 2;
@@ -14766,6 +14771,11 @@ int TLuaInterpreter::postHTTP(lua_State* L)
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->post(request, fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
+
+    if (mudlet::debugMode) {
+        TDebug(QColor(Qt::white), QColor(Qt::blue)) << "postHTTP: script is uploading data to " << reply->url().toString() << "\n" >> 0;
+    }
+
     lua_pushboolean(L, true);
     lua_pushstring(L, reply->url().toString().toUtf8().constData()); // Returns the Url that was ACTUALLY used
     return 2;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -210,8 +210,12 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        event.mArgumentList << QString(reply->readAll());
-        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
+
+            // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
+            event.mArgumentList << replyText;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        }
         break;
 
     case QNetworkAccessManager::CustomOperation:
@@ -224,8 +228,11 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        event.mArgumentList << QString(reply->readAll());
-        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
+            // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
+            event.mArgumentList << replyText;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        }
         break;
 
     case QNetworkAccessManager::PutOperation:
@@ -233,8 +240,12 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        event.mArgumentList << QString(reply->readAll());
-        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
+
+            // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
+            event.mArgumentList << replyText;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+        }
         break;
 
     case QNetworkAccessManager::GetOperation:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -191,12 +191,18 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentList << QStringLiteral("sysPostHttpDone");
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
+        event.mArgumentList << reply->url().toString();
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+
         event.mArgumentList << QString(reply->readAll());
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         break;
 
     case QNetworkAccessManager::PutOperation:
         event.mArgumentList << QStringLiteral("sysPutHttpDone");
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+
+        event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
         event.mArgumentList << QString(reply->readAll());

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14642,6 +14642,27 @@ int TLuaInterpreter::putHTTP(lua_State* L)
     }
 #endif
 
+    if (lua_gettop(L) >= 3) {
+        if (!lua_istable(L, 3)) {
+            lua_pushfstring(L, "putHTTP: bad argument #3 type (headers as a table expected, got %s!)", luaL_typename(L, 3));
+            return lua_error(L);
+        } else {
+            lua_pushnil(L);
+            while (lua_next(L, 3) != 0) {
+                // key at index -2 and value at index -1
+                if (lua_type(L, -1) == LUA_TSTRING && lua_type(L, -2) == LUA_TSTRING) {
+                    QString cmd = lua_tostring(L, -1);
+                    request.setRawHeader(QByteArray(lua_tostring(L, -2)), QByteArray(lua_tostring(L, -1)));
+                } else {
+                    lua_pushfstring(L, "putHTTP: bad argument #3 type (custom headers must be strings, got header: %s (should be string) and value: %s (should be string))", luaL_typename(L, -2), luaL_typename(L, -1));
+                    return lua_error(L);
+                }
+                // removes value, but keeps key for next iteration
+                lua_pop(L, 1);
+            }
+        }
+    }
+
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->put(request, dataToPut.toUtf8());
     lua_pushboolean(L, true);
@@ -14657,8 +14678,7 @@ int TLuaInterpreter::postHTTP(lua_State* L)
     QString dataToPost;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "postHTTP: bad argument #1 type (data to send as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         dataToPost = QString::fromUtf8(lua_tostring(L, 1));
     }
@@ -14666,8 +14686,7 @@ int TLuaInterpreter::postHTTP(lua_State* L)
     QString urlString;
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "postHTTP: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         urlString = QString::fromUtf8(lua_tostring(L, 2));
     }
@@ -14693,6 +14712,27 @@ int TLuaInterpreter::postHTTP(lua_State* L)
         request.setSslConfiguration(config);
     }
 #endif
+
+    if (lua_gettop(L) >= 3) {
+        if (!lua_istable(L, 3)) {
+            lua_pushfstring(L, "postHTTP: bad argument #3 type (headers as a table expected, got %s!)", luaL_typename(L, 3));
+            return lua_error(L);
+        } else {
+            lua_pushnil(L);
+            while (lua_next(L, 3) != 0) {
+                // key at index -2 and value at index -1
+                if (lua_type(L, -1) == LUA_TSTRING && lua_type(L, -2) == LUA_TSTRING) {
+                    QString cmd = lua_tostring(L, -1);
+                    request.setRawHeader(QByteArray(lua_tostring(L, -2)), QByteArray(lua_tostring(L, -1)));
+                } else {
+                    lua_pushfstring(L, "postHTTP: bad argument #3 type (custom headers must be strings, got header: %s (should be string) and value: %s (should be string))", luaL_typename(L, -2), luaL_typename(L, -1));
+                    return lua_error(L);
+                }
+                // removes value, but keeps key for next iteration
+                lua_pop(L, 1);
+            }
+        }
+    }
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->post(request, dataToPost.toUtf8());

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10422,16 +10422,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-
-    // This should fix: https://bugs.launchpad.net/mudlet/+bug/1366781
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-#ifndef QT_NO_SSL
-    if (url.scheme() == QStringLiteral("https")) {
-        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
-        request.setSslConfiguration(config);
-    }
-#endif
+    setRequestDefaults(url, request);
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
@@ -14632,15 +14623,7 @@ int TLuaInterpreter::putHTTP(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-#ifndef QT_NO_SSL
-    if (url.scheme() == QStringLiteral("https")) {
-        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
-        request.setSslConfiguration(config);
-    }
-#endif
+    setRequestDefaults(url, request);
 
     if (lua_gettop(L) >= 3) {
         if (!lua_istable(L, 3)) {
@@ -14668,6 +14651,19 @@ int TLuaInterpreter::putHTTP(lua_State* L)
     lua_pushboolean(L, true);
     lua_pushstring(L, reply->url().toString().toUtf8().constData()); // Returns the Url that was ACTUALLY used
     return 2;
+}
+
+void TLuaInterpreter::setRequestDefaults(const QUrl& url, QNetworkRequest& request)
+{
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
+#ifndef QT_NO_SSL
+    if (url.scheme() == QStringLiteral("https")) {
+        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
+        request.setSslConfiguration(config);
+    }
+#endif
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#postHttp
@@ -14703,15 +14699,7 @@ int TLuaInterpreter::postHTTP(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-#ifndef QT_NO_SSL
-    if (url.scheme() == QStringLiteral("https")) {
-        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
-        request.setSslConfiguration(config);
-    }
-#endif
+    setRequestDefaults(url, request);
 
     if (lua_gettop(L) >= 3) {
         if (!lua_istable(L, 3)) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14598,13 +14598,13 @@ int TLuaInterpreter::getAvailableFonts(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#putHttp
-int TLuaInterpreter::putHttp(lua_State* L)
+int TLuaInterpreter::putHTTP(lua_State* L)
 {
     auto& host = getHostFromLua(L);
 
     QString dataToPut;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "putHttp: bad argument #1 type (data to send as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "putHTTP: bad argument #1 type (data to send as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -14613,7 +14613,7 @@ int TLuaInterpreter::putHttp(lua_State* L)
 
     QString urlString;
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "putHttp: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
+        lua_pushfstring(L, "putHTTP: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
         lua_error(L);
         return 1;
     } else {
@@ -14625,7 +14625,7 @@ int TLuaInterpreter::putHttp(lua_State* L)
     if (!url.isValid()) {
         lua_pushnil(L);
         lua_pushfstring(L,
-                        "putHttp: bad argument #2 value (url is not deemed valid), validation\n"
+                        "putHTTP: bad argument #2 value (url is not deemed valid), validation\n"
                         "produced the following error message:\n%s.",
                         url.errorString().toUtf8().constData());
         return 2;
@@ -14650,13 +14650,13 @@ int TLuaInterpreter::putHttp(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#postHttp
-int TLuaInterpreter::postHttp(lua_State* L)
+int TLuaInterpreter::postHTTP(lua_State* L)
 {
     auto& host = getHostFromLua(L);
 
     QString dataToPost;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "postHttp: bad argument #1 type (data to send as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "postHTTP: bad argument #1 type (data to send as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -14665,7 +14665,7 @@ int TLuaInterpreter::postHttp(lua_State* L)
 
     QString urlString;
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "postHttp: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
+        lua_pushfstring(L, "postHTTP: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
         lua_error(L);
         return 1;
     } else {
@@ -14677,7 +14677,7 @@ int TLuaInterpreter::postHttp(lua_State* L)
     if (!url.isValid()) {
         lua_pushnil(L);
         lua_pushfstring(L,
-                        "postHttp: bad argument #2 value (url is not deemed valid), validation\n"
+                        "postHTTP: bad argument #2 value (url is not deemed valid), validation\n"
                         "produced the following error message:\n%s.",
                         url.errorString().toUtf8().constData());
         return 2;
@@ -15224,8 +15224,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getDictionaryWordList", TLuaInterpreter::getDictionaryWordList);
     lua_register(pGlobalLua, "getTextFormat", TLuaInterpreter::getTextFormat);
     lua_register(pGlobalLua, "getWindowsCodepage", TLuaInterpreter::getWindowsCodepage);
-    lua_register(pGlobalLua, "putHttp", TLuaInterpreter::putHttp);
-    lua_register(pGlobalLua, "postHttp", TLuaInterpreter::postHttp);
+    lua_register(pGlobalLua, "putHTTP", TLuaInterpreter::putHTTP);
+    lua_register(pGlobalLua, "postHTTP", TLuaInterpreter::postHTTP);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -136,12 +136,12 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
         return;
     }
 
-    if (!networkRequests.contains(reply)) {
+    if (!downloadMap.contains(reply)) {
         reply->deleteLater();
         return;
     }
 
-    QString localFileName = networkRequests.value(reply);
+    QString localFileName = downloadMap.value(reply);
     if (reply->error() != QNetworkReply::NoError) {
         TEvent event {};
         switch (reply->operation()) {
@@ -165,7 +165,7 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
         }
 
         reply->deleteLater();
-        networkRequests.remove(reply);
+        downloadMap.remove(reply);
         pHost->raiseEvent(event);
         return;
     }
@@ -175,7 +175,7 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
 
 void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
 {
-    QString localFileName = networkRequests.value(reply);
+    QString localFileName = downloadMap.value(reply);
     TEvent event {};
     Host* pHost = mpHost;
     if (!pHost) {
@@ -241,7 +241,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
 
 
     reply->deleteLater();
-    networkRequests.remove(reply);
+    downloadMap.remove(reply);
     pHost->raiseEvent(event);
 }
 
@@ -10413,7 +10413,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
-    host.mLuaInterpreter.networkRequests.insert(reply, localFile);
+    host.mLuaInterpreter.downloadMap.insert(reply, localFile);
     lua_pushboolean(L, true);
     lua_pushstring(L, reply->url().toString().toUtf8().constData()); // Returns the Url that was ACTUALLY used
     return 2;
@@ -14621,7 +14621,7 @@ int TLuaInterpreter::putHttp(lua_State* L)
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->put(request, dataToPut.toUtf8().constData());
-    host.mLuaInterpreter.networkRequests.insert(reply, url.toString());
+    host.mLuaInterpreter.downloadMap.insert(reply, url.toString());
     lua_pushboolean(L, true);
     lua_pushstring(L, reply->url().toString().toUtf8().constData()); // Returns the Url that was ACTUALLY used
     return 2;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -507,8 +507,8 @@ public:
     static int getDictionaryWordList(lua_State*);
     static int getTextFormat(lua_State*);
     static int getWindowsCodepage(lua_State*);
-    static int putHttp(lua_State*);
-    static int postHttp(lua_State*);
+    static int putHTTP(lua_State* L);
+    static int postHTTP(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -507,6 +507,7 @@ public:
     static int getDictionaryWordList(lua_State*);
     static int getTextFormat(lua_State*);
     static int getWindowsCodepage(lua_State*);
+    static int putHttp(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 
@@ -515,7 +516,7 @@ public:
     void encodingChanged(const QString&);
 
 public slots:
-    void slot_replyFinished(QNetworkReply*);
+    void slot_httpRequestFinished(QNetworkReply*);
     void slotPurge();
     void slotDeleteSender(int, QProcess::ExitStatus);
 
@@ -528,6 +529,7 @@ private:
     static std::pair<bool, QString> discordApiEnabled(lua_State* L, bool writeAccess = false);
     void setupLanguageData();
     QString readScriptFile(const QString& path) const;
+    void handleHttpOK(QNetworkReply*);
 #if defined(Q_OS_WIN32)
     void loadUtf8Filenames();
 #endif
@@ -539,7 +541,7 @@ private:
     std::list<std::list<std::string>> mMultiCaptureGroupList;
     std::list<std::list<int>> mMultiCaptureGroupPosList;
 
-    QMap<QNetworkReply*, QString> downloadMap;
+    QMap<QNetworkReply*, QString> networkRequests;
 
     lua_State* pGlobalLua;
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -530,16 +530,18 @@ private:
     static std::pair<bool, QString> discordApiEnabled(lua_State* L, bool writeAccess = false);
     void setupLanguageData();
     QString readScriptFile(const QString& path) const;
+    static void setRequestDefaults(const QUrl& url, QNetworkRequest& request);
     void handleHttpOK(QNetworkReply*);
 #if defined(Q_OS_WIN32)
     void loadUtf8Filenames();
+
 #endif
 
     QNetworkAccessManager* mpFileDownloader;
-
     std::list<std::string> mCaptureGroupList;
     std::list<int> mCaptureGroupPosList;
     std::list<std::list<std::string>> mMultiCaptureGroupList;
+
     std::list<std::list<int>> mMultiCaptureGroupPosList;
 
     QMap<QNetworkReply*, QString> downloadMap;
@@ -553,7 +555,6 @@ private:
     };
 
     std::unique_ptr<lua_State, lua_state_deleter> pIndenterState;
-
     QPointer<Host> mpHost;
     int mHostID;
     QList<QObject*> objectsToDelete;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -541,7 +541,7 @@ private:
     std::list<std::list<std::string>> mMultiCaptureGroupList;
     std::list<std::list<int>> mMultiCaptureGroupPosList;
 
-    QMap<QNetworkReply*, QString> networkRequests;
+    QMap<QNetworkReply*, QString> downloadMap;
 
     lua_State* pGlobalLua;
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -508,6 +508,7 @@ public:
     static int getTextFormat(lua_State*);
     static int getWindowsCodepage(lua_State*);
     static int putHttp(lua_State*);
+    static int postHttp(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -509,6 +509,7 @@ public:
     static int getWindowsCodepage(lua_State*);
     static int putHTTP(lua_State* L);
     static int postHTTP(lua_State* L);
+    static int deleteHTTP(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add postHTTP(), putHTTP() to interact with online services.
Functions:
`postHTTP("data to send", "url to send it to", (optional) {a_table="of headers to send"}, (optional) "file to upload")`

`putHTTP("data to send", "url to send it to", (optional) {a_table="of headers to send"}, (optional) "file to upload")`

`deleteHTTP("url to send it to", (optional) {a_table="of headers to send"})`

The syntax is similar to `sendGMCP`, `sendATCP`, `sendMSDP`.

Events:
`sysPutHttpDone`, `sysPostHttpDone` `sysDeleteHttpDone` - URL and response body are the event arguments. Response body is only added if it's less than 10k characters in length, because some responses were all on one line and line wrapping 100k character line takes... a while.
`sysPutHttpError`, `sysPostHttpError`, `sysDeleteHttpError` - error & URL are the event arguments.
#### Motivation for adding to Mudlet
A tool in the toolbox for scripters.
#### Other info (issues closed, discussion etc)
`GET` is already supported via [downloadFile()](https://wiki.mudlet.org/w/Manual:Networking_Functions#downloadFile).

Closes https://github.com/Mudlet/Mudlet/issues/782.