### PR TITLE
Add `table.flatten` global function

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -20,6 +20,20 @@ function table.is_empty(tbl)
 end
 
 
+-- The flatten() method creates a new table with all sub-table elements concatenated into it recursively.
+function table.n_flatten(input)
+  local flattened = {}
+  for _, element in ipairs(input) do
+    if type(element) == 'table' then
+      for i, v in ipairs(table.n_flatten(element)) do
+        flattened[#flattened + 1] = v
+      end
+    else
+      flattened[#flattened + 1] = element
+    end
+  end
+  return flattened
+end
 
 --- Lua debug function that prints the content of a Lua table on the screen, split up in keys and values.
 --- Useful if you want to see what the capture groups contain i. e. the Lua table "matches".

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -36,7 +36,7 @@ function table.n_flatten(input)
   local flattened = {}
   for _, element in ipairs(input) do
     if type(element) == 'table' then
-      for i, v in ipairs(table.n_flatten(element)) do
+      for _, v in ipairs(table.n_flatten(element)) do
         flattened[#flattened + 1] = v
       end
     else

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -41,4 +41,15 @@ describe("Tests TableUtils.lua functions", function()
       assert.are.same(filterItems(fruits, 'an'), {'banana', 'mango', 'orange'})
     end)
   end)
+
+  describe("Tests table.n_flatten() method", function()
+    it("Should flatten nested tables", function()
+      local t1 = {1, 2, {3, 4}};
+      local t2 = {1, 2, {3, 4, {5, 6}}};
+      local t3 = {1, 2, {3, 4, {5, 6, {7, 8, {9, 10}}}}};
+      assert.are.same(table.n_flatten(t1), {1, 2, 3, 4})
+      assert.are.same(table.n_flatten(t2), {1, 2, 3, 4, 5, 6})
+      assert.are.same(table.n_flatten(t3), {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+    end)
+  end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a single function to the table class that allows users to flatten deeply-nested lists together.

#### Motivation for adding to Mudlet

I was attempting to implement a quicksort function and ran across some limitations with `table.n_union` that didn't allow me to get the result I wished. The example image below shows the limitation I faced, and the solution that adding this function would solve.

```lua
function quicksort(arr)
  if #arr <= 1 then return arr end
  local pivot = table.remove(arr)
  local left = table.n_filter(arr, function(num) return num < pivot end)
  local right = table.n_filter(arr, function(num) return num >= pivot end)
  return table.n_flatten({quicksort(left), {pivot}, quicksort(right)})
end

quicksort({1, 9, 2, 8, 3, 7, 4, 6, 5})
```

![image](https://user-images.githubusercontent.com/8473052/63625218-f3745b00-c5cc-11e9-9658-156343e4ddd6.png)