### PR TITLE
Add `table.filter` global function

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -19,6 +19,17 @@ function table.is_empty(tbl)
   end
 end
 
+-- The filter() method creates a new table with all elements that pass the test
+-- implemented by the provided function.
+function table.n_filter(t, cb)
+  local filtered = {}
+  for i, v in ipairs(t) do
+    if cb(v) then
+      filtered[#filtered + 1] = v
+    end
+  end
+  return filtered
+end
 
 
 --- Lua debug function that prints the content of a Lua table on the screen, split up in keys and values.

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -24,7 +24,7 @@ end
 function table.n_filter(t, cb)
   local filtered = {}
   for i, v in ipairs(t) do
-    if cb(v) then
+    if cb(v, i, t) then
       filtered[#filtered + 1] = v
     end
   end

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -24,7 +24,7 @@ describe("Tests TableUtils.lua functions", function()
       end
 
       local entriesByID = table.n_filter(entries, filterByID)
-      assert.are.equal(invalidEntries, 4)
+      assert.are.equal(invalidEntries, 5)
       assert.are.same(entriesByID, {
         { id = 15 }, { id = -1 }, { id = 3 }, { id = 12.2 }
       })

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -1,0 +1,44 @@
+describe("Tests TableUtils.lua functions", function()
+  describe("Tests table.n_filter() method", function()
+    it("Should filter out small values", function()
+      local function isBigEnough(value) return value >= 10 end
+      local filtered = table.n_filter({12, 5, 8, 130, 44}, isBigEnough)
+      assert.are.same(filtered, {12, 130, 44})
+    end)
+
+    it("Should filter out invalid entries", function()
+      local invalidEntries = 0
+      local entries = {
+        { id = 15 }, { id = -1 }, { id = 0 }, { id = 3 },
+        { id = 12.2 }, { }, { id = nil }, { id = false },
+        { id = 'not a number' }
+      }
+
+      local function isNumber(t) return t and type(t) == 'number' end
+      local function filterByID(item)
+        if isNumber(item.id) and item.id ~= 0 then
+          return true
+        end
+        invalidEntries = invalidEntries + 1
+        return false
+      end
+
+      local entriesByID = table.n_filter(entries, filterByID)
+      assert.are.equal(invalidEntries, 4)
+      assert.are.same(entriesByID, {
+        { id = 15 }, { id = -1 }, { id = 3 }, { id = 12.2 }
+      })
+    end)
+
+    it("Should filter out content based on search criteria", function()
+      local fruits = {'apple', 'banana', 'grapes', 'mango', 'orange'}
+      local function filterItems(t, query)
+        return table.n_filter(t, function(item)
+          return item:lower():find(query:lower())
+        end)
+      end
+      assert.are.same(filterItems(fruits, 'ap'), {'apple', 'grapes'})
+      assert.are.same(filterItems(fruits, 'an'), {'banana', 'mango', 'orange'})
+    end)
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds a handy utility function for filtering table values that return true for a specific condition.

#### Motivation for adding to Mudlet

There are times when you'll need to grab specific items out of a table that meet a certain condition. This function simplifies the process. Here's an example:

```lua
function isBigEnough(value)
  return value >= 10
end

local filtered = table.n_filter({12, 5, 8, 130, 44}, isBigEnough)

display(filtered) -- {12, 130, 44}
```
