### PR TITLE
BugFix: allow clicking on timeStamp region of TConsole to select whole line

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -482,6 +482,15 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen) co
 
     if (mShowTimeStamps) {
         TChar timeStampStyle(QColor(200, 150, 0), QColor(22, 22, 22));
+        if (!mpBuffer->buffer.at(lineNumber).empty()) {
+            const std::deque<TChar>& lineAttributes = mpBuffer->buffer.at(lineNumber);
+            std::size_t lastTCharIndex = lineAttributes.size() - 1;
+            if (lineAttributes.at(0).isSelected() || lineAttributes.at(lastTCharIndex).isSelected()) {
+                // Activate the "selection" flag if the first OR last character
+                // on a non-empty line has the selected flag set:
+                timeStampStyle.select();
+            }
+        }
         QString timestamp(mpBuffer->timeBuffer.at(lineNumber));
         for (const QChar c : timestamp) {
             cursor.setX(cursor.x() + drawGrapheme(painter, cursor, c, 0, timeStampStyle));

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1038,10 +1038,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
 
 // Returns the index into the relevant TBuffer::lineBuffer of the FIRST QChar
 // of the grapheme under the mouse - it ALSO returns zero (which will probably
-// NOT be a valid index) if there is no valid index to return; it might be
-// worth changing that to -1 but that will probably require revision to the
-// caller(s):
-int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber) const
+// NOT be a valid index) if there is no valid index to retur.
+// If a pointer to a boolean is provided as a third argument then it will
+// be set to true if the mouse is positioned over a visible time stamp
+// and left unchanged otherwise.
+int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOverTimeStamp) const
 {
     if (lineNumber >= 0 && lineNumber < mpBuffer->lineBuffer.size()) {
         // Line number is (should be) within range of lines in the
@@ -1074,6 +1075,17 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber) co
                 charWidth = getGraphemeWidth(unicode);
             }
             column +=charWidth;
+
+            // Do an additional check if we need to establish whether we are
+            // over just the timestamp part of the line:
+            if (Q_UNLIKELY(isOverTimeStamp && mShowTimeStamps && indexOfChar == 0)) {
+                if (mouseX < (mTimeStampWidth * mFontWidth)) {
+                    // The mouse position is actually over the timestamp region
+                    // to the left of the main text:
+                    *isOverTimeStamp = true;
+                }
+            }
+
             leftX = rightX;
             rightX = (mShowTimeStamps ? mTimeStampWidth + column : column) * mFontWidth;
             // debugText << QStringLiteral("[%1]%2[%3]").arg(QString::number(leftX), grapheme, QString::number(rightX - 1));
@@ -1135,14 +1147,25 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
     }
 
     if (event->button() == Qt::LeftButton) {
+        int y = (event->y() / mFontHeight) + imageTopLine();
+        int x = 0;
+        y = std::max(y, 0);
+
         if (event->modifiers() & Qt::ControlModifier) {
             mCtrlSelecting = true;
         }
 
-        int y = (event->y() / mFontHeight) + imageTopLine();
-        y = std::max(y, 0);
-
-        int x = convertMouseXToBufferX(event->x(), y);
+        if (!mCtrlSelecting && mShowTimeStamps) {
+            bool isOverTimeStamp = false;
+            x = convertMouseXToBufferX(event->x(), y, &isOverTimeStamp);
+            if (isOverTimeStamp) {
+                // If we have clicked on the timestamp then emulate the effect
+                // of control clicking - i.e. select the WHOLE line:
+                mCtrlSelecting = true;
+            }
+        } else {
+            x = convertMouseXToBufferX(event->x(), y);
+        }
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
             if (x < static_cast<int>(mpBuffer->buffer[y].size())) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -482,15 +482,6 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen) co
 
     if (mShowTimeStamps) {
         TChar timeStampStyle(QColor(200, 150, 0), QColor(22, 22, 22));
-        if (!mpBuffer->buffer.at(lineNumber).empty()) {
-            const std::deque<TChar>& lineAttributes = mpBuffer->buffer.at(lineNumber);
-            std::size_t lastTCharIndex = lineAttributes.size() - 1;
-            if (lineAttributes.at(0).isSelected() || lineAttributes.at(lastTCharIndex).isSelected()) {
-                // Activate the "selection" flag if the first OR last character
-                // on a non-empty line has the selected flag set:
-                timeStampStyle.select();
-            }
-        }
         QString timestamp(mpBuffer->timeBuffer.at(lineNumber));
         for (const QChar c : timestamp) {
             cursor.setX(cursor.x() + drawGrapheme(painter, cursor, c, 0, timeStampStyle));

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1029,7 +1029,7 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
 
 // Returns the index into the relevant TBuffer::lineBuffer of the FIRST QChar
 // of the grapheme under the mouse - it ALSO returns zero (which will probably
-// NOT be a valid index) if there is no valid index to retur.
+// NOT be a valid index) if there is no valid index to return.
 // If a pointer to a boolean is provided as a third argument then it will
 // be set to true if the mouse is positioned over a visible time stamp
 // and left unchanged otherwise.

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -130,7 +130,7 @@ private:
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;
-    int convertMouseXToBufferX(const int mouseX, const int lineNumber) const;
+    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOverTimeStamp = nullptr) const;
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
 


### PR DESCRIPTION
This commit should allow the timestamp region on the left of the display in a `TConsole` to appear as if it were selected when the first OR last character in the main text is selected. This is so that selection of one or more lines of text seem to also include the timestamps - as they will be if copied and pasted elsewhere.

This might be (at least part of) the solution to: https://github.com/Mudlet/Mudlet/issues/2978

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>