### PR TITLE
Fix: setBold, setItalics, etc now apply changes to selections when used on named miniconsoles.

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2093,6 +2093,7 @@ bool mudlet::setDisplayAttributes(Host* pHost, const QString& name, const TChar:
     if (pC) {
         // Set or reset all the specified attributes (but leave others unchanged)
         pC->mFormatCurrent.setAllDisplayAttributes((pC->mFormatCurrent.allDisplayAttributes() &~(attributes)) | (state ? attributes : TChar::None));
+        pC->buffer.applyAttribute(pC->P_begin, pC->P_end, attributes, state);
         return true;
     } else {
         return false;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Added code to update the display attributes of any selection as well, as the function setBold and others are intended to do.

#### Motivation for adding to Mudlet
setBold, setUnderline, etc were all claiming to update selections, but the function that was updating the formatting was NOT updating selected buffers, when it was being used on anything except for the "main" console.

#### Other info (issues closed, discussion etc)
