### PR TITLE
Enhance: Update consoles immediately when formatting is changed.

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2056,6 +2056,8 @@ std::tuple<bool, QString, int, int> TConsole::getSelection()
 void TConsole::setLink(const QStringList& linkFunction, const QStringList& linkHint)
 {
     buffer.applyLink(P_begin, P_end, linkFunction, linkHint);
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 // Set or Reset ALL the specified (but not others)
@@ -2063,28 +2065,38 @@ void TConsole::setDisplayAttributes(const TChar::AttributeFlags attributes, cons
 {
     mFormatCurrent.setAllDisplayAttributes((mFormatCurrent.allDisplayAttributes() & ~(attributes)) | (b ? attributes : TChar::None));
     buffer.applyAttribute(P_begin, P_end, attributes, b);
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 void TConsole::setFgColor(int r, int g, int b)
 {
     setFgColor(QColor(r, g, b));
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 void TConsole::setBgColor(int r, int g, int b)
 {
     setBgColor(QColor(r, g, b));
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 void TConsole::setBgColor(const QColor& newColor)
 {
     mFormatCurrent.setBackground(newColor);
     buffer.applyBgColor(P_begin, P_end, newColor);
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 void TConsole::setFgColor(const QColor& newColor)
 {
     mFormatCurrent.setForeground(newColor);
     buffer.applyFgColor(P_begin, P_end, newColor);
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 void TConsole::setScrollBarVisible(bool isVisible)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2077,6 +2077,8 @@ bool mudlet::setTextFormat(Host* pHost, const QString& name, const QColor& bgCol
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (pC) {
         pC->mFormatCurrent.setTextFormat(fgColor, bgColor, attributes);
+        pC->mUpperPane->forceUpdate();
+        pC->mLowerPane->forceUpdate();
         return true;
     } else {
         return false;
@@ -2093,6 +2095,8 @@ bool mudlet::setDisplayAttributes(Host* pHost, const QString& name, const TChar:
     if (pC) {
         // Set or reset all the specified attributes (but leave others unchanged)
         pC->mFormatCurrent.setAllDisplayAttributes((pC->mFormatCurrent.allDisplayAttributes() &~(attributes)) | (state ? attributes : TChar::None));
+        pC->mUpperPane->forceUpdate();
+        pC->mLowerPane->forceUpdate();
         return true;
     } else {
         return false;
@@ -2559,6 +2563,8 @@ void mudlet::setLink(Host* pHost, const QString& name, QStringList& linkFunction
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (pC) {
         pC->setLink(linkFunction, linkHint);
+        pC->mUpperPane->forceUpdate();
+        pC->mLowerPane->forceUpdate();
     }
 }
 
@@ -2571,6 +2577,8 @@ void mudlet::setFgColor(Host* pHost, const QString& name, int r, int g, int b)
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (pC) {
         pC->setFgColor(r, g, b);
+        pC->mUpperPane->forceUpdate();
+        pC->mLowerPane->forceUpdate();
     }
 }
 
@@ -2583,6 +2591,8 @@ void mudlet::setBgColor(Host* pHost, const QString& name, int r, int g, int b)
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (pC) {
         pC->setBgColor(r, g, b);
+        pC->mUpperPane->forceUpdate();
+        pC->mLowerPane->forceUpdate();
     }
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds manual updates to the functions that modify the formatting of a selection, so you don't need to add an extra `echo("")` or click on the buffer to get formatting changes to show.

#### Motivation for adding to Mudlet
If you're use `setBold`, `setFgColor`, or other similar selection format modifying functions, you then have to either click somewhere in the console, or `echo` to the console to update it, visually. This change causes these functions to update the console, because that's how it should work.

#### Other info (issues closed, discussion etc)
