### PR TITLE
Changed to accept any text entered as confirmation

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -556,8 +556,7 @@ void dlgConnectionProfiles::slot_addProfile()
 // enables the deletion button once the correct text (profile name) is entered
 void dlgConnectionProfiles::slot_deleteprofile_check(const QString& text)
 {
-    QString profile = profiles_tree_widget->currentItem()->text();
-    if (profile != text) {
+    if (text.isEmpty()) {
         delete_button->setDisabled(true);
     } else {
         delete_button->setEnabled(true);
@@ -591,8 +590,6 @@ void dlgConnectionProfiles::slot_deleteProfile()
         return;
     }
 
-    QString profile = profiles_tree_widget->currentItem()->text();
-
     QUiLoader loader;
 
     QFile file(QStringLiteral(":/ui/delete_profile_confirmation.ui"));
@@ -616,10 +613,10 @@ void dlgConnectionProfiles::slot_deleteProfile()
     connect(delete_profile_lineedit, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_deleteprofile_check);
     connect(delete_profile_dialog, &QDialog::accepted, this, &dlgConnectionProfiles::slot_reallyDeleteProfile);
 
-    delete_profile_lineedit->setPlaceholderText(profile);
+    delete_profile_lineedit->setPlaceholderText("Type Anything Here To Confirm");
     delete_profile_lineedit->setFocus();
     delete_button->setDisabled(true);
-    delete_profile_dialog->setWindowTitle(tr("Deleting '%1'").arg(profile));
+    delete_profile_dialog->setWindowTitle(tr("Deleting '%1'").arg(profiles_tree_widget->currentItem()->text()));
 
     delete_profile_dialog->show();
     delete_profile_dialog->raise();

--- a/src/ui/delete_profile_confirmation.ui
+++ b/src/ui/delete_profile_confirmation.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>389</width>
-    <height>180</height>
+    <height>196</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,7 +25,7 @@
      <property name="text">
       <string>Are you sure that you'd like to delete this profile? Everything (aliases, triggers, backups, etc) will be gone.
 
-If you are, please type in the profile name as a confirmation:</string>
+If you are, please type anything in the box below to confirm:</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adjusted UI to reflect change
delete_profile_confirmation will now accept any text entered into delete_profile_lineedit as confirmation of deletion of profile
#### Motivation for adding to Mudlet
Unless I'm way off-base here, the motivation behind "enter profile name" is to prevent accidental profile deletions, not to make deleting profiles difficult. This change accomplishes the task of preventing accidental removal, while also being fairly easy and straightforward.

Unless someone's cat walks across their laptop and happens to hit the mouse on 'remove profile', then a keyboard key, then hit the mouse again on 'delete', There is no more risk of accidental deletion by making the process simpler.
#### Other info (issues closed, discussion etc)
