### PR TITLE
Corrected a divide-by-zero error (fixes #3044)

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1649,7 +1649,7 @@ void dlgConnectionProfiles::fillout_form() {
     if (firstMudletLaunch) {
         // Select a random pre-defined profile to give all MUDs a fair go first time
         // make sure not to select the test_profile though
-        if (profiles_tree_widget->count() != 1) {
+        if (profiles_tree_widget->count() > 1) {
             while (toselectRow == -1 || toselectRow == test_profile_row) {
                 toselectRow = qrand() % profiles_tree_widget->count();
             }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1656,7 +1656,9 @@ void dlgConnectionProfiles::fillout_form() {
         }
     }
 
-    profiles_tree_widget->setCurrentRow(toselectRow);
+    if (toselectRow != -1) {
+        profiles_tree_widget->setCurrentRow(toselectRow);
+    }
 
     updateDiscordStatus();
 }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Changed comparison operator in dlgConnectionProfiles::fillout_form() to prevent a divide by zero exception when deleting all profiles. (Deleting default profiles on firstMudletLaunch)
#### Motivation for adding to Mudlet
Fixing crashbug.
#### Other info (issues closed, discussion etc)
Closes #3044 