### PR TITLE
Fix Mudlet 4.1 crash with getLastLineNumber("invalid console")

### DIFF
--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -39,7 +39,9 @@ TDebug::TDebug(const QColor& c, const QColor& d)
 TDebug& TDebug::operator>>(const int code)
 {
     Q_UNUSED(code);
-    mudlet::mpDebugConsole->print(msg, fgColor, bgColor);
+    if (mudlet::mpDebugConsole) {
+        mudlet::mpDebugConsole->print(msg, fgColor, bgColor);
+    }
     return *this;
 }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix error messages printed regardless if error console actually exists - which doesn't anymore until you open it :wink: 
#### Motivation for adding to Mudlet
Fix a crashing issue.
#### Other info (issues closed, discussion etc)
