### PR TITLE
Update generic_mapper.xml

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1931,7 +1931,14 @@ local function capture_move_cmd(dir,priority)
         end
     end
 end
+local function deduplicate_exits(exits)
+  local deduplicated_exits = {}
+  for _, v in ipairs(exits) do
+    deduplicated_exits[v] = true
+  end
 
+  return table.keys(deduplicated_exits)
+end
 local function capture_room_info(name, exits)
     -- captures room info, and tries to move map to match
     if (not vision_fail) and name and exits then
@@ -1952,6 +1959,8 @@ local function capture_room_info(name, exits)
                 table.insert(map.currentExits,w)
             end
         end
+	undupeExits = deduplicate_exits(map.currentExits)
+	map.set("currentExits", undupeExits)
         map.echo(string.format("Exits Captured: %s (%s)",exits, table.concat(map.currentExits, " ")),true)
         move_map()
     elseif vision_fail then


### PR DESCRIPTION
Handles duplicate exits

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
 Added function to remove duplicate exits from captured exits
Changed capture_room_info to make use of function
#### Motivation for adding to Mudlet
Mapper had no way to handle duplicate exits
#### Other info (issues closed, discussion etc)
