### PR TITLE
Remove grey area after error box in triggers

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -180,6 +180,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpSystemMessageArea = new dlgSystemMessageArea(this);
     mpSystemMessageArea->setObjectName(QStringLiteral("mpSystemMessageArea"));
     mpSystemMessageArea->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
+    // set the stretch factor of the message area to 0 and everything else to 1,
+    // so our errors box doesn't stretch to produce a grey area
     layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, mpSystemMessageArea, &QWidget::hide);
 
@@ -280,36 +282,12 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     splitter_right->addWidget(mpErrorConsole);
 
-//    layoutColumn->setStretchFactor(0, 0); // mpSystemMessageArea
-//    layoutColumn->setStretchFactor(1, 0); // mpTriggersMainArea
-//    layoutColumn->setStretchFactor(2, 0); // mpTimersMainArea
-//    layoutColumn->setStretchFactor(3, 0); // mpAliasMainArea
-//    layoutColumn->setStretchFactor(4, 0); // mpActionsMainArea
-//    layoutColumn->setStretchFactor(5, 0); // mpKeysMainArea
-//    layoutColumn->setStretchFactor(6, 0); // mpVarsMainArea
-//    layoutColumn->setStretchFactor(7, 1); // mpScriptsMainArea
-
     splitter_right->setStretchFactor(0, 1); // mpNonCodeWidgets
     splitter_right->setCollapsible(0, false);
     splitter_right->setStretchFactor(1, 1); // mpSourceEditorArea
     splitter_right->setCollapsible(1, false);
     splitter_right->setStretchFactor(2, 1); // mpErrorConsole
     splitter_right->setCollapsible(2, false);
-
-//    splitter_right->setStretchFactor(3, 1); // mpAliasMainArea
-//    splitter_right->setCollapsible(3, false);
-//    splitter_right->setStretchFactor(4, 1); // mpActionsMainArea
-//    splitter_right->setCollapsible(4, false);
-//    splitter_right->setStretchFactor(5, 1); // mpKeysMainArea
-//    splitter_right->setCollapsible(5, false);
-//    splitter_right->setStretchFactor(6, 1); // mpVarsMainArea
-//    splitter_right->setCollapsible(6, false);
-//    splitter_right->setStretchFactor(7, 1); // mpScriptsMainArea
-//    splitter_right->setCollapsible(7, false);
-//    splitter_right->setStretchFactor(8, 3); // mpSourceEditorArea
-//    splitter_right->setCollapsible(8, false);
-//    splitter_right->setStretchFactor(9, 1); // mpErrorConsole
-//    splitter_right->setCollapsible(9, false);
 
     mpErrorConsole->hide();
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -172,16 +172,20 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     setStatusBar(statusBar);
     statusBar->show();
 
+    mpNonCodeWidgets = new QWidget(this);
+    auto *layoutColumn = new QVBoxLayout(mpNonCodeWidgets);
+    splitter_right->addWidget(mpNonCodeWidgets);
+
     // system message area
     mpSystemMessageArea = new dlgSystemMessageArea(this);
     mpSystemMessageArea->setObjectName(QStringLiteral("mpSystemMessageArea"));
     mpSystemMessageArea->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
-    splitter_right->addWidget(mpSystemMessageArea);
+    layoutColumn->addWidget(mpSystemMessageArea);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, mpSystemMessageArea, &QWidget::hide);
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
-    splitter_right->addWidget(mpTriggersMainArea);
+    layoutColumn->addWidget(mpTriggersMainArea);
     connect(mpTriggersMainArea->pushButtonFgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorizeTriggerSetFgColor);
     connect(mpTriggersMainArea->pushButtonBgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorizeTriggerSetBgColor);
     connect(mpTriggersMainArea->pushButtonSound, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_soundTrigger);
@@ -189,24 +193,24 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpTriggersMainArea->toolButton_clearSoundFile, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_clearSoundFile);
 
     mpTimersMainArea = new dlgTimersMainArea(this);
-    splitter_right->addWidget(mpTimersMainArea);
+    layoutColumn->addWidget(mpTimersMainArea);
 
     mpAliasMainArea = new dlgAliasMainArea(this);
-    splitter_right->addWidget(mpAliasMainArea);
+    layoutColumn->addWidget(mpAliasMainArea);
 
     mpActionsMainArea = new dlgActionMainArea(this);
-    splitter_right->addWidget(mpActionsMainArea);
+    layoutColumn->addWidget(mpActionsMainArea);
     connect(mpActionsMainArea->checkBox_action_button_isPushDown, &QCheckBox::stateChanged, this, &dlgTriggerEditor::slot_toggle_isPushDownButton);
 
     mpKeysMainArea = new dlgKeysMainArea(this);
-    splitter_right->addWidget(mpKeysMainArea);
+    layoutColumn->addWidget(mpKeysMainArea);
     connect(mpKeysMainArea->pushButton_key_grabKey, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_key_grab);
 
     mpVarsMainArea = new dlgVarsMainArea(this);
-    splitter_right->addWidget(mpVarsMainArea);
+    layoutColumn->addWidget(mpVarsMainArea);
 
     mpScriptsMainArea = new dlgScriptsMainArea(this);
-    splitter_right->addWidget(mpScriptsMainArea);
+    layoutColumn->addWidget(mpScriptsMainArea);
 
     mIsScriptsMainAreaEditHandler = false;
     mpScriptsMainAreaEditHandlerItem = nullptr;
@@ -276,26 +280,26 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     splitter_right->addWidget(mpErrorConsole);
 
-    splitter_right->setStretchFactor(0, 0); // mpSystemMessageArea
+    splitter_right->setStretchFactor(0, 1); // mpSystemMessageArea
     splitter_right->setCollapsible(0, false);
     splitter_right->setStretchFactor(1, 1); // mpTriggersMainArea
     splitter_right->setCollapsible(1, false);
     splitter_right->setStretchFactor(2, 1); // mpTimersMainArea
     splitter_right->setCollapsible(2, false);
-    splitter_right->setStretchFactor(3, 1); // mpAliasMainArea
-    splitter_right->setCollapsible(3, false);
-    splitter_right->setStretchFactor(4, 1); // mpActionsMainArea
-    splitter_right->setCollapsible(4, false);
-    splitter_right->setStretchFactor(5, 1); // mpKeysMainArea
-    splitter_right->setCollapsible(5, false);
-    splitter_right->setStretchFactor(6, 1); // mpVarsMainArea
-    splitter_right->setCollapsible(6, false);
-    splitter_right->setStretchFactor(7, 1); // mpScriptsMainArea
-    splitter_right->setCollapsible(7, false);
-    splitter_right->setStretchFactor(8, 3); // mpSourceEditorArea
-    splitter_right->setCollapsible(8, false);
-    splitter_right->setStretchFactor(9, 1); // mpErrorConsole
-    splitter_right->setCollapsible(9, false);
+//    splitter_right->setStretchFactor(3, 1); // mpAliasMainArea
+//    splitter_right->setCollapsible(3, false);
+//    splitter_right->setStretchFactor(4, 1); // mpActionsMainArea
+//    splitter_right->setCollapsible(4, false);
+//    splitter_right->setStretchFactor(5, 1); // mpKeysMainArea
+//    splitter_right->setCollapsible(5, false);
+//    splitter_right->setStretchFactor(6, 1); // mpVarsMainArea
+//    splitter_right->setCollapsible(6, false);
+//    splitter_right->setStretchFactor(7, 1); // mpScriptsMainArea
+//    splitter_right->setCollapsible(7, false);
+//    splitter_right->setStretchFactor(8, 3); // mpSourceEditorArea
+//    splitter_right->setCollapsible(8, false);
+//    splitter_right->setStretchFactor(9, 1); // mpErrorConsole
+//    splitter_right->setCollapsible(9, false);
 
     mpErrorConsole->hide();
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -180,12 +180,12 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpSystemMessageArea = new dlgSystemMessageArea(this);
     mpSystemMessageArea->setObjectName(QStringLiteral("mpSystemMessageArea"));
     mpSystemMessageArea->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
-    layoutColumn->addWidget(mpSystemMessageArea);
+    layoutColumn->addWidget(mpSystemMessageArea, 0);
     connect(mpSystemMessageArea->messageAreaCloseButton, &QAbstractButton::clicked, mpSystemMessageArea, &QWidget::hide);
 
     // main areas
     mpTriggersMainArea = new dlgTriggersMainArea(this);
-    layoutColumn->addWidget(mpTriggersMainArea);
+    layoutColumn->addWidget(mpTriggersMainArea, 1);
     connect(mpTriggersMainArea->pushButtonFgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorizeTriggerSetFgColor);
     connect(mpTriggersMainArea->pushButtonBgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_colorizeTriggerSetBgColor);
     connect(mpTriggersMainArea->pushButtonSound, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_soundTrigger);
@@ -193,24 +193,24 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpTriggersMainArea->toolButton_clearSoundFile, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_clearSoundFile);
 
     mpTimersMainArea = new dlgTimersMainArea(this);
-    layoutColumn->addWidget(mpTimersMainArea);
+    layoutColumn->addWidget(mpTimersMainArea, 1);
 
     mpAliasMainArea = new dlgAliasMainArea(this);
-    layoutColumn->addWidget(mpAliasMainArea);
+    layoutColumn->addWidget(mpAliasMainArea, 1);
 
     mpActionsMainArea = new dlgActionMainArea(this);
-    layoutColumn->addWidget(mpActionsMainArea);
+    layoutColumn->addWidget(mpActionsMainArea, 1);
     connect(mpActionsMainArea->checkBox_action_button_isPushDown, &QCheckBox::stateChanged, this, &dlgTriggerEditor::slot_toggle_isPushDownButton);
 
     mpKeysMainArea = new dlgKeysMainArea(this);
-    layoutColumn->addWidget(mpKeysMainArea);
+    layoutColumn->addWidget(mpKeysMainArea, 1);
     connect(mpKeysMainArea->pushButton_key_grabKey, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_key_grab);
 
     mpVarsMainArea = new dlgVarsMainArea(this);
-    layoutColumn->addWidget(mpVarsMainArea);
+    layoutColumn->addWidget(mpVarsMainArea, 1);
 
     mpScriptsMainArea = new dlgScriptsMainArea(this);
-    layoutColumn->addWidget(mpScriptsMainArea);
+    layoutColumn->addWidget(mpScriptsMainArea, 1);
 
     mIsScriptsMainAreaEditHandler = false;
     mpScriptsMainAreaEditHandlerItem = nullptr;
@@ -280,12 +280,22 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     splitter_right->addWidget(mpErrorConsole);
 
-    splitter_right->setStretchFactor(0, 1); // mpSystemMessageArea
+//    layoutColumn->setStretchFactor(0, 0); // mpSystemMessageArea
+//    layoutColumn->setStretchFactor(1, 0); // mpTriggersMainArea
+//    layoutColumn->setStretchFactor(2, 0); // mpTimersMainArea
+//    layoutColumn->setStretchFactor(3, 0); // mpAliasMainArea
+//    layoutColumn->setStretchFactor(4, 0); // mpActionsMainArea
+//    layoutColumn->setStretchFactor(5, 0); // mpKeysMainArea
+//    layoutColumn->setStretchFactor(6, 0); // mpVarsMainArea
+//    layoutColumn->setStretchFactor(7, 1); // mpScriptsMainArea
+
+    splitter_right->setStretchFactor(0, 1); // mpNonCodeWidgets
     splitter_right->setCollapsible(0, false);
-    splitter_right->setStretchFactor(1, 1); // mpTriggersMainArea
+    splitter_right->setStretchFactor(1, 1); // mpSourceEditorArea
     splitter_right->setCollapsible(1, false);
-    splitter_right->setStretchFactor(2, 1); // mpTimersMainArea
+    splitter_right->setStretchFactor(2, 1); // mpErrorConsole
     splitter_right->setCollapsible(2, false);
+
 //    splitter_right->setStretchFactor(3, 1); // mpAliasMainArea
 //    splitter_right->setCollapsible(3, false);
 //    splitter_right->setStretchFactor(4, 1); // mpActionsMainArea

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -427,6 +427,9 @@ private:
 
     QScrollArea* mpScrollArea;
     QWidget* HpatternList;
+    // this widget holds the errors, trigger patterns, and all other widgets that aren't edbee
+    // in it, as a workaround for an extra splitter getting created by Qt below the error msg otherwise
+    QWidget *mpNonCodeWidgets;
     dlgTriggersMainArea* mpTriggersMainArea;
     dlgTimersMainArea* mpTimersMainArea;
     dlgSystemMessageArea* mpSystemMessageArea;

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>

--- a/src/ui/system_message_area.ui
+++ b/src/ui/system_message_area.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -10,6 +10,12 @@
     <height>270</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <layout class="QGridLayout" name="gridLayout_triggers_main_area" rowstretch="0,1" columnstretch="1,0">
    <property name="leftMargin">
     <number>0</number>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix the grey area in the triggers section.
#### Motivation for adding to Mudlet
The feedback on it is that it's pretty annoying and a waste of space - which it is!
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/2631.

Note that the change that added the splitter also added the grey area to the aliases and keys sections - I'll fix that in follow-up PRs after this one is done. Better to do it one at a time.

Thanks to Thorbjørn Lindeijer of [Tiled](https://www.mapeditor.org/) for giving the stretching hint.