### PR TITLE
Give a bit of comfort to 'clear moves' in generic mapper

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -2241,8 +2241,9 @@ function map.stop_mapping()
 end
 
 function map.clear_moves()
+    local commands_in_queue = #move_queue
     move_queue = {}
-    map.echo("Move queue cleared.")
+    map.echo("Move queue cleared, "..commands_in_queue.." commands removed.")
 end
 
 function map.set_area(name)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
When you do 'clear moves' right now you don't know if you had any clogged up or not... now you do.
#### Motivation for adding to Mudlet
Better player experience.
#### Other info (issues closed, discussion etc)
