### PR TITLE
Geyser Gauge echo and message constraint improvements.

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -85,10 +85,8 @@ end
 
 --- Sets the text on the gauge, overwrites inherited echo function.
 -- @param text The text to set.
-function Geyser.Gauge:echo (text)
-  if text then
-    self.text:echo(text)
-  end
+function Geyser.Gauge:echo(message, color, format)
+  self.text:echo(message, color, format)
 end
 
 -- Sets the style sheet for the gauge
@@ -137,17 +135,20 @@ function Geyser.Gauge:new (cons, container)
   -- Now create the Gauge using primitives and tastey classes
 
   -- Set up the constraints for the front label, the label that changes size to
-  -- indicated levels in the gauges.
+  -- indicated levels in the gauges. Message set to nil to avoid unwanted text
   local front = Geyser.copyTable(cons)
   front.name = me.name .. "_front"
   front.color = me.color
+  front.message = nil
   front.x, front.y, front.width, front.height = 0, 0, "100%", "100%"
 
   -- Set up the constraints for the back label, which is always the size of the gauge.
+  -- Message set to nil to avoid unwanted text
   local back = Geyser.copyTable(front)
   back.name = me.name .. "_back"
   local br, bg, bb = Geyser.Color.parse(me.color)
   back.color = Geyser.Color.hexa(br, bg, bb, 100)
+  back.message = nil
 
   -- Set up the constraints for the text label, which is also always the size of the gauge.
   -- We also set this label's color to 0,0,0,0 so it's black and full transparent.
@@ -168,6 +169,9 @@ function Geyser.Gauge:new (cons, container)
 
   -- Set clickthrough if included in constructor
   if cons.clickthrough then me:enableClickthrough() end
+
+  -- Echo text to the text label if 'message' constraint is set
+  if cons.message then me:echo(me.message) end
   
   --print("  New in " .. self.name .. " : " .. me.name)
   return me


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This changes Geyser.Gauge:echo() to pass along all arguments to the text label of the Gauge, so you can format your text, color it, etc the same way you would a normal Geyser Label.
It also causes it to respect the 'message' constraint the same way Geyser.Label does, by echoing it out to the text label.
#### Motivation for adding to Mudlet
Someone mentioned it wasn't working in the Mudlet discord, and I thought it made the most sense to give the normal label echo functionality to the gauges, and allow setting a message on instantiation.
#### Other info (issues closed, discussion etc)
Handles https://github.com/Mudlet/Mudlet/issues/3077