### PR TITLE
Make flash label clickthrough so it doesn't prevent callbacks

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -233,9 +233,7 @@ function Geyser.Container:flash (time)
   resizeWindow(name, width, height)
   moveWindow(name, x, y)
   setBackgroundColor(name, 190, 190, 190, 128)
-  if self.clickCallback then
-    setLabelClickCallback(name, self.clickCallback, unpack(self.clickArgs))
-  end
+  enableClickthrough(name)
   showWindow(name)
   tempTimer(time, "hideWindow(\"" .. name .. "\")")
 end

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -233,8 +233,8 @@ function Geyser.Container:flash (time)
   resizeWindow(name, width, height)
   moveWindow(name, x, y)
   setBackgroundColor(name, 190, 190, 190, 128)
-  if self.callback then
-    setLabelClickCallback(name, self.callback, unpack(self.args))
+  if self.clickCallback then
+    setLabelClickCallback(name, self.clickCallback, unpack(self.clickArgs))
   end
   showWindow(name)
   tempTimer(time, "hideWindow(\"" .. name .. "\")")


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
The flash() function was checking for the wrong field to see if it needed to set a click callback during the flash. Since we have double click callbacks, right click callbacks etc now, I opted to instead enable clickthrough on the label created by flash()
#### Motivation for adding to Mudlet
Was keeping me from clicking through to the tab on EMCO.
#### Other info (issues closed, discussion etc)
