### PR TITLE
Clarify 'room not found' in generic mapper

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -2400,9 +2400,9 @@ function map.find_me(name, exits, dir, manual)
         find_portal = false
     elseif table.is_empty(match_IDs) then
         if not manual then
-            map.echo("Room not found", true, true)
+            map.echo("Room not found in map database", true, true)
         else
-            map.echo("Room not found", false, true)
+            map.echo("Room not found in map database", false, true)
         end
     end
 end


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
You start the generic mapper script for the first time, turn on `map debug`, start walking around and see this:

![image](https://user-images.githubusercontent.com/110988/64903832-b9c0dc80-d6c0-11e9-9dca-a0af9839e708.png)

Why isn't it found... ? The room name and exits are detected fine.

What the script is really trying to say:

![image](https://user-images.githubusercontent.com/110988/64903861-1de3a080-d6c1-11e9-87c3-b6cc4fadc31b.png)

Because my map database is empty. Now it makes more sense :)
#### Motivation for adding to Mudlet
More intuitive mapper.
#### Other info (issues closed, discussion etc)
