### PR TITLE
Render the default room colour as a more pleasing blue

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -940,7 +940,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
             roomEnvironment = mpMap->envColors[roomEnvironment];
         } else {
             if (!mpMap->customEnvColors.contains(roomEnvironment)) {
-                roomEnvironment = 1;
+                roomColor = QColor(0, 164, 204, 255);
             }
         }
         switch (roomEnvironment) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
A less ugly default for rooms without a known environment? A calm blue.

The generic mapper doesn't pick up environments so all rooms are red, and it's not a very appealing red.

![image](https://user-images.githubusercontent.com/110988/64910102-79d71500-d713-11e9-9f7a-0ab9abbe759e.png)

#### Motivation for adding to Mudlet
Better first time player experience.
#### Other info (issues closed, discussion etc)
