### PR TITLE
Bring table.is_empty() error message up to standard

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -21,13 +21,7 @@ if not string.trim then
   require "StringUtils"
 end
 
--- TODO those funciton are already definde elsewhere
--- Tests if a table is empty: this is useful in situations where you find
--- yourself wanting to do 'if my_table == {}' and such.
-function table.is_empty(tbl)
-  return next(tbl) == nil
-end
-
+-- TODO those functions are already definde elsewhere
 function string.starts(String, Start)
   return string.sub(String, 1, string.len(Start)) == Start
 end

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -14,9 +14,8 @@
 ---   end
 ---   </pre>
 function table.is_empty(tbl)
-  if next(tbl) == nil then
-    return true else return false
-  end
+  assert(type(tbl) == "table", string.format("bad argument #1 type (table expected, got %s!)", type(currentValue)))
+  return next(tbl) == nil
 end
 
 -- The filter() method creates a new table with all elements that pass the test


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Bring table.is_empty() error message up to standard, and remove the duplicate definition.
#### Motivation for adding to Mudlet
Fix this really confusing error message you can see even though the are 0 databases involved:

```
DB.lua:28: bad argument #1 to 'next' (table expected, got nil)
```
