### PR TITLE
Allow GUI.Client, Client.Map URLs to follow redirects

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10464,7 +10464,7 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    setRequestDefaults(url, request);
+    mudlet::self()->setNetworkRequestDefaults(url, request);
 
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
@@ -14747,7 +14747,7 @@ int TLuaInterpreter::putHTTP(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    setRequestDefaults(url, request);
+    mudlet::self()->setNetworkRequestDefaults(url, request);
 
     if (!lua_istable(L, 3) && !lua_isnoneornil(L, 3)) {
         lua_pushfstring(L, "putHTTP: bad argument #3 type (headers as a table expected, got %s!)", luaL_typename(L, 3));
@@ -14804,19 +14804,6 @@ int TLuaInterpreter::putHTTP(lua_State* L)
     return 2;
 }
 
-void TLuaInterpreter::setRequestDefaults(const QUrl& url, QNetworkRequest& request)
-{
-    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
-
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-#ifndef QT_NO_SSL
-    if (url.scheme() == QStringLiteral("https")) {
-        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
-        request.setSslConfiguration(config);
-    }
-#endif
-}
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#postHTTP
 int TLuaInterpreter::postHTTP(lua_State* L)
 {
@@ -14850,7 +14837,7 @@ int TLuaInterpreter::postHTTP(lua_State* L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    setRequestDefaults(url, request);
+    mudlet::self()->setNetworkRequestDefaults(url, request);
 
     if (!lua_istable(L, 3) && !lua_isnoneornil(L, 3)) {
         lua_pushfstring(L, "postHTTP: bad argument #3 type (headers as a table expected, got %s!)", luaL_typename(L, 3));
@@ -14931,7 +14918,7 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    setRequestDefaults(url, request);
+    mudlet::self()->setNetworkRequestDefaults(url, request);
 
     if (!lua_istable(L, 2) && !lua_isnoneornil(L, 2)) {
         lua_pushfstring(L, "postHTTP: bad argument #2 type (headers as a table expected, got %s!)", luaL_typename(L, 2));

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2179,18 +2179,8 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     QNetworkRequest request = QNetworkRequest(url);
-    // This should prevent similar problems to those mentioned in:
-    // https://bugs.launchpad.net/mudlet/+bug/1366781 although the fix for THAT
-    // is elsewhere and is to be inserted separately to the changeset that
-    // placed this code here:
-    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-
-#ifndef QT_NO_SSL
-    if (url.scheme() == QStringLiteral("https")) {
-        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
-        request.setSslConfiguration(config);
-    }
-#endif
+    pHost->updateProxySettings(mpNetworkAccessManager);
+    mudlet::self()->setNetworkRequestDefaults(url, request);
 
     mExpectedFileSize = 4000000;
 
@@ -2199,9 +2189,7 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     qApp->processEvents();
     // Attempts to ensure INFO message gets shown before download is initiated!
 
-    pHost->updateProxySettings(mpNetworkAccessManager);
-    mudlet::self()->setNetworkRequestDefaults(url, request);
-    mpNetworkReply = mpNetworkAccessManager->get(QNetworkRequest(url));
+    mpNetworkReply = mpNetworkAccessManager->get(request);
     // Using zero for both min and max values should cause the bar to oscillate
     // until the first update
     mpProgressDialog = new QProgressDialog(tr("Downloading XML map file for use in %1...",

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2200,7 +2200,8 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     // Attempts to ensure INFO message gets shown before download is initiated!
 
     pHost->updateProxySettings(mpNetworkAccessManager);
-    mpNetworkReply = mpNetworkAccessManager->get(QNetworkRequest(QUrl(url)));
+    mudlet::self()->setNetworkRequestDefaults(url, request);
+    mpNetworkReply = mpNetworkAccessManager->get(QNetworkRequest(url));
     // Using zero for both min and max values should cause the bar to oscillate
     // until the first update
     mpProgressDialog = new QProgressDialog(tr("Downloading XML map file for use in %1...",

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1408,7 +1408,9 @@ void cTelnet::processTelnetCommand(const std::string& command)
 
                 mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mProfileName, fileName);
                 mpHost->updateProxySettings(mpDownloader);
-                QNetworkReply* reply = mpDownloader->get(QNetworkRequest(QUrl(url)));
+                auto request = QNetworkRequest(QUrl(url));
+                mudlet::self()->setNetworkRequestDefaults(url, request);
+                QNetworkReply* reply = mpDownloader->get(request);
                 mpProgressDialog = new QProgressDialog(tr("downloading game GUI from server"), tr("Cancel", "Cancel download of GUI package from Server"), 0, 4000000, mpHost->mpConsole);
                 connect(reply, &QNetworkReply::downloadProgress, this, &cTelnet::setDownloadProgress);
                 mpProgressDialog->show();
@@ -1757,7 +1759,9 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
 
         mServerPackage = mudlet::getMudletPath(mudlet::profileDataItemPath, mProfileName, fileName);
         mpHost->updateProxySettings(mpDownloader);
-        QNetworkReply* reply = mpDownloader->get(QNetworkRequest(QUrl(url)));
+        auto request = QNetworkRequest(QUrl(url));
+        mudlet::self()->setNetworkRequestDefaults(url, request);
+        QNetworkReply* reply = mpDownloader->get(request);
         mpProgressDialog = new QProgressDialog(tr("downloading game GUI from server"), tr("Cancel", "Cancel download of GUI package from Server"), 0, 4000000, mpHost->mpConsole);
         connect(reply, &QNetworkReply::downloadProgress, this, &cTelnet::setDownloadProgress);
         mpProgressDialog->show();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5363,3 +5363,17 @@ void mudlet::sanitizeUtf8Path(QString& originalLocation, const QString& fileName
     }
 }
 #endif
+
+// Enable redirects and HTTPS support for a given url
+void mudlet::setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request)
+{
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
+    request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
+#ifndef QT_NO_SSL
+    if (url.scheme() == QStringLiteral("https")) {
+        QSslConfiguration config(QSslConfiguration::defaultConfiguration());
+        request.setSslConfiguration(config);
+    }
+#endif
+}

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -383,6 +383,7 @@ public:
     QPair<bool, QStringList> getLines(Host* pHost, const QString& windowName, const int lineFrom, const int lineTo);
     void setEnableFullScreenMode(const bool);
     void migratePasswordsToSecureStorage();
+    static void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
 
     // Both of these revises the contents of the .aff file: the first will
     // handle a .dic file that has been updated externally/manually (to add


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Allow GUI.Client URLs to follow redirects
#### Motivation for adding to Mudlet
So games' http to https redirects work.
#### Other info (issues closed, discussion etc)
Moved the common request to enable redirects into `mudlet.cpp` for re-usability.