### PR TITLE
Load Mudlet maps from Client.Map as well

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2380,6 +2380,27 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
                 file.flush();
                 file.close();
 
+                if (file.fileName().endsWith(QStringLiteral("xml"), Qt::CaseInsensitive)) {
+                    auto pHost = mpHost;
+                    if (!pHost) {
+                        return;
+                    }
+
+                    QString infoMsg = tr("[ INFO ]  - ... map downloaded and stored, now parsing it...");
+                    postMessage(infoMsg);
+                    if (pHost->mpConsole->loadMap(file.fileName())) {
+                        TEvent mapDownloadEvent {};
+                        mapDownloadEvent.mArgumentList.append(QLatin1String("sysMapDownloadEvent"));
+                        mapDownloadEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                        pHost->raiseEvent(mapDownloadEvent);
+                    } else {
+                        QString alertMsg = tr("[ ERROR ] - Map download problem, failure in parsing destination file:\n%1.").arg(file.fileName());
+                        postMessage(alertMsg);
+                    }
+
+                    return;
+                }
+
                 if (file.open(QFile::ReadOnly | QFile::Text)) {
                     QString infoMsg = tr("[ INFO ]  - ... map downloaded and stored, now parsing it...");
                     postMessage(infoMsg);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2398,7 +2398,7 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
                 file.flush();
                 file.close();
 
-                if (file.fileName().endsWith(QStringLiteral("xml"), Qt::CaseInsensitive)) {
+                if (!file.fileName().endsWith(QStringLiteral("xml"), Qt::CaseInsensitive)) {
                     auto pHost = mpHost;
                     if (!pHost) {
                         cleanup();

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2173,7 +2173,11 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     }
 
     if (localFileName.isEmpty()) {
-        mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, mProfileName);
+        if (url.toString().endsWith(QLatin1String("xml"))) {
+            mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, mProfileName);
+        } else {
+            mLocalMapFileName = mudlet::getMudletPath(mudlet::profileMapPathFileName, mProfileName, QStringLiteral("map.dat"));
+        }
     } else {
         mLocalMapFileName = localFileName;
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2432,7 +2432,6 @@ void TMap::slot_replyFinished(QNetworkReply* reply)
                     Host* pHost = mpHost;
                     if (!pHost) {
                         qWarning() << "TMap::slot_replyFinished( QNetworkReply * ) ERROR - NULL Host pointer - something is really wrong!";
-                        mXmlImportMutex.unlock();
                         cleanup();
                         return;
                     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -326,8 +326,8 @@ public:
         // Takes two extra arguments (profile name, mapFileName) that returns
         // the pathFile name for any map file:
         profileMapPathFileName,
-        // Takes one extra argument (profile name) that returns the pathFile
-        // name for the downloaded IRE Server provided XML map:
+        // Takes one extra argument (profile name) that returns the file
+        // location for the downloaded MMP map:
         profileXmlMapPathFileName,
         // Takes two extra arguments (profile name, data item) that gives a
         // path file name for, typically a data item stored as a single item


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Load Mudlet maps from Client.Map as well
#### Motivation for adding to Mudlet
People expect to be able to export a Mudlet map and load it via `Client.Map`
#### Other info (issues closed, discussion etc)
We need a MUD server on `mudlet.org` so we can test these things ourselves.

Also fixed a bug that in the case the Host was unavailable, the reply would not be properly disposed of... though I've yet to see a case where the Host wasn't available.