### PR TITLE
Add getConnectionInfo()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14968,6 +14968,8 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
     return 2;
 }
 
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getConnectionInfo
 int TLuaInterpreter::getConnectionInfo(lua_State *L)
 {
     Host& host = getHostFromLua(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14968,6 +14968,16 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
     return 2;
 }
 
+int TLuaInterpreter::getConnectionInfo(lua_State *L)
+{
+    Host& host = getHostFromLua(L);
+
+    auto [hostName, hostPort] = host.mTelnet.getConnectionInfo();
+    lua_pushstring(L, hostName.toUtf8().constData());
+    lua_pushnumber(L, hostPort);
+    return 2;
+}
+
 // No documentation available in wiki - internal function
 void TLuaInterpreter::set_lua_table(const QString& tableName, QStringList& variableList)
 {
@@ -15494,6 +15504,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "putHTTP", TLuaInterpreter::putHTTP);
     lua_register(pGlobalLua, "postHTTP", TLuaInterpreter::postHTTP);
     lua_register(pGlobalLua, "deleteHTTP", TLuaInterpreter::deleteHTTP);
+    lua_register(pGlobalLua, "getConnectionInfo", TLuaInterpreter::getConnectionInfo);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -512,6 +512,7 @@ public:
     static int putHTTP(lua_State* L);
     static int postHTTP(lua_State* L);
     static int deleteHTTP(lua_State* L);
+    static int getConnectionInfo(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -870,6 +870,15 @@ QString cTelnet::decodeOption(const unsigned char ch) const
     }
 }
 
+std::pair<QString, int> cTelnet::getConnectionInfo() const
+{
+    if (hostName.isEmpty() && hostPort == 0) {
+        return {mpHost->getUrl(), mpHost->getPort()};
+    } else {
+        return {hostName, hostPort};
+    }
+}
+
 void cTelnet::processTelnetCommand(const std::string& command)
 {
     char ch = command[1];

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -175,6 +175,7 @@ public:
     void requestDiscordInfo();
     QString decodeOption(const unsigned char) const;
     QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
+    std::pair<QString, int> getConnectionInfo() const;
 
 
     QMap<int, bool> supportedTelnetOptions;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add getConnectionInfo()
#### Motivation for adding to Mudlet
So game-specific tweaks can be applied out of the box, and scripts don't have to trigger on login screens and etc to know what game you're playing.
#### Other info (issues closed, discussion etc)
This isn't enough to know what game you're playing, but it's a start. Perhaps we could have some Lua-side functions that come with a mapping of hostnames and IPs to the game name?