### PR TITLE
Remove Discord game deduction warning

### DIFF
--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -463,8 +463,6 @@ QString Discord::deduceGameName(const QString& address)
             break;
         }
     }
-        qDebug().noquote().noquote() << "Discord::deduceGameName(\"" << address << "\") WARN - Unable to deduce MUD name from given address - even after discarding last element to consider just: \""
-                                     << otherName << "\".";
         otherName.clear();
         break;
     case 1:


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove Discord game deduction warning
#### Motivation for adding to Mudlet
We're seeing it all the time and... there's nothing to do about it? It's not adding value.
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/2813.