### PR TITLE
Add missing newline in --version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,7 +211,7 @@ int main(int argc, char* argv[])
         texts << QCoreApplication::translate("main", "Copyright © 2008-%1  Mudlet developers\n").arg(QStringLiteral(__DATE__).mid(7, 4));
         texts << QCoreApplication::translate("main", "Licence GPLv2+: GNU GPL version 2 or later - http://gnu.org/licenses/gpl.html\n");
         texts << QCoreApplication::translate("main", "This is free software: you are free to change and redistribute it.\n"
-                                                     "There is NO WARRANTY, to the extent permitted by law.");
+                                                     "There is NO WARRANTY, to the extent permitted by law.\n");
         std::cout << texts.join(QString()).toStdString();
         return 0;
     } else if (startupAction & 1) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add missing newline in `--version` command line flag..
#### Motivation for adding to Mudlet
Fix this output:

```
$ ./Mudlet.AppImage --vaaaarsion
mudlet 4.1.2 
Qt libraries 5.12.3 (compilation) 5.12.3 (runtime)
Copyright © 2008-2019  Mudlet developers
Licence GPLv2+: GNU GPL version 2 or later - http://gnu.org/licenses/gpl.html
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.vadi@volga:~/Programs/Mudlet$ 
```
#### Other info (issues closed, discussion etc)
