### PR TITLE
Fix macOS compilation

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -50,6 +50,7 @@ for i in $BREWS; do
     fi
   done
 done
+gem install concurrent-ruby
 gem update cocoapods
 
 # create an alias to avoid the need to list the lua dir all the time


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Cocoapods added a new dependency of concurrent-ruby which the gem does not install yet. It should be added in a soon to be published future version, but until then, we'll need to manually install it.

#### Motivation for adding to Mudlet
Fix macOS compilation.

#### Other info (issues closed, discussion etc)
