### PR TITLE
BugFix ameliorate Qt changes to binary formats for QDataStream

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1298,6 +1298,9 @@ QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& 
     QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, getName(), item));
     if (file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
         QDataStream ofs(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ofs.setVersion(18);
+        }
         ofs << what;
         file.close();
     }
@@ -1317,6 +1320,9 @@ QString Host::readProfileData(const QString& item)
     QString ret;
     if (success) {
         QDataStream ifs(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ifs.setVersion(18);
+        }
         ifs >> ret;
         file.close();
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1299,7 +1299,7 @@ QPair<bool, QString> Host::writeProfileData(const QString& item, const QString& 
     if (file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
         QDataStream ofs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ofs.setVersion(18);
+            ofs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ofs << what;
         file.close();
@@ -1321,7 +1321,7 @@ QString Host::readProfileData(const QString& item)
     if (success) {
         QDataStream ifs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ifs.setVersion(18);
+            ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ifs >> ret;
         file.close();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -787,6 +787,9 @@ void TConsole::closeEvent(QCloseEvent* event)
             QFile file_map(filename_map);
             if (file_map.open(QIODevice::WriteOnly)) {
                 QDataStream out(&file_map);
+                if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+                    out.setVersion(18);
+                }
                 mpHost->mpMap->serialize(out);
                 file_map.close();
             }
@@ -823,6 +826,9 @@ void TConsole::closeEvent(QCloseEvent* event)
                 QFile file_map(filename_map);
                 if (file_map.open(QIODevice::WriteOnly)) {
                     QDataStream out(&file_map);
+                    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+                        out.setVersion(18);
+                    }
                     mpHost->mpMap->serialize(out);
                     file_map.close();
                 }
@@ -1090,6 +1096,9 @@ void TConsole::slot_toggleReplayRecording()
         }
         mReplayFile.setFileName(mLogFileName);
         mReplayFile.open(QIODevice::WriteOnly);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            mReplayStream.setVersion(QDataStream::Qt_5_12);
+        }
         mReplayStream.setDevice(&mReplayFile);
         mpHost->mTelnet.recordReplay();
         QString message = QString("Replay recording has started. File: ") + mReplayFile.fileName() + "\n";
@@ -1543,6 +1552,9 @@ bool TConsole::saveMap(const QString& location, int saveVersion)
     QFile file_map(filename_map);
     if (file_map.open(QIODevice::WriteOnly)) {
         QDataStream out(&file_map);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            out.setVersion(18);
+        }
         mpHost->mpMap->serialize(out, saveVersion);
         file_map.close();
     } else {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -788,7 +788,7 @@ void TConsole::closeEvent(QCloseEvent* event)
             if (file_map.open(QIODevice::WriteOnly)) {
                 QDataStream out(&file_map);
                 if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-                    out.setVersion(18);
+                    out.setVersion(mudlet::scmQDataStreamFormat_5_12);
                 }
                 mpHost->mpMap->serialize(out);
                 file_map.close();
@@ -827,7 +827,7 @@ void TConsole::closeEvent(QCloseEvent* event)
                 if (file_map.open(QIODevice::WriteOnly)) {
                     QDataStream out(&file_map);
                     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-                        out.setVersion(18);
+                        out.setVersion(mudlet::scmQDataStreamFormat_5_12);
                     }
                     mpHost->mpMap->serialize(out);
                     file_map.close();
@@ -1097,7 +1097,7 @@ void TConsole::slot_toggleReplayRecording()
         mReplayFile.setFileName(mLogFileName);
         mReplayFile.open(QIODevice::WriteOnly);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            mReplayStream.setVersion(QDataStream::Qt_5_12);
+            mReplayStream.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         mReplayStream.setDevice(&mReplayFile);
         mpHost->mTelnet.recordReplay();
@@ -1553,7 +1553,7 @@ bool TConsole::saveMap(const QString& location, int saveVersion)
     if (file_map.open(QIODevice::WriteOnly)) {
         QDataStream out(&file_map);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            out.setVersion(18);
+            out.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         mpHost->mpMap->serialize(out, saveVersion);
         file_map.close();

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1365,7 +1365,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             // we want to force to be used but we cannot use the enum directly
             // because it will not be defined in older versions of the Qt
             // library when the code is compilated:
-            ifs.setVersion(18);
+            ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ifs >> mVersion;
         if (mVersion > mMaxVersion) {
@@ -1664,7 +1664,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     int otherProfileVersion = 0;
     QDataStream ifs(&file);
     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-        ifs.setVersion(18);
+        ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
     }
     ifs >> otherProfileVersion;
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1354,6 +1354,19 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         }
 
         QDataStream ifs(&file);
+        // Is the RUN-TIME version of the Qt libraries equal to or more than
+        // Qt 5.13.0? Then force things to use the backwards compatible format
+        // - for us - of Qt 5.12.0 - this is needed because the way that the
+        // QFont class is stored in a binary format has changed at 5.13 and it
+        // causes crashes when a new version of the Qt libraries tries to read
+        // the older format:
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            // 18 is the enum value corresponding to QDataStream::Qt_5_12 which
+            // we want to force to be used but we cannot use the enum directly
+            // because it will not be defined in older versions of the Qt
+            // library when the code is compilated:
+            ifs.setVersion(18);
+        }
         ifs >> mVersion;
         if (mVersion > mMaxVersion) {
             QString errMsg = tr("[ ERROR ] - Map file is too new, its file format (%1) is higher than this version of\n"
@@ -1650,6 +1663,9 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     }
     int otherProfileVersion = 0;
     QDataStream ifs(&file);
+    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+        ifs.setVersion(18);
+    }
     ifs >> otherProfileVersion;
 
     QString infoMsg = tr(R"([ INFO ]  - Checking map file: "%1", format version:%2...)").arg(file.fileName()).arg(otherProfileVersion);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2181,6 +2181,9 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
             mIsReplayRunFromLua = false;
         }
         replayStream.setDevice(&replayFile);
+        if (QVersionNumber::fromString(QString(qVersion())) >= QVersionNumber(5, 13, 0)) {
+            replayStream.setVersion(18);
+        }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
             // TODO: consider moving to a QTimeLine based system...?

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2182,7 +2182,7 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         }
         replayStream.setDevice(&replayFile);
         if (QVersionNumber::fromString(QString(qVersion())) >= QVersionNumber(5, 13, 0)) {
-            replayStream.setVersion(18);
+            replayStream.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -675,7 +675,7 @@ QString dlgConnectionProfiles::readProfileData(const QString& profile, const QSt
     if (success) {
         QDataStream ifs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ifs.setVersion(18);
+            ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ifs >> ret;
         file.close();
@@ -691,7 +691,7 @@ QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& prof
     if (file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
         QDataStream ofs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ofs.setVersion(18);
+            ofs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ofs << what;
         file.close();

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -674,6 +674,9 @@ QString dlgConnectionProfiles::readProfileData(const QString& profile, const QSt
     QString ret;
     if (success) {
         QDataStream ifs(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ifs.setVersion(18);
+        }
         ifs >> ret;
         file.close();
     }
@@ -687,6 +690,9 @@ QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& prof
     QFile file(f);
     if (file.open(QIODevice::WriteOnly | QIODevice::Unbuffered)) {
         QDataStream ofs(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ofs.setVersion(18);
+        }
         ofs << what;
         file.close();
     }

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -760,6 +760,9 @@ QString dlgIRC::readAppDefaultIrcNick()
     QString rstr;
     if (opened) {
         QDataStream ifs(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ifs.setVersion(18);
+        }
         ifs >> rstr;
         file.close();
     }
@@ -771,8 +774,11 @@ void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
     QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("irc_nick")));
     bool opened = file.open(QIODevice::WriteOnly);
     if (opened) {
-        QDataStream ifs(&file);
-        ifs << nick;
+        QDataStream ofs(&file);
+        if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ofs.setVersion(18);
+        }
+        ofs << nick;
         file.close();
     }
 }

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -761,7 +761,7 @@ QString dlgIRC::readAppDefaultIrcNick()
     if (opened) {
         QDataStream ifs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ifs.setVersion(18);
+            ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ifs >> rstr;
         file.close();
@@ -776,7 +776,7 @@ void dlgIRC::writeAppDefaultIrcNick(const QString& nick)
     if (opened) {
         QDataStream ofs(&file);
         if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ofs.setVersion(18);
+            ofs.setVersion(mudlet::scmQDataStreamFormat_5_12);
         }
         ofs << nick;
         file.close();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -111,6 +111,10 @@ bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
 //          codes would break or destroy the script that used it.
 const QString mudlet::scmMudletXmlDefaultVersion = QString::number(1.001f, 'f', 3);
 
+// The Qt runtime version is needed in various places but as it is a constant
+// during the application run it is easiest to define it as one once:
+const QVersionNumber mudlet::scmRunTimeQtVersion = QVersionNumber::fromString(QString(qVersion()));
+
 QPointer<TConsole> mudlet::mpDebugConsole = nullptr;
 QPointer<QMainWindow> mudlet::mpDebugArea = nullptr;
 bool mudlet::debugMode = false;
@@ -1725,6 +1729,9 @@ bool mudlet::saveWindowLayout()
 
         QByteArray layoutData = saveState();
         QDataStream ofs(&layoutFile);
+        if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+            ofs.setVersion(18);
+        }
         ofs << layoutData;
         layoutFile.close();
         mHasSavedLayout = true;
@@ -1751,6 +1758,9 @@ bool mudlet::loadWindowLayout()
 
             QByteArray layoutData;
             QDataStream ifs(&layoutFile);
+            if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+                ifs.setVersion(18);
+            }
             ifs >> layoutData;
             layoutFile.close();
 
@@ -3587,10 +3597,13 @@ QString mudlet::readProfileData(const QString& profile, const QString& item)
     QFile file(getMudletPath(profileDataItemPath, profile, item));
     file.open(QIODevice::ReadOnly);
     if (!file.exists()) {
-        return "";
+        return QString();
     }
 
     QDataStream ifs(&file);
+    if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+        ifs.setVersion(18);
+    }
     QString ret;
 
     ifs >> ret;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -115,6 +115,10 @@ const QString mudlet::scmMudletXmlDefaultVersion = QString::number(1.001f, 'f', 
 // during the application run it is easiest to define it as one once:
 const QVersionNumber mudlet::scmRunTimeQtVersion = QVersionNumber::fromString(QString(qVersion()));
 
+// This is equivalent to QDataStream::Qt_5_12 but it is needed when we are
+// compiling with versions older than that which do not have that enum value:
+const int mudlet::scmQDataStreamFormat_5_12 = 18;
+
 QPointer<TConsole> mudlet::mpDebugConsole = nullptr;
 QPointer<QMainWindow> mudlet::mpDebugArea = nullptr;
 bool mudlet::debugMode = false;
@@ -1730,7 +1734,7 @@ bool mudlet::saveWindowLayout()
         QByteArray layoutData = saveState();
         QDataStream ofs(&layoutFile);
         if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-            ofs.setVersion(18);
+            ofs.setVersion(scmQDataStreamFormat_5_12);
         }
         ofs << layoutData;
         layoutFile.close();
@@ -1759,7 +1763,7 @@ bool mudlet::loadWindowLayout()
             QByteArray layoutData;
             QDataStream ifs(&layoutFile);
             if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-                ifs.setVersion(18);
+                ifs.setVersion(scmQDataStreamFormat_5_12);
             }
             ifs >> layoutData;
             layoutFile.close();
@@ -3602,7 +3606,7 @@ QString mudlet::readProfileData(const QString& profile, const QString& item)
 
     QDataStream ifs(&file);
     if (scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-        ifs.setVersion(18);
+        ifs.setVersion(scmQDataStreamFormat_5_12);
     }
     QString ret;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -59,7 +59,7 @@
 #include <QToolButton>
 #include <QVersionNumber>
 #include "edbee/models/textautocompleteprovider.h"
-#include "qtkeychain/keychain.h"
+#include <../3rdparty/qtkeychain/keychain.h>
 #include "post_guard.h"
 
 #include <hunspell/hunspell.hxx>
@@ -229,6 +229,10 @@ public:
 
     static const bool scmIsDevelopmentVersion;
     static const QVersionNumber scmRunTimeQtVersion;
+    // A constant equivalent to QDataStream::Qt_5_12 needed in several places
+    // which can't be pulled from Qt as it is not going to be defined for older
+    // versions:
+    static const int scmQDataStreamFormat_5_12;
     QTime mReplayTime;
     int mReplaySpeed;
     QToolBar* mpMainToolBar;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -40,6 +40,10 @@
 
 #include "pre_guard.h"
 #include <QFlags>
+#ifdef QT_GAMEPAD_LIB
+#include <QGamepad>
+#endif
+#include <QKeySequence>
 #include <QMainWindow>
 #include <QMap>
 #include <QMediaPlayer>
@@ -48,17 +52,14 @@
 #include <QQueue>
 #include <QReadWriteLock>
 #include <QSettings>
+#include <QShortcut>
 #include <QTextOption>
 #include <QTime>
 #include <QTimer>
 #include <QToolButton>
+#include <QVersionNumber>
 #include "edbee/models/textautocompleteprovider.h"
-#include <../3rdparty/qtkeychain/keychain.h>
-#include <QShortcut>
-#include <QKeySequence>
-#ifdef QT_GAMEPAD_LIB
-#include <QGamepad>
-#endif
+#include "qtkeychain/keychain.h"
 #include "post_guard.h"
 
 #include <hunspell/hunspell.hxx>
@@ -227,6 +228,7 @@ public:
 #endif
 
     static const bool scmIsDevelopmentVersion;
+    static const QVersionNumber scmRunTimeQtVersion;
     QTime mReplayTime;
     int mReplaySpeed;
     QToolBar* mpMainToolBar;

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -346,7 +346,7 @@ void Updater::recordUpdateTime() const
 
     QDataStream ifs(&file);
     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-        ifs.setVersion(18);
+        ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
     }
     ifs << QDateTime::currentDateTime().toMSecsSinceEpoch();
     file.close();
@@ -365,7 +365,7 @@ void Updater::recordUpdatedVersion() const
 
     QDataStream ifs(&file);
     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-        ifs.setVersion(18);
+        ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
     }
     ifs << APP_VERSION;
     file.close();
@@ -394,7 +394,7 @@ bool Updater::shouldShowChangelog()
     }
     QDataStream ifs(&file);
     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-        ifs.setVersion(18);
+        ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
     }
     ifs >> updateTimestamp;
     file.close();
@@ -422,7 +422,7 @@ QString Updater::getPreviousVersion() const
     }
     QDataStream ifs(&file);
     if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
-        ifs.setVersion(18);
+        ifs.setVersion(mudlet::scmQDataStreamFormat_5_12);
     }
     ifs >> previousVersion;
     file.close();

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -345,6 +345,9 @@ void Updater::recordUpdateTime() const
     }
 
     QDataStream ifs(&file);
+    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+        ifs.setVersion(18);
+    }
     ifs << QDateTime::currentDateTime().toMSecsSinceEpoch();
     file.close();
 }
@@ -361,6 +364,9 @@ void Updater::recordUpdatedVersion() const
     }
 
     QDataStream ifs(&file);
+    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+        ifs.setVersion(18);
+    }
     ifs << APP_VERSION;
     file.close();
 }
@@ -387,6 +393,9 @@ bool Updater::shouldShowChangelog()
         return false;
     }
     QDataStream ifs(&file);
+    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+        ifs.setVersion(18);
+    }
     ifs >> updateTimestamp;
     file.close();
 
@@ -412,6 +421,9 @@ QString Updater::getPreviousVersion() const
         return QString();
     }
     QDataStream ifs(&file);
+    if (mudlet::scmRunTimeQtVersion >= QVersionNumber(5, 13, 0)) {
+        ifs.setVersion(18);
+    }
     ifs >> previousVersion;
     file.close();
     file.remove();


### PR DESCRIPTION
In other words - fix https://github.com/Mudlet/Mudlet/issues/3088 ...!

This forces the binary file format to be that which is used for Qt 5.12 if the **run-time** version of the Qt libraries are Qt 5.13 or later. This is needed to handle a change in the format that `QFont`s are saved/loaded in a binary form in a `QDataStream` but it also clamps the binary format to be equivalent to `QDataStream::Qt_5_12` everywhere I could see it used so that future Mudlet versions do not suffer further issues going forward when Qt revise the `QDataStream` format for the classes it handles.

This should also close https://github.com/Mudlet/Mudlet/issues/785 !

NOTE: THIS WILL BREAK THINGS TEMPORARILY FOR USERS OF MUDLET VERSIONS AFTER 4.0.1 OR THOSE WHO HAVE MANUALLY SET THE FILE FORMAT ON THEIR MAP TO BE VERSION 19 OR HIGHER AND HAVE MOVED BETWEEN A MUDLET USING A RUN-TIME QT VERSION LESS THAN QT 5.13 AND ONE USING THAT OR LATER. IT WILL LIKELY CAUSE EXISTING MAP FILE CONTENTS TO BECOME GARBAGE WHEN READ BY A MUDLET VERSION INCLUDING THIS PULL-REQUEST - SO IT IS NECESSARY TO OPEN ANY WANTED VERSION 19 OR LATER MAP FILES IN THE CURRENT (BUGGY) QT 5.13 OR LATER USING MUDLET AND RESAVE IT IN MUDLET FILE FORMAT 18 BEFORE UPGRADING TO A MUDLET WITH THIS PULL-REQUEST INCLUDED. ONCE THE MAP IS THEN LOADED IN THE NEWER MUDLET IT CAN BE RESET TO THE LATEST MAP FORMAT - and we should avoid similar Qt library change induced problems in the future.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>