### PR TITLE
Fix selection to select one character OK

### DIFF
--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -132,6 +132,9 @@ private:
     int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOverTimeStamp = nullptr) const;
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
+    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
+    void handleCtrlSelection(int lineIndex);
+    void raiseMousePressEvent(QMouseEvent* event);
 
     int mFontHeight;
     int mFontWidth;
@@ -147,6 +150,7 @@ private:
     bool mMouseTracking;
     bool mCtrlSelecting {};
     int mCtrlDragStartY {};
+    QPoint mDragStart;
     int mOldScrollPos;
     // top-left point of the selection
     QPoint mPA;
@@ -177,8 +181,6 @@ private:
     // would only be valid to change this by clearing the buffer first - so
     // making this a const value for the moment:
     const int mTimeStampWidth;
-    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
-    void handleCtrlSelection(int lineIndex);
 };
 
 #endif // MUDLET_TTEXTEDIT_H

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -147,7 +147,7 @@ private:
     int mLastRenderBottom;
     bool mMouseTracking;
     bool mCtrlSelecting {};
-    int mDragStartY {};
+    int mCtrlDragStartY {};
     int mOldScrollPos;
     QPoint mPA;
     QPoint mPB;
@@ -176,6 +176,8 @@ private:
     // would only be valid to change this by clearing the buffer first - so
     // making this a const value for the moment:
     const int mTimeStampWidth;
+    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
+    void handleCtrlSelection(int lineIndex);
 };
 
 #endif // MUDLET_TTEXTEDIT_H

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -74,9 +74,8 @@ public:
     void mouseMoveEvent(QMouseEvent*) override;
     void showEvent(QShowEvent* event) override;
     void updateScreenView();
-    void highlight();
+    void highlightSelection();
     void unHighlight();
-    void swap(QPoint& p1, QPoint& p2);
     void focusInEvent(QFocusEvent* event) override;
     int imageTopLine();
     int bufferScrollUp(int lines);
@@ -149,7 +148,9 @@ private:
     bool mCtrlSelecting {};
     int mCtrlDragStartY {};
     int mOldScrollPos;
+    // top-left point of the selection
     QPoint mPA;
+    // bottom-right point of the selection
     QPoint mPB;
     TBuffer* mpBuffer;
     TConsole* mpConsole;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Refactor the big `TTextEdit::mouseMoveEvent()` - extract 3 functions out of it and rename variables to make more sense. This lays the foundation for working on it easier.

Fix single-character selection where Mudlet would only start selecting from 2+ characters:

![Peek 2019-10-03 13-03](https://user-images.githubusercontent.com/110988/66123578-b1cecb00-e5e2-11e9-91f3-8424e75838d7.gif)
#### Motivation for adding to Mudlet
Part of fixing selection to work.
#### Other info (issues closed, discussion etc)
Instead of making a giant PR that "fixes" everything there is to fix with selection, I'll do it bit by bit. This means it's much easier to test and bugs are easier to find. This also means the faster the PR is approved, the faster I'll be able to work on the next bit.