### PR TITLE
Fix generic mapper config - can't set an option to true after setting it to false

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1487,7 +1487,7 @@ function map.setConfigs(key, val, sub_key)
             else
                 map.echo("Custom Exit config must be in the form of a table.", false, true)
             end
-        elseif map.configs[key] then
+        elseif map.configs[key] ~= nil then
             map.configs[key] = val
             map.echo(string.format("Config %s set to: %s", key, tostring(val)))
         else


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix generic mapper config - can't set an option to true after setting it to false
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Once the fix is applied, configuration starts working again:

![image](https://user-images.githubusercontent.com/110988/66142474-bc4e8c00-e605-11e9-9893-17be894382e7.png)
