### PR TITLE
Store and reapply stylesheet in Geyser labels

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -131,6 +131,17 @@ function Geyser.Container:reposition ()
   end
 end
 
+--- Responsible for reapplying any stored stylesheet which was previously applied to a Geyser Label using Label:setStyleSheet(css)
+-- Called on sysAppStyleSheetChange events so that Labels which have set their CSS do not have it overwritten by setAppStyleSheet()
+function Geyser.Container:restyle()
+  if self.setStyleSheet then self:setStyleSheet() end
+  for k,v in pairs(self.windowList) do
+    if k ~= self then
+      v:restyle()
+    end
+  end
+end
+
 --- Hides this window and all its contained windows.
 function Geyser.Container:hide (auto)
   if not (self.hidden or self.auto_hidden) then

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -166,7 +166,11 @@ end
 --- Sets the style sheet of the label
 -- @param css The style sheet string
 function Geyser.Label:setStyleSheet(css)
-  setLabelStyleSheet(self.name, css)
+  css = css or self.css
+  if css then
+    self.css = css
+    setLabelStyleSheet(self.name, css)
+  end
 end
 
 --- Returns the Geyser object associated with the label name

--- a/src/mudlet-lua/lua/geyser/GeyserReposition.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserReposition.lua
@@ -13,3 +13,13 @@ function GeyserReposition()
 end
 
 registerAnonymousEventHandler("sysWindowResizeEvent", "GeyserReposition")
+
+--- Responds to sysAppStyleSheetChange event and causes all windows 
+-- managed by Geyser to reapply their stylesheet, if they have it.
+function GeyserRestyle()
+  for _, window in pairs(Geyser.windowList) do
+    window:restyle()
+  end
+end
+
+registerAnonymousEventHandler("sysAppStyleSheetChange", "GeyserRestyle")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Stores css for Geyser labels, and hooks to the sysApStylesheetChange to reapply the stylesheets to any labels which have one set.

#### Motivation for adding to Mudlet
This has been a long standing issue with labels and changing the app stylesheet, as it has cascading effects.

#### Other info (issues closed, discussion etc)
Should hopefully finally close https://github.com/Mudlet/Mudlet/issues/2464