### PR TITLE
Upgrade macOS builds to 10.13 High Sierra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ git:
 matrix:
   include:
   - os: osx
-    osx_image: xcode9.2
+    osx_image: xcode10.1
     compiler: clang
     env:
     - Q_OR_C_MAKE=qmake
       DEPLOY=deploy
 
   - os: osx
-    osx_image: xcode9.2
+    osx_image: xcode10.1
     compiler: clang
     env:
     - Q_OR_C_MAKE=cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 # Should be called before PROJECT.
 cmake_minimum_required(VERSION 3.1)
 if(APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12") # Qt 5.11.2 with which we build on OS X supports 10.11 and up, but some tools are not provided as bottles for that anymore.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13") # Qt 5.11.2 with which we build on OS X supports 10.11 and up, but some tools are not provided as bottles for that anymore.
 endif()
 
 project(mudlet)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -82,7 +82,7 @@ lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_
 msvc:QMAKE_CXXFLAGS += -MP
 
 # Mac specific flags.
-macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.12
+macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
 
 QT += network uitools multimedia gui concurrent
 qtHaveModule(gamepad) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This PR upgrades our macOS build environment to 10.13 High Sierra.

#### Motivation for adding to Mudlet
Homebrew doesn't provide bottles (precompiled binaries) for new versions of software anymore. That means that dependencies will slowly but surely start to require compiling, which will make our builds time out.

#### Other info (issues closed, discussion etc)
This means that we have to drop support for Mudlet on macOS 10.12 Sierra.