### PR TITLE
Initialise GMS config on open, not connect

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -2933,7 +2933,7 @@ function map.eventHandler(event, ...)
         elseif string.ends(file,"/generic_mapper.xml") then
             update_version()
         end
-    elseif event == "sysConnectionEvent" or event == "sysInstall" then
+    elseif event == "sysLoadEvent" or event == "sysInstall" then
         config()
     elseif event == "mapOpenEvent" then
         if not help_shown and not map.save.prompt_pattern[map.character or ""] then


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Initialise generic mapping script config on profile open, not connect
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
This didn't matter before, but with Offline now being an option, the generic mapping script doesn't initialise its configuration until you load.