### PR TITLE
BugFix: recreate prior start stop-watch when it is created behaviour

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -191,6 +191,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mAllowToSendCommand(true)
 , mAutoClearCommandLineAfterSend(false)
 , mBlockScriptCompile(true)
+, mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)
 , mBorderBottomHeight(0)
 , mBorderLeftWidth(0)
@@ -852,17 +853,12 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 
 QPair<int, QString> Host::createStopWatch(const QString& name)
 {
-    if (mResetProfile || mIsProfileLoadingSequence) {
+    if (mResetProfile || mBlockStopWatchCreation) {
         // Don't create stopwatches when test loading scripts or during a profile reset:
         return qMakePair(0, QStringLiteral("unable to create a stopwatch at this time"));
     }
 
     if (!mStopWatchMap.isEmpty() && !name.isEmpty()) {
-        // As we need to check the names we will need a different algorithm
-        // than just looking for the first gap in the integer sequence
-        // 1,2,3,...n if we want to avoid going through the list twice,
-        // the first time to check the name is not in use and a second time
-        // to find the lower positive unused integer id:
         QMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
         while (itStopWatch.hasNext()) {
             itStopWatch.next();

--- a/src/Host.h
+++ b/src/Host.h
@@ -331,6 +331,7 @@ public:
     // after the main TConsole for a new profile has been created during the
     // period when mIsProfileLoadingSequence has been set:
     bool mBlockScriptCompile;
+    bool mBlockStopWatchCreation;
     bool mEchoLuaErrors;
     int mBorderBottomHeight;
     int mBorderLeftWidth;
@@ -362,6 +363,10 @@ public:
     QString mProxyPassword;
 
     bool mIsGoingDown;
+    // Used to force the test compilation of the scripts for TActions ("Buttons")
+    // that are pushdown buttons that run when they are "pushed down" during
+    // loading even though the buttons start out with themselves NOT being
+    // pushed down:
     bool mIsProfileLoadingSequence;
 
     bool mLF_ON_GA;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3811,6 +3811,7 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
     pHost->mLuaInterpreter.loadGlobal();
     hideMudletsVariables(pHost);
 
+    pHost->mBlockStopWatchCreation = false;
     pHost->getScriptUnit()->compileAll();
     pHost->mIsProfileLoadingSequence = false;
 


### PR DESCRIPTION
Also allow them to be created during the profile startup sequence when lua scripts are run on loading (but after a prior compilation to test for script validity has been done).

It wasn't obvious to me at the time but the old type of stopwatch had the characteristic that their mere creation was sufficient to start them running. My new design did not replicate that behaviour so it broke existing scripts that expected this. This commit restores that action IF `createStopWatch()` IS INVOKED WITHOUT ANY ARGUMENTS - as it would be if existing scripts used that API call. An optional boolean argument will prevent the auto-start if it is provided as a `false` but if a "name" for the stopwatch to be created it is assumed that the user wants the newer behaviour and then it will be created in a "stopped" and "reset" state. This may be overridden by a further boolean argument which in this case must be `true` to "autostart" the (named) stopwatch so created.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>