### PR TITLE
Move win32 executable flag to avoid code duplication

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,21 +251,13 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(WIN32)
-  add_executable(mudlet WIN32
-    ${mudlet_SRCS}
-    ${mudlet_RCCS}
-    ${mudlet_HDRS}
-    ${mudlet_LUA_FILES}
-    ${mudlet_UIS})
-else()
-  add_executable(mudlet
-    ${mudlet_SRCS}
-    ${mudlet_RCCS}
-    ${mudlet_HDRS}
-    ${mudlet_LUA_FILES}
-    ${mudlet_UIS})
-endif()
+
+add_executable(mudlet
+  ${mudlet_SRCS}
+  ${mudlet_RCCS}
+  ${mudlet_HDRS}
+  ${mudlet_UIS}
+)
 
 set_target_properties(mudlet
   PROPERTIES
@@ -348,7 +340,10 @@ if(USE_3DMAPPER)
 endif()
 
 if(WIN32)
-    target_link_libraries(mudlet ws2_32
+    target_link_libraries(mudlet ws2_32)
+    set_target_properties(mudlet
+      PROPERTIES
+        WIN32_EXECUTABLE ON
     )
 endif()
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This is a minor change to avoid a little code duplication for windows.

#### Motivation for adding to Mudlet
Less code

#### Other info (issues closed, discussion etc)
Relates to #1392
