### PR TITLE
Fix initialisation of generic mapper

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1383,11 +1383,11 @@ local err_tag = "&lt;255,0,0&gt;(&lt;178,34,34&gt;error&lt;255,0,0&gt;): &lt;255
 
 
 local function parse_help_text(text)
-  text = text:gsub("%$ROOM_NAME_STATUS", (map.currentName and map.currentName ~= "") and '✔' or '❌')
+  text = text:gsub("%$ROOM_NAME_STATUS", (map.currentName and map.currentName ~= "") and '✔️' or '❌')
   text = text:gsub("%$ROOM_NAME", map.currentName or '')
 
-  text = text:gsub("%$ROOM_EXITS_STATUS", table.is_empty(map.currentExits) and '❌' or '✔️')
-  text = text:gsub("%$ROOM_EXITS", table.concat(map.currentExits, ' '))
+  text = text:gsub("%$ROOM_EXITS_STATUS", (not map.currentExits or table.is_empty(map.currentExits)) and '❌' or '✔️')
+  text = text:gsub("%$ROOM_EXITS", map.currentExits and table.concat(map.currentExits, ' ') or '')
 
   return text
 end
@@ -2948,6 +2948,7 @@ function map.eventHandler(event, ...)
 end
 
 registerAnonymousEventHandler("sysDownloadDone", "map.eventHandler")
+registerAnonymousEventHandler("sysLoadEvent", "map.eventHandler")
 registerAnonymousEventHandler("sysConnectionEvent", "map.eventHandler")
 registerAnonymousEventHandler("sysInstall", "map.eventHandler")
 registerAnonymousEventHandler("sysDataSendRequest", "map.eventHandler")


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
I previously changed the `sysConnectionEvent` to a `sysLoadEvent`, but never registered the event handler for it.

Also handle `currentExits()` being `nil` in `map help` and `map basic` display.
#### Motivation for adding to Mudlet
Fix script to work right when used before rooms are seen.
#### Other info (issues closed, discussion etc)
