### PR TITLE
Add a 'show moves' alias for debugging

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -561,6 +561,13 @@ end</script>
 				<regex>^add portal (.*)$</regex>
 			</Alias>
 			<Alias isActive="yes" isFolder="no">
+				<name>Show Moves Alias</name>
+				<script>map.show_moves()</script>
+				<command></command>
+				<packageName></packageName>
+				<regex>^show moves$</regex>
+			</Alias>
+			<Alias isActive="yes" isFolder="no">
 				<name>Clear Moves Alias</name>
 				<script>map.clear_moves()</script>
 				<command></command>
@@ -1944,6 +1951,7 @@ local function capture_move_cmd(dir,priority)
         end
     end
 end
+
 local function deduplicate_exits(exits)
   local deduplicated_exits = {}
   for _, v in ipairs(exits) do
@@ -2257,6 +2265,10 @@ function map.clear_moves()
     local commands_in_queue = #move_queue
     move_queue = {}
     map.echo("Move queue cleared, "..commands_in_queue.." commands removed.")
+end
+
+function map.show_moves()
+    map.echo("Moves: "..(move_queue and table.concat(move_queue, ', ' or 'none')))
 end
 
 function map.set_area(name)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add a 'show moves' alias for debugging what the mapper thinks your move command queue is.
#### Motivation for adding to Mudlet
Easier debugging.
#### Other info (issues closed, discussion etc)
