### PR TITLE
BugFix: allow builds without updater code to compile/link

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -541,11 +541,12 @@ private slots:
 #if defined(INCLUDE_UPDATER)
     void slot_update_installed();
     void slot_updateAvailable(const int);
+    void slot_report_issue();
 #endif
     void slot_toggle_compact_input_line();
     void slot_password_migrated_to_secure(QKeychain::Job *job);
     void slot_password_migrated_to_profile(QKeychain::Job *job);
-    void slot_report_issue();
+
 
 private:
     void initEdbee();


### PR DESCRIPTION
As the definition of `(void) mudlet::slot_report_issue()` is contained within `#if defined(INCLUDE_UPDATER)` ... `#endif` preprocessor directives the method is not defined when the updater code is exclude and was causing failures at the link stage of building.  This PR corrects this so that
the option to "report an issue" will only be available for "Public Test" versions that do have the updater code present - as they will do - but it will be disabled for other builds (release or general PR testing) from the official site and will not be present in the code when compiled with the environmental variable `WITH_UPDATER` set to `NO`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>