### PR TITLE
Refactor: remove two `mudlet` non-SLOT methods from `public slot:` part

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -414,6 +414,8 @@ public:
     QSet<QString> getWordSet();
     void scanForMudletTranslations(const QString&);
     void scanForQtTranslations(const QString&);
+    void layoutModules();
+    void startAutoLogin();
 
 
 #if defined(INCLUDE_UPDATER)
@@ -473,7 +475,6 @@ public slots:
     void slot_notes();
     void slot_reconnect();
     void slot_close_profile_requested(int);
-    void startAutoLogin();
     void slot_irc();
     void slot_discord();
     void slot_uninstall_package();
@@ -483,7 +484,6 @@ public slots:
     void slot_uninstall_module();
     void slot_install_module();
     void slot_module_manager();
-    void layoutModules();
     void slot_help_module();
 #if defined(INCLUDE_UPDATER)
     void slot_check_manual_update();


### PR DESCRIPTION
Both `(void) mudlet::layoutModules()` and `(void) mudlet::startAutoLogin()` are normal `public:` methods and do not need to be processed by Qt's `moc` {Meta-Object Compiler} so should not be declared as *slot* methods.

I spotted this whilst trying to find why my builds were all failing after PR #3182 had gone in when I was working on #3191 . This nice and short PR should pass the *non-complex* PR criterion with ease! :rofl:

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>