### PR TITLE
Licensing: add acknowledgement of TinTin++ MSDP code

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14340,6 +14340,8 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
 
 // No documentation available in wiki - internal function
 // src is in Mud Server encoding and may need transcoding
+// Includes MSDP code originally from recv_sb_msdp(...) in TinTin++'s telopt.c,
+// https://tintin.sourceforge.io:
 void TLuaInterpreter::msdp2Lua(const char* src)
 {
     Host& host = getHostFromLua(pGlobalLua);


### PR DESCRIPTION
Following a discussion about this in the TinTin++ Discord channel I can see that there are strong reasons to believe Scandum's assertion that we have used a snippet of code that he produced to support MSDP (which is his creation) and which is present in the TinTin++ product which he maintains.

It is not entirely clear whether the code concerned was released as public domain or GPL but if it was the latter then it is not entirely unreasonable to mention where we got the code from - and avoid any confusion by third parties as to who came up with the code, which does seem to have arisen.

In placing a comment in the position I have, I am attempted to restore: "the in-source mention above the function that Heiko didn't include." that Scandum requests.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>