### PR TITLE
Upstream-BugFix: change out wchar_t type which is too narrow on Windows

### DIFF
--- a/src/widechar_width.h
+++ b/src/widechar_width.h
@@ -1,5 +1,5 @@
 /**
- * widechar_width.h, generated on 2019-05-13.
+ * widechar_width.h, generated on 2019-10-30.
  * See https://github.com/ridiculousfish/widecharwidth/
  *
  * SHA1 file hashes:
@@ -508,12 +508,12 @@ static const struct widechar_range widechar_widened_table[] = {
 template<typename Collection>
 bool widechar_in_table(const Collection &arr, int32_t c) {
     auto where = std::lower_bound(std::begin(arr), std::end(arr), c,
-        [](widechar_range p, wchar_t c) { return p.hi < c; });
+        [](widechar_range p, int32_t c) { return p.hi < c; });
     return where != std::end(arr) && where->lo <= c;
 }
 
 /* Return the width of character c, or a special negative value. */
-int widechar_wcwidth(wchar_t c) {
+int widechar_wcwidth(int32_t c) {
     if (widechar_in_table(widechar_ascii_table, c))
         return 1;
     if (widechar_in_table(widechar_private_table, c))


### PR DESCRIPTION
This is a bugfix that I got into upstream and fixes some issues on Windows where some Emojis (off of the BMP) were not being correctly typed - they were being identified as private use characters on Windows because the argument to a function was not wide enough (did not have enough bits) to convey the values required.

I believe this may be a simpler fix for the issue that PR #2943 was trying to fix.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
