### PR TITLE
Don't use Qt 5.13 for Windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ environment:
   DBLSQD_PASS:
     secure: Bm5PLJjC39XmRC55RPGVP9c5CFxvWu2VorAAmu5QS38=
   matrix:
-  - QT_BASE_DIR: C:\Qt\5.13.0\mingw73_32
+  - QT_BASE_DIR: C:\Qt\5.12.3\mingw73_32
     MINGW_BASE_DIR: C:\Qt\Tools\mingw730_32
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -22,7 +22,7 @@ function SetQtBaseDir([string] $logFile) {
     }
     catch
     {
-      $Env:QT_BASE_DIR = "C:\Qt\5.13.0\mingw73_32"
+      $Env:QT_BASE_DIR = "C:\Qt\5.12.3\mingw73_32"
     }
   }
   Write-Output "Using $Env:QT_BASE_DIR as QT base directory." | Tee-Object -File "$logFile" -Append
@@ -229,7 +229,7 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1d-win32.zip" "openssl-win32.zip"
+  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.0.2s-win32.zip" "openssl-win32.zip"
   ExtractZip "openssl-win32.zip" "openssl"
   Step "installing"
   exec "XCOPY" @("/S", "/I", "/Q", "openssl", "$Env:MINGW_BASE_DIR\bin")
@@ -449,7 +449,7 @@ function CheckAndInstallPython(){
 }
 
 function CheckAndInstallOpenSSL(){
-    CheckAndInstall "openssl" "$Env:MINGW_BASE_DIR\bin\libssl-1_1.dll" { InstallOpenssl }
+    CheckAndInstall "openssl" "$Env:MINGW_BASE_DIR\bin\ssleay32.dll" { InstallOpenssl }
 }
 
 function CheckAndInstallHunspell(){

--- a/CI/copy-non-qt-win-dependencies.ps1
+++ b/CI/copy-non-qt-win-dependencies.ps1
@@ -1,7 +1,7 @@
 COPY $Env:MINGW_BASE_DIR\bin\libyajl.dll .
 COPY $Env:MINGW_BASE_DIR\bin\lua51.dll .
-COPY $Env:MINGW_BASE_DIR\bin\libcrypto-1_1.dll .
-COPY $Env:MINGW_BASE_DIR\bin\libssl-1_1.dll .
+COPY $Env:MINGW_BASE_DIR\bin\libeay32.dll .
+COPY $Env:MINGW_BASE_DIR\bin\ssleay32.dll .
 COPY $Env:MINGW_BASE_DIR\bin\libzip.dll .
 COPY $Env:MINGW_BASE_DIR\bin\libhunspell-1.6-0.dll .
 COPY $Env:MINGW_BASE_DIR\bin\libpcre-1.dll .

--- a/CI/qt-silent-install.qs
+++ b/CI/qt-silent-install.qs
@@ -27,7 +27,7 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent("qt.qt5.5130.win32_mingw73");
+    widget.selectComponent("qt.qt5.5123.win32_mingw73");
     widget.selectComponent("qt.tools.win32_mingw730");
 
     gui.clickButton(buttons.NextButton);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Don't use Qt 5.13 for Windows builds, go back to latest LTS available.
#### Motivation for adding to Mudlet
It's the cause for https://github.com/Mudlet/Mudlet/issues/3211 😒
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/3211.

Perhaps newer Qt fixes it, but we're pretty limited in what we can select on the 2017 image, need to upgrade to 2019!