### PR TITLE
Enhance: overhaul stopwatches redux

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -38,11 +38,149 @@
 #include "mudlet.h"
 
 #include "pre_guard.h"
+#include <chrono>
 #include <QtUiTools>
 #include <QNetworkProxy>
 #include <zip.h>
 #include <memory>
 #include "post_guard.h"
+
+stopWatch::stopWatch()
+: mIsInitialised(false)
+, mIsRunning(false)
+, mIsPersistent(false)
+, mEffectiveStartDateTime()
+, mElapsedTime()
+{
+    mEffectiveStartDateTime.setTimeSpec(Qt::UTC);
+}
+
+bool stopWatch::start()
+{
+    if (!mIsInitialised) {
+        mIsInitialised = true;
+        mEffectiveStartDateTime = QDateTime::currentDateTimeUtc();
+        mIsRunning = true;
+        return true;
+    }
+
+    if (mIsRunning) {
+        // Nothing to do, already running
+        return false;
+    }
+
+    // Is stopped, so subtract elapsed time from current and set that to be the
+    // effective start time:
+    mEffectiveStartDateTime = QDateTime::currentDateTimeUtc().addMSecs(-mElapsedTime);
+    mIsRunning = true;
+    return true;
+}
+
+bool stopWatch::stop()
+{
+    if (!mIsInitialised) {
+        // Nothing to do, never started
+        return false;
+    }
+
+    if (!mIsRunning) {
+        // Nothing to do, already stopped
+        return false;
+    }
+
+    // Is running - so stop and note time:
+    mElapsedTime = mEffectiveStartDateTime.msecsTo(QDateTime::currentDateTimeUtc());
+    mIsRunning = false;
+    return true;
+}
+
+bool stopWatch::reset()
+{
+    if (!mIsInitialised) {
+        // Nothing to do, never started
+        return false;
+    }
+
+    if (!mIsRunning) {
+        // Not running, so reset elapsed time:
+        mElapsedTime = 0;
+        // And reset initialised flag:
+        mIsInitialised = false;
+        return true;
+    }
+
+    // Is running so reset effective start time - BUT THIS DOES NOT stop the
+    // stopwatch:
+    mEffectiveStartDateTime = QDateTime::currentDateTimeUtc();
+    return true;
+}
+
+void stopWatch::adjustMilliSeconds(const qint64 adjustment)
+{
+    if (!mIsInitialised) {
+        // We can initialise things in this case by setting the flag and falling
+        // through into the is not running situation - with the elapsed time
+        // being zero up to now we just have to add on the adjustment:
+        mIsInitialised = true;
+    }
+
+    if (!mIsRunning) {
+        // Not running so adjust stored elapsed time:
+        mElapsedTime += adjustment;
+    }
+
+    // Is running so adjust effective start time - to increase the effective
+    // elapsed time we must subtract the adjustment from the effect start time:
+    mEffectiveStartDateTime = mEffectiveStartDateTime.addMSecs(-adjustment);
+}
+
+qint64 stopWatch::getElapsedMilliSeconds() const
+{
+    if (!mIsInitialised) {
+        // Never started so no elapsed time:
+        return 0;
+    }
+
+    if (!mIsRunning) {
+        // Not running - so return elapsed time:
+        return mElapsedTime;
+    }
+
+    // Is running so calculate elapsed time:
+    return mEffectiveStartDateTime.msecsTo(QDateTime::currentDateTimeUtc());
+}
+
+QString stopWatch::getElapsedDayTimeString() const
+{
+    using namespace std::chrono_literals;
+
+    if (!mIsInitialised) {
+        return QStringLiteral("+:0:0:0:0:000");
+    }
+
+    qint64 elapsed = 0;
+    if (mIsRunning) {
+        elapsed = mEffectiveStartDateTime.msecsTo(QDateTime::currentDateTimeUtc());
+    } else {
+        elapsed = mElapsedTime;
+    }
+
+    bool isNegative = false;
+    if (elapsed < 0) {
+        isNegative = true;
+        elapsed *= -1;
+    }
+
+    qint64 days = elapsed / std::chrono::milliseconds(24h).count();
+    qint64 remainder = elapsed - (days * std::chrono::milliseconds(24h).count());
+    quint8 hours = static_cast<quint8>(remainder / std::chrono::milliseconds(1h).count());
+    remainder = remainder - (hours * std::chrono::milliseconds(1h).count());
+    quint8 minutes = static_cast<quint8>(remainder / std::chrono::milliseconds(1min).count());
+    remainder = remainder - (minutes * std::chrono::milliseconds(1min).count());
+    quint8 seconds = static_cast<quint8>(remainder / std::chrono::milliseconds(1s).count());
+    quint16 milliSeconds = static_cast<quint16>(remainder - (seconds * std::chrono::milliseconds(1s).count()));
+    return QStringLiteral("%1:%2:%3:%4:%5:%6").arg((isNegative ? QLatin1String("-") : QLatin1String("+")), QString::number(days), QString::number(hours), QString::number(minutes), QString::number(seconds), QString::number(milliSeconds));
+}
 
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
 : mTelnet(this, hostname)
@@ -53,6 +191,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mAllowToSendCommand(true)
 , mAutoClearCommandLineAfterSend(false)
 , mBlockScriptCompile(true)
+, mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)
 , mBorderBottomHeight(0)
 , mBorderLeftWidth(0)
@@ -402,6 +541,7 @@ void Host::resetProfile_phase2()
     getTimerUnit()->removeAllTempTimers();
     getTriggerUnit()->removeAllTempTriggers();
     getKeyUnit()->removeAllTempKeys();
+    removeAllNonPersistentStopWatches();
 
     mTimerUnit.doCleanup();
     mTriggerUnit.doCleanup();
@@ -711,49 +851,340 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
     }
 }
 
-int Host::createStopWatch()
+QPair<int, QString> Host::createStopWatch(const QString& name)
 {
-    int newWatchID = mStopWatchMap.size() + 1;
-    mStopWatchMap[newWatchID] = QTime(0, 0, 0, 0);
-    return newWatchID;
-}
-
-double Host::getStopWatchTime(int watchID)
-{
-    if (mStopWatchMap.contains(watchID)) {
-        return static_cast<double>(mStopWatchMap[watchID].elapsed()) / 1000;
-    } else {
-        return -1.0;
+    if (mResetProfile || mBlockStopWatchCreation) {
+        // Don't create stopwatches when test loading scripts or during a profile reset:
+        return qMakePair(0, QStringLiteral("unable to create a stopwatch at this time"));
     }
+
+    if (!mStopWatchMap.isEmpty() && !name.isEmpty()) {
+        QMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
+        while (itStopWatch.hasNext()) {
+            itStopWatch.next();
+            if (itStopWatch.value()->name() == name) {
+                return qMakePair(0, QStringLiteral("a stopwatch with id %1 called \"%2\" already exists").arg(QString::number(itStopWatch.key()), name));
+            }
+        }
+    }
+    int newWatchId = 1;
+    while (mStopWatchMap.contains(newWatchId)) {
+        ++newWatchId;
+    };
+
+    // It is hard to imagine a situation in which this will fail - so we won't
+    // bother coding for it:
+    auto pStopWatch = new stopWatch();
+    Q_ASSERT_X(pStopWatch, "Host::createStopWatch", "out of memory, unable to create new stopwatch");
+    if (!name.isEmpty()) {
+        pStopWatch->setName(name);
+    }
+
+    mStopWatchMap.insert(newWatchId, pStopWatch);
+    return qMakePair(newWatchId, QString());
 }
 
-bool Host::startStopWatch(int watchID)
+bool Host::destroyStopWatch(const int id)
 {
-    if (mStopWatchMap.contains(watchID)) {
-        mStopWatchMap[watchID].start();
-        return true;
-    } else {
+    auto pStopWatch = mStopWatchMap.take(id);
+    if (!pStopWatch) {
         return false;
     }
+
+    delete pStopWatch;
+    return true;
 }
 
-double Host::stopStopWatch(int watchID)
+bool Host::adjustStopWatch(const int id, const qint64 milliSeconds)
 {
-    if (mStopWatchMap.contains(watchID)) {
-        return static_cast<double>(mStopWatchMap[watchID].elapsed()) / 1000;
-    } else {
-        return -1.0;
-    }
-}
-
-bool Host::resetStopWatch(int watchID)
-{
-    if (mStopWatchMap.contains(watchID)) {
-        mStopWatchMap[watchID].setHMS(0, 0, 0, 0);
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        pStopWatch->adjustMilliSeconds(milliSeconds);
         return true;
-    } else {
-        return false;
     }
+
+    return false;
+}
+
+// Find the first (lowest ID) stopwatch with the given name and return its id,
+// returns 0 (not a valid id) if the name is not found. It WILL return the first
+// unnamed one if a blank string is given:
+int Host::findStopWatchId(const QString& name) const
+{
+    // Scan through existing names, in ascending id order
+    QList<int> stopWatchIdList = mStopWatchMap.keys();
+    int total = stopWatchIdList.size();
+    if (total > 1) {
+        std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
+    }
+    for (int index = 0, total = stopWatchIdList.size(); index < total; ++index) {
+        auto currentId = stopWatchIdList.at(index);
+        auto pCurrentStopWatch = mStopWatchMap.value(currentId);
+        if (pCurrentStopWatch->name() == name) {
+            return currentId;
+        }
+    }
+    return 0;
+}
+
+QPair<bool, double> Host::getStopWatchTime(const int id) const
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        return qMakePair(true, pStopWatch->getElapsedMilliSeconds() / 1000.0);
+    } else {
+        return qMakePair(false, 0.0);
+    }
+}
+
+QPair<bool, QString> Host::getBrokenDownStopWatchTime(const int id) const
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        return qMakePair(true, pStopWatch->getElapsedDayTimeString());
+    } else {
+        return qMakePair(false, QStringLiteral("stopwatch with id %1 not found").arg(id));
+    }
+}
+
+QPair<bool, QString> Host::startStopWatch(const QString& name)
+{
+    auto watchId = findStopWatchId(name);
+    if (!watchId) {
+        if (name.isEmpty()) {
+            return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
+        } else {
+            return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" not found").arg(name));
+        }
+    }
+
+    auto pStopWatch = mStopWatchMap.value(watchId);
+    if (Q_LIKELY(pStopWatch)) {
+        if (pStopWatch->start()) {
+            return qMakePair(true, QString());
+        }
+
+        return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" (id:%2) was already running").arg(name, QString::number(watchId)));
+    }
+
+    // This should, indeed, be:
+    Q_UNREACHABLE();
+    return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" (id:%2) not found").arg(name, QString::number(watchId)));
+}
+
+QPair<bool, QString> Host::startStopWatch(int id)
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        if (pStopWatch->start()) {
+            return qMakePair(true, QString());
+        }
+
+        return qMakePair(false, QStringLiteral("stopwatch with id %1 was already running").arg(id));
+    }
+
+    return qMakePair(false, QStringLiteral("stopwatch with id %1 not found").arg(id));
+}
+
+QPair<bool, QString> Host::stopStopWatch(const QString& name)
+{
+    auto watchId = findStopWatchId(name);
+    if (!watchId) {
+        if (name.isEmpty()) {
+            return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
+        } else {
+            return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" not found").arg(name));
+        }
+    }
+
+    auto pStopWatch = mStopWatchMap.value(watchId);
+    if (Q_LIKELY(pStopWatch)) {
+        if (pStopWatch->stop()) {
+            return qMakePair(true, QString());
+        }
+
+        return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" (id:%2) was already stopped").arg(name, QString::number(watchId)));
+    }
+
+    // This should, indeed, be:
+    Q_UNREACHABLE();
+    return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" (id:%2) not found").arg(name, QString::number(watchId)));
+}
+
+QPair<bool, QString> Host::stopStopWatch(const int id)
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        if (pStopWatch->stop()) {
+            return qMakePair(true, QString());
+        }
+
+        return qMakePair(false, QStringLiteral("stopwatch with id %1 was already stopped").arg(id));
+    }
+
+    return qMakePair(false, QStringLiteral("stopwatch with id %1 not found").arg(id));
+}
+
+QPair<bool, QString> Host::resetStopWatch(const QString& name)
+{
+    auto watchId = findStopWatchId(name);
+    if (!watchId) {
+        if (name.isEmpty()) {
+            return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
+        } else {
+            return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" not found").arg(name));
+        }
+    }
+
+    auto pStopWatch = mStopWatchMap.value(watchId);
+    if (Q_LIKELY(pStopWatch)) {
+        if (pStopWatch->reset()) {
+            return qMakePair(true, QString());
+        }
+
+        if (name.isEmpty()) {
+            return qMakePair(false, QStringLiteral("the first unnamed stopwatch (id:%1) was already reset").arg(watchId));
+        } else {
+            return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" (id:%2) was already reset").arg(name, QString::number(watchId)));
+        }
+    }
+
+    // This should, indeed, be:
+    Q_UNREACHABLE();
+    return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" (id:%2) not found").arg(name, QString::number(watchId)));
+}
+
+QPair<bool, QString> Host::resetStopWatch(const int id)
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        if (pStopWatch->reset()) {
+            return qMakePair(true, QString());
+        }
+
+        return qMakePair(false, QStringLiteral("stopwatch with id %1 was already reset").arg(id));
+    }
+
+    return qMakePair(false, QStringLiteral("stopwatch with id %1 not found").arg(id));
+}
+
+// Used when emulating past behavior for startStopWatch - there is only one
+// which takes a numeric argument as that is what old scripts will be using and
+// not a text name:
+QPair<bool, QString> Host::resetAndRestartStopWatch(const int id)
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        pStopWatch->stop();
+        pStopWatch->reset();
+        pStopWatch->start();
+        return qMakePair(true, QString());
+    }
+
+    return qMakePair(false, QStringLiteral("stopwatch with id %1 not found").arg(id));
+}
+
+bool Host::makeStopWatchPersistent(const int id, const bool state)
+{
+    auto pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        pStopWatch->setPersistent(state);
+        return true;
+    }
+
+    return false;
+}
+
+QPair<bool, QString> Host::setStopWatchName(const int id, const QString& newName)
+{
+    stopWatch* pStopWatch = nullptr;
+    if (!newName.isEmpty()) {
+        // Scan through existing names
+        QMutableMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
+        while (itStopWatch.hasNext()) {
+            itStopWatch.next();
+            if (itStopWatch.value()->name() == newName) {
+                if (itStopWatch.key() != id) {
+                    return qMakePair(false, QStringLiteral("the name \"%1\" is already in use for another stopwatch (id:%2)").arg(newName, QString::number(itStopWatch.key())));
+                } else {
+                    // Trivial case - the stopwatch is already called by the NEW name:
+                    return qMakePair(true, QString());
+                }
+            }
+        }
+    }
+
+    pStopWatch = mStopWatchMap.value(id);
+    if (pStopWatch) {
+        // Okay found the one we want:
+        pStopWatch->setName(newName);
+        return qMakePair(true, QString());
+    }
+
+    return qMakePair(false, QStringLiteral("stopwatch with id %1 not found").arg(id));
+}
+
+QPair<bool, QString> Host::setStopWatchName(const QString& currentName, const QString& newName)
+{
+    stopWatch* pStopWatch = nullptr;
+    // Scan through existing names, in ascending id order
+    QList<int> stopWatchIdList = mStopWatchMap.keys();
+    int total = stopWatchIdList.size();
+    if (total > 1) {
+        std::sort(stopWatchIdList.begin(), stopWatchIdList.end());
+    }
+    int id = 0;
+    // Although it would be quicker code to return immediately if we detect the
+    // newName is in use the run-time error about it being used will mask a
+    // failure to find the current one (perhaps because it has already been set
+    // to the new value) - so don't moan about that until we have (or have not)
+    // found the current name:
+    bool isAlreadyUsed = false;
+    int alreadyUsedId = 0;
+    // we are looking BOTH for the current name and checking that any other
+    // ones WITH names do not match the new name:
+    for (int index = 0; index < total; ++index) {
+        auto currentId = stopWatchIdList.at(index);
+        auto pCurrentStopWatch = mStopWatchMap.value(currentId);
+        // This will also pick up the FIRST (lowest id) currently unnamed
+        // stopwatch:
+        if (!id && pCurrentStopWatch->name() == currentName) {
+            pStopWatch = pCurrentStopWatch;
+            id = currentId;
+        }
+        // As zero is never used as an Id it okay to use it here before it
+        // is set to the value of the wanted entry:
+        if (!newName.isEmpty() && currentId != id && pCurrentStopWatch->name() == newName) {
+            isAlreadyUsed = true;
+            alreadyUsedId = currentId;
+        }
+    }
+
+    // if pStopWatch is nullptr then the currentName was not found:
+    if (!pStopWatch) {
+        if (currentName.isEmpty()) {
+            return qMakePair(false, QLatin1String("no unnamed stopwatches found"));
+        } else {
+            return qMakePair(false, QStringLiteral("stopwatch with name \"%1\" not found").arg(currentName));
+        }
+    }
+
+    if (isAlreadyUsed) {
+        return qMakePair(false, QStringLiteral("the name \"%1\" is already in use for another stopwatch (id:%2)").arg(newName, QString::number(alreadyUsedId)));
+    }
+
+    if (currentName == newName) {
+        // Trivial case that always succeeds
+        return qMakePair(true, QString());
+    }
+
+    pStopWatch->setName(newName);
+    return qMakePair(true, QString());
+}
+
+QList<int> Host::getStopWatchIds() const
+{
+    return mStopWatchMap.keys();
 }
 
 void Host::incomingStreamProcessor(const QString& data, int line)
@@ -1835,6 +2266,21 @@ void Host::setName(const QString& newName)
         mpConsole->setProfileName(newName);
     }
     mTimerUnit.changeHostName(newName);
+}
+
+void Host::removeAllNonPersistentStopWatches()
+{
+    QMutableMapIterator<int, stopWatch*> itStopWatch(mStopWatchMap);
+    while (itStopWatch.hasNext()) {
+        itStopWatch.next();
+        auto pStopWatch = itStopWatch.value();
+        if (!pStopWatch || pStopWatch->persistent()) {
+            continue;
+        }
+
+        itStopWatch.remove();
+        delete pStopWatch;
+    }
 }
 
 void Host::updateProxySettings(QNetworkAccessManager* manager)

--- a/src/Host.h
+++ b/src/Host.h
@@ -58,6 +58,69 @@ class TConsole;
 class dlgNotepad;
 class TMap;
 
+class stopWatch {
+    friend class XMLimport;
+
+public:
+    stopWatch();
+
+    bool start();
+    bool stop();
+    bool reset();
+    bool running() const {return mIsRunning;}
+    void adjustMilliSeconds(const qint64);
+    qint64 getElapsedMilliSeconds() const;
+    QString getElapsedDayTimeString() const;
+    void setPersistent(const bool state) {mIsPersistent = state;}
+    bool persistent() const {return mIsPersistent;}
+    void setName(const QString& name) {mName = name;}
+    const QString& name() const {return mName;}
+
+#ifndef QT_NO_DEBUG_STREAM
+    // Only used for debugging:
+    bool initialised() const {return mIsInitialised;}
+    qint64 elapsed() const {return mElapsedTime;}
+    QDateTime effectiveStartDateTime() const {return mEffectiveStartDateTime;}
+#endif // QT_NO_DEBUG_STREAM
+
+private:
+    // true once started the first time - but provides some code short cuts if
+    // prior to that:
+    bool mIsInitialised;
+    // true when RUNNING, false when STOPPED:
+    bool mIsRunning;
+    // If true this stopwatch is saved with the profile and reloaded - if it is
+    // running when saved it will seem to continue to run - so can be used to
+    // track real time events outside of the profile, it is intended that the
+    // parent Host class that makes use of it will save and restore the id
+    // number that that class assigns the stopwatch:
+    bool mIsPersistent;
+    // When RUNNING this contains the effective point in time when the stop
+    // watch was started - so that taking a difference between then and
+    // "now" gives the total elapsed time:
+    QDateTime mEffectiveStartDateTime;
+    // When STOPPED this contains the cumulative elasped time in milliSeconds:
+    qint64 mElapsedTime;
+    // As the id is generated according to what other ones have been created but
+    // persists between saves it is useful for the user or script writer to be
+    // able to name a particular stop watch for identification later:
+    QString mName;
+};
+
+#ifndef QT_NO_DEBUG_STREAM
+inline QDebug& operator<<(QDebug& debug, const stopWatch& stopwatch)
+{
+    QDebugStateSaver saver(debug);
+    Q_UNUSED(saver);
+    debug.nospace() << QStringLiteral("stopwatch(mIsRunning: %1 mInitialised: %2 mIsPersistent: %3 mEffectiveStartDateTime: %4 mElapsedTime: %5)")
+                       .arg((stopwatch.running() ? QLatin1String("true") : QLatin1String("false")),
+                            (stopwatch.initialised() ? QLatin1String("true") : QLatin1String("false")),
+                            (stopwatch.persistent() ? QLatin1String("true") : QLatin1String("false")),
+                            stopwatch.effectiveStartDateTime().toString(),
+                            QString::number(stopwatch.elapsed()));
+    return debug;
+}
+#endif // QT_NO_DEBUG_STREAM
 
 class Host : public QObject
 {
@@ -164,11 +227,26 @@ public:
     void disableKey(const QString&);
     bool killTimer(const QString&);
     bool killTrigger(const QString&);
-    double stopStopWatch(int);
-    bool resetStopWatch(int);
-    bool startStopWatch(int);
-    double getStopWatchTime(int);
-    int createStopWatch();
+
+    QPair<int, QString> createStopWatch(const QString&);
+    bool destroyStopWatch(const int);
+    bool adjustStopWatch(const int, const qint64 milliSeconds);
+    QList<int> getStopWatchIds() const;
+    QPair<bool, double> getStopWatchTime(const int) const;
+    QPair<bool, QString> getBrokenDownStopWatchTime(const int) const;
+    bool makeStopWatchPersistent(const int, const bool);
+    QPair<bool, QString> resetStopWatch(const int);
+    QPair<bool, QString> resetStopWatch(const QString&);
+    QPair<bool, QString> startStopWatch(const int);
+    QPair<bool, QString> startStopWatch(const QString&);
+    QPair<bool, QString> stopStopWatch(const int);
+    QPair<bool, QString> stopStopWatch(const QString&);
+    stopWatch* getStopWatch(const int id) const { return mStopWatchMap.value(id); }
+    int findStopWatchId(const QString&) const;
+    QPair<bool, QString> setStopWatchName(const int, const QString&);
+    QPair<bool, QString> setStopWatchName(const QString&, const QString&);
+    QPair<bool, QString> resetAndRestartStopWatch(const int);
+
     void startSpeedWalk();
     void saveModules(int sync, bool backup = true);
     void reloadModule(const QString& reloadModuleName);
@@ -248,7 +326,12 @@ public:
     bool mAlertOnNewData;
     bool mAllowToSendCommand;
     bool mAutoClearCommandLineAfterSend;
+    // Set in constructor and used in (bool) TScript::setScript(const QString&)
+    // to prevent compilation of the script that was being set therein, cleared
+    // after the main TConsole for a new profile has been created during the
+    // period when mIsProfileLoadingSequence has been set:
     bool mBlockScriptCompile;
+    bool mBlockStopWatchCreation;
     bool mEchoLuaErrors;
     int mBorderBottomHeight;
     int mBorderLeftWidth;
@@ -280,6 +363,10 @@ public:
     QString mProxyPassword;
 
     bool mIsGoingDown;
+    // Used to force the test compilation of the scripts for TActions ("Buttons")
+    // that are pushdown buttons that run when they are "pushed down" during
+    // loading even though the buttons start out with themselves NOT being
+    // pushed down:
     bool mIsProfileLoadingSequence;
 
     bool mLF_ON_GA;
@@ -459,9 +546,15 @@ private slots:
 
 private:
     void installPackageFonts(const QString &packageName);
+    void processGMCPDiscordStatus(const QJsonObject& discordInfo);
+    void processGMCPDiscordInfo(const QJsonObject& discordInfo);
+    void updateModuleZips() const;
+    void loadSecuredPassword();
+    void removeAllNonPersistentStopWatches();
+    void updateConsolesFont();
+
     QFont mDisplayFont;
     QStringList mModulesToSync;
-
     QScopedPointer<LuaInterface> mLuaInterface;
 
     TriggerUnit mTriggerUnit;
@@ -494,7 +587,12 @@ private:
 
     QString mUserDefinedName;
 
-    QMap<int, QTime> mStopWatchMap;
+    // To keep things simple for Lua the first stopwatch will be allocated a key
+    // of 1 - and anything less that that will be rejected - and we force
+    // createStopWatch() to return 0 during script loading so that we do not get
+    // superious stopwatches from being created then (when
+    // mIsProfileLoadingSequence is true):
+    QMap<int, stopWatch*> mStopWatchMap;
 
     QMap<QString, QStringList> mAnonymousEventHandlerFunctions;
 
@@ -549,12 +647,6 @@ private:
     // looked up directly by that class:
     bool mEnableUserDictionary;
     bool mUseSharedDictionary;
-
-    void processGMCPDiscordStatus(const QJsonObject& discordInfo);
-    void processGMCPDiscordInfo(const QJsonObject& discordInfo);
-    void updateModuleZips() const;
-    void updateConsolesFont();
-    void loadSecuredPassword();
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1910,77 +1910,500 @@ int TLuaInterpreter::getColumnNumber(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getStopWatchTime
 int TLuaInterpreter::getStopWatchTime(lua_State* L)
 {
-    int watchID;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "getStopWatchTime: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        watchID = lua_tointeger(L, 1);
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "getStopWatchTime: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
     }
+
+    int watchId = 0;
+    QPair<bool, double> result;
     Host& host = getHostFromLua(L);
-    double time = host.getStopWatchTime(watchID);
-    lua_pushnumber(L, time);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+        result = host.getStopWatchTime(watchId);
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "stopwatch with id %d not found", watchId);
+            return 2;
+        }
+
+    } else {
+        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        // Using an empty string will return the first unnamed stopwatch:
+        watchId = host.findStopWatchId(name);
+        if (!watchId) {
+            lua_pushnil(L);
+            if (name.isEmpty()) {
+                lua_pushstring(L, "no unnamed stopwatches found");
+            } else {
+                lua_pushfstring(L, "stopwatch with name \"%s\" not found", name.toUtf8().constData());
+            }
+            return 2;
+        }
+
+        result = host.getStopWatchTime(watchId);
+        // We have already validated the name to get the watchId - so for things
+        // to fail now is, unlikely?
+        if (Q_UNLIKELY(!result.first)) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "stopwatch with name \"%s\" (id: %d) has disappeared - this should not happen, please report it to Mudlet developers", name.toUtf8().constData(), watchId);
+            return 2;
+        }
+    }
+
+    lua_pushnumber(L, result.second);
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createStopWatch
 int TLuaInterpreter::createStopWatch(lua_State* L)
 {
+    QString name;
+    bool autoStart = true;
+    int n = lua_gettop(L);
+    int s = 0;
+    if (n) {
+        if (lua_type(L, ++s) == LUA_TBOOLEAN) {
+            autoStart = lua_toboolean(L, s);
+        } else if (lua_type(L, s) == LUA_TSTRING) {
+            autoStart = false;
+            name = QString::fromUtf8(lua_tostring(L, 1));
+        } else {
+            lua_pushfstring(L, "createStopWatch: bad argument #%d type (name as string or autostart as boolean are optional, got %s!)", luaL_typename(L, s));
+            return lua_error(L);
+        }
+
+        if (n > 1) {
+            if (lua_type(L, ++s) == LUA_TBOOLEAN) {
+                autoStart = lua_toboolean(L, s);
+            } else {
+                lua_pushfstring(L, "createStopWatch: bad argument #%d type (autostart as boolean is optional, got %s!)", luaL_typename(L, s));
+                return lua_error(L);
+            }
+        }
+    }
+
+
     Host& host = getHostFromLua(L);
-    double watchID = host.createStopWatch();
-    lua_pushnumber(L, watchID);
+    QPair<int, QString> result = host.createStopWatch(name);
+    if (!result.first) {
+        lua_pushnil(L);
+        lua_pushfstring(L, result.second.toUtf8().constData());
+        return 2;
+    }
+
+    if (autoStart) {
+        host.startStopWatch(result.first);
+    }
+
+    lua_pushnumber(L, result.first);
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopStopWatch
 int TLuaInterpreter::stopStopWatch(lua_State* L)
 {
-    int watchID;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "stopStopWatch: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        watchID = lua_tointeger(L, 1);
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "stopStopWatch: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
     }
+
     Host& host = getHostFromLua(L);
-    double time = host.stopStopWatch(watchID);
-    lua_pushnumber(L, time);
+    int watchId = 0;
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+        QPair<bool, QString> result = host.stopStopWatch(watchId);
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushstring(L, result.second.toUtf8().constData());
+            return 2;
+        }
+
+    } else {
+        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        QPair<bool, QString> result = host.stopStopWatch(name);
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushstring(L, result.second.toUtf8().constData());
+            return 2;
+        }
+
+        watchId = host.findStopWatchId(name);
+        // We have already validated the name to get the watchId - so for things
+        // to fail now is, unlikely?
+        if (Q_UNLIKELY(!watchId)) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "stopwatch with name \"%s\" (id: %d) has disappeared - this should not happen, please report it to Mudlet developers", name.toUtf8().constData(), watchId);
+            return 2;
+        }
+    }
+
+    // We know that this watchId is valid so can use the return value directly
+    // as we want to emulate the past behaviour where stopping the stopWatch
+    // returned the elapsed time ONCE:
+    lua_pushnumber(L, host.getStopWatchTime(watchId).second);
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#startStopWatch
 int TLuaInterpreter::startStopWatch(lua_State* L)
 {
-    int watchID;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "startStopWatch: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        watchID = lua_tointeger(L, 1);
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "startStopWatch: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
     }
+
     Host& host = getHostFromLua(L);
-    bool b = host.startStopWatch(watchID);
-    lua_pushboolean(L, b);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        // Flag (if true) to replicate previous (reset and start again from zero
+        // if call is repeated without any other actions being carried out on
+        // stopwatch) behaviour if only a single NUMERIC argument (ID) supplied:
+        bool autoResetAndRestart = true;
+        if (lua_gettop(L) > 1) {
+            if (!lua_isboolean(L, 2)) {
+                lua_pushfstring(L, "startStopWatch: bad argument #2 type (automatic reset and restart as boolean is optional with a numeric stopwatch id, got %s!)", luaL_typename(L, 2));
+                return lua_error(L);
+            }
+            autoResetAndRestart = lua_toboolean(L, 2);
+        }
+
+        QPair<bool, QString> result;
+        if (autoResetAndRestart) {
+            result = host.resetAndRestartStopWatch(static_cast<int>(lua_tointeger(L, 1)));
+        } else {
+            result = host.startStopWatch(static_cast<int>(lua_tointeger(L, 1)));
+        }
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushstring(L, result.second.toUtf8().constData());
+            return 2;
+        }
+
+        lua_pushboolean(L, true);
+        return 1;
+    }
+
+    QPair<bool, QString> result = host.startStopWatch(QString::fromUtf8(lua_tostring(L, 1)));
+    if (!result.first) {
+        lua_pushnil(L);
+        lua_pushstring(L, result.second.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetStopWatch
 int TLuaInterpreter::resetStopWatch(lua_State* L)
 {
-    int watchID;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "resetStopWatch: wrong argument type");
-        lua_error(L);
-        return 1;
-    } else {
-        watchID = lua_tointeger(L, 1);
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "resetStopWatch: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
     }
+
     Host& host = getHostFromLua(L);
-    bool b = host.resetStopWatch(watchID);
-    lua_pushboolean(L, b);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        QPair<bool, QString> result = host.resetStopWatch(static_cast<int>(lua_tointeger(L, 1)));
+        if (!result.first) {
+            lua_pushnil(L);
+            lua_pushstring(L, result.second.toUtf8().constData());
+            return 2;
+        }
+
+        lua_pushboolean(L, true);
+        return 1;
+    }
+
+    QPair<bool, QString> result = host.resetStopWatch(QString::fromUtf8(lua_tostring(L, 1)));
+    if (!result.first) {
+        lua_pushnil(L);
+        lua_pushstring(L, result.second.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#adjustStopWatch
+int TLuaInterpreter::adjustStopWatch(lua_State* L)
+{
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "adjustStopWatch: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+
+    int watchId = 0;
+    Host& host = getHostFromLua(L);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+    } else {
+        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        // Using an empty string will return the first unnamed stopwatch:
+        watchId = host.findStopWatchId(name);
+        if (!watchId) {
+            lua_pushnil(L);
+            if (name.isEmpty()) {
+                lua_pushstring(L, "no unnamed stopwatches found");
+            } else {
+                lua_pushfstring(L, "stopwatch with name \"%s\" not found", name.toUtf8().constData());
+            }
+            return 2;
+        }
+    }
+
+    if (!lua_isnumber(L, 2)) {
+        lua_pushfstring(L, "adjustStopWatch: bad argument #2 type (modification in seconds as number expected, got %s!)", luaL_typename(L, 2));
+        return lua_error(L);
+    }
+
+    double adjustment = lua_tonumber(L, 2);
+    bool result = host.adjustStopWatch(watchId, qRound(adjustment * 1000.0));
+    // This is only likely to fail when a numeric first argument was given:
+    if (!result) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "stopwatch with id %d not found", watchId);
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteStopWatch
+int TLuaInterpreter::deleteStopWatch(lua_State* L)
+{
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "deleteStopWatch: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+
+    int watchId = 0;
+    Host& host = getHostFromLua(L);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+    } else {
+        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        // Using an empty string will return the first unnamed stopwatch:
+        watchId = host.findStopWatchId(name);
+        if (!watchId) {
+            lua_pushnil(L);
+            if (name.isEmpty()) {
+                lua_pushstring(L, "no unnamed stopwatches found");
+            } else {
+                lua_pushfstring(L, "stopwatch with name \"%s\" not found", name.toUtf8().constData());
+            }
+            return 2;
+        }
+    }
+
+    bool result = host.destroyStopWatch(watchId);
+    // This is only likely to fail when a numeric first argument was given:
+    if (!result) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "stopwatch with id %d not found", watchId);
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setStopWatchPersistence
+int TLuaInterpreter::setStopWatchPersistence(lua_State* L)
+{
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "setStopWatchPersistence: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+
+    int watchId = 0;
+    Host& host = getHostFromLua(L);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+    } else {
+        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        // Using an empty string will return the first unnamed stopwatch:
+        watchId = host.findStopWatchId(name);
+        if (!watchId) {
+            lua_pushnil(L);
+            if (name.isEmpty()) {
+                lua_pushstring(L, "no unnamed stopwatches found");
+            } else {
+                lua_pushfstring(L, "stopwatch with name \"%s\" not found", name.toUtf8().constData());
+            }
+            return 2;
+        }
+    }
+
+    if (!lua_isboolean(L, 2)) {
+        lua_pushfstring(L, "setStopWatchPersistence: bad argument #2 type (persistence as boolean expected, got %s!)", luaL_typename(L, 2));
+        return lua_error(L);
+    }
+    bool isPersistent = lua_toboolean(L, 2);
+    // This is only likely to fail when a numeric first argument was given:
+    if (!host.makeStopWatchPersistent(watchId, isPersistent)) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "stopwatch with id %d not found", watchId);
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setStopWatchName
+int TLuaInterpreter::setStopWatchName(lua_State* L)
+{
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "setStopWatchName: bad argument #1 type (stopwatch id as number or current name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+
+    int watchId = 0;
+    Host& host = getHostFromLua(L);
+    QString currentName;
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+    } else {
+        // Using an empty string will return the first unnamed stopwatch:
+        currentName = QString::fromUtf8(lua_tostring(L, 1));
+    }
+
+    if (!lua_isstring(L, 2)) {
+        lua_pushfstring(L, "setStopWatchName: bad argument #2 type (stopwatch new name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+    QString newName = QString::fromUtf8(lua_tostring(L, 2));
+
+    QPair<bool, QString> result;
+    if (currentName.isNull()) {
+        // Will be null if no value was assigned to it - so use the id form:
+        result = host.setStopWatchName(watchId, newName);
+    } else {
+        result = host.setStopWatchName(currentName, newName);
+    }
+
+    if (!result.first) {
+        lua_pushnil(L);
+        lua_pushstring(L, result.second.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: none - internal helper for getStopWatchBrokenDownTime()/getStopWatches()
+void TLuaInterpreter::generateElapsedTimeTable(lua_State* L, const QStringList& elapsedTimeSplitString, const bool includeDecimalSeconds, const qint64 elapsedTimeMilliSeconds)
+{
+    lua_newtable(L);
+    lua_pushstring(L, "negative");
+    // Qt 5.7 seemed to not like comparing a QString with a QLatin1Char so
+    // use a QLatin1String instead even though it is only a single character:
+    lua_pushboolean(L, elapsedTimeSplitString.at(0) == QLatin1String("-"));
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "days");
+    lua_pushinteger(L, elapsedTimeSplitString.at(1).toInt());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "hours");
+    lua_pushinteger(L, elapsedTimeSplitString.at(2).toInt());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "minutes");
+    lua_pushinteger(L, elapsedTimeSplitString.at(3).toInt());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "seconds");
+    lua_pushinteger(L, elapsedTimeSplitString.at(4).toInt());
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "milliSeconds");
+    lua_pushinteger(L, elapsedTimeSplitString.at(5).toInt());
+    lua_settable(L, -3);
+
+    if (includeDecimalSeconds) {
+        lua_pushstring(L, "decimalSeconds");
+        lua_pushnumber(L, elapsedTimeMilliSeconds / 1000.0);
+        lua_settable(L, -3);
+    }
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getStopWatchBrokenDownTime
+int TLuaInterpreter::getStopWatchBrokenDownTime(lua_State* L)
+{
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "getStopWatchBrokenDownTime: bad argument #1 type (stopwatch id as number or name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+
+    int watchId = 0;
+    Host& host = getHostFromLua(L);
+    if (lua_type(L, 1) == LUA_TNUMBER) {
+        watchId = static_cast<int>(lua_tointeger(L, 1));
+    } else {
+        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        // Using an empty string will return the first unnamed stopwatch:
+        watchId = host.findStopWatchId(name);
+        if (!watchId) {
+            lua_pushnil(L);
+            if (name.isEmpty()) {
+                lua_pushstring(L, "no unnamed stopwatches found");
+            } else {
+                lua_pushfstring(L, "stopwatch with name \"%s\" not found", name.toUtf8().constData());
+            }
+            return 2;
+        }
+    }
+
+    QPair<bool, QString> result = host.getBrokenDownStopWatchTime(watchId);
+    // This is only likely to fail when a numeric first argument was given:
+    if (!result.first) {
+        lua_pushnil(L);
+        lua_pushstring(L, result.second.toUtf8().constData());
+        return 2;
+    }
+
+    const QStringList splitTimeString(result.second.split(QLatin1Char(':')));
+    generateElapsedTimeTable(L, splitTimeString, false);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getStopWatches
+int TLuaInterpreter::getStopWatches(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    const QList<int> stopWatchIds = host.getStopWatchIds();
+    lua_newtable(L);
+    for (int index = 0, total = stopWatchIds.count(); index < total; ++index) {
+        int watchId = stopWatchIds.at(index);
+        lua_pushnumber(L, watchId);
+        auto pStopWatch = host.getStopWatch(watchId);
+        lua_newtable(L);
+        {
+            lua_pushstring(L, "name");
+            lua_pushstring(L, pStopWatch->name().toUtf8().constData());
+            lua_settable(L, -3);
+
+            lua_pushstring(L, "isRunning");
+            lua_pushboolean(L, pStopWatch->running());
+            lua_settable(L, -3);
+
+            lua_pushstring(L, "isPersistent");
+            lua_pushboolean(L, pStopWatch->persistent());
+            lua_settable(L, -3);
+
+            lua_pushstring(L, "elapsedTime");
+            const QStringList splitTimeString(pStopWatch->getElapsedDayTimeString().split(QLatin1Char(':')));
+            generateElapsedTimeTable(L, splitTimeString, true, pStopWatch->getElapsedMilliSeconds());
+            lua_settable(L, -3);
+        }
+        lua_settable(L, -3);
+    }
+
     return 1;
 }
 
@@ -15189,6 +15612,12 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "stopStopWatch", TLuaInterpreter::stopStopWatch);
     lua_register(pGlobalLua, "startStopWatch", TLuaInterpreter::startStopWatch);
     lua_register(pGlobalLua, "resetStopWatch", TLuaInterpreter::resetStopWatch);
+    lua_register(pGlobalLua, "adjustStopWatch", TLuaInterpreter::adjustStopWatch);
+    lua_register(pGlobalLua, "deleteStopWatch", TLuaInterpreter::deleteStopWatch);
+    lua_register(pGlobalLua, "setStopWatchPersistence", TLuaInterpreter::setStopWatchPersistence);
+    lua_register(pGlobalLua, "getStopWatches", TLuaInterpreter::getStopWatches);
+    lua_register(pGlobalLua, "setStopWatchName", TLuaInterpreter::setStopWatchName);
+    lua_register(pGlobalLua, "getStopWatchBrokenDownTime", TLuaInterpreter::getStopWatchBrokenDownTime);
     lua_register(pGlobalLua, "closeUserWindow", TLuaInterpreter::closeUserWindow);
     lua_register(pGlobalLua, "resizeWindow", TLuaInterpreter::resizeWindow);
     lua_register(pGlobalLua, "appendBuffer", TLuaInterpreter::appendBuffer);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -548,6 +548,7 @@ private:
     void insertColorTableEntry(lua_State*, const QColor&, const QString&);
     // The last argument is only needed if the third one is true:
     static void generateElapsedTimeTable(lua_State*, const QStringList&, const bool, const qint64 elapsedTimeMilliSeconds = 0);
+    static std::tuple<bool, int> getWatchId(lua_State*, Host&);
 
 
     QNetworkAccessManager* mpFileDownloader;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -321,6 +321,12 @@ public:
     static int getStopWatchTime(lua_State*);
     static int startStopWatch(lua_State*);
     static int resetStopWatch(lua_State*);
+    static int adjustStopWatch(lua_State*);
+    static int deleteStopWatch(lua_State*);
+    static int setStopWatchPersistence(lua_State*);
+    static int getStopWatches(lua_State*);
+    static int setStopWatchName(lua_State*);
+    static int getStopWatchBrokenDownTime(lua_State*);
     static int createMiniConsole(lua_State*);
     static int createLabel(lua_State*);
     static int moveWindow(lua_State*);
@@ -538,9 +544,11 @@ private:
     void handleHttpOK(QNetworkReply*);
 #if defined(Q_OS_WIN32)
     void loadUtf8Filenames();
-
 #endif
     void insertColorTableEntry(lua_State*, const QColor&, const QString&);
+    // The last argument is only needed if the third one is true:
+    static void generateElapsedTimeTable(lua_State*, const QStringList&, const bool, const qint64 elapsedTimeMilliSeconds = 0);
+
 
     QNetworkAccessManager* mpFileDownloader;
     std::list<std::string> mCaptureGroupList;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -533,6 +533,27 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("mRoomSize").text().set(QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData());
     }
 
+    {
+        auto stopwatches = host.append_child("stopwatches");
+        QListIterator<int> itStopWatchId(pHost->getStopWatchIds());
+        while (itStopWatchId.hasNext()) {
+            auto stopWatchId = itStopWatchId.next();
+            auto pStopWatch = pHost->getStopWatch(stopWatchId);
+            if (pStopWatch->persistent()) {
+                auto stopwatch = stopwatches.append_child("stopwatch");
+                // Three QStrings used here are purely numeric so can be expressed in Latin1 encoding:
+                stopwatch.append_attribute("id") = QString::number(stopWatchId).toLatin1().constData();
+                if (pStopWatch->running()) {
+                    stopwatch.append_attribute("running") = "yes";
+                    stopwatch.append_attribute("effectiveStartDateTimeEpochMSecs") = QString::number(QDateTime::currentMSecsSinceEpoch() - pStopWatch->getElapsedMilliSeconds()).toLatin1().constData();
+                } else {
+                    stopwatch.append_attribute("running") = "no";
+                    stopwatch.append_attribute("elapsedDateTimeMSecs") = QString::number(pStopWatch->getElapsedMilliSeconds()).toLatin1().constData();
+                }
+                stopwatch.append_attribute("name") = pStopWatch->name().toUtf8().constData();
+            }
+        }
+    }
     writeTriggerPackage(pHost, mudletPackage, true);
     writeTimerPackage(pHost, mudletPackage, true);
     writeAliasPackage(pHost, mudletPackage, true);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1059,6 +1059,8 @@ void XMLimport::readHostPackage(Host* pHost)
                 // QDebug() error reporting associated with the following
                 // readUnknownHostElement() for "anything not otherwise parsed"
                 Q_UNUSED(readElementText());
+            } else if (name() == "stopwatches") {
+                readStopWatchMap();
             } else {
                 readUnknownHostElement();
             }
@@ -1755,6 +1757,40 @@ void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<i
         } else {
             // Must advance the pattern interator if it isn't a colour pattern
             itPattern.next();
+        }
+    }
+}
+
+void XMLimport::readStopWatchMap()
+{
+    while (!atEnd()) {
+        readNext();
+
+        if (isEndElement()) {
+            break;
+        } else if (isStartElement()) {
+            if (name() == "stopwatch") {
+                int watchId = attributes().value("id").toInt();
+                auto pStopWatch = new stopWatch();
+                pStopWatch->setName(attributes().value("name").toString());
+                pStopWatch->mIsPersistent = true;
+                pStopWatch->mIsInitialised = true;
+                if (attributes().value("running") == "yes") {
+                    pStopWatch->mIsRunning = true;
+                    // The stored value is the point in epoch time that the
+                    // stopwatch appears to have been started so we need to
+                    // make that into a QDateTime that is the equivalent:
+                    pStopWatch->mEffectiveStartDateTime.setMSecsSinceEpoch(attributes().value("effectiveStartDateTimeEpochMSecs").toLongLong());
+                } else {
+                    pStopWatch->mIsRunning = false;
+                    pStopWatch->mElapsedTime = attributes().value("elapsedDateTimeMSecs").toLongLong();
+                }
+                mpHost->mStopWatchMap.insert(watchId, pStopWatch);
+                // A dummy read as there should not be any text for this element:
+                readElementText();
+            } else {
+                readUnknownHostElement();
+            }
         }
     }
 }

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -86,6 +86,7 @@ private:
     void readUnknownKeyElement();
 
     void readHostPackage(Host*);
+    void readStopWatchMap();
     int readTriggerGroup(TTrigger*);
     int readTimerGroup(TTimer*);
     int readAliasGroup(TAlias*);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3843,6 +3843,7 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
     pHost->mLuaInterpreter.loadGlobal();
     hideMudletsVariables(pHost);
 
+    pHost->mBlockStopWatchCreation = false;
     pHost->getScriptUnit()->compileAll();
     pHost->mIsProfileLoadingSequence = false;
 


### PR DESCRIPTION
This commit is a rework of the original PR #2516 squash-and-merged with the bugfix that I proposed as PR #3162 but which became difficult to apply when the original PR was eliminated from the development branch because it has been reverted from the 4.2.0 release and then that had been merged into the development branch!

This PR allows stopwatches to be stopped and read at any time afterwards, for any number of times. It also:
* allows stopwatches to be destroyed - so ID numbers WILL get reused - with a Lua `(bool) destroyStopWatch((int) id)` function.
* allows them to be marked as persistent so that they are saved with the profile and reloaded again - if they were running then they will continue to increment when the profile is not loaded so they can be used to real time events outside of the profile/session; this uses a new Lua function `(bool) setStopWatchPersistence((int) id, (bool) setPersistent)`.
* allows them to be adjusted (even so they become negative) so can be used to count down as well as count up time - whether the stopwatch concerned is running or not.
* have error messages that conform to our current style
* have more run-time handling - most actions that produce no effect will advise that this is the case -  e.g. stopping a stopwatch that was NOT running...
* can handle periods of time longer than a day - the previous implementation wrapped around after 24 hours.
* should not affected by DST changes - OS permitting.
* the Lua API also gains a `getStopWatches()` function that returns a table with the id numbers as keys and values as tables of:
  * `(bool) isRunning`
  * `(bool) isPersistent`
  * `(string) name`
  * `(table) elapsedTime` - containing broken down time:
    * `(bool) negative`
    * `(int) days`
    * `(int) hours (0 to 23)`
    * `(int) minutes (0 to 59)`
    * `(int) seconds (0 to 59)`
    * `(int) milliSeconds (0 to 999)`
    * `(float) decimalSeconds` floating point value of whole of the time in seconds (can be negative!)
* allows stop watches to be named - which is useful as then they can be identified in scripts; this means that all the stop watch functions can now take a name string as well as a numeric argument. Using an empty string will access the first (lowest id) stopwatch that does not have a name and the `createStopWatch()` function will accept an optional string argument as a name.  For simplicity each name must be unique and this is enforced for that function and the added `setStopWatchName(id or name, newName)` function. The latter will also accept an empty string as either the first or second argument; in the first case it will assign the name to the first unnamed stopwatch and the second will clear the name of the specified one.
* added `getStopWatchBrokenDownTime(...)` which returns the same broken down elements in a table for a single specified timer (day count; hours; minutes; seconds; milliseconds and whether the time is positive or negative {when preset with a negative adjustment and used as a count down})...

During debugging I found out that the process of loading an existing profile that contained `createStopWatch()` calls was creating them during the testing/loading phase so I had to add extra code to prevent that function from taking effect whilst `(bool)` ~~`Host::mIsProfileLoadingSequence`~~ *EDIT: revised to use a different, new, flag: `Host::mBlockStopWatchCreation` which is cleared earlier in the loading sequence* is true. Then, when testing the `resetProfile()` function I found that the same thing was happening AND that the non-persistent stopwatches needed to be removed as well - which is solved by also preventing stopwatch creation whilst `(bool) Host::mResetProfile` is set and by running a new method `(void) Host::removeAllNonPersistentStopWatches()`! This thus allows stopwatches to be created during the profile startup sequence when lua scripts are run on loading (but after a prior compilation to test for script validity has been done).

`(QString) stopWatch::getElapsedDayTimeString() const` made use of `int` for some intermediate local variables but on Windows platforms the `int` type may be 32-bit long and thus not big enough to contain 64-bit values - and some other locals can be much shorter because of the limits that the code places on their values but will give compiler warnings without `static_cast <T>`.

Use `std::chrono_literals` to specify some needed time intervals rather than large long integer literal constants.

Refactor a block of code used to generate the broken down time as a Lua table so that two instances are handled by a single helper function.

Additional code (the bug fix) has been included to provide backwards-compatibility for Lua `startStopWatch(id)` function which recreates prior start stop-watch behaviour when it is created:

The prior form of `startStopWatch(...)` would reset and restart the indicated stopwatch each time that it was called.  This is not really compatible with the revised functionality which allows the recorded time to be adjusted even before the stopwatch is first used.  To allow existing scripts to
continue to experience the same API this commit adds an optional second boolean argument to the `startStopWatch(...)` call ONLY WHEN the first argument is an id number and NOT a string name.  If the second argument is omitted (as it will be when using older scripts) or is true then each time the function is used the stopwatch will be reset and restarted. Just in case the same behaviour ***is*** wanted with stop watch created **with** a **name** then a second boolean `true` will start the stopwatch from zero.

This PR replaces (and thus will) close #3162 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>