### PR TITLE
Add simple 2min autosave for notepad contents

### DIFF
--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -90,7 +90,8 @@ void dlgNotepad::slot_text_written()
     mNeedToSave = true;
 }
 
-void dlgNotepad::timerEvent(QTimerEvent *event) {
+void dlgNotepad::timerEvent(QTimerEvent* event)
+{
     Q_UNUSED(event);
 
     if (!mNeedToSave) {

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -28,6 +28,8 @@
 #include <QDir>
 #include "post_guard.h"
 
+using namespace std::chrono;
+
 dlgNotepad::dlgNotepad(Host* pH)
 : mpHost(pH)
 {
@@ -36,6 +38,10 @@ dlgNotepad::dlgNotepad(Host* pH)
     if (mpHost) {
         restore();
     }
+
+    connect(notesEdit, &QPlainTextEdit::textChanged, this, &dlgNotepad::slot_text_written);
+
+    startTimer(2min);
 }
 
 dlgNotepad::~dlgNotepad()
@@ -62,6 +68,9 @@ void dlgNotepad::save()
     fileStream.setDevice(&file);
     fileStream << notesEdit->toPlainText();
     file.close();
+
+    mNeedToSave = false;
+    qDebug()<<"saved";
 }
 
 void dlgNotepad::restore()
@@ -75,4 +84,19 @@ void dlgNotepad::restore()
     QString txt = fileStream.readAll();
     notesEdit->setPlainText(txt);
     file.close();
+}
+
+void dlgNotepad::slot_text_written()
+{
+    mNeedToSave = true;
+}
+
+void dlgNotepad::timerEvent(QTimerEvent *event) {
+    Q_UNUSED(event);
+
+    if (!mNeedToSave) {
+        return;
+    }
+
+    save();
 }

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -81,7 +81,9 @@ void dlgNotepad::restore()
     QTextStream fileStream;
     fileStream.setDevice(&file);
     QString txt = fileStream.readAll();
+    notesEdit->blockSignals(true);
     notesEdit->setPlainText(txt);
+    notesEdit->blockSignals(false);
     file.close();
 }
 

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -70,7 +70,6 @@ void dlgNotepad::save()
     file.close();
 
     mNeedToSave = false;
-    qDebug()<<"saved";
 }
 
 void dlgNotepad::restore()

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -43,8 +43,14 @@ public:
     void save();
     void restore();
 
+private slots:
+    void slot_text_written();
+
 private:
     QPointer<Host> mpHost;
+    bool mNeedToSave{};
+
+    void timerEvent(QTimerEvent *event);
 };
 
 #endif // MUDLET_DLGNOTEPAD_H

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -50,7 +50,7 @@ private:
     QPointer<Host> mpHost;
     bool mNeedToSave{};
 
-    void timerEvent(QTimerEvent *event);
+    void timerEvent(QTimerEvent *event) override;
 };
 
 #endif // MUDLET_DLGNOTEPAD_H


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add simple 2min autosave for notepad contents. Right now, notepad is only saved when the profile is closed.
#### Motivation for adding to Mudlet
In the rare case that Mudlet or computer crashes.
#### Other info (issues closed, discussion etc)
Only autosave if content was changed, to prevent laptop battery drain every 2min for no reason.