### PR TITLE
Enhance add support for more than 3 mouse buttons

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -95,7 +95,9 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 {
     if (forwardEventToMapper(event)) {
         return;
-    } else if (mpHost && !mClick.isEmpty()) {
+    }
+
+    if (mpHost && !mClick.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mClick, mClickParams, event);
         event->accept();
     } else {
@@ -107,7 +109,9 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 {
     if (forwardEventToMapper(event)) {
         return;
-    } else if (mpHost && !mDoubleClick.isEmpty()) {
+    }
+
+    if (mpHost && !mDoubleClick.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mDoubleClick, mDoubleClickParams, event);
         event->accept();
     } else {
@@ -119,7 +123,9 @@ void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
     if (forwardEventToMapper(event)) {
         return;
-    } else if (mpHost && !mRelease.isEmpty()) {
+    }
+
+    if (mpHost && !mRelease.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mRelease, mReleaseParams, event);
         event->accept();
     } else {
@@ -131,7 +137,9 @@ void TLabel::mouseMoveEvent(QMouseEvent* event)
 {
     if (forwardEventToMapper(event)) {
         return;
-    } else if (mpHost && !mMove.isEmpty()) {
+    }
+
+    if (mpHost && !mMove.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mMove, mMoveParams, event);
         event->accept();
     } else {
@@ -141,9 +149,11 @@ void TLabel::mouseMoveEvent(QMouseEvent* event)
 
 void TLabel::wheelEvent(QWheelEvent* event)
 {
-    if (forwardEventToMapper(event))
+    if (forwardEventToMapper(event)) {
         return;
-    else if (mpHost && !mWheel.isEmpty()) {
+    }
+
+    if (mpHost && !mWheel.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mWheel, mWheelParams, event);
         event->accept();
     } else {
@@ -155,7 +165,9 @@ void TLabel::leaveEvent(QEvent* event)
 {
     if (forwardEventToMapper(event)) {
         return;
-    } else if (mpHost && !mLeave.isEmpty()) {
+    }
+
+    if (mpHost && !mLeave.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mLeave, mLeaveParams, event);
         event->accept();
     } else {
@@ -167,7 +179,9 @@ void TLabel::enterEvent(QEvent* event)
 {
     if (forwardEventToMapper(event)) {
         return;
-    } else if (mpHost && !mEnter.isEmpty()) {
+    }
+
+    if (mpHost && !mEnter.isEmpty()) {
         mpHost->getLuaInterpreter()->callEventHandler(mEnter, mEnterParams, event);
         event->accept();
     } else {
@@ -185,8 +199,11 @@ bool TLabel::forwardEventToMapper(QEvent* event)
 
     switch (event->type()) {
     case (QEvent::MouseButtonPress):
+        [[fallthrough]];
     case (QEvent::MouseButtonDblClick):
+        [[fallthrough]];
     case (QEvent::MouseButtonRelease):
+        [[fallthrough]];
     case (QEvent::MouseMove): {
         auto mouseEvent = static_cast<QMouseEvent*>(event);
         QWidget* qw = qApp->widgetAt(mouseEvent->globalPos());
@@ -199,6 +216,7 @@ bool TLabel::forwardEventToMapper(QEvent* event)
         break;
     }
     case (QEvent::Enter):
+        [[fallthrough]];
     case (QEvent::Leave): {
         QWidget* qw = qApp->widgetAt(QCursor::pos());
 

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -214,15 +214,20 @@ bool TLabel::forwardEventToMapper(QEvent* event)
         QWidget* qw = qApp->widgetAt(wheelEvent->globalPos());
 
         if (qw && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper")) && parentWidget()->findChild<QWidget*>(QStringLiteral("mapper"))->isAncestorOf(qw)) {
+            // Have switched to the latest QWheelEvent as that handles both X
+            // and Y wheels at the same time whereas previously we said the
+            // event was a vertical one - even if it wasn't! Additionally we
+            // pass on the source of the Qt event - and whether the delta values
+            // are inverted:
             QWheelEvent newEvent(qw->mapFromGlobal(wheelEvent->globalPos()),
                                  wheelEvent->globalPos(),
                                  wheelEvent->pixelDelta(),
                                  wheelEvent->angleDelta(),
-                                 wheelEvent->angleDelta().y() / 8,
-                                 Qt::Vertical,
                                  wheelEvent->buttons(),
                                  wheelEvent->modifiers(),
-                                 wheelEvent->phase());
+                                 wheelEvent->phase(),
+                                 wheelEvent->inverted(),
+                                 wheelEvent->source());
             qApp->sendEvent(qw, &newEvent);
             return true;
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14527,8 +14527,11 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
             break;
         // These are all QMouseEvents
         case (QEvent::MouseButtonPress):
+            [[fallthrough]];
         case (QEvent::MouseButtonDblClick):
+            [[fallthrough]];
         case (QEvent::MouseButtonRelease):
+            [[fallthrough]];
         case (QEvent::MouseMove): {
             auto qME = static_cast<const QMouseEvent*>(qE);
             lua_newtable(L);
@@ -14647,8 +14650,9 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
             break;
         }
         }
-    } else
+    } else {
         error = lua_pcall(L, pE.mArgumentList.size(), LUA_MULTRET, 0);
+    }
 
     if (error) {
         std::string err = "";

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1018,23 +1018,39 @@ void TTextEdit::slot_popupMenu()
     mpHost->mLuaInterpreter.compileAndExecuteScript(cmd);
 }
 
-void TTextEdit::raiseMousePressEvent(QMouseEvent* event)
+void TTextEdit::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const bool isPressEvent)
 {
     TEvent mudletEvent{};
-    mudletEvent.mArgumentList.append(QStringLiteral("sysWindowMousePressEvent"));
+    mudletEvent.mArgumentList.append(isPressEvent ? QStringLiteral("sysWindowMousePressEvent") : QStringLiteral("sysWindowMouseReleaseEvent"));
     switch (event->button()) {
-    case Qt::LeftButton:
-        mudletEvent.mArgumentList.append(QString::number(1));
-        break;
-    case Qt::RightButton:
-        mudletEvent.mArgumentList.append(QString::number(2));
-        break;
-    case Qt::MidButton:
-        mudletEvent.mArgumentList.append(QString::number(3));
-        break;
-    default: // TODO: What about those of us with more than three mouse buttons?
-        mudletEvent.mArgumentList.append(QString());
-        break;
+    case Qt::LeftButton:    mudletEvent.mArgumentList.append(QString::number(1));   break;
+    case Qt::RightButton:   mudletEvent.mArgumentList.append(QString::number(2));   break;
+    case Qt::MidButton:     mudletEvent.mArgumentList.append(QString::number(3));   break;
+    case Qt::BackButton:    mudletEvent.mArgumentList.append(QString::number(4));   break;
+    case Qt::ForwardButton: mudletEvent.mArgumentList.append(QString::number(5));   break;
+    case Qt::TaskButton:    mudletEvent.mArgumentList.append(QString::number(6));   break;
+    case Qt::ExtraButton4:  mudletEvent.mArgumentList.append(QString::number(7));   break;
+    case Qt::ExtraButton5:  mudletEvent.mArgumentList.append(QString::number(8));   break;
+    case Qt::ExtraButton6:  mudletEvent.mArgumentList.append(QString::number(9));   break;
+    case Qt::ExtraButton7:  mudletEvent.mArgumentList.append(QString::number(10));  break;
+    case Qt::ExtraButton8:  mudletEvent.mArgumentList.append(QString::number(11));  break;
+    case Qt::ExtraButton9:  mudletEvent.mArgumentList.append(QString::number(12));  break;
+    case Qt::ExtraButton10: mudletEvent.mArgumentList.append(QString::number(13));  break;
+    case Qt::ExtraButton11: mudletEvent.mArgumentList.append(QString::number(14));  break;
+    case Qt::ExtraButton12: mudletEvent.mArgumentList.append(QString::number(15));  break;
+    case Qt::ExtraButton13: mudletEvent.mArgumentList.append(QString::number(16));  break;
+    case Qt::ExtraButton14: mudletEvent.mArgumentList.append(QString::number(17));  break;
+    case Qt::ExtraButton15: mudletEvent.mArgumentList.append(QString::number(18));  break;
+    case Qt::ExtraButton16: mudletEvent.mArgumentList.append(QString::number(19));  break;
+    case Qt::ExtraButton17: mudletEvent.mArgumentList.append(QString::number(20));  break;
+    case Qt::ExtraButton18: mudletEvent.mArgumentList.append(QString::number(21));  break;
+    case Qt::ExtraButton19: mudletEvent.mArgumentList.append(QString::number(22));  break;
+    case Qt::ExtraButton20: mudletEvent.mArgumentList.append(QString::number(23));  break;
+    case Qt::ExtraButton21: mudletEvent.mArgumentList.append(QString::number(24));  break;
+    case Qt::ExtraButton22: mudletEvent.mArgumentList.append(QString::number(25));  break;
+    case Qt::ExtraButton23: mudletEvent.mArgumentList.append(QString::number(26));  break;
+    case Qt::ExtraButton24: mudletEvent.mArgumentList.append(QString::number(27));  break;
+    default:                mudletEvent.mArgumentList.append(QString::number(0));
     }
     mudletEvent.mArgumentList.append(QString::number(event->x()));
     mudletEvent.mArgumentList.append(QString::number(event->y()));
@@ -1047,8 +1063,8 @@ void TTextEdit::raiseMousePressEvent(QMouseEvent* event)
 
 void TTextEdit::mousePressEvent(QMouseEvent* event)
 {
-    if (mpConsole->getType() & (TConsole::MainConsole | TConsole::Buffer)) {
-        raiseMousePressEvent(event);
+    if (mpConsole->getType() == TConsole::MainConsole) {
+        raiseMudletMousePressOrReleaseEvent(event, true);
     }
 
     if (event->button() == Qt::LeftButton) {
@@ -1604,29 +1620,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
     }
 
     if (mpConsole->getType() == TConsole::MainConsole) {
-        TEvent mudletEvent{};
-        mudletEvent.mArgumentList.append(QLatin1String("sysWindowMouseReleaseEvent"));
-        switch (event->button()) {
-        case Qt::LeftButton:
-            mudletEvent.mArgumentList.append(QString::number(1));
-            break;
-        case Qt::RightButton:
-            mudletEvent.mArgumentList.append(QString::number(2));
-            break;
-        case Qt::MidButton:
-            mudletEvent.mArgumentList.append(QString::number(3));
-            break;
-        default:
-            mudletEvent.mArgumentList.append(QString::number(0));
-            break;
-        }
-        mudletEvent.mArgumentList.append(QString::number(event->x()));
-        mudletEvent.mArgumentList.append(QString::number(event->y()));
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-        mpHost->raiseEvent(mudletEvent);
+        raiseMudletMousePressOrReleaseEvent(event, false);
     } else if (mpConsole->getType() == TConsole::UserWindow && mpConsole->mpDockWidget && mpConsole->mpDockWidget->isFloating()) {
         // Need to take an extra step to return focus to main profile TConsole's
         // instance - using same method as TAction::execute():

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -133,7 +133,7 @@ private:
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
     void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
-    void raiseMousePressEvent(QMouseEvent* event);
+    void raiseMudletMousePressOrReleaseEvent(QMouseEvent*, const bool);
 
     int mFontHeight;
     int mFontWidth;


### PR DESCRIPTION
This applies to the main console window for a profile and now reports all mouse button presses and releases in the `sysWindowMousePressEvent` and `sysWindowMouseReleaseEvent` instead of only the first three (left, right, middle).

The code for the same things in Labels was checked and I found that we were generally okay there already except that we were fabricating native Qt mouse events for the mapper where it overlaid a label but we were using an older (Qt4 compatible) event that only handled one mouse wheel at a time and we were assuming it was for a vertical mouse wheel. As the owner of a mouse with two wheels that assumption is misplaced so I have rejigged `(bool) TLabel::forwardEventToMapper(QEvent*)` so that it can pass horizontal and vertical mouse wheel events in the future.

This will hopefully help to address #3220 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>