### PR TITLE
Remove temporary aliases when calling resetProfile()

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -138,6 +138,16 @@ void AliasUnit::removeAliasRootNode(TAlias* pT)
     mAliasRootNodeList.remove(pT);
 }
 
+void AliasUnit::removeAllTempAliases()
+{
+    for (auto alias : mAliasRootNodeList) {
+        if (alias->isTemporary()) {
+            alias->setIsActive(false);
+            markCleanup(alias);
+        }
+    }
+}
+
 TAlias* AliasUnit::getAlias(int id)
 {
     QMutexLocker locker(&mAliasUnitLock);

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -49,6 +49,7 @@ public:
     bool enableAlias(const QString&);
     bool disableAlias(const QString&);
     bool killAlias(const QString& name);
+    void removeAllTempAliases();
     bool registerAlias(TAlias* pT);
     void unregisterAlias(TAlias* pT);
     void uninstall(const QString&);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -387,6 +387,7 @@ void Host::reloadModule(const QString& reloadModuleName)
 
 void Host::resetProfile_phase1()
 {
+    mAliasUnit.stopAllTriggers();
     mTriggerUnit.stopAllTriggers();
     mTimerUnit.stopAllTriggers();
     mKeyUnit.stopAllTriggers();
@@ -404,6 +405,7 @@ void Host::resetProfile_phase2()
     getTriggerUnit()->removeAllTempTriggers();
     getKeyUnit()->removeAllTempKeys();
 
+    mAliasUnit.doCleanup();
     mTimerUnit.doCleanup();
     mTriggerUnit.doCleanup();
     mKeyUnit.doCleanup();
@@ -422,6 +424,7 @@ void Host::resetProfile_phase2()
     // All the Timers are NOT compiled here;
     mResetProfile = false;
 
+    mAliasUnit.reenableAllTriggers();
     mTimerUnit.reenableAllTriggers();
     mTriggerUnit.reenableAllTriggers();
     mKeyUnit.reenableAllTriggers();

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -399,6 +399,7 @@ void Host::resetProfile_phase1()
 
 void Host::resetProfile_phase2()
 {
+    getAliasUnit()->removeAllTempAliases();
     getTimerUnit()->removeAllTempTimers();
     getTriggerUnit()->removeAllTempTriggers();
     getKeyUnit()->removeAllTempKeys();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR causes aliases created with `tempAlias` to be reset upon calling `resetProfile()`, similar to `tempTrigger`, etc.

#### Motivation for adding to Mudlet
It makes it a lot easier to enable a development flow where your aliases are defined in external source files and required via `require`/`dofile`. You can create triggers, aliases, etc. with `tempAlias`/`tempTrigger`/etc, and simply call `resetProfile` when you want to reload changes. Currently this isn't the case, since aliases are not reloaded, causing old aliases to hang around.

#### Other info (issues closed, discussion etc)

