### PR TITLE
Don't error out if trigger expiration is given as 0

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7011,10 +7011,8 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     if (lua_isnumber(L, 14)) {
         expiryCount = lua_tonumber(L, 14);
 
-        if (expiryCount < 1) {
-            lua_pushnil(L);
-            lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #14 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
-            return 2;
+        if (expiryCount <= 0) {
+            expiryCount = -1;
         }
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7011,8 +7011,9 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     if (lua_isnumber(L, 14)) {
         expiryCount = lua_tonumber(L, 14);
 
-        if (expiryCount <= 0) {
-            expiryCount = -1;
+        if (expiryCount < 1) {
+            lua_pushfstring(L, "tempComplexRegexTrigger: bad argument #14 value (trigger expiration count must be greater than zero, got %d)", expiryCount);
+            return lua_error(L);
         }
     }
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
The wiki had `tempComplexRegexTrigger("anyText", "^(.*)$", [[echo("Text received!")]], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)` as an example of a trigger.

Try running it and nothing will work, neither will you get any error messages... :)

So the wiki was wrong and it was really frustrating to use. Turns out because the extra 0's (why were the now extra?) were causing the if to error out. It's pretty easy to add an extra 0 to that train of 0's, so - make it easier for the user and ignore it, instead of ambushing them with a silent error (which should have been a lua_error as it's an API parameter error).
#### Motivation for adding to Mudlet
Better user experience.
#### Other info (issues closed, discussion etc)
