### PR TITLE
BugFix: revise to remove qmake project file error

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -207,9 +207,14 @@ unix:!macx {
 # destination place for local builds for software for all users:
     isEmpty( PREFIX ) PREFIX = /usr/local
     # Now picks up the first element of the environmental XDG_DATA_DIRS if
-    # not overridden:
+    # not overridden by providing a DATAROOTDIR:
     isEmpty( DATAROOTDIR ) {
-        DATAROOTDIR = $$first($$replace( XDG_DATA_DIRS, ":", " "))
+        XDG_DATA_DIRS_TEST = $$(XDG_DATA_DIRS)
+        ! isEmpty( XDG_DATA_DIRS_TEST ) {
+            XDG_DATA_DIRS_TEST_SPLIT = $$split(XDG_DATA_DIRS_TEST, :)
+            DATAROOTDIR = $$first(XDG_DATA_DIRS_TEST_SPLIT)
+            message("First (most significant) element of XDG_DATA_DIRS has been determined to be: $${DATAROOTDIR} ...")
+        }
         isEmpty( DATAROOTDIR ) DATAROOTDIR = $${PREFIX}/share
     }
 


### PR DESCRIPTION
This was coming from mishandling the `XDG_DATA_DIRS` environmental variable - as environmental variables have to be converted to qmake variables before they can be used easily in the qmake profile file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>