### PR TITLE
Fix uninitialized member in TMap

### DIFF
--- a/src/TMap.h
+++ b/src/TMap.h
@@ -250,7 +250,7 @@ public:
     // marking, integer percentage clamped in the preferences between 83 and 0,
     // with a default of 70. NOT USED FOR "Original" style marking (the 0'th
     // one):
-    quint8 mPlayerRoomInnerDiameterPercentage;
+    quint8 mPlayerRoomInnerDiameterPercentage {};
 
 public slots:
     // Moved and revised from dlgMapper:


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix uninitialized member in TMap.
#### Motivation for adding to Mudlet
Less Coverity warnings.
#### Other info (issues closed, discussion etc)
Don't have to duplicate it in the class constructor when using C++20, nice :) 