### PR TITLE
BugFix: ensure TMap members controlling 2D player room mark are initialised

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2256,6 +2256,13 @@ TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int 
 void TConsole::createMapper(int x, int y, int width, int height)
 {
     if (!mpMapper) {
+        // Arrange for TMap member values to be copied from the Host masters so they
+        // are in place when the 2D mapper is created:
+        mpHost->getPlayerRoomStyleDetails(mpHost->mpMap->mPlayerRoomStyle,
+                                          mpHost->mpMap->mPlayerRoomOuterDiameterPercentage,
+                                          mpHost->mpMap->mPlayerRoomInnerDiameterPercentage,
+                                          mpHost->mpMap->mPlayerRoomOuterColor,
+                                          mpHost->mpMap->mPlayerRoomInnerColor);
         mpMapper = new dlgMapper(mpMainFrame, mpHost, mpHost->mpMap.data());
 #if defined(INCLUDE_3DMAPPER)
         mpHost->mpMap->mpM = mpMapper->glWidget;


### PR DESCRIPTION
Forgot this when I was producing #2621 as I tend to use the other form of the map in a floating/dockable window.

This might eliminate the CodeFactor suggestion that was being addressed by #3256 as then the members should always be initialised before use which they are not *without* this commit in place.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>