### PR TITLE
Enhance: store and reproduce the editor right side splitter settings

### DIFF
--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -83,6 +83,7 @@ class TKey;
 class TConsole;
 class dlgVarsMainArea;
 
+class QSettings;
 
 class dlgTriggerEditor : public QMainWindow, private Ui::trigger_editor
 {
@@ -216,7 +217,7 @@ public slots:
     void slot_var_selected(QTreeWidgetItem*);
     void slot_var_changed(QTreeWidgetItem*);
     void slot_show_vars();
-    void slot_viewErrorsAction();
+    void slot_toggleErrorsConsole();
     void slot_setupPatternControls(const int);
     void slot_soundTrigger();
     void slot_colorizeTriggerSetBgColor();
@@ -402,6 +403,8 @@ private:
     void setupPatternControls(const int type, dlgTriggerPatternEdit* pItem);
     void key_grab_callback(int key, int modifier);
 
+    void readSplitValues(QSettings&, const EditorViewType, const bool, const QString&);
+    void writeSplitValues(QSettings&, const EditorViewType, const bool, const QString&);
 
     QToolBar* toolBar;
     QToolBar* toolBar2;
@@ -487,6 +490,10 @@ private:
     QString msgInfoAddButton;
     QString msgInfoAddVar;
     QString msgInfoAddKey;
+
+    // Holds the splitter settings for each different view so each one can be
+    // restored when the view is changed:
+    QMap<QPair<EditorViewType, bool>, QList<int>> mSplitSizesMap;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(dlgTriggerEditor::SearchOptions)


### PR DESCRIPTION
This is done for each Mudlet item view with and without the Errors Console being visible.

This is a proposal to reduce the impact that: #3225 has and it also makes the size and position for the editor be profile specific instead of being the same for every profile which will help when using the editor and multi-playing. Similarly the auto-save interval, being technically a per profile option is
also now stored in a per profile manner - though it is not user settable as far as I can tell.

Also:
* swapped around an item in the `dlgTriggerEditor` constructor to fix an ordering error.
* renamed: `dlgTriggerEditor::slot_viewErrorsAction()` to: `dlgTriggerEditor::slot_toggleErrorsConsole()` to better describe its action.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>