### PR TITLE
Fix potential createStopWatch when given nil crash

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1968,8 +1968,10 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
         } else if (lua_type(L, s) == LUA_TSTRING) {
             autoStart = false;
             name = QString::fromUtf8(lua_tostring(L, 1));
+        } else if (lua_type(L, s) == LUA_TNIL) {
+            ; // fallthrough for compatibility with old-style stopwatches in case createStopWatch(nil) is passed
         } else {
-            lua_pushfstring(L, "createStopWatch: bad argument #%d type (name as string or autostart as boolean are optional, got %s!)", luaL_typename(L, s));
+            lua_pushfstring(L, "createStopWatch: bad argument #%d type (name as string or autostart as boolean are optional, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
 
@@ -1977,7 +1979,7 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
             if (lua_type(L, ++s) == LUA_TBOOLEAN) {
                 autoStart = lua_toboolean(L, s);
             } else {
-                lua_pushfstring(L, "createStopWatch: bad argument #%d type (autostart as boolean is optional, got %s!)", luaL_typename(L, s));
+                lua_pushfstring(L, "createStopWatch: bad argument #%d type (autostart as boolean is optional, got %s!)", s,  luaL_typename(L, s));
                 return lua_error(L);
             }
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1970,6 +1970,7 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
             name = QString::fromUtf8(lua_tostring(L, 1));
         } else if (lua_type(L, s) == LUA_TNIL) {
             ; // fallthrough for compatibility with old-style stopwatches in case createStopWatch(nil) is passed
+            // note that 'nil' will still count towards the stack's gettop amount
         } else {
             lua_pushfstring(L, "createStopWatch: bad argument #%d type (name as string or autostart as boolean are optional, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix createStopWatch crash because not all variables were passed to the printf-like function.
#### Motivation for adding to Mudlet
Mudlet should never crash!
#### Other info (issues closed, discussion etc)
Also "name as string or autostart as boolean are optional, got nil!" sounds pretty confusing to me, so I've edited out the optional part, like with other messages. If it's optional, then don't complain that you got nil...