### PR TITLE
BugFix: close IRC window when single profile session ends

### DIFF
--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -108,14 +108,14 @@ dlgIRC::dlgIRC(Host* pHost) : mReadyForSending(false), mpHost(pHost), mIrcStarte
 dlgIRC::~dlgIRC()
 {
     writeQSettings();
-    
+
     if (connection->isActive()) {
         const QString quitMsg = tr("%1 closed their client.").arg(mNickName);
         connection->quit(quitMsg);
         connection->close();
     }
 
-    if (mudlet::self()->mpIrcClientMap.value(mpHost)) {
+    if (mudlet::self() && mudlet::self()->mpIrcClientMap.value(mpHost)) {
         mudlet::self()->mpIrcClientMap.remove(mpHost);
     }
 }
@@ -818,6 +818,9 @@ QPair<bool, QString> dlgIRC::writeIrcChannels(Host* pH, const QStringList& chann
     return pH->writeProfileData(dlgIRC::ChannelsCfgItem, channels.join(QStringLiteral(" ")));
 }
 
-void dlgIRC::writeQSettings() {
-    mudlet::self()->mpSettings->setValue("ircMessageBufferLimit", mMessageBufferLimit);
+void dlgIRC::writeQSettings()
+{
+    if (mudlet::self()) {
+        mudlet::self()->mpSettings->setValue("ircMessageBufferLimit", mMessageBufferLimit);
+    }
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2862,6 +2862,11 @@ void mudlet::closeEvent(QCloseEvent* event)
             pC->mpHost->mpNotePad->close();
             pC->mpHost->mpNotePad = nullptr;
         }
+        // close IRC client window if it is open.
+        if (mpIrcClientMap.contains(pC->mpHost)) {
+            mpIrcClientMap[pC->mpHost]->setAttribute(Qt::WA_DeleteOnClose);
+            mpIrcClientMap[pC->mpHost]->deleteLater();
+        }
 
         // Wait for disconnection to complete
         while (pC->mpHost->mTelnet.getConnectionState() != QAbstractSocket::UnconnectedState) {


### PR DESCRIPTION
This was reported on Discord by user Highope#9700 and I confirmed that when an IRC session is opened for a single profile (NOT multi-playing) and then the Mudlet application is closed the IRC session and the window are not closed. Whilst the `/quit` command will terminate them a seg. fault then immediately occurs because the `dlgIRC` destructor tries to save the settings but needs to use the `mudlet::self()` pointer which is a dangling one by that time.

This commit ensures that the IRC window is closed when the single profile is closed along with the Mudlet application. If this is not required then the change in the `mudlet.cpp` file could be omitted in which case the other changes in the `dlgIRC.cpp` file prevent a segment fault from using a mudlet` pointer that is no longer valid.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>