### PR TITLE
BugFix: allow compilation to complete when 3D Mapper is disabled

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -42,6 +42,7 @@
 #include <QFileDialog>
 #include <QFontDialog>
 #include <QNetworkDiskCache>
+#include <QPainter>
 #include <QString>
 #include <QTableWidget>
 #include <QToolBar>


### PR DESCRIPTION
Due to some internal differences when `WITH_MAPPER` is defined to `NO` the forward reference to `QPainter` in `qwindwsdefs.h` is not resolved in our `dlgProfilePreferences.cpp` - this PR corrects that issue.

This was brought to my attention by the user `lol#1046` on Discord who found this issue when trying to build Mudlet on a Raspberry Pi 4.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>