### PR TITLE
 When downloading a map, ensure map directory exists.

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2186,17 +2186,15 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
     // Check to ensure we have a map directory to save the map files to.
     QDir toProfileDir;
     QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
-    if (!toProfileDir.exists(toProfileDirPathString)) {
-        if (!toProfileDir.mkpath(toProfileDirPathString)) {
-            QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
-                                "Please check that you have permissions/access to:\n"
-                                "\"%1\"\n"
-                                "and there is enough space. The download operation has failed.")
-                                        .arg(toProfileDirPathString);
-            pHost->postMessage(errMsg);
-            mXmlImportMutex.unlock();
-            return;
-        }
+    if (!toProfileDir.mkpath(toProfileDirPathString)) {
+        QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
+                            "Please check that you have permissions/access to:\n"
+                            "\"%1\"\n"
+                            "and there is enough space. The download operation has failed.")
+                                    .arg(toProfileDirPathString);
+        pHost->postMessage(errMsg);
+        mXmlImportMutex.unlock();
+        return;
     }
 
     if (localFileName.isEmpty()) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2183,6 +2183,22 @@ void TMap::downloadMap(const QString& remoteUrl, const QString& localFileName)
         return;
     }
 
+    // Check to ensure we have a map directory to save the map files to.
+    QDir toProfileDir;
+    QString toProfileDirPathString = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+    if (!toProfileDir.exists(toProfileDirPathString)) {
+        if (!toProfileDir.mkpath(toProfileDirPathString)) {
+            QString errMsg = tr("[ ERROR ] - Unable to use or create directory to store map.\n"
+                                "Please check that you have permissions/access to:\n"
+                                "\"%1\"\n"
+                                "and there is enough space. The download operation has failed.")
+                                        .arg(toProfileDirPathString);
+            pHost->postMessage(errMsg);
+            mXmlImportMutex.unlock();
+            return;
+        }
+    }
+
     if (localFileName.isEmpty()) {
         if (url.toString().endsWith(QLatin1String("xml"))) {
             mLocalMapFileName = mudlet::getMudletPath(mudlet::profileXmlMapPathFileName, mProfileName);


### PR DESCRIPTION
There is a  bug when downloading a map via the gmcp server request or by going to options and clicking download the map.  If the map directory doesn't exist, it fails to download the map.  This isn't a problem for XML maps since they're not stored in the map directory (for some unknown reason.)  I would have changed that, but I'm not sure if there would be other effects by doing so.

#### Motivation for adding to Mudlet
Fix a failure to download mudlet .dat map files.

#### Other info (issues closed, discussion etc)
Fixes  #3295