### PR TITLE
Re-enable GMCP modules from gmod when GMCP is enabled rather than at connection time.

### DIFF
--- a/src/mudlet-lua/lua/GMCP.lua
+++ b/src/mudlet-lua/lua/GMCP.lua
@@ -100,7 +100,11 @@ function gmod.reenableModules()
     sendGMCP("Core.Supports.Add " .. yajl.to_string(list))
   end
 end
-registerAnonymousEventHandler("sysConnectionEvent", "gmod.reenableModules")
+registerAnonymousEventHandler("sysProtocolEnabled", function(_, protocol)
+  if protocol == "GMCP" then
+    gmod.reenableModules()
+  end
+end)
 
 -- Remove a user from a module's user list. Disable the module if nobody is using it.
 function disableModule(user, module)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
By changing gmod.reenableModules() execution time to after GMCP is enabled, this PR prevents the built-in Core.Supports.Set (https://github.com/Mudlet/Mudlet/blob/573eaaba4789fe3f541e73cbc1fb0f640b7f45e0/src/ctelnet.cpp#L1028-L1034) from overriding the gmod.reenableModules() Core.Supports.Add list.

#### Motivation for adding to Mudlet
Without this PR, every connection except the first may not enable gmod's registered modules, as the built-in Core.Supports.Set overrides them. This is the cause of #2970.

#### Other info (issues closed, discussion etc)
Alternatives:
* Replace the built-in Core.Supports.Set with Core.Supports.Add (I'm fine with implementing this one)
* Make gmod.enableModule() always send Core.Supports.Add (This shouldn't be necessary if gmod.reenableModules() works correctly)

Fixes #2970 
