### PR TITLE
Update: revise displayed Copyright year to 2020

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -83,7 +83,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
-        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2019");
+        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
         QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -339,7 +339,7 @@ int main(int argc, char* argv[])
 
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
-        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2019");
+        QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
         QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();


### PR DESCRIPTION
We do this manually so as to avoid offending those looking for "reproducible builds" - and thus we do not define the year as a value determined at compilation time (typically by manipulation of the `__DATE__` value)!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>