### PR TITLE
BugFix: remove BOM from start of file

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *


### PR DESCRIPTION
This got introduced in commit 2def7a96257f1eb7071a16db2a54237cc4721f24 but is generally not seen as Git tends to hide it, but it can show up on Windows ... I think.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>