### PR TITLE
BugFix: force UTF-8 coding for notepad so that all languages work

### DIFF
--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -78,10 +78,9 @@ void dlgNotepad::save()
     mNeedToSave = false;
 }
 
-void dlgNotepad::restoreFile(const QString& fName, const bool useUtf8Encoding)
+void dlgNotepad::restoreFile(const QString& fn, const bool useUtf8Encoding)
 {
-    QFile file;
-    file.setFileName(fName);
+    QFile file(fn);
     file.open(QIODevice::ReadOnly);
     QTextStream fileStream;
     fileStream.setDevice(&file);

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -66,6 +66,7 @@ void dlgNotepad::save()
     file.open(QIODevice::WriteOnly);
     QTextStream fileStream;
     fileStream.setDevice(&file);
+    fileStream.setCodec(QTextCodec::codecForName("UTF-8"));
     fileStream << notesEdit->toPlainText();
     file.close();
 
@@ -80,6 +81,7 @@ void dlgNotepad::restore()
     file.open(QIODevice::ReadOnly);
     QTextStream fileStream;
     fileStream.setDevice(&file);
+    fileStream.setCodec(QTextCodec::codecForName("UTF-8"));
     QString txt = fileStream.readAll();
     notesEdit->blockSignals(true);
     notesEdit->setPlainText(txt);

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -47,10 +47,11 @@ private slots:
     void slot_text_written();
 
 private:
+    void timerEvent(QTimerEvent *event) override;
+    void restoreFile(const QString&, const bool);
+
     QPointer<Host> mpHost;
     bool mNeedToSave{};
-
-    void timerEvent(QTimerEvent *event) override;
 };
 
 #endif // MUDLET_DLGNOTEPAD_H


### PR DESCRIPTION
Without this, at least on Windows, a `local8Bit` encoding is used which breaks,  for instance, on Emoji characters in the notepad. As it happens I discovered this when working on a separate PR to ensure better behaviour with using Emoji characters in parts of Mudlet other than the main console window for each profile.

Note that the argument to `QTextCodec::codecForName(...)` is a `QByteArray` rather than a `QString` so does not need wrapping in `QStringLiteral(...)` AFAICT.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>