### PR TITLE
Refactor: simplify some TLabel stuff

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2019 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -2238,7 +2238,7 @@ TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int 
 {
     auto pL = mLabelMap.value(name);
     if (!pL) {
-        pL = new TLabel(mpMainFrame);
+        pL = new TLabel(mpHost, mpMainFrame);
         mLabelMap[name] = pL;
         pL->setObjectName(name);
         pL->setAutoFillBackground(fillBackground);
@@ -2305,23 +2305,6 @@ void TConsole::createMapper(int x, int y, int width, int height)
 #else
     mpMapper->show();
 #endif
-}
-
-bool TConsole::createButton(const QString& name, int x, int y, int width, int height, bool fillBackground)
-{
-    if (!mLabelMap.contains(name)) {
-        auto pC = new TLabel(mpMainFrame);
-        mLabelMap[name] = pC;
-        pC->setObjectName(name);
-        pC->setAutoFillBackground(fillBackground);
-        pC->resize(width, height);
-        pC->setContentsMargins(0, 0, 0, 0);
-        pC->move(x, y);
-        pC->show();
-        return true;
-    } else {
-        return false;
-    }
 }
 
 bool TConsole::setBackgroundImage(const QString& name, const QString& path)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2019 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2016, 2018-2020 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -148,7 +148,6 @@ public:
     TLabel*
     createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
     TConsole* createMiniConsole(const QString& name, int x, int y, int width, int height);
-    bool createButton(const QString& name, int x, int y, int width, int height, bool fillBackground);
     bool raiseWindow(const QString& name);
     bool lowerWindow(const QString& name);
     bool showWindow(const QString& name);

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -3,6 +3,7 @@
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -30,63 +31,58 @@
 #include "post_guard.h"
 
 
-TLabel::TLabel(QWidget* pW) : QLabel(pW), mpHost(nullptr), mouseInside()
+TLabel::TLabel(Host* pH, QWidget* pW)
+: QLabel(pW)
+, mpHost(pH)
 {
     setMouseTracking(true);
 }
 
-void TLabel::setClick(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setClick(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mClickParams);
-    mpHost = pHost;
+    releaseParams(mClickParams);
     mClick = func;
     mClickParams = args;
 }
 
-void TLabel::setDoubleClick(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setDoubleClick(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mDoubleClickParams);
-    mpHost = pHost;
+    releaseParams(mDoubleClickParams);
     mDoubleClick = func;
     mDoubleClickParams = args;
 }
 
-void TLabel::setRelease(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setRelease(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mReleaseParams);
-    mpHost = pHost;
+    releaseParams(mReleaseParams);
     mRelease = func;
     mReleaseParams = args;
 }
 
-void TLabel::setMove(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setMove(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mMoveParams);
-    mpHost = pHost;
+    releaseParams(mMoveParams);
     mMove = func;
     mMoveParams = args;
 }
 
-void TLabel::setWheel(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setWheel(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mWheelParams);
-    mpHost = pHost;
+    releaseParams(mWheelParams);
     mWheel = func;
     mWheelParams = args;
 }
 
-void TLabel::setEnter(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setEnter(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mEnterParams);
-    mpHost = pHost;
+    releaseParams(mEnterParams);
     mEnter = func;
     mEnterParams = args;
 }
 
-void TLabel::setLeave(Host* pHost, const QString& func, const TEvent& args)
+void TLabel::setLeave(const QString& func, const TEvent& args)
 {
-    releaseParams(pHost, mLeaveParams);
-    mpHost = pHost;
+    releaseParams(mLeaveParams);
     mLeave = func;
     mLeaveParams = args;
 }
@@ -280,14 +276,15 @@ bool TLabel::forwardEventToMapper(QEvent* event)
 // searching for parameters that are references to values in the
 // Lua registry, and correctly dereferences them. This allows
 // the parameters to be safely overwritten.
-void TLabel::releaseParams(Host* pHost, TEvent& params) {
+void TLabel::releaseParams(TEvent& params)
+{
     if (params.mArgumentList.isEmpty()) {
         return;
     }
 
     for (int i = 0; i < params.mArgumentList.size(); i++) {
         if ( params.mArgumentTypeList.at(i) == ARGUMENT_TYPE_TABLE || params.mArgumentTypeList.at(i) == ARGUMENT_TYPE_FUNCTION) {
-            pHost->getLuaInterpreter()->freeLuaRegistryIndex(i);
+            mpHost->getLuaInterpreter()->freeLuaRegistryIndex(i);
         }
     }
 

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -6,6 +6,7 @@
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -41,14 +42,14 @@ class TLabel : public QLabel
 
 public:
     Q_DISABLE_COPY(TLabel)
-    TLabel(QWidget* pW = nullptr);
-    void setClick(Host* pHost, const QString& func, const TEvent& args);
-    void setDoubleClick(Host* pHost, const QString& func, const TEvent& args);
-    void setRelease(Host* pHost, const QString& func, const TEvent& args);
-    void setMove(Host* pHost, const QString& func, const TEvent& args);
-    void setWheel(Host* pHost, const QString& func, const TEvent& args);
-    void setEnter(Host* pHost, const QString& func, const TEvent& args);
-    void setLeave(Host* pHost, const QString& func, const TEvent& args);
+    TLabel(Host* pH, QWidget* pW = nullptr);
+    void setClick(const QString& func, const TEvent& args);
+    void setDoubleClick(const QString& func, const TEvent& args);
+    void setRelease(const QString& func, const TEvent& args);
+    void setMove(const QString& func, const TEvent& args);
+    void setWheel(const QString& func, const TEvent& args);
+    void setEnter(const QString& func, const TEvent& args);
+    void setLeave(const QString& func, const TEvent& args);
     void mousePressEvent(QMouseEvent*) override;
     void mouseDoubleClickEvent(QMouseEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
@@ -75,10 +76,9 @@ public:
     TEvent mWheelParams;
     TEvent mLeaveParams;
     TEvent mEnterParams;
-    bool mouseInside;
 
 private:
-    void releaseParams(Host* pHost, TEvent& params);
+    void releaseParams(TEvent& params);
 };
 
 #endif // MUDLET_TLABEL_H

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2019 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
@@ -2386,7 +2386,7 @@ bool mudlet::setLabelClickCallback(Host* pHost, const QString& name, const QStri
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setClick(pHost, func, pA);
+        pL->setClick(func, pA);
         return true;
     } else {
         return false;
@@ -2401,7 +2401,7 @@ bool mudlet::setLabelDoubleClickCallback(Host* pHost, const QString& name, const
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setDoubleClick(pHost, func, pA);
+        pL->setDoubleClick(func, pA);
         return true;
     } else {
         return false;
@@ -2416,7 +2416,7 @@ bool mudlet::setLabelReleaseCallback(Host* pHost, const QString& name, const QSt
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setRelease(pHost, func, pA);
+        pL->setRelease(func, pA);
         return true;
     } else {
         return false;
@@ -2431,7 +2431,7 @@ bool mudlet::setLabelMoveCallback(Host* pHost, const QString& name, const QStrin
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setMove(pHost, func, pA);
+        pL->setMove(func, pA);
         return true;
     } else {
         return false;
@@ -2446,7 +2446,7 @@ bool mudlet::setLabelWheelCallback(Host* pHost, const QString& name, const QStri
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setWheel(pHost, func, pA);
+        pL->setWheel(func, pA);
         return true;
     } else {
         return false;
@@ -2461,7 +2461,7 @@ bool mudlet::setLabelOnEnter(Host* pHost, const QString& name, const QString& fu
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setEnter(pHost, func, pA);
+        pL->setEnter(func, pA);
         return true;
     } else {
         return false;
@@ -2476,7 +2476,7 @@ bool mudlet::setLabelOnLeave(Host* pHost, const QString& name, const QString& fu
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        pL->setLeave(pHost, func, pA);
+        pL->setLeave(func, pA);
         return true;
     } else {
         return false;


### PR DESCRIPTION
Removes a `Host` pointer argument from several methods as it is cleaner to get the information when a `TLabel` is instantiated.

Also remove unused:
* `(bool) TLabel::mouseInside`
* `(bool) TConsole::createButton(const QString&, int, int, int, int, bool)`

TODO: migrate the `mudlet::setLabelXxxx(...)` methods to the individual profiles main `TConsole` instance.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>