### PR TITLE
Change check for arguments to apply to ALL sendMSDP arguments

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6758,7 +6758,7 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
     
     for (int i = 1; i <= n; ++i) {
         if (!lua_isstring(L, i)) {
-            lua_pushfstring(L, "sendMSDP: bad argument type #" + std::to_string(i) + " type (variable name as string expected, not %1!)", luaL_typename(L, 1));
+            lua_pushfstring(L, "sendMSDP: bad argument #%d type (%s as string expected, not %s!)", i, (i == 1 ? "variable name" : "value"), luaL_typename(L, i));
             return lua_error(L);
         }
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6754,12 +6754,16 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     std::string variable;
-    if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "sendMSDP: bad argument #1 type (variable name as string expected, got %1!)", luaL_typename(L,1));
-        return lua_error(L);
-    } else {
-        variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    int n = lua_gettop(L);
+    
+    for (int i = 1; i <= n; ++i) {
+        if (!lua_isstring(L, i)) {
+            lua_pushfstring(L, "sendMSDP: bad argument type #" + std::to_string(i) + " type (variable name as string expected, not %1!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
     }
+
+    variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string output;
     output += TN_IAC;
@@ -6768,7 +6772,6 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
     output += MSDP_VAR;
     output += variable;
 
-    int n = lua_gettop(L);
     for (int i = 2; i <= n; ++i) {
         output += MSDP_VAL;
         output += host.mTelnet.encodeAndCookBytes(lua_tostring(L, i));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6758,7 +6758,7 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
     
     for (int i = 1; i <= n; ++i) {
         if (!lua_isstring(L, i)) {
-            lua_pushfstring(L, "sendMSDP: bad argument #%d type (%s as string expected, not %s!)", i, (i == 1 ? "variable name" : "value"), luaL_typename(L, i));
+            lua_pushfstring(L, "sendMSDP: bad argument #%d type (%s as string expected, got %s!)", i, (i == 1 ? "variable name" : "value"), luaL_typename(L, i));
             return lua_error(L);
         }
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6755,6 +6755,11 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
     Host& host = getHostFromLua(L);
     int n = lua_gettop(L);
     
+    if (n < 1) {
+        lua_pushstring(L, "sendMSDP: bad argument #1 type (variable name as string expected, got nil!)");
+        return lua_error(L);
+    }
+
     for (int i = 1; i <= n; ++i) {
         if (!lua_isstring(L, i)) {
             lua_pushfstring(L, "sendMSDP: bad argument #%d type (%s as string expected, got %s!)", i, (i == 1 ? "variable name" : "value"), luaL_typename(L, i));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6753,7 +6753,6 @@ int TLuaInterpreter::sendGMCP(lua_State* L)
 int TLuaInterpreter::sendMSDP(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    std::string variable;
     int n = lua_gettop(L);
     
     for (int i = 1; i <= n; ++i) {
@@ -6763,7 +6762,7 @@ int TLuaInterpreter::sendMSDP(lua_State* L)
         }
     }
 
-    variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
+    std::string variable = host.mTelnet.encodeAndCookBytes(lua_tostring(L, 1));
 
     std::string output;
     output += TN_IAC;


### PR DESCRIPTION


<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Used a for loop to iterate through ALL the arguments in sendMSDP, instead of just checking the first one, and throw an error if ANY are not strings.

#### Motivation for adding to Mudlet
sendMSDP currently crashes Mudlet if a nil value is passed on the 2nd+ argument

#### Other info (issues closed, discussion etc)
Applies to issue #3311 