### PR TITLE
Enhance: add the ability to destroy labels without resetting a profile

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2253,6 +2253,25 @@ TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int 
     }
 }
 
+std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
+{
+    if (name.isEmpty()) {
+        return std::make_pair(false, QStringLiteral("a label cannot have an empty string as its name"));
+    }
+
+    auto pL = mLabelMap.take(name);
+    if (pL) {
+        // Using deleteLater() rather than delete as it seems a safer option
+        // given that this item is likely to be linked to some events and
+        // suchlike:
+        pL->deleteLater();
+        return std::make_pair(true, QString());
+    }
+
+    // Message is of the form needed for a Lua API function call run-time error
+    return std::make_pair(false, QStringLiteral("label name \"%1\" not found").arg(name));
+}
+
 void TConsole::createMapper(int x, int y, int width, int height)
 {
     if (!mpMapper) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2278,7 +2278,7 @@ std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
     }
 
     // Message is of the form needed for a Lua API function call run-time error
-    return {false, QStringLiteral("label name \"%1\" not found").arg(name)} ;
+    return {false, QStringLiteral("label name \"%1\" not found").arg(name)};
 }
 
 void TConsole::createMapper(int x, int y, int width, int height)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2269,7 +2269,7 @@ std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
         // It remains to be seen if the label has "gone" as a result of the
         // above by the time the Lua subsystem processes the following:
         TEvent mudletEvent{};
-        mudletEvent.mArgumentList.append(QLatin1String("sysLabelDeletion"));
+        mudletEvent.mArgumentList.append(QLatin1String("sysLabelDeleted"));
         mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mudletEvent.mArgumentList.append(name);
         mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -2875,4 +2875,3 @@ void TConsole::setProfileName(const QString& newName)
         pC->setProfileName(newName);
     }
 }
-

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2256,7 +2256,7 @@ TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int 
 std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
 {
     if (name.isEmpty()) {
-        return std::make_pair(false, QStringLiteral("a label cannot have an empty string as its name"));
+        return {false, QLatin1String("a label cannot have an empty string as its name")};
     }
 
     auto pL = mLabelMap.take(name);
@@ -2265,11 +2265,20 @@ std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
         // given that this item is likely to be linked to some events and
         // suchlike:
         pL->deleteLater();
-        return std::make_pair(true, QString());
+
+        // It remains to be seen if the label has "gone" as a result of the
+        // above by the time the Lua subsystem processes the following:
+        TEvent mudletEvent{};
+        mudletEvent.mArgumentList.append(QLatin1String("sysLabelDeletion"));
+        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mudletEvent.mArgumentList.append(name);
+        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mpHost->raiseEvent(mudletEvent);
+        return {true, QString()};
     }
 
     // Message is of the form needed for a Lua API function call run-time error
-    return std::make_pair(false, QStringLiteral("label name \"%1\" not found").arg(name));
+    return {false, QStringLiteral("label name \"%1\" not found").arg(name)} ;
 }
 
 void TConsole::createMapper(int x, int y, int width, int height)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -147,6 +147,7 @@ public:
     void refresh();
     TLabel*
     createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
+    std::pair<bool, QString> deleteLabel(const QString&);
     TConsole* createMiniConsole(const QString& name, int x, int y, int width, int height);
     bool raiseWindow(const QString& name);
     bool lowerWindow(const QString& name);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
 *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
-*   Copyright (C) 2013-2019 by Stephen Lyons - slysven@virginmedia.com    *
+*   Copyright (C) 2013-2020 by Stephen Lyons - slysven@virginmedia.com    *
 *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
 *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
 *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
@@ -3626,6 +3626,24 @@ int TLuaInterpreter::createLabel(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     lua_pushboolean(L, mudlet::self()->createLabel(&host, name, x, y, width, height, fillBackground, clickthrough));
+    return 1;
+}
+
+int TLuaInterpreter::deleteLabel(lua_State* L)
+{
+    if (!lua_isstring(L, 1)) {
+        lua_pushfstring(L, "deleteLabel: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+    QString labelName{QString::fromUtf8(lua_tostring(L, 1))};
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = host.mpConsole->deleteLabel(labelName); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -15603,6 +15621,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getNetworkLatency", TLuaInterpreter::getNetworkLatency);
     lua_register(pGlobalLua, "createMiniConsole", TLuaInterpreter::createMiniConsole);
     lua_register(pGlobalLua, "createLabel", TLuaInterpreter::createLabel);
+    lua_register(pGlobalLua, "deleteLabel", TLuaInterpreter::deleteLabel);
     lua_register(pGlobalLua, "raiseWindow", TLuaInterpreter::raiseWindow);
     lua_register(pGlobalLua, "lowerWindow", TLuaInterpreter::lowerWindow);
     lua_register(pGlobalLua, "hideWindow", TLuaInterpreter::hideUserWindow);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2016, 2018-2019 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2016, 2018-2020 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *
@@ -329,6 +329,7 @@ public:
     static int getStopWatchBrokenDownTime(lua_State*);
     static int createMiniConsole(lua_State*);
     static int createLabel(lua_State*);
+    static int deleteLabel(lua_State*);
     static int moveWindow(lua_State*);
     static int setTextFormat(lua_State*);
     static int setBackgroundImage(lua_State*);


### PR DESCRIPTION
Note that this may require Geyser and the like to rethink how they handle labels so that they can remove their label metadata (e.g. for parent containers so that the data on labels that get destroyed from them gets cleaned up).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>