### PR TITLE
setModulePriority() now works when called from install event

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1535,6 +1535,9 @@ bool Host::installPackage(const QString& fileName, int module)
                 moduleEntry << fileName;
                 moduleEntry << QStringLiteral("0");
                 mInstalledModules[packageName] = moduleEntry;
+                if (module == 1 || module == 3) {
+                    mModulePriorities[packageName] = 0;
+                }
                 mActiveModules.append(packageName);
             } else {
                 mInstalledPackages.append(packageName);
@@ -1548,7 +1551,6 @@ bool Host::installPackage(const QString& fileName, int module)
     } else {
         file2.setFileName(fileName);
         file2.open(QFile::ReadOnly | QFile::Text);
-        //mInstalledPackages.append( packageName );
         QString profileName = getName();
         QString login = getLogin();
         QString pass = getPass();
@@ -1558,6 +1560,9 @@ bool Host::installPackage(const QString& fileName, int module)
             moduleEntry << fileName;
             moduleEntry << QStringLiteral("0");
             mInstalledModules[packageName] = moduleEntry;
+            if (module == 1 || module == 3) {
+                mModulePriorities[packageName] = 0;
+            }
             mActiveModules.append(packageName);
         } else {
             mInstalledPackages.append(packageName);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
setModulePriority() now works when called from install event - it previously didn't because the map holding priorities didn't have the module name inserted into it as it should have.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/3324