### PR TITLE
Geyser:show only unhidden children

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -163,7 +163,7 @@ function Geyser.Container:show (auto)
     self:show_impl()
   end
   for _, v in pairs(self.windowList) do
-    v:show(true)
+    if v.hidden == false then v:show(true) end
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -159,12 +159,18 @@ function Geyser.Container:show (auto)
   else
     self.hidden = false
   end
+  -- If my container is hidden I stay hidden and put my setting to auto_hidden
+  if self.container.hidden or self.container.auto_hidden then
+    self.auto_hidden = true 
+    return false 
+  end
   if not self.hidden and not self.auto_hidden then
     self:show_impl()
   end
   for _, v in pairs(self.windowList) do
-    if v.hidden == false then v:show(true) end
+    v:show(true)
   end
+  return true
 end
 
 function Geyser.Container:show_impl()


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
When using container:show()  hidden elements also will appear.
With this change the elements which have the property hidden will stay hidden.
#### Motivation for adding to Mudlet
Especially when using the GUIFrame with anitimer or other elements which use hide()
it can cause a mess to show everything. The problem appeared on Discord
for example:
Brax Last Sunday at 10:12
I am playing with anitimers in the drag and drop framework, if I drag a container all the 'dead' timers reappear ? What am I doing wrong hehe
#### Other info (issues closed, discussion etc)
