### PR TITLE
Add getImageSize()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4327,6 +4327,33 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getImageSize
+int TLuaInterpreter::getImageSize(lua_State* L)
+{
+    QString imageLocation;
+    if (!lua_isstring(L, 1)) {
+        lua_pushfstring(L, "getImageSize: bad argument #1 type (image location as string as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    } else {
+        imageLocation = QString::fromUtf8(lua_tostring(L, 1));
+        if (imageLocation.isEmpty()) {
+            lua_pushnil(L);
+            lua_pushstring(L, "bad argument #1 value (image location cannot be an empty string)");
+            return 2;
+        }
+    }
+
+    if (auto size = mudlet::self()->getImageSize(imageLocation); size) {
+        lua_pushnumber(L, size->width());
+        lua_pushnumber(L, size->height());
+        return 2;
+    } else {
+        lua_pushnil(L);
+        lua_pushfstring(L, "couldn't retrieve image size. Is the location '%s' correct?", imageLocation.toUtf8().constData());
+        return 2;
+    }
+}
+
 // No documentation available in wiki - internal function
 int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 {
@@ -15639,6 +15666,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setLabelWheelCallback", TLuaInterpreter::setLabelWheelCallback);
     lua_register(pGlobalLua, "setLabelOnEnter", TLuaInterpreter::setLabelOnEnter);
     lua_register(pGlobalLua, "setLabelOnLeave", TLuaInterpreter::setLabelOnLeave);
+    lua_register(pGlobalLua, "getImageSize", TLuaInterpreter::getImageSize);
     lua_register(pGlobalLua, "moveWindow", TLuaInterpreter::moveWindow);
     lua_register(pGlobalLua, "setTextFormat", TLuaInterpreter::setTextFormat);
     lua_register(pGlobalLua, "getMainWindowSize", TLuaInterpreter::getMainWindowSize);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4332,7 +4332,7 @@ int TLuaInterpreter::getImageSize(lua_State* L)
 {
     QString imageLocation;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "getImageSize: bad argument #1 type (image location as string as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "getImageSize: bad argument #1 type (image location as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     } else {
         imageLocation = QString::fromUtf8(lua_tostring(L, 1));
@@ -4348,7 +4348,7 @@ int TLuaInterpreter::getImageSize(lua_State* L)
         lua_pushnumber(L, size->height());
     } else {
         lua_pushnil(L);
-        lua_pushfstring(L, "couldn't retrieve image size. Is the location '%s' correct?", imageLocation.toUtf8().constData());
+        lua_pushfstring(L, "couldn't retrieve image size, is the location '%s' correct?", imageLocation.toUtf8().constData());
     }
     return 2;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4343,15 +4343,14 @@ int TLuaInterpreter::getImageSize(lua_State* L)
         }
     }
 
-    if (auto size = mudlet::self()->getImageSize(imageLocation); size) {
+    if (auto size = mudlet::self()->getImageSize(imageLocation)) {
         lua_pushnumber(L, size->width());
         lua_pushnumber(L, size->height());
-        return 2;
     } else {
         lua_pushnil(L);
         lua_pushfstring(L, "couldn't retrieve image size. Is the location '%s' correct?", imageLocation.toUtf8().constData());
-        return 2;
     }
+    return 2;
 }
 
 // No documentation available in wiki - internal function

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -335,6 +335,7 @@ public:
     static int setBackgroundColor(lua_State*);
     static int createButton(lua_State*);
     static int setLabelClickCallback(lua_State*);
+    static int getImageSize(lua_State*);
     static int setLabelDoubleClickCallback(lua_State*);
     static int setLabelReleaseCallback(lua_State*);
     static int setLabelMoveCallback(lua_State*);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2584,6 +2584,17 @@ void mudlet::deleteLine(Host* pHost, const QString& name)
     }
 }
 
+std::optional<QSize> mudlet::getImageSize(const QString& imageLocation)
+{
+    QImage image(imageLocation);
+
+    if (image.isNull()) {
+        return {};
+    }
+
+    return {image.size()};
+}
+
 bool mudlet::insertText(Host* pHost, const QString& windowName, const QString& text)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2592,7 +2592,7 @@ std::optional<QSize> mudlet::getImageSize(const QString& imageLocation)
         return {};
     }
 
-    return {image.size()};
+    return image.size();
 }
 
 bool mudlet::insertText(Host* pHost, const QString& windowName, const QString& text)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -60,6 +60,7 @@
 #include <QVersionNumber>
 #include "edbee/models/textautocompleteprovider.h"
 #include <../3rdparty/qtkeychain/keychain.h>
+#include <optional>
 #include "post_guard.h"
 
 #include <hunspell/hunspell.hxx>
@@ -157,6 +158,7 @@ public:
     bool setLabelOnLeave(Host*, const QString&, const QString&, const TEvent&);
     bool moveWindow(Host*, const QString& name, int, int);
     void deleteLine(Host*, const QString& name);
+    std::optional<QSize> getImageSize(const QString& imageLocation);
     bool insertText(Host*, const QString& windowName, const QString&);
     void replace(Host*, const QString& name, const QString&);
     int selectString(Host*, const QString& name, const QString& what, int);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add getImageSize(). Use it like this:

```lua
local width, height = getImageSize("image location here")
```
#### Motivation for adding to Mudlet
So you can size a label appropriately when you download an image from the Internet. This is also necessary for an important script on the pkuxkx game.
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/813.

I used a new thing here - std::optional, instead of the usual std::pair<bool, result> pattern - because we have access to it now, and it's much cleaner! See https://www.bfilipek.com/2018/05/using-optional.html about it.