### PR TITLE
Allow Geyser in userwindows

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2206,13 +2206,10 @@ TConsole* TConsole::createBuffer(const QString& name)
 void TConsole::resetMainConsole()
 {
     //resetProfile should reset also UserWindows
-    //save WindowLayout before deleting UserWindows
-    mudlet::self()->saveWindowLayout();
     QMutableMapIterator<QString, TDockWidget*> itDockWidget(mDockWidgetMap);
     while (itDockWidget.hasNext()) {
         itDockWidget.next();
         itDockWidget.value()->close();
-        itDockWidget.value()->deleteLater();
         itDockWidget.remove();
     }
 
@@ -2221,7 +2218,6 @@ void TConsole::resetMainConsole()
         itSubConsole.next();
         // CHECK: Do we need to handle the float/dockable widgets here:
         itSubConsole.value()->close();
-        itSubConsole.value()->deleteLater();
         itSubConsole.remove();
     }
 
@@ -2229,7 +2225,6 @@ void TConsole::resetMainConsole()
     while (itLabel.hasNext()) {
         itLabel.next();
         itLabel.value()->close();
-        itLabel.value()->deleteLater();
         itLabel.remove();
     }
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2205,9 +2205,9 @@ TConsole* TConsole::createBuffer(const QString& name)
 
 void TConsole::resetMainConsole()
 {
-//resetProfile should reset also UserWindows
-//save WindowLayout before deleting UserWindows
-    mudlet::self()->saveWindowLayout(); 
+    //resetProfile should reset also UserWindows
+    //save WindowLayout before deleting UserWindows
+    mudlet::self()->saveWindowLayout();
     QMutableMapIterator<QString, TDockWidget*> itDockWidget(mDockWidgetMap);
     while (itDockWidget.hasNext()) {
         itDockWidget.next();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2206,10 +2206,13 @@ TConsole* TConsole::createBuffer(const QString& name)
 void TConsole::resetMainConsole()
 {
 //resetProfile should reset also UserWindows
+//save WindowLayout before deleting UserWindows
+    mudlet::self()->saveWindowLayout(); 
     QMutableMapIterator<QString, TDockWidget*> itDockWidget(mDockWidgetMap);
     while (itDockWidget.hasNext()) {
         itDockWidget.next();
         itDockWidget.value()->close();
+        itDockWidget.value()->deleteLater();
         itDockWidget.remove();
     }
 
@@ -2218,6 +2221,7 @@ void TConsole::resetMainConsole()
         itSubConsole.next();
         // CHECK: Do we need to handle the float/dockable widgets here:
         itSubConsole.value()->close();
+        itSubConsole.value()->deleteLater();
         itSubConsole.remove();
     }
 
@@ -2225,6 +2229,7 @@ void TConsole::resetMainConsole()
     while (itLabel.hasNext()) {
         itLabel.next();
         itLabel.value()->close();
+        itLabel.value()->deleteLater();
         itLabel.remove();
     }
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2230,9 +2230,9 @@ void TConsole::resetMainConsole()
 }
 
 // This is a sub-console overlaid on to the main console
-TConsole* TConsole::createMiniConsole(const QString& windowname,const QString& name, int x, int y, int width, int height)
+TConsole* TConsole::createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height)
 {
-//if pW then add Console as Overlay to the Userwindow
+    //if pW then add Console as Overlay to the Userwindow
     auto pW = mDockWidgetMap.value(windowname);
     auto pC = mSubConsoleMap.value(name);
     if (!pC) {
@@ -2241,7 +2241,7 @@ TConsole* TConsole::createMiniConsole(const QString& windowname,const QString& n
         }else{
             pC = new TConsole(mpHost, SubConsole, pW->widget());
         }
-	if (!pC) {
+        if (!pC) {
             return nullptr;
         }
         mSubConsoleMap[name] = pC;
@@ -2268,7 +2268,7 @@ TConsole* TConsole::createMiniConsole(const QString& windowname,const QString& n
 
 TLabel* TConsole::createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough)
 {
-//if pW put Label in Userwindow
+    //if pW put Label in Userwindow
     auto pL = mLabelMap.value(name);
     auto pW = mDockWidgetMap.value(windowname);
     if (!pL) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -666,6 +666,24 @@ void TConsole::resizeEvent(QResizeEvent* event)
         mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent(mudletEvent);
     }
+//create the sysUserWindowResize Event for automatic resizing with Geyser
+    if (mType & (UserWindow)) {
+        TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
+        QString func = "handleWindowResizeEvent";
+        QString n = "WindowResizeEvent";
+        pLua->call(func, n);
+
+        TEvent mudletEvent {};
+        mudletEvent.mArgumentList.append(QLatin1String("sysUserWindowResizeEvent"));
+        mudletEvent.mArgumentList.append(QString::number(x));
+        mudletEvent.mArgumentList.append(QString::number(y));
+        mudletEvent.mArgumentList.append(mConsoleName);
+        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+        mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mpHost->raiseEvent(mudletEvent);
+    }
 }
 
 void TConsole::refresh()
@@ -2187,6 +2205,14 @@ TConsole* TConsole::createBuffer(const QString& name)
 
 void TConsole::resetMainConsole()
 {
+//resetProfile should reset also UserWindows
+    QMutableMapIterator<QString, TDockWidget*> itDockWidget(mDockWidgetMap);
+    while (itDockWidget.hasNext()) {
+        itDockWidget.next();
+        itDockWidget.value()->close();
+        itDockWidget.remove();
+    }
+
     QMutableMapIterator<QString, TConsole*> itSubConsole(mSubConsoleMap);
     while (itSubConsole.hasNext()) {
         itSubConsole.next();
@@ -2204,12 +2230,18 @@ void TConsole::resetMainConsole()
 }
 
 // This is a sub-console overlaid on to the main console
-TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int width, int height)
+TConsole* TConsole::createMiniConsole(const QString& windowname,const QString& name, int x, int y, int width, int height)
 {
+//if pW then add Console as Overlay to the Userwindow
+    auto pW = mDockWidgetMap.value(windowname);
     auto pC = mSubConsoleMap.value(name);
     if (!pC) {
-        pC = new TConsole(mpHost, SubConsole, mpMainFrame);
-        if (!pC) {
+        if (!pW){
+            pC = new TConsole(mpHost, SubConsole, mpMainFrame);
+        }else{
+            pC = new TConsole(mpHost, SubConsole, pW->widget());
+        }
+	if (!pC) {
             return nullptr;
         }
         mSubConsoleMap[name] = pC;
@@ -2234,11 +2266,17 @@ TConsole* TConsole::createMiniConsole(const QString& name, int x, int y, int wid
     }
 }
 
-TLabel* TConsole::createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough)
+TLabel* TConsole::createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough)
 {
+//if pW put Label in Userwindow
     auto pL = mLabelMap.value(name);
+    auto pW = mDockWidgetMap.value(windowname);
     if (!pL) {
-        pL = new TLabel(mpHost, mpMainFrame);
+        if (!pW){
+            pL = new TLabel(mpHost, mpMainFrame);
+        }else{
+            pL = new TLabel(mpHost, pW->widget());
+        }
         mLabelMap[name] = pL;
         pL->setObjectName(name);
         pL->setAutoFillBackground(fillBackground);
@@ -2654,6 +2692,17 @@ QSize TConsole::getMainWindowSize() const
     int commandLineHeight = mpCommandLine->height();
     QSize mainWindowSize(consoleSize.width() - toolbarWidth, consoleSize.height() - (commandLineHeight + toolbarHeight));
     return mainWindowSize;
+}
+//getUserWindowSize for resizing in Geyser
+QSize TConsole::getUserWindowSize(const QString& windowname) const
+{
+    auto pW = mDockWidgetMap.value(windowname);
+    if (pW){
+        QSize windowSize = pW->widget()->size();
+        QSize userWindowSize(windowSize.width(), windowSize.height());
+        return userWindowSize;
+    }
+    return getMainWindowSize();
 }
 
 void TConsole::slot_reloadMap(QList<QString> profilesList)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2271,8 +2271,7 @@ TLabel* TConsole::createLabel(const QString& windowname, const QString& name, in
     //if pW put Label in Userwindow
     auto pL = mLabelMap.value(name);
     auto pW = mDockWidgetMap.value(windowname);
-    auto pC = mSubConsoleMap.value(name);
-    if (!pL && !pC) {
+    if (!pL) {
         if (!pW) {
             pL = new TLabel(mpHost, mpMainFrame);
         } else {
@@ -2320,8 +2319,9 @@ std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
     return {false, QStringLiteral("label name \"%1\" not found").arg(name)};
 }
 
-void TConsole::createMapper(int x, int y, int width, int height)
+void TConsole::createMapper(const QString& windowname, int x, int y, int width, int height)
 {
+    auto pW = mDockWidgetMap.value(windowname);
     if (!mpMapper) {
         // Arrange for TMap member values to be copied from the Host masters so they
         // are in place when the 2D mapper is created:
@@ -2330,7 +2330,11 @@ void TConsole::createMapper(int x, int y, int width, int height)
                                           mpHost->mpMap->mPlayerRoomInnerDiameterPercentage,
                                           mpHost->mpMap->mPlayerRoomOuterColor,
                                           mpHost->mpMap->mPlayerRoomInnerColor);
-        mpMapper = new dlgMapper(mpMainFrame, mpHost, mpHost->mpMap.data());
+        if (!pW) {
+            mpMapper = new dlgMapper(mpMainFrame, mpHost, mpHost->mpMap.data());
+        } else {
+            mpMapper = new dlgMapper(pW->widget(), mpHost, mpHost->mpMap.data());
+        }
 #if defined(INCLUDE_3DMAPPER)
         mpHost->mpMap->mpM = mpMapper->glWidget;
 #endif

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2236,9 +2236,9 @@ TConsole* TConsole::createMiniConsole(const QString& windowname, const QString& 
     auto pW = mDockWidgetMap.value(windowname);
     auto pC = mSubConsoleMap.value(name);
     if (!pC) {
-        if (!pW){
+        if (!pW) {
             pC = new TConsole(mpHost, SubConsole, mpMainFrame);
-        }else{
+        } else {
             pC = new TConsole(mpHost, SubConsole, pW->widget());
         }
         if (!pC) {
@@ -2271,10 +2271,11 @@ TLabel* TConsole::createLabel(const QString& windowname, const QString& name, in
     //if pW put Label in Userwindow
     auto pL = mLabelMap.value(name);
     auto pW = mDockWidgetMap.value(windowname);
-    if (!pL) {
-        if (!pW){
+    auto pC = mSubConsoleMap.value(name);
+    if (!pL && !pC) {
+        if (!pW) {
             pL = new TLabel(mpHost, mpMainFrame);
-        }else{
+        } else {
             pL = new TLabel(mpHost, pW->widget());
         }
         mLabelMap[name] = pL;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -105,7 +105,7 @@ public:
     void luaWrapLine(std::string& buf, int line);
 
     int getColumnNumber();
-    void createMapper(int, int, int, int);
+    void createMapper(const QString &windowname, int, int, int, int);
 
     void setWrapAt(int pos)
     {

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -146,8 +146,8 @@ public:
     int getLastLineNumber();
     void refresh();
     TLabel*
-    createLabel(const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
-    TConsole* createMiniConsole(const QString& name, int x, int y, int width, int height);
+    createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
+    TConsole* createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height);
     bool raiseWindow(const QString& name);
     bool lowerWindow(const QString& name);
     bool showWindow(const QString& name);
@@ -180,6 +180,7 @@ public:
 
     // Returns the size of the main buffer area (excluding the command line and toolbars).
     QSize getMainWindowSize() const;
+    QSize getUserWindowSize(const QString& windowname) const;
 
     void toggleLogging(bool);
     ConsoleType getType() const { return mType; }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3537,7 +3537,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     counter = 3;
     //make the windowname optional by using counter. If windowname "main" add to main console
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "createMiniConsole: wrong argument type");
+        lua_pushfstring(L, "createMiniConsole: bad argument #1 type (MiniConsole name/windowname as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3549,13 +3549,13 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
             luaSendWindow.clear();
         }
     }
-    if (!lua_isnumber(L, 2)) {
-        luaSendText = lua_tostring(L, 2);
+    if (!lua_isnumber(L, 2)) {      
         if (!lua_isstring(L, 2)) {
-            lua_pushstring(L, "createMiniConsole: wrong argument type");
+            lua_pushfstring(L, "createMiniConsole: bad argument #2 type (MiniConsole name as string expected, got %s!)", luaL_typename(L, 2));
             lua_error(L);
             return 1;
         }
+        luaSendText = lua_tostring(L, 2);
     } else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
@@ -3563,7 +3563,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createMiniConsole: wrong argument type");
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3571,7 +3571,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter++;
     }
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createMiniConsole: wrong argument type");
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3579,7 +3579,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter++;
     }
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createMiniConsole: wrong argument type");
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole width as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3587,7 +3587,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter++;
     }
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createMiniConsole: wrong argument type");
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole height as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3596,7 +3596,13 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     QString windowname(luaSendWindow.c_str());
-    lua_pushboolean(L, mudlet::self()->createMiniConsole(&host, windowname, name, x, y, width, height));
+    if (auto [success, message] = mudlet::self()->createMiniConsole(&host, windowname, name, x, y, width, height); !success) {
+        lua_pushboolean(L, false);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -3609,7 +3615,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     counter = 3;
 
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushfstring(L, "createLabel: bad argument #1 type (label name/windowname as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3623,12 +3629,12 @@ int TLuaInterpreter::createLabel(lua_State* L)
     }
 
     if (!lua_isnumber(L, 2)) {
-        luaSendText = lua_tostring(L, 2);
         if (!lua_isstring(L, 2)) {
-            lua_pushstring(L, "createLabel: wrong argument type");
+            lua_pushfstring(L, "createLabel: bad argument #2 type (label name as string expected, got %s!)", luaL_typename(L, 2));
             lua_error(L);
             return 1;
         }
+        luaSendText = lua_tostring(L, 2);
     } else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
@@ -3637,7 +3643,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
 
     bool fillBackground, clickthrough = false;
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushfstring(L, "createLabel: bad argument #%d type (label x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3646,7 +3652,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushfstring(L, "createLabel: bad argument #%d type (label y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3655,7 +3661,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushfstring(L, "createLabel: bad argument #%d type (label width as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3664,7 +3670,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushfstring(L, "createLabel: bad argument #%d type (label height as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3673,7 +3679,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushfstring(L, "createLabel: bad argument #%d type (label fillBackground as boolean/number (0/1) expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3683,7 +3689,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     if (lua_gettop(L) > counter) {
         counter++;
         if (!lua_isboolean(L, counter)) {
-            lua_pushstring(L, "createLabel: wrong argument type");
+            lua_pushfstring(L, "createLabel: bad argument #%d type (label clickthrough as boolean/number (0/1) expected, got %s!)", counter, luaL_typename(L, counter));
             lua_error(L);
             return 1;
         } else {
@@ -3693,7 +3699,13 @@ int TLuaInterpreter::createLabel(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     QString windowname(luaSendWindow.c_str());
-    lua_pushboolean(L, mudlet::self()->createLabel(&host, windowname, name, x, y, width, height, fillBackground, clickthrough));
+    if (auto [success, message] = mudlet::self()->createLabel(&host, windowname, name, x, y, width, height, fillBackground, clickthrough); !success) {
+        lua_pushboolean(L, false);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -3718,37 +3730,57 @@ int TLuaInterpreter::deleteLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapper
 int TLuaInterpreter::createMapper(lua_State* L)
 {
-    int x, y, width, height;
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "createMapper: wrong argument type");
+    std::string luaSendWindow = "";
+    int x, y, width, height, counter;
+    counter = 1;
+    if (!lua_isstring(L, 1) && !lua_isnumber(L, 1)) {
+        lua_pushfstring(L, "createMapper: bad argument #1 type (number or string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
-    } else {
-        x = lua_tonumber(L, 1);
+    } else if (!lua_isnumber(L, 1)) {
+        luaSendWindow = lua_tostring(L, 1);
+        counter = 2;
+        if (luaSendWindow == "main") {
+            // QString::compare is zero for a match on the "default"
+            // case so clear the variable - to flag this as the main
+            // window case - as is the case for an empty string
+            luaSendWindow.clear();
+        }
     }
-    if (!lua_isnumber(L, 2)) {
-        lua_pushstring(L, "createMapper: wrong argument type");
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createMapper: bad argument #%d type (mapper x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
-        y = lua_tonumber(L, 2);
+        x = lua_tonumber(L, counter);
+        counter++;
     }
-    if (!lua_isnumber(L, 3)) {
-        lua_pushstring(L, "createMapper: wrong argument type");
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createMapper: bad argument #%d type (mapper y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
-        width = lua_tonumber(L, 3);
+        y = lua_tonumber(L, counter);
+        counter++;
     }
-    if (!lua_isnumber(L, 4)) {
-        lua_pushstring(L, "createMapper: wrong argument type");
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createMapper: bad argument #%d type (mapper width as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
-        height = lua_tonumber(L, 4);
+        width = lua_tonumber(L, counter);
+        counter++;
+    }
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createMapper: bad argument #%d type (mapper height as number expected, got %s!)", counter, luaL_typename(L, counter));
+        lua_error(L);
+        return 1;
+    } else {
+        height = lua_tonumber(L, counter);
     }
     Host& host = getHostFromLua(L);
-    host.mpConsole->createMapper(x, y, width, height);
+    QString windowname(luaSendWindow.c_str());
+    host.mpConsole->createMapper(windowname, x, y, width, height);
     return 0;
 }
 
@@ -3761,7 +3793,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     counter = 3;
 
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "createButton: wrong argument type");
+        lua_pushfstring(L, "createButton: bad argument #1 type (label name/windowname as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3775,12 +3807,12 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, 2)) {
-        luaSendText = lua_tostring(L, 2);
         if (!lua_isstring(L, 2)) {
-            lua_pushstring(L, "createButton: wrong argument type");
+            lua_pushfstring(L, "createButton: bad argument #2 type (label name as string expected, got %s!)", luaL_typename(L, 2));
             lua_error(L);
             return 1;
         }
+        luaSendText = lua_tostring(L, 2);
     } else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
@@ -3789,7 +3821,7 @@ int TLuaInterpreter::createButton(lua_State* L)
 
     bool fillBackground, clickthrough = false;
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createButton: wrong argument type");
+        lua_pushfstring(L, "createButton: bad argument #%d type (label x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3798,7 +3830,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createButton: wrong argument type");
+        lua_pushfstring(L, "createButton: bad argument #%d type (label y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3807,7 +3839,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createButton: wrong argument type");
+        lua_pushfstring(L, "createButton: bad argument #%d type (label width as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3816,7 +3848,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createButton: wrong argument type");
+        lua_pushfstring(L, "createButton: bad argument #%d type (label height as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3825,7 +3857,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createButton: wrong argument type");
+        lua_pushfstring(L, "createButton: bad argument #%d type (label fillBackground as boolean/number (0/1) expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3835,18 +3867,23 @@ int TLuaInterpreter::createButton(lua_State* L)
     if (lua_gettop(L) > counter) {
         counter++;
         if (!lua_isboolean(L, counter)) {
-            lua_pushstring(L, "createButton: wrong argument type");
+            lua_pushfstring(L, "createButton: bad argument #%d type (label clickthrough as boolean/number (0/1) expected, got %s!)", counter, luaL_typename(L, counter));
             lua_error(L);
             return 1;
         } else {
-            counter--;
             clickthrough = lua_toboolean(L, counter);
         }
     }
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     QString windowname(luaSendWindow.c_str());
-    lua_pushboolean(L, mudlet::self()->createLabel(&host, windowname, name, x, y, width, height, fillBackground, clickthrough));
+    if (auto [success, message] = mudlet::self()->createLabel(&host, windowname, name, x, y, width, height, fillBackground, clickthrough); !success) {
+        lua_pushboolean(L, false);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3533,7 +3533,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
 {
     std::string luaSendText = "";
     std::string luaSendWindow = "";
-    int x, y, width, height,counter;
+    int x, y, width, height, counter;
     counter = 3;
     //make the windowname optional by using counter. If windowname "main" add to main console
     if (!lua_isstring(L, 1)) {
@@ -3551,11 +3551,12 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     }
     if (!lua_isnumber(L, 2)) {
         luaSendText = lua_tostring(L, 2);
-        if(!lua_isstring(L,2)){
+        if (!lua_isstring(L, 2)) {
             lua_pushstring(L, "createMiniConsole: wrong argument type");
             lua_error(L);
-            return 1;}
-    }else {
+            return 1;
+        }
+    } else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
         counter = 2;
@@ -3595,12 +3596,6 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     QString windowname(luaSendWindow.c_str());
-    auto pC = host.mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        lua_pushfstring(L, "createMiniConsole: Cannot create Miniconsole. %s exists already!", name.toUtf8().constData());
-        lua_error(L);
-        return 1;
-    }
     lua_pushboolean(L, mudlet::self()->createMiniConsole(&host, windowname, name, x, y, width, height));
     return 1;
 }
@@ -3629,11 +3624,12 @@ int TLuaInterpreter::createLabel(lua_State* L)
 
     if (!lua_isnumber(L, 2)) {
         luaSendText = lua_tostring(L, 2);
-        if(!lua_isstring(L,2)){
+        if (!lua_isstring(L, 2)) {
             lua_pushstring(L, "createLabel: wrong argument type");
             lua_error(L);
-            return 1;}
-    }else {
+            return 1;
+        }
+    } else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
         counter = 2;
@@ -3697,12 +3693,6 @@ int TLuaInterpreter::createLabel(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     QString windowname(luaSendWindow.c_str());
-    auto pC = host.mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        lua_pushfstring(L, "createLabel: Cannot create Label. %s exists already!",name.toUtf8().constData());
-        lua_error(L);
-        return 1;
-    }
     lua_pushboolean(L, mudlet::self()->createLabel(&host, windowname, name, x, y, width, height, fillBackground, clickthrough));
     return 1;
 }
@@ -3786,11 +3776,12 @@ int TLuaInterpreter::createButton(lua_State* L)
 
     if (!lua_isnumber(L, 2)) {
         luaSendText = lua_tostring(L, 2);
-        if(!lua_isstring(L,2)){
+        if (!lua_isstring(L, 2)) {
             lua_pushstring(L, "createButton: wrong argument type");
             lua_error(L);
-            return 1;}
-    }else {
+            return 1;
+        }
+    } else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
         counter = 2;
@@ -3855,12 +3846,6 @@ int TLuaInterpreter::createButton(lua_State* L)
     Host& host = getHostFromLua(L);
     QString name(luaSendText.c_str());
     QString windowname(luaSendWindow.c_str());
-    auto pC = host.mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        lua_pushfstring(L, "createButton: Cannot create Label. %s exists already!",name.toUtf8().constData());
-        lua_error(L);
-        return 1;
-    }
     lua_pushboolean(L, mudlet::self()->createLabel(&host, windowname, name, x, y, width, height, fillBackground, clickthrough));
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3535,7 +3535,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     std::string luaSendWindow = "";
     int x, y, width, height,counter;
     counter = 3;
-//make the windowname optional by using counter. If windowname "main" add to main console
+    //make the windowname optional by using counter. If windowname "main" add to main console
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "createMiniConsole: wrong argument type");
         lua_error(L);
@@ -3543,11 +3543,11 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     } else {
         luaSendWindow = lua_tostring(L, 1);
         if (luaSendWindow == "main") {
-                // QString::compare is zero for a match on the "default"
-                // case so clear the variable - to flag this as the main
-                // window case - as is the case for an empty string
-                luaSendWindow.clear();
-            }
+            // QString::compare is zero for a match on the "default"
+            // case so clear the variable - to flag this as the main
+            // window case - as is the case for an empty string
+            luaSendWindow.clear();
+        }
     }
     if (!lua_isnumber(L, 2)) {
         luaSendText = lua_tostring(L, 2);
@@ -3555,7 +3555,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
             lua_pushstring(L, "createMiniConsole: wrong argument type");
             lua_error(L);
             return 1;}
-     }else {
+    }else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
         counter = 2;
@@ -3620,11 +3620,11 @@ int TLuaInterpreter::createLabel(lua_State* L)
     } else {
         luaSendWindow = lua_tostring(L, 1);
         if (luaSendWindow == "main") {
-                // QString::compare is zero for a match on the "default"
-                // case so clear the variable - to flag this as the main
-                // window case - as is the case for an empty string
-                luaSendWindow.clear();
-            }
+            // QString::compare is zero for a match on the "default"
+            // case so clear the variable - to flag this as the main
+            // window case - as is the case for an empty string
+            luaSendWindow.clear();
+        }
     }
 
     if (!lua_isnumber(L, 2)) {
@@ -3633,21 +3633,21 @@ int TLuaInterpreter::createLabel(lua_State* L)
             lua_pushstring(L, "createLabel: wrong argument type");
             lua_error(L);
             return 1;}
-     }else {
+    }else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
         counter = 2;
     }
 
     bool fillBackground, clickthrough = false;
-       if (!lua_isnumber(L, counter)) {
-            lua_pushstring(L, "createLabel: wrong argument type");
-            lua_error(L);
-            return 1;
-        } else {
-            x = lua_tonumber(L, counter);
-            counter++;
-        }
+    if (!lua_isnumber(L, counter)) {
+        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_error(L);
+        return 1;
+    } else {
+        x = lua_tonumber(L, counter);
+        counter++;
+    }
 
     if (!lua_isnumber(L, counter)) {
         lua_pushstring(L, "createLabel: wrong argument type");
@@ -3759,11 +3759,11 @@ int TLuaInterpreter::createButton(lua_State* L)
     } else {
         luaSendWindow = lua_tostring(L, 1);
         if (luaSendWindow == "main") {
-                // QString::compare is zero for a match on the "default"
-                // case so clear the variable - to flag this as the main
-                // window case - as is the case for an empty string
-                luaSendWindow.clear();
-            }
+            // QString::compare is zero for a match on the "default"
+            // case so clear the variable - to flag this as the main
+            // window case - as is the case for an empty string
+            luaSendWindow.clear();
+        }
     }
 
     if (!lua_isnumber(L, 2)) {
@@ -3772,21 +3772,21 @@ int TLuaInterpreter::createButton(lua_State* L)
             lua_pushstring(L, "createButton: wrong argument type");
             lua_error(L);
             return 1;}
-     }else {
+    }else {
         luaSendText = luaSendWindow;
         luaSendWindow.clear();
         counter = 2;
     }
 
     bool fillBackground, clickthrough = false;
-       if (!lua_isnumber(L, counter)) {
-            lua_pushstring(L, "createButton: wrong argument type");
-            lua_error(L);
-            return 1;
-        } else {
-            x = lua_tonumber(L, counter);
-            counter++;
-        }
+    if (!lua_isnumber(L, counter)) {
+        lua_pushstring(L, "createButton: wrong argument type");
+        lua_error(L);
+        return 1;
+    } else {
+        x = lua_tonumber(L, counter);
+        counter++;
+    }
 
     if (!lua_isnumber(L, counter)) {
         lua_pushstring(L, "createButton: wrong argument type");
@@ -3807,7 +3807,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushstring(L, "createButton: wrong argument type");
         lua_error(L);
         return 1;
     } else {
@@ -3816,7 +3816,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushstring(L, "createLabel: wrong argument type");
+        lua_pushstring(L, "createButton: wrong argument type");
         lua_error(L);
         return 1;
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1293,7 +1293,7 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 {
     QString windowName;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #1 type (MiniConsole name as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #1 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     } else {
         windowName = QString::fromUtf8(lua_tostring(L, 1));
@@ -1310,7 +1310,7 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
         lua_pushboolean(L, true);
     } else {
         lua_pushnil(L);
-        lua_pushfstring(L, R"(MiniConsole "%s" not found)", windowName.toUtf8().constData());
+        lua_pushfstring(L, R"(miniconsole "%s" not found)", windowName.toUtf8().constData());
     }
     return 0;
 }
@@ -3537,7 +3537,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     counter = 3;
     //make the windowname optional by using counter. If windowname "main" add to main console
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "createMiniConsole: bad argument #1 type (MiniConsole name/windowname as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "createMiniConsole: bad argument #1 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3551,7 +3551,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     }
     if (!lua_isnumber(L, 2)) {      
         if (!lua_isstring(L, 2)) {
-            lua_pushfstring(L, "createMiniConsole: bad argument #2 type (MiniConsole name as string expected, got %s!)", luaL_typename(L, 2));
+            lua_pushfstring(L, "createMiniConsole: bad argument #2 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 2));
             lua_error(L);
             return 1;
         }
@@ -3563,7 +3563,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     }
 
     if (!lua_isnumber(L, counter)) {
-        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3571,7 +3571,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter++;
     }
     if (!lua_isnumber(L, counter)) {
-        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3579,7 +3579,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter++;
     }
     if (!lua_isnumber(L, counter)) {
-        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole width as number expected, got %s!)", counter, luaL_typename(L, counter));
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole width as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3587,7 +3587,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
         counter++;
     }
     if (!lua_isnumber(L, counter)) {
-        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (MiniConsole height as number expected, got %s!)", counter, luaL_typename(L, counter));
+        lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole height as number expected, got %s!)", counter, luaL_typename(L, counter));
         lua_error(L);
         return 1;
     } else {
@@ -3615,7 +3615,7 @@ int TLuaInterpreter::createLabel(lua_State* L)
     counter = 3;
 
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "createLabel: bad argument #1 type (label name/windowname as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "createLabel: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -3793,7 +3793,7 @@ int TLuaInterpreter::createButton(lua_State* L)
     counter = 3;
 
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "createButton: bad argument #1 type (label name/windowname as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "createButton: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
@@ -7047,7 +7047,7 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
 {
     std::string luaSendWindow = "";
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "getUserWindowSize: wrong argument type");
+        lua_pushfstring(L, "getUserWindowSize: bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -342,6 +342,7 @@ public:
     static int setLabelOnEnter(lua_State*);
     static int setLabelOnLeave(lua_State*);
     static int getMainWindowSize(lua_State*);
+    static int getUserWindowSize(lua_State*);
     static int getMousePosition(lua_State*);
     static int setMiniConsoleFontSize(lua_State*);
     static int setProfileIcon(lua_State*);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -461,7 +461,7 @@ end
 ---   <pre>
 ---   createGauge("healthBar", 300, 20, 30, 300, "Now with some text", "green", "horizontal, vertical, goofy, or batty")
 ---   </pre>
-function createGauge(windowname,gaugeName, width, height, x, y, gaugeText, r, g, b, orientation)
+function createGauge(windowname, gaugeName, width, height, x, y, gaugeText, r, g, b, orientation)
   --Make windowname optional
   if type(gaugeName) == "number" then
     orientation = b
@@ -490,13 +490,13 @@ function createGauge(windowname,gaugeName, width, height, x, y, gaugeText, r, g,
   orientation = orientation or "horizontal"
   assert(table.contains({ "horizontal", "vertical", "goofy", "batty" }, orientation), "createGauge: orientation must be horizontal, vertical, goofy, or batty")
   local tbl = { width = width, height = height, x = x, y = y, text = gaugeText, r = r, g = g, b = b, orientation = orientation, value = 1 }
-  createLabel(windowname,gaugeName .. "_back", 0, 0, 0, 0, 1)
+  createLabel(windowname, gaugeName .. "_back", 0, 0, 0, 0, 1)
   setBackgroundColor(gaugeName .. "_back", r, g, b, 100)
 
-  createLabel(windowname,gaugeName .. "_front", 0, 0, 0, 0, 1)
+  createLabel(windowname, gaugeName .. "_front", 0, 0, 0, 0, 1)
   setBackgroundColor(gaugeName .. "_front", r, g, b, 255)
 
-  createLabel(windowname,gaugeName .. "_text", 0, 0, 0, 0, 1)
+  createLabel(windowname, gaugeName .. "_text", 0, 0, 0, 0, 1)
   setBackgroundColor(gaugeName .. "_text", 0, 0, 0, 0)
 
   -- save new values in table

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -461,7 +461,22 @@ end
 ---   <pre>
 ---   createGauge("healthBar", 300, 20, 30, 300, "Now with some text", "green", "horizontal, vertical, goofy, or batty")
 ---   </pre>
-function createGauge(gaugeName, width, height, x, y, gaugeText, r, g, b, orientation)
+function createGauge(windowname,gaugeName, width, height, x, y, gaugeText, r, g, b, orientation)
+  --Make windowname optional
+  if type(gaugeName) == "number" then
+    orientation = b
+    b = g
+    g = r
+    r = gaugeText
+    gaugeText = y
+    y = x
+    x = height
+    height = width
+    width = gaugeName
+    gaugeName = windowname
+    windowname= nil
+   end
+  windowname = windowname or "main"
   gaugeText = gaugeText or ""
   if type(r) == "string" then
     orientation = g
@@ -475,13 +490,13 @@ function createGauge(gaugeName, width, height, x, y, gaugeText, r, g, b, orienta
   orientation = orientation or "horizontal"
   assert(table.contains({ "horizontal", "vertical", "goofy", "batty" }, orientation), "createGauge: orientation must be horizontal, vertical, goofy, or batty")
   local tbl = { width = width, height = height, x = x, y = y, text = gaugeText, r = r, g = g, b = b, orientation = orientation, value = 1 }
-  createLabel(gaugeName .. "_back", 0, 0, 0, 0, 1)
+  createLabel(windowname,gaugeName .. "_back", 0, 0, 0, 0, 1)
   setBackgroundColor(gaugeName .. "_back", r, g, b, 100)
 
-  createLabel(gaugeName .. "_front", 0, 0, 0, 0, 1)
+  createLabel(windowname,gaugeName .. "_front", 0, 0, 0, 0, 1)
   setBackgroundColor(gaugeName .. "_front", r, g, b, 255)
 
-  createLabel(gaugeName .. "_text", 0, 0, 0, 0, 1)
+  createLabel(windowname,gaugeName .. "_text", 0, 0, 0, 0, 1)
   setBackgroundColor(gaugeName .. "_text", 0, 0, 0, 0)
 
   -- save new values in table

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -112,6 +112,7 @@ local packages = {
   "geyser/GeyserReposition.lua",
   "geyser/GeyserHBox.lua",
   "geyser/GeyserVBox.lua",
+  "geyser/GeyserUserWindow.lua",
   -- TODO probably don't need to load this file
   "geyser/GeyserTests.lua",
   "GUIUtils.lua",

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -113,6 +113,7 @@ local packages = {
   "geyser/GeyserHBox.lua",
   "geyser/GeyserVBox.lua",
   "geyser/GeyserUserWindow.lua",
+
   -- TODO probably don't need to load this file
   "geyser/GeyserTests.lua",
   "GUIUtils.lua",

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -277,7 +277,7 @@ function Geyser.Container:new(cons, container)
     end
    --Create Root-Container for UserWindow and add Children
    if (container == Geyser) and (me.windowname) and (me.windowname ~= "main") then
-        container = Geyser.Container:new({name=me.windowname.."Container",x=0,y=0,width="100%",height="100%"})
+        container = Geyser.Container:new({name=me.windowname.."Container", type = "userwindow", x=0, y=0, width="100%", height="100%"})
         container:add(me)
         container.get_width = function()
             return getUserWindowSize(me.windowname)

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -114,9 +114,10 @@ end
 -- Called on window resize events.
 function Geyser.Container:reposition ()
   local x, y, w, h = self:get_x(), self:get_y(), self:get_width(), self:get_height()
-  moveWindow(self.name, self:get_x(), self:get_y())
-  resizeWindow(self.name, self:get_width(), self:get_height())
-
+  if self.type ~= "userwindow" then
+    moveWindow(self.name, self:get_x(), self:get_y())
+    resizeWindow(self.name, self:get_width(), self:get_height())
+  end
   -- deal with all children of this container
   for k, v in pairs(self.windowList) do
     if k ~= self and not v.nestLabels then
@@ -229,7 +230,7 @@ function Geyser.Container:flash (time)
   local time = time or 1.0
   local x, y, width, height = self.get_x(), self.get_y(), self.get_width(), self.get_height()
   local name = self.name .. "_dimensions_flash"
-  createLabel(name, x, y, width, height, 1)
+  createLabel(self.windowname ,name, x, y, width, height, 1)
   resizeWindow(name, width, height)
   moveWindow(name, x, y)
   setBackgroundColor(name, 190, 190, 190, 128)

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -282,7 +282,8 @@ function Geyser.Container:new(cons, container)
             return getUserWindowSize(me.windowname)
         end
         container.get_height = function()
-            local w, h = getUserWindowSize(me.windowname) return h
+            local w, h = getUserWindowSize(me.windowname)
+            return h
         end
     end
   end

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -272,6 +272,18 @@ function Geyser.Container:new(cons, container)
     else
       -- Else assume the root window is my container
       Geyser:add(me)
+      container=Geyser
+    end
+   --Create Root-Container for UserWindow and add Children
+   if (container == Geyser) and (me.windowname) and (me.windowname ~= "main") then
+        container = Geyser.Container:new({name=me.windowname.."Container",x=0,y=0,width="100%",height="100%"})
+        container:add(me)
+        container.get_width = function()
+            return getUserWindowSize(me.windowname)
+        end
+        container.get_height = function()
+            local w, h = getUserWindowSize(me.windowname) return h
+        end
     end
   end
 

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -132,7 +132,7 @@ function Geyser.Gauge:new (cons, container)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self
-
+  me.windowname = me.windowname or me.container.windowname or "main"
   -----------------------------------------------------------
   -- Now create the Gauge using primitives and tastey classes
 

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -69,6 +69,7 @@ function Geyser:add (window, cons)
   window.container = self
   self.windowList[window.name] = window
   table.insert(self.windows, window.name)
+  window.windowname = window.windowname or window.container.windowname or "main"
   Geyser.set_constraints(window, cons, self)
   if not self.defer_updates then
     window:reposition()

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -463,9 +463,9 @@ function Geyser.Label:new (cons, container)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self
-
+  me.windowname = me.windowname or me.container.windowname or "main"
   -- Create the label using primitives
-  createLabel(me.name, me:get_x(), me:get_y(),
+  createLabel(me.windowname, me.name, me:get_x(), me:get_y(),
   me:get_width(), me:get_height(), me.fillBg)
 
   -- Set any defined colors

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -22,15 +22,15 @@ function Geyser.Mapper:reposition()
   if self.hidden or self.auto_hidden then
     return
   end
-  createMapper(self:get_x(), self:get_y(), self:get_width(), self:get_height())
+  createMapper(self.windowname, self:get_x(), self:get_y(), self:get_width(), self:get_height())
 end
 
 function Geyser.Mapper:hide_impl()
-  createMapper(self:get_x(), self:get_y(), 0, 0)
+  createMapper(self.windowname, self:get_x(), self:get_y(), 0, 0)
 end
 
 function Geyser.Mapper:show_impl()
-  createMapper(self:get_x(), self:get_y(), self:get_width(), self:get_height())
+  createMapper(self.windowname, self:get_x(), self:get_y(), self:get_width(), self:get_height())
 end
 
 -- Overridden constructor
@@ -40,7 +40,7 @@ function Geyser.Mapper:new (cons, container)
 
   -- Call parent's constructor
   local me = self.parent:new(cons, container)
-
+  me.windowname = me.windowname or me.container.windowname or "main"
   me.was_hidden = false
 
   -- Set the metatable.
@@ -49,7 +49,7 @@ function Geyser.Mapper:new (cons, container)
 
   -----------------------------------------------------------
   -- Now create the Mapper using primitives
-  createMapper(me:get_x(), me:get_y(),
+  createMapper(me.windowname, me:get_x(), me:get_y(),
   me:get_width(), me:get_height())
 
   -- Set any defined colors

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -312,7 +312,8 @@ function Geyser.MiniConsole:new (cons, container)
 
   -----------------------------------------------------------
   -- Now create the MiniConsole using primitives
-  createMiniConsole(me.name, me:get_x(), me:get_y(),
+  me.windowname = me.windowname or me.container.windowname or "main"
+  createMiniConsole(me.windowname,me.name, me:get_x(), me:get_y(),
   me:get_width(), me:get_height())
 
   -- Set any defined colors

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -312,35 +312,37 @@ function Geyser.MiniConsole:new (cons, container)
 
   -----------------------------------------------------------
   -- Now create the MiniConsole using primitives
-  me.windowname = me.windowname or me.container.windowname or "main"
-  createMiniConsole(me.windowname,me.name, me:get_x(), me:get_y(),
-  me:get_width(), me:get_height())
+  if not string.find(me.name, ".*Class") then
+    me.windowname = me.windowname or me.container.windowname or "main"
+    createMiniConsole(me.windowname,me.name, me:get_x(), me:get_y(),
+    me:get_width(), me:get_height())
 
-  -- Set any defined colors
-  Geyser.Color.applyColors(me)
+    -- Set any defined colors
+    Geyser.Color.applyColors(me)
 
-  if cons.fontSize then
-    me:setFontSize(cons.fontSize)
-  elseif container then
-    me:setFontSize(container.fontSize)
-    cons.fontSize = container.fontSize
-  else
-    me:setFontSize(8)
-    cons.fontSize = 8
+    if cons.fontSize then
+      me:setFontSize(cons.fontSize)
+    elseif container then
+      me:setFontSize(container.fontSize)
+      cons.fontSize = container.fontSize
+    else
+      me:setFontSize(8)
+      cons.fontSize = 8
+    end
+    if cons.scrollBar then
+      me:enableScrollBar()
+    else
+      me:disableScrollBar()
+    end
+    if cons.font then
+      me:setFont(cons.font)
+    end
+    if cons.wrapAt == "auto" then
+      me:setAutoWrap()
+    elseif cons.wrapAt then
+      me:setWrap(cons.wrapAt)
+    end
+    --print("  New in " .. self.name .. " : " .. me.name)
   end
-  if cons.scrollBar then
-    me:enableScrollBar()
-  else
-    me:disableScrollBar()
-  end
-  if cons.font then
-    me:setFont(cons.font)
-  end
-  if cons.wrapAt == "auto" then
-    me:setAutoWrap()
-  elseif cons.wrapAt then
-    me:setWrap(cons.wrapAt)
-  end
-  --print("  New in " .. self.name .. " : " .. me.name)
   return me
 end

--- a/src/mudlet-lua/lua/geyser/GeyserReposition.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserReposition.lua
@@ -6,9 +6,13 @@
 
 --- Responds to sysWindowResizeEvent and causes all windows managed
 -- by Geyser to update their sizes and positions.
-function GeyserReposition()
+function GeyserReposition(event, w, h, arg)
   for _, window in pairs(Geyser.windowList) do
-    window:reposition()
+    if event == "sysUserWindowResizeEvent" and window.type == "userwindow" and arg.."Container" == window.name then
+      window:reposition()
+    elseif event == "sysWindowResizeEvent" and window.type ~= "userwindow" then 
+      window:reposition()
+    end
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserReposition.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserReposition.lua
@@ -13,3 +13,4 @@ function GeyserReposition()
 end
 
 registerAnonymousEventHandler("sysWindowResizeEvent", "GeyserReposition")
+registerAnonymousEventHandler("sysUserWindowResizeEvent", "GeyserReposition")

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -1,0 +1,76 @@
+--------------------------------------
+--                                  --
+-- The Geyser Layout Manager by guy --
+--                                  --
+--------------------------------------
+
+--- Represents a UserWindow Class
+-- @class table
+-- @name Geyser.UserWindow
+--UserWindow is just a MiniConsole
+Geyser.UserWindow = Geyser.MiniConsole:new({
+  name = "UserWindowClass"})
+
+--Set Constraints and use main Window (Geyser) as reference
+function Geyser.UserWindow:set_uwconstr()
+  Geyser.set_constraints(self,self,Geyser)
+end
+
+function Geyser.UserWindow:move(x,y)
+  self.x = x or self.x
+  self.y = y or self.y
+  self:set_uwconstr()
+  moveWindow(self.name,self.get_x(),self.get_y())
+  self:resetWindow()
+end
+
+function Geyser.UserWindow:resize(width,height)
+  self.width = width or self.width
+  self.height = height or self.height
+  self:set_uwconstr()
+  resizeWindow(self.name,self.get_width(),self.get_height())
+  self:resetWindow()
+end
+
+--Reset Root Container to cover all the UserWindow
+function Geyser.UserWindow:resetWindow()
+  self.x = 0
+  self.y = 0
+  self.width = "100%"
+  self.height = "100%"
+  self:set_constraints(self)
+end
+
+--Override show to keep the dimensions of the UserWindow
+function Geyser.UserWindow:show()
+  local w,h = self.get_width(),self.get_height()
+  self.Parent.show(self)
+  self:resize(w,h)
+end
+
+Geyser.UserWindow.Parent = Geyser.Window
+
+function Geyser.UserWindow:new (cons)
+  cons = cons or {}
+  cons.name = cons.name or Geyser.nameGen()
+  cons.type = cons.type or "userwindow"
+  cons.windowname = cons.name
+  cons.width = cons.width or 435
+  cons.height = cons.height or 375
+  cons.x = cons.x or 10
+  cons.y = cons.y or 140
+  --Root Container for UserWindows 
+  me = self.Parent:new(cons)
+  -- Set the metatable.
+  setmetatable(me, self)
+  self.__index = self
+  
+  me.restoreLayout = me.restoreLayout or false
+  
+  openUserWindow(me.name,me.restoreLayout)
+  
+  me:move(cons.x,cons.y)
+  me:resize(cons.width,cons.height)
+  me:resetWindow()
+  return me
+end

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -71,8 +71,8 @@ function Geyser.UserWindow:new(cons)
   openUserWindow(me.name,me.restoreLayout)
 
   --Resizing not possible if docked
-  --Docking position not choosable
-  if me.docked == false then
+  --Docking position not choosable if restoreLayout don't move/resize at start
+  if me.docked == false and me.restoreLayout == false then
       me:move(cons.x,cons.y)
       me:resize(cons.width,cons.height)
   end

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -50,7 +50,7 @@ end
 
 Geyser.UserWindow.Parent = Geyser.Window
 
-function Geyser.UserWindow:new (cons)
+function Geyser.UserWindow:new(cons)
   cons = cons or {}
   cons.name = cons.name or Geyser.nameGen()
   cons.type = cons.type or "userwindow"
@@ -66,11 +66,17 @@ function Geyser.UserWindow:new (cons)
   self.__index = self
   
   me.restoreLayout = me.restoreLayout or false
-  
+  me.docked = me.docked or false
+
   openUserWindow(me.name,me.restoreLayout)
-  
-  me:move(cons.x,cons.y)
-  me:resize(cons.width,cons.height)
+
+  --Resizing not possible if docked
+  --Docking position not choosable
+  if me.docked == false then
+      me:move(cons.x,cons.y)
+      me:resize(cons.width,cons.height)
+  end
+
   me:resetWindow()
   return me
 end

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2029,6 +2029,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QSt
     }
 
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
+    auto pW = pHost->mpConsole->mDockWidgetMap.value(name);
     if (!pC) {
         pC = pHost->mpConsole->createMiniConsole(windowname, name, x, y, width, height);
         if (pC) {
@@ -2039,8 +2040,11 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QSt
         // CHECK: The absence of an explict return statement in this block means that
         // reusing an existing mini console causes the lua function to seem to
         // fail - is this as per Wiki?
-        pC->resize(width, height);
-        pC->move(x, y);
+        // This part was causing problems with UserWindows
+        if (!pW) {
+            pC->resize(width, height);
+            pC->move(x, y);
+        }
     }
     return false;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2042,7 +2042,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QSt
     return false;
 }
 
-bool mudlet::createLabel(Host* pHost, const QString& windowname, const QString& name,int x, int y, int width, int height, bool fillBg,
+bool mudlet::createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg,
                          bool clickthrough)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2022,10 +2022,10 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
     return false;
 }
 
-bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height)
+std::pair<bool, QString> mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height)
 {
     if (!pHost || !pHost->mpConsole) {
-        return false;
+        return {false, QString()};
     }
 
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
@@ -2034,9 +2034,9 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QSt
         pC = pHost->mpConsole->createMiniConsole(windowname, name, x, y, width, height);
         if (pC) {
             pC->setMiniConsoleFontSize(12);
-            return true;
+            return {true, QString()};
         }
-    } else {
+    } else if (pC) {
         // CHECK: The absence of an explict return statement in this block means that
         // reusing an existing mini console causes the lua function to seem to
         // fail - is this as per Wiki?
@@ -2044,26 +2044,32 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QSt
         if (!pW) {
             pC->resize(width, height);
             pC->move(x, y);
+            return {false, QStringLiteral("miniconsole \"%1\" exists already. moving/resizing \"%1\".").arg(name)};
         }
     }
-    return false;
+    return {false, QStringLiteral("miniconsole/userwindow \"%1\" exists already.").arg(name)};
 }
 
-bool mudlet::createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg,
-                         bool clickthrough)
+std::pair<bool, QString> mudlet::createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg, bool clickthrough)
 {
     if (!pHost || !pHost->mpConsole) {
-        return false;
+        return {false, QString()};
     }
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
-    if (!pL) {
+    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
+    if (!pL && !pC) {
         pL = pHost->mpConsole->createLabel(windowname, name, x, y, width, height, fillBg, clickthrough);
         if (pL) {
-            return true;
+            return {true, QString()};
         }
+    } else if (pL) {
+        return {false, QStringLiteral("label \"%1\" exists already.").arg(name)};
+    } else if (pC) {
+        return {false, QStringLiteral("a miniconsole/userwindow with the name \"%1\" exists already. label name has to be unique.").arg(name)};
     }
-    return false;
+    return {false, QString()};
+
 }
 
 bool mudlet::createBuffer(Host* pHost, const QString& name)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2019,7 +2019,7 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
     return false;
 }
 
-bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, int width, int height)
+bool mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height)
 {
     if (!pHost || !pHost->mpConsole) {
         return false;
@@ -2027,7 +2027,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
 
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (!pC) {
-        pC = pHost->mpConsole->createMiniConsole(name, x, y, width, height);
+        pC = pHost->mpConsole->createMiniConsole(windowname, name, x, y, width, height);
         if (pC) {
             pC->setMiniConsoleFontSize(12);
             return true;
@@ -2042,7 +2042,7 @@ bool mudlet::createMiniConsole(Host* pHost, const QString& name, int x, int y, i
     return false;
 }
 
-bool mudlet::createLabel(Host* pHost, const QString& name, int x, int y, int width, int height, bool fillBg,
+bool mudlet::createLabel(Host* pHost, const QString& windowname, const QString& name,int x, int y, int width, int height, bool fillBg,
                          bool clickthrough)
 {
     if (!pHost || !pHost->mpConsole) {
@@ -2051,7 +2051,7 @@ bool mudlet::createLabel(Host* pHost, const QString& name, int x, int y, int wid
 
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (!pL) {
-        pL = pHost->mpConsole->createLabel(name, x, y, width, height, fillBg, clickthrough);
+        pL = pHost->mpConsole->createLabel(windowname, name, x, y, width, height, fillBg, clickthrough);
         if (pL) {
             return true;
         }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -129,9 +129,8 @@ public:
     int getFontSize(Host*, const QString&);
     QSize calcFontSize(Host* pHost, const QString& windowName);
     bool openWindow(Host*, const QString&, bool loadLayout = true);
-    bool createMiniConsole(Host*, const QString& windowname, const QString& name, int, int, int, int);
-    bool createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg,
-                         bool clickthrough);
+    std::pair<bool, QString> createMiniConsole(Host*, const QString& windowname, const QString& name, int, int, int, int);
+    std::pair<bool, QString> createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg, bool clickthrough);
     bool echoWindow(Host*, const QString&, const QString&);
     bool echoLink(Host* pHost, const QString& name, const QString& text, QStringList&, QStringList&, bool customFormat = false);
     void insertLink(Host*, const QString&, const QString&, QStringList&, QStringList&, bool customFormat = false);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -129,8 +129,8 @@ public:
     int getFontSize(Host*, const QString&);
     QSize calcFontSize(Host* pHost, const QString& windowName);
     bool openWindow(Host*, const QString&, bool loadLayout = true);
-    bool createMiniConsole(Host*, const QString&, int, int, int, int);
-    bool createLabel(Host* pHost, const QString& name, int x, int y, int width, int height, bool fillBg,
+    bool createMiniConsole(Host*, const QString& windowname, const QString& name, int, int, int, int);
+    bool createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg,
                          bool clickthrough);
     bool echoWindow(Host*, const QString&, const QString&);
     bool echoLink(Host* pHost, const QString& name, const QString& text, QStringList&, QStringList&, bool customFormat = false);


### PR DESCRIPTION
…in them

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add Labels, MiniConsoles, Gauges to the UserWindow.
Allow resetProfile() to reset also UserWindows (for testing)

createLabel([windowname],...) --new optional first parameter windowname (UserWindow Name)
createMiniconsole([windowname],...) --new optional first parameter windowname (UserWindow Name)
createGauge([windowname],...) --new optional first parameter windowname (UserWindow Name)
Geyser.Container:new({windowname="UserWindow"}) --new optional variable windowname which adds the Container to the UserWindow
New event: sysUserWindowResizeEvent -> Used to make Geyser reposition work
New function: getUserWindowSize(windowname) -> Used to get the UserWindow size (also for Geyser)


#### Motivation for adding to Mudlet
Every other day there are request for adding more functionality to the UserWindows. 
One of the mods told us to try to contribute it ourself so I did that.

#### Other info (issues closed, discussion etc)

I know this changes a lot of functionality at once and I know it probably won't get accepted but I'm new at contributing and I read the CONTRIBUTING.md  to late.

I thought better try to contribute in this way then not at all and of course this needs still a lot of testing but it wasn't breaking anything on my side.

Next time and in future I will follow the suggestions in the CONTRIBUTING.md.
Nonetheless if someone finds some of my ideas in this implementation useful it was already a great success.

tldr : I had lot of fun coding it and if it doesn't fit just ignore/delete/block this PR.

