### PR TITLE
Enhance: add the ability to destroy consoles without resetting a profile

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -218,7 +218,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mProxyPort(0)
 , mProxyUsername(QString())
 , mProxyPassword(QString())
-, mIsGoingDown(false)
 , mIsProfileLoadingSequence(false)
 , mLF_ON_GA(true)
 , mNoAntiAlias(false)
@@ -357,6 +356,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mKeyUnit(this)
 , mHostID(id)
 , mHostName(hostname)
+, mIsGoingDown(false)
 , mIsClosingDown(false)
 , mLogin(login)
 , mPass(pass)
@@ -435,8 +435,8 @@ Host::~Host()
     if (mpDockableMapWidget) {
         mpDockableMapWidget->deleteLater();
     }
-    mIsGoingDown = true;
-    mIsClosingDown = true;
+    mIsGoingDown = true; // Only place this is set
+    mIsClosingDown = true; // Also set by isClosingDown() call in
     mErrorLogStream.flush();
     mErrorLogFile.close();
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -324,6 +324,7 @@ public:
     // Store/retrieve all the settings in one call:
     void setPlayerRoomStyleDetails(const quint8 styleCode, const quint8 outerDiameter = 120, const quint8 innerDiameter = 70, const QColor& outerColor = QColor(), const QColor& innerColor = QColor());
     void getPlayerRoomStyleDetails(quint8& styleCode, quint8& outerDiameter, quint8& innerDiameter, QColor& outerColor, QColor& innerColor);
+    bool isGoingDown() const { return mIsGoingDown; }
 
     cTelnet mTelnet;
     QPointer<TConsole> mpConsole;
@@ -372,7 +373,6 @@ public:
     QString mProxyUsername;
     QString mProxyPassword;
 
-    bool mIsGoingDown;
     // Used to force the test compilation of the scripts for TActions ("Buttons")
     // that are pushdown buttons that run when they are "pushed down" during
     // loading even though the buttons start out with themselves NOT being
@@ -585,6 +585,8 @@ private:
     int mHostID;
     QString mHostName;
 
+    // Was public:
+    bool mIsGoingDown;
     bool mIsClosingDown;
 
     QString mLine;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -210,6 +210,9 @@ public:
     // 2 = Selection not valid
     QPair<quint8, TChar> getTextAttributes() const;
     QPair<quint8, TChar> getTextAttributes(const QString&) const;
+    std::pair<bool, QString> closeWindow(const QString& name, const bool destroy);
+    bool dying() const { return mDieFlag; }
+
 
 
     QPointer<Host> mpHost;
@@ -355,6 +358,10 @@ private:
     // for the ".aff" file - this member is for the per profile option only as
     // the shared one is held by the mudlet singleton class:
     QSet<QString> mWordSet_profile;
+
+    // Flag for user generated windows so that receiving a close event will
+    // actually close rather than just hide this TConsole instance
+    bool mDieFlag;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)

--- a/src/TDockWidget.cpp
+++ b/src/TDockWidget.cpp
@@ -41,14 +41,14 @@ void TDockWidget::setTConsole(TConsole* pC)
 
 void TDockWidget::closeEvent(QCloseEvent* event)
 {
-    if (!mpHost->isClosingDown()) {
+    if (!(mpHost->isClosingDown() || mpConsole->dying())) {
         mudlet::self()->hideWindow(mpHost, widgetConsoleName);
         event->ignore();
         return;
-    } else {
-        event->accept();
-        return;
     }
+
+    setAttribute(Qt::WA_DeleteOnClose);
+    event->accept();
 }
 
 void TDockWidget::resizeEvent(QResizeEvent* event)

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -479,7 +479,7 @@ void cTelnet::handle_socket_signal_disconnected()
     mNeedDecompression = false;
     reset();
 
-    if (!mpHost->mIsGoingDown) {
+    if (!mpHost->isGoingDown()) {
         postMessage(spacer);
 
 #if !defined(QT_NO_SSL)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2817,12 +2817,6 @@ Host* mudlet::getActiveHost()
     }
 }
 
-void mudlet::addSubWindow(TConsole* pConsole)
-{
-    mainPane->layout()->addWidget(pConsole);
-    pConsole->show(); //NOTE: this is important for Apple OSX otherwise the console isnt displayed
-}
-
 void mudlet::closeEvent(QCloseEvent* event)
 {
     foreach (TConsole* pC, mConsoleMap) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1429,7 +1429,7 @@ void mudlet::slot_close_profile_requested(int tab)
     }
 
     pH->mpConsole->mUserAgreedToCloseConsole = true;
-    pH->closingDown();
+    pH->closingDown(); // Only place this is used
 
     // disconnect before removing objects from memory as sysDisconnectionEvent needs that stuff.
 #if defined (Q_OS_WIN32)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2361,26 +2361,6 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
     return false;
 }
 
-bool mudlet::closeWindow(Host* pHost, const QString& name)
-{
-    if (!pHost || !pHost->mpConsole) {
-        return false;
-    }
-
-    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        auto pD = pHost->mpConsole->mDockWidgetMap.value(name);
-        if (pD) {
-            pD->hide();
-            pD->update();
-        }
-        return pHost->mpConsole->hideWindow(name);
-
-    } else {
-        return false;
-    }
-}
-
 bool mudlet::setLabelClickCallback(Host* pHost, const QString& name, const QString& func, const TEvent& pA)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -140,7 +140,6 @@ public:
     bool showWindow(Host*, const QString&);
     bool hideWindow(Host*, const QString&);
     bool paste(Host*, const QString&);
-    bool closeWindow(Host*, const QString&);
     bool resizeWindow(Host*, const QString&, int, int);
     bool clearWindow(Host*, const QString&);
     bool pasteWindow(Host* pHost, const QString& name);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -108,7 +108,7 @@ public:
     FontManager mFontManager;
     Discord mDiscord;
     QPointer<QSettings> mpSettings;
-    void addSubWindow(TConsole* p);
+
     int getColumnNumber(Host* pHost, QString& name);
     std::pair<bool, int> getLineNumber(Host* pHost, QString& windowName);
     void printSystemMessage(Host* pH, const QString& s);


### PR DESCRIPTION
It removes from the Lua API `closeUserWindow(...)` the need to go via an intermediate method in the `mudlet` class.

It also takes out some instances of "return-after-else" that CLazy will pick up on.

It will be a good idea to actually reinsert some documentation for the previously undocumented `closeUserWindow(...)` to also account for the new optional second boolean argument which has to be present and `true` for the window/console to be deleted.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>