### PR TITLE
Fix AppVeyor builds due to image upgrade

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 environment:
   signing_password:
     secure: gOKqBtIvfDuGkEeaHGaguMmafynYAG06iVuD6Krem7M=


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
The new image upgrade as of yesterday is giving a `Could not find qmake spec 'win32-g++'.` error.
#### Motivation for adding to Mudlet
Fix AppVeyor builds.
#### Other info (issues closed, discussion etc)
