### PR TITLE
Fix module priorities not to get lost

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1535,9 +1535,6 @@ bool Host::installPackage(const QString& fileName, int module)
                 moduleEntry << fileName;
                 moduleEntry << QStringLiteral("0");
                 mInstalledModules[packageName] = moduleEntry;
-                if (module == 1 || module == 3) {
-                    mModulePriorities[packageName] = 0;
-                }
                 mActiveModules.append(packageName);
             } else {
                 mInstalledPackages.append(packageName);
@@ -1551,6 +1548,7 @@ bool Host::installPackage(const QString& fileName, int module)
     } else {
         file2.setFileName(fileName);
         file2.open(QFile::ReadOnly | QFile::Text);
+        //mInstalledPackages.append( packageName );
         QString profileName = getName();
         QString login = getLogin();
         QString pass = getPass();
@@ -1560,9 +1558,6 @@ bool Host::installPackage(const QString& fileName, int module)
             moduleEntry << fileName;
             moduleEntry << QStringLiteral("0");
             mInstalledModules[packageName] = moduleEntry;
-            if (module == 1 || module == 3) {
-                mModulePriorities[packageName] = 0;
-            }
             mActiveModules.append(packageName);
         } else {
             mInstalledPackages.append(packageName);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2947,26 +2947,26 @@ int TLuaInterpreter::setModulePriority(lua_State* L)
     QString moduleName;
     int modulePriority;
     if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "setModulePriority: Module be be a string");
+        lua_pushfstring(L, "setModulePriority: bad argument #1 type (module name as string expected, got %s!)", luaL_typename(L, 1));
         lua_error(L);
         return 1;
     } else {
         moduleName = lua_tostring(L, 1);
     }
     if (!lua_isnumber(L, 2)) {
-        lua_pushstring(L, "setModulePriority: Module priority must be an integer");
+        lua_pushfstring(L, "setModulePriority: bad argument #2 type (module priority as number expected, got %s!)", luaL_typename(L, 2));
         lua_error(L);
         return 1;
     } else {
         modulePriority = lua_tonumber(L, 2);
     }
     Host& host = getHostFromLua(L);
-    if (host.mModulePriorities.contains(moduleName)) {
+    if (host.mInstalledModules.contains(moduleName)) {
         host.mModulePriorities[moduleName] = modulePriority;
     } else {
-        lua_pushstring(L, "setModulePriority: Module doesn't exist");
-        lua_error(L);
-        return 1;
+        lua_pushnil(L);
+        lua_pushstring(L, "module doesn't exist");
+        return 2;
     }
     return 0;
 }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Fix module priorities not to get lost on saving, while still keeping `setModulePriority()` working if called during the module installation event.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/3345.

I took a different approach to solving it this time - since it seems a few things down the pipeline rely on the presence of a module as a flag for something. Instead of adding every module at priority 0, the `setModulePriority()` function will instead set the value as needed.