### PR TITLE
Add unzipAsync()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15511,7 +15511,8 @@ int TLuaInterpreter::unzip2(lua_State *L)
     });
     watcher->setFuture(future);
 
-    return 0;
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // No documentation available in wiki - internal function

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15452,19 +15452,17 @@ int TLuaInterpreter::getConnectionInfo(lua_State *L)
 
 int TLuaInterpreter::unzipAsync(lua_State *L)
 {
-    QString zipLocation;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "unzipAsync: bad argument #1 type (zip location as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    zipLocation = QString::fromUtf8(lua_tostring(L, 1));
+    QString zipLocation {QString::fromUtf8(lua_tostring(L, 1))};
 
-    QString extractLocation;
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "unzipAsync: bad argument #2 type (extract location as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    extractLocation = QString::fromUtf8(lua_tostring(L, 2));
+    QString extractLocation {QString::fromUtf8(lua_tostring(L, 2))};
 
     QTemporaryDir temporaryDir;
     if (!temporaryDir.isValid()) {
@@ -15483,7 +15481,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
     if (!dir.mkpath(extractLocation)) {
         lua_pushnil(L);
         lua_pushstring(L,
-                       "couldn't create output directory to extract the zip into");
+                       "couldn't create output directory to put the extracted files into");
         return 2;
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15470,7 +15470,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
     if (!temporaryDir.isValid()) {
         lua_pushnil(L);
         lua_pushstring(L,
-                       "coudln't create temporary directory to extract the zip into");
+                       "couldn't create temporary directory to extract the zip into");
         return 2;
     }
 
@@ -15483,7 +15483,7 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
     if (!dir.mkpath(extractLocation)) {
         lua_pushnil(L);
         lua_pushstring(L,
-                       "coudln't create output directory to extract the zip into");
+                       "couldn't create output directory to extract the zip into");
         return 2;
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15450,23 +15450,21 @@ int TLuaInterpreter::getConnectionInfo(lua_State *L)
     return 2;
 }
 
-int TLuaInterpreter::unzip2(lua_State *L)
+int TLuaInterpreter::unzipAsync(lua_State *L)
 {
     QString zipLocation;
     if (!lua_isstring(L, 1)) {
-        lua_pushfstring(L, "unzip2: bad argument #1 type (zip location as string expected, got %s!)", luaL_typename(L, 1));
+        lua_pushfstring(L, "unzipAsync: bad argument #1 type (zip location as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        zipLocation = QString::fromUtf8(lua_tostring(L, 1));
     }
+    zipLocation = QString::fromUtf8(lua_tostring(L, 1));
 
     QString extractLocation;
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "unzip2: bad argument #2 type (extract location as string expected, got %s!)", luaL_typename(L, 2));
+        lua_pushfstring(L, "unzipAsync: bad argument #2 type (extract location as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
-    } else {
-        extractLocation = QString::fromUtf8(lua_tostring(L, 2));
     }
+    extractLocation = QString::fromUtf8(lua_tostring(L, 2));
 
     QTemporaryDir temporaryDir;
     if (!temporaryDir.isValid()) {
@@ -16049,7 +16047,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "postHTTP", TLuaInterpreter::postHTTP);
     lua_register(pGlobalLua, "deleteHTTP", TLuaInterpreter::deleteHTTP);
     lua_register(pGlobalLua, "getConnectionInfo", TLuaInterpreter::getConnectionInfo);
-    lua_register(pGlobalLua, "unzip2", TLuaInterpreter::unzip2);
+    lua_register(pGlobalLua, "unzipAsync", TLuaInterpreter::unzipAsync);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     // prepend profile path to package.path and package.cpath

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -522,7 +522,7 @@ public:
     static int postHTTP(lua_State* L);
     static int deleteHTTP(lua_State* L);
     static int getConnectionInfo(lua_State* L);
-    static int unzip2(lua_State* L);
+    static int unzipAsync(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -522,6 +522,7 @@ public:
     static int postHTTP(lua_State* L);
     static int deleteHTTP(lua_State* L);
     static int getConnectionInfo(lua_State* L);
+    static int unzip2(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add `unzipAsync(path, location)`, an asynchronous and better version of unzip().

Returns `true` if unzipping was able to start, or `nil+msg` if unzipping wasn't able to start. Once the unzip process is finished, either `sysUnzipDone` or `sysUnzipError` is raised with the zip location and the extract location as the arguments.
#### Motivation for adding to Mudlet
Documenting `unzip()` was a mistake as it's synchronous and freezes Mudlet - bad for the user experience. 
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/3350.

Big thanks to `QtConcurrent::run()` for making async very simple.