### PR TITLE
UserWindow Settings at creation

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -560,8 +560,17 @@ end
 ---   <pre>
 ---   createConsole("myConsoleWindow", 8, 80, 20, 200, 400)
 ---   </pre>
-function createConsole(consoleName, fontSize, charsPerLine, numberOfLines, Xpos, Ypos)
-  createMiniConsole(consoleName, 0, 0, 1, 1)
+function createConsole(windowname, consoleName, fontSize, charsPerLine, numberOfLines, Xpos, Ypos)
+  if Ypos == nil then
+    Ypos = Xpos
+    Xpos = numberOfLines
+    numberOfLines = charsPerLine
+    charsPerLine = fontSize
+    fontSize = consoleName
+    consoleName = windowname
+    windowname = "main"
+  end
+  createMiniConsole(windowname, consoleName, 0, 0, 1, 1)
   setMiniConsoleFontSize(consoleName, fontSize)
   local x, y = calcFontSize( fontSize )
   resizeWindow(consoleName, x * charsPerLine, y * numberOfLines)

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -338,7 +338,7 @@ function Geyser.MiniConsole:new (cons, container)
       me:setFont(cons.font)
     end
     if cons.wrapAt == "auto" then
-      me:setAutoWrap()
+      me:enableAutoWrap()
     elseif cons.wrapAt then
       me:setWrap(cons.wrapAt)
     end

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -9,7 +9,8 @@
 -- @name Geyser.UserWindow
 --UserWindow is just a MiniConsole
 Geyser.UserWindow = Geyser.MiniConsole:new({
-  name = "UserWindowClass"})
+  name = "UserWindowClass",
+  color = "black"})
 
 --Set Constraints and use main Window (Geyser) as reference
 function Geyser.UserWindow:set_uwconstr()
@@ -69,6 +70,31 @@ function Geyser.UserWindow:new(cons)
   me.docked = me.docked or false
 
   openUserWindow(me.name,me.restoreLayout)
+  -- Set any defined colors
+  Geyser.Color.applyColors(me)
+
+  if cons.fontSize then
+    me:setFontSize(cons.fontSize)
+  elseif container then
+    me:setFontSize(container.fontSize)
+    cons.fontSize = container.fontSize
+  else
+    me:setFontSize(8)
+    cons.fontSize = 8
+  end
+  if cons.scrollBar then
+    me:enableScrollBar()
+  else
+    me:disableScrollBar()
+  end
+  if cons.font then
+    me:setFont(cons.font)
+  end
+  if cons.wrapAt == "auto" then
+    me:enableAutoWrap()
+  elseif cons.wrapAt then
+    me:setWrap(cons.wrapAt)
+  end
 
   --Resizing not possible if docked
   --Docking position not choosable if restoreLayout don't move/resize at start


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Some changes in Geyser.UserWindow to allow settings at creation.
addition for createConsole and bugfix for Geyser.MiniConsole

#### Motivation for adding to Mudlet
- Some settings like color, fontSize, wrapAt... were not included to work at creation of the UserWindow. 

- createConsole couldn't handle UserWindows. 

- Found a wrong function name in Geyser.MiniConsole
#### Other info (issues closed, discussion etc)
