### PR TITLE
Allow setting variable width font from the menu

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -260,6 +260,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 
     label_languageChangeWarning->hide();
     label_invalidFontError->hide();
+    label_variableWidthFontWarning->hide();
 
     comboBox_guiLanguage->clear();
     for (auto& code : pMudlet->getAvailableTranslationCodes()) {
@@ -1613,11 +1614,14 @@ void dlgProfilePreferences::setDisplayFont()
         return;
     }
 
+    label_invalidFontError->hide();
+    label_variableWidthFontWarning->hide();
     if (auto [validFont, errorMessage] = pHost->setDisplayFont(newFont); !validFont) {
         label_invalidFontError->show();
         return;
+    } else if (!QFontInfo(newFont).fixedPitch()) {
+        label_variableWidthFontWarning->show();
     }
-    label_invalidFontError->hide();
 
     QFont::insertSubstitution(pHost->mDisplayFont.family(), QStringLiteral("Noto Color Emoji"));
     auto* mainConsole = mudlet::self()->mConsoleMap.value(pHost);

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -727,13 +727,6 @@
            </widget>
           </item>
          </layout>
-         <zorder>label_30</zorder>
-         <zorder>fontComboBox</zorder>
-         <zorder>label_35</zorder>
-         <zorder>fontSize</zorder>
-         <zorder>mNoAntiAlias</zorder>
-         <zorder>label_variableWidthFontWarning</zorder>
-         <zorder>label_invalidFontError</zorder>
         </widget>
        </item>
        <item row="1" column="0">

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -704,18 +704,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="3">
-           <widget class="QLabel" name="label_variableWidthFontWarning">
-            <property name="font">
-             <font>
-              <pointsize>8</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>This font isn't monospace, which is not ideal for playing text games: you're welcome to use it but beware of issues</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
            <widget class="QCheckBox" name="mNoAntiAlias">
             <property name="toolTip">
@@ -723,6 +711,18 @@
             </property>
             <property name="text">
              <string>Enable anti-aliasing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="4">
+           <widget class="QLabel" name="label_variableWidthFontWarning">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>This font is not monospace, which may not be ideal for playing some text games: you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -680,9 +680,6 @@
             <property name="maxVisibleItems">
              <number>20</number>
             </property>
-            <property name="fontFilters">
-             <set>QFontComboBox::MonospacedFonts</set>
-            </property>
            </widget>
           </item>
           <item row="0" column="2">
@@ -695,7 +692,7 @@
           <item row="0" column="3">
            <widget class="QComboBox" name="fontSize"/>
           </item>
-          <item row="1" column="0" colspan="4">
+          <item row="1" column="0" colspan="2">
            <widget class="QLabel" name="label_invalidFontError">
             <property name="font">
              <font>
@@ -707,7 +704,19 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="4">
+          <item row="2" column="0" colspan="3">
+           <widget class="QLabel" name="label_variableWidthFontWarning">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>This font isn't monospace, which is not ideal for playing text games: you're welcome to use it but beware of issues</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QCheckBox" name="mNoAntiAlias">
             <property name="toolTip">
              <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
@@ -718,6 +727,13 @@
            </widget>
           </item>
          </layout>
+         <zorder>label_30</zorder>
+         <zorder>fontComboBox</zorder>
+         <zorder>label_35</zorder>
+         <zorder>fontSize</zorder>
+         <zorder>mNoAntiAlias</zorder>
+         <zorder>label_variableWidthFontWarning</zorder>
+         <zorder>label_invalidFontError</zorder>
         </widget>
        </item>
        <item row="1" column="0">


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Allow setting variable width font from the menu, instead of only via `setFont()` as before.
#### Motivation for adding to Mudlet
Font rendering seems to be able to handle weird fonts OK - except when the font is too weird, and then it's on the font.
#### Other info (issues closed, discussion etc)
