### PR TITLE
Improve tab order in the connection screen

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2588,8 +2588,22 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>dialog_buttonbox</tabstop>
+  <tabstop>profiles_tree_widget</tabstop>
+  <tabstop>welcome_message</tabstop>
+  <tabstop>profile_name_entry</tabstop>
+  <tabstop>host_name_entry</tabstop>
+  <tabstop>port_entry</tabstop>
+  <tabstop>port_ssl_tsl</tabstop>
+  <tabstop>profile_history</tabstop>
+  <tabstop>login_entry</tabstop>
+  <tabstop>character_password_entry</tabstop>
+  <tabstop>discord_optin_checkBox</tabstop>
+  <tabstop>autologin_checkBox</tabstop>
+  <tabstop>auto_reconnect</tabstop>
+  <tabstop>mud_description_textedit</tabstop>
   <tabstop>remove_profile_button</tabstop>
+  <tabstop>copy_profile_toolbutton</tabstop>
+  <tabstop>new_profile_button</tabstop>
  </tabstops>
  <resources>
   <include location="../mudlet.qrc"/>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Pressing `Tab` before navigated in this order:

![tab-order-before](https://user-images.githubusercontent.com/110988/75385657-72ca4a80-58e0-11ea-8e1e-cb9c76e8bb63.png)

Now it will be this:

![tab-order-after](https://user-images.githubusercontent.com/110988/75385670-7958c200-58e0-11ea-85f6-b58c0a2b14c0.png)

#### Motivation for adding to Mudlet
Better a11t.
#### Other info (issues closed, discussion etc)
Not sure if this is a lot better, I have not actually tried it with a screenreader yet.