### PR TITLE
BugFix: prevent crash if editor theme tab clicked without a Host anymore

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2848,8 +2848,9 @@ void dlgProfilePreferences::addActionsToPreview(TAction* pActionParent, std::vec
 // updates latest edbee themes when the user opens up the editor tab
 void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
 {
-    // bail out if this is not an editor tab
-    if (tabIndex != 3) {
+    // bail out if this is not the editor tab - or if the Host has gone away
+    Host* pHost = mpHost;
+    if (tabIndex != 3 || !pHost) {
         return;
     }
 
@@ -2894,7 +2895,7 @@ void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
     request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
     // load from cache if possible
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
-    mpHost->updateProxySettings(manager);
+    pHost->updateProxySettings(manager);
     QNetworkReply* getReply = manager->get(request);
 
     connect(getReply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), this, [=](QNetworkReply::NetworkError) {


### PR DESCRIPTION
Found this whilst working on something else that involved multiple active profiles and one of them being closed whilst their profile preferences dialogue was open - under those circumstances the Host specific data is cleared and disabled on the dialogue but clicking on the editor tab - which should have presenting a tab with no data on it instead caused Mudlet to crash because `Host::updateProxySettings(QNetworkAccessManager*)` was being called...

Although this causes a fatal crash, it is a rather *corner* case so I am only assigning it a **medium** priority whereas I would normal go *high*! :wink: 

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>