### PR TITLE
Label input fields which require an accessibile name

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2208,9 +2208,6 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
-              <property name="accessibleName">
-               <string>profile name</string>
-              </property>
               <property name="readOnly">
                <bool>false</bool>
               </property>
@@ -2236,9 +2233,6 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
-              </property>
-              <property name="accessibleName">
-               <string>server address</string>
               </property>
              </widget>
             </item>
@@ -2268,9 +2262,6 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
-              </property>
-              <property name="accessibleName">
-               <string>game port</string>
               </property>
               <property name="text">
                <string/>
@@ -2316,12 +2307,6 @@
                 <width>0</width>
                 <height>0</height>
                </size>
-              </property>
-              <property name="toolTip">
-               <string>Load an older version of this profile. A new version is saved every time you save the profile</string>
-              </property>
-              <property name="accessibleName">
-               <string>profile history</string>
               </property>
               <item>
                <property name="text">
@@ -2375,9 +2360,6 @@
               <property name="toolTip">
                <string>The characters name</string>
               </property>
-              <property name="accessibleName">
-               <string>character name</string>
-              </property>
               <property name="echoMode">
                <enum>QLineEdit::Normal</enum>
               </property>
@@ -2416,9 +2398,6 @@
              <widget class="QLineEdit" name="character_password_entry">
               <property name="toolTip">
                <string>Characters password. Note that the password isn't encrypted in storage</string>
-              </property>
-              <property name="accessibleName">
-               <string>password</string>
               </property>
               <property name="echoMode">
                <enum>QLineEdit::Password</enum>
@@ -2537,10 +2516,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Game description or your notes about the game</string>
-              </property>
-              <property name="accessibleName">
-               <string>Game description or your notes about the game</string>
+               <string>Game description</string>
               </property>
               <property name="tabChangesFocus">
                <bool>true</bool>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -97,6 +97,9 @@
              <height>0</height>
             </size>
            </property>
+           <property name="accessibleName">
+            <string>profiles list</string>
+           </property>
            <property name="resizeMode">
             <enum>QListView::Adjust</enum>
            </property>
@@ -2176,6 +2179,9 @@
              <height>16777215</height>
             </size>
            </property>
+           <property name="accessibleName">
+            <string>welcome message</string>
+           </property>
            <property name="openLinks">
             <bool>false</bool>
            </property>
@@ -2198,6 +2204,9 @@
               <property name="text">
                <string>Profile name:</string>
               </property>
+              <property name="buddy">
+               <cstring>profile_name_entry</cstring>
+              </property>
              </widget>
             </item>
             <item row="0" column="1" colspan="2">
@@ -2217,6 +2226,9 @@
              <widget class="QLabel" name="label_serverUrl">
               <property name="text">
                <string>Server address:</string>
+              </property>
+              <property name="buddy">
+               <cstring>host_name_entry</cstring>
               </property>
              </widget>
             </item>
@@ -2240,6 +2252,9 @@
              <widget class="QLabel" name="label_port">
               <property name="text">
                <string>Port:</string>
+              </property>
+              <property name="buddy">
+               <cstring>port_entry</cstring>
               </property>
              </widget>
             </item>
@@ -2291,6 +2306,9 @@
              <widget class="QLabel" name="label_profileHistory">
               <property name="text">
                <string>Profile history:</string>
+              </property>
+              <property name="buddy">
+               <cstring>profile_history</cstring>
               </property>
              </widget>
             </item>
@@ -2346,12 +2364,18 @@
               <property name="text">
                <string>Password:</string>
               </property>
+              <property name="buddy">
+               <cstring>character_password_entry</cstring>
+              </property>
              </widget>
             </item>
             <item row="0" column="0">
              <widget class="QLabel" name="label_characterName">
               <property name="text">
                <string>Character name:</string>
+              </property>
+              <property name="buddy">
+               <cstring>login_entry</cstring>
               </property>
              </widget>
             </item>
@@ -2411,6 +2435,9 @@
               </property>
               <property name="toolTip">
                <string>Enable Discord integration (not supported by game)</string>
+              </property>
+              <property name="accessibleName">
+               <string>Discord integration</string>
               </property>
               <property name="text">
                <string/>
@@ -2516,7 +2543,10 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Game description</string>
+               <string>Game description or your notes</string>
+              </property>
+              <property name="accessibleName">
+               <string>Game description or your notes</string>
               </property>
               <property name="tabChangesFocus">
                <bool>true</bool>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2431,9 +2431,6 @@
                <bool>false</bool>
               </property>
               <property name="toolTip">
-               <string>Discord integration</string>
-              </property>
-              <property name="accessibleName">
                <string>Enable Discord integration (not supported by game)</string>
               </property>
               <property name="text">

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2198,6 +2198,9 @@
               <property name="text">
                <string>Profile name:</string>
               </property>
+              <property name="buddy">
+               <cstring>profile_name_entry</cstring>
+              </property>
              </widget>
             </item>
             <item row="0" column="1" colspan="2">
@@ -2208,9 +2211,6 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
-              <property name="accessibleName">
-               <string>profile name</string>
-              </property>
               <property name="readOnly">
                <bool>false</bool>
               </property>
@@ -2220,6 +2220,9 @@
              <widget class="QLabel" name="label_serverUrl">
               <property name="text">
                <string>Server address:</string>
+              </property>
+              <property name="buddy">
+               <cstring>host_name_entry</cstring>
               </property>
              </widget>
             </item>
@@ -2236,9 +2239,6 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
-              </property>
-              <property name="accessibleName">
-               <string>server address</string>
               </property>
              </widget>
             </item>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2431,6 +2431,9 @@
                <bool>false</bool>
               </property>
               <property name="toolTip">
+               <string>Discord integration</string>
+              </property>
+              <property name="accessibleName">
                <string>Enable Discord integration (not supported by game)</string>
               </property>
               <property name="text">

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2208,6 +2208,9 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
+              <property name="accessibleName">
+               <string>profile name</string>
+              </property>
               <property name="readOnly">
                <bool>false</bool>
               </property>
@@ -2233,6 +2236,9 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
+              </property>
+              <property name="accessibleName">
+               <string>server address</string>
               </property>
              </widget>
             </item>
@@ -2262,6 +2268,9 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
+              </property>
+              <property name="accessibleName">
+               <string>game port</string>
               </property>
               <property name="text">
                <string/>
@@ -2307,6 +2316,12 @@
                 <width>0</width>
                 <height>0</height>
                </size>
+              </property>
+              <property name="toolTip">
+               <string>Load an older version of this profile. A new version is saved every time you save the profile</string>
+              </property>
+              <property name="accessibleName">
+               <string>profile history</string>
               </property>
               <item>
                <property name="text">
@@ -2360,6 +2375,9 @@
               <property name="toolTip">
                <string>The characters name</string>
               </property>
+              <property name="accessibleName">
+               <string>character name</string>
+              </property>
               <property name="echoMode">
                <enum>QLineEdit::Normal</enum>
               </property>
@@ -2398,6 +2416,9 @@
              <widget class="QLineEdit" name="character_password_entry">
               <property name="toolTip">
                <string>Characters password. Note that the password isn't encrypted in storage</string>
+              </property>
+              <property name="accessibleName">
+               <string>password</string>
               </property>
               <property name="echoMode">
                <enum>QLineEdit::Password</enum>
@@ -2516,7 +2537,10 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Game description</string>
+               <string>Game description or your notes about the game</string>
+              </property>
+              <property name="accessibleName">
+               <string>Game description or your notes about the game</string>
               </property>
               <property name="tabChangesFocus">
                <bool>true</bool>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2198,9 +2198,6 @@
               <property name="text">
                <string>Profile name:</string>
               </property>
-              <property name="buddy">
-               <cstring>profile_name_entry</cstring>
-              </property>
              </widget>
             </item>
             <item row="0" column="1" colspan="2">
@@ -2211,6 +2208,9 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
+              <property name="accessibleName">
+               <string>profile name</string>
+              </property>
               <property name="readOnly">
                <bool>false</bool>
               </property>
@@ -2220,9 +2220,6 @@
              <widget class="QLabel" name="label_serverUrl">
               <property name="text">
                <string>Server address:</string>
-              </property>
-              <property name="buddy">
-               <cstring>host_name_entry</cstring>
               </property>
              </widget>
             </item>
@@ -2239,6 +2236,9 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
+              </property>
+              <property name="accessibleName">
+               <string>server address</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Give input elements a name so they can be read out. Other elements already have a name.
#### Motivation for adding to Mudlet
Better ayy1.
#### Other info (issues closed, discussion etc)
> This is the primary name by which assistive technology such as screen readers announce this widget. For most widgets setting this property is not required. For example for QPushButton the button's text will be used.

> It is important to set this property when the widget does not provide any text. For example a button that only contains an icon needs to set this property to work with screen readers. The name should be short and equivalent to the visual information conveyed by the widget.