### PR TITLE
add setLabelToolTip

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2319,17 +2319,22 @@ std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
     return {false, QStringLiteral("label name \"%1\" not found").arg(name)};
 }
 
-bool TConsole::setLabelToolTip(const QString& name, const QString& text, double duration)
+std::pair<bool, QString> TConsole::setLabelToolTip(const QString& name, const QString& text, double duration)
 {
+    if (name.isEmpty()) {
+        return {false, QLatin1String("a label cannot have an empty string as its name")};
+    }
+
     auto pL = mLabelMap.value(name);
     if (pL) {
         duration = duration * 1000;
         pL->setToolTip(text);
         pL->setToolTipDuration(duration);
-        return true;
-    } else {
-        return false;
+        return {true, QString()};
     }
+
+    // Message is of the form needed for a Lua API function call run-time error
+    return {false, QStringLiteral("label name \"%1\" not found").arg(name)};
 }
 
 void TConsole::createMapper(const QString& windowname, int x, int y, int width, int height)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2319,6 +2319,19 @@ std::pair<bool, QString> TConsole::deleteLabel(const QString& name)
     return {false, QStringLiteral("label name \"%1\" not found").arg(name)};
 }
 
+bool TConsole::setLabelToolTip(const QString& name, const QString& text, double duration)
+{
+    auto pL = mLabelMap.value(name);
+    if (pL) {
+        duration = duration * 1000;
+        pL->setToolTip(text);
+        pL->setToolTipDuration((int)duration);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 void TConsole::createMapper(const QString& windowname, int x, int y, int width, int height)
 {
     auto pW = mDockWidgetMap.value(windowname);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2325,7 +2325,7 @@ bool TConsole::setLabelToolTip(const QString& name, const QString& text, double 
     if (pL) {
         duration = duration * 1000;
         pL->setToolTip(text);
-        pL->setToolTipDuration((int)duration);
+        pL->setToolTipDuration(duration);
         return true;
     } else {
         return false;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -149,7 +149,7 @@ public:
     createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
     TConsole* createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height);
     std::pair<bool, QString> deleteLabel(const QString&);
-    bool setLabelToolTip(const QString& name, const QString& text, double duration);
+    std::pair<bool, QString> setLabelToolTip(const QString& name, const QString& text, double duration);
     bool raiseWindow(const QString& name);
     bool lowerWindow(const QString& name);
     bool showWindow(const QString& name);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -149,6 +149,7 @@ public:
     createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
     TConsole* createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height);
     std::pair<bool, QString> deleteLabel(const QString&);
+    bool setLabelToolTip(const QString& name, const QString& text, double duration);
     bool raiseWindow(const QString& name);
     bool lowerWindow(const QString& name);
     bool showWindow(const QString& name);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3727,6 +3727,30 @@ int TLuaInterpreter::deleteLabel(lua_State* L)
     return 1;
 }
 
+int TLuaInterpreter::setLabelToolTip(lua_State* L)
+{
+    if (!lua_isstring(L, 1)) {
+        lua_pushfstring(L, "setLabelToolTip: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+    if (!lua_isstring(L, 2)) {
+        lua_pushfstring(L, "setLabelToolTip: bad argument #2 type (text as string expected, got %s!)", luaL_typename(L, 2));
+        return lua_error(L);
+    }
+    if ((lua_gettop(L) > 2) && !lua_isnumber(L, 3)) {
+        lua_pushfstring(L, "setLabelToolTip: bad argument #3 type (duration as number expected, got %s!)", luaL_typename(L, 3));
+        return lua_error(L);
+    }
+
+    QString labelName{QString::fromUtf8(lua_tostring(L, 1))};
+    QString labelToolTip{QString::fromUtf8(lua_tostring(L, 2))};
+    double duration = lua_tonumber(L, 3);
+    Host& host = getHostFromLua(L);
+
+    lua_pushboolean(L, host.mpConsole->setLabelToolTip(labelName, labelToolTip, duration));
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapper
 int TLuaInterpreter::createMapper(lua_State* L)
 {
@@ -15823,6 +15847,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "createMiniConsole", TLuaInterpreter::createMiniConsole);
     lua_register(pGlobalLua, "createLabel", TLuaInterpreter::createLabel);
     lua_register(pGlobalLua, "deleteLabel", TLuaInterpreter::deleteLabel);
+    lua_register(pGlobalLua, "setLabelToolTip", TLuaInterpreter::setLabelToolTip);
     lua_register(pGlobalLua, "raiseWindow", TLuaInterpreter::raiseWindow);
     lua_register(pGlobalLua, "lowerWindow", TLuaInterpreter::lowerWindow);
     lua_register(pGlobalLua, "hideWindow", TLuaInterpreter::hideUserWindow);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3747,7 +3747,13 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
     double duration = lua_tonumber(L, 3);
     Host& host = getHostFromLua(L);
 
-    lua_pushboolean(L, host.mpConsole->setLabelToolTip(labelName, labelToolTip, duration));
+    if (auto [success, message] = host.mpConsole->setLabelToolTip(labelName, labelToolTip, duration); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
     return 1;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -330,6 +330,7 @@ public:
     static int createMiniConsole(lua_State*);
     static int createLabel(lua_State*);
     static int deleteLabel(lua_State*);
+    static int setLabelToolTip(lua_State*);
     static int moveWindow(lua_State*);
     static int setTextFormat(lua_State*);
     static int setBackgroundImage(lua_State*);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1800,3 +1800,7 @@ end
 function hreplace(window, text)
   xReplace(window, text, 'h')
 end
+
+function resetLabelToolTip(label)
+  return setLabelToolTip(label, "")
+end


### PR DESCRIPTION
Adds the functionality of setLabelToolTip(labelname, tooltiptext, [duration])

<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This PR adds the functionality of adding a ToolTip to a Label
#### Motivation for adding to Mudlet
Lacking of this functionality
#### Other info (issues closed, discussion etc)
ToolTips are highly customizable as they are html. And they are also customizable by the StyleSheet option for example:
changing the ToolTips (from Label "testlabel") background and text color by
```lua
setLabelStyleSheet("testlabel", "QToolTip{background: yellow; color: blue; border:none;}")
```
