### PR TITLE
Extend geyser label formatting

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -85,10 +85,68 @@ function Geyser.Gauge:setText (text)
   end
 end
 
+--- Set the format for text on the gauge
+-- @param format the format to set. Same as Geyser.Label:setFormat
+function Geyser.Gauge:setFormat(format)
+  self.text:setFormat(format)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
+--- Set whether or not the text in the gauge should be bold
+-- @param bool True for bold
+function Geyser.Gauge:setBold(bool)
+  self.text:setBold(bool)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
+--- Set whether or not the text in the gauge should be italic
+-- @param bool True for bold
+function Geyser.Gauge:setItalics(bool)
+  self.text:setItalics(bool)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
+--- Set whether or not the text in the gauge should be underlined
+-- @param bool True for underlined
+function Geyser.Gauge:setUnderline(bool)
+  self.text:setUnderline(bool)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
+--- Set whether or not the text in the gauge should be strikethrough
+-- @param bool True for strikethrough
+function Geyser.Gauge:setStrikethrough(bool)
+  self.text:setStrikethrough(bool)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
+--- Set the font size for the gauge to use
+-- @param fontSize the font size to use for the gauge. Should be a number
+function Geyser.Gauge:setFontSize(fontSize)
+  self.text:setFontSize(fontSize)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
+--- Set the alignment of the text on the gauge
+-- @param alignment Valid alignments are 'c', 'center', 'l', 'left', 'r', 'right', or '' to not include the alignment as part of the echo
+function Geyser.Gauge:setAlignment(alignment)
+  self.text:setAlignment(alignment)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
+end
+
 --- Sets the text on the gauge, overwrites inherited echo function.
 -- @param text The text to set.
 function Geyser.Gauge:echo(message, color, format)
   self.text:echo(message, color, format)
+  self.format = self.text.format
+  self.formatTable = self.text.formatTable
 end
 
 -- Sets the style sheet for the gauge
@@ -165,6 +223,8 @@ function Geyser.Gauge:new (cons, container)
   me.back = Geyser.Label:new(back, me)
   me.front = Geyser.Label:new(front, me)
   me.text = Geyser.Label:new(text, me)
+  me.format = me.text.format
+  me.formatTable = me.text.formatTable
 
   -- Set whether this gauge is strict about its max value being 100 or not
   if cons.strict then me.strict = true else me.strict = false end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -27,43 +27,32 @@ Geyser.Label.numChildren = 0
 function Geyser.Label:echo(message, color, format)
   message = message or self.message
   self.message = message
-  format = format or self.format
-  self.format = format
   color = color or self.fgColor
   self.fgColor = color
+  if format then self:processFormatString(format) end
 
-  local fs = ""
-  local alignment = ""
-  -- check for formatting commands
-  if format then
-    if string.find(format, "b") then
-      message = "<b>" .. message .. "</b>"
-    end
-    if string.find(format, "i") then
-      message = "<i>" .. message .. "</i>"
-    end
-    if string.find(format, "c") then
-      alignment = "center"
-    elseif string.find(format, "l") then
-      alignment = "left"
-    elseif string.find(format, "r") then
-      alignment = "right"
-    end
-    if alignment ~= "" then
-      alignment = string.format([[align="%s" ]], alignment)
-    end
-    if string.find(format, "u") then
-      message = "<u>" .. message .. "</u>"
-    end
-    if string.find(format, 's') then
-      message = "<s>" .. message .. "</s>"
-    end
-    fs = string.gmatch(format, "%d+")()
-    if not fs then
-      fs = tostring(self.fontSize)
-    end
-    fs = "font-size: " .. fs .. "pt; "
+  local ft = self.formatTable
+  local fs = ft.fontSize
+  local alignment = ft.alignment
+  if alignment ~= "" then
+    alignment = string.format([[align="%s" ]], alignment)
   end
+  if ft.bold then
+    message = "<b>" .. message .. "</b>"
+  end
+  if ft.italics then
+    message = "<i>" .. message .. "</i>"
+  end
+  if ft.underline then
+    message = "<u>" .. message .. "</u>"
+  end
+  if ft.strikethrough then
+    message = "<s>" .. message .. "</s>"
+  end
+  if not fs then
+    fs = tostring(self.fontSize)
+  end
+  fs = "font-size: " .. fs .. "pt; "
   message = [[<div ]] .. alignment .. [[ style="color: ]] .. Geyser.Color.hex(self.fgColor) .. "; " .. fs ..
   [[">]] .. message .. [[</div>]]
   echo(self.name, message)
@@ -77,7 +66,133 @@ function Geyser.Label:setFormat(format)
   self:echo(nil, nil, format)
 end
 
+
+-- Internal function used for processing format strings.
+function Geyser.Label:processFormatString(format)
+  local formatType = type(format)
+  assert(formatType == "string", "format as string expected, got " .. formatType)
+  self.format = format
+  self.formatTable = {}
+  self.formatTable.bold = format:find("b") and true or false
+  self.formatTable.italics = format:find("i") and true or false
+  self.formatTable.underline = format:find("u") and true or false
+  self.formatTable.strikethrough = format:find("s") and true or false
+  local fs = format:gmatch("%d+")()
+  if not fs then
+    fs = self.fontSize
+    self.format = self.format .. self.fontSize
+  end
+  self.formatTable.fontSize = fs
+  self.fontSize = fs
+  if format:find("c") then
+    self.formatTable.alignment = "center"
+  elseif format:find("l") then
+    self.formatTable.alignment = "left"
+  elseif format:find("r") then
+    self.formatTable.alignment = "right"
+  else
+    self.formatTable.alignment = ""
+  end
+end
+
+--- Set whether or not the text in the label should be bold
+-- @param bool True for bold
+function Geyser.Label:setBold(bool)
+  if bool then
+    self.formatTable.bold = true
+    if not self.format:find("b") then self.format = self.format .. "b" end
+  else
+    self.formatTable.bold = false
+    if self.format:find("b") then self.format = self.format:gsub("b", "") end
+  end
+  self:echo()
+end
+
+--- Set whether or not the text in the label should be underline
+-- @param bool True for underline
+function Geyser.Label:setUnderline(bool)
+  if bool then
+    self.formatTable.underline = true
+    if not self.format:find("u") then self.format = self.format .. "u" end
+  else
+    self.formatTable.underline = false
+    if self.format:find("u") then self.format = self.format:gsub("u", "") end
+  end
+  self:echo()
+end
+
+--- Set whether or not the text in the label should be italics
+-- @param bool True for italics
+function Geyser.Label:setItalics(bool)
+  if bool then
+    self.formatTable.italics = true
+    if not self.format:find("i") then self.format = self.format .. "i" end
+  else
+    self.formatTable.italics = false
+    if self.format:find("i") then self.format = self.format:gsub("i", "") end
+  end
+  self:echo()
+end
+
+--- Set whether or not the text in the label should be strikethrough
+-- @param bool True for strikethrough
+function Geyser.Label:setStrikethrough(bool)
+  if bool then
+    self.formatTable.strikethrough = true
+    if not self.format:find("s") then self.format = self.format .. "s" end
+  else
+    self.formatTable.strikethrough = false
+    if self.format:find("s") then self.format = self.format:gsub("s", "") end
+  end
+  self:echo()
+end
+
+--- Set the font size for the label to use
+-- @param fontSize the font size to use for the label. Should be a number
+function Geyser.Label:setFontSize(fontSize)
+  local fontSizeType = type(fontSize)
+  fontSize = tonumber(fontSize)
+  assert(fontSize, "fontSize as number expected, got " .. fontSizeType)
+  self.fontSize = fontSize
+  self.formatTable.fontSize = fontSize
+  self.format = self.format:gsub("%d", "")
+  self.format = self.format .. fontSize
+  self:echo()
+end
+
+--- Sets the alignment for the label
+-- @param alignment Valid alignments are 'c', 'center', 'l', 'left', 'r', 'right', or '' to not include the alignment as part of the echo
+function Geyser.Label:setAlignment(alignment)
+  local alignmentType = type(alignment)
+  assert(alignmentType == "string", "alignment as string expected, got " .. alignmentType)
+  local acceptedAlignments = {"c", "center", "l", "left", "r", "right", ""}
+  assert(table.contains(acceptedAlignments, alignment), "invalid alignment sent. Valid alignments are 'c', 'center', 'l', 'left', 'r', 'right', or ''")
+  if alignment:find('c') then
+    self.formatTable.alignment = 'center'
+    self.format = self.format .. "c"
+    self.format = self.format:gsub("l", "")
+    self.format = self.format:gsub("r", "")
+  elseif alignment:find('l') then
+    self.formatTable.alignment = 'left'
+    self.format = self.format:gsub("c", "")
+    self.format = self.format .. "l"
+    self.format = self.format:gsub("r", "")
+  elseif alignment:find('r') then
+    self.formatTable.alignment = 'right'
+    self.format = self.format:gsub("c", "")
+    self.format = self.format:gsub("l", "")
+    self.format = self.format .. "r"
+  else
+    self.formatTable.alignment = ""
+    self.format = self.format:gsub("c", "")
+    self.format = self.format:gsub("l", "")
+    self.format = self.format:gsub("r", "")
+  end
+  self:echo()
+end
+
 function Geyser.Label:clear()
+  self.message = ""
   echo(self.name, "")
 end
 
@@ -456,6 +571,7 @@ function Geyser.Label:new (cons, container)
   cons = cons or {}
   cons.type = cons.type or "label"
   cons.nestParent = cons.nestParent or nil
+  cons.format = cons.format or ""
 
   -- Call parent's constructor
   local me = self.parent:new(cons, container)
@@ -467,6 +583,9 @@ function Geyser.Label:new (cons, container)
   -- Create the label using primitives
   createLabel(me.windowname, me.name, me:get_x(), me:get_y(),
   me:get_width(), me:get_height(), me.fillBg)
+
+  -- parse any given format string and set sensible defaults
+  me:processFormatString(cons.format)
 
   -- Set any defined colors
   Geyser.Color.applyColors(me)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Small refactor around how Geyser.Label stores formatting, and some functions to set different aspects of the formatting without having to build and pass in your entire formatting string.
Maintains compatibility with previous functionality by reparsing the entire format if a format string is passed in to echo or setFormat. 
#### Motivation for adding to Mudlet
Geyser labels (and by extension Gauges) do not have a convenient way to change the format without having to set the entire thing at once. This changes that.
Started because someone asked me how to set the font size on an anitimer, and I realized there was not a proper method to access that and other formatting options individually.
#### Other info (issues closed, discussion etc)
Adds formatTable property to Geyser.Labels, which contains a key for each viable option in the format string. This property is the one actually used by :echo now.
Maintains the format property so that existing scripts which parse this property will continue to function as expected
added methods:
setBold(bool)
setUnderline(bool)
setItalics(bool)
setStrikethrough(bool)
setAlignment(alignment)
setFontSize(fontSize)

Also adds wrappers for Geyser.Gauge which just pass along to the text label. Syncs the format and formatTable properties of the text label to the gauge, so you can more easily read what the text formatting for the gauge is.