### PR TITLE
Adding font management for geyser labels without needing to use css

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -13,6 +13,7 @@
 Geyser.Label = Geyser.Window:new({
   name = "LabelClass",
   format = "",
+  font = "",
   args = "",
   fillBg = 1, })
 Geyser.Label.currentLabel = nil
@@ -48,6 +49,9 @@ function Geyser.Label:echo(message, color, format)
   end
   if ft.strikethrough then
     message = "<s>" .. message .. "</s>"
+  end
+  if self.font and self.font ~= "" then
+    message = string.format('<font face ="%s">%s</font>', self.font, message)
   end
   if not fs then
     fs = tostring(self.fontSize)
@@ -93,6 +97,15 @@ function Geyser.Label:processFormatString(format)
   else
     self.formatTable.alignment = ""
   end
+end
+
+--- Sets the font face for the label, use empty string to clear the font and use css/default
+-- @param font font face to use
+function Geyser.Label:setFont(font)
+  local af = getAvailableFonts()
+  assert(af[font] or font == "", "attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options")
+  self.font = font
+  self:echo()
 end
 
 --- Set whether or not the text in the label should be bold

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -104,7 +104,7 @@ end
 function Geyser.Label:setFont(font)
   local af = getAvailableFonts()
   if not (af[font] or font == "") then
-    local err = "attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\n"
+    local err = "Geyser.Label:setFont(): attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\n"
     err = err .. "In the meantime, Qt will use some font which isn't the one you asked for but we hope is close enough"
     debugc(err)
   end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -99,13 +99,18 @@ function Geyser.Label:processFormatString(format)
   end
 end
 
---- Sets the font face for the label, use empty string to clear the font and use css/default
+--- Sets the font face for the label, use empty string to clear the font and use css/default. Returns true if the font changed, nil+error if not.
 -- @param font font face to use
 function Geyser.Label:setFont(font)
   local af = getAvailableFonts()
-  assert(af[font] or font == "", "attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options")
+  if not (af[font] or font == "") then
+    local err = "attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\nFont left as " .. self.font .. " in the meantime"
+    debugc(err)
+    return nil, err
+  end
   self.font = font
   self:echo()
+  return true
 end
 
 --- Set whether or not the text in the label should be bold

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -105,7 +105,7 @@ function Geyser.Label:setFont(font)
   local af = getAvailableFonts()
   if not (af[font] or font == "") then
     local err = "Geyser.Label:setFont(): attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\n"
-    err = err .. "In the meantime, we'll will use some font which isn't the one you asked for but we hope is close enough"
+    err = err .. "In the meantime, we will use a similar font which isn't the one you asked for but we hope is close enough"
     debugc(err)
   end
   self.font = font

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -105,7 +105,7 @@ function Geyser.Label:setFont(font)
   local af = getAvailableFonts()
   if not (af[font] or font == "") then
     local err = "Geyser.Label:setFont(): attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\n"
-    err = err .. "In the meantime, Qt will use some font which isn't the one you asked for but we hope is close enough"
+    err = err .. "In the meantime, we'll will use some font which isn't the one you asked for but we hope is close enough"
     debugc(err)
   end
   self.font = font

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -104,13 +104,12 @@ end
 function Geyser.Label:setFont(font)
   local af = getAvailableFonts()
   if not (af[font] or font == "") then
-    local err = "attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\nFont left as " .. self.font .. " in the meantime"
+    local err = "attempt to call setFont with font '" .. font .. "' which is not available, see getAvailableFonts() for valid options\n"
+    err = err .. "In the meantime, Qt will use some font which isn't the one you asked for but we hope is close enough"
     debugc(err)
-    return nil, err
   end
   self.font = font
   self:echo()
-  return true
 end
 
 --- Set whether or not the text in the label should be bold


### PR DESCRIPTION


<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds font property to Geyser.Label objects, adds setFont method to change the font for the label. 
Geyser.Label:echo() now reads the font property and adds the appropriate `<font face="font name">` tag for the user.

#### Motivation for adding to Mudlet
Came up that Geyser Labels didn't have a method for this as it stands without managing it via CSS. This makes handling fonts in Geyser Labels more like other Geyser objects.

#### Other info (issues closed, discussion etc)
