### PR TITLE
Fix missing include for buiding with WITH_FONTS=NO WITH_UPDATER=NO

### DIFF
--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -24,10 +24,9 @@
 
 #include "mudlet.h"
 
-#include <QTextCodec>
-
 #include "pre_guard.h"
 #include <QDir>
+#include <QTextCodec>
 #include "post_guard.h"
 
 using namespace std::chrono;

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -24,6 +24,8 @@
 
 #include "mudlet.h"
 
+#include <QTextCodec>
+
 #include "pre_guard.h"
 #include <QDir>
 #include "post_guard.h"


### PR DESCRIPTION
Fixes buiding when fonts and updater are exclued.
