### PR TITLE
Fix problems with Composer window closing

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -220,6 +220,9 @@ cTelnet::~cTelnet()
 #endif
         }
     }
+    if (mpComposer) {
+        mpComposer->deleteLater();
+    }
     socket.deleteLater();
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -220,9 +220,6 @@ cTelnet::~cTelnet()
 #endif
         }
     }
-    if (mpComposer) {
-        mpComposer->close();
-    }
     socket.deleteLater();
 }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -220,6 +220,9 @@ cTelnet::~cTelnet()
 #endif
         }
     }
+    if (mpComposer) {
+        mpComposer->close();
+    }
     socket.deleteLater();
 }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -187,7 +187,7 @@ public:
     bool mAlertOnNewData;
     bool mGA_Driver;
     bool mFORCE_GA_OFF;
-    dlgComposer* mpComposer;
+    QPointer<dlgComposer> mpComposer;
     QNetworkAccessManager* mpDownloader;
     QProgressDialog* mpProgressDialog;
     QString mServerPackage;

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -34,6 +34,7 @@ dlgComposer::dlgComposer(Host* pH) : mpHost(pH)
     edit->setFont(f);
     connect(saveButton, &QAbstractButton::pressed, this, &dlgComposer::save);
     connect(cancelButton, &QAbstractButton::pressed, this, &dlgComposer::cancel);
+    setAttribute(Qt::WA_DeleteOnClose);
 }
 
 void dlgComposer::cancel()
@@ -52,11 +53,4 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
 {
     title->setText(newTitle);
     edit->setPlainText(newText);
-}
-
-void dlgComposer::closeEvent(QCloseEvent* event){
-    // Called when closed via window system, save/cancel buttons, or cTelnet destructor when closing profile
-    // Closing via window system simply closes the composer,
-    // unlike Cancel button which sends "*q\nno\n" to quit the in-game editor
-    mpHost->mTelnet.mpComposer = nullptr;
 }

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -53,3 +53,10 @@ void dlgComposer::init(const QString &newTitle, const QString &newText)
     title->setText(newTitle);
     edit->setPlainText(newText);
 }
+
+void dlgComposer::closeEvent(QCloseEvent* event){
+    // Called when closed via window system, save/cancel buttons, or cTelnet destructor when closing profile
+    // Closing via window system simply closes the composer,
+    // unlike Cancel button which sends "*q\nno\n" to quit the in-game editor
+    mpHost->mTelnet.mpComposer = nullptr;
+}

--- a/src/dlgComposer.h
+++ b/src/dlgComposer.h
@@ -39,6 +39,7 @@ public:
     dlgComposer(Host*);
 
     void init(const QString &title, const QString &newText);
+    void closeEvent(QCloseEvent* event) override;
 
 public slots:
     void save();

--- a/src/dlgComposer.h
+++ b/src/dlgComposer.h
@@ -39,7 +39,6 @@ public:
     dlgComposer(Host*);
 
     void init(const QString &title, const QString &newText);
-    void closeEvent(QCloseEvent* event) override;
 
 public slots:
     void save();


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
* Added closeEvent to Composer window which clears pointer to itself in cTelnet when it gets closed other than using save/cancel button (such as clicking X or right-click and close), so that the parent object will know that it is gone
* Added to cTelnet destructor saying to close Composer window, so that there won't be an orphaned composer window
#### Motivation for adding to Mudlet
Allows you to open an editor window again after closing an earlier editor window by clicking the X instead of cancel/save.  Avoids segfault that currently happens if you click cancel on the composer window after closing the profile that it was associated with.
#### Other info (issues closed, discussion etc)
This should solve issue #3300 
In addition to not being able to open a new editor after closing it, there is also problem where if you leave the composer window open and close your profile then the window is still there and crashes mudlet if you push button to save or cancel, should solve that too.