### PR TITLE
Fix for MacOS flickering caused by QOpenGLWidget

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -897,7 +897,11 @@ QPair<QString, QString> Host::getSearchEngine()
 // cTelnet::sendData(...) call:
 void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 {
-    if (wantPrint && (! mIsRemoteEchoingActive) && mPrintCommand) {
+#if defined(Q_OS_MACOS)
+    // possible fix for MacOS flickering caused by QOpenGLWidget
+    mpConsole->finalize();
+#endif
+    if (wantPrint && (!mIsRemoteEchoingActive) && mPrintCommand) {
         mInsertedMissingLF = true;
         if (!cmd.isEmpty() || !mUSE_IRE_DRIVER_BUGFIX || mUSE_FORCE_LF_AFTER_PROMPT) {
             // used to print the terminal <LF> that terminates a telnet command

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -898,7 +898,7 @@ QPair<QString, QString> Host::getSearchEngine()
 void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 {
 #if defined(Q_OS_MACOS)
-    // possible fix for MacOS flickering caused by QOpenGLWidget
+    // Fix for MacOS flickering caused by upgrade to QOpenGLWidget
     mpConsole->finalize();
 #endif
     if (wantPrint && (!mIsRemoteEchoingActive) && mPrintCommand) {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This small change updates the Console if a command is sent to the Mud (only for macos)
to prevent the flickering caused by QOpenGLWidget
#### Motivation for adding to Mudlet
flickering in macos caused by QOpenGlWidget
#### Other info (issues closed, discussion etc)
Please someone with mac os test it.
I could only test it in virtualbox but it seems to fix the issue.