### PR TITLE
BugFix: workaround for older compilers having std::experimental::optional

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2631,7 +2631,11 @@ void mudlet::deleteLine(Host* pHost, const QString& name)
     }
 }
 
+#if defined(OPTIONAL_IS_EXPERIMENTAL)
+std::experimental::optional<QSize> mudlet::getImageSize(const QString& imageLocation)
+#else
 std::optional<QSize> mudlet::getImageSize(const QString& imageLocation)
+#endif
 {
     QImage image(imageLocation);
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -60,7 +60,11 @@
 #include <QVersionNumber>
 #include "edbee/models/textautocompleteprovider.h"
 #include <../3rdparty/qtkeychain/keychain.h>
+#if defined(OPTIONAL_IS_EXPERIMENTAL)
+#include <experimental/optional>
+#else
 #include <optional>
+#endif
 #include "post_guard.h"
 
 #include <hunspell/hunspell.hxx>
@@ -158,7 +162,11 @@ public:
     bool setLabelOnLeave(Host*, const QString&, const QString&, const TEvent&);
     bool moveWindow(Host*, const QString& name, int, int);
     void deleteLine(Host*, const QString& name);
+#if defined(OPTIONAL_IS_EXPERIMENTAL)
+    std::experimental::optional<QSize> getImageSize(const QString& imageLocation);
+#else
     std::optional<QSize> getImageSize(const QString& imageLocation);
+#endif
     bool insertText(Host*, const QString& windowName, const QString&);
     void replace(Host*, const QString& name, const QString&);
     int selectString(Host*, const QString& name, const QString& what, int);


### PR DESCRIPTION
My mobile Devuan "Ascii" machine only has Clang 5.0 and 6.0 that support C++17 but they seem to have the `std::optional` marked as `experimental` which means some lines have to be modified to suit.

To build on such platforms it is necessary to define `OPTIONAL_IS_EXPERIMENTAL` at build time.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>