### PR TITLE
FlyoutLabels in UserWindows

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -315,17 +315,15 @@ end
 
 --- Returns the Geyser object associated with the label name
 -- @param label The name of the label to use
-function Geyser.Label:getWindow(label)
-  for i, v in pairs(Geyser.windowList) do
+function Geyser.Label:getWindow(label, cont)
+  cont = cont or Geyser
+  for i, v in pairs(cont.windowList) do
     if v.name == label then
       return v
     end
-
-    -- search down one level to enable nesting in a container
-    for key, val in pairs(v.windowList) do
-      if val.name == label then
-        return val
-      end
+    -- search down one or more levels to enable nesting in a container
+    if self:getWindow(label, v) then 
+      return self:getWindow(label, v) 
     end
   end
 end
@@ -343,6 +341,13 @@ function closeAllLevels()
   for i, v in pairs(Geyser.windowList) do
     if v.nestParent then
       v:hide()
+    end
+    if v.type == "userwindow" then
+      for i,v in pairs (v.windowList[v.windows[1]].windowList) do 
+        if v.nestParent then
+          v:hide()
+        end
+      end
     end
   end
 end
@@ -733,6 +738,9 @@ end
 function Geyser.Label:addChild(cons, container)
   cons = cons or {}
   cons.type = cons.type or "nestedLabel"
+  if self.windowname ~= "main" and not container then
+    container = Geyser.windowList[self.windowname.."Container"].windowList[self.windowname]
+  end
   local flyOut = false
   local flyDir, layoutDir
   if cons.layoutDir then

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -382,7 +382,7 @@ function closeNest(label)
   local lNestLabels = label.nestedLabels
   if lNestLabels then
     for i, v in pairs(lNestLabels) do
-      if v.name == Geyser.Label.currentLabel then
+      if v == Geyser.Label.currentLabel then
         --  echo("new element is nested of prior table\n")
         --if so, don't do anything
         return
@@ -390,9 +390,9 @@ function closeNest(label)
     end
   end
   --is the current label the parent of the prior label?
-  if (lParent.name ~= Geyser.Label.currentLabel) then
+  if (lParent ~= Geyser.Label.currentLabel) then
     -- echo("new element isn't parent of prior element\n")
-    closeNestChildren(lParent.name)
+    closeNestChildren(lParent)
   end
 end
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This change allows flyout labels to be put into UserWindows.

With this change it is also possible to put flyoutlabels in nested containers.

wiki documentation that flyout labels cannot be put into containers is not valid anymore.
#### Motivation for adding to Mudlet
It wasn't possible to add flyout labels to UserWindows or containers with more then one level of depth
#### Other info (issues closed, discussion etc)
