### PR TITLE
Add GeyserUserWindow to Mudlet.pro

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -737,6 +737,7 @@ LUA_GEYSER.files = \
     $${PWD}/mudlet-lua/lua/geyser/GeyserReposition.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserSetConstraints.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserTests.lua \
+    $${PWD}/mudlet-lua/lua/geyser/GeyserUsrerWindow.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserUtil.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserVBox.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserWindow.lua

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -737,7 +737,7 @@ LUA_GEYSER.files = \
     $${PWD}/mudlet-lua/lua/geyser/GeyserReposition.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserSetConstraints.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserTests.lua \
-    $${PWD}/mudlet-lua/lua/geyser/GeyserUsrerWindow.lua \
+    $${PWD}/mudlet-lua/lua/geyser/GeyserUserWindow.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserUtil.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserVBox.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserWindow.lua


### PR DESCRIPTION
GeyserUserWindow.lua is a new file that was added in the 4.6 release, but it was not mentioned it mudlet.pro among Geyser files, thus _make install_ does not know that it is supposed to install it.
Simple one liner.
(ofcourse I typoed and had to correct it)