### PR TITLE
Update Boost to 1.71 in Windows builds

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -204,14 +204,14 @@ function InstallMsys() {
 }
 
 function InstallBoost() {
-  DownloadFile "https://sourceforge.net/projects/boost/files/boost/1.67.0/boost_1_67_0.tar.gz/download" "boost.tar.gz" $true
+  DownloadFile "https://sourceforge.net/projects/boost/files/boost/1.71.0/boost_1_71_0.tar.gz/download" "boost.tar.gz" $true
   if (!(Test-Path -Path "C:\Libraries\" -PathType Container)) {
     Step "Creating Boost path"
     New-Item -Path "C:\Libraries\" -ItemType "directory" >> "$logFile" 2>&1
   }
   ExtractTar "boost.tar.gz" "."
   Step "Copying folder"
-  Move-Item "boost_1_67_0" "C:\Libraries\" >> "$logFile" 2>&1
+  Move-Item "boost_1_71_0" "C:\Libraries\" >> "$logFile" 2>&1
 }
 
 function InstallQt() {
@@ -437,7 +437,7 @@ function CheckAndInstallMsys(){
 }
 
 function CheckAndInstallBoost(){
-    CheckAndInstall "Boost" "C:\Libraries\boost_1_67_0\bootstrap.bat" { InstallBoost }
+    CheckAndInstall "Boost" "C:\Libraries\boost_1_71_0\bootstrap.bat" { InstallBoost }
 }
 
 function CheckAndInstallQt(){

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -266,7 +266,7 @@ unix:!macx {
         -lWs2_32 \
         -L"$${MINGW_BASE_DIR}\\bin"
     INCLUDEPATH += \
-                   "C:\\Libraries\\boost_1_67_0" \
+                   "C:\\Libraries\\boost_1_71_0" \
                    "$${MINGW_BASE_DIR}\\include" \
                    "$${MINGW_BASE_DIR}\\lib\include"
 # Leave this undefined so mudlet::readSettings() preprocessing will fall back to


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Update Boost to 1.71 in Windows builds, because that's what is available in the 2019 image we use.
#### Motivation for adding to Mudlet
Decrease Windows build times to something more sane.
#### Other info (issues closed, discussion etc)
See https://www.appveyor.com/docs/windows-images-software/#boost for available versions.