### PR TITLE
Add option to disable search including variables.

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -244,6 +244,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mWrapAt(100)
 , mWrapIndentCount(0)
 , mEditorAutoComplete(true)
+, mSearchIncludesVariables(true)
 , mEditorTheme(QLatin1String("Mudlet"))
 , mEditorThemeFile(QLatin1String("Mudlet.tmTheme"))
 , mThemePreviewItemID(-1)

--- a/src/Host.h
+++ b/src/Host.h
@@ -444,6 +444,7 @@ public:
     int mWrapIndentCount;
 
     bool mEditorAutoComplete;
+    bool mSearchIncludesVariables;
 
     // code editor theme (human-friendly name)
     QString mEditorTheme;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -418,6 +418,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mShowPanel") = pHost->mShowPanel ? "yes" : "no";
     host.append_attribute("mHaveMapperScript") = pHost->mHaveMapperScript ? "yes" : "no";
     host.append_attribute("mEditorAutoComplete") = pHost->mEditorAutoComplete ? "yes" : "no";
+    host.append_attribute("mSearchIncludesVariables") = pHost->mSearchIncludesVariables ? "yes" : "no";
     host.append_attribute("mEditorTheme") = pHost->mEditorTheme.toUtf8().constData();
     host.append_attribute("mEditorThemeFile") = pHost->mEditorThemeFile.toUtf8().constData();
     host.append_attribute("mThemePreviewItemID") = QString::number(pHost->mThemePreviewItemID).toUtf8().constData();

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -822,6 +822,9 @@ void XMLimport::readHostPackage(Host* pHost)
     if (attributes().hasAttribute(QStringLiteral("mEditorAutoComplete"))) {
         pHost->mEditorAutoComplete = (attributes().value(QStringLiteral("mEditorAutoComplete")) == "yes");
     }
+    if (attributes().hasAttribute(QStringLiteral("mSearchIncludesVariables"))) {
+        pHost->mSearchIncludesVariables = (attributes().value(QStringLiteral("mSearchIncludesVariables")) == "yes");
+    }
     if (attributes().hasAttribute(QLatin1String("mEditorTheme"))) {
         pHost->mEditorTheme = attributes().value(QLatin1String("mEditorTheme")).toString();
     }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1311,6 +1311,7 @@ void dlgProfilePreferences::loadEditorTab()
     theme_download_label->hide();
 
     checkBox_autocompleteLuaCode->setChecked(pHost->mEditorAutoComplete);
+    checkBox_searchIncludesVariables->setChecked(pHost->mSearchIncludesVariables);
 
     // changes the theme being previewed
     connect(code_editor_theme_selection_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_theme_selected);
@@ -2533,6 +2534,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mEditorTheme = code_editor_theme_selection_combobox->currentText();
         pHost->mEditorThemeFile = code_editor_theme_selection_combobox->currentData().toString();
         pHost->mEditorAutoComplete = checkBox_autocompleteLuaCode->isChecked();
+        pHost->mSearchIncludesVariables = checkBox_searchIncludesVariables->isChecked();
         if (pHost->mpEditorDialog) {
             pHost->mpEditorDialog->setThemeAndOtherSettings(pHost->mEditorTheme);
         }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1252,7 +1252,8 @@ void dlgTriggerEditor::slot_searchMudletItems(const QString& s)
     searchActions(s);
     searchTimers(s);
     searchKeys(s);
-    searchVariables(s);
+    if (mpHost->mSearchIncludesVariables)
+        searchVariables(s);
 
 
     // TODO: Edbee search term highlighter

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1321,6 +1321,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Other</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="checkBox_searchIncludesVariables">
+            <property name="text">
+             <string>Include variables in search results</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_codeEditor">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a toggle in the Editor tab of Preferences that controls whether or not variables are included in the search functionality in the Editor.

![image](https://user-images.githubusercontent.com/15068394/76314359-015da500-62ad-11ea-9353-9842353fde66.png)

#### Motivation for adding to Mudlet
Over the course of many years using Mudlet, I'm not sure that I have searched variables intentionally more than a single time. However, due to the large amounts of data I keep saved in various tables in Lua, searching through the variables causes Mudlet to lag for several seconds any time I want to search.

#### Other info (issues closed, discussion etc)
I'm inclined to think searching variables should be disabled by default, seeing as it has almost never been useful for me, and I've seen/heard other people mention that it was unnecessary for them, and just served to inflate search times and disincentivizes using it.

That said, I'm not certain that all the primary devs of Mudlet will agree with me on that, so I've set it to default to ON.