### PR TITLE
Fix issue in _comp

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -470,9 +470,6 @@ function _comp(a, b)
     return false
   end
   if type(a) == 'table' then
-    if table.size(a) ~= table.size(b) then
-      return false
-    end
     for k, v in pairs(a) do
       if not b[k] then
         return false
@@ -480,6 +477,9 @@ function _comp(a, b)
       if not _comp(v, b[k]) then
         return false
       end
+    end
+    if table.size(a) ~= table.size(b) then
+      return false
     end
   else
     if a ~= b then

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -470,6 +470,9 @@ function _comp(a, b)
     return false
   end
   if type(a) == 'table' then
+    if table.size(a) ~= table.size(b) then
+      return false
+    end
     for k, v in pairs(a) do
       if not b[k] then
         return false

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -470,7 +470,9 @@ function _comp(a, b)
     return false
   end
   if type(a) == 'table' then
+    local a_size = 0
     for k, v in pairs(a) do
+      a_size = a_size + 1
       if not b[k] then
         return false
       end
@@ -478,7 +480,7 @@ function _comp(a, b)
         return false
       end
     end
-    if table.size(a) ~= table.size(b) then
+    if a_size ~= table.size(b) then
       return false
     end
   else

--- a/src/mudlet-lua/tests/Other_spec.lua
+++ b/src/mudlet-lua/tests/Other_spec.lua
@@ -346,6 +346,26 @@ describe("Tests Other.lua functions", function()
       assert.is_true(_comp(tableA, tableB))
       assert.is_false(_comp(tableB, tableC))
     end)
+
+    it("should return the same regardless of the order of the arguments", function()
+      local tableA = {
+        "One",
+        { "First", "Second" },
+        "Three"
+      }
+      local tableB = {
+        "One",
+        { "First", "Second" },
+        "Three"
+      }
+      local tableC = {
+        "One",
+        { "First", "2nd" },
+        "Three"
+      }
+      assert.are.same(_comp(tableA, tableB), _comp(tableB, tableA))
+      assert.are.same(_comp(tableB, tableC), _comp(tableC, tableB))
+    end)
   end)
 
     --[[ 

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -287,9 +287,6 @@ describe("Tests TableUtils.lua functions", function()
       local actual = table.union(tblA, tblB, tblC)
       assert.same(expected,actual)
     end)
-
-    it("should return the union of more than two tables", function()
-    end)
   end)
 
   describe("table.n_union(tblA, tblB, ...)", function()

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -229,37 +229,176 @@ describe("Tests TableUtils.lua functions", function()
   end)
 
   describe("table.union(tblA, tblB, ...)", function()
-    pending("should have some tests", function()
+    setup(function()
+      tblA = {
+        [1] = 123,
+        [2] = 456,
+        ["test"] = "test",
+      }
+      tblB = {
+        [1] = 23,
+        [3] = 7,
+        ["test2"] = { "a", "b" },
+      }
+      tblC = {
+        [5] = "c",
+        ["hammer"] = "head",
+      }
+    end)
+    teardown(function()
+      tblA = nil
+      tblB = nil
+      tblC = nil
+    end)
+    it("should return the union of two simple tables without collisions", function()
+     local expected = {
+       [1] = 123,
+       [2] = 456,
+       [5] = "c",
+       ["test"] = "test",
+       ["hammer"] = "head",
+     }
+     local actual = table.union(tblA, tblC)
+     assert.same(expected, actual)
+    end)
+
+    it("should return tables of values for keys which have value collisions", function()
+      local expected = {
+        [1] = { 123, 23 },
+        [2] = 456,
+        [3] = 7,
+        ["test"] = 'test',
+        ["test2"] = { "a", "b" }
+      }
+      local actual = table.union(tblA, tblB)
+      assert.same(expected,actual)
+    end)
+
+    it("should work for more than two tables", function()
+      local expected = {
+        [1] = { 123, 23 },
+        [2] = 456,
+        [3] = 7,
+        [5] = "c",
+        ["test"] = 'test',
+        ["test2"] = { "a", "b" },
+        ["hammer"] = "head",
+      }
+      local actual = table.union(tblA, tblB, tblC)
+      assert.same(expected,actual)
+    end)
+
+    it("should return the union of more than two tables", function()
     end)
   end)
 
   describe("table.n_union(tblA, tblB, ...)", function()
-    pending("should have some tests", function()
+    setup(function()
+      tblA = { "bob", "mary" }
+      tblB = { "august", "justinian" }
+      tblC = { 3, { "recursive", "tables" } }
+      sortfn = function(a,b) return tostring(a) < tostring(b) end
+    end)
+    teardown(function()
+      tblA = nil
+      tblB = nil
+      tblC = nil
+      sortfn = nil
+    end)
+    it("should return the union of values between two lists", function()
+      local expected = { "bob", "mary", "august", "justinian" }
+      local actual = table.n_union(tblA, tblB)
+      table.sort(expected, sortfn)
+      table.sort(actual,sortfn)
+      assert.same(expected,actual)
+    end)
+
+    it("should return the union of values between more than two lists", function()
+      local expected = { "bob", "mary", "august", "justinian", 3, {"recursive", "tables"}}
+      local actual = table.n_union(tblA, tblB, tblC)
+      table.sort(expected, sortfn)
+      table.sort(actual, sortfn)
+      assert.same(expected, actual)
     end)
   end)
 
   describe("table.intersection(tblA, tblB, ...)", function()
-    pending("should have some tests", function()
+    it("should return the relative intersection of key value pairs of two tables", function()
+      local t1 = {key = 1,1,2,3}
+      local t2 = {key = 1,1,1,1}
+      local expected = { key = 1, 1 }
+      local actual = table.intersection(t1,t2)
+      assert.same(expected, actual)
+    end)
+
+    it("should be able to do the same for three tables", function()
+      local t1 = {key = 1,1,2,3}
+      local t2 = {key = 1,1,1,3}
+      local t3 = {key = 1,1,"two",3}
+      local expected = { 
+        key = 1,
+        [1] = 1,
+        [3] = 3
+      }
+      local actual = table.intersection(t1,t2,t3)
+      assert.same(expected, actual)
     end)
   end)
 
   describe("table.n_intersection(tblA, tblB, ...)", function()
-    pending("should have some tests", function()
+    it("should produce a table which is the relative intersection of values of two tables", function()
+      local t1 = {1,2,3,4,5,6}
+      local t2 = {2,4,6,8}
+      local expected = {2,4,6}
+      local actual = table.n_intersection(t1,t2)
+      assert.same(expected, actual)
+    end)
+
+    it("should produce a table which is the relative intersection of values of more than two tables", function()
+      local t1 = {1,2,3,4,5,6}
+      local t2 = {2,4,6,8}
+      local t3 = {10, 2, 6}
+      local expected = {2,6}
+      local actual = table.n_intersection(t1,t2,t3)
+      assert.same(expected, actual)
     end)
   end)
 
   describe("table.complement(tblA, tblB)", function()
-    pending("should have some tests", function()
+    it("should return the complement of key value pairs of two maps", function()
+      local t1 = {key = 1,1,2,3}
+      local t2 = {key = 2,1,1,1}
+      local expected = { key = 1,[2] = 2, [3] = 3 }
+      local actual = table.complement(t1,t2)
+      assert.same(expected, actual)
     end)
   end)
 
   describe("table.n_complement(tblA, tblB)", function()
-    pending("should have some tests", function()
+    it("should return the complement of values of two lists", function()
+      local t1 = {1,2,3,4,5,6}
+      local t2 = {2,4,6}
+      local expected = {1,3,5}
+      local actual = table.n_complement(t1,t2)
+      assert.same(expected, actual)
     end)
   end)
 
   describe("table.update(tblA, tblB)", function()
-    pending("should have some tests", function()
+    it("should return a table that is tblA but with updated values from tblB", function()
+      local tblA = {a = 1, b = 2, c = 3}
+      local tblB = {b = 4}
+      local expected = {a = 1, b = 4, c = 3}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
+    end)
+
+    it("should insert keys from tblB which do not exist in tblA", function()
+      local tblA = {a = 1, b = 2, c = 3}
+      local tblB = {b = 4, d = 10}
+      local expected = {a = 1, b = 4, c = 3, d = 10}
+      local actual = table.update(tblA, tblB)
+      assert.same(expected, actual)
     end)
   end)
 end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Currently, _comp will return true if table B has items in it which table A does not, as it loops table A and checks if table B has the same value at the same key.

This checks to make sure they're the same size first, and if not returns false

#### Motivation for adding to Mudlet

Bug found by busted test added in https://github.com/Mudlet/Mudlet/pull/3414

#### Other info (issues closed, discussion etc)

![image](https://user-images.githubusercontent.com/3660/76365489-d0f22700-62fd-11ea-91ac-6bbfe39ad3a7.png)

