### PR TITLE
Api for mapping widget

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4371,7 +4371,7 @@ int TLuaInterpreter::openMapWidget(lua_State* L)
     }
 
     Host& host = getHostFromLua(L);
-    if (auto [success, message] = mudlet::self()->openMapWidget(&host, area, x, y, width, height); !success) {
+    if (auto [success, message] = mudlet::self()->openMapWidget(&host, area.toLower(), x, y, width, height); !success) {
         lua_pushnil(L);
         lua_pushfstring(L, message.toUtf8().constData());
         return 2;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3553,7 +3553,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
             luaSendWindow.clear();
         }
     }
-    if (!lua_isnumber(L, 2)) {      
+    if (!lua_isnumber(L, 2)) {
         if (!lua_isstring(L, 2)) {
             lua_pushfstring(L, "createMiniConsole: bad argument #2 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 2));
             lua_error(L);
@@ -4341,7 +4341,7 @@ int TLuaInterpreter::openMapWidget(lua_State* L)
         }
     }
     if (n > 1) {
-        area = QLatin1String("f");
+        area = QStringLiteral("f");
         if (!lua_isnumber(L, 1)) {
             lua_pushfstring(L, "openMapWidget: bad argument #1 type (x-coordinate as number expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4327,6 +4327,71 @@ int TLuaInterpreter::moveWindow(lua_State* L)
     return 0;
 }
 
+int TLuaInterpreter::openMapWidget(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString area = QString();
+    int x = -1, y = -1, width = -1, height = -1;
+    if (n == 1) {
+        if (lua_type(L, 1) != LUA_TSTRING) {
+            lua_pushfstring(L, "openMapWidget: bad argument #1 type (area as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        } else {
+            area = QString::fromUtf8(lua_tostring(L, 1));
+        }
+    }
+    if (n > 1) {
+        area = QLatin1String("f");
+        if (!lua_isnumber(L, 1)) {
+            lua_pushfstring(L, "openMapWidget: bad argument #1 type (x-coordinate as number expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        } else {
+            x = lua_tonumber(L, 1);
+        }
+        if (!lua_isnumber(L, 2)) {
+            lua_pushfstring(L, "openMapWidget: bad argument #2 type (y-coordinate as number expected, got %s!)", luaL_typename(L, 2));
+            return lua_error(L);
+        } else {
+            y = lua_tonumber(L, 2);
+        }
+    }
+    if (n > 2) {
+        if (!lua_isnumber(L, 3)) {
+            lua_pushfstring(L, "openMapWidget: bad argument #3 type (width as number expected, got %s!)", luaL_typename(L, 3));
+            return lua_error(L);
+        } else {
+            width = lua_tonumber(L, 3);
+        }
+        if (!lua_isnumber(L, 4)) {
+            lua_pushfstring(L, "openMapWidget: bad argument #4 type (height as number expected, got %s!)", luaL_typename(L, 4));
+            return lua_error(L);
+        } else {
+            height = lua_tonumber(L, 4);
+        }
+    }
+
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = mudlet::self()->openMapWidget(&host, area, x, y, width, height); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+int TLuaInterpreter::closeMapWidget(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = mudlet::self()->closeMapWidget(&host); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMainWindowSize
 int TLuaInterpreter::setMainWindowSize(lua_State* L)
 {
@@ -16071,6 +16136,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setLabelOnLeave", TLuaInterpreter::setLabelOnLeave);
     lua_register(pGlobalLua, "getImageSize", TLuaInterpreter::getImageSize);
     lua_register(pGlobalLua, "moveWindow", TLuaInterpreter::moveWindow);
+    lua_register(pGlobalLua, "openMapWidget", TLuaInterpreter::openMapWidget);
+    lua_register(pGlobalLua, "closeMapWidget", TLuaInterpreter::closeMapWidget);
     lua_register(pGlobalLua, "setTextFormat", TLuaInterpreter::setTextFormat);
     lua_register(pGlobalLua, "getMainWindowSize", TLuaInterpreter::getMainWindowSize);
     lua_register(pGlobalLua, "getUserWindowSize", TLuaInterpreter::getUserWindowSize);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -335,6 +335,8 @@ public:
     static int deleteLabel(lua_State*);
     static int setLabelToolTip(lua_State*);
     static int moveWindow(lua_State*);
+    static int openMapWidget(lua_State*);
+    static int closeMapWidget(lua_State*);
     static int setTextFormat(lua_State*);
     static int setBackgroundImage(lua_State*);
     static int setBackgroundColor(lua_State*);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1830,3 +1830,17 @@ end
 function resetLabelToolTip(label)
   return setLabelToolTip(label, "")
 end
+
+-- functions to move and resize Map Widget
+-- be aware that moving or resizing Map Widget puts the Map Widget in floating state
+function moveMapWidget(x, y)
+  assert(type(x) == 'number', 'moveMapWidget: bad argument #1 type (x-coordinate as number expected, got '..type(x)..'!)')
+  assert(type(y) == 'number', 'moveMapWidget: bad argument #2 type (y-coordinate as number expected, got '..type(y)..'!)')
+  openMapWidget(x, y)
+end
+
+function resizeMapWidget(width, height)
+  assert(type(width) == 'number', 'resizeMapWidget: bad argument #1 type (width as number expected, got '..type(width)..'!)')
+  assert(type(height) == 'number', 'resizeMapWidget: bad argument #2 type (height as number expected, got '..type(height)..'!)')
+  openMapWidget(-1, -1, width, height)
+end

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -85,7 +85,7 @@ function Geyser.Mapper:new (cons, container)
   setmetatable(me, self)
   self.__index = self
   
-  if me.embedded == nil then
+  if me.embedded == nil and not me.dockPosition then
      me.embedded = true 
   end
   -----------------------------------------------------------
@@ -97,6 +97,7 @@ function Geyser.Mapper:new (cons, container)
     createMapper(me.windowname, me:get_x(), me:get_y(),
     me:get_width(), me:get_height())
   else
+    me.embedded = false
     if me.dockPosition and me.dockPosition ~= "f" then
       openMapWidget(me.dockPosition)
     elseif me.dockPosition == "f" or cons.x or cons.y or cons.width or cons.height then 

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -23,7 +23,7 @@ function Geyser.Mapper:reposition()
   if self.hidden or self.auto_hidden then
     return
   end
-  if not self.mapWidget then
+  if self.embedded then
     createMapper(self.windowname, self:get_x(), self:get_y(), self:get_width(), self:get_height())
   end
 end
@@ -34,7 +34,7 @@ function Geyser.Mapper:move(x, y)
     return
   end
   Geyser.Container.move (self, x, y)
-  if self.mapWidget then
+  if not self.embedded then
     moveMapWidget(self:get_x(), self:get_y())
   end
 end
@@ -44,13 +44,13 @@ function Geyser.Mapper:resize(width, height)
     return
   end
   Geyser.Container.resize (self, width, height)
-  if self.mapWidget then
+  if not self.embedded then
     resizeMapWidget(self:get_width(), self:get_height())
   end
 end
 
 function Geyser.Mapper:hide_impl()
-  if not self.mapWidget then
+  if self.embedded then
     createMapper(self.windowname, self:get_x(), self:get_y(), 0, 0)
   else
     closeMapWidget()
@@ -58,7 +58,7 @@ function Geyser.Mapper:hide_impl()
 end
 
 function Geyser.Mapper:show_impl()
-  if not self.mapWidget then
+  if self.embedded then
     createMapper(self.windowname, self:get_x(), self:get_y(), self:get_width(), self:get_height())
   else
     openMapWidget()
@@ -66,7 +66,7 @@ function Geyser.Mapper:show_impl()
 end
 
 function Geyser.Mapper:setDockPosition(pos)
-  if self.mapWidget then
+  if not self.embedded then
     return openMapWidget(pos)
   end
 end
@@ -84,21 +84,20 @@ function Geyser.Mapper:new (cons, container)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self
-
+  
+  if me.embedded == nil then
+     me.embedded = true 
+  end
   -----------------------------------------------------------
   -- Now create the Mapper using primitives
   if me.dockPosition and me.dockPosition:lower() == "floating" then
     me.dockPosition = "f"
   end
-
-  if not me.mapWidget and not me.docked and not me.dockPosition then
+  if me.embedded then
     createMapper(me.windowname, me:get_x(), me:get_y(),
     me:get_width(), me:get_height())
   else
-    me.mapWidget = true
-    if me.docked or (me.dockPosition and me.dockPosition ~= "f") then
-      me.docked = true
-      me.dockPosition = me.dockPosition or "r"
+    if me.dockPosition and me.dockPosition ~= "f" then
       openMapWidget(me.dockPosition)
     elseif me.dockPosition == "f" or cons.x or cons.y or cons.width or cons.height then 
       openMapWidget(me:get_x(), me:get_y(),

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -65,7 +65,7 @@ function Geyser.Mapper:show_impl()
   end
 end
 
-function Geyser.Mapper:setDockPos(pos)
+function Geyser.Mapper:setDockPosition(pos)
   if self.mapWidget then
     return openMapWidget(pos)
   end
@@ -87,16 +87,20 @@ function Geyser.Mapper:new (cons, container)
 
   -----------------------------------------------------------
   -- Now create the Mapper using primitives
-  if not me.mapWidget and not me.docked and not me.dockPos then
+  if me.dockPosition and me.dockPosition:lower() == "floating" then
+    me.dockPosition = "f"
+  end
+
+  if not me.mapWidget and not me.docked and not me.dockPosition then
     createMapper(me.windowname, me:get_x(), me:get_y(),
     me:get_width(), me:get_height())
   else
     me.mapWidget = true
-    if me.docked or (me.dockPos and me.dockPos ~= "f") then
+    if me.docked or (me.dockPosition and me.dockPosition ~= "f") then
       me.docked = true
-      me.dockPos = me.dockPos or "r"
-      openMapWidget(me.dockPos)
-    elseif me.dockPos == "f" or cons.x or cons.y or cons.width or cons.height then 
+      me.dockPosition = me.dockPosition or "r"
+      openMapWidget(me.dockPosition)
+    elseif me.dockPosition == "f" or cons.x or cons.y or cons.width or cons.height then 
       openMapWidget(me:get_x(), me:get_y(),
       me:get_width(), me:get_height())
     else

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2421,7 +2421,7 @@ std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area,
         pM = pHost->mpDockableMapWidget;
     }
     if (!pM) {
-        return {false, "cannot create map widget. Do you already use an embedded mapper?"};
+        return {false, QStringLiteral("cannot create map widget. Do you already use an embedded mapper?")};
     }
     pM->show();
     if (area.isEmpty()) {
@@ -2474,10 +2474,10 @@ std::pair<bool, QString> mudlet::closeMapWidget(Host* pHost)
 
     auto pM = pHost->mpDockableMapWidget;
     if (!pM) {
-        return {false, "no map widget found to close"};
+        return {false, QStringLiteral("no map widget found to close")};
     }
     if (!pM->isVisible()) {
-        return {false, "map widget already closed"};
+        return {false, QStringLiteral("map widget already closed")};
     }
     pM->hide();
     return {true, QString()};

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2480,7 +2480,7 @@ std::pair<bool, QString> mudlet::closeMapWidget(Host* pHost)
         return {false, "map widget already closed"};
     }
     pM->hide();
-    return {true,QString()};
+    return {true, QString()};
 }
 
 bool mudlet::closeWindow(Host* pHost, const QString& name)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2408,6 +2408,81 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
     return false;
 }
 
+std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area, int x, int y, int width, int height)
+{
+    if (!pHost || !pHost->mpConsole) {
+        return {false, QString()};
+    }
+
+    auto pM = pHost->mpDockableMapWidget;
+    auto pMapper = pHost->mpMap.data()->mpMapper;
+    if (!pM && !pMapper) {
+        createMapper(true);
+        pM = pHost->mpDockableMapWidget;
+    }
+    if (!pM) {
+        return {false, "cannot create map widget. do you already use an embedded mapper?"};
+    }
+    pM->show();
+    if (area.isEmpty()) {
+        return {true, QString()};
+    }
+
+    if (area == "f") {
+        if (!pM->isFloating()) {
+            // Undock a docked window
+            // Change of position or size is only possible when floating
+            pM->setFloating(true);
+        }
+        if ((x != -1) && (y != -1)) {
+            pM->move(x, y);
+        }
+        if ((width != -1) && (height != -1)) {
+            pM->resize(width, height);
+        }
+        return {true, QString()};
+    } else {
+        if (area == "r") {
+            pM->setFloating(false);
+            addDockWidget(Qt::RightDockWidgetArea, pM);
+            return {true, QString()};
+        } else if (area == "l") {
+            pM->setFloating(false);
+            addDockWidget(Qt::LeftDockWidgetArea, pM);
+            return {true, QString()};
+        } else if (area == "t") {
+            pM->setFloating(false);
+            addDockWidget(Qt::TopDockWidgetArea, pM);
+            return {true, QString()};
+        } else if (area == "b") {
+            pM->setFloating(false);
+            addDockWidget(Qt::BottomDockWidgetArea, pM);
+            return {true, QString()};
+        } else {
+            return {false, QStringLiteral("docking option \"%1\" not available. available docking options are \"t\" top, \"b\" bottom, \"r\" right, \"l\" left and \"f\" floating").arg(area)};
+        }
+    }
+
+    return {false, QString()};
+}
+
+std::pair<bool, QString> mudlet::closeMapWidget(Host* pHost)
+{
+    if (!pHost || !pHost->mpConsole) {
+        return {false, QString()};
+    }
+
+    auto pM = pHost->mpDockableMapWidget;
+    if (!pM) {
+        return {false, "no map widget found to close"};
+    }
+    if (!pM->isVisible()) {
+        return {false, "map widget already closed"};
+    }
+    pM->hide();
+    return {true,QString()};
+}
+
 bool mudlet::closeWindow(Host* pHost, const QString& name)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2428,7 +2428,7 @@ std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area,
         return {true, QString()};
     }
 
-    if (area == "f") {
+    if (area == "f" || area == "floating") {
         if (!pM->isFloating()) {
             // Undock a docked window
             // Change of position or size is only possible when floating
@@ -2442,19 +2442,19 @@ std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area,
         }
         return {true, QString()};
     } else {
-        if (area == "r") {
+        if (area == "r" || area == "right") {
             pM->setFloating(false);
             addDockWidget(Qt::RightDockWidgetArea, pM);
             return {true, QString()};
-        } else if (area == "l") {
+        } else if (area == "l" || area == "left") {
             pM->setFloating(false);
             addDockWidget(Qt::LeftDockWidgetArea, pM);
             return {true, QString()};
-        } else if (area == "t") {
+        } else if (area == "t" || area == "top") {
             pM->setFloating(false);
             addDockWidget(Qt::TopDockWidgetArea, pM);
             return {true, QString()};
-        } else if (area == "b") {
+        } else if (area == "b" || area == "bottom") {
             pM->setFloating(false);
             addDockWidget(Qt::BottomDockWidgetArea, pM);
             return {true, QString()};

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2421,14 +2421,14 @@ std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area,
         pM = pHost->mpDockableMapWidget;
     }
     if (!pM) {
-        return {false, "cannot create map widget. do you already use an embedded mapper?"};
+        return {false, "cannot create map widget. Do you already use an embedded mapper?"};
     }
     pM->show();
     if (area.isEmpty()) {
         return {true, QString()};
     }
 
-    if (area == "f" || area == "floating") {
+    if (area == QLatin1String("f") || area == QLatin1String("floating")) {
         if (!pM->isFloating()) {
             // Undock a docked window
             // Change of position or size is only possible when floating
@@ -2442,24 +2442,24 @@ std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area,
         }
         return {true, QString()};
     } else {
-        if (area == "r" || area == "right") {
+        if (area == QLatin1String("r") || area == QLatin1String("right")) {
             pM->setFloating(false);
             addDockWidget(Qt::RightDockWidgetArea, pM);
             return {true, QString()};
-        } else if (area == "l" || area == "left") {
+        } else if (area == QLatin1String("l") || area == QLatin1String("left")) {
             pM->setFloating(false);
             addDockWidget(Qt::LeftDockWidgetArea, pM);
             return {true, QString()};
-        } else if (area == "t" || area == "top") {
+        } else if (area == QLatin1String("t") || area == QLatin1String("top")) {
             pM->setFloating(false);
             addDockWidget(Qt::TopDockWidgetArea, pM);
             return {true, QString()};
-        } else if (area == "b" || area == "bottom") {
+        } else if (area == QLatin1String("b") || area == QLatin1String("bottom")) {
             pM->setFloating(false);
             addDockWidget(Qt::BottomDockWidgetArea, pM);
             return {true, QString()};
         } else {
-            return {false, QStringLiteral("docking option \"%1\" not available. available docking options are \"t\" top, \"b\" bottom, \"r\" right, \"l\" left and \"f\" floating").arg(area)};
+            return {false, QStringLiteral(R"("docking option "%1" not available. available docking options are "t" top, "b" bottom, "r" right, "l" left and "f" floating")").arg(area)};
         }
     }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -157,6 +157,8 @@ public:
     bool setLabelOnEnter(Host*, const QString&, const QString&, const TEvent&);
     bool setLabelOnLeave(Host*, const QString&, const QString&, const TEvent&);
     bool moveWindow(Host*, const QString& name, int, int);
+    std::pair<bool, QString> openMapWidget(Host* pHost, const QString& area, int x, int y, int width, int height);
+    std::pair<bool, QString> closeMapWidget(Host* pHost);
     void deleteLine(Host*, const QString& name);
     std::optional<QSize> getImageSize(const QString& imageLocation);
     bool insertText(Host*, const QString& windowName, const QString&);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Adds commands to open a MapWidget.
**openMapWidget()** -> opens MapWidget similar to clicking the Icon
**openMapWidget(dockingArea)** -> opens MapWidget and puts the widget in the chosen dockingArea. dockingArea is a string there are "f" floating "t" top "b" bottom "r" right and "l" left to choose
**openMapWidget(x,y,width,height)->** creates floating map Widget with given coordinates/sizes as numbers
**resizeMapWidget(width, height)** -> resizes MapWidget with given constraints
**moveMapWidget(x, y)** -> moves MapWidget to position x,y
**closeMapWidget()** -> closes (hides) the MapWidget

Geyser Wrapper for mentioned functions are added to Geyser.Mapper example:
**myMapWidget = Geyser.Mapper:new({embedded= false})**
Geyser constraints are:
**bool embedded** --is this an embedded mapper or a map widget?
**string dockPosition** --docking position at creation

+ if embedded is set to false at creation the mapper will be created as map window.
+ If embedded is set to true or is not set at all the mapper will be created as embedded mapper. 

+ If only embedded is set ( and no x, y, width, height values ) the mapping window will use the saved layout at creation if there is one.

+ If dockPosition is set to something other then floating the x, y, width, height values will be ignored (as we cannot set them in docking mode) and the MapWindow will be set into the dockPosition.

Geyser functions for the map window are
**myMapWidget:setDockPosition(dockPosition)**
#### Motivation for adding to Mudlet
https://github.com/Mudlet/Mudlet/issues/1256
#### Other info (issues closed, discussion etc)
If this works well I'm thinking about adding this functions (choose docking site...) also to UserWindows