### PR TITLE
Remove stray \r in connection dialog string

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2342,7 +2342,7 @@ bool dlgConnectionProfiles::validateProfile()
         int num = port.trimmed().toInt(&ok);
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("Port number must be above zero and below 65535.\r\n")));
+            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("Port number must be above zero and below 65535.\n\n")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
             valid = false;


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove stray \r in connection dialog string
#### Motivation for adding to Mudlet
It messes with translation for a bit:

![image](https://user-images.githubusercontent.com/110988/76562516-d5594400-64a5-11ea-86fc-5a16e3c98408.png)

#### Other info (issues closed, discussion etc)
Changed to `\n\n` like the following message has it.