### PR TITLE
String utils updates and tests

### DIFF
--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -88,7 +88,7 @@ end
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.title
 function string:title()
   local strType = type(self)
-  assert(strType == "string", string.format("string.title: bad argument #1 type. (String to title as string expected, got %s!)", strType))
+  assert(strType == "string", string.format("string.title: bad argument #1 type (string to title as string expected, got %s!)", strType))
   self = self:gsub("^%l", string.upper, 1)
   return self
 end

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -88,7 +88,7 @@ end
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.title
 function string:title()
   local strType = type(self)
-  assert(strType == "string", "string.title(str): str as string expected, got " .. strType)
+  assert(strType == "string", string.format("string.title: bad argument #1 type. (String to title as string expected, got %s!)", strType))
   self = self:gsub("^%l", string.upper, 1)
   return self
 end

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -5,27 +5,27 @@
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.cut
-function string.cut(s, maxLen)
-  if string.len(s) > maxLen then
-    return string.sub(s, 1, maxLen)
+function string:cut(maxLen)
+  if string.len(self) > maxLen then
+    return string.sub(self, 1, maxLen)
   else
-    return s
+    return self
   end
 end
 
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.enclose
-function string.enclose(s, maxlevel)
-  s = "[" .. s .. "]"
+function string:enclose(maxlevel)
+  self = "[" .. self .. "]"
   local level = 0
   while 1 do
     if maxlevel and level == maxlevel then
       error( "error: maxlevel too low, " .. maxlevel )
-    elseif string.find( s, "%[" .. string.rep( "=", level ) .. "%[" ) or string.find( s, "]" .. string.rep( "=", level ) .. "]" ) then
+    elseif string.find( self, "%[" .. string.rep( "=", level ) .. "%[" ) or string.find( self, "]" .. string.rep( "=", level ) .. "]" ) then
       level = level + 1
     else
-      return "[" .. string.rep( "=", level ) .. s .. string.rep( "=", level ) .. "]"
+      return "[" .. string.rep( "=", level ) .. self .. string.rep( "=", level ) .. "]"
     end
   end
 end
@@ -33,15 +33,15 @@ end
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.ends
-function string.ends(String, Suffix)
-  return Suffix == '' or string.sub(String, -string.len(Suffix)) == Suffix
+function string:ends(suffix)
+  return suffix == '' or string.sub(self, -string.len(suffix)) == suffix
 end
 
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.genNocasePattern
-function string.genNocasePattern(s)
-  s = string.gsub(s, "%a",
+function string:genNocasePattern()
+  local s = string.gsub(self, "%a",
   function(c)
     return string.format("[%s%s]", string.lower(c), string.upper(c))
   end)
@@ -51,9 +51,9 @@ end
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.findPattern
-function string.findPattern(text, pattern)
-  if string.find(text, pattern, 1) then
-    return string.sub(text, string.find(text, pattern, 1))
+function string:findPattern(pattern)
+  if string.find(self, pattern, 1) then
+    return string.sub(self, string.find(self, pattern, 1))
   else
     return nil
   end
@@ -63,6 +63,7 @@ end
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.split
 function string:split(delimiter)
+  delimiter = delimiter or " "
   local result = { }
   local from = 1
   local delim_from, delim_to = string.find( self, delimiter, from  )
@@ -78,15 +79,16 @@ end
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.starts
-function string.starts(String, Prefix)
-  return string.sub(String, 1, string.len(Prefix)) == Prefix
+function string:starts(prefix)
+  return string.sub(self, 1, string.len(prefix)) == prefix
 end
 
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.title
 function string:title()
-  assert(type(self) == "string", "string.title(): no word given to capitalize")
+  local strType = type(self)
+  assert(strType == "string", "string.title(str): str as string expected, got " .. strType)
   self = self:gsub("^%l", string.upper, 1)
   return self
 end
@@ -94,12 +96,12 @@ end
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.trim
-function string.trim(s)
-  if s then
+function string:trim()
+  if self then
     -- return only the trimmed string, and not the # of replacements done as well
-    local trimmed = string.gsub(s, "^%s*(.-)%s*$", "%1")
+    local trimmed = string.gsub(self, "^%s*(.-)%s*$", "%1")
     return trimmed
   else
-    return s
+    return self
   end
 end

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -1,2 +1,179 @@
-describe("Tests Other.lua functions", function()
+describe("Tests StringUtils.lua functions", function()
+  describe("string.cut(str, maxLen)", function()
+    it("should return the same string if it is <= maxLen", function()
+      local testString = "test"
+      assert.equals(testString, string.cut(testString, testString:len()))
+      assert.equals(testString, testString:cut(testString:len()))
+      assert.equals(testString, string.cut(testString, testString:len() + 1 ))
+      assert.equals(testString, testString:cut(testString:len() + 1 ))
+    end)
+
+    it("should return a string of length maxLen if it is given a string longer than that", function()
+      local testString = "This is a test of the emergency string cutting system"
+      local expected = "This is a "
+      local expectedLength = 10
+      local actual = string.cut(testString, expectedLength)
+      local actualLength = actual:len()
+      assert.equals(expected, actual)
+      assert.equals(expectedLength, actualLength)
+      actual = testString:cut(expectedLength)
+      actualLength = actual:len()
+      assert.equals(expectedLength, actualLength)
+    end)
+  end)
+
+  describe("string.enclose(str, maxlevel)", function()
+    it("should return [[]] is empty string is given", function()
+      assert.equals("[[]]", string.enclose(""))
+      local testString = ""
+      assert.equals("[[]]", testString:enclose())
+    end)
+
+    it("should return the string str wrapped in [[]]", function()
+      local s = "This is a test"
+      local expected = '[[This is a test]]'
+      local actual = string.enclose(s)
+      assert.equals(expected, actual)
+    end)
+
+    it("should detect and insert = up to maxlevel to avoid accidental string closure", function()
+      local s = "[[This is a [=[test]=] of string.enclose]]"
+      local expected = "[==[" .. s .. "]==]"
+      local actual = string.enclose(s, 3)
+      assert.equals(expected, actual)
+    end)
+
+    it("should error if maxlevel is not high enough to properly wrap the string", function()
+      local s = "[=[[[This is a test]]]=]"
+      local errfn = function() string.enclose(s,1) end
+      assert.has_error(errfn, "error: maxlevel too low, 1")
+    end)
+  end)
+
+  describe("string.ends(str, suffix)", function()
+    it("should return true if str ends in suffix", function()
+      local s = "This is a test"
+      local suffix = "a test"
+      assert.is_true(string.ends(s, suffix))
+      assert.is_true(s:ends(suffix))
+      s = "Of the emergency broadcasting system"
+      suffix = "system"
+      assert.is_true(string.ends(s, suffix))
+    end)
+    it("should return false if str does not end in suffix", function()
+      local s = "This is a test"
+      local suffix = "system"
+      assert.is_false(string.ends(s, suffix))
+    end)
+  end)
+
+  describe("string.genNocasePattern(str)", function()
+    it("should create a case insensitive lua pattern based on str", function()
+      local str = "123abc"
+      local expected = "123[aA][bB][cC]"
+      local actual = string.genNocasePattern(str)
+      assert.equals(expected, actual)
+      local actual = str:genNocasePattern()
+      assert.equals(expected, actual)
+    end)
+
+    it("should be able to match the string it was generated from", function()
+      local str = "123abc"
+      local pattern = string.genNocasePattern(str)
+      assert.is_truthy(str:find(pattern))
+    end)
+  end)
+
+  describe("string.findPattern(str,pattern)", function()
+    it("should return the first match of pattern in str", function()
+      local str = "This is test 2"
+      local pattern = "test %d"
+      local expected = "test 2"
+      local actual = string.findPattern(str, pattern)
+      assert.equals(expected, actual)
+      local actual = str:findPattern(pattern)
+      assert.equals(expected, actual)
+    end)
+
+    it("should return nil if there is no match", function()
+      local str = "This is the test"
+      local pattern = "is a"
+      assert.is_nil(string.findPattern(str, pattern))
+    end)
+  end)
+
+  describe("string.split(str,delimiter)", function()
+    it("should return a table which contain the pieces of str, cut by delimiter", function()
+      local str = "This is,a comma,separated string,with stuff in it"
+      local delimiter = ","
+      local expected = {
+        "This is",
+        "a comma",
+        "separated string",
+        "with stuff in it"
+      }
+      local actual = str:split(delimiter)
+      assert.same(expected, actual)
+      local actual = string.split(str, delimiter)
+      assert.same(expected, actual)
+    end)
+
+    it("should return a table with one item being the original string", function()
+      local str = "This is a test"
+      local expected = { str }
+      local actual = str:split(":")
+      assert.same(expected, actual)
+    end)
+  end)
+
+  describe("string.starts(str, prefix)", function()
+    it("should return true if str starts with prefix", function()
+      local str = "This is a test"
+      assert.is_true(str:starts("This"))
+      assert.is_true(string.starts(str, "This"))
+    end)
+    it("should return false if str does not start with prefix", function()
+      local str = "This is a test"
+      assert.is_false(str:starts("Elephant"))
+    end)
+  end)
+
+  describe("string.title(str)", function()
+    it("should return the string with the first letter capitalized", function()
+      local str = "this"
+      local expected = "This"
+      local actual = str:title()
+      assert.equals(expected, actual)
+    end)
+
+    it("should return the original string if the first letter is already capitalized", function()
+      local str = "This"
+      local actual = str:title()
+      assert.equals(str, actual)
+    end)
+
+    it("should error if given something other than a string", function()
+      local str = {}
+      local errfn = function() string.title(str) end
+      assert.has_error(errfn, "string.title(str): str as string expected, got table")
+    end)
+  end)
+
+  describe("string.trim(str)", function()
+    it("should return str with all spaces stripped from the beginning and end", function()
+      local str = "    this is a test      "
+      local expected = "this is a test"
+      local actual = str:trim()
+      assert.equals(expected, actual)
+      actual = string.trim(str)
+      assert.equals(expected, actual)
+    end)
+
+    it("should return whatever you pass in if it's falsey", function()
+      local str = false
+      assert.is_false(string.trim(str))
+      str = nil
+      assert.is_nil(string.trim(str))
+    end)
+  end)
 end)

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -171,9 +171,15 @@ describe("Tests StringUtils.lua functions", function()
 
     it("should return whatever you pass in if it's falsey", function()
       local str = false
-      assert.is_false(string.trim(str))
+      assert.equals(str, string.trim(str))
       str = nil
-      assert.is_nil(string.trim(str))
+      assert.equals(str, string.trim(str))
+    end)
+
+    it("should return the same string if str has no spaces at front or back", function()
+      local str = "This is a test"
+      assert.equals(str, string.trim(str))
+      assert.equals(str, str:trim())
     end)
   end)
 end)

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -1,0 +1,2 @@
+describe("Tests Other.lua functions", function()
+end)

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -155,7 +155,7 @@ describe("Tests StringUtils.lua functions", function()
     it("should error if given something other than a string", function()
       local str = {}
       local errfn = function() string.title(str) end
-      assert.has_error(errfn, "string.title(str): str as string expected, got table")
+      assert.has_error(errfn, "string.title: bad argument #1 type. (String to title as string expected, got table!)")
     end)
   end)
 

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -155,7 +155,7 @@ describe("Tests StringUtils.lua functions", function()
     it("should error if given something other than a string", function()
       local str = {}
       local errfn = function() string.title(str) end
-      assert.has_error(errfn, "string.title: bad argument #1 type. (String to title as string expected, got table!)")
+      assert.has_error(errfn, "string.title: bad argument #1 type (string to title as string expected, got table!)")
     end)
   end)
 


### PR DESCRIPTION
### Brief overview of PR changes/additions

While writing the tests for StringUtils I realized it would only take a bit of adjustment to support the : notation for the functions we add. 

- So I added that functionality.
- I also adjusted the error message for string.title to be more informative/match other errors
- added tests for all the functions in StringUtils.lua which also ensured the functional changes didn't break anything. At least one test for each functions tests both . and : notation.

### Motivation for adding to Mudlet

TEST ALL THE THINGS

### Other info (issues closed, discussion etc)

![image](https://user-images.githubusercontent.com/3660/76584514-51f21f80-64b2-11ea-8b67-fdab359cce89.png)

