### PR TITLE
Remove untranslatable splash screen tests

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -359,22 +359,6 @@ int main(int argc, char* argv[])
     }
     app->processEvents();
 
-    QString splash_message;
-    if (show_splash) {
-        splash_message.append(QLatin1String("\n\n"));
-        splash_message.append(QCoreApplication::translate("main",
-                              "Mudlet comes with\n"
-                              "ABSOLUTELY NO WARRANTY!\n"
-                              "This is free software, and you are\n"
-                              "welcome to redistribute it under\n"
-                              "certain conditions; select the\n"
-                              "'About' item for details."));
-        splash_message.append(QLatin1String("\n\n"));
-        splash_message.append(QCoreApplication::translate("main", "Locating profiles..."));
-        splash.showMessage(splash_message, Qt::AlignHCenter | Qt::AlignTop);
-        app->processEvents();
-    }
-
     // seed random number generator (should be done once per lifetime)
     qsrand(static_cast<quint64>(QTime::currentTime().msecsSinceStartOfDay()));
 
@@ -384,12 +368,6 @@ int main(int argc, char* argv[])
     if (!dir.exists(homeDirectory)) {
         dir.mkpath(homeDirectory);
         first_launch = true;
-    }
-
-    if (show_splash) {
-        splash_message.append(QCoreApplication::translate("main", "Done.\n\nLoading font files..."));
-        splash.showMessage(splash_message, Qt::AlignHCenter | Qt::AlignTop);
-        app->processEvents();
     }
 
 #if defined(INCLUDE_FONTS)
@@ -459,14 +437,6 @@ int main(int argc, char* argv[])
 #endif
 
     mudlet::debugMode = false;
-
-    if (show_splash) {
-        splash_message.append(QCoreApplication::translate("main", "Done.\n\n"
-                              "All data has been loaded successfully.\n\n"
-                              "Starting... Have fun!\n\n"));
-        splash.showMessage(splash_message, Qt::AlignHCenter | Qt::AlignTop);
-        app->processEvents();
-    }
 
     QString homeLink = QStringLiteral("%1/mudlet-data").arg(QDir::homePath());
 #ifdef Q_OS_WIN32


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Remove untranslatable splash screen tests.
#### Motivation for adding to Mudlet
So we have full i18n coverage and because the splash screen texts offer no value - for most computers, Mudlet starts too fast to read. Not fashionable in 2020 either!
#### Other info (issues closed, discussion etc)
As discussed in #mudlet-development