### PR TITLE
Only make PR to update translation texts if content changed

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -25,11 +25,9 @@ jobs:
     - name: check if translation strings were modified
       id: getdiff
       run: |
-        git diff --patch --unified=0 > diff.txt
-        cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
-        lines_changed=$(cat diff.txt | wc --lines | xargs echo -n)
+        # see if we had any changes in the diff, ignoring the <location... changes
+        lines_changed=$(git diff --patch --unified=0 translations/mudlet.ts | awk '! /^((@@|diff|index|---|\+\+\+)|((-|+) *<location))/ { count++ } END { print count " lines changed." }')
         echo "$lines_changed lines changed."
-        rm diff.txt
         echo ::set-output name=lines_changed::$lines_changed
 
     - name: commit changes

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         git diff --patch --unified=0 > diff.txt
         cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
-        lines_changed=$(cat diff.txt | wc --lines)
+        lines_changed=$(cat diff.txt | wc --lines | xargs echo -n)
         echo "$lines_changed lines changed."
         echo ::set-output name=lines_changed::$lines_changed
         

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,5 +1,5 @@
 name: Update translations
-on:    
+on:
   push:
     branches:
       - 'release-**'
@@ -21,7 +21,7 @@ jobs:
       uses: Mudlet/lupdate-action@master
       with:
         args: -recursive ./src/ ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ./translations/mudlet.ts
-        
+
     - name: check if translation strings were modified
       id: getdiff
       run: |
@@ -30,7 +30,7 @@ jobs:
         lines_changed=$(cat diff.txt | wc --lines | xargs echo -n)
         echo "$lines_changed lines changed."
         echo ::set-output name=lines_changed::$lines_changed
-        
+
     - name: commit changes
       uses: teaminkling/autocommit@master
       if: steps.getdiff.outputs.lines_changed > 0

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -20,6 +20,11 @@ jobs:
       uses: Mudlet/lupdate-action@master
       with:
         args: -recursive ./src/ ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ./translations/mudlet.ts
+        
+    - name: check if translation strings were modified
+      run: |
+        git diff --patch --unified=0 > diff.txt
+        cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
 
     - name: commit changes
       uses: teaminkling/autocommit@master

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -22,17 +22,21 @@ jobs:
         args: -recursive ./src/ ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ./translations/mudlet.ts
         
     - name: check if translation strings were modified
+      id: getdiff
       run: |
         git diff --patch --unified=0 > diff.txt
         cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
-
+        echo ::set-output name=lines_changed::$(cat diff.txt | wc --lines)
+        
     - name: commit changes
       uses: teaminkling/autocommit@master
+      if: steps.getdiff.outputs.lines_changed > 0
       with:
        commit-message: (autocommit) Updated text for translation
 
     - name: create texts branch
       uses: peterjgrainger/action-create-branch@v1.0.0
+      if: steps.getdiff.outputs.lines_changed > 0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -40,6 +44,7 @@ jobs:
 
     - name: push new text
       uses: ad-m/github-push-action@v0.5.0
+      if: steps.getdiff.outputs.lines_changed > 0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: updated-text-${{ github.sha }}
@@ -47,6 +52,7 @@ jobs:
 
     - name: pull-request
       uses: repo-sync/pull-request@v2
+      if: steps.getdiff.outputs.lines_changed > 0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         source_branch: updated-text-${{ github.sha }}

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -16,6 +16,7 @@ jobs:
     # have to use v1 due to https://github.com/repo-sync/pull-request/issues/17
     - uses: actions/checkout@v1
       with:
+        ref: development
         submodules: true
 
     - name: update text for translation
@@ -28,7 +29,9 @@ jobs:
       run: |
         git diff --patch --unified=0 > diff.txt
         cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
-        echo ::set-output name=lines_changed::$(cat diff.txt | wc --lines)
+        lines_changed=$(cat diff.txt | wc --lines)
+        echo "$lines_changed lines changed."
+        echo ::set-output name=lines_changed::$(lines_changed)
         
     - name: commit changes
       uses: teaminkling/autocommit@master

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,7 +1,7 @@
 name: Update texts for translators
 on:
   pull_request:
-    
+
   push:
     branches:
       - 'release-**'
@@ -43,7 +43,7 @@ jobs:
           #### Brief overview of PR changes/additions
           :crown: An automated PR to make new text available for translation in Crowdin from ${{ github.ref }} (${{ github.sha }}).
           #### Motivation for adding to Mudlet
-          So translators can translate the new text before the upcoming release.:  
+          So translators can translate the new text before the upcoming release.:
         branch: update-texts-for-translators
         path: translations/
         commit-message: (autocommit) Updated text for translation

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,4 +1,4 @@
-name: Update translations
+name: Update texts for translators
 on:
   pull_request:
     
@@ -24,11 +24,11 @@ jobs:
       with:
         args: -recursive ./src/ ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ./translations/mudlet.ts
 
-    - name: check if translation strings were modified
+    - name: check if any UI text was modified
       id: getdiff
       run: |
         # see if we had any changes in the diff, ignoring the <location... changes
-        lines_changed=$(git diff --patch --unified=0 translations/mudlet.ts | awk '! /^((@@|diff|index|---|\+\+\+)|((-|+) *<location))/ { count++ } END { print count " lines changed." }')
+        lines_changed=$(git diff --patch --unified=0 translations/mudlet.ts | awk '! /^((@@|diff|index|---|\+\+\+)|((-|+) *<location))/ { count++ } END { print count }')
         echo "$lines_changed lines changed."
         echo ::set-output name=lines_changed::$lines_changed
 
@@ -54,7 +54,7 @@ jobs:
         branch: updated-text-${{ github.sha }}
         force: true
 
-    - name: pull-request
+    - name: make a PR
       uses: repo-sync/pull-request@v2
       if: steps.getdiff.outputs.lines_changed > 0
       with:

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,5 +1,7 @@
 name: Update translations
 on:
+  pull_request:
+    
   push:
     branches:
       - 'release-**'

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,7 +1,5 @@
 name: Update texts for translators
 on:
-  pull_request:
-
   push:
     branches:
       - 'release-**'

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -14,10 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # have to use v1 due to https://github.com/repo-sync/pull-request/issues/17
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
       with:
         ref: development
         submodules: true
+        fetch-depth: 0
 
     - name: update text for translation
       uses: Mudlet/lupdate-action@master

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -44,7 +44,7 @@ jobs:
           :crown: An automated PR to make new text available for translation in Crowdin from ${{ github.ref }} (${{ github.sha }}).
           #### Motivation for adding to Mudlet
           So translators can translate the new text before the upcoming release.:
-        branch: update-texts-for-translators
+        branch: update-texts-for-translators-${{ github.sha }}
         path: translations/
         commit-message: (autocommit) Updated text for translation
         author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -29,6 +29,7 @@ jobs:
         cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
         lines_changed=$(cat diff.txt | wc --lines | xargs echo -n)
         echo "$lines_changed lines changed."
+        rm diff.txt
         echo ::set-output name=lines_changed::$lines_changed
 
     - name: commit changes

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -50,7 +50,7 @@ jobs:
           :crown: An automated PR to make new text available for translation in Crowdin from ${{ github.ref }} (${{ github.sha }}).
           #### Motivation for adding to Mudlet
           So translators can translate the new text before the upcoming release.:  
-        branch: development
+        branch: update-texts-for-translators
         path: translations/
         commit-message: (autocommit) Updated text for translation
         author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -32,38 +32,54 @@ jobs:
         echo "$lines_changed lines changed."
         echo ::set-output name=lines_changed::$lines_changed
 
-    - name: commit changes
-      uses: teaminkling/autocommit@master
-      if: steps.getdiff.outputs.lines_changed > 0
-      with:
-       commit-message: (autocommit) Updated text for translation
+#     - name: commit changes
+#       uses: teaminkling/autocommit@master
+#       with:
+#        commit-message: (autocommit) Updated text for translation
 
-    - name: create texts branch
-      uses: peterjgrainger/action-create-branch@v1.0.0
+    - name: send in a pull request
+      uses: gr2m/create-or-update-pull-request-action@v1.x
       if: steps.getdiff.outputs.lines_changed > 0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        branch: updated-text-${{ github.sha }}
-
-    - name: push new text
-      uses: ad-m/github-push-action@v0.5.0
-      if: steps.getdiff.outputs.lines_changed > 0
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: updated-text-${{ github.sha }}
-        force: true
-
-    - name: make a PR
-      uses: repo-sync/pull-request@v2
-      if: steps.getdiff.outputs.lines_changed > 0
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        source_branch: updated-text-${{ github.sha }}
-        destination_branch: development
-        pr_title: "Update text for translation in Crowdin"
-        pr_body: |
+        title: "Update text for translation in Crowdin"
+        body: |
           #### Brief overview of PR changes/additions
           :crown: An automated PR to make new text available for translation in Crowdin from ${{ github.ref }} (${{ github.sha }}).
           #### Motivation for adding to Mudlet
-          So translators can translate the new text before the upcoming release.
+          So translators can translate the new text before the upcoming release.:  
+        branch: development
+        path: translations/
+        commit-message: (autocommit) Updated text for translation
+        author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+#     - name: create texts branch
+#       uses: peterjgrainger/action-create-branch@v1.0.0
+#       if: steps.getdiff.outputs.lines_changed > 0
+#       env:
+#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#       with:
+#         branch: updated-text-${{ github.sha }}
+
+#     - name: push new text
+#       uses: ad-m/github-push-action@v0.5.0
+#       if: steps.getdiff.outputs.lines_changed > 0
+#       with:
+#         github_token: ${{ secrets.GITHUB_TOKEN }}
+#         branch: updated-text-${{ github.sha }}
+#         force: true
+
+#     - name: make a PR
+#       uses: repo-sync/pull-request@v2
+#       if: steps.getdiff.outputs.lines_changed > 0
+#       with:
+#         github_token: ${{ secrets.GITHUB_TOKEN }}
+#         source_branch: updated-text-${{ github.sha }}
+#         destination_branch: development
+#         pr_title: "Update text for translation in Crowdin"
+#         pr_body: |
+#           #### Brief overview of PR changes/additions
+#           :crown: An automated PR to make new text available for translation in Crowdin from ${{ github.ref }} (${{ github.sha }}).
+#           #### Motivation for adding to Mudlet
+#           So translators can translate the new text before the upcoming release.

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -31,7 +31,7 @@ jobs:
         cat diff.txt | grep -v "<location" | grep -v "^@@" | grep -v "^diff" | grep -v "^index" | grep -v "^\-\-\-" | egrep -v '^\+\+\+'
         lines_changed=$(cat diff.txt | wc --lines)
         echo "$lines_changed lines changed."
-        echo ::set-output name=lines_changed::$(lines_changed)
+        echo ::set-output name=lines_changed::$lines_changed
         
     - name: commit changes
       uses: teaminkling/autocommit@master

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,7 +1,5 @@
 name: Update translations
-on:
-  pull_request:
-    
+on:    
   push:
     branches:
       - 'release-**'

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -13,7 +13,6 @@ jobs:
   update-and-commit-text:
     runs-on: ubuntu-latest
     steps:
-    # have to use v1 due to https://github.com/repo-sync/pull-request/issues/17
     - uses: actions/checkout@master
       with:
         ref: development
@@ -33,11 +32,6 @@ jobs:
         echo "$lines_changed lines changed."
         echo ::set-output name=lines_changed::$lines_changed
 
-#     - name: commit changes
-#       uses: teaminkling/autocommit@master
-#       with:
-#        commit-message: (autocommit) Updated text for translation
-
     - name: send in a pull request
       uses: gr2m/create-or-update-pull-request-action@v1.x
       if: steps.getdiff.outputs.lines_changed > 0
@@ -54,33 +48,3 @@ jobs:
         path: translations/
         commit-message: (autocommit) Updated text for translation
         author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
-
-#     - name: create texts branch
-#       uses: peterjgrainger/action-create-branch@v1.0.0
-#       if: steps.getdiff.outputs.lines_changed > 0
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#       with:
-#         branch: updated-text-${{ github.sha }}
-
-#     - name: push new text
-#       uses: ad-m/github-push-action@v0.5.0
-#       if: steps.getdiff.outputs.lines_changed > 0
-#       with:
-#         github_token: ${{ secrets.GITHUB_TOKEN }}
-#         branch: updated-text-${{ github.sha }}
-#         force: true
-
-#     - name: make a PR
-#       uses: repo-sync/pull-request@v2
-#       if: steps.getdiff.outputs.lines_changed > 0
-#       with:
-#         github_token: ${{ secrets.GITHUB_TOKEN }}
-#         source_branch: updated-text-${{ github.sha }}
-#         destination_branch: development
-#         pr_title: "Update text for translation in Crowdin"
-#         pr_body: |
-#           #### Brief overview of PR changes/additions
-#           :crown: An automated PR to make new text available for translation in Crowdin from ${{ github.ref }} (${{ github.sha }}).
-#           #### Motivation for adding to Mudlet
-#           So translators can translate the new text before the upcoming release.


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Only make PR to update translation texts if content changed - because it currently makes PRs even if no lines were changed.
#### Motivation for adding to Mudlet
Less spam... from newly added automation.
#### Other info (issues closed, discussion etc)
I am sure my bash hackery can be done better!