### PR TITLE
3d mapper creation at clicking

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2353,9 +2353,6 @@ void TConsole::createMapper(const QString& windowname, int x, int y, int width, 
         } else {
             mpMapper = new dlgMapper(pW->widget(), mpHost, mpHost->mpMap.data());
         }
-#if defined(INCLUDE_3DMAPPER)
-        mpHost->mpMap->mpM = mpMapper->glWidget;
-#endif
         mpHost->mpMap->mpHost = mpHost;
         mpHost->mpMap->mpMapper = mpMapper;
         qDebug() << "TConsole::createMapper() - restore map case 2.";

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2337,9 +2337,13 @@ std::pair<bool, QString> TConsole::setLabelToolTip(const QString& name, const QS
     return {false, QStringLiteral("label name \"%1\" not found").arg(name)};
 }
 
-void TConsole::createMapper(const QString& windowname, int x, int y, int width, int height)
+std::pair<bool, QString> TConsole::createMapper(const QString& windowname, int x, int y, int width, int height)
 {
     auto pW = mDockWidgetMap.value(windowname);
+    auto pM = mpHost->mpDockableMapWidget;
+    if (pM) {
+        return {false, "cannot create mapper. Do you already use a map window?"};
+    }
     if (!mpMapper) {
         // Arrange for TMap member values to be copied from the Host masters so they
         // are in place when the 2D mapper is created:
@@ -2368,7 +2372,7 @@ void TConsole::createMapper(const QString& windowname, int x, int y, int width, 
 
         mpHost->mpMap->pushErrorMessagesToFile(tr("Loading map(2) at %1 report").arg(now.toString(Qt::ISODate)), true);
 
-        TEvent mapOpenEvent {};
+        TEvent mapOpenEvent{};
         mapOpenEvent.mArgumentList.append(QLatin1String("mapOpenEvent"));
         mapOpenEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         mpHost->raiseEvent(mapOpenEvent);
@@ -2391,6 +2395,7 @@ void TConsole::createMapper(const QString& windowname, int x, int y, int width, 
 #else
     mpMapper->show();
 #endif
+    return {true, QString()};
 }
 
 bool TConsole::setBackgroundImage(const QString& name, const QString& path)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -105,7 +105,7 @@ public:
     void luaWrapLine(std::string& buf, int line);
 
     int getColumnNumber();
-    void createMapper(const QString &windowname, int, int, int, int);
+    std::pair<bool, QString> createMapper(const QString &windowname, int, int, int, int);
 
     void setWrapAt(int pos)
     {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2007,7 +2007,9 @@ void TMap::postMessage(const QString text)
 void TMap::set3DViewCenter(const int areaId, const int xPos, const int yPos, const int zPos)
 {
 #if defined(INCLUDE_3DMAPPER)
-    mpM->setViewCenter(areaId, xPos, yPos, zPos);
+    if (mpM) {
+        mpM->setViewCenter(areaId, xPos, yPos, zPos);
+    }
 #endif
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -232,7 +232,7 @@ void dlgMapper::show2dView()
         if (glWidget->isVisible()) {
             d3buttons->setVisible(true);
         } else {
-            // Use timer do not let the buttons dissappear
+            // workaround for buttons reloading oddly
             QTimer::singleShot(100, [this]() {d3buttons->setVisible(false);});
         }
     }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -45,23 +45,9 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     setupUi(this);
 
 #if defined(INCLUDE_3DMAPPER)
-    if (mpHost->mpMap->mpM && mpHost->mpMap->mpMapper) {
-        mpHost->mpMap->mpM->update();
-    }
     QSurfaceFormat fmt;
     fmt.setSamples(10);
     QSurfaceFormat::setDefaultFormat(fmt);
-    glWidget = new GLWidget(widget);
-    glWidget->setObjectName(QString::fromUtf8("glWidget"));
-
-    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    sizePolicy.setHorizontalStretch(0);
-    sizePolicy.setVerticalStretch(0);
-    sizePolicy.setHeightForWidth(glWidget->sizePolicy().hasHeightForWidth());
-    glWidget->setSizePolicy(sizePolicy);
-    verticalLayout_2->insertWidget(0, glWidget);
-
-    glWidget->mpMap = pM;
 #endif
 
     mp2dMap->mpMap = pM;
@@ -110,34 +96,6 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(showArea, qOverload<const QString&>(&QComboBox::activated), mp2dMap, &T2DMap::slot_switchArea);
     connect(dim2, &QAbstractButton::pressed, this, &dlgMapper::show2dView);
     connect(showRoomIDs, &QCheckBox::stateChanged, this, &dlgMapper::slot_toggleShowRoomIDs);
-
-#if defined(INCLUDE_3DMAPPER)
-    connect(ortho, &QAbstractButton::pressed, glWidget, &GLWidget::fullView);
-    connect(singleLevel, &QAbstractButton::pressed, glWidget, &GLWidget::singleView);
-    connect(increaseTop, &QAbstractButton::pressed, glWidget, &GLWidget::increaseTop);
-    connect(increaseBottom, &QAbstractButton::pressed, glWidget, &GLWidget::increaseBottom);
-    connect(reduceTop, &QAbstractButton::pressed, glWidget, &GLWidget::reduceTop);
-    connect(reduceBottom, &QAbstractButton::pressed, glWidget, &GLWidget::reduceBottom);
-    connect(shiftZup, &QAbstractButton::pressed, glWidget, &GLWidget::shiftZup);
-    connect(shiftZdown, &QAbstractButton::pressed, glWidget, &GLWidget::shiftZdown);
-    connect(shiftLeft, &QAbstractButton::pressed, glWidget, &GLWidget::shiftLeft);
-    connect(shiftRight, &QAbstractButton::pressed, glWidget, &GLWidget::shiftRight);
-    connect(shiftUp, &QAbstractButton::pressed, glWidget, &GLWidget::shiftUp);
-    connect(shiftDown, &QAbstractButton::pressed, glWidget, &GLWidget::shiftDown);
-    connect(showInfo, &QAbstractButton::clicked, glWidget, &GLWidget::showInfo);
-    connect(defaultView, &QAbstractButton::pressed, glWidget, &GLWidget::defaultView);
-    connect(sideView, &QAbstractButton::pressed, glWidget, &GLWidget::sideView);
-    connect(topView, &QAbstractButton::pressed, glWidget, &GLWidget::topView);
-    connect(scale, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setScale);
-    connect(xRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setXRotation);
-    connect(yRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setYRotation);
-    connect(zRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setZRotation);
-
-    glWidget->hide();
-#else
-    dim2->setDisabled(true);
-    dim2->setToolTip(tr("3D mapper is not available in this version of Mudlet"));
-#endif
 
     // Explicitly set the font otherwise it changes between the Application and
     // the default System one as the mapper is docked and undocked!
@@ -230,16 +188,60 @@ void dlgMapper::slot_togglePanel()
 void dlgMapper::show2dView()
 {
 #if defined(INCLUDE_3DMAPPER)
-    glWidget->setVisible(!glWidget->isVisible());
-    mp2dMap->setVisible(!mp2dMap->isVisible());
-    if (glWidget->isVisible()) {
-        d3buttons->setVisible(true);
-    } else {
-        d3buttons->setVisible(false);
+
+    if (mpHost->mpMap->mpM && mpHost->mpMap->mpMapper) {
+        mpHost->mpMap->mpM->update();
+    }
+    if (!mpHost->mpMap->mpM) {
+        glWidget = new GLWidget(widget);
+        glWidget->setObjectName(QString::fromUtf8("glWidget"));
+
+        QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+        sizePolicy.setHorizontalStretch(0);
+        sizePolicy.setVerticalStretch(0);
+        sizePolicy.setHeightForWidth(glWidget->sizePolicy().hasHeightForWidth());
+        glWidget->setSizePolicy(sizePolicy);
+        verticalLayout_2->insertWidget(0, glWidget);
+
+        glWidget->mpMap = mpMap;
+        mpMap->mpM = mpMap->mpMapper->glWidget;
+        connect(ortho, &QAbstractButton::pressed, glWidget, &GLWidget::fullView);
+        connect(singleLevel, &QAbstractButton::pressed, glWidget, &GLWidget::singleView);
+        connect(increaseTop, &QAbstractButton::pressed, glWidget, &GLWidget::increaseTop);
+        connect(increaseBottom, &QAbstractButton::pressed, glWidget, &GLWidget::increaseBottom);
+        connect(reduceTop, &QAbstractButton::pressed, glWidget, &GLWidget::reduceTop);
+        connect(reduceBottom, &QAbstractButton::pressed, glWidget, &GLWidget::reduceBottom);
+        connect(shiftZup, &QAbstractButton::pressed, glWidget, &GLWidget::shiftZup);
+        connect(shiftZdown, &QAbstractButton::pressed, glWidget, &GLWidget::shiftZdown);
+        connect(shiftLeft, &QAbstractButton::pressed, glWidget, &GLWidget::shiftLeft);
+        connect(shiftRight, &QAbstractButton::pressed, glWidget, &GLWidget::shiftRight);
+        connect(shiftUp, &QAbstractButton::pressed, glWidget, &GLWidget::shiftUp);
+        connect(shiftDown, &QAbstractButton::pressed, glWidget, &GLWidget::shiftDown);
+        connect(showInfo, &QAbstractButton::clicked, glWidget, &GLWidget::showInfo);
+        connect(defaultView, &QAbstractButton::pressed, glWidget, &GLWidget::defaultView);
+        connect(sideView, &QAbstractButton::pressed, glWidget, &GLWidget::sideView);
+        connect(topView, &QAbstractButton::pressed, glWidget, &GLWidget::topView);
+        connect(scale, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setScale);
+        connect(xRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setXRotation);
+        connect(yRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setYRotation);
+        connect(zRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setZRotation);
+    }
+
+    if (mpHost->mpMap->mpM) {
+        mp2dMap->setVisible(!mp2dMap->isVisible());
+        glWidget->setVisible(!glWidget->isVisible());
+        if (glWidget->isVisible()) {
+            d3buttons->setVisible(true);
+        } else {
+            // Use timer do not let the buttons dissappear
+            QTimer::singleShot(100, [this]() {d3buttons->setVisible(false);});
+        }
     }
 #else
     mp2dMap->setVisible(true);
     d3buttons->setVisible(false);
+    dim2->setDisabled(true);
+    dim2->setToolTip(tr("3D mapper is not available in this version of Mudlet"));
 #endif
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -49,7 +49,6 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     fmt.setSamples(10);
     QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-
     mp2dMap->mpMap = pM;
     mp2dMap->mpHost = pH;
     // Have to do this here rather than in the T2DMap constructor because that

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3508,9 +3508,6 @@ void mudlet::createMapper(bool loadDefaultMap)
 
     pMap->mpMapper = new dlgMapper(pHost->mpDockableMapWidget, pHost, pMap); //FIXME: mpHost definieren
     pMap->mpMapper->setStyleSheet(pHost->mProfileStyleSheet);
-#if defined(INCLUDE_3DMAPPER)
-    pMap->mpM = pMap->mpMapper->glWidget;
-#endif
     pHost->mpDockableMapWidget->setWidget(pMap->mpMapper);
 
     if (loadDefaultMap && pMap->mpRoomDB->getRoomIDList().isEmpty()) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
With this PR the 3d Mapper is only created if clicked on the 2d/3d button
#### Motivation for adding to Mudlet
Some people which didn't even use the 3d mapper had problems caused by it.
#### Other info (issues closed, discussion etc)
fixed by the way button dissapearance if clicking 2d/3d button
also changed createMapper that is no longer possible to create an embedded mapper and a dockwindow mapper at the same time (which caused crash of the Mudlet application)