### PR TITLE
Remove stray whitespace from translation

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2309,9 +2309,10 @@ bool dlgConnectionProfiles::validateProfile()
             if (!allowedChars.contains(name.at(i))) {
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
-                        QStringLiteral("%1\n%2").arg(
-                            notificationAreaMessageBox->text(), 
-                            QStringLiteral("%1\n%2\n").arg(tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), allowedChars)));
+                    QStringLiteral("%1\n%2\n%3\n").arg(
+                        notificationAreaMessageBox->text(), 
+                        tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), 
+                        allowedChars));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
                 validName = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2309,8 +2309,9 @@ bool dlgConnectionProfiles::validateProfile()
             if (!allowedChars.contains(name.at(i))) {
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
-                        QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                        QStringLiteral("%1\n%2\n").arg(tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), allowedChars)));
+                        QStringLiteral("%1\n%2").arg(
+                            notificationAreaMessageBox->text(), 
+                            QStringLiteral("%1\n%2\n").arg(tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), allowedChars)));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
                 validName = false;
@@ -2322,8 +2323,10 @@ bool dlgConnectionProfiles::validateProfile()
         // see if there is an edit that already uses a similar name
         if (pItem->text() != name && mProfileList.contains(name)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                                                tr("This profile name is already in use.")));
+            notificationAreaMessageBox->setText(
+                QStringLiteral("%1\n%2").arg(
+                    notificationAreaMessageBox->text(), 
+                    tr("This profile name is already in use.")));
             validName = false;
             valid = false;
         }
@@ -2334,8 +2337,10 @@ bool dlgConnectionProfiles::validateProfile()
             val.chop(1);
             port_entry->setText(val);
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                                                tr("You have to enter a number. Other characters are not permitted.")));
+            notificationAreaMessageBox->setText(
+                QStringLiteral("%1\n%2").arg(
+                    notificationAreaMessageBox->text(), 
+                    tr("You have to enter a number. Other characters are not permitted.")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
             valid = false;
@@ -2345,8 +2350,10 @@ bool dlgConnectionProfiles::validateProfile()
         int num = port.trimmed().toInt(&ok);
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                                                QStringLiteral("%1\n\n").arg(tr("Port number must be above zero and below 65535."))));
+            notificationAreaMessageBox->setText(
+                QStringLiteral("%1\n%2").arg(
+                    notificationAreaMessageBox->text(), 
+                    QStringLiteral("%1\n\n").arg(tr("Port number must be above zero and below 65535."))));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
             valid = false;
@@ -2357,8 +2364,10 @@ bool dlgConnectionProfiles::validateProfile()
         port_ssl_tsl->setToolTip(tr("Mudlet is not configured for secure connections."));
         if (port_ssl_tsl->isChecked()) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                                                QStringLiteral("%1\n\n").arg(tr("Mudlet is not configured for secure connections."))));
+            notificationAreaMessageBox->setText(
+                QStringLiteral("%1\n%2").arg(
+                    notificationAreaMessageBox->text(), 
+                    QStringLiteral("%1\n\n").arg(tr("Mudlet is not configured for secure connections."))));
             port_ssl_tsl->setEnabled(true);
             validPort = false;
             valid = false;
@@ -2367,8 +2376,10 @@ bool dlgConnectionProfiles::validateProfile()
         if (!QSslSocket::supportsSsl()) {
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
-                notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(),
-                                                    QStringLiteral("%1\n\n").arg(tr("Mudlet can not load support for secure connections."))));
+                notificationAreaMessageBox->setText(
+                    QStringLiteral("%1\n%2").arg(
+                        notificationAreaMessageBox->text(),
+                        QStringLiteral("%1\n\n").arg(tr("Mudlet can not load support for secure connections."))));
                 validPort = false;
                 valid = false;
             }
@@ -2382,8 +2393,10 @@ bool dlgConnectionProfiles::validateProfile()
         check.setHost(url);
         if (!check.isValid()) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                                                QStringLiteral("%1\n\n%2").arg(tr("Please enter the URL or IP address of the Game server."), check.errorString())));
+            notificationAreaMessageBox->setText(
+                QStringLiteral("%1\n%2").arg(
+                    notificationAreaMessageBox->text(), 
+                    QStringLiteral("%1\n\n%2").arg(tr("Please enter the URL or IP address of the Game server."), check.errorString())));
             host_name_entry->setPalette(mErrorPalette);
             validUrl = false;
             valid = false;
@@ -2392,8 +2405,10 @@ bool dlgConnectionProfiles::validateProfile()
         if (url.indexOf(QRegularExpression(QStringLiteral("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$")), 0) != -1) {
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
-                notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                                                    QStringLiteral("%1\n\n%2").arg(tr("SSL connections require the URL of the Game server.", check.errorString()))));
+                notificationAreaMessageBox->setText(
+                    QStringLiteral("%1\n%2").arg(
+                        notificationAreaMessageBox->text(), 
+                        QStringLiteral("%1\n\n%2").arg(tr("SSL connections require the URL of the Game server.", check.errorString()))));
                 host_name_entry->setPalette(mErrorPalette);
                 validUrl = false;
                 valid = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2310,7 +2310,7 @@ bool dlgConnectionProfiles::validateProfile()
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
                         QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                        QStringLiteral("%1\n\"%2\".\n").arg(tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), allowedChars)));
+                        QStringLiteral("%1\n%2\n").arg(tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), allowedChars)));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
                 validName = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2309,7 +2309,8 @@ bool dlgConnectionProfiles::validateProfile()
             if (!allowedChars.contains(name.at(i))) {
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
-                        QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("The %1 character is not permitted. Use one of the following:\n\"%2\".\n").arg(name.at(i), allowedChars)));
+                        QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                        tr("The %1 character is not permitted. Use one of the following:\n\"%2\".\n").arg(name.at(i), allowedChars)));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
                 validName = false;
@@ -2321,7 +2322,8 @@ bool dlgConnectionProfiles::validateProfile()
         // see if there is an edit that already uses a similar name
         if (pItem->text() != name && mProfileList.contains(name)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("This profile name is already in use.")));
+            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                                                tr("This profile name is already in use.")));
             validName = false;
             valid = false;
         }
@@ -2332,7 +2334,8 @@ bool dlgConnectionProfiles::validateProfile()
             val.chop(1);
             port_entry->setText(val);
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("You have to enter a number. Other characters are not permitted.")));
+            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                                                tr("You have to enter a number. Other characters are not permitted.")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
             valid = false;
@@ -2342,7 +2345,8 @@ bool dlgConnectionProfiles::validateProfile()
         int num = port.trimmed().toInt(&ok);
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("Port number must be above zero and below 65535.\n\n")));
+            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                                                QStringLiteral("%1\n\n").arg(tr("Port number must be above zero and below 65535."))));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
             valid = false;
@@ -2353,7 +2357,8 @@ bool dlgConnectionProfiles::validateProfile()
         port_ssl_tsl->setToolTip(tr("Mudlet is not configured for secure connections."));
         if (port_ssl_tsl->isChecked()) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("Mudlet is not configured for secure connections.\n\n")));
+            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                                                QStringLiteral("%1\n\n").arg(tr("Mudlet is not configured for secure connections."))));
             port_ssl_tsl->setEnabled(true);
             validPort = false;
             valid = false;
@@ -2362,7 +2367,8 @@ bool dlgConnectionProfiles::validateProfile()
         if (!QSslSocket::supportsSsl()) {
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
-                notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("Mudlet can not load support for secure connections.\n\n")));
+                notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(),
+                                                    QStringLiteral("%1\n\n").arg(tr("Mudlet can not load support for secure connections."))));
                 validPort = false;
                 valid = false;
             }
@@ -2376,7 +2382,8 @@ bool dlgConnectionProfiles::validateProfile()
         check.setHost(url);
         if (!check.isValid()) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("Please enter the URL or IP address of the Game server.\n\n%1").arg(check.errorString())));
+            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                                                QStringLiteral("%1\n\n%2").arg(tr("Please enter the URL or IP address of the Game server."), check.errorString())));
             host_name_entry->setPalette(mErrorPalette);
             validUrl = false;
             valid = false;
@@ -2385,7 +2392,8 @@ bool dlgConnectionProfiles::validateProfile()
         if (url.indexOf(QRegularExpression(QStringLiteral("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$")), 0) != -1) {
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
-                notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), tr("SSL connections require the URL of the Game server.\n\n%1").arg(check.errorString())));
+                notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                                                    QStringLiteral("%1\n\n%2").arg(tr("SSL connections require the URL of the Game server.", check.errorString()))));
                 host_name_entry->setPalette(mErrorPalette);
                 validUrl = false;
                 valid = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2309,7 +2309,7 @@ bool dlgConnectionProfiles::validateProfile()
             if (!allowedChars.contains(name.at(i))) {
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
-                        QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                        QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                         tr("The %1 character is not permitted. Use one of the following:\n\"%2\".\n").arg(name.at(i), allowedChars)));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
@@ -2322,7 +2322,7 @@ bool dlgConnectionProfiles::validateProfile()
         // see if there is an edit that already uses a similar name
         if (pItem->text() != name && mProfileList.contains(name)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                                                 tr("This profile name is already in use.")));
             validName = false;
             valid = false;
@@ -2334,7 +2334,7 @@ bool dlgConnectionProfiles::validateProfile()
             val.chop(1);
             port_entry->setText(val);
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                                                 tr("You have to enter a number. Other characters are not permitted.")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
@@ -2345,7 +2345,7 @@ bool dlgConnectionProfiles::validateProfile()
         int num = port.trimmed().toInt(&ok);
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                                                 QStringLiteral("%1\n\n").arg(tr("Port number must be above zero and below 65535."))));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
@@ -2357,7 +2357,7 @@ bool dlgConnectionProfiles::validateProfile()
         port_ssl_tsl->setToolTip(tr("Mudlet is not configured for secure connections."));
         if (port_ssl_tsl->isChecked()) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                                                 QStringLiteral("%1\n\n").arg(tr("Mudlet is not configured for secure connections."))));
             port_ssl_tsl->setEnabled(true);
             validPort = false;
@@ -2367,7 +2367,7 @@ bool dlgConnectionProfiles::validateProfile()
         if (!QSslSocket::supportsSsl()) {
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
-                notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(),
+                notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(),
                                                     QStringLiteral("%1\n\n").arg(tr("Mudlet can not load support for secure connections."))));
                 validPort = false;
                 valid = false;
@@ -2382,7 +2382,7 @@ bool dlgConnectionProfiles::validateProfile()
         check.setHost(url);
         if (!check.isValid()) {
             notificationAreaIconLabelError->show();
-            notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+            notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                                                 QStringLiteral("%1\n\n%2").arg(tr("Please enter the URL or IP address of the Game server."), check.errorString())));
             host_name_entry->setPalette(mErrorPalette);
             validUrl = false;
@@ -2392,7 +2392,7 @@ bool dlgConnectionProfiles::validateProfile()
         if (url.indexOf(QRegularExpression(QStringLiteral("^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$")), 0) != -1) {
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
-                notificationAreaMessageBox->setText(QString("%1\n%2").arg(notificationAreaMessageBox->text(), 
+                notificationAreaMessageBox->setText(QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
                                                     QStringLiteral("%1\n\n%2").arg(tr("SSL connections require the URL of the Game server.", check.errorString()))));
                 host_name_entry->setPalette(mErrorPalette);
                 validUrl = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2310,7 +2310,7 @@ bool dlgConnectionProfiles::validateProfile()
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
                         QStringLiteral("%1\n%2").arg(notificationAreaMessageBox->text(), 
-                        tr("The %1 character is not permitted. Use one of the following:\n\"%2\".\n").arg(name.at(i), allowedChars)));
+                        QStringLiteral("%1\n\"%2\".\n").arg(tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), allowedChars)));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
                 validName = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2310,8 +2310,8 @@ bool dlgConnectionProfiles::validateProfile()
                 notificationAreaIconLabelWarning->show();
                 notificationAreaMessageBox->setText(
                     QStringLiteral("%1\n%2\n%3\n").arg(
-                        notificationAreaMessageBox->text(), 
-                        tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)), 
+                        notificationAreaMessageBox->text(),
+                        tr("The %1 character is not permitted. Use one of the following:").arg(name.at(i)),
                         allowedChars));
                 name.replace(name.at(i--), QString());
                 profile_name_entry->setText(name);
@@ -2326,7 +2326,7 @@ bool dlgConnectionProfiles::validateProfile()
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
                 QStringLiteral("%1\n%2").arg(
-                    notificationAreaMessageBox->text(), 
+                    notificationAreaMessageBox->text(),
                     tr("This profile name is already in use.")));
             validName = false;
             valid = false;
@@ -2340,7 +2340,7 @@ bool dlgConnectionProfiles::validateProfile()
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
                 QStringLiteral("%1\n%2").arg(
-                    notificationAreaMessageBox->text(), 
+                    notificationAreaMessageBox->text(),
                     tr("You have to enter a number. Other characters are not permitted.")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
@@ -2353,7 +2353,7 @@ bool dlgConnectionProfiles::validateProfile()
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
                 QStringLiteral("%1\n%2\n\n").arg(
-                    notificationAreaMessageBox->text(), 
+                    notificationAreaMessageBox->text(),
                     tr("Port number must be above zero and below 65535.")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
@@ -2367,7 +2367,7 @@ bool dlgConnectionProfiles::validateProfile()
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
                 QStringLiteral("%1\n%2\n\n").arg(
-                    notificationAreaMessageBox->text(), 
+                    notificationAreaMessageBox->text(),
                     tr("Mudlet is not configured for secure connections.")));
             port_ssl_tsl->setEnabled(true);
             validPort = false;
@@ -2396,8 +2396,8 @@ bool dlgConnectionProfiles::validateProfile()
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
                 QStringLiteral("%1\n%2\n\n%3").arg(
-                    notificationAreaMessageBox->text(), 
-                    tr("Please enter the URL or IP address of the Game server."), 
+                    notificationAreaMessageBox->text(),
+                    tr("Please enter the URL or IP address of the Game server."),
                     check.errorString()));
             host_name_entry->setPalette(mErrorPalette);
             validUrl = false;
@@ -2409,8 +2409,8 @@ bool dlgConnectionProfiles::validateProfile()
                 notificationAreaIconLabelError->show();
                 notificationAreaMessageBox->setText(
                     QStringLiteral("%1\n%2\n\n%3").arg(
-                        notificationAreaMessageBox->text(), 
-                        tr("SSL connections require the URL of the Game server."), 
+                        notificationAreaMessageBox->text(),
+                        tr("SSL connections require the URL of the Game server."),
                         check.errorString()));
                 host_name_entry->setPalette(mErrorPalette);
                 validUrl = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2410,8 +2410,8 @@ bool dlgConnectionProfiles::validateProfile()
                 notificationAreaMessageBox->setText(
                     QStringLiteral("%1\n%2\n\n%3").arg(
                         notificationAreaMessageBox->text(), 
-                        tr("SSL connections require the URL of the Game server.", 
-                        check.errorString())));
+                        tr("SSL connections require the URL of the Game server."), 
+                        check.errorString()));
                 host_name_entry->setPalette(mErrorPalette);
                 validUrl = false;
                 valid = false;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2352,9 +2352,9 @@ bool dlgConnectionProfiles::validateProfile()
         if (!port.isEmpty() && (num > 65536 && ok)) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
-                QStringLiteral("%1\n%2").arg(
+                QStringLiteral("%1\n%2\n\n").arg(
                     notificationAreaMessageBox->text(), 
-                    QStringLiteral("%1\n\n").arg(tr("Port number must be above zero and below 65535."))));
+                    tr("Port number must be above zero and below 65535.")));
             port_entry->setPalette(mErrorPalette);
             validPort = false;
             valid = false;
@@ -2366,9 +2366,9 @@ bool dlgConnectionProfiles::validateProfile()
         if (port_ssl_tsl->isChecked()) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
-                QStringLiteral("%1\n%2").arg(
+                QStringLiteral("%1\n%2\n\n").arg(
                     notificationAreaMessageBox->text(), 
-                    QStringLiteral("%1\n\n").arg(tr("Mudlet is not configured for secure connections."))));
+                    tr("Mudlet is not configured for secure connections.")));
             port_ssl_tsl->setEnabled(true);
             validPort = false;
             valid = false;
@@ -2378,9 +2378,9 @@ bool dlgConnectionProfiles::validateProfile()
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
                 notificationAreaMessageBox->setText(
-                    QStringLiteral("%1\n%2").arg(
+                    QStringLiteral("%1\n%2\n\n").arg(
                         notificationAreaMessageBox->text(),
-                        QStringLiteral("%1\n\n").arg(tr("Mudlet can not load support for secure connections."))));
+                        tr("Mudlet can not load support for secure connections.")));
                 validPort = false;
                 valid = false;
             }
@@ -2395,9 +2395,10 @@ bool dlgConnectionProfiles::validateProfile()
         if (!check.isValid()) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
-                QStringLiteral("%1\n%2").arg(
+                QStringLiteral("%1\n%2\n\n%3").arg(
                     notificationAreaMessageBox->text(), 
-                    QStringLiteral("%1\n\n%2").arg(tr("Please enter the URL or IP address of the Game server."), check.errorString())));
+                    tr("Please enter the URL or IP address of the Game server."), 
+                    check.errorString()));
             host_name_entry->setPalette(mErrorPalette);
             validUrl = false;
             valid = false;
@@ -2407,9 +2408,10 @@ bool dlgConnectionProfiles::validateProfile()
             if (port_ssl_tsl->isChecked()) {
                 notificationAreaIconLabelError->show();
                 notificationAreaMessageBox->setText(
-                    QStringLiteral("%1\n%2").arg(
+                    QStringLiteral("%1\n%2\n\n%3").arg(
                         notificationAreaMessageBox->text(), 
-                        QStringLiteral("%1\n\n%2").arg(tr("SSL connections require the URL of the Game server.", check.errorString()))));
+                        tr("SSL connections require the URL of the Game server.", 
+                        check.errorString())));
                 host_name_entry->setPalette(mErrorPalette);
                 validUrl = false;
                 valid = false;


### PR DESCRIPTION
### Brief overview of PR changes/additions
Refactored some code, removed whitespace from texts for translation.

#### Motivation for adding to Mudlet
- Actually identical text was not recognized as such, because one had double line breaks at the end.
- Translators don't need to worry matching a number of empty lines at the end of a translated text.

#### Other info (issues closed, discussion etc)
- Double string content reported in Crowdin

- [ ] Compare 2-3 dozen more occurences of said worry by searching for `\n</source>` in [mudlet.ts](https://github.com/Mudlet/Mudlet/tree/development/translations)