### PR TITLE
Create whitespace-linter action

### DIFF
--- a/.github/workflows/whitespace-linter
+++ b/.github/workflows/whitespace-linter
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Whitespace linter
-      uses: hexrabbit/test-action@v0.0.1
+      uses: hexrabbit/whitespace-lint@v0.0.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/whitespace-linter
+++ b/.github/workflows/whitespace-linter
@@ -1,0 +1,16 @@
+name: Whitespace linter
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  whitespace_lint:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '/wslint')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Whitespace linter
+      uses: hexrabbit/test-action@v0.0.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Use it by typing `/wslint` in a PR. For example after we merge this, typing that in https://github.com/Mudlet/Mudlet/pull/3458 would fix all the whitespace issues.
#### Motivation for adding to Mudlet
Easy trailing whitespace fixing.
#### Other info (issues closed, discussion etc)
Why not just disable the check? It has a good reason behind it:

> Adding trailing whitespace can cause extra work for others editing the same file, when they merge, as can removing existing trailing whitespace. So: Don't introduce trailing whitespace. Remove it if you're already changing that line, or do it in a separate clean-up operation (preferably when no-one else is working on the file).