### PR TITLE
another fix for macosx flickering

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -905,7 +905,7 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
             mpConsole->printCommand(cmd);
         }
         //If 3D Mapper is active mpConsole->update(); seems to be superfluous and even cause problems in MacOS
-        if (!mpMap->mpMapper->glWidget) {
+        if (!mpMap->mpMapper || !mpMap->mpMapper->glWidget) {
             mpConsole->update();
         }
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -897,10 +897,6 @@ QPair<QString, QString> Host::getSearchEngine()
 // cTelnet::sendData(...) call:
 void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 {
-#if defined(Q_OS_MACOS)
-    // Fix for MacOS flickering caused by upgrade to QOpenGLWidget
-    mpConsole->finalize();
-#endif
     if (wantPrint && (!mIsRemoteEchoingActive) && mPrintCommand) {
         mInsertedMissingLF = true;
         if (!cmd.isEmpty() || !mUSE_IRE_DRIVER_BUGFIX || mUSE_FORCE_LF_AFTER_PROMPT) {
@@ -908,7 +904,10 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
             // this is important to get the cursor position right
             mpConsole->printCommand(cmd);
         }
-        mpConsole->update();
+        //If 3D Mapper is active mpConsole->update(); seems to be superfluous and even cause problems in MacOS
+        if (!mpMap->mpMapper->glWidget) {
+            mpConsole->update();
+        }
     }
     QStringList commandList;
     if (!mCommandSeparator.isEmpty()) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -227,16 +227,16 @@ void dlgMapper::show2dView()
         connect(zRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setZRotation);
     }
 
-    if (glWidget) {
-        mp2dMap->setVisible(!mp2dMap->isVisible());
-        glWidget->setVisible(!glWidget->isVisible());
-        if (glWidget->isVisible()) {
-            d3buttons->setVisible(true);
-        } else {
-            // workaround for buttons reloading oddly
-            QTimer::singleShot(100, [this]() {d3buttons->setVisible(false);});
-        }
+
+    mp2dMap->setVisible(!mp2dMap->isVisible());
+    glWidget->setVisible(!glWidget->isVisible());
+    if (glWidget->isVisible()) {
+        d3buttons->setVisible(true);
+    } else {
+        // workaround for buttons reloading oddly
+        QTimer::singleShot(100, [this]() { d3buttons->setVisible(false); });
     }
+
 #else
     mp2dMap->setVisible(true);
     d3buttons->setVisible(false);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2462,8 +2462,6 @@ std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area,
             return {false, QStringLiteral(R"("docking option "%1" not available. available docking options are "t" top, "b" bottom, "r" right, "l" left and "f" floating")").arg(area)};
         }
     }
-
-    return {false, QString()};
 }
 
 std::pair<bool, QString> mudlet::closeMapWidget(Host* pHost)


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Should fix the problem for macos flickering.
If Mudlet used ASUI ( A GUI for Asteria) it was still flickering.
I think I got the cause which was mpConsole->update() in Host::send
Which seems to have no effect other then causing problems in macos when the 3d mapper is active.

#### Motivation for adding to Mudlet
https://github.com/Mudlet/Mudlet/issues/3433
#### Other info (issues closed, discussion etc)
Changed btw the code for coverty. ( I hope it stops complaining now ;))
