### PR TITLE
Add action to automatically update 3rdparty dependencies to latest versions

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -1,8 +1,8 @@
 name: Update 3rdparty sources
 on:
   push:
-#     branches:
-#       - 'release-**'
+    branches:
+      - 'release-**'
 
   schedule:
     - cron:  '0 0 * * fri'

--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -1,0 +1,254 @@
+name: Update 3rdparty sources
+on:
+  push:
+#     branches:
+#       - 'release-**'
+
+  schedule:
+    - cron:  '0 0 * * fri'
+
+jobs:
+  update-iremapper-source:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: development
+        
+      - name: Download latest IRE mapper
+        uses: carlosperate/download-file-action@v1.0.0
+        with:
+          file-url: https://raw.githubusercontent.com/IRE-Mudlet-Mapping/ire-mapping-script/gh-pages/downloads/mudlet-mapper.xml
+          file-name: mudlet-mapper.xml
+          location: src/
+
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 src/mudlet-mapper.xml | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+          
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Update bundled IRE mapper script"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update the IRE mapper script to the latest version.
+            #### Motivation for adding to Mudlet
+            So people don't get attacked with a "your mapping script is out of date!" notification as soon as they create a profile for a new IRE game.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-ire-mapping-script-${{ github.sha }}
+          path: src/
+          commit-message: (autocommit) Updated IRE mapping script to latest upstream
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-edbee-fork:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@master
+        with:
+          ref: development
+          submodules: true
+          fetch-depth: 0
+
+      - name: update submodule to latest
+        run: git submodule update --remote 3rdparty/edbee-lib/
+        
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/edbee-lib/ | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+          
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Update edbee to latest"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update edbee to its latest version in our fork.
+            #### Motivation for adding to Mudlet
+            Get new features, bugfixes, improvements! Stay modern.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-edbee-lib-${{ github.sha }}
+          path: 3rdparty/edbee-lib
+          commit-message: (autocommit) Updated edbee-lib submodule to latest in our fork
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-sparkle-glue-fork:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@master
+        with:
+          ref: development
+          submodules: true
+          fetch-depth: 0
+
+      - name: update submodule to latest
+        run: git submodule update --remote 3rdparty/sparkle-glue/
+        
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/sparkle-glue | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+          
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Update sparkle-glue to latest"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update sparkle-glue to its latest in our fork.
+            #### Motivation for adding to Mudlet
+            Get new features, bugfixes, improvements! Stay modern.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-sparkle-glue-${{ github.sha }}
+          path: 3rdparty/sparkle-glue
+          commit-message: (autocommit) Updated sparkle-glue submodule to latest in our fork
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-dblsqd-source:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@master
+        with:
+          ref: development
+          submodules: true
+          fetch-depth: 0
+
+      - name: update submodule to latest
+        run: git submodule update --remote 3rdparty/dblsqd/
+        
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/dblsqd/ | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+          
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Update dblsqd to latest"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update dblsqd to its latest version in upstream.
+            #### Motivation for adding to Mudlet
+            Get new features, bugfixes, improvements! Stay modern.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-dblsqd-${{ github.sha }}
+          path: 3rdparty/dblsqd
+          commit-message: (autocommit) Updated dblsqd submodule to latest upstream
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-qtkeychain-fork:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@master
+        with:
+          ref: development
+          submodules: true
+          fetch-depth: 0
+
+      - name: update submodule to latest
+        run: git submodule update --remote 3rdparty/qtkeychain/
+        
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/qtkeychain/ | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+          
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Update qtkeychain to latest"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update qtkeychain to its latest version in our fork.
+            #### Motivation for adding to Mudlet
+            Get new features, bugfixes, improvements! Stay modern.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-qtkeychain-${{ github.sha }}
+          path: 3rdparty/qtkeychain
+          commit-message: (autocommit) Updated qtkeychain submodule to latest in our fork
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-lcf-source-51:
+    runs-on: ubuntu-latest
+    steps:      
+      - uses: actions/checkout@master
+        with:
+          ref: development
+          submodules: true
+          fetch-depth: 0
+
+      - name: update submodule to latest in 5.1 branch
+        run: |
+          cd 3rdparty/lcf/
+          git checkout 5.1
+          git pull
+        
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/lcf/ | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+          
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "Update Lua code formatter to latest"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update the built-in Lua code formatter to its latest version in upstream `5.1` branch.
+            #### Motivation for adding to Mudlet
+            Get new features, bugfixes, improvements! Stay modern.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-lcf-${{ github.sha }}
+          path: 3rdparty/lcf
+          commit-message: (autocommit) Updated lcf submodule to latest upstream 5.1 branch
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"

--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           ref: development
-        
+
       - name: Download latest IRE mapper
         uses: carlosperate/download-file-action@v1.0.0
         with:
@@ -30,14 +30,14 @@ jobs:
           lines_changed=$(git diff --patch --unified=0 src/mudlet-mapper.xml | wc --lines)
           echo "$lines_changed lines changed."
           echo ::set-output name=lines_changed::$lines_changed
-          
+
       - name: send in a pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "Update bundled IRE mapper script"
+          title: "Update bundled IRE mapper script to latest upstream"
           body: |
             #### Brief overview of PR changes/additions
             :crown: An automated PR to update the IRE mapper script to the latest version.
@@ -52,7 +52,7 @@ jobs:
 
   update-edbee-fork:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@master
         with:
           ref: development
@@ -61,7 +61,7 @@ jobs:
 
       - name: update submodule to latest
         run: git submodule update --remote 3rdparty/edbee-lib/
-        
+
       # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
       # to see in github UI's if PR creation was skipped when we have an explicit pre-check
       - name: check if we have any updates
@@ -70,14 +70,14 @@ jobs:
           lines_changed=$(git diff --patch --unified=0 3rdparty/edbee-lib/ | wc --lines)
           echo "$lines_changed lines changed."
           echo ::set-output name=lines_changed::$lines_changed
-          
+
       - name: send in a pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "Update edbee to latest"
+          title: "Update edbee to latest in our fork"
           body: |
             #### Brief overview of PR changes/additions
             :crown: An automated PR to update edbee to its latest version in our fork.
@@ -92,7 +92,7 @@ jobs:
 
   update-sparkle-glue-fork:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@master
         with:
           ref: development
@@ -101,7 +101,7 @@ jobs:
 
       - name: update submodule to latest
         run: git submodule update --remote 3rdparty/sparkle-glue/
-        
+
       # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
       # to see in github UI's if PR creation was skipped when we have an explicit pre-check
       - name: check if we have any updates
@@ -110,14 +110,14 @@ jobs:
           lines_changed=$(git diff --patch --unified=0 3rdparty/sparkle-glue | wc --lines)
           echo "$lines_changed lines changed."
           echo ::set-output name=lines_changed::$lines_changed
-          
+
       - name: send in a pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "Update sparkle-glue to latest"
+          title: "Update sparkle-glue to latest in our fork"
           body: |
             #### Brief overview of PR changes/additions
             :crown: An automated PR to update sparkle-glue to its latest in our fork.
@@ -132,7 +132,7 @@ jobs:
 
   update-dblsqd-source:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@master
         with:
           ref: development
@@ -141,7 +141,7 @@ jobs:
 
       - name: update submodule to latest
         run: git submodule update --remote 3rdparty/dblsqd/
-        
+
       # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
       # to see in github UI's if PR creation was skipped when we have an explicit pre-check
       - name: check if we have any updates
@@ -150,14 +150,14 @@ jobs:
           lines_changed=$(git diff --patch --unified=0 3rdparty/dblsqd/ | wc --lines)
           echo "$lines_changed lines changed."
           echo ::set-output name=lines_changed::$lines_changed
-          
+
       - name: send in a pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "Update dblsqd to latest"
+          title: "Update dblsqd to latest upstream"
           body: |
             #### Brief overview of PR changes/additions
             :crown: An automated PR to update dblsqd to its latest version in upstream.
@@ -172,7 +172,7 @@ jobs:
 
   update-qtkeychain-fork:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@master
         with:
           ref: development
@@ -181,7 +181,7 @@ jobs:
 
       - name: update submodule to latest
         run: git submodule update --remote 3rdparty/qtkeychain/
-        
+
       # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
       # to see in github UI's if PR creation was skipped when we have an explicit pre-check
       - name: check if we have any updates
@@ -190,14 +190,14 @@ jobs:
           lines_changed=$(git diff --patch --unified=0 3rdparty/qtkeychain/ | wc --lines)
           echo "$lines_changed lines changed."
           echo ::set-output name=lines_changed::$lines_changed
-          
+
       - name: send in a pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "Update qtkeychain to latest"
+          title: "Update qtkeychain to latest in our fork"
           body: |
             #### Brief overview of PR changes/additions
             :crown: An automated PR to update qtkeychain to its latest version in our fork.
@@ -212,7 +212,7 @@ jobs:
 
   update-lcf-source-51:
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - uses: actions/checkout@master
         with:
           ref: development
@@ -224,7 +224,7 @@ jobs:
           cd 3rdparty/lcf/
           git checkout 5.1
           git pull
-        
+
       # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
       # to see in github UI's if PR creation was skipped when we have an explicit pre-check
       - name: check if we have any updates
@@ -233,14 +233,14 @@ jobs:
           lines_changed=$(git diff --patch --unified=0 3rdparty/lcf/ | wc --lines)
           echo "$lines_changed lines changed."
           echo ::set-output name=lines_changed::$lines_changed
-          
+
       - name: send in a pull request
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          title: "Update Lua code formatter to latest"
+          title: "Update Lua code formatter to latest upstream 5.1 branch"
           body: |
             #### Brief overview of PR changes/additions
             :crown: An automated PR to update the built-in Lua code formatter to its latest version in upstream `5.1` branch.


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add action to automatically update 3rdparty dependencies to latest versions, to be run both nightly on Friday as well as on any pushes to a release branch.
#### Motivation for adding to Mudlet
Stay up to date better!
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/3402.

One thing I am unsure on - in case of a fork, it'll only update to latest in our fork, not upstream - because we made a fork for a reason. However that action masks the fact that upstream might have some updates and we'll never know about them unless we check.

Pull requests https://github.com/Mudlet/Mudlet/pull/3469, https://github.com/Mudlet/Mudlet/pull/3470, https://github.com/Mudlet/Mudlet/pull/3471, https://github.com/Mudlet/Mudlet/pull/3473, and https://github.com/Mudlet/Mudlet/pull/3472 have been automatically created as a result of this action.