### PR TITLE
BugFix: don't apply profile s. sheet to preferences when no profile loaded

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3437,7 +3437,7 @@ void mudlet::show_options_dialog(QString tab)
     // case {when there is no profile loaded}:
     if (pHost) {
         mpProfilePreferencesDlgMap.value(pHost)->setStyleSheet(pHost->mProfileStyleSheet);
-    }        mpProfilePreferencesDlgMap.value(pHost)->setStyleSheet(pHost->mProfileStyleSheet);
+    }
     mpProfilePreferencesDlgMap.value(pHost)->setTab(tab);
     mpProfilePreferencesDlgMap.value(pHost)->raise();
     mpProfilePreferencesDlgMap.value(pHost)->show();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3431,8 +3431,13 @@ void mudlet::show_options_dialog(QString tab)
         connect(mpActionReconnect.data(), &QAction::triggered, mpProfilePreferencesDlgMap.value(pHost)->need_reconnect_for_specialoption, &QWidget::hide);
         connect(dactionReconnect, &QAction::triggered, mpProfilePreferencesDlgMap.value(pHost)->need_reconnect_for_specialoption, &QWidget::hide);
         mpProfilePreferencesDlgMap.value(pHost)->setAttribute(Qt::WA_DeleteOnClose);
-        mpProfilePreferencesDlgMap.value(pHost)->setStyleSheet(pHost->mProfileStyleSheet);
     }
+
+    // pHost can be a nullptr here so we do not want to dereference it in that
+    // case {when there is no profile loaded}:
+    if (pHost) {
+        mpProfilePreferencesDlgMap.value(pHost)->setStyleSheet(pHost->mProfileStyleSheet);
+    }        mpProfilePreferencesDlgMap.value(pHost)->setStyleSheet(pHost->mProfileStyleSheet);
     mpProfilePreferencesDlgMap.value(pHost)->setTab(tab);
     mpProfilePreferencesDlgMap.value(pHost)->raise();
     mpProfilePreferencesDlgMap.value(pHost)->show();


### PR DESCRIPTION
This will close Issue #3465 - which was causing a crash-to-desktop on selecting the preferences when no profile was active.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>