### PR TITLE
Set limits on a single echo and maximum buffer size

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -779,20 +779,29 @@ TBuffer::TBuffer(Host* pH)
 #endif
 }
 
+// user-defined literal to represent megabytes
 auto operator""_MB(unsigned long long const x)
         -> long
 { return 1024L*1024L*x; }
 
-void TBuffer::setBufferSize(int s, int batch)
+void TBuffer::setBufferSize(int requestedLinesLimit, int batch)
 {
-    if (s < 100) {
-        s = 100;
+    if (requestedLinesLimit < 100) {
+        requestedLinesLimit = 100;
     }
-    if (batch >= s) {
-        batch = s / 10;
+    if (batch >= requestedLinesLimit) {
+        batch = requestedLinesLimit / 10;
     }
     // clip the maximum to something reasonable, else users will abuse this, and then complain
-    mLinesLimit = std::min(s, getMaxBufferSize());
+    auto max = getMaxBufferSize();
+    if (requestedLinesLimit > max) {
+        qWarning().nospace() << "setBufferSize(): " << requestedLinesLimit <<
+                "lines for buffer requested but your computer can only handle " << max << ", clipping it";
+        mLinesLimit = max;
+    } else {
+        mLinesLimit = requestedLinesLimit;
+    }
+
     mBatchDeleteSize = batch;
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -811,9 +811,12 @@ int TBuffer::getMaxBufferSize()
     const int64_t physicalMemoryTotal = mudlet::self()->getPhysicalMemoryTotal();
     // Mudlet is 32bit mainly on Windows, see where the practical limit for a process 2GB:
     // https://docs.microsoft.com/en-us/windows/win32/memory/memory-limits-for-windows-releases#memory-and-address-space-limits
-    // set to 80% of what is available to us, ignoring that swap can exist
+    // 64bit: set to 80% of what is available to us, swap not included
     const int64_t maxProcessMemoryBytes = (QSysInfo::WordSize == 32) ? 1600_MB : (physicalMemoryTotal * 0.80);
-    const auto maxLines = (maxProcessMemoryBytes / TCHAR_IN_BYTES) / mpHost->mWrapAt;
+    auto maxLines = (maxProcessMemoryBytes / TCHAR_IN_BYTES) / mpHost->mWrapAt;
+    // now we've calculated how many lines can we fit in 80% of memory, ignoring memory use for other things like triggers/aliases, Lua scripts, etc
+    // so shave that down by 20%
+    maxLines = (maxLines / 100) * 80;
 
     return maxLines;
 }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -802,7 +802,7 @@ int TBuffer::getMaxBufferSize()
     const int64_t physicalMemoryTotal = mudlet::self()->getPhysicalMemoryTotal();
     // Mudlet is 32bit mainly on Windows, see where the practical limit for a process 2GB:
     // https://docs.microsoft.com/en-us/windows/win32/memory/memory-limits-for-windows-releases#memory-and-address-space-limits
-    // otherwise set to 80% of physical ram, ignoring that swap can exist
+    // set to 80% of what is available to us, ignoring that swap can exist
     const int64_t maxProcessMemoryBytes = (QSysInfo::WordSize == 32) ? 1600_MB : (physicalMemoryTotal * 0.80);
     const auto maxLines = (maxProcessMemoryBytes / TCHAR_IN_BYTES) / mpHost->mWrapAt;
 

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -189,7 +189,7 @@ public:
     TBuffer copy(QPoint&, QPoint&);
     TBuffer cut(QPoint&, QPoint&);
     void paste(QPoint&, TBuffer);
-    void setBufferSize(int s, int batch);
+    void setBufferSize(int requestedLinesLimit, int batch);
     int getMaxBufferSize();
     static const QList<QString> getComputerEncodingNames() { return csmEncodingTable.keys(); }
     static const QList<QString> getFriendlyEncodingNames();

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -141,6 +141,13 @@ class TBuffer
 
     static const QMap<QString, QVector<QString>> mSupportedMxpElements;
 
+    // TChar is 44bytes on a 64bit system and in testing ends up taking ~60 bytes per character
+    // with all other resources included
+    inline static const int TCHAR_IN_BYTES = 60;
+
+    // arbitrary limit on how many characters a single echo can accept. On an average screen,
+    // a line is usually set to wrap at 200 max
+    inline static const int MAX_CHARACTERS_PER_ECHO = 10000;
 
 public:
     TBuffer(Host* pH);
@@ -174,7 +181,7 @@ public:
     void translateToPlainText(std::string& s, bool isFromServer=false);
     void append(const QString& chunk, int sub_start, int sub_end, const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     // Only the bits within TChar::TestMask are considered for formatting:
-    void append(const QString& chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
+    void append(const QString &chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
     void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     void setWrapAt(int i) { mWrapAt = i; }
     void setWrapIndent(int i) { mWrapIndent = i; }
@@ -183,6 +190,7 @@ public:
     TBuffer cut(QPoint&, QPoint&);
     void paste(QPoint&, TBuffer);
     void setBufferSize(int s, int batch);
+    int getMaxBufferSize();
     static const QList<QString> getComputerEncodingNames() { return csmEncodingTable.keys(); }
     static const QList<QString> getFriendlyEncodingNames();
     static const QString& getComputerEncoding(const QString& encoding);

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -141,9 +141,7 @@ class TBuffer
 
     static const QMap<QString, QVector<QString>> mSupportedMxpElements;
 
-    // TChar is 44bytes on a 64bit system and in testing ends up taking ~60 bytes per character
-    // with all other resources included
-    inline static const int TCHAR_IN_BYTES = 60;
+    inline static const int TCHAR_IN_BYTES = sizeof(TChar);
 
     // arbitrary limit on how many characters a single echo can accept. On an average screen,
     // a line is usually set to wrap at 200 max
@@ -181,7 +179,7 @@ public:
     void translateToPlainText(std::string& s, bool isFromServer=false);
     void append(const QString& chunk, int sub_start, int sub_end, const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     // Only the bits within TChar::TestMask are considered for formatting:
-    void append(const QString &chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
+    void append(const QString& chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
     void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     void setWrapAt(int i) { mWrapAt = i; }
     void setWrapIndent(int i) { mWrapIndent = i; }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3881,7 +3881,7 @@ int64_t mudlet::getPhysicalMemoryTotal()
     int64_t memInfo{0};
     auto len = sizeof(memInfo);
 
-    if(sysctl(mib, 2, &memInfo, &len, nullptr, 0) == 0)
+    if (sysctl(mib, 2, &memInfo, &len, nullptr, 0) == 0)
     {
         return memInfo;
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3858,6 +3858,40 @@ void mudlet::startAutoLogin()
     }
 }
 
+// credit to https://github.com/DigitalInBlue/Celero/blob/master/src/Memory.cpp
+int64_t mudlet::getPhysicalMemoryTotal()
+{
+#ifdef WIN32
+    MEMORYSTATUSEX memInfo;
+    memInfo.dwLength = sizeof(MEMORYSTATUSEX);
+    GlobalMemoryStatusEx(&memInfo);
+    return static_cast<int64_t>(memInfo.ullTotalPhys);
+#elif defined(__unix__) || defined(__unix) || defined(unix)
+    // Prefer sysctl() over sysconf() except sysctl() HW_REALMEM and HW_PHYSMEM
+    // return static_cast<int64_t>(sysconf(_SC_PHYS_PAGES)) * static_cast<int64_t>(sysconf(_SC_PAGE_SIZE));
+    struct sysinfo memInfo;
+    sysinfo(&memInfo);
+    int64_t total = memInfo.totalram;
+    return total * static_cast<int64_t>(memInfo.mem_unit);
+#elif defined(__APPLE__)
+    int mib[2];
+    mib[0] = CTL_HW;
+    mib[1] = HW_MEMSIZE;
+
+    int64_t memInfo{0};
+    auto len = sizeof(memInfo);
+
+    if(sysctl(mib, 2, &memInfo, &len, nullptr, 0) == 0)
+    {
+        return memInfo;
+    }
+
+    return -1;
+#else
+    return -1;
+#endif
+}
+
 // Ensure the debug area is attached to at least one Host
 void mudlet::attachDebugArea(const QString& hostname)
 {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -66,6 +66,27 @@
 #include <hunspell/hunspell.hxx>
 #include <hunspell/hunspell.h>
 
+// for system physical memory info
+#ifdef WIN32
+#include <Windows.h>
+
+#include <Psapi.h>
+#elif defined(__APPLE__)
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <array>
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/sysinfo.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
 
 class QAction;
 class QCloseEvent;
@@ -426,6 +447,7 @@ public:
     void scanForQtTranslations(const QString&);
     void layoutModules();
     void startAutoLogin();
+    int64_t getPhysicalMemoryTotal();
 
 
 #if defined(INCLUDE_UPDATER)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -69,7 +69,6 @@
 // for system physical memory info
 #ifdef WIN32
 #include <Windows.h>
-
 #include <Psapi.h>
 #elif defined(__APPLE__)
 #include <sys/param.h>
@@ -78,12 +77,8 @@
 #include <unistd.h>
 #include <array>
 #else
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/resource.h>
 #include <sys/sysinfo.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
This addresses a couple of issues at once because the conversation around this is floating from one subject to another:
- ability to echo abnormally large strings
- ability to set the max to something above the 32bit process memory limit or in case of 64bit, more than what your OS is capable of handling


#### Motivation for adding to Mudlet
Less possibilities for people shooting themselves in the foot.
#### Other info (issues closed, discussion etc)
Max buffer size in action:

![Heaptrack - heaptrack mudlet 18285 gz — Heaptrack GUI_204](https://user-images.githubusercontent.com/110988/76950534-71ea6e80-690a-11ea-8fdb-499413b35023.png)

As seen here, way more than the maximum was allocated:
![Selection_205](https://user-images.githubusercontent.com/110988/76950619-96464b00-690a-11ea-8e83-cf6311fb7aaf.png)
