### PR TITLE
set new window parent

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4338,7 +4338,8 @@ int TLuaInterpreter::setWindow(lua_State* L)
     QString windowname;
     QString name;
     int n = lua_gettop(L);
-    int x=0, y=0;
+    int x = 0, y = 0;
+    bool show = true;
 
     if (lua_type(L, 1) != LUA_TSTRING) {
         lua_pushfstring(L, "setWindow: bad argument #1 type (parent windowname as string expected, got %s!)", luaL_typename(L, 1));
@@ -4353,33 +4354,28 @@ int TLuaInterpreter::setWindow(lua_State* L)
     } else {
         name = QString::fromUtf8(lua_tostring(L, 2));
     }
+    if (n > 2) {
+        if (!lua_isnumber(L, 3)) {
+            lua_pushfstring(L, "setWindow: bad argument #3 type (x-coordinate as number expected, got %s!)", luaL_typename(L, 3));
+            return lua_error(L);
 
-    if (!lua_isnumber(L, 3)) {
-        lua_pushfstring(L, "setWindow: bad argument #3 type (x-coordinate as number expected, got %s!)", luaL_typename(L, 3));
-        return lua_error(L);
-
-    } else {
-        x = lua_tonumber(L, 3);
-    }
-    if (!lua_isnumber(L, 4)) {
-        lua_pushfstring(L, "setWindow: bad argument #4 type (y-coordinate as number expected, got %s!)", luaL_typename(L, 4));
-        return lua_error(L);
-    } else {
-        y = lua_tonumber(L, 4);
-    }
-    bool show = true;
-    if (n > 4) {
-        if ((!lua_isnumber(L, 5)) && (!lua_isboolean(L, 5))) {
-            lua_pushfstring(L, "setWindow: bad argument #5 type (show element as boolean/number (0/1) expected, got %s!)", luaL_typename(L, 5));
+        } else {
+            x = lua_tonumber(L, 3);
+        }
+        if (!lua_isnumber(L, 4)) {
+            lua_pushfstring(L, "setWindow: bad argument #4 type (y-coordinate as number expected, got %s!)", luaL_typename(L, 4));
             return lua_error(L);
         } else {
-            if (lua_isboolean(L, 5)) {
-                show = lua_toboolean(L, 5);
-            } else {
-                show = (lua_tointeger(L, 5) != 0);
-            }
+            y = lua_tonumber(L, 4);
+        }
+        if (!lua_isboolean(L, 5)) {
+            lua_pushfstring(L, "setWindow: bad argument #5 type (show element as boolean expected, got %s!)", luaL_typename(L, 5));
+            return lua_error(L);
+        } else {
+            show = lua_toboolean(L, 5);
         }
     }
+
     Host& host = getHostFromLua(L);
     if (auto [success, message] = mudlet::self()->setWindow(&host, windowname, name, x, y, show); !success) {
         lua_pushnil(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4337,7 +4337,8 @@ int TLuaInterpreter::setWindow(lua_State* L)
 {
     QString windowname;
     QString name;
-    int x, y;
+    int n = lua_gettop(L);
+    int x=0, y=0;
 
     if (lua_type(L, 1) != LUA_TSTRING) {
         lua_pushfstring(L, "setWindow: bad argument #1 type (parent windowname as string expected, got %s!)", luaL_typename(L, 1));
@@ -4366,9 +4367,21 @@ int TLuaInterpreter::setWindow(lua_State* L)
     } else {
         y = lua_tonumber(L, 4);
     }
-
+    bool show = true;
+    if (n > 4) {
+        if ((!lua_isnumber(L, 5)) && (!lua_isboolean(L, 5))) {
+            lua_pushfstring(L, "setWindow: bad argument #5 type (show element as boolean/number (0/1) expected, got %s!)", luaL_typename(L, 5));
+            return lua_error(L);
+        } else {
+            if (lua_isboolean(L, 5)) {
+                show = lua_toboolean(L, 5);
+            } else {
+                show = (lua_tointeger(L, 5) != 0);
+            }
+        }
+    }
     Host& host = getHostFromLua(L);
-    if (auto [success, message] = mudlet::self()->setWindow(&host, windowname, name, x, y); !success) {
+    if (auto [success, message] = mudlet::self()->setWindow(&host, windowname, name, x, y, show); !success) {
         lua_pushnil(L);
         lua_pushfstring(L, message.toUtf8().constData());
         return 2;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4332,6 +4332,51 @@ int TLuaInterpreter::moveWindow(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindow
+int TLuaInterpreter::setWindow(lua_State* L)
+{
+    QString windowname;
+    QString name;
+    int x, y;
+
+    if (lua_type(L, 1) != LUA_TSTRING) {
+        lua_pushfstring(L, "setWindow: bad argument #1 type (parent windowname as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    } else {
+        windowname = QString::fromUtf8(lua_tostring(L, 1));
+    }
+
+    if (lua_type(L, 2) != LUA_TSTRING) {
+        lua_pushfstring(L, "setWindow: bad argument #2 type (element name as string expected, got %s!)", luaL_typename(L, 2));
+        return lua_error(L);
+    } else {
+        name = QString::fromUtf8(lua_tostring(L, 2));
+    }
+
+    if (!lua_isnumber(L, 3)) {
+        lua_pushfstring(L, "setWindow: bad argument #3 type (x-coordinate as number expected, got %s!)", luaL_typename(L, 3));
+        return lua_error(L);
+
+    } else {
+        x = lua_tonumber(L, 3);
+    }
+    if (!lua_isnumber(L, 4)) {
+        lua_pushfstring(L, "setWindow: bad argument #4 type (y-coordinate as number expected, got %s!)", luaL_typename(L, 4));
+        return lua_error(L);
+    } else {
+        y = lua_tonumber(L, 4);
+    }
+
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = mudlet::self()->setWindow(&host, windowname, name, x, y); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 int TLuaInterpreter::openMapWidget(lua_State* L)
 {
     int n = lua_gettop(L);
@@ -16141,6 +16186,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setLabelOnLeave", TLuaInterpreter::setLabelOnLeave);
     lua_register(pGlobalLua, "getImageSize", TLuaInterpreter::getImageSize);
     lua_register(pGlobalLua, "moveWindow", TLuaInterpreter::moveWindow);
+    lua_register(pGlobalLua, "setWindow", TLuaInterpreter::setWindow);
     lua_register(pGlobalLua, "openMapWidget", TLuaInterpreter::openMapWidget);
     lua_register(pGlobalLua, "closeMapWidget", TLuaInterpreter::closeMapWidget);
     lua_register(pGlobalLua, "setTextFormat", TLuaInterpreter::setTextFormat);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -335,6 +335,7 @@ public:
     static int deleteLabel(lua_State*);
     static int setLabelToolTip(lua_State*);
     static int moveWindow(lua_State*);
+    static int setWindow(lua_State*);
     static int openMapWidget(lua_State*);
     static int closeMapWidget(lua_State*);
     static int setTextFormat(lua_State*);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -330,9 +330,10 @@ end
 --- @see createGauge
 function setGaugeWindow(windowName, gaugeName, x, y, show)
   windowName = windowName or "main"
+  x = x or 0
+  y = y or 0
   show = show or true
   assert(gaugesTable[gaugeName], "setGaugeWindow: no such gauge exists.")
-  assert(x and y, "setGaugeWindow: need to have both X and Y dimensions.")
   setWindow(windowName, gaugeName .. "_back", x, y, show)
   setWindow(windowName, gaugeName .. "_front", x, y, show)
   setWindow(windowName, gaugeName .. "_text", x, y, show)

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -327,6 +327,19 @@ function showGauge(gaugeName)
   showWindow(gaugeName .. "_text")
 end
 
+--- @see createGauge
+function setGaugeWindow(windowName, gaugeName, x, y, show)
+  windowName = windowName or "main"
+  show = show or true
+  assert(gaugesTable[gaugeName], "setGaugeWindow: no such gauge exists.")
+  assert(x and y, "setGaugeWindow: need to have both X and Y dimensions.")
+  setWindow(windowName, gaugeName .. "_back", x, y, show)
+  setWindow(windowName, gaugeName .. "_front", x, y, show)
+  setWindow(windowName, gaugeName .. "_text", x, y, show)
+  -- save new values in table
+  gaugesTable[gaugeName].x, gaugesTable[gaugeName].y = x, y
+  setGauge(gaugeName, gaugesTable[gaugeName].value, 1)
+end
 
 --- Set the text on a custom gauge.
 ---

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -142,9 +142,9 @@ function Geyser:changeContainer (container)
   windowname = windowname or "main"
 
   self.container:remove(self)
-  if self.windowname ~= container.windowname then
-    setMyWindow(self, container.windowname)
-    setContainerWindow(self, container.windowname)
+  if self.windowname ~= windowname then
+    setMyWindow(self, windowname)
+    setContainerWindow(self, windowname)
   end
   container:add(self)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -85,3 +85,32 @@ function Geyser:remove (window)
   index = table.index_of(self.windows, window.name) or 0
   table.remove(self.windows, index)
 end
+
+--- Removes a window from the parent it is in and put's it in a new one
+-- This is used internally, don't use it. Use changeContainer instead
+-- @param window The new parents windowname 
+local function setContainerWindow(self, windowname)
+  local name
+  self.windowname = windowname
+  windowname = windowname or "main"
+  for k,v in pairs(self.windowList) do
+    name = v.name
+    if v.type == "mapper" then
+      name = v.type
+    end
+    setWindow(windowname, name, 0, 0)
+    v:reposition()
+    setContainerWindow(v, windowname)
+  end
+end
+
+--- Removes a window from the container that it manages
+-- @param container The new container the window will be set in
+function Geyser:changeContainer (container)
+  
+  self.container:remove(self)
+  if self.windowname ~= container.windowname then
+    setContainerWindow(self, container.windowname)
+  end
+  container:add(self)
+end

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -74,9 +74,7 @@ function Geyser:add (window, cons)
   if not self.defer_updates then
     window:reposition()
   end
-  if window.hidden or window.auto_hidden then
-    --do nothing
-  else 
+  if not (window.hidden or window.auto_hidden) then
     window:show()
   end
 end

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -74,7 +74,11 @@ function Geyser:add (window, cons)
   if not self.defer_updates then
     window:reposition()
   end
-  window:show()
+  if window.hidden or window.auto_hidden then
+    --do nothing
+  else 
+    window:show()
+  end
 end
 
 --- Removes a window from the list that it manages

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -87,8 +87,8 @@ function Geyser:remove (window)
 end
 
 
---- Removes a window from the parent it is in and put's it in a new one
--- This is used internally, don't use it. Use changeContainer instead
+--- Removes a window from the parent it is in and puts it in a new one
+-- This is only used internally.
 -- @param window The new parents windowname 
 local function setMyWindow(self, windowname)
   windowname = windowname or "main"
@@ -112,32 +112,41 @@ local function setMyWindow(self, windowname)
   
   -- Prevent hidden children to get visible  
   if self.hidden or self.auto_hidden then
-    setWindow(windowname, name, 0, 0, 0)
+    setWindow(windowname, name, 0, 0, false)
   else 
-    setWindow(windowname, name, 0, 0, 1)
+    setWindow(windowname, name, 0, 0, true)
   end
 end
 
 
---- Removes all containers windows from the parent they are in and put's them in a new one
--- This is used internally, don't use it. Use changeContainer instead
+--- Removes all containers windows from the parent they are in and puts them in a new one
+-- This is only used internally
 -- @param window The new parents windowname 
 local function setContainerWindow(self, windowname)
   self.windowname = windowname
-  for k,v in pairs(self.windowList) do
-    setMyWindow(v, windowname)
-    setContainerWindow(v, windowname)
+  --Iterate through windows has a given order and prevents problems with z-coordinate
+  for k,v in ipairs(self.windows) do
+    setMyWindow(self.windowList[v], windowname)
+    setContainerWindow(self.windowList[v], windowname)
   end
 end
 
 --- Removes a window from the container that it manages
 -- @param container The new container the window will be set in
 function Geyser:changeContainer (container)
+  --Change container to Geyser if "main" is given
+  if type(container) == "string" and container:lower() == "main" then
+    container = Geyser
+  end
+  --only a container has a windowList
+  if not container or not container.windowList or self == container then
+    return nil, "didn't get a valid container"
+  end
   --Nothing to change
   if self.container == container then
-    return
+    return nil, "nothing to change. "..self.name.." is already in this container"
   end 
-  --If there is no windowname then windowname is main
+  --If there is no windowname then windowname is "main"
   local windowname = container.windowname
   windowname = windowname or "main"
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2408,7 +2408,7 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
     return false;
 }
 
-std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windowname, const QString& name, int x1, int y1)
+std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windowname, const QString& name, int x1, int y1, bool show)
 {
     if (!pHost || !pHost->mpConsole) {
         return {false, QString()};
@@ -2431,19 +2431,25 @@ std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windownam
     if (pL) {
         pL->setParent(pW);
         pL->move(x1, y1);
-        pL->show();
+        if (show) {
+            pL->show();
+        }
         return {true, QString()};
     } else if (pC) {
         pC->setParent(pW);
         pC->move(x1, y1);
         pC->mOldX = x1;
         pC->mOldY = y1;
-        pC->show();
+        if (show) {
+            pC->show();
+        }
         return {true, QString()};
     } else if (pM && name.toLower() == QLatin1String("mapper")) {
         pM->setParent(pW);
         pM->move(x1, y1);
-        pM->show();
+        if (show) {
+            pM->show();
+        }
         return {true, QString()};
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2408,6 +2408,48 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
     return false;
 }
 
+std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windowname, const QString& name, int x1, int y1)
+{
+    if (!pHost || !pHost->mpConsole) {
+        return {false, QString()};
+    }
+
+    auto pL = pHost->mpConsole->mLabelMap.value(name);
+    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
+    auto pD = pHost->mpConsole->mDockWidgetMap.value(windowname);
+    auto pW = pHost->mpConsole->mpMainFrame;
+    auto pM = pHost->mpConsole->mpMapper;
+
+    if (!pD && windowname.toLower() != QLatin1String("main")) {
+        return {false, QStringLiteral("Window \"%1\" not found.").arg(windowname)};
+    }
+
+    if (pD) {
+        pW = pD->widget();
+    }
+
+    if (pL) {
+        pL->setParent(pW);
+        pL->move(x1, y1);
+        pL->show();
+        return {true, QString()};
+    } else if (pC) {
+        pC->setParent(pW);
+        pC->move(x1, y1);
+        pC->mOldX = x1;
+        pC->mOldY = y1;
+        pC->show();
+        return {true, QString()};
+    } else if (pM && name.toLower() == QLatin1String("mapper")) {
+        pM->setParent(pW);
+        pM->move(x1, y1);
+        pM->show();
+        return {true, QString()};
+    }
+
+    return {false, QStringLiteral("Element \"%1\" not found.").arg(name)};
+}
+
 std::pair<bool, QString> mudlet::openMapWidget(Host* pHost, const QString& area, int x, int y, int width, int height)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -157,6 +157,7 @@ public:
     bool setLabelOnEnter(Host*, const QString&, const QString&, const TEvent&);
     bool setLabelOnLeave(Host*, const QString&, const QString&, const TEvent&);
     bool moveWindow(Host*, const QString& name, int, int);
+    std::pair<bool, QString> setWindow(Host* pHost, const QString& windowname, const QString& name, int x1, int y1);
     std::pair<bool, QString> openMapWidget(Host* pHost, const QString& area, int x, int y, int width, int height);
     std::pair<bool, QString> closeMapWidget(Host* pHost);
     void deleteLine(Host*, const QString& name);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -157,7 +157,7 @@ public:
     bool setLabelOnEnter(Host*, const QString&, const QString&, const TEvent&);
     bool setLabelOnLeave(Host*, const QString&, const QString&, const TEvent&);
     bool moveWindow(Host*, const QString& name, int, int);
-    std::pair<bool, QString> setWindow(Host* pHost, const QString& windowname, const QString& name, int x1, int y1);
+    std::pair<bool, QString> setWindow(Host* pHost, const QString& windowname, const QString& name, int x1, int y1, bool show);
     std::pair<bool, QString> openMapWidget(Host* pHost, const QString& area, int x, int y, int width, int height);
     std::pair<bool, QString> closeMapWidget(Host* pHost);
     void deleteLine(Host*, const QString& name);


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions

New lua ui function.
**setWindow**(windowname, name, [x, y, show])
Changes the window parent of the element (label, miniconsole, mapper) to the parent (userwindow) called windowname.
For mapper use the name "mapper".
To go back to the main window use the windowname "main".
the parameters x,y and show are optional.
x and y are set to 0 and show is true if not set.

new Geyser function :**changeContainer**(container)
Use it like:
testlabel:changeContainer(testcontainer2)
or
testemco:changeContainer(testuserwindow)
to change back to the main window (if your element wasn't in a container) use:
teslabel:changeContainer(Geyser)
...

Add the ability to Geyser to changes an elements container.
This works also if the container is in another parent window (userwindow)

to change the container and/or even the parent window.
#### Motivation for adding to Mudlet
Discussion on Discord and it was pretty simple.

#### Other info (issues closed, discussion etc)
All Geyser Elements should work. (plz test)
(now even flyout labels)