### PR TITLE
Autodetect and set the language on first launch

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -944,7 +944,7 @@ void mudlet::scanForMudletTranslations(const QString& path)
                 }
             }
             // PLACEMARKER: Start of locale codes to native language decoding - insert an entry here for any futher Mudlet supported languages
-            translation currentTranslation(percentageTranslated, languageCode);
+            translation currentTranslation(percentageTranslated);
             if (!languageCode.compare(QLatin1String("en_US"), Qt::CaseInsensitive)) {
                 currentTranslation.mNativeName = QStringLiteral("English (American)");
             } else if (!languageCode.compare(QLatin1String("en_GB"), Qt::CaseInsensitive)) {
@@ -5202,7 +5202,7 @@ QString mudlet::autodetectPreferredLanguage()
         if (translation.fromResourceFile()) {
             auto& translatedPc = translation.getTranslatedPercentage();
             if (translatedPc >= mTranslationGoldStar) {
-                availableQualityTranslations.append(translation.getLocaleCode());
+                availableQualityTranslations.append(code);
             }
         }
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -193,11 +193,6 @@ mudlet::mudlet()
 
     scanForMudletTranslations(QStringLiteral(":/lang"));
     scanForQtTranslations(getMudletPath(qtTranslationsPath));
-
-    if (firstLaunch()) {
-        mInterfaceLanguage = autodetectPreferredLanguage();
-    }
-
     loadTranslators(mInterfaceLanguage);
 
     setupUi(this);
@@ -3115,7 +3110,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
         mEnableFullScreenMode = file_use_smallscreen.exists();
     }
 
-    mInterfaceLanguage = settings.value("interfaceLanguage", QStringLiteral("en_US")).toString();
+    mInterfaceLanguage = settings.value("interfaceLanguage", autodetectPreferredLanguage()).toString();
 }
 
 void mudlet::readLateSettings(const QSettings& settings)
@@ -5199,8 +5194,9 @@ void mudlet::setInterfaceLanguage(const QString& languageCode)
 // or a back-up language they've specified
 QString mudlet::autodetectPreferredLanguage()
 {
-    // en_UK is a special exception due to its likeness to en_US
-    QVector<QString> availableQualityTranslations {QStringLiteral("en_UK")};
+    // en_GB is a temporary special exception due to its likeness to en_US, while its
+    // translation is still only at 20%
+    QVector<QString> availableQualityTranslations {QStringLiteral("en_GB")};
     for (auto& code : getAvailableTranslationCodes()) {
         auto& translation = mTranslationsMap.value(code);
         if (translation.fromResourceFile()) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5196,7 +5196,8 @@ void mudlet::setInterfaceLanguage(const QString& languageCode)
 // or a back-up language they've specified
 QString mudlet::autodetectPreferredLanguage()
 {
-    QVector<QString> availableQualityTranslations;
+    // en_UK is a special exception due to its likeness to en_US
+    QVector<QString> availableQualityTranslations {QStringLiteral("en_UK")};
     for (auto& code : getAvailableTranslationCodes()) {
         auto& translation = mTranslationsMap.value(code);
         if (translation.fromResourceFile()) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -572,6 +572,8 @@ private:
     void loadTranslators(const QString &languageCode);
     void loadDictionaryLanguageMap();
     void migrateDebugConsole(Host* currentHost);
+    static bool firstLaunch();
+    QString autodetectPreferredLanguage();
 
     QMap<QString, TConsole*> mTabMap;
     QWidget* mainPane;
@@ -671,7 +673,7 @@ private:
     // Has default form of "en_US" but can be just an ISO langauge code e.g. "fr" for french,
     // without a country designation. Replaces xx in "mudlet_xx.qm" to provide the translation
     // file for GUI translation
-    QString mInterfaceLanguage;
+    QString mInterfaceLanguage {};
     // The next pair retains the path argument supplied to the corresponding
     // scanForXxxTranslations(...) method so it is available to the subsquent
     // loadTranslators(...) call
@@ -719,9 +721,10 @@ class translation
     friend void mudlet::scanForQtTranslations(const QString&);
 
 public:
-    translation(const int translationPercent = -1) : mTranslatedPercentage(translationPercent) {}
+    translation(const int translationPercent = -1, const QString localeCode = {}) : mTranslatedPercentage(translationPercent), mLocaleCode(localeCode) {}
 
     const QString& getNativeName() const { return mNativeName; }
+    const QString& getLocaleCode() const { return mLocaleCode; }
     const QString& getMudletTranslationFileName() const { return mMudletTranslationFileName; }
     const QString& getQtTranslationFileName() const { return mQtTranslationFileName; }
     const int& getTranslatedPercentage() const { return mTranslatedPercentage; }
@@ -743,9 +746,8 @@ private:
     // cases the loaded file will be a "xx" language only file even though it
     // is an "xx_YY" one here:
     QString mQtTranslationFileName;
-    // Further items like the above pair may be needed should some of the
-    // separate libraries with a textual content have their own translations
-    // that we do not provide ourselves.
+
+    QString mLocaleCode {};
 };
 
 #endif // MUDLET_MUDLET_H

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -721,10 +721,9 @@ class translation
     friend void mudlet::scanForQtTranslations(const QString&);
 
 public:
-    translation(const int translationPercent = -1, const QString localeCode = {}) : mTranslatedPercentage(translationPercent), mLocaleCode(localeCode) {}
+    translation(const int translationPercent = -1) : mTranslatedPercentage(translationPercent) {}
 
     const QString& getNativeName() const { return mNativeName; }
-    const QString& getLocaleCode() const { return mLocaleCode; }
     const QString& getMudletTranslationFileName() const { return mMudletTranslationFileName; }
     const QString& getQtTranslationFileName() const { return mQtTranslationFileName; }
     const int& getTranslatedPercentage() const { return mTranslatedPercentage; }
@@ -746,8 +745,6 @@ private:
     // cases the loaded file will be a "xx" language only file even though it
     // is an "xx_YY" one here:
     QString mQtTranslationFileName;
-
-    QString mLocaleCode {};
 };
 
 #endif // MUDLET_MUDLET_H

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -733,18 +733,15 @@ private:
     // Used for display in the profile preferences and is never translated:
     QString mNativeName;
     // ONLY if the translation is loaded from an embedded resource file,
-    // is the percentage complete of the translation - determined via a lua
-    // script that parses the output of the lrelease executable that
-    // converts the source mudlet_xx_YY.ts files into the binary
-    // mudlet_xx_YY.qm files placed into the embedded resource file during
-    // building the application:
+    // this is the percentage complete of the translation
     int mTranslatedPercentage;
-    // What the usable Mudlet translation file-was found to be:
+    // filename translation is loaded from
     QString mMudletTranslationFileName;
-    // What the usable Qt translation file was found to be, note that in most
+    // Qt translation file was found to be, note that in most
     // cases the loaded file will be a "xx" language only file even though it
     // is an "xx_YY" one here:
     QString mQtTranslationFileName;
+    // Similar filename locations will require adding for any 3rd party translations we load
 };
 
 #endif // MUDLET_MUDLET_H


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Autodetect and set the language to the user's desktop environment language if it's one of those that we have a quality translation for.
#### Motivation for adding to Mudlet
Better i18n experience out of the box
#### Other info (issues closed, discussion etc)
@wiploo if you could test it as well.

Needs testing on:
- [x] Linux
- [x] Windows
- [ ] macOS