### PR TITLE
string.split(str, "") to return table of characters in str

### DIFF
--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -64,6 +64,7 @@ end
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.split
 function string:split(delimiter)
   delimiter = delimiter or " "
+  if delimiter == "" then return {self:match( (self:gsub(".", "(.)")) )} end
   local result = { }
   local from = 1
   local delim_from, delim_to = string.find( self, delimiter, from  )

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -124,6 +124,20 @@ describe("Tests StringUtils.lua functions", function()
       local actual = str:split(":")
       assert.same(expected, actual)
     end)
+
+    it("should default to splitting on a space", function()
+      local str = "This is a test"
+      local expected = { "This", "is", "a", "test" }
+      local actual = str:split()
+      assert.same(expected, actual)
+    end)
+
+    it("should return a table with the characters that make up the string if empty string is used for the delimiter", function()
+      local str = "This is a test"
+      local expected = {"T", "h", "i", "s", " ", "i", "s", " ", "a", " ", "t", "e", "s", "t"}
+      local actual = str:split("")
+      assert.same(expected, actual)
+    end)
   end)
 
   describe("string.starts(str, prefix)", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a quick handler for returning the string as a table of characters using empty string for the delimiter. 

#### Motivation for adding to Mudlet
Something came up on discord for which obtaining "This" as {"T", "h", "i", "s"} was desirable, and I realized that we had no way of doing that currently. Did a bit of googling and pieced together an easy one line addition to allow using `""` as the delimiter causing it to return the table of characters making up the string. 

Also includes tests for the default `" "` delimiter and that using `""` works as described.

#### Other info (issues closed, discussion etc)
Currently, trying to use the empty string will error or lock up Mudlet. This both eliminates that undesirable behaviour and increases the method's functionality.

![image](https://user-images.githubusercontent.com/3660/77028647-c247e780-696f-11ea-8d8f-65d536c7507e.png)
