### PR TITLE
Allow drag and drop Event on MainConsole and UserWindows

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -578,7 +578,10 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         mDisplayFontSize = mDisplayFont.pointSize();
         refreshMiniConsole();
     }
-    setAcceptDrops(true);
+
+    if (mType & (MainConsole | UserWindow)) {
+        setAcceptDrops(true);
+    }
 }
 
 TConsole::~TConsole()
@@ -2962,29 +2965,25 @@ void TConsole::dragEnterEvent(QDragEnterEvent* e)
 //https://amin-ahmadi.com/2016/01/04/qt-drag-drop-files-images/
 void TConsole::dropEvent(QDropEvent* e)
 {
-    QStringList accepted_types;
-    accepted_types << "jpeg"
-                   << "jpg"
-                   << "png";
-    foreach(const QUrl& url, e->mimeData()->urls()) {
+    for (const auto& url : e->mimeData()->urls()) {
         QString fname = url.toLocalFile();
         QFileInfo info(fname);
         if (info.exists()) {
-            if (accepted_types.contains(info.suffix().trimmed(), Qt::CaseInsensitive)) {
-                QPoint pos = e->pos();
-                TEvent mudletEvent{};
-                mudletEvent.mArgumentList.append(QLatin1String("sysImageDropEvent"));
-                mudletEvent.mArgumentList.append(fname);
-                mudletEvent.mArgumentList.append(QString::number(pos.x()));
-                mudletEvent.mArgumentList.append(QString::number(pos.y()));
-                mudletEvent.mArgumentList.append(mConsoleName);
-                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-                mpHost->raiseEvent(mudletEvent);
-            }
+            QPoint pos = e->pos();
+            TEvent mudletEvent{};
+            mudletEvent.mArgumentList.append(QLatin1String("sysDropEvent"));
+            mudletEvent.mArgumentList.append(fname);
+            mudletEvent.mArgumentList.append(info.suffix().trimmed());
+            mudletEvent.mArgumentList.append(QString::number(pos.x()));
+            mudletEvent.mArgumentList.append(QString::number(pos.y()));
+            mudletEvent.mArgumentList.append(mConsoleName);
+            mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+            mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+            mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mpHost->raiseEvent(mudletEvent);
         }
     }
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -578,6 +578,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         mDisplayFontSize = mDisplayFont.pointSize();
         refreshMiniConsole();
     }
+    setAcceptDrops(true);
 }
 
 TConsole::~TConsole()
@@ -2947,5 +2948,44 @@ void TConsole::setProfileName(const QString& newName)
 
     for (auto pC : mSubConsoleMap) {
         pC->setProfileName(newName);
+    }
+}
+
+
+void TConsole::dragEnterEvent(QDragEnterEvent* e)
+{
+    if (e->mimeData()->hasUrls())
+    {
+        e->acceptProposedAction();
+    }
+}
+
+//https://amin-ahmadi.com/2016/01/04/qt-drag-drop-files-images/
+void TConsole::dropEvent(QDropEvent* e)
+{
+    QStringList accepted_types;
+    accepted_types << "jpeg"
+                   << "jpg"
+                   << "png";
+    foreach (const QUrl& url, e->mimeData()->urls()) {
+        QString fname = url.toLocalFile();
+        QFileInfo info(fname);
+        if (info.exists()) {
+            if (accepted_types.contains(info.suffix().trimmed(), Qt::CaseInsensitive)) {
+                QPoint pos = e->pos();
+                TEvent mudletEvent {};
+                mudletEvent.mArgumentList.append(QLatin1String("sysImageDropEvent"));
+                mudletEvent.mArgumentList.append(fname);
+                mudletEvent.mArgumentList.append(QString::number(pos.x()));
+                mudletEvent.mArgumentList.append(QString::number(pos.y()));
+                mudletEvent.mArgumentList.append(mConsoleName);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                mpHost->raiseEvent(mudletEvent);
+            }
+        }
     }
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2954,8 +2954,7 @@ void TConsole::setProfileName(const QString& newName)
 
 void TConsole::dragEnterEvent(QDragEnterEvent* e)
 {
-    if (e->mimeData()->hasUrls())
-    {
+    if (e->mimeData()->hasUrls()) {
         e->acceptProposedAction();
     }
 }
@@ -2967,13 +2966,13 @@ void TConsole::dropEvent(QDropEvent* e)
     accepted_types << "jpeg"
                    << "jpg"
                    << "png";
-    foreach (const QUrl& url, e->mimeData()->urls()) {
+    foreach(const QUrl& url, e->mimeData()->urls()) {
         QString fname = url.toLocalFile();
         QFileInfo info(fname);
         if (info.exists()) {
             if (accepted_types.contains(info.suffix().trimmed(), Qt::CaseInsensitive)) {
                 QPoint pos = e->pos();
-                TEvent mudletEvent {};
+                TEvent mudletEvent{};
                 mudletEvent.mArgumentList.append(QLatin1String("sysImageDropEvent"));
                 mudletEvent.mArgumentList.append(fname);
                 mudletEvent.mArgumentList.append(QString::number(pos.x()));

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -326,8 +326,8 @@ public slots:
     void slot_reloadMap(QList<QString>);
 
 protected:
-    void dragEnterEvent(QDragEnterEvent *e);
-    void dropEvent(QDropEvent *e);
+    void dragEnterEvent(QDragEnterEvent* e);
+    void dropEvent(QDropEvent* e);
 
 private:
     void refreshMiniConsole() const;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -325,6 +325,10 @@ public slots:
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
 
+protected:
+    void dragEnterEvent(QDragEnterEvent *e);
+    void dropEvent(QDropEvent *e);
+
 private:
     void refreshMiniConsole() const;
 


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Dropping a file on a mudlet main console (also on userwindows) raises an event with:
Eventname: sysDropEvent, filepath, suffix, xpos, ypos, consolename

This event could make it possible to add images by drag and drop to mudlet
#### Motivation for adding to Mudlet
With some additional lua magic it should be possible through this to add the suggested changes in
https://github.com/Mudlet/Mudlet/issues/1399
#### Other info (issues closed, discussion etc)
