### PR TITLE
Add updater validation to linux/macos/windows release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,9 @@ before_script: |
   # set the luarocks path here for OSX as we installed it later for that OS.
   if [ "${TRAVIS_OS_NAME}" = "osx" ]; then eval $(luarocks --lua-dir="$(brew --prefix lua@5.1)" path); fi
   mkdir -p build
+
+  # finally, validate that everthing is kosher before starting the build
+  source CI/travis.validate_deployment.sh
 script:
 - ./CI/travis.compile.sh
 after_success:

--- a/CI/appveyor.build.ps1
+++ b/CI/appveyor.build.ps1
@@ -6,6 +6,7 @@ SetMingwBaseDir "C:\src\verbose_output.log"
 SetLuarocksPath "C:\src\verbose_output.log"
 
 . CI\appveyor.set-build-info.ps1
+. CI\appveyor.validate_deployment.ps1
 
 cd "$Env:APPVEYOR_BUILD_FOLDER\src"
 

--- a/CI/appveyor.validate_deployment.ps1
+++ b/CI/appveyor.validate_deployment.ps1
@@ -1,0 +1,43 @@
+if ($Env:APPVEYOR_REPO_TAG -ne "true") {
+  echo "Not a release build - skipping release validation."
+  exit 0
+}
+
+function error([string]$message) {
+  echo "$message"
+  exit 1
+}
+
+function validate_qmake() {
+  $VALID_QMAKE = select-string -path src/mudlet.pro -pattern "^VERSION ? = ?(\d+\.\d+\.\d+)$"
+  if ($VALID_QMAKE.Matches.Success -ne $True) {
+    error "mudlet.pro's VERSION variable isn't formatted following the semantic versioning rules in a release build."
+  }
+
+  $VALID_BUILD = select-string -path src/mudlet.pro -pattern ' +BUILD ? = ? ("")'
+  if ($VALID_BUILD.Matches.Success -ne $True) {
+    error "mudlet.pro's BUILD variable isn't set to `"`" as it should be in a release build."
+  }
+}
+
+function validate_cmake() {
+  $VALID_CMAKE = select-string -path CMakeLists.txt -pattern "set\(APP_VERSION (\d+\.\d+\.\d+)\)$"
+  if ($VALID_CMAKE.Matches.Success -ne $True) {
+    error "CMakeLists.txt's APP_VERSION variable isn't formatted following the semantic versioning rules in a release build."
+  }
+
+  $VALID_BUILD = select-string -path CMakeLists.txt -pattern 'set\(APP_BUILD ("")\)$'
+  if ($VALID_BUILD.Matches.Success -ne $True) {
+    error "CMakeLists.txt APP_BUILD variable isn't set to `"`" as it should be in a release build."
+  }
+}
+
+function validate_updater_environment_variable() {
+  if ($Env:WITH_UPDATER -eq "NO") {
+    error "Updater is disabled in a release build."
+  }
+}
+
+validate_qmake
+validate_cmake
+validate_updater_environment_variable

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ -z "${TRAVIS_TAG}" ]; then
   exit 0
 fi
@@ -8,7 +10,7 @@ function validate_qmake() {
   VALID_QMAKE=$(cat src/mudlet.pro | pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$")
 
   if [ -z "${VALID_QMAKE}" ]; then
-  echo "mudlet.pro isn't set to a valid version in a release build."
+  echo "mudlet.pro isn't set to a valid semantic version in a release build."
   exit 1
   fi
 }
@@ -17,7 +19,7 @@ function validate_cmake() {
   VALID_CMAKE=$(cat CMakeLists.txt | pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$")
 
   if [ -z "${VALID_CMAKE}" ]; then
-    echo "CMakeLists.txt isn't set to a valid version in a release build."
+    echo "CMakeLists.txt isn't set to a valid semantic version in a release build."
     exit 1
   fi
 }

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -25,7 +25,7 @@ function validate_cmake() {
 }
 
 function validate_updater_environment_variable() {
-  if [ "$WITH_UPDATER" != "NO" ]; then
+  if [ "$WITH_UPDATER" == "NO" ]; then
      echo "Updater is disabled in a release build."
      exit 1
   fi

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -1,33 +1,47 @@
 #!/bin/bash
 
-set -e
-
 if [ -z "${TRAVIS_TAG}" ]; then
+  echo "Not a release build - skipping release validation."
   exit 0
 fi
 
-function validate_qmake() {
-  VALID_QMAKE=$(cat src/mudlet.pro | pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$")
-
-  if [ -z "${VALID_QMAKE}" ]; then
-  echo "mudlet.pro isn't set to a valid semantic version in a release build."
+error() {
+  # shellcheck disable=SC2059
+  printf "error: $1\n" "${@:2}" >&2
   exit 1
+}
+
+function validate_qmake() {
+  local VALID_QMAKE VALID_BUILD
+
+  VALID_QMAKE=$(pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$" < src/mudlet.pro)
+  if [ -z "${VALID_QMAKE}" ]; then
+    error "mudlet.pro's VERSION variable isn't formatted following the semantic versioning rules in a release build."
+  fi
+
+  VALID_BUILD=$(pcregrep --only-matching=1 ' +BUILD ? = ? ("")' < src/mudlet.pro)
+  if [ "${VALID_BUILD}" != '""' ]; then
+    error "mudlet.pro's BUILD variable isn't set to \"\" as it should be in a release build."
   fi
 }
 
 function validate_cmake() {
-  VALID_CMAKE=$(cat CMakeLists.txt | pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$")
+  local VALID_CMAKE VALID_BUILD
+  VALID_CMAKE=$(pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
 
   if [ -z "${VALID_CMAKE}" ]; then
-    echo "CMakeLists.txt isn't set to a valid semantic version in a release build."
-    exit 1
+    error "CMakeLists.txt VERSION variable isn't formatted following the semantic versioning rules in a release build."
+  fi
+
+  VALID_BUILD=$(pcregrep --only-matching=1 'set\(APP_BUILD ("")\)$' < CMakeLists.txt)
+  if [ "${VALID_BUILD}" != '""' ]; then
+    error "CMakeLists.txt APP_BUILD variable isn't set to \"\" as it should be in a release build."
   fi
 }
 
 function validate_updater_environment_variable() {
   if [ "$WITH_UPDATER" == "NO" ]; then
-     echo "Updater is disabled in a release build."
-     exit 1
+     error "Updater is disabled in a release build."
   fi
 }
 

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -4,16 +4,31 @@ if [ -z "${TRAVIS_TAG}" ]; then
   exit 0
 fi
 
-VALID_QMAKE=$(cat src/mudlet.pro | pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$")
+function validate_qmake() {
+  VALID_QMAKE=$(cat src/mudlet.pro | pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$")
 
-if [ -z "${VALID_QMAKE}" ]; then
-  echo "mudlet.pro isn't set to a valid version - aborting build."
+  if [ -z "${VALID_QMAKE}" ]; then
+  echo "mudlet.pro isn't set to a valid version in a release build."
   exit 1
-fi
+  fi
+}
 
-VALID_CMAKE=$(cat CMakeLists.txt | pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$")
+function validate_cmake() {
+  VALID_CMAKE=$(cat CMakeLists.txt | pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$")
 
-if [ -z "${VALID_CMAKE}" ]; then
-  echo "CMakeLists.txt isn't set to a valid version - aborting build."
-  exit 1
-fi
+  if [ -z "${VALID_CMAKE}" ]; then
+    echo "CMakeLists.txt isn't set to a valid version in a release build."
+    exit 1
+  fi
+}
+
+function validate_updater_environment_variable() {
+  if [ "$WITH_UPDATER" != "NO" ]; then
+     echo "Updater is disabled in a release build."
+     exit 1
+  fi
+}
+
+validate_qmake
+validate_cmake
+validate_updater_environment_variable

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ -z "${TRAVIS_TAG}" ]; then
+  exit 0
+fi
+
+VALID_QMAKE=$(cat src/mudlet.pro | pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$")
+
+if [ -z "${VALID_QMAKE}" ]; then
+  echo "mudlet.pro isn't set to a valid version - aborting build."
+  exit 1
+fi
+
+VALID_CMAKE=$(cat CMakeLists.txt | pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$")
+
+if [ -z "${VALID_CMAKE}" ]; then
+  echo "CMakeLists.txt isn't set to a valid version - aborting build."
+  exit 1
+fi


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Add version validation to release builds
#### Motivation for adding to Mudlet
So `4.5.1-de` doesn't get published ever again.
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/3403.

Useful resource for powershell syntax: https://learnxinyminutes.com/docs/powershell