### PR TITLE
Refactor: make getMudletLuaDefaultPaths() return actual used details

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6365,8 +6365,6 @@ int TLuaInterpreter::getMudletHomeDir(lua_State* L)
 int TLuaInterpreter::getMudletLuaDefaultPaths(lua_State* L)
 {
     int index = 0;
-    // This is a static method so does not have a this pointer - so go and get
-    // the one used by the profile so we can read the instance's data:
     auto& host = getHostFromLua(L);
     auto* pLua = host.getLuaInterpreter();
     Q_ASSERT_X(pLua, "TLuaInterpreter::getMudletLuaDefaultPaths", "nullptr received when looking for the instantiated instance of TLuaInterpreter for a Host.");
@@ -6374,7 +6372,8 @@ int TLuaInterpreter::getMudletLuaDefaultPaths(lua_State* L)
     QStringListIterator itPath(pLua->mPossiblePaths);
     lua_newtable(L);
     while (itPath.hasNext()) {
-        // We are hoping that backslashes are not going to be a problem in reporting the details:
+        // We are hoping that the directory separators are not going to be a
+        // problem in reporting the details:
         QString nativePath = QDir::toNativeSeparators(itPath.next());
         lua_pushnumber(L, ++index); // Lua indexes start at 1 not 0 so preincrement it:
         lua_pushstring(L, nativePath.toUtf8().constData());

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -16711,7 +16711,7 @@ void TLuaInterpreter::loadGlobal()
     QStringList failedMessages{};
 
     // uncomment the following to enable some debugging texts in the LuaGlobal.lua script:
-    luaL_dostring(pGlobalLua, QStringLiteral("debugLoading = true").toUtf8().constData());
+    // luaL_dostring(pGlobalLua, QStringLiteral("debugLoading = true").toUtf8().constData());
 
 #if defined(Q_OS_WIN32)
     // Needed to enable permissions checks on NTFS file systems - normally

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -584,6 +584,9 @@ private:
     int mHostID;
     QList<QObject*> objectsToDelete;
     QTimer purgeTimer;
+
+    // Holds the list of places to look for the LuaGlobal.lua file:
+    QStringList mPossiblePaths;
 };
 
 Host& getHostFromLua(lua_State* L);

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -1,11 +1,24 @@
-----------------------------------------------------------------------------------
---- Mudlet Lua packages loader
-----------------------------------------------------------------------------------
+-- Mudlet Lua packages loader
 
--- set to true (or provide a global with the same name and also set to true) to
--- report on the determination of what path to use to load the other Mudlet
--- and Geyser provided Lua files...
-local debugLoading = debugLoading or false
+-- Set to true (possibly via code in the C++ TLuaInterpreter::loadGlobal()
+-- method) to report on the determination of what path to use to load the other
+-- Mudlet and Geyser provided Lua files...
+debugLoading = debugLoading or false
+
+-- Set via code in C++ TLuaInterpreter::loadGlobal() but fall back to current
+-- directory if nil.
+if luaGlobalPath == nil then
+  luaGlobalPath = lfs.currentdir() .. package.config:sub(1,1) .. "LuaGlobal.lua"
+  if debugLoading then
+    echo([[luaGlobalPath was nil so has been defaulted to: "]] .. luaGlobalPath .. [[".
+
+]])
+  end
+elseif debugLoading then
+  echo([[luaGlobalPath has been preset to: "]] .. luaGlobalPath .. [[".
+
+]])
+end
 
 if package.loaded["rex_pcre"] then
   rex = require "rex_pcre"
@@ -92,6 +105,16 @@ end
 function handleWindowResizeEvent()
 end
 
+function toNativeSeparators(rawPath)
+  if package.config:sub(1,1) == '\\' then
+    return string.gsub(rawPath, '/', '\\')
+  end
+
+  assert((package.config:sub(1,1) == '/'), "package path directory separator is neither '\\' nor '/' and cannot be handled")
+
+  return string.gsub(rawPath, '\\', '/')
+end
+
 local packages = {
   "StringUtils.lua",
   "TableUtils.lua",
@@ -123,80 +146,38 @@ local packages = {
   "TTSValues.lua"
 }
 
--- on windows LuaGlobal gets loaded with the current directory set to mudlet.exe's location
--- on Mac, it's set to LuaGlobals location - or the Applications folder, or something else...
--- So work out where to load Lua files from using some heuristics
--- Addition of "../src/" to front of path allows things to work when "Shadow Building"
--- option of Qt Creator is used (separates object code from source code in directories
--- beside the latter, allowing parallel builds against different Qt Library versions
--- or {Release|Debug} types).  A further "../../src/" does the same when the
--- qmake CONFIG has both "debug_and_release" (default on Windows) and
--- "debug_and_release_target" (default on all platforms) options which puts the
--- executable in a further sub-directory down when shadow building!
--- TODO: extend to support common Lua code being placed in system shared directory
--- tree as ought to happen for *nix install builds.
-local prefixes = { "./../../src/mudlet-lua/lua/",
-                   "./../src/mudlet-lua/lua/",
-                   "./../Resources/mudlet-lua/lua/",
-                   "./mudlet-lua/lua/",
-                   "./lua/",
-                   "mudlet.app/Contents/Resources/mudlet-lua/lua/" }
-
--- add default search paths coming from the C++ side as well
-if getMudletLuaDefaultPaths then
-  for _, path in ipairs(getMudletLuaDefaultPaths()) do
-    prefixes[#prefixes + 1] = path
-  end
+if debugLoading then
+   echo("Path separator is: '" .. package.config:sub(1,1) .. "'\n\n")
 end
 
--- this is based on directory separators only ever being '/' or '\\' which does
--- seem to cover the cases that we are likely to encounter...!
-for i, path in ipairs(prefixes) do
-  prefixes[i] = string.gsub(path, '[/\\]', package.config:sub(1,1))
-  if debugLoading then
-    echo([[Directory separator conversion: "]] .. path .. [[" becomes: "]] .. prefixes[i] .. [["
-]])
-  end
-end
+nativeLuaGlobalPath = toNativeSeparators(luaGlobalPath)
 
 if debugLoading then
-  echo([[Current directory is: "]] .. lfs.currentdir() .. [[".
+  echo([[Directory separator conversion gives: "]] .. nativeLuaGlobalPath .. [[".
+
+Current directory is: "]] .. lfs.currentdir() .. [[".
+
 ]])
 end
 
-local prefix
-for i = 1, #prefixes do
-  -- lfs.attributes returns a table if the given file-system object exists
+for _, packageName in ipairs(packages) do
+  local packagePath = nativeLuaGlobalPath .. package.config:sub(1,1) .. toNativeSeparators(packageName)
   if debugLoading then
-    echo([[Testing: "]] .. prefixes[i] .. [[LuaGlobal.lua"...]])
-  end
-  if lfs.attributes(prefixes[i] .. "LuaGlobal.lua") then
-    if debugLoading then
-      echo(" found something!\n")
-    end
-    prefix = prefixes[i]
-    break
-  else
-    if debugLoading then
-      echo(" not found.\n")
-    end
-  end
-end
-
-if not prefix then
-  echo([[Error locating Lua files from LuaGlobal.lua - we are looking from ']] .. lfs.currentdir() .. [['.
+    echo([[Trying to load: "]] .. packagePath .. [["
 ]])
-  return
-end
-
-if debugLoading then
-  echo([[Locating other Lua files from LuaGlobal.lua - we are looking from ']] .. lfs.currentdir() .. [['.
-]])
-end
-
-for _, package in ipairs(packages) do
-  local result, msg = pcall(dofile, prefix .. package)
-  if not result then
-    echo("Error attempting to load file: " .. package .. ": " .. msg .. "\n")
   end
+  local result, msg = pcall(dofile, packagePath)
+  if debugLoading then
+    if result then
+      echo([[Loaded: "]] .. packageName .. [[".
+
+]])
+    else
+      echo([[Error attempting to load file:
+  ]] .. msg .. [[.
+
+]])
+    end
+  end
+  assert(result, msg)
 end

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -187,13 +187,6 @@ isEmpty( 3DMAPPER_TEST ) | !equals(3DMAPPER_TEST, "NO" ) {
     DEFINES += INCLUDE_3DMAPPER
 }
 
-
-# Some temporary tests to see whether either of these are present in the
-# AppVeyor CI environment, the second is true on a local Desktop MSYS2 Windows
-# OS:
-cygwin : message("A 'cygwin' qmake scope is defined.")
-mingw : message("A 'mingw' qmake scope is defined.")
-
 ###################### Platform Specific Paths and related #####################
 # Specify default location for Lua files, in OS specific LUA_DEFAULT_DIR value
 # below, if this is not done then a hardcoded default of a ./mudlet-lua/lua

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -187,6 +187,13 @@ isEmpty( 3DMAPPER_TEST ) | !equals(3DMAPPER_TEST, "NO" ) {
     DEFINES += INCLUDE_3DMAPPER
 }
 
+
+# Some temporary tests to see whether either of these are present in the
+# AppVeyor CI environment, the second is true on a local Desktop MSYS2 Windows
+# OS:
+cygwin : message("A 'cygwin' qmake scope is defined.")
+mingw : message("A 'mingw' qmake scope is defined.")
+
 ###################### Platform Specific Paths and related #####################
 # Specify default location for Lua files, in OS specific LUA_DEFAULT_DIR value
 # below, if this is not done then a hardcoded default of a ./mudlet-lua/lua
@@ -251,11 +258,12 @@ unix:!macx {
 
     LUA_DEFAULT_DIR = $${DATADIR}/lua
 } else:win32 {
-    MINGW_BASE_DIR = $$(MINGW_BASE_DIR)
-    isEmpty(MINGW_BASE_DIR) {
-        MINGW_BASE_DIR = "C:\\Qt\\Tools\\mingw730_32"
+    MINGW_BASE_DIR_TEST = $$(MINGW_BASE_DIR)
+    isEmpty( MINGW_BASE_DIR_TEST ) {
+        MINGW_BASE_DIR_TEST = "C:\\Qt\\Tools\\mingw730_32"
     }
     LIBS +=  \
+        -L"$${MINGW_BASE_DIR_TEST}\\bin" \
         -llua51 \
         -lpcre-1 \
         -llibhunspell-1.6 \
@@ -263,15 +271,13 @@ unix:!macx {
         -lz \                   # for ctelnet.cpp
         -lyajl \
         -lpugixml \
-        -lWs2_32 \
-        -L"$${MINGW_BASE_DIR}\\bin"
+        -lWs2_32
     INCLUDEPATH += \
-                   "C:\\Libraries\\boost_1_71_0" \
-                   "$${MINGW_BASE_DIR}\\include" \
-                   "$${MINGW_BASE_DIR}\\lib\include"
-# Leave this undefined so mudlet::readSettings() preprocessing will fall back to
-# hard-coded executable's /mudlet-lua/lua/ subdirectory
-#    LUA_DEFAULT_DIR = $$clean_path($$system(echo %ProgramFiles%)/lua)
+         "C:\\Libraries\\boost_1_71_0" \
+         "$${MINGW_BASE_DIR_TEST}\\include" \
+         "$${MINGW_BASE_DIR_TEST}\\lib\include"
+    # Leave this unset - we do not need it on Windows:
+    # LUA_DEFAULT_DIR =
 }
 
 unix:!macx {


### PR DESCRIPTION
The previous code did not link this function to the actual list of paths used - this makes debugging when things go wrong (or when porting to a new platform) more difficult than it need be!

This is part of my work toward migrating to MSYS2 builds on the Windows platform.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>