### PR TITLE
add copy2decho and copy2html functions from forums

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1920,12 +1920,12 @@ end
 --- @param inst optional, the instance of the string to copy. Defaults to the first instance.
 --- @usage to copy matches[2] with color information and echo it to miniconsole "test"
 ---   <pre>
----   echo("test", copy2decho(matches[2]))
+---   decho("test", copy2decho(matches[2]))
 ---   </pre>
 ---
 --- @usage to copy the entire line with color information, then echo it to miniconsole "test"
 ---   <pre>
----   echo("test", copy2decho())
+---   decho("test", copy2decho())
 ---   </pre>
 function copy2decho(win, str, inst)
   return copy2color("copy2decho", win, str, inst)

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1879,6 +1879,7 @@ local function copy2color(name,win,str,inst)
     error(name..": string not found",3)
   end
   local style, endspan, result, r, g, b, br, bg, bb, cr, cg, cb, crb, cgb, cbb
+  local selectSection, getFgColor, getBgColor = selectSection, getFgColor, getBgColor
   if name == "copy2html" then
     style = "%s<span style=\'color: rgb(%d,%d,%d);background: rgb(%d,%d,%d);'>%s"
     endspan = "</span>"
@@ -1897,7 +1898,7 @@ local function copy2color(name,win,str,inst)
       rb,gb,bb = getBgColor()
     end
     
-    if not table.is_empty(table.complement({r,g,b,rb,gb,bb},{cr,cg,cb,crb,cgb,cbb})) then
+    if r ~= cr or g ~= cg or b ~= cb or rb ~= crb or gb ~= cgb or bb ~= cbb then
       cr,cg,cb,crb,cgb,cbb = r,g,b,rb,gb,bb
       result = string.format(style, result and (result..endspan) or "", r, g, b, rb, gb, bb, line:sub(index, index))
     else

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1863,8 +1863,6 @@ end
 -- createButton is deprecated better use createLabel instead
 createButton = createLabel
 
-<<<<<<< HEAD
-
 -- Internal function used by copy2html and copy2decho
 local function copy2color(name,win,str,inst)
   local line = getCurrentLine(win or "main")
@@ -1949,7 +1947,7 @@ end
 function copy2html(win, str, inst)
   return copy2color("copy2html", win, str, inst)
 end
-=======
+
 function resetLabelCursor(name)
   assert(type(name) == 'string', 'resetLabelCursor: bad argument #1 type (name as string expected, got '..type(name)..'!)')
   return setLabelCursor(name, -1)
@@ -1962,4 +1960,3 @@ function setLabelCursor(labelname, cursorShape)
   end
   return setLabelCursorLayer(labelname, cursorShape)
 end
->>>>>>> upstream/development

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1862,3 +1862,88 @@ end
 --wrapper for createButton 
 -- createButton is deprecated better use createLabel instead
 createButton = createLabel
+
+
+-- Internal function used by copy2html and copy2decho
+local function copy2color(name,win,str,inst)
+  local line = getCurrentLine(win or "main")
+  if (not str and line == "ERROR: mini console does not exist") or type(str) == "number" then
+    win, str, inst = "main", win, str
+    line = getCurrentLine(win)
+  end
+  win = win or "main"
+  str = str or line
+  inst = inst or 1
+  local start, len = selectString(win, str, inst), #str
+  if not start then
+    error(name..": string not found",3)
+  end
+  local style, endspan, result, r, g, b, br, bg, bb, cr, cg, cb, crb, cgb, cbb
+  if name == "copy2html" then
+    style = "%s<span style=\'color: rgb(%d,%d,%d);background: rgb(%d,%d,%d);'>%s"
+    endspan = "</span>"
+  elseif name == "copy2decho" then
+    style = "%s<%d,%d,%d:%d,%d,%d>%s"
+    endspan = "<r>"
+  end
+  for index = start + 1, start + len do
+    if win ~= "main" then
+      selectSection(win, index - 1, 1)
+      r,g,b = getFgColor(win)
+      rb,gb,bb = getBgColor(win)
+    else
+      selectSection(index - 1, 1)
+      r,g,b = getFgColor()
+      rb,gb,bb = getBgColor()
+    end
+    
+    if not table.is_empty(table.complement({r,g,b,rb,gb,bb},{cr,cg,cb,crb,cgb,cbb})) then
+      cr,cg,cb,crb,cgb,cbb = r,g,b,rb,gb,bb
+      result = string.format(style, result and (result..endspan) or "", r, g, b, rb, gb, bb, line:sub(index, index))
+    else
+      result = result .. line:sub(index, index)
+    end
+  end
+  result = result .. endspan
+  if name == "copy2html" then
+    local conversions = {["¦"] = "&brvbar;", ["×"] = "&times;", ["«"] = "&#171;", ["»"] = "&raquo;"}
+    for from, to in pairs(conversions) do
+      result = string.gsub(result, from, to)
+    end
+  end
+  return result
+end
+
+--- copies text with color information in decho format
+--- @param win optional, the window to copy from. Defaults to the main window
+--- @param str optional, the string to copy. Defaults to copying the entire line
+--- @param inst optional, the instance of the string to copy. Defaults to the first instance.
+--- @usage to copy matches[2] with color information and echo it to miniconsole "test"
+---   <pre>
+---   echo("test", copy2decho(matches[2]))
+---   </pre>
+---
+--- @usage to copy the entire line with color information, then echo it to miniconsole "test"
+---   <pre>
+---   echo("test", copy2decho())
+---   </pre>
+function copy2decho(win, str, inst)
+  return copy2color("copy2decho", win, str, inst)
+end
+
+--- copies text with color information in html format, for echoing to a label for instance
+--- @param win optional, the window to copy from. Defaults to the main window
+--- @param str optional, the string to copy. Defaults to copying the entire line
+--- @param inst optional, the instance of the string to copy. Defaults to the first instance.
+--- @usage to copy matches[2] with color information and echo it to label "test"
+---   <pre>
+---   echo("test", copy2html(matches[2]))
+---   </pre>
+---
+--- @usage to copy the entire line with color information, then echo it to label "test"
+---   <pre>
+---   echo("test", copy2html())
+---   </pre>
+function copy2html(win, str, inst)
+  return copy2color("copy2html", win, str, inst)
+end


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds two functions for copying text from the current line in a (mini)console. 
copy2decho(window, stringToCopy, instanceToCopy)
copy2html(window, stringToCopy, instanceToCopy)

in both cases all arguments are optional. window defaults to 'main', stringToCopy defaults to the entire line, and instanceToCopy defaults to 1. 

Based mostly on code found on the forums at: https://forums.mudlet.org/viewtopic.php?f=6&t=22642&p=45611#p44764

had to make some slight modifications to get it working and make the potential ldoc output better.

#### Motivation for adding to Mudlet

Came up in #help and is functionality we probably should have been providing for a while now.

#### Other info (issues closed, discussion etc)

decho("\n" .. copy2decho()) will copy a line and decho it out immediately below. Useful for testing purposes.
Did similar with `testLabel:decho(copy2html())` to make sure the label always had the last line from the game in it.

Similar tests done using `copy2decho(matches[2])` and a perl regex trigger. 

![image](https://user-images.githubusercontent.com/3660/77348672-3e478400-6d10-11ea-88f4-1c90378ba314.png)

Both functions documented using ldoc in source, but:

- [x]  document copy2decho on wiki

- [x]  document copy2html on wiki