### PR TITLE
Remove use of old native openGL flag on Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,10 +124,6 @@ QCoreApplication* createApplication(int& argc, char* argv[], unsigned int& actio
         // Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute
         // before constructing QGuiApplication."
         QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#elif defined(Q_OS_WIN32)
-        // Force OpenGL use as we use some functions that aren't provided by
-        // Qt's OpenGL layer on Windows (QOpenGLFunctions)
-        QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
 #endif
         return new QApplication(argc, argv); // Normal course of events - (GUI), so: game on!
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,8 +125,9 @@ QCoreApplication* createApplication(int& argc, char* argv[], unsigned int& actio
         // before constructing QGuiApplication."
         QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 #elif defined(Q_OS_WIN32)
-        // Force ANGLE use - some nvidia cards on windows tend to 'freeze'
-        QApplication::setAttribute(Qt::AA_UseOpenGLES);
+        // Force OpenGL use as we use some functions that aren't provided by
+        // Qt's OpenGL layer on Windows (QOpenGLFunctions)
+        QApplication::setAttribute(Qt::AA_UseOpenGLES);        
 #endif
         return new QApplication(argc, argv); // Normal course of events - (GUI), so: game on!
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,9 +125,8 @@ QCoreApplication* createApplication(int& argc, char* argv[], unsigned int& actio
         // before constructing QGuiApplication."
         QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 #elif defined(Q_OS_WIN32)
-        // Force OpenGL use as we use some functions that aren't provided by
-        // Qt's OpenGL layer on Windows (QOpenGLFunctions)
-        QApplication::setAttribute(Qt::AA_UseOpenGLES);        
+        // Force ANGLE use - some nvidia cards on windows tend to 'freeze'
+        QApplication::setAttribute(Qt::AA_UseOpenGLES);
 #endif
         return new QApplication(argc, argv); // Normal course of events - (GUI), so: game on!
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,6 +124,10 @@ QCoreApplication* createApplication(int& argc, char* argv[], unsigned int& actio
         // Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute
         // before constructing QGuiApplication."
         QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+#elif defined(Q_OS_WIN32)
+        // Force OpenGL use as we use some functions that aren't provided by
+        // Qt's OpenGL layer on Windows (QOpenGLFunctions)
+        QApplication::setAttribute(Qt::AA_UseOpenGLES);        
 #endif
         return new QApplication(argc, argv); // Normal course of events - (GUI), so: game on!
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,10 +124,6 @@ QCoreApplication* createApplication(int& argc, char* argv[], unsigned int& actio
         // Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute
         // before constructing QGuiApplication."
         QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#elif defined(Q_OS_WIN32)
-        // Force OpenGL use as we use some functions that aren't provided by
-        // Qt's OpenGL layer on Windows (QOpenGLFunctions)
-        QApplication::setAttribute(Qt::AA_UseOpenGLES);        
 #endif
         return new QApplication(argc, argv); // Normal course of events - (GUI), so: game on!
     }

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -664,6 +664,11 @@ contains( DEFINES, INCLUDE_3DMAPPER ) {
     SOURCES += glwidget.cpp
     QT += opengl
 
+    win32 {
+        LIBS += -lopengl32 \
+                -lglu32
+    }
+
     !build_pass{
         message("The 3D mapper code is included in this configuration")
     }

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -665,8 +665,7 @@ contains( DEFINES, INCLUDE_3DMAPPER ) {
     QT += opengl
 
     win32 {
-        LIBS += -lopengl32 \
-                -lglu32
+        LIBS += -lglu32
     }
 
     !build_pass{

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -665,7 +665,8 @@ contains( DEFINES, INCLUDE_3DMAPPER ) {
     QT += opengl
 
     win32 {
-        LIBS += -lglu32
+        LIBS += -lopengl32 \
+                -lglu32
     }
 
     !build_pass{

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -664,11 +664,6 @@ contains( DEFINES, INCLUDE_3DMAPPER ) {
     SOURCES += glwidget.cpp
     QT += opengl
 
-    win32 {
-        LIBS += -lopengl32 \
-                -lglu32
-    }
-
     !build_pass{
         message("The 3D mapper code is included in this configuration")
     }


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
We had the old flag in place to force native opengl because the old mapper widget required some functions that ANGLE didn't provide, but now we don't need it anymore having had upgraded the mapper.
#### Motivation for adding to Mudlet
Fix Mudlet hangs on Windows in certain setups.
#### Other info (issues closed, discussion etc)
See https://doc.qt.io/qt-5/windows-requirements.html `Qt::AA_UseDesktopOpenGL`