### PR TITLE
Fix: Correct Geyser.UserWindow:new to use a local `me` not global

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -61,7 +61,7 @@ function Geyser.UserWindow:new(cons)
   cons.x = cons.x or 10
   cons.y = cons.y or 140
   --Root Container for UserWindows 
-  me = self.Parent:new(cons)
+  local me = self.Parent:new(cons)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Per Issue #3513, fixes the incorrect use of global `me` that overwrites user's existing global `me` variable.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
