### PR TITLE
Refactor: only include Noto Color Font where usable (on Linux only)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 ############################################################################
 #    Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       #
-#    Copyright (C) 2015-2018 by Stephen Lyons - slysven@virginmedia.com    #
+#    Copyright (C) 2015-2018, 2020 by Stephen Lyons                        #
+#                                                - slysven@virginmedia.com #
 #    Copyright (C) 2018 by Huadong Qi - novload@outlook.com                #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
@@ -22,7 +23,13 @@
 set(mudlet_RCCS mudlet.qrc)
 
 if(USE_FONTS)
-  list(APPEND mudlet_RCCS mudlet_fonts.qrc)
+  list(APPEND mudlet_RCCS mudlet_fonts_common.qrc)
+  # There is not an equivalent to WIN32 for Linux specifically instead we must
+  # check the value of CMAKE_SYSTEM_NAME - see:
+  # https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/How-To-Write-Platform-Checks:
+  if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    list(APPEND mudlet_RCCS mudlet_fonts_linux.qrc)
+  endif()
 endif()
 
 if(WIN32)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -40,6 +40,7 @@
 #include "pre_guard.h"
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QMimeData>
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QShortcut>

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3338,8 +3338,11 @@ int TLuaInterpreter::setFont(lua_State* L)
         font = QString::fromUtf8(lua_tostring(L, s));
     }
 
-    // ensure that emojis are displayed in colour even if this font doesn't support it
+#if defined(Q_OS_LINUX)
+    // On Linux ensure that emojis are displayed in colour even if this font
+    // doesn't support it:
     QFont::insertSubstitution(font, QStringLiteral("Noto Color Emoji"));
+#endif
 
     if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
         if (mudlet::self()->mConsoleMap.contains(pHost)) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2019 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -1032,7 +1032,11 @@ void XMLimport::readHostPackage(Host* pHost)
                 pHost->mLightWhite.setNamedColor(readElementText());
             } else if (name() == "mDisplayFont") {
                 pHost->setDisplayFontFromString(readElementText());
+#if defined(Q_OS_LINUX)
+                // On Linux ensure that emojis are displayed in colour even if
+                // this font doesn't support it:
                 QFont::insertSubstitution(pHost->mDisplayFont.family(), QStringLiteral("Noto Color Emoji"));
+#endif
                 pHost->setDisplayFontFixedPitch(true);
             } else if (name() == "mCommandLineFont") {
                 pHost->mCommandLineFont.fromString(readElementText());

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014, 2016-2018 by Stephen Lyons                        *
+ *   Copyright (C) 2014, 2016-2018, 2020 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -1623,7 +1623,12 @@ void dlgProfilePreferences::setDisplayFont()
         label_variableWidthFontWarning->show();
     }
 
+#if defined(Q_OS_LINUX)
+    // On Linux ensure that emojis are displayed in colour even if this font
+    // doesn't support it:
     QFont::insertSubstitution(pHost->mDisplayFont.family(), QStringLiteral("Noto Color Emoji"));
+#endif
+
     auto* mainConsole = mudlet::self()->mConsoleMap.value(pHost);
     if (!mainConsole) {
         return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014, 2016-2019 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2014, 2016-2020 by Stephen Lyons                   *
  *                                            - slysven@virginmedia.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *                                                                         *
@@ -380,10 +380,13 @@ int main(int argc, char* argv[])
     if (!dir.exists(ubuntuFontDirectory)) {
         dir.mkpath(ubuntuFontDirectory);
     }
+#if defined(Q_OS_LINUX)
+    // Only needed/works on Linux to provide color emojis:
     QString notoFontDirectory(QStringLiteral("%1/notocoloremoji-unhinted-2018-04-24-pistol-update").arg(mudlet::getMudletPath(mudlet::mainFontsPath)));
     if (!dir.exists(notoFontDirectory)) {
         dir.mkpath(notoFontDirectory);
     }
+#endif
 
     // The original code plonks the fonts AND the Copyright into the MAIN mudlet
     // directory - but the Copyright statement is specifically for the fonts
@@ -433,9 +436,12 @@ int main(int argc, char* argv[])
     copyFont(ubuntuFontDirectory, QLatin1String("fonts/ubuntu-font-family-0.83"), QLatin1String("UbuntuMono-R.ttf"));
     copyFont(ubuntuFontDirectory, QLatin1String("fonts/ubuntu-font-family-0.83"), QLatin1String("UbuntuMono-RI.ttf"));
 
+#if defined(Q_OS_LINUX)
     copyFont(notoFontDirectory, QStringLiteral("fonts/notocoloremoji-unhinted-2018-04-24-pistol-update"), QStringLiteral("NotoColorEmoji.ttf"));
     copyFont(notoFontDirectory, QStringLiteral("fonts/notocoloremoji-unhinted-2018-04-24-pistol-update"), QStringLiteral("LICENSE_OFL.txt"));
-#endif
+    copyFont(notoFontDirectory, QStringLiteral("fonts/notocoloremoji-unhinted-2018-04-24-pistol-update"), QStringLiteral("README"));
+#endif // defined(Q_OS_LINUX)
+#endif // defined(INCLUDE_FONTS)
 
     mudlet::debugMode = false;
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1,5 +1,5 @@
 ############################################################################
-#    Copyright (C) 2013-2015, 2017-2018 by Stephen Lyons                   #
+#    Copyright (C) 2013-2015, 2017-2018, 2020 by Stephen Lyons             #
 #                                                - slysven@virginmedia.com #
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
 #    Copyright (C) 2017 by Ian Adkins - ieadkins@gmail.com                 #
@@ -623,11 +623,19 @@ FORMS += \
     ui/trigger_pattern_edit.ui \
     ui/vars_main_area.ui
 
-RESOURCES = mudlet.qrc \
-            ../translations/translated/qm.qrc
+RESOURCES += \
+    mudlet.qrc \
+    ../translations/translated/qm.qrc
 
 contains(DEFINES, INCLUDE_FONTS) {
-    RESOURCES += mudlet_fonts.qrc
+    RESOURCES += \
+        mudlet_fonts_common.qrc
+
+    linux {
+        RESOURCES += \
+            mudlet_fonts_linux.qrc
+    }
+
     !build_pass{
         # On windows or on platforms that support CONFIG having debug_and_release"
         # then there can be three passes through this file and we only want the

--- a/src/mudlet_fonts_common.qrc
+++ b/src/mudlet_fonts_common.qrc
@@ -34,8 +34,5 @@
         <file>fonts/ubuntu-font-family-0.83/Ubuntu-MI.ttf</file>
         <file>fonts/ubuntu-font-family-0.83/Ubuntu-R.ttf</file>
         <file>fonts/ubuntu-font-family-0.83/Ubuntu-RI.ttf</file>
-        <file>fonts/notocoloremoji-unhinted-2018-04-24-pistol-update/LICENSE_OFL.txt</file>
-        <file>fonts/notocoloremoji-unhinted-2018-04-24-pistol-update/NotoColorEmoji.ttf</file>
-        <file>fonts/notocoloremoji-unhinted-2018-04-24-pistol-update/README</file>
     </qresource>
 </RCC>

--- a/src/mudlet_fonts_linux.qrc
+++ b/src/mudlet_fonts_linux.qrc
@@ -1,0 +1,7 @@
+<RCC>
+    <qresource prefix="/">
+        <file>fonts/notocoloremoji-unhinted-2018-04-24-pistol-update/LICENSE_OFL.txt</file>
+        <file>fonts/notocoloremoji-unhinted-2018-04-24-pistol-update/NotoColorEmoji.ttf</file>
+        <file>fonts/notocoloremoji-unhinted-2018-04-24-pistol-update/README</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
Only on that OS does it provide the Colour Emojis characters we want, on Windows and MacOs the system forces the use of their proprietary font and FreeBSD does not seem to provide color font support...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>