### PR TITLE
Fix missing include/file

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -40,6 +40,7 @@
 #include "pre_guard.h"
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QMimeData>
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QShortcut>

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -710,6 +710,7 @@ TRANSLATIONS = $$files(../translations/translated/*.ts)
 
 # Main lua files:
 LUA.files = \
+    $${PWD}/mudlet-lua/lua/CursorShapes.lua \
     $${PWD}/mudlet-lua/lua/DB.lua \
     $${PWD}/mudlet-lua/lua/DebugTools.lua \
     $${PWD}/mudlet-lua/lua/GMCP.lua \


### PR DESCRIPTION
Include is needed for compiling when WITH_FONTS=NO WITH_UPDATER=NO

CursorShapes.lua is a new file that needs to be listed with other lua files in mudlet.pro so that make install knows it should install it.