### PR TITLE
Script manipulation via lua

### DIFF
--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -206,3 +206,15 @@ void ScriptUnit::compileAll()
         }
     }
 }
+
+// This is currently only used during the lua scripted creation of a new
+// permScript to find a parent with the given name:
+TScript* ScriptUnit::findFirstScript(const QString& name) const
+{
+    for (auto script : mScriptMap) {
+        if (script->getName() == name) {
+            return script;
+        }
+    }
+    return nullptr;
+}

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -208,14 +208,13 @@ void ScriptUnit::compileAll()
     }
 }
 
-TScript* ScriptUnit::findFirstScript(const QString& name, bool noFolder) const
+QVector<int> ScriptUnit::findScriptId(const QString& name) const
 {
+    QVector<int> Ids;
     for (auto script : mScriptMap) {
-        if (script->getName() == name && noFolder == false) {
-            return script;
-        } else if (script->getName() == name && !script->isFolder()) {
-            return script;
+        if (script->getName() == name) {
+            Ids.append(script->getID());
         }
     }
-    return nullptr;
+    return Ids;
 }

--- a/src/ScriptUnit.cpp
+++ b/src/ScriptUnit.cpp
@@ -158,6 +158,7 @@ void ScriptUnit::unregisterScript(TScript* pT)
         removeScript(pT);
         return;
     } else {
+        removeScript(pT);
         removeScriptRootNode(pT);
         return;
     }
@@ -207,12 +208,12 @@ void ScriptUnit::compileAll()
     }
 }
 
-// This is currently only used during the lua scripted creation of a new
-// permScript to find a parent with the given name:
-TScript* ScriptUnit::findFirstScript(const QString& name) const
+TScript* ScriptUnit::findFirstScript(const QString& name, bool noFolder) const
 {
     for (auto script : mScriptMap) {
-        if (script->getName() == name) {
+        if (script->getName() == name && noFolder == false) {
+            return script;
+        } else if (script->getName() == name && !script->isFolder()) {
             return script;
         }
     }

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -66,7 +66,7 @@ public:
     int getNewID();
     QMutex mScriptUnitLock;
     QList<TScript*> uninstallList;
-    TScript* findFirstScript(const QString& name, bool noFolder = false) const;
+    QVector<int> findScriptId(const QString& name) const;
 
 private:
     ScriptUnit() = default;

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -66,7 +66,7 @@ public:
     int getNewID();
     QMutex mScriptUnitLock;
     QList<TScript*> uninstallList;
-    TScript* findFirstScript(const QString& name) const;
+    TScript* findFirstScript(const QString& name, bool noFolder = false) const;
 
 private:
     ScriptUnit() = default;

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -49,6 +49,12 @@ public:
         return mScriptRootNodeList;
     }
 
+    QMap<int, TScript*> getScriptList()
+    {
+        QMutexLocker locker(&mScriptUnitLock);
+        return mScriptMap;
+    }
+
     TScript* getScript(int id);
     void compileAll();
     bool registerScript(TScript* pT);
@@ -60,6 +66,7 @@ public:
     int getNewID();
     QMutex mScriptUnitLock;
     QList<TScript*> uninstallList;
+    TScript* findFirstScript(const QString& name) const;
 
 private:
     ScriptUnit() = default;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8398,7 +8398,7 @@ int TLuaInterpreter::setScript(lua_State* L)
     }
     QString luaCode = QString::fromUtf8(lua_tostring(L, 2));
 
-    if (n > 1) {
+    if (n > 2) {
         if (!lua_isnumber(L, 3)) {
             lua_pushfstring(L, "setScript: bad argument #3 type (script position as number expected, got %s!)", luaL_typename(L, 3));
             return lua_error(L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -129,7 +129,7 @@ public:
     int startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
     QPair<int, QString> startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
     QPair<int, QString> createPermScript(const QString& name, const QString& parent, const QString& luaCode);
-    QPair<int, QString> setScriptCode(QString &name, const QString& luaCode);
+    QPair<int, QString> setScriptCode(QString &name, const QString& luaCode, int pos);
     int startPermAlias(const QString& name, const QString& parent, const QString& regex, const QString& function);
     int startPermKey(QString&, QString&, int&, int&, QString&);
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -129,7 +129,7 @@ public:
     int startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
     QPair<int, QString> startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
     QPair<int, QString> createPermScript(const QString& name, const QString& parent, const QString& luaCode);
-    QPair<int, QString> setScriptCode(const QString& name, const QString& luaCode);
+    QPair<int, QString> setScriptCode(QString &name, const QString& luaCode);
     int startPermAlias(const QString& name, const QString& parent, const QString& regex, const QString& function);
     int startPermKey(QString&, QString&, int&, int&, QString&);
 
@@ -409,6 +409,8 @@ public:
     static int permScript(lua_State*);
     static int getScript(lua_State*);
     static int setScript(lua_State*);
+    static int enableScript(lua_State*);
+    static int disableScript(lua_State*);
     static int permAlias(lua_State*);
     static int exists(lua_State*);
     static int isActive(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -128,6 +128,8 @@ public:
     int startPermBeginOfLineStringTrigger(const QString& name, const QString& parent, QStringList& regex, const QString& function);
     int startPermPromptTrigger(const QString& name, const QString& parent, const QString& function);
     QPair<int, QString> startPermTimer(const QString& name, const QString& parent, double timeout, const QString& function);
+    QPair<int, QString> createPermScript(const QString& name, const QString& parent, const QString& luaCode);
+    QPair<int, QString> setScriptCode(const QString& name, const QString& luaCode);
     int startPermAlias(const QString& name, const QString& parent, const QString& regex, const QString& function);
     int startPermKey(QString&, QString&, int&, int&, QString&);
 
@@ -404,6 +406,9 @@ public:
     static int permRegexTrigger(lua_State*);
     static int permSubstringTrigger(lua_State*);
     static int permTimer(lua_State*);
+    static int permScript(lua_State*);
+    static int getScript(lua_State*);
+    static int setScript(lua_State*);
     static int permAlias(lua_State*);
     static int exists(lua_State*);
     static int isActive(lua_State*);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4358,6 +4358,9 @@ void dlgTriggerEditor::writeScript(int id)
     if (!pItem) {
         return;
     }
+    if (mCurrentView == EditorViewType::cmUnknownView || mCurrentView != EditorViewType::cmScriptView) {
+        return;
+    }
     int scriptID = pItem->data(0, Qt::UserRole).toInt();
     if (scriptID != id) {
         return;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4352,6 +4352,22 @@ void dlgTriggerEditor::saveAction()
     mudlet::self()->processEventLoopHack();
 }
 
+void dlgTriggerEditor::writeScript(int id)
+{
+    QTreeWidgetItem* pItem = mpCurrentScriptItem;
+    if (!pItem) {
+        return;
+    }
+    int scriptID = pItem->data(0, Qt::UserRole).toInt();
+    if (scriptID != id) {
+        return;
+    }
+
+    TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
+    QString scriptCode = pT->getScript();
+    mpSourceEditorEdbeeDocument->setText(scriptCode);
+}
+
 void dlgTriggerEditor::saveScript()
 {
     QTreeWidgetItem* pItem = mpCurrentScriptItem;
@@ -8001,7 +8017,6 @@ void dlgTriggerEditor::doCleanReset()
         runScheduledCleanReset();
     });
 }
-
 void dlgTriggerEditor::runScheduledCleanReset()
 {
     switch (mCurrentView) {
@@ -8040,7 +8055,6 @@ void dlgTriggerEditor::runScheduledCleanReset()
     mpCurrentKeyItem = nullptr;
     slot_show_triggers();
 }
-
 
 void dlgTriggerEditor::slot_profileSaveAction()
 {

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -180,6 +180,7 @@ public:
     void children_icon_alias(QTreeWidgetItem* pWidgetItemParent);
     void children_icon_key(QTreeWidgetItem* pWidgetItemParent);
     void doCleanReset();
+    void writeScript(int id);
     void addVar(bool);
     int canRecast(QTreeWidgetItem*, int newNameType, int newValueType);
     void saveVar();

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -185,7 +185,7 @@ function appendScript(name, luaCode, pos)
   assert(type(name) == "string", "appendScript: bad argument #1 type (script name as string expected, got "..type(name).."!)")
   assert(type(name) == "string", "appendScript: bad argument #2 type (lua code as string expected, got "..type(luaCode).."!)")
   if not getScript(name, pos) then
-    return nil, 'script "'..name..'" not found'
+    return nil, 'script "'..name..'" at position "'..pos..'" not found'
   end
   return setScript(name, getScript(name, pos).."\n"..luaCode, pos)
 end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -180,13 +180,14 @@ end
 ---
 --- @param name name of the script item
 --- @param luaCode 
-function appendScript(name, luaCode)
+function appendScript(name, luaCode, pos)
+  pos = pos or 1
   assert(type(name) == "string", "appendScript: bad argument #1 type (script name as string expected, got "..type(name).."!)")
   assert(type(name) == "string", "appendScript: bad argument #2 type (lua code as string expected, got "..type(luaCode).."!)")
-  if not getScript(name) then
+  if not getScript(name, pos) then
     return nil, 'script "'..name..'" not found'
   end
-  return setScript(name, getScript(name).."\n"..luaCode)
+  return setScript(name, getScript(name, pos).."\n"..luaCode, pos)
 end
 
 --- Checks to see if a given file or folder exists. If it exists, it'll return the Lua true boolean value, otherwise false.

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -144,6 +144,9 @@ local group_creation_functions = {
   end,
   alias = function(name, parent)
     return not (permAlias(name, parent, "", "") == -1)
+  end,
+  script = function(name, parent)
+    return not (permScript(name, parent, "", "") == -1)
   end
 }
 
@@ -173,7 +176,18 @@ function permGroup(name, itemtype, parent)
   return group_creation_functions[itemtype](name, parent)
 end
 
-
+--- Appends code to an existing script
+---
+--- @param name name of the script item
+--- @param luaCode 
+function appendScript(name, luaCode)
+  assert(type(name) == "string", "appendScript: bad argument #1 type (script name as string expected, got "..type(name).."!)")
+  assert(type(name) == "string", "appendScript: bad argument #2 type (lua code as string expected, got "..type(luaCode).."!)")
+  if not getScript(name) then
+    return nil, 'script "'..name..'" not found'
+  end
+  return setScript(name, getScript(name).."\n"..luaCode)
+end
 
 --- Checks to see if a given file or folder exists. If it exists, it'll return the Lua true boolean value, otherwise false.
 ---


### PR DESCRIPTION
#### Brief overview of PR changes/additions
New functions:
**permScript**(name, parent, luacode) -- works the same way as other perm functions
**enableScript**("script-name") -- enables all scripts found with the name "script-name"
**disableScript**("script-name")-- disables all scripts found with the name "script-name"
**getScript**("script-name", [occurrence]) -- returns the luacode of the n occurrence of  "script-name" as string (if occurence is not set it is 1 which is the first occurrence)
**setScript**("scriptname", luacode, [occurrence]) -- set the luacode of the n occurrence of "scriptname" (overwrites old code, if occurrence is not set it is 1 which is the first occurrence
**appendScript**("script-name", luacode, [occurrence]) -- appends luacode to n occurrence of "scriptname" (if occurrence is not set it is 1 which is the first occurrence)
additionally **permGroup** accepts the type "*script*" now.
#### Motivation for adding to Mudlet
Mudlet was lacking this abilities by itself.
Script manipulation was only possible in a hacky way.
https://github.com/Mudlet/Mudlet/issues/2897
#### Other info (issues closed, discussion etc)
The new permGroup and permScript functions have the same limitations as the old ones (for timers, alias...).

It is possible to get/set a script even with the same name through the value occurrence.
To know how many occurrences of the same script are there it's possible to use: **exists("myscriptname", "script")**

Found an issue (and fixed it) in exists and isActive for scripts, they were only finding scripts which were located in the root node.

