### PR TITLE
Enhance: allow Mudlet packager to disable variable splash-screens

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,11 @@ include_optional_module(
   OPTION_VARIABLE USE_3DMAPPER
   READABLE_NAME "3D mapper"
 )
+include_optional_module(
+  ENVIRONMENT_VARIABLE WITH_VARIABLE_SPLASH_SCREEN
+  OPTION_VARIABLE USE_VARIABLE_SPLASH_SCREEN
+  READABLE_NAME "build-type splash screen"
+)
 
 include(InitGitSubmodule)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -348,6 +348,13 @@ if(USE_3DMAPPER)
   )
 endif()
 
+if(USE_VARIABLE_SPLASH_SCREEN)
+  target_compile_definitions(mudlet
+    PRIVATE
+      INCLUDE_VARIABLE_SPLASH_SCREEN
+  )
+endif()
+
 if(WIN32)
     target_link_libraries(mudlet ws2_32)
     set_target_properties(mudlet

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -41,9 +41,13 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 
     // Copied from main():
 
+#if defined(INCLUDE_VARIABLE_SPLASH_SCREEN)
     QImage splashImage(mudlet::scmIsReleaseVersion ? QStringLiteral(":/Mudlet_splashscreen_main.png")
                                                    : mudlet::scmIsPublicTestVersion ? QStringLiteral(":/Mudlet_splashscreen_ptb.png")
                                                                                     : QStringLiteral(":/Mudlet_splashscreen_development.png"));
+#else
+    QImage splashImage(QStringLiteral(":/Mudlet_splashscreen_main.png"));
+#endif
 
     { // Brace code using painter to ensure it is freed at right time...
         QPainter painter(&splashImage);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,9 +293,14 @@ int main(int argc, char* argv[])
 
 
     bool show_splash = !(startupAction & 4); // Not --quiet.
+#if defined(INCLUDE_VARIABLE_SPLASH_SCREEN)
     QImage splashImage(mudlet::scmIsReleaseVersion ? QStringLiteral(":/Mudlet_splashscreen_main.png")
                                                    : mudlet::scmIsPublicTestVersion ? QStringLiteral(":/Mudlet_splashscreen_ptb.png")
                                                                                     : QStringLiteral(":/Mudlet_splashscreen_development.png"));
+#else
+    QImage splashImage(QStringLiteral(":/Mudlet_splashscreen_main.png"));
+#endif
+
     if (show_splash) {
         QPainter painter(&splashImage);
         unsigned fontSize = 16;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -114,6 +114,15 @@ isEmpty( BUILD ) {
    BUILD = "-dev"
 }
 
+# As the above also modifies the splash screen image (so developers get reminded
+# what they are working with!) Packagers (e.g. for Linux distributions) will
+# want to set the environmental variable WITH_VARIABLE_SPLASH_SCREEN to NO so
+# that their build does not appear to be a "DEV"elopment build!
+WITH_VS_SCREEN_TEST = $$upper($$(WITH_VARIABLE_SPLASH_SCREEN))
+isEmpty( WITH_VS_SCREEN_TEST ) | !equals(WITH_VS_SCREEN_TEST, "NO" ) {
+    DEFINES += INCLUDE_VARIABLE_SPLASH_SCREEN
+}
+
 # Changing BUILD and VERSION values affects: ctelnet.cpp, main.cpp, mudlet.cpp
 # dlgAboutDialog.cpp and TLuaInterpreter.cpp.  It does NOT cause those files to
 # be automatically rebuilt so you will need to 'touch' them...!


### PR DESCRIPTION
Someone building a packaged version of Mudlet will want to define `WITH_VARIABLE_SPLASH_SCREEN` to `NO` otherwise their build - whether it sets `MUDLET_VERSION_BUILD` or not will be treated as if it was a development build and get the splash-screen for THAT build type rather than the original that they would previously get prior to PR #3521 !

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>