### PR TITLE
Ensure Windows Start Menu PTB is unique

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -8,7 +8,7 @@ windeployqt.exe --release mudlet.exe
 
 Remove-Item * -include *.cpp, *.o
 
-$Script:PublicTestBuild = if ($Env:MUDLET_VERSION_BUILD) { $Env:MUDLET_VERSION_BUILD.StartsWith('-ptb' } else { $FALSE }
+$Script:PublicTestBuild = if ($Env:MUDLET_VERSION_BUILD) { $Env:MUDLET_VERSION_BUILD.StartsWith('-ptb') } else { $FALSE }
 
 if (Test-Path Env:APPVEYOR_PULL_REQUEST_NUMBER) {
   $Script:Commit = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1288,7 +1288,7 @@ win32 {
     QMAKE_TARGET_DESCRIPTION = "Mudlet the MUD client"
 
     # Product name determines the Windows Start Menu shortcut name
-    contains(BUILD, "-public-test-build.+") {
+    contains(BUILD, "-ptb.+") {
         QMAKE_TARGET_PRODUCT = "Mudlet PTB"
     } else {
         QMAKE_TARGET_PRODUCT = "Mudlet"


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Ensure Windows Start Menu PTB is unique - missed a spot when renaming. Without this fix, ptb will overwrite the usual 'Mudlet' start menu.
#### Motivation for adding to Mudlet
Post-fix on https://github.com/Mudlet/Mudlet/pull/3535.
#### Other info (issues closed, discussion etc)
