### PR TITLE
Fix macOS/Linux builds

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -86,10 +86,10 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
     if [ "${public_test_build}" == "true" ]; then
       echo "=== Creating release in Dblsqd ==="
-      dblsqd release -a mudlet -c public-test-build -m "(test release message here)" "${VERSION,,}${MUDLET_VERSION_BUILD,,}"
+      dblsqd release -a mudlet -c public-test-build -m "(test release message here)" "${VERSION}${MUDLET_VERSION_BUILD}"
 
       echo "=== Registering release with Dblsqd ==="
-      dblsqd push -a mudlet -c public-test-build -r "${VERSION,,}${MUDLET_VERSION_BUILD,,}" -s mudlet --type "standalone" --attach mac:x86_64 "${DEPLOY_URL}"
+      dblsqd push -a mudlet -c public-test-build -r "${VERSION}${MUDLET_VERSION_BUILD}" -s mudlet --type "standalone" --attach mac:x86_64 "${DEPLOY_URL}"
     else
       echo "=== Registering release with Dblsqd ==="
       dblsqd push -a mudlet -c release -r "${VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${DEPLOY_URL}"

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -18,9 +18,6 @@ if [ -z "${TRAVIS_TAG}" ]; then
   fi
 fi
 
-# not all systems we deal with allow uppercase ascii characters
-MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD,,}"
-
 VERSION=""
 
 if [ "${Q_OR_C_MAKE}" = "cmake" ]; then
@@ -28,6 +25,10 @@ if [ "${Q_OR_C_MAKE}" = "cmake" ]; then
 elif [ "${Q_OR_C_MAKE}" = "qmake" ]; then
   VERSION=$(perl -lne 'print $1 if /^VERSION = (.+)/' < "${TRAVIS_BUILD_DIR}/src/mudlet.pro")
 fi
+
+# not all systems we deal with allow uppercase ascii characters
+MUDLET_VERSION_BUILD=$(echo "$MUDLET_VERSION_BUILD" | tr '[:upper:]' '[:lower:]')
+VERSION=$(echo "$VERSION" | tr '[:upper:]' '[:lower:]')
 
 export VERSION
 export MUDLET_VERSION_BUILD

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -2,49 +2,51 @@
 
 if [ -z "${TRAVIS_TAG}" ]; then
   echo "Not a release build - skipping release validation."
-  exit
+  # don't use exit here:
+  # https://docs.travis-ci.com/user/job-lifecycle#how-does-this-work-or-why-you-should-not-use-exit-in-build-steps
+else
+
+  error() {
+    # shellcheck disable=SC2059
+    printf "error: $1\n" "${@:2}" >&2
+    exit 1
+  }
+
+  function validate_qmake() {
+    local VALID_QMAKE VALID_BUILD
+
+    VALID_QMAKE=$(pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$" < src/mudlet.pro)
+    if [ -z "${VALID_QMAKE}" ]; then
+      error "mudlet.pro's VERSION variable isn't formatted following the semantic versioning rules in a release build."
+    fi
+
+    VALID_BUILD=$(pcregrep --only-matching=1 ' +BUILD ? = ? ("")' < src/mudlet.pro)
+    if [ "${VALID_BUILD}" != '""' ]; then
+      error "mudlet.pro's BUILD variable isn't set to \"\" as it should be in a release build."
+    fi
+  }
+
+  function validate_cmake() {
+    local VALID_CMAKE VALID_BUILD
+    VALID_CMAKE=$(pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
+
+    if [ -z "${VALID_CMAKE}" ]; then
+      error "CMakeLists.txt VERSION variable isn't formatted following the semantic versioning rules in a release build."
+    fi
+
+    VALID_BUILD=$(pcregrep --only-matching=1 'set\(APP_BUILD ("")\)$' < CMakeLists.txt)
+    if [ "${VALID_BUILD}" != '""' ]; then
+      error "CMakeLists.txt APP_BUILD variable isn't set to \"\" as it should be in a release build."
+    fi
+  }
+
+  function validate_updater_environment_variable() {
+    if [ "$WITH_UPDATER" == "NO" ]; then
+       error "Updater is disabled in a release build."
+    fi
+  }
+
+  validate_qmake
+  validate_cmake
+  validate_updater_environment_variable
 fi
-
-error() {
-  # shellcheck disable=SC2059
-  printf "error: $1\n" "${@:2}" >&2
-  exit 1
-}
-
-function validate_qmake() {
-  local VALID_QMAKE VALID_BUILD
-
-  VALID_QMAKE=$(pcregrep --only-matching=1 "^VERSION ? = ?(\d+\.\d+\.\d+)$" < src/mudlet.pro)
-  if [ -z "${VALID_QMAKE}" ]; then
-    error "mudlet.pro's VERSION variable isn't formatted following the semantic versioning rules in a release build."
-  fi
-
-  VALID_BUILD=$(pcregrep --only-matching=1 ' +BUILD ? = ? ("")' < src/mudlet.pro)
-  if [ "${VALID_BUILD}" != '""' ]; then
-    error "mudlet.pro's BUILD variable isn't set to \"\" as it should be in a release build."
-  fi
-}
-
-function validate_cmake() {
-  local VALID_CMAKE VALID_BUILD
-  VALID_CMAKE=$(pcregrep --only-matching=1 "set\(APP_VERSION (\d+\.\d+\.\d+)\)$" < CMakeLists.txt)
-
-  if [ -z "${VALID_CMAKE}" ]; then
-    error "CMakeLists.txt VERSION variable isn't formatted following the semantic versioning rules in a release build."
-  fi
-
-  VALID_BUILD=$(pcregrep --only-matching=1 'set\(APP_BUILD ("")\)$' < CMakeLists.txt)
-  if [ "${VALID_BUILD}" != '""' ]; then
-    error "CMakeLists.txt APP_BUILD variable isn't set to \"\" as it should be in a release build."
-  fi
-}
-
-function validate_updater_environment_variable() {
-  if [ "$WITH_UPDATER" == "NO" ]; then
-     error "Updater is disabled in a release build."
-  fi
-}
-
-validate_qmake
-validate_cmake
-validate_updater_environment_variable

--- a/CI/travis.validate_deployment.sh
+++ b/CI/travis.validate_deployment.sh
@@ -2,7 +2,7 @@
 
 if [ -z "${TRAVIS_TAG}" ]; then
   echo "Not a release build - skipping release validation."
-  exit 0
+  exit
 fi
 
 error() {


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
All of the macOS/Linux builds are stopping after release validation: https://travis-ci.com/github/Mudlet/Mudlet/builds/156136716

I'm not sure why, because the validation script is returning `0` and according to the [docs](https://docs.travis-ci.com/user/job-lifecycle#how-does-this-work-or-why-you-should-not-use-exit-in-build-steps) it's already all kosher. But let's try returning nothing like the other script does.
#### Motivation for adding to Mudlet
Fix macOS/Linux builds.
#### Other info (issues closed, discussion etc)