### PR TITLE
Fix: Trigger Editor Splitter Improvements

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6926,7 +6926,7 @@ void dlgTriggerEditor::slot_show_actions()
         mpSourceEditorArea->show();
         slot_action_selected(treeWidget_actions->currentItem());
     }
-    if (mActionEditorSplitterState.length() > 0) {
+    if (!mActionEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mActionEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6708,7 +6708,7 @@ void dlgTriggerEditor::slot_show_timers()
         mpSourceEditorArea->show();
         slot_timer_selected(treeWidget_timers->currentItem());
     }
-    if (mTimerEditorSplitterState.length() > 0) {
+    if (!mTimerEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mTimerEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6753,7 +6753,7 @@ void dlgTriggerEditor::slot_show_triggers()
         mpSourceEditorArea->show();
         slot_trigger_selected(treeWidget_triggers->currentItem());
     }
-    if (mTriggerEditorSplitterState.length() > 0) {
+    if (!mTriggerEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mTriggerEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};
@@ -6777,7 +6777,7 @@ void dlgTriggerEditor::slot_show_scripts()
         mpSourceEditorArea->show();
         slot_scripts_selected(treeWidget_scripts->currentItem());
     }
-    if (mScriptEditorSplitterState.length() > 0) {
+    if (!mScriptEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mScriptEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};
@@ -6801,7 +6801,7 @@ void dlgTriggerEditor::slot_show_keys()
         mpSourceEditorArea->show();
         slot_key_selected(treeWidget_keys->currentItem());
     }
-    if (mKeyEditorSplitterState.length() > 0) {
+    if (!mKeyEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mKeyEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};
@@ -6829,7 +6829,7 @@ void dlgTriggerEditor::slot_show_vars()
         mpSourceEditorArea->show();
         slot_var_selected(treeWidget_variables->currentItem());
     }
-    if (mVarEditorSplitterState.length() > 0) {
+    if (!mVarEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mVarEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};
@@ -6875,7 +6875,7 @@ void dlgTriggerEditor::slot_show_aliases()
         mpSourceEditorArea->show();
         slot_alias_selected(treeWidget_aliases->currentItem());
     }
-    if (mAliasEditorSplitterState.length() > 0) {
+    if (!mAliasEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mAliasEditorSplitterState);
     } else {
         const QList<int> sizes = {30, 900, 30};

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -85,7 +85,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 , mCleanResetQueued(false)
 , mSavingAs(false)
 , mAutosaveInterval{}
-, mTriggerEditorSplitterState(QByteArray())
+, mTriggerEditorSplitterState{}
 , mAliasEditorSplitterState(QByteArray())
 , mScriptEditorSplitterState(QByteArray())
 , mActionEditorSplitterState(QByteArray())

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -85,6 +85,13 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 , mCleanResetQueued(false)
 , mSavingAs(false)
 , mAutosaveInterval{}
+, mTriggerEditorSplitterState(QByteArray())
+, mAliasEditorSplitterState(QByteArray())
+, mScriptEditorSplitterState(QByteArray())
+, mActionEditorSplitterState(QByteArray())
+, mKeyEditorSplitterState(QByteArray())
+, mTimerEditorSplitterState(QByteArray())
+, mVarEditorSplitterState(QByteArray())
 {
     // init generated dialog
     setupUi(this);
@@ -849,6 +856,14 @@ void dlgTriggerEditor::readSettings()
     move(pos);
 
     mAutosaveInterval = settings.value("autosaveIntervalMinutes", 2).toInt();
+
+    mTriggerEditorSplitterState = settings.value("mTriggerEditorSplitterState", QByteArray()).toByteArray();
+    mAliasEditorSplitterState = settings.value("mAliasEditorSplitterState", QByteArray()).toByteArray();
+    mScriptEditorSplitterState = settings.value("mScriptEditorSplitterState", QByteArray()).toByteArray();
+    mActionEditorSplitterState = settings.value("mActionEditorSplitterState", QByteArray()).toByteArray();
+    mKeyEditorSplitterState = settings.value("mKeyEditorSplitterState", QByteArray()).toByteArray();
+    mTimerEditorSplitterState = settings.value("mTimerEditorSplitterState", QByteArray()).toByteArray();
+    mVarEditorSplitterState = settings.value("mVarEditorSplitterState", QByteArray()).toByteArray();
 }
 
 void dlgTriggerEditor::writeSettings()
@@ -861,6 +876,14 @@ void dlgTriggerEditor::writeSettings()
     settings.setValue("script_editor_pos", pos());
     settings.setValue("script_editor_size", size());
     settings.setValue("autosaveIntervalMinutes", mAutosaveInterval);
+
+    settings.setValue("mTriggerEditorSplitterState", mTriggerEditorSplitterState);
+    settings.setValue("mAliasEditorSplitterState", mAliasEditorSplitterState);
+    settings.setValue("mScriptEditorSplitterState", mScriptEditorSplitterState);
+    settings.setValue("mActionEditorSplitterState", mActionEditorSplitterState);
+    settings.setValue("mKeyEditorSplitterState", mKeyEditorSplitterState);
+    settings.setValue("mTimerEditorSplitterState", mTimerEditorSplitterState);
+    settings.setValue("mVarEditorSplitterState", mVarEditorSplitterState);
 }
 
 void dlgTriggerEditor::slot_item_selected_search_list(QTreeWidgetItem* pItem)
@@ -6685,6 +6708,13 @@ void dlgTriggerEditor::slot_show_timers()
         mpSourceEditorArea->show();
         slot_timer_selected(treeWidget_timers->currentItem());
     }
+    if (mTimerEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mTimerEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mTimerEditorSplitterState = splitter_right->saveState();
+    }
 }
 
 void dlgTriggerEditor::slot_show_current()
@@ -6723,6 +6753,13 @@ void dlgTriggerEditor::slot_show_triggers()
         mpSourceEditorArea->show();
         slot_trigger_selected(treeWidget_triggers->currentItem());
     }
+    if (mTriggerEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mTriggerEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mTriggerEditorSplitterState = splitter_right->saveState();
+    }
 }
 
 void dlgTriggerEditor::slot_show_scripts()
@@ -6740,6 +6777,13 @@ void dlgTriggerEditor::slot_show_scripts()
         mpSourceEditorArea->show();
         slot_scripts_selected(treeWidget_scripts->currentItem());
     }
+    if (mScriptEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mScriptEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mScriptEditorSplitterState = splitter_right->saveState();
+    }
 }
 
 void dlgTriggerEditor::slot_show_keys()
@@ -6756,6 +6800,13 @@ void dlgTriggerEditor::slot_show_keys()
         mpKeysMainArea->show();
         mpSourceEditorArea->show();
         slot_key_selected(treeWidget_keys->currentItem());
+    }
+    if (mKeyEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mKeyEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mKeyEditorSplitterState = splitter_right->saveState();
     }
 }
 
@@ -6777,6 +6828,13 @@ void dlgTriggerEditor::slot_show_vars()
         mpVarsMainArea->show();
         mpSourceEditorArea->show();
         slot_var_selected(treeWidget_variables->currentItem());
+    }
+    if (mVarEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mVarEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mVarEditorSplitterState = splitter_right->saveState();
     }
 }
 
@@ -6816,6 +6874,13 @@ void dlgTriggerEditor::slot_show_aliases()
         mpAliasMainArea->show();
         mpSourceEditorArea->show();
         slot_alias_selected(treeWidget_aliases->currentItem());
+    }
+    if (mAliasEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mAliasEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mAliasEditorSplitterState = splitter_right->saveState();
     }
 }
 
@@ -6860,6 +6925,13 @@ void dlgTriggerEditor::slot_show_actions()
         mpActionsMainArea->show();
         mpSourceEditorArea->show();
         slot_action_selected(treeWidget_actions->currentItem());
+    }
+    if (mActionEditorSplitterState.length() > 0) {
+        splitter_right->restoreState(mActionEditorSplitterState);
+    } else {
+        const QList<int> sizes = {30, 900, 30};
+        splitter_right->setSizes(sizes);
+        mActionEditorSplitterState = splitter_right->saveState();
     }
 }
 
@@ -8739,6 +8811,7 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
     const int hysteresis = 10;
     static int bottomWidgetHeight = 0;
     if (mpTriggersMainArea->isVisible()) {
+        mTriggerEditorSplitterState = splitter_right->saveState();
         // The triggersMainArea is visible
         if (mpTriggersMainArea->toolButton_toggleExtraControls->isChecked()) {
             // The extra controls are visible in the triggersMainArea
@@ -8758,5 +8831,17 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
                 slot_showAllTriggerControls(true);
             }
         }
+    } else if (mpActionsMainArea->isVisible()) {
+        mActionEditorSplitterState = splitter_right->saveState();
+    } else if (mpAliasMainArea->isVisible()) {
+        mAliasEditorSplitterState = splitter_right->saveState();
+    } else if (mpKeysMainArea->isVisible()) {
+        mKeyEditorSplitterState = splitter_right->saveState();
+    } else if (mpScriptsMainArea->isVisible()) {
+        mScriptEditorSplitterState = splitter_right->saveState();
+    } else if (mpTimersMainArea->isVisible()) {
+        mTimerEditorSplitterState = splitter_right->saveState();
+    } else if (mpVarsMainArea->isVisible()) {
+        mVarEditorSplitterState = splitter_right->saveState();
     }
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -86,12 +86,12 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 , mSavingAs(false)
 , mAutosaveInterval{}
 , mTriggerEditorSplitterState{}
-, mAliasEditorSplitterState(QByteArray())
-, mScriptEditorSplitterState(QByteArray())
-, mActionEditorSplitterState(QByteArray())
-, mKeyEditorSplitterState(QByteArray())
-, mTimerEditorSplitterState(QByteArray())
-, mVarEditorSplitterState(QByteArray())
+, mAliasEditorSplitterState{}
+, mScriptEditorSplitterState{}
+, mActionEditorSplitterState{}
+, mKeyEditorSplitterState{}
+, mTimerEditorSplitterState{}
+, mVarEditorSplitterState{}
 {
     // init generated dialog
     setupUi(this);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -477,6 +477,15 @@ private:
     // profile autosave interval in minutes
     int mAutosaveInterval;
 
+    // tracks location of the splitter in the trigger editor for each tab
+    QByteArray mTriggerEditorSplitterState;
+    QByteArray mAliasEditorSplitterState;
+    QByteArray mScriptEditorSplitterState;
+    QByteArray mActionEditorSplitterState;
+    QByteArray mKeyEditorSplitterState;
+    QByteArray mTimerEditorSplitterState;
+    QByteArray mVarEditorSplitterState;
+
     // approximate max duration "Copy as image" can take in seconds
     int mCopyAsImageMax;
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds persistence to the positioning of the right splitter in the trigger editor. Each tab has its own persistent setting.

Splitters now default to be mostly towards the top before being set the first time.

#### Motivation for adding to Mudlet
It's rather annoying to have the splitter moving around between tabs, and sessions, and for it to default to making the top portion of everything MUCH bigger than necessary. This addresses that.

#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/3225,
