### PR TITLE
Add ability to check multiple items to table.contains

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -123,7 +123,7 @@ end
 
 
 --- Determines if a table contains a value as a key or as a value (recursive).
-function table.contains(t, value)
+function table._contains(t, value)
   if type(t) ~= "table" then
     return nil, "first parameter passed isn't a table"
   end
@@ -142,6 +142,12 @@ function table.contains(t, value)
   return false
 end
 
+function table.contains(tbl, ...)
+  for _,item in ipairs({...}) do
+    if table._contains(tbl, item) then return true end
+  end
+  return false
+end
 
 
 --- Table Union.

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -133,6 +133,25 @@ describe("Tests TableUtils.lua functions", function()
       assert.is_true(table.contains(tbl, "levels"))
     end)
 
+    it("should return true if any of the passed arguments is in the table", function()
+      local tbl = {
+        one = 1,
+        two = 2,
+        three = {
+          {
+            ludicrous = {
+              levels = {
+                of = {
+                  buried = "beeblebrox"
+                }
+              }
+            }
+          }
+        }
+      }
+      assert.is_true(table.contains(tbl, "transparent", "things", "buried"))
+    end)
+
     it("should return false if item is not in the table at all", function()
       local tbl = {
         one = 1,
@@ -151,6 +170,7 @@ describe("Tests TableUtils.lua functions", function()
       }
       assert.is_false(table.contains(tbl, "five"))
     end)
+
   end)
 
   describe("table.index_of(tbl,item)", function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Make table.contains table multiple arguments to check, returning true if the table contains any of them.

#### Motivation for adding to Mudlet

We're often asked how to shorten this sort of thing, and adding this capability doesn't break old usage of the function

#### Other info (issues closed, discussion etc)

![image](https://user-images.githubusercontent.com/3660/77831236-59493800-7104-11ea-83c3-e3ffd4bf10a9.png)
