### PR TITLE
Do install dependencies for OSX in Cron for PTB's

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-  echo Job not executed under cron run
-  exit
-fi
 
 set +e
 shopt -s expand_aliases


### PR DESCRIPTION
<!-- To keep things simple, focus on just one topic in your PR and make changes just for that topic.
     This'll make it a lot easier to review, and thus your PR will get in faster.
     Remember can open multiple PRs at a time! -->
#### Brief overview of PR changes/additions
Do install dependencies for OSX in Cron for PTB's, and not abort the build entirely with an `exit` call.
#### Motivation for adding to Mudlet
Closer to macOS PTB builds up and running.
#### Other info (issues closed, discussion etc)
Related to https://github.com/Mudlet/Mudlet/issues/3074.