### PR TITLE
Consistency in error handling of permScript

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8369,7 +8369,7 @@ int TLuaInterpreter::getScript(lua_State* L)
     auto ids = host.getScriptUnit()->findScriptId(name);
     auto pS = host.getScriptUnit()->getScript(ids.value(pos, -1));
     if (!pS) {
-        lua_pushnil(L);
+        lua_pushnumber(L, -1);
         lua_pushstring(L, QStringLiteral("script \"%1\" at position \"%2\" not found").arg(name).arg(++pos).toUtf8().constData());
         return 2;
     }
@@ -8413,7 +8413,6 @@ int TLuaInterpreter::setScript(lua_State* L)
     auto [id, message] = pLuaInterpreter->setScriptCode(name, luaCode, pos);
     lua_pushnumber(L, id);
     if (id == -1) {
-        lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
         return 2;
     }
@@ -8449,7 +8448,6 @@ int TLuaInterpreter::permScript(lua_State* L)
     auto [id, message] = pLuaInterpreter->createPermScript(name, parent, luaCode);
     lua_pushnumber(L, id);
     if (id == -1) {
-        lua_pushboolean(L, false);
         lua_pushstring(L, message.toUtf8().constData());
         return 2;
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8364,10 +8364,9 @@ int TLuaInterpreter::getScript(lua_State* L)
         pos = lua_tonumber(L, 2);
     }
     Host& host = getHostFromLua(L);
-    pos--;
 
     auto ids = host.getScriptUnit()->findScriptId(name);
-    auto pS = host.getScriptUnit()->getScript(ids.value(pos, -1));
+    auto pS = host.getScriptUnit()->getScript(ids.value(--pos, -1));
     if (!pS) {
         lua_pushnumber(L, -1);
         lua_pushstring(L, QStringLiteral("script \"%1\" at position \"%2\" not found").arg(name).arg(++pos).toUtf8().constData());
@@ -8405,12 +8404,11 @@ int TLuaInterpreter::setScript(lua_State* L)
         }
         pos = lua_tonumber(L, 3);
     }
-    pos--;
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
 
-    auto [id, message] = pLuaInterpreter->setScriptCode(name, luaCode, pos);
+    auto [id, message] = pLuaInterpreter->setScriptCode(name, luaCode, --pos);
     lua_pushnumber(L, id);
     if (id == -1) {
         lua_pushstring(L, message.toUtf8().constData());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4367,6 +4367,10 @@ void dlgTriggerEditor::writeScript(int id)
     }
 
     TScript* pT = mpHost->getScriptUnit()->getScript(scriptID);
+    if (!pT) {
+        return;
+    }
+
     QString scriptCode = pT->getScript();
     mpSourceEditorEdbeeDocument->setText(scriptCode);
 }

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -184,8 +184,8 @@ function appendScript(name, luaCode, pos)
   pos = pos or 1
   assert(type(name) == "string", "appendScript: bad argument #1 type (script name as string expected, got "..type(name).."!)")
   assert(type(name) == "string", "appendScript: bad argument #2 type (lua code as string expected, got "..type(luaCode).."!)")
-  if not getScript(name, pos) then
-    return nil, 'script "'..name..'" at position "'..pos..'" not found'
+  if getScript(name, pos) == -1 then
+    return getScript(name, pos)
   end
   return setScript(name, getScript(name, pos).."\n"..luaCode, pos)
 end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -183,10 +183,7 @@ end
 function appendScript(name, luaCode, pos)
   pos = pos or 1
   assert(type(name) == "string", "appendScript: bad argument #1 type (script name as string expected, got "..type(name).."!)")
-  assert(type(name) == "string", "appendScript: bad argument #2 type (lua code as string expected, got "..type(luaCode).."!)")
-  if getScript(name, pos) == -1 then
-    return getScript(name, pos)
-  end
+  assert(type(luaCode) == "string", "appendScript: bad argument #2 type (lua code as string expected, got "..type(luaCode).."!)")
   return setScript(name, getScript(name, pos).."\n"..luaCode, pos)
 end
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
In order to be consistent with other perm options I changed the error handling
of permScript, setScript, getScript, appendScript to  -1 + error message
#### Motivation for adding to Mudlet
Main motivation is the discussion at https://github.com/Mudlet/Mudlet/issues/3539
#### Other info (issues closed, discussion etc)
