### PR TITLE
Refactor: remove pointless QFontLetterSpacing code

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1139,24 +1139,7 @@ void TConsole::changeColors()
         mUpperPane->setPalette(palette);
         mLowerPane->setPalette(palette);
     } else if (mType & (ErrorConsole|SubConsole|UserWindow|Buffer)) {
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
         mDisplayFont.setStyleStrategy(QFont::StyleStrategy(QFont::NoAntialias | QFont::PreferQuality));
-        QPixmap pixmap = QPixmap(2000, 600);
-        QPainter p(&pixmap);
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, 0);
-        p.setFont(mDisplayFont);
-        const QRectF r = QRectF(0, 0, 2000, 600);
-        QRectF r2;
-        const QString t = "123";
-        p.drawText(r, 1, t, &r2);
-        // N/U:        int mFontHeight = QFontMetrics( mDisplayFont ).height();
-        int mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
-        auto letterSpacing = static_cast<qreal>(mFontWidth - static_cast<qreal>(r2.width() / t.size()));
-        mUpperPane->mLetterSpacing = letterSpacing;
-        mLowerPane->mLetterSpacing = letterSpacing;
-        mpHost->setDisplayFontSpacing(letterSpacing);
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mUpperPane->mLetterSpacing);
-#endif
         mDisplayFont.setFixedPitch(true);
         mUpperPane->setFont(mDisplayFont);
         mLowerPane->setFont(mDisplayFont);
@@ -1185,24 +1168,6 @@ void TConsole::changeColors()
         }
         mpHost->setDisplayFontFixedPitch(true);
         mDisplayFont.setFixedPitch(true);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        QPixmap pixmap = QPixmap(2000, 600);
-        QPainter p(&pixmap);
-        QFont _font = mpHost->getDisplayFont();
-        _font.setLetterSpacing(QFont::AbsoluteSpacing, 0);
-        p.setFont(_font);
-        const QRectF r = QRectF(0, 0, 2000, 600);
-        QRectF r2;
-        const QString t = "123";
-        p.drawText(r, 1, t, &r2);
-        // N/U:        int mFontHeight = QFontMetrics( mpHost->getDisplayFont() ).height();
-        int mFontWidth = QFontMetrics(mpHost->getDisplayFont()).averageCharWidth();
-        auto letterSpacing = static_cast<qreal>(mFontWidth - static_cast<qreal>(r2.width() / t.size()));
-        mUpperPane->mLetterSpacing = letterSpacing;
-        mLowerPane->mLetterSpacing = letterSpacing;
-        mpHost->setDisplayFontSpacing(letterSpacing);
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mUpperPane->mLetterSpacing);
-#endif
         mUpperPane->setFont(mpHost->getDisplayFont());
         mLowerPane->setFont(mpHost->getDisplayFont());
         QPalette palette;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -78,17 +78,6 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
         }
 
         mpHost->setDisplayFontFixedPitch(true);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * 2, mFontHeight * 2);
-        QPainter p(&pixmap);
-        p.setFont(hostFont);
-        const QRectF r = QRectF(0, 0, mScreenWidth * mFontWidth * 2, mFontHeight * 2);
-        QRectF r2;
-        const QString t = "1234";
-        p.drawText(r, 1, t, &r2);
-        mLetterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-        mpHost->setDisplayFontSpacing(mLetterSpacing);
-#endif
         setFont(hostFont);
     } else {
         // This is part of the Central Debug Console
@@ -97,17 +86,6 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
         mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         mScreenWidth = 100;
         mDisplayFont.setFixedPitch(true);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * 2, mFontHeight * 2);
-        QPainter p(&pixmap);
-        p.setFont(mDisplayFont);
-        const QRectF r = QRectF(0, 0, mScreenWidth * mFontWidth * 2, mFontHeight * 2);
-        QRectF r2;
-        const QString t = "1234";
-        p.drawText(r, 1, t, &r2);
-        mLetterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
-#endif
         setFont(mDisplayFont);
         // initialize after mFontHeight and mFontWidth have been set, because the function uses them!
         initDefaultSettings();
@@ -202,24 +180,6 @@ void TTextEdit::initDefaultSettings()
     mFgColor = QColor(192, 192, 192);
     mBgColor = QColor(Qt::black);
     mDisplayFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 14, QFont::Normal);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-    int width = mScreenWidth * mFontWidth * 2;
-    int height = mFontHeight * 2;
-    // sometimes mScreenWidth is 0, and QPainter doesn't like dimensions of 0x#. Need to work out why is
-    // mScreenWidth ever zero and it gets used in the follow calculations.
-    if (width > 0 && height > 0) {
-        QPixmap pixmap = QPixmap(width, height);
-        QPainter p(&pixmap);
-        p.setFont(mDisplayFont);
-        const QRectF r = QRectF(0, 0, width, height);
-        QRectF r2;
-        const QString t = "1234";
-        p.drawText(r, 1, t, &r2);
-        mLetterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
-    }
-#endif
-    mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
     mDisplayFont.setFixedPitch(true);
     setFont(mDisplayFont);
     mWrapAt = 100;
@@ -233,21 +193,6 @@ void TTextEdit::updateScreenView()
         mFontDescent = QFontMetrics(mDisplayFont).descent();
         mFontAscent = QFontMetrics(mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        QPixmap pixmap = QPixmap(2000, 600);
-        QPainter p(&pixmap);
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, 0);
-        if (!p.isActive()) {
-            return;
-        }
-        p.setFont(mDisplayFont);
-        const QRectF r = QRectF(0, 0, 2000, 600);
-        QRectF r2;
-        const QString t = "1234";
-        p.drawText(r, 1, t, &r2);
-        mLetterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-        mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
-#endif
         return; //NOTE: das ist wichtig, damit ich keine floating point exception bekomme, wenn mScreenHeight==0, was hier der Fall wäre
     }
     // This was "if (pC->mType == TConsole::MainConsole) {"
@@ -259,45 +204,11 @@ void TTextEdit::updateScreenView()
         mFontHeight = mFontAscent + mFontDescent;
         mBgColor = mpHost->mBgColor;
         mFgColor = mpHost->mFgColor;
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        QPixmap pixmap = QPixmap(mScreenWidth * mFontWidth * 2, mFontHeight * 2);
-        QPainter p(&pixmap);
-        mpHost->setDisplayFontSpacing(0);
-        if (p.isActive()) {
-            p.setFont(mpHost->getDisplayFont());
-            const QRectF r = QRectF(0, 0, mScreenWidth * mFontWidth * 2, mFontHeight * 2);
-            QRectF r2;
-            const QString t = "1234";
-            p.drawText(r, 1, t, &r2);
-            mLetterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-            mpHost->setDisplayFontSpacing(mLetterSpacing);
-        }
-#endif
     } else {
         mFontWidth = QFontMetrics(mDisplayFont).averageCharWidth();
         mFontDescent = QFontMetrics(mDisplayFont).descent();
         mFontAscent = QFontMetrics(mDisplayFont).ascent();
         mFontHeight = mFontAscent + mFontDescent;
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        int width = mScreenWidth * mFontWidth * 2;
-        int height = mFontHeight * 2;
-        // sometimes mScreenWidth is 0, and QPainter doesn't like dimensions of 0x#. Need to work out why is
-        // mScreenWidth ever zero and it gets used in the follow calculations.
-        if (width > 0 && height > 0) {
-            QPixmap pixmap = QPixmap(width, height);
-            QPainter p(&pixmap);
-            mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, 0);
-            if (p.isActive()) {
-                p.setFont(mDisplayFont);
-                const QRectF r = QRectF(0, 0, width, height);
-                QRectF r2;
-                const QString t = "1234";
-                p.drawText(r, 1, t, &r2);
-                mLetterSpacing = (qreal)((qreal)mFontWidth - (qreal)(r2.width() / t.size()));
-                mDisplayFont.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
-            }
-        }
-#endif
     }
     mScreenHeight = visibleRegion().boundingRect().height() / mFontHeight;
     int currentScreenWidth = visibleRegion().boundingRect().width() / mFontWidth;
@@ -425,9 +336,6 @@ inline void TTextEdit::drawCharacters(QPainter& painter, const QRect& rect, QStr
         font.setItalic(flags & TChar::Italic);
         font.setStrikeOut(flags & TChar::StrikeOut);
         font.setOverline(flags & TChar::Overline);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        font.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
-#endif
         painter.setFont(font);
     }
 
@@ -536,9 +444,6 @@ int TTextEdit::drawGrapheme(QPainter& painter, const QPoint& cursor, const QStri
         font.setOverline(isOverline);
         font.setStrikeOut(isStrikeOut);
         font.setUnderline(isUnderline);
-#if defined(Q_OS_MACOS) || defined(Q_OS_LINUX)
-        font.setLetterSpacing(QFont::AbsoluteSpacing, mLetterSpacing);
-#endif
         painter.setFont(font);
     }
 

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -106,7 +106,6 @@ public:
     bool mShowTimeStamps;
     int mWrapAt;
     int mWrapIndentCount {};
-    qreal mLetterSpacing;
 
 public slots:
     void slot_toggleTimeStamps(const bool);


### PR DESCRIPTION
This code (for Linux and MacOs builds only) was fiddling with `QFont::letterSpacing` which inserts extra space between runs of glyphs when they are "painted" however our code prints each glyph independently and never runs them together - so this setting is irrelevant and the code that sets it is dead-code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>