### PR TITLE
Geyser.container raiseAll lowerAll

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2487,15 +2487,17 @@ bool TConsole::raiseWindow(const QString& name)
     if (pC) {
         pC->raise();
         return true;
-    } else if (pL) {
+    }
+    if (pL) {
         pL->raise();
         return true;
-    } else if (pM && name.toLower() == QLatin1String("mapper")) {
+    }
+    if (pM && !name.compare(QLatin1String("mapper"), Qt::CaseInsensitive)) {
         pM->raise();
         return true;
-    } else {
-        return false;
     }
+
+    return false;
 }
 
 bool TConsole::lowerWindow(const QString& name)
@@ -2507,17 +2509,18 @@ bool TConsole::lowerWindow(const QString& name)
         pC->lower();
         mpMainDisplay->lower();
         return true;
-    } else if (pL) {
+    }
+    if (pL) {
         pL->lower();
         mpMainDisplay->lower();
         return true;
-    } else if (pM && name.toLower() == QLatin1String("mapper")) {
+    }
+    if (pM && !name.compare(QLatin1String("mapper"), Qt::CaseInsensitive)) {
         pM->lower();
         mpMainDisplay->lower();
         return true;
-    } else {
-        return false;
     }
+    return false;
 }
 
 bool TConsole::showWindow(const QString& name)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2483,11 +2483,15 @@ bool TConsole::raiseWindow(const QString& name)
 {
     auto pC = mSubConsoleMap.value(name);
     auto pL = mLabelMap.value(name);
+    auto pM = mpMapper;
     if (pC) {
         pC->raise();
         return true;
     } else if (pL) {
         pL->raise();
+        return true;
+    } else if (pM && name.toLower() == QLatin1String("mapper")) {
+        pM->raise();
         return true;
     } else {
         return false;
@@ -2498,12 +2502,17 @@ bool TConsole::lowerWindow(const QString& name)
 {
     auto pC = mSubConsoleMap.value(name);
     auto pL = mLabelMap.value(name);
+    auto pM = mpMapper;
     if (pC) {
         pC->lower();
         mpMainDisplay->lower();
         return true;
     } else if (pL) {
         pL->lower();
+        mpMainDisplay->lower();
+        return true;
+    } else if (pM && name.toLower() == QLatin1String("mapper")) {
+        pM->lower();
         mpMainDisplay->lower();
         return true;
     } else {

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -158,9 +158,9 @@ function Geyser.Container:show (auto)
   -- If my container is hidden I stay hidden and after it get visible again I'm visible too
   if self.container.hidden or self.container.auto_hidden then
     if auto == false then
-      self.hidden = false 
+      self.hidden = false
     end
-    return false 
+    return false
   end
   if auto then
     self.auto_hidden = false
@@ -194,10 +194,9 @@ function Geyser.Container:raiseAll(container, me)
   me = me or true
   container = container or self
   -- raise myself
-  if me then 
-    container:raise() 
+  if me then
+    container:raise()
   end
-  
   local v
   for i=1,#container.windows do
     v = container.windows[i]
@@ -206,22 +205,23 @@ function Geyser.Container:raiseAll(container, me)
   end
 end
 
-local function createReverseTable(container)
- local v
-  Geyser.Container.reverseTable = Geyser.Container.reverseTable or {}
-    for i=1,#container.windows do
+local function createWindowTable(container)
+  local v
+  Geyser.Container.windowTable = Geyser.Container.windowTable or {}
+  for i=1,#container.windows do
     v = container.windows[i]
-    table.insert(Geyser.Container.reverseTable, container.windowList[v])
-    createReverseTable(container.windowList[v])
+    Geyser.Container.windowTable[#Geyser.Container.windowTable+1] = container.windowList[v]
+    createWindowTable(container.windowList[v])
   end
 end
 
 function Geyser.Container:lowerAll()
-  createReverseTable(self)
-  for i=#Geyser.Container.reverseTable,1,-1 do
-    Geyser.Container.reverseTable[i]:lower()
+  createWindowTable(self)
+  -- iterate in reverse order through all elements to keep the same z-axis inside the container
+  for i=#Geyser.Container.windowTable,1,-1 do
+    Geyser.Container.windowTable[i]:lower()
   end
-  Geyser.Container.reverseTable = nil
+  Geyser.Container.windowTable = nil
   self:lower()
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -190,6 +190,41 @@ function Geyser.Container:lower ()
 	lowerWindow(self.name)
 end
 
+function Geyser.Container:raiseAll(container, me)
+  me = me or true
+  container = container or self
+  -- raise myself
+  if me then 
+    container:raise() 
+  end
+  
+  local v
+  for i=1,#container.windows do
+    v = container.windows[i]
+    container.windowList[v]:raise()
+    container.windowList[v]:raiseAll(container.windowList[v], false)
+  end
+end
+
+local function createReverseTable(container)
+ local v
+  Geyser.Container.reverseTable = Geyser.Container.reverseTable or {}
+    for i=1,#container.windows do
+    v = container.windows[i]
+    table.insert(Geyser.Container.reverseTable, container.windowList[v])
+    createReverseTable(container.windowList[v])
+  end
+end
+
+function Geyser.Container:lowerAll()
+  createReverseTable(self)
+  for i=#Geyser.Container.reverseTable,1,-1 do
+    Geyser.Container.reverseTable[i]:lower()
+  end
+  Geyser.Container.reverseTable = nil
+  self:lower()
+end
+
 --- Moves this window according to the new x and y contraints set.
 -- @param x New x constraint to use. If nil, uses current value.
 -- @param y New y constraint to use. If nil, uses current value.

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -65,6 +65,15 @@ function Geyser.Mapper:show_impl()
   end
 end
 
+-- Overridden raise and lower functions - mapper does it differently right now
+function Geyser.Mapper:raise()
+	raiseWindow("mapper")
+end
+
+function Geyser.Mapper:lower()
+	lowerWindow("mapper")
+end
+
 function Geyser.Mapper:setDockPosition(pos)
   if not self.embedded then
     return openMapWidget(pos)

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -65,7 +65,7 @@ function Geyser.Mapper:show_impl()
   end
 end
 
--- Overridden raise and lower functions - mapper does it differently right now
+-- Overridden raise and lower functions
 function Geyser.Mapper:raise()
 	raiseWindow("mapper")
 end


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- Adds 2 function to Geyser Containers which are used to use :raise() or :lower() to all elements in a container and still keeping the container internal z values. example:
**mycontainer:raiseAll()**
**mycontainer:lowerAll()**

- mapper is also able to raise and lower by using the string mapper as window name. for example:
raiseWindow("mapper")
lowerWindow("mapper")

#### Motivation for adding to Mudlet
Is a nice to have especially for Adjustable.Containers to decide whether they are in front or behind on another.

The mapper was lacking this feature.
#### Other info (issues closed, discussion etc)
