### PR TITLE
Add option for specifying profile on command line

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,6 +291,12 @@ int main(int argc, char* argv[])
         app->setApplicationVersion(APP_VERSION);
     }
 
+    QCommandLineParser parser;
+    QCommandLineOption profileToOpen("profile", QCoreApplication::translate("main", "Profile to open automatically"), QCoreApplication::translate("main", "profile"));
+    parser.addOption(profileToOpen);
+    parser.process(app->arguments());
+    QString cliProfile = parser.value(profileToOpen);
+
 
     bool show_splash = !(startupAction & 4); // Not --quiet.
 #if defined(INCLUDE_VARIABLE_SPLASH_SCREEN)
@@ -495,7 +501,7 @@ int main(int argc, char* argv[])
 
     mudlet::self()->show();
 
-    mudlet::self()->startAutoLogin();
+    mudlet::self()->startAutoLogin(cliProfile);
 
 #if defined(INCLUDE_UPDATER)
     mudlet::self()->checkUpdatesOnStart();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3897,14 +3897,14 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 }
 
 // this slot is called via a timer in the constructor of mudlet::mudlet()
-void mudlet::startAutoLogin()
+void mudlet::startAutoLogin(const QString& cliProfile)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
     bool openedProfile = false;
 
     for (auto& host : hostList) {
         QString val = readProfileData(host, QStringLiteral("autologin"));
-        if (val.toInt() == Qt::Checked) {
+        if (val.toInt() == Qt::Checked || host == cliProfile) {
             doAutoLogin(host);
             openedProfile = true;
         }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -442,7 +442,7 @@ public:
     void scanForMudletTranslations(const QString&);
     void scanForQtTranslations(const QString&);
     void layoutModules();
-    void startAutoLogin();
+    void startAutoLogin(const QString&);
     QPointer<QTableWidget> moduleTable;
     int64_t getPhysicalMemoryTotal();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Adds the `--profile="My Cool Profile"` cli option to open profile "My Cool Profile"

#### Motivation for adding to Mudlet

* add busted cli tests to CI builds. First step is being able to open the testing profile to run the tests.
* by using the QCommandLineParser it will be easier to implement new cli options in the future as well

#### Other info (issues closed, discussion etc)

* does not take current cli options and shift them to the QCommandLineParser; while I'm willing to work on doing that the commandline parser requires the app be initialized and the code as written currently initializes the app differently depending on if the option is --version or --help. I don't know if this is strictly necessary or just optimization though.