### PR TITLE
Enhance: remove glyph overlapping/clipping

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1966,7 +1966,7 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 
         if (parameters.count() >= 3 && !parameters.at(2).isEmpty()) {
             if (!isColonSeparated) {
-#if ! defined(DEBUG_SGR_PROCESSING)
+#if !defined(DEBUG_SGR_PROCESSING)
                 qDebug() << "Unhandled color space identifier in a SGR...;38;2;" << parameters.at(2) << ";...m sequence - if 16M colors items are missing blue elements you may have checked the \"Expect Color Space Id in SGR...(3|4)8;2;....m codes\" option on the Special Options tab of the preferences when it is not needed!";
 #else
                 qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unhandled color space identifier in a SGR...;38;2;" << parameters.at(2) << ";...m sequence treating it as the default (empty) case!";
@@ -2176,7 +2176,7 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 
         if (parameters.count() >= 3 && !parameters.at(2).isEmpty()) {
             if (!isColonSeparated) {
-#if ! defined(DEBUG_SGR_PROCESSING)
+#if !defined(DEBUG_SGR_PROCESSING)
                 qDebug() << "Unhandled color space identifier in a SGR...;48;2;" << parameters.at(2) << ";...m sequence - if 16M colors items are missing blue elements you may have checked the \"Expect Color Space Id in SGR...(3|4)8;2;....m codes\" option on the Special Options tab of the preferences when it is not needed!";
 #else
                 qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unhandled color space identifier in a SGR...;48;2;" << parameters.at(2) << ";...m sequence treating it as the default (empty) case!";

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -101,6 +101,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mCurrentSearchResult(0)
 , mSearchQuery()
 , mpButtonMainLayer(nullptr)
+, mFontFactor(1.0)
 , mType(type)
 , mSpellDic()
 , mpHunspell_system(nullptr)
@@ -1895,8 +1896,9 @@ bool TConsole::setMiniConsoleFontSize(int size)
     return true;
 }
 
-void TConsole::refreshMiniConsole() const
+void TConsole::refreshMiniConsole()
 {
+    mFontFactor = 1.0;
     mUpperPane->mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
     mUpperPane->setFont(mUpperPane->mDisplayFont);
     mUpperPane->updateScreenView();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -161,7 +161,7 @@ public:
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
     QString getCurrentLine(std::string&);
     void selectCurrentLine(std::string&);
-    bool setMiniConsoleFontSize(int);    
+    bool setMiniConsoleFontSize(int);
     bool setMiniConsoleFont(const QString& font);
     void setLink(const QStringList& linkFunction, const QStringList& linkHint);
     // Cannot be called setAttributes as that would mask an inherited method
@@ -307,6 +307,12 @@ public:
     QList<int> mSearchResults;
     QString mSearchQuery;
     QWidget* mpButtonMainLayer;
+    // How much we must increase TTextEdit::mFontWidth in order to accomodate
+    // glyphs that are wider than mFontWidth * numberOfSpaces
+    // (from widechar_width.h) - it is a multiplier and should quickly max out
+    // once we hit the largest character in EITHER top or bottom pane - but
+    // needs to be applied to BOTH of them:
+    double mFontFactor;
 
 signals:
     // Raised when new data is incoming to trigger Alert handling in mudlet
@@ -332,7 +338,7 @@ protected:
     void dropEvent(QDropEvent* e);
 
 private:
-    void refreshMiniConsole() const;
+    void refreshMiniConsole();
 
 
     ConsoleType mType;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -54,7 +54,7 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 , mIsCommandPopup(false)
 , mIsTailMode(true)
 , mShowTimeStamps(false)
-#if ! defined(QT_NO_DEBUG)
+#if !defined(QT_NO_DEBUG)
 , mGlyphOutlines(false)
 #endif
 , mForceUpdate(false)
@@ -471,8 +471,8 @@ QPair<int, int> TTextEdit::drawGrapheme(QPainter& painter, const QPoint& cursor,
         painter.setPen(fgColor);
     }
 
-#if ! defined(QT_NO_DEBUG)
-    QColor outlineColor{QColor(std::rand()%256,std::rand()%256,std::rand()%256)};
+#if !defined(QT_NO_DEBUG)
+    QColor outlineColor{QColor(std::rand()%256, std::rand()%256, std::rand()%256)};
     if (mGlyphOutlines) {
         painter.save();
         QPen pen{painter.pen()};
@@ -494,7 +494,7 @@ QPair<int, int> TTextEdit::drawGrapheme(QPainter& painter, const QPoint& cursor,
     // mFontAscent+mFontHeight is used to offset the base line of the text - or
     // something like that:
     painter.drawText(textRect, Qt::AlignCenter, grapheme, &boundingRect);
-#if ! defined(QT_NO_DEBUG)
+#if !defined(QT_NO_DEBUG)
     if (mGlyphOutlines) {
         painter.save();
         QPen pen{painter.pen()};

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -430,7 +430,8 @@ std::tuple<int, int> TTextEdit::drawGrapheme(QPainter& painter, const QPoint& cu
     if (unicode == '\t') {
         charWidth = mTabStopwidth - (column % mTabStopwidth);
     } else {
-        charWidth = getGraphemeWidth(unicode);
+        // charWidth = getGraphemeWidth(unicode);
+        charWidth = 1;
     }
 
     TChar::AttributeFlags attributes = charStyle.allDisplayAttributes();

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2018 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2015, 2018, 2020 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
@@ -58,8 +59,8 @@ public:
     void drawForeground(QPainter&, const QRect&);
     void drawBackground(QPainter&, const QRect&, const QColor&) const;
     uint getGraphemeBaseCharacter(const QString& str) const;
-    void drawLine(QPainter& painter, int lineNumber, int rowOfScreen) const;
-    int drawGrapheme(QPainter &painter, const QPoint &cursor, const QString &c, int column, TChar &style) const;
+    int drawLine(QPainter&, int lineNumber, int rowOfScreen) const;
+    QPair<int, int> drawGrapheme(QPainter &painter, const QPoint &cursor, const QString &c, int column, TChar &style) const;
     void drawCharacters(QPainter&, const QRect&, QString&, const QColor&, const TChar::AttributeFlags);
     void showNewLines();
     void forceUpdate();
@@ -106,6 +107,13 @@ public:
     bool mShowTimeStamps;
     int mWrapAt;
     int mWrapIndentCount {};
+#if ! defined(QT_NO_DEBUG)
+    // In debug builds can be set via debugger to put a (dotted) rectangle
+    // around the space that a glyph is to be painted in and a (dashed)
+    // rectangle around the space that the QPainter thinks it needs for that
+    // glyph:
+    bool mGlyphOutlines{false};
+#endif
 
 public slots:
     void slot_toggleTimeStamps(const bool);
@@ -136,6 +144,10 @@ private:
 
     int mFontHeight;
     int mFontWidth;
+    // Derived from mFontWidth it is the space that we are to use for a "normal"
+    // width character, which gets tweaked to allow for the characters that are
+    // wider than QFontMetrics::averageCharWidth():
+    int mStandardCharWidth;
     bool mForceUpdate;
 
     // Each TConsole instance uses two instances of this class, one above the

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -60,7 +60,7 @@ public:
     void drawBackground(QPainter&, const QRect&, const QColor&) const;
     uint getGraphemeBaseCharacter(const QString& str) const;
     int drawLine(QPainter&, int lineNumber, int rowOfScreen) const;
-    QPair<int, int> drawGrapheme(QPainter &painter, const QPoint &cursor, const QString &c, int column, TChar &style) const;
+    std::tuple<int, int> drawGrapheme(QPainter&, const QPoint &, const QString &, int, TChar&) const;
     void drawCharacters(QPainter&, const QRect&, QString&, const QColor&, const TChar::AttributeFlags);
     void showNewLines();
     void forceUpdate();
@@ -107,7 +107,7 @@ public:
     bool mShowTimeStamps;
     int mWrapAt;
     int mWrapIndentCount {};
-#if !defined(QT_NO_DEBUG)
+#if defined(QT_DEBUG)
     // In debug builds can be set via debugger to put a (dotted) rectangle
     // around the space that a glyph is to be painted in and a (dashed)
     // rectangle around the space that the QPainter thinks it needs for that

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -107,7 +107,7 @@ public:
     bool mShowTimeStamps;
     int mWrapAt;
     int mWrapIndentCount {};
-#if ! defined(QT_NO_DEBUG)
+#if !defined(QT_NO_DEBUG)
     // In debug builds can be set via debugger to put a (dotted) rectangle
     // around the space that a glyph is to be painted in and a (dashed)
     // rectangle around the space that the QPainter thinks it needs for that


### PR DESCRIPTION
This commit monitors the space needed to paint each glyph onto `TConsole`s so that if a glyph is too wide to fit in the space that was allocated then the unit space for a character is increased so that it will fit. This is particularly an issue now that we permit the use of proportional fonts because the default space that we allocate is based on `QFontMetrics::averageCharWidth()` which, by definition, is only going to be enough for *half* of the characters of a proportional font...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>