### PR TITLE
Enhance: add AppVeyor and CodeFactor status badges to GitHub README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@
   <a href="https://www.codefactor.io/repository/github/mudlet/mudlet">
     <img src="https://www.codefactor.io/repository/github/mudlet/mudlet/badge" alt="CodeFactor" />
   </a>
-  <sup><b>Windows:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://camo.githubusercontent.com/8bb49aa4609cb6399cd004fb55920ff0ead7d15d/68747470733a2f2f63692e6170707665796f722e636f6d2f6170692f70726f6a656374732f7374617475732f333166717138343462723667366934302f6272616e63682f646576656c6f706d656e743f7376673d74727565" alt="AppVeyor (Windows) CI Build status" data-canonical-src="https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true" style="max-width:100%;">
+  <br>
+  <sup><b>Windows:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true" alt="AppVeyor (Windows) CI Build status" style="max-width:100%;">
   </a>
-  <sup><b>Linux &amp; MacOS:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://camo.githubusercontent.com/05e8ca41df1f7780a8450b64a02cb87710235346/68747470733a2f2f7472617669732d63692e6f72672f4d75646c65742f4d75646c65742e7376673f6272616e63683d646576656c6f706d656e74" alt="Travis (Linux &amp; MacOs) CI Build status" data-canonical-src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development" style="max-width:100%;">
+  <sup><b>Linux &amp; MacOS:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development" alt="Travis (Linux &amp; MacOs) CI Build status" style="max-width:100%;">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,25 @@
 </h1>
 
 <h4 align="center">Play immersive, multiplayer, pure-text RPGs on Mudlet.</h4>
-
+<table style="margin-left: auto; margin-right: auto;">
+  <thead>
+    <tr>
+      <th>Linux & MacOs</th>
+      <th>Windows</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="center"><a href="http://mudlet.org/download/">
+        <img src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development"
+          alt="Travis (Linux & MacOs) CI Build status"></a></td>
+      <td align="center"><a href="http://mudlet.org/download/">
+        <img src="https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true"
+          alt="AppVeyor (Windows) CI Build status"></a></td>
+    </tr>
+  <tbody>
+</table>
 <p align="center">
-  <a href="http://mudlet.org/download/">
-    <img src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development"
-         alt="Build status">
-  </a>
   <a href="https://discord.gg/kuYvMQ9">
     <img src="https://discordapp.com/api/guilds/283581582550237184/embed.png?style=shield">
   </a>
@@ -20,7 +33,9 @@
     <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat">
   </a>
   <a href="https://github.com/Mudlet/Mudlet/stargazers">
-    <img src="https://img.shields.io/github/stars/Mudlet/Mudlet.svg"/>
+    <img src="https://img.shields.io/github/stars/Mudlet/Mudlet.svg"/></a>
+  <a href="https://www.codefactor.io/repository/github/mudlet/mudlet">
+    <img src="https://www.codefactor.io/repository/github/mudlet/mudlet/badge" alt="CodeFactor" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -7,24 +7,7 @@
 </h1>
 
 <h4 align="center">Play immersive, multiplayer, pure-text RPGs on Mudlet.</h4>
-<table style="margin-left: auto; margin-right: auto;">
-  <thead>
-    <tr>
-      <th>Linux & MacOs</th>
-      <th>Windows</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td align="center"><a href="http://mudlet.org/download/">
-        <img src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development"
-          alt="Travis (Linux & MacOs) CI Build status"></a></td>
-      <td align="center"><a href="http://mudlet.org/download/">
-        <img src="https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true"
-          alt="AppVeyor (Windows) CI Build status"></a></td>
-    </tr>
-  <tbody>
-</table>
+
 <p align="center">
   <a href="https://discord.gg/kuYvMQ9">
     <img src="https://discordapp.com/api/guilds/283581582550237184/embed.png?style=shield">
@@ -33,9 +16,14 @@
     <img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat">
   </a>
   <a href="https://github.com/Mudlet/Mudlet/stargazers">
-    <img src="https://img.shields.io/github/stars/Mudlet/Mudlet.svg"/></a>
+    <img src="https://img.shields.io/github/stars/Mudlet/Mudlet.svg"/>
+  </a>
   <a href="https://www.codefactor.io/repository/github/mudlet/mudlet">
     <img src="https://www.codefactor.io/repository/github/mudlet/mudlet/badge" alt="CodeFactor" />
+  </a>
+  <sup><b>Windows:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://camo.githubusercontent.com/8bb49aa4609cb6399cd004fb55920ff0ead7d15d/68747470733a2f2f63692e6170707665796f722e636f6d2f6170692f70726f6a656374732f7374617475732f333166717138343462723667366934302f6272616e63682f646576656c6f706d656e743f7376673d74727565" alt="AppVeyor (Windows) CI Build status" data-canonical-src="https://ci.appveyor.com/api/projects/status/31fqq844br6g6i40/branch/development?svg=true" style="max-width:100%;">
+  </a>
+  <sup><b>Linux &amp; MacOS:</b></sup>&nbsp;<a href="http://mudlet.org/download/" rel="nofollow"><img src="https://camo.githubusercontent.com/05e8ca41df1f7780a8450b64a02cb87710235346/68747470733a2f2f7472617669732d63692e6f72672f4d75646c65742f4d75646c65742e7376673f6272616e63683d646576656c6f706d656e74" alt="Travis (Linux &amp; MacOs) CI Build status" data-canonical-src="https://travis-ci.org/Mudlet/Mudlet.svg?branch=development" style="max-width:100%;">
   </a>
 </p>
 


### PR DESCRIPTION
So that we can show off even more.

For the life of me I **cannot** get the table with the two different CI systems' development branch build results to centralise on the page of my Web -browser (PaleMoon 28.9.0.2 on Linux in Native mode - rendering in Standards compliance mode)...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>