### PR TITLE
BugFix: fix broken compilation when QT_NO_SSL defined

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -500,7 +500,7 @@ void TMedia::downloadFile(TMediaData& mediaData)
         request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
         request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
-#ifndef QT_NO_SSL
+#if !defined(QT_NO_SSL)
         if (fileUrl.scheme() == QStringLiteral("https")) {
             QSslConfiguration config(QSslConfiguration::defaultConfiguration());
             request.setSslConfiguration(config);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -507,9 +507,8 @@ void cTelnet::handle_socket_signal_disconnected()
             }
             QString err = tr("[ ALERT ] - Socket got disconnected.\nReason: ") % reason;
             postMessage(err);
-        } else
+        } else {
 #endif
-        {
             if (mDontReconnect) {
                 reason = QStringLiteral("User Disconnected");
             } else {
@@ -522,9 +521,9 @@ void cTelnet::handle_socket_signal_disconnected()
             postMessage(err);
         }
         postMessage(msg);
+#if !defined(QT_NO_SSL)
     }
 
-#if !defined(QT_NO_SSL)
     if (sslerr) {
         mudlet::self()->show_options_dialog(QStringLiteral("Security"));
     }
@@ -564,25 +563,28 @@ void cTelnet::handle_socket_signal_hostFound(QHostInfo hostInfo)
         postMessage(tr("[ INFO ]  - Trying secure connection to %1: %2 ...\n").arg(hostInfo.hostName(), QString::number(hostPort)));
         socket.connectToHostEncrypted(hostInfo.hostName(), hostPort, QIODevice::ReadWrite);
 
-    } else
-#endif
-    if (!hostInfo.addresses().isEmpty()) {
-        mHostAddress = hostInfo.addresses().constFirst();
-        postMessage(tr("[ INFO ]  - The IP address of %1 has been found. It is: %2\n").arg(hostName, mHostAddress.toString()));
-        if (!mConnectViaProxy) {
-            postMessage(tr("[ INFO ]  - Trying to connect to %1:%2 ...\n").arg(mHostAddress.toString(), QString::number(hostPort)));
-        } else {
-            postMessage(tr("[ INFO ]  - Trying to connect to %1:%2 via proxy...\n").arg(mHostAddress.toString(), QString::number(hostPort)));
-        }
-        socket.connectToHost(mHostAddress, hostPort);
     } else {
-        socket.connectToHost(hostInfo.hostName(), hostPort);
-        postMessage(tr("[ ERROR ] - Host name lookup Failure!\n"
-                       "Connection cannot be established.\n"
-                       "The server name is not correct, not working properly,\n"
-                       "or your nameservers are not working properly."));
-        return;
+#endif
+        if (!hostInfo.addresses().isEmpty()) {
+            mHostAddress = hostInfo.addresses().constFirst();
+            postMessage(tr("[ INFO ]  - The IP address of %1 has been found. It is: %2\n").arg(hostName, mHostAddress.toString()));
+            if (!mConnectViaProxy) {
+                postMessage(tr("[ INFO ]  - Trying to connect to %1:%2 ...\n").arg(mHostAddress.toString(), QString::number(hostPort)));
+            } else {
+                postMessage(tr("[ INFO ]  - Trying to connect to %1:%2 via proxy...\n").arg(mHostAddress.toString(), QString::number(hostPort)));
+            }
+            socket.connectToHost(mHostAddress, hostPort);
+        } else {
+            socket.connectToHost(hostInfo.hostName(), hostPort);
+            postMessage(tr("[ ERROR ] - Host name lookup Failure!\n"
+                           "Connection cannot be established.\n"
+                           "The server name is not correct, not working properly,\n"
+                           "or your nameservers are not working properly."));
+            return;
+        }
+#if !defined(QT_NO_SSL)
     }
+#endif
 }
 
 // This uses UTF-16BE encoded data but needs to be converted to the selected

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -210,11 +210,12 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 #if !defined(QT_NO_SSL)
     if (QSslSocket::supportsSsl()) {
         port_ssl_tsl->setEnabled(true);
-    } else
+    } else {
 #endif
-    {
         port_ssl_tsl->setEnabled(false);
+#if !defined(QT_NO_SSL)
     }
+#endif
 
     mRegularPalette.setColor(QPalette::Text, QColor(0, 0, 192));
     mRegularPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,9 @@
 
 #include "pre_guard.h"
 #include <chrono>
+#if !defined(INCLUDE_UPDATER)
+#include <QCommandLineParser>
+#endif
 #include <QDesktopWidget>
 #include <QDir>
 #if defined(Q_OS_WIN32) && !defined(INCLUDE_UPDATER)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,9 +26,6 @@
 
 #include "pre_guard.h"
 #include <chrono>
-#if !defined(INCLUDE_UPDATER)
-#include <QCommandLineParser>
-#endif
 #include <QDesktopWidget>
 #include <QDir>
 #if defined(Q_OS_WIN32) && !defined(INCLUDE_UPDATER)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5821,7 +5821,7 @@ void mudlet::setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
 
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-#ifndef QT_NO_SSL
+#if !defined(QT_NO_SSL)
     if (url.scheme() == QStringLiteral("https")) {
         QSslConfiguration config(QSslConfiguration::defaultConfiguration());
         request.setSslConfiguration(config);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -39,6 +39,7 @@
 #include "discord.h"
 
 #include "pre_guard.h"
+#include <QDir>
 #include <QFlags>
 #ifdef QT_GAMEPAD_LIB
 #include <QGamepad>


### PR DESCRIPTION
`mudlet.h` needs the include for `QDir` if `Q_NO_SSL` is defined (might happen on, particularly, Windows builds) - I did not test whether it is a problem only if the updater is excluded or not...

I also found a BUG in Qt Creator which meant that code marked with `#ifndef ...` was not being correctly grey-ed out in that editor.  I have reported THAT upstream as: https://bugreports.qt.io/browse/QTCREATORBUG-23817 and have switched the Mudlet code-base to use `#if !defined(...)` instead.

From previous recent experience with CodeFactor I was aware that it does not like lines where there are `else`s with a miss-matching `{` or `}` either side of them so I have put in or rearranged some `#if ... #endif`
extra stuff to provide the balancing things needed.

Unfortunately there is also an `#ifndef ...` as part of the *include-guard* in every Mudlet class header file - but I will leave changing those files to another occasion!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>