### PR TITLE
Build CI with all optional compile flags off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,9 @@ jobs:
     compiler: gcc
     env:
     - Q_OR_C_MAKE=cmake
+    - WITH_UPDATER=no
+    - WITH_3DMAPPER=no
+    - WITH_FONTS=no
     - QT_VERSION=511 # actually Qt 5.11, used to check minimum supported Qt works
     addons:
       apt:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Use the 5.11 build (minimum supported Qt version) as also a build with all optional flags turned off.
#### Motivation for adding to Mudlet
Eliminate a class of errors we've been seeing lately, and support our Linux packagers & Raspberry Pi users.
#### Other info (issues closed, discussion etc)
