### PR TITLE
Adds standard text editor FIND functionality to source editor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(mudlet_SRCS
     dlgRoomExits.cpp
     dlgScriptsMainArea.cpp
     dlgSourceEditorArea.cpp
+    dlgSourceEditorFindArea.cpp
     dlgSystemMessageArea.cpp
     dlgTimersMainArea.cpp
     dlgTriggerEditor.cpp
@@ -128,6 +129,7 @@ set(mudlet_UIS
   ui/room_exits.ui
   ui/scripts_main_area.ui
   ui/source_editor_area.ui
+  ui/source_editor_find_area.ui
   ui/system_message_area.ui
   ui/timers_main_area.ui
   ui/triggers_main_area.ui
@@ -155,6 +157,7 @@ set(mudlet_HDRS
     dlgRoomExits.h
     dlgScriptsMainArea.h
     dlgSourceEditorArea.h
+    dlgSourceEditorFindArea.h
     dlgSystemMessageArea.h
     dlgTimersMainArea.h
     dlgTriggerEditor.h

--- a/src/dlgSourceEditorFindArea.cpp
+++ b/src/dlgSourceEditorFindArea.cpp
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (C) 2020 by Ian Adkins - ieadkins@gmail.com                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include "dlgSourceEditorFindArea.h"
+#include "ui_dlgPackageExporter.h"
+
+#include "pre_guard.h"
+#include <QDebug>
+#include "post_guard.h"
+
+dlgSourceEditorFindArea::dlgSourceEditorFindArea(QWidget* pF) : QWidget(pF)
+{
+    // init generated dialog
+    setupUi(this);
+    lineEdit_findText->installEventFilter(this);
+}
+
+bool dlgSourceEditorFindArea::eventFilter(QObject* obj, QEvent* event)
+{
+    if (obj == lineEdit_findText) {
+        if (event->type() == QEvent::KeyPress) {
+            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+            if (keyEvent->key() == Qt::Key_Enter or keyEvent->key() == Qt::Key_Return) {
+                if (keyEvent->modifiers().testFlag(Qt::ShiftModifier)) {
+                    emit signal_sourceEditorFindPrevious();
+                } else {
+                    emit signal_sourceEditorFindNext();
+                }
+                return true;
+            }
+        }
+    } else {
+        if (event->type() == QEvent::Show || event->type() == QEvent::Hide) {
+            emit signal_sourceEditorMovementNecessary();
+        }
+    }
+    return QObject::eventFilter(obj, event);
+}

--- a/src/dlgSourceEditorFindArea.h
+++ b/src/dlgSourceEditorFindArea.h
@@ -37,7 +37,7 @@ class dlgSourceEditorFindArea : public QWidget, public Ui::source_editor_find_ar
 
 public:
     Q_DISABLE_COPY(dlgSourceEditorFindArea)
-    dlgSourceEditorFindArea(QWidget*);
+    explicit dlgSourceEditorFindArea(QWidget*);
 
     bool eventFilter(QObject*, QEvent* event) override;
 

--- a/src/dlgSourceEditorFindArea.h
+++ b/src/dlgSourceEditorFindArea.h
@@ -1,0 +1,51 @@
+#ifndef MUDLET_DLGSOURCEEDITORFINDAREA_H
+#define MUDLET_DLGSOURCEEDITORFINDAREA_H
+
+/***************************************************************************
+ *   Copyright (C) 2020 by Ian Adkins - ieadkins@gmail.com                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include "pre_guard.h"
+#include "ui_source_editor_find_area.h"
+#include "Host.h"
+#include <QTextEdit>
+#include <QKeyEvent>
+#include "post_guard.h"
+
+/*namespace Ui {
+class dlgSourceEditorFindArea;
+}*/
+
+class dlgSourceEditorFindArea : public QWidget, public Ui::source_editor_find_area
+{
+    Q_OBJECT
+
+public:
+    Q_DISABLE_COPY(dlgSourceEditorFindArea)
+    dlgSourceEditorFindArea(QWidget*);
+
+    bool eventFilter(QObject*, QEvent* event) override;
+
+signals:
+    void signal_sourceEditorFindPrevious();
+    void signal_sourceEditorFindNext();
+    void signal_sourceEditorMovementNecessary();
+};
+
+#endif // MUDLET_DLGSOURCEEDITORFINDAREA_H

--- a/src/dlgSourceEditorFindArea.h
+++ b/src/dlgSourceEditorFindArea.h
@@ -23,7 +23,6 @@
 
 #include "pre_guard.h"
 #include "ui_source_editor_find_area.h"
-#include "Host.h"
 #include <QTextEdit>
 #include <QKeyEvent>
 #include "post_guard.h"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7132,12 +7132,10 @@ void dlgTriggerEditor::slot_move_source_find()
 {
     int x = mpSourceEditorEdbee->width() - mpSourceEditorFindArea->width();
     int y = mpSourceEditorEdbee->height() - mpSourceEditorFindArea->height();
-    if (mpSourceEditorEdbee->verticalScrollBar()->isVisible())
-    {
+    if (mpSourceEditorEdbee->verticalScrollBar()->isVisible()) {
         x = x - mpSourceEditorEdbee->verticalScrollBar()->width();
     }
-    if (mpSourceEditorEdbee->horizontalScrollBar()->isVisible())
-    {
+    if (mpSourceEditorEdbee->horizontalScrollBar()->isVisible()) {
         y = y - mpSourceEditorEdbee->horizontalScrollBar()->height();
     }
     mpSourceEditorFindArea->move(x, y);
@@ -8346,8 +8344,7 @@ bool dlgTriggerEditor::event(QEvent* event)
 
 void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
 {
-    if (mpSourceEditorArea->isVisible())
-    {
+    if (mpSourceEditorArea->isVisible()) {
         slot_move_source_find();
     }
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -262,7 +262,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorFindNext, this, &dlgTriggerEditor::slot_source_find_next);
     connect(mpSourceEditorFindArea->pushButton_close, &QPushButton::clicked, this, &dlgTriggerEditor::slot_close_source_find);
 
-    QAction* openSourceFindAction = new QAction(this);
+    auto openSourceFindAction = new QAction(this);
     openSourceFindAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     openSourceFindAction->setShortcut(QKeySequence(QKeySequence::Find));
     mpSourceEditorArea->addAction(openSourceFindAction);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -46,6 +46,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QToolBar>
+#include <QScrollBar>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;
@@ -246,6 +247,44 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpSourceEditorEdbeeDocument->setText(tr("-- Enter your lua code here\n"));
 
     mudlet::loadEdbeeTheme(mpHost->mEditorTheme, mpHost->mEditorThemeFile);
+
+    // edbee editor find area
+    mpSourceEditorFindArea = new dlgSourceEditorFindArea(mpSourceEditorEdbee);
+    mpSourceEditorEdbee->horizontalScrollBar()->installEventFilter(mpSourceEditorFindArea);
+    mpSourceEditorEdbee->verticalScrollBar()->installEventFilter(mpSourceEditorFindArea);
+    mpSourceEditorFindArea->hide();
+
+    connect(mpSourceEditorFindArea->lineEdit_findText, &QLineEdit::textChanged, this, &dlgTriggerEditor::slot_source_find_text_changed);
+    connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorMovementNecessary, this, &dlgTriggerEditor::slot_move_source_find);
+    connect(mpSourceEditorFindArea->pushButton_findPrevious, &QPushButton::clicked, this, &dlgTriggerEditor::slot_source_find_previous);
+    connect(mpSourceEditorFindArea->pushButton_findNext, &QPushButton::clicked, this, &dlgTriggerEditor::slot_source_find_next);
+    connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorFindPrevious, this, &dlgTriggerEditor::slot_source_find_previous);
+    connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorFindNext, this, &dlgTriggerEditor::slot_source_find_next);
+    connect(mpSourceEditorFindArea->pushButton_close, &QPushButton::clicked, this, &dlgTriggerEditor::slot_close_source_find);
+
+    QAction* openSourceFindAction = new QAction(this);
+    openSourceFindAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    openSourceFindAction->setShortcut(QKeySequence(QKeySequence::Find));
+    mpSourceEditorArea->addAction(openSourceFindAction);
+    connect(openSourceFindAction, &QAction::triggered, this, &dlgTriggerEditor::slot_open_source_find);
+
+    QAction* closeSourceFindAction = new QAction(this);
+    closeSourceFindAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    closeSourceFindAction->setShortcut(QKeySequence(QKeySequence::Cancel));
+    mpSourceEditorArea->addAction(closeSourceFindAction);
+    connect(closeSourceFindAction, &QAction::triggered, this, &dlgTriggerEditor::slot_close_source_find);
+
+    QAction* sourceFindNextAction = new QAction(this);
+    sourceFindNextAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    sourceFindNextAction->setShortcut(QKeySequence(QKeySequence::FindNext));
+    mpSourceEditorArea->addAction(sourceFindNextAction);
+    connect(sourceFindNextAction, &QAction::triggered, this, &dlgTriggerEditor::slot_source_find_next);
+
+    QAction* sourceFindPreviousAction = new QAction(this);
+    sourceFindPreviousAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    sourceFindPreviousAction->setShortcut(QKeySequence(QKeySequence::FindPrevious));
+    mpSourceEditorArea->addAction(sourceFindPreviousAction);
+    connect(sourceFindPreviousAction, &QAction::triggered, this, &dlgTriggerEditor::slot_source_find_previous);
 
     auto* provider = new edbee::StringTextAutoCompleteProvider();
     //QScopedPointer<edbee::StringTextAutoCompleteProvider> provider(new edbee::StringTextAutoCompleteProvider);
@@ -7089,6 +7128,71 @@ void dlgTriggerEditor::slot_toggle_active()
     }
 }
 
+void dlgTriggerEditor::slot_move_source_find()
+{
+    int x = mpSourceEditorEdbee->width() - mpSourceEditorFindArea->width();
+    int y = mpSourceEditorEdbee->height() - mpSourceEditorFindArea->height();
+    if (mpSourceEditorEdbee->verticalScrollBar()->isVisible())
+        x = x - mpSourceEditorEdbee->verticalScrollBar()->width();
+    if (mpSourceEditorEdbee->horizontalScrollBar()->isVisible())
+        y = y - mpSourceEditorEdbee->horizontalScrollBar()->height();
+    mpSourceEditorFindArea->move(x, y);
+    mpSourceEditorFindArea->update();
+}
+
+void dlgTriggerEditor::slot_open_source_find()
+{
+    slot_move_source_find();
+    mpSourceEditorFindArea->show();
+    mpSourceEditorFindArea->lineEdit_findText->setFocus();
+    mpSourceEditorFindArea->lineEdit_findText->selectAll();
+}
+
+void dlgTriggerEditor::slot_close_source_find()
+{
+    auto controller = mpSourceEditorEdbee->controller();
+    controller->borderedTextRanges()->clear();
+    controller->textSelection()->range(0).clearSelection();
+    controller->update();
+    mpSourceEditorFindArea->hide();
+    mpSourceEditorEdbee->setFocus();
+}
+
+void dlgTriggerEditor::slot_source_find_previous()
+{
+    auto controller = mpSourceEditorEdbee->controller();
+    auto searcher = controller->textSearcher();
+    searcher->setSearchTerm(mpSourceEditorFindArea->lineEdit_findText->text());
+    searcher->setCaseSensitive(false);
+    searcher->findPrev(mpSourceEditorEdbee);
+    controller->scrollCaretVisible();
+    controller->update();
+    slot_move_source_find();
+}
+
+void dlgTriggerEditor::slot_source_find_next()
+{
+    auto controller = mpSourceEditorEdbee->controller();
+    auto searcher = controller->textSearcher();
+    searcher->setSearchTerm(mpSourceEditorFindArea->lineEdit_findText->text());
+    searcher->setCaseSensitive(false);
+    searcher->findNext(mpSourceEditorEdbee);
+    controller->scrollCaretVisible();
+    controller->update();
+    slot_move_source_find();
+}
+
+void dlgTriggerEditor::slot_source_find_text_changed()
+{
+    auto controller = mpSourceEditorEdbee->controller();
+    auto searcher = controller->textSearcher();
+    controller->borderedTextRanges()->clear();
+    controller->textSelection()->range(0).clearSelection();
+    searcher->setSearchTerm(mpSourceEditorFindArea->lineEdit_findText->text());
+    searcher->markAll(controller->borderedTextRanges());
+    controller->update();
+}
+
 void dlgTriggerEditor::slot_delete_item()
 {
     switch (mCurrentView) {
@@ -8236,6 +8340,11 @@ bool dlgTriggerEditor::event(QEvent* event)
     return QMainWindow::event(event);
 }
 
+void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
+{
+    if (mpSourceEditorArea->isVisible())
+        slot_move_source_find();
+}
 
 void dlgTriggerEditor::slot_key_grab()
 {
@@ -8537,6 +8646,7 @@ void dlgTriggerEditor::slot_changeEditorTextOptions(QTextOption::Flags state)
 
 void dlgTriggerEditor::clearDocument(edbee::TextEditorWidget* ew, const QString& initialText)
 {
+    mpSourceEditorFindArea->hide();
     mpSourceEditorEdbeeDocument = new edbee::CharTextDocument();
     // Buck.lua is a fake filename for edbee to figure out its lexer type with. Referencing the
     // lexer directly by name previously gave problems.
@@ -8891,6 +9001,9 @@ void dlgTriggerEditor::slot_rightSplitterMoved(const int, const int)
         mTimerEditorSplitterState = splitter_right->saveState();
     } else if (mpVarsMainArea->isVisible()) {
         mVarEditorSplitterState = splitter_right->saveState();
+    }
+    if (mpSourceEditorFindArea->isVisible()) {
+        slot_move_source_find();
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7133,9 +7133,13 @@ void dlgTriggerEditor::slot_move_source_find()
     int x = mpSourceEditorEdbee->width() - mpSourceEditorFindArea->width();
     int y = mpSourceEditorEdbee->height() - mpSourceEditorFindArea->height();
     if (mpSourceEditorEdbee->verticalScrollBar()->isVisible())
+    {
         x = x - mpSourceEditorEdbee->verticalScrollBar()->width();
+    }
     if (mpSourceEditorEdbee->horizontalScrollBar()->isVisible())
+    {
         y = y - mpSourceEditorEdbee->horizontalScrollBar()->height();
+    }
     mpSourceEditorFindArea->move(x, y);
     mpSourceEditorFindArea->update();
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8347,7 +8347,9 @@ bool dlgTriggerEditor::event(QEvent* event)
 void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
 {
     if (mpSourceEditorArea->isVisible())
+    {
         slot_move_source_find();
+    }
 }
 
 void dlgTriggerEditor::slot_key_grab()

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -39,6 +39,7 @@
 #include "TTrigger.h"
 #include "TVar.h"
 #include "dlgSourceEditorArea.h"
+#include "dlgSourceEditorFindArea.h"
 #include "dlgSystemMessageArea.h"
 #include "dlgTimersMainArea.h"
 #include "dlgTriggersMainArea.h"
@@ -64,6 +65,7 @@
 #include "edbee/texteditorcontroller.h"
 #include "edbee/texteditorwidget.h"
 #include "edbee/views/components/texteditorcomponent.h"
+#include "edbee/views/textselection.h"
 
 #include "edbee/models/textsearcher.h" // These three are required for search highlighting
 #include "edbee/views/texttheme.h"
@@ -72,6 +74,7 @@
 class dlgTimersMainArea;
 class dlgSystemMessageArea;
 class dlgSourceEditorArea;
+class dlgSourceEditorFindArea;
 class dlgTriggersMainArea;
 class dlgActionMainArea;
 class dlgSearchArea;
@@ -174,6 +177,7 @@ public:
     void enterEvent(QEvent* pE) override;
     bool eventFilter(QObject*, QEvent* event) override;
     bool event(QEvent* event) override;
+    void resizeEvent(QResizeEvent *event) override;
     void fillout_form();
     void showError(const QString&);
     void showWarning(const QString&);
@@ -253,6 +257,12 @@ public slots:
     void slot_searchMudletItems(const QString&); // Was slot_search_triggers(...)
     void slot_item_selected_search_list(QTreeWidgetItem*);
     void slot_delete_item();
+    void slot_open_source_find();
+    void slot_close_source_find();
+    void slot_move_source_find();
+    void slot_source_find_previous();
+    void slot_source_find_next();
+    void slot_source_find_text_changed();
     void slot_save_edit();
     void slot_copy_xml();
     void slot_paste_xml();
@@ -439,6 +449,7 @@ private:
     dlgTimersMainArea* mpTimersMainArea;
     dlgSystemMessageArea* mpSystemMessageArea;
     dlgSourceEditorArea* mpSourceEditorArea;
+    dlgSourceEditorFindArea* mpSourceEditorFindArea;
     dlgAliasMainArea* mpAliasMainArea;
     dlgActionMainArea* mpActionsMainArea;
     dlgScriptsMainArea* mpScriptsMainArea;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -472,6 +472,7 @@ SOURCES += \
     dlgRoomExits.cpp \
     dlgScriptsMainArea.cpp \
     dlgSourceEditorArea.cpp \
+    dlgSourceEditorFindArea.cpp \
     dlgSystemMessageArea.cpp \
     dlgTimersMainArea.cpp \
     dlgTriggerEditor.cpp \
@@ -544,6 +545,7 @@ HEADERS += \
     dlgRoomExits.h \
     dlgScriptsMainArea.h \
     dlgSourceEditorArea.h \
+    dlgSourceEditorFindArea.h \
     dlgSystemMessageArea.h \
     dlgTimersMainArea.h \
     dlgTriggerEditor.h \
@@ -624,6 +626,7 @@ FORMS += \
     ui/room_exits.ui \
     ui/scripts_main_area.ui \
     ui/source_editor_area.ui \
+    ui/source_editor_find_area.ui \
     ui/system_message_area.ui \
     ui/timers_main_area.ui \
     ui/triggers_main_area.ui \

--- a/src/ui/source_editor_find_area.ui
+++ b/src/ui/source_editor_find_area.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>source_editor_find_area</class>
+ <widget class="QWidget" name="source_editor_find_area">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>340</width>
+    <height>30</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::StrongFocus</enum>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="6,1,1,0">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetDefaultConstraint</enum>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <widget class="QLineEdit" name="lineEdit_findText">
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_findPrevious">
+     <property name="maximumSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="icon">
+      <iconset resource="../mudlet.qrc">
+       <normaloff>:/icons/export.png</normaloff>:/icons/export.png</iconset>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_findNext">
+     <property name="maximumSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="icon">
+      <iconset resource="../mudlet.qrc">
+       <normaloff>:/icons/import.png</normaloff>:/icons/import.png</iconset>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_close">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="icon">
+      <iconset resource="../mudlet.qrc">
+       <normaloff>:/icons/dialog-close.png</normaloff>:/icons/dialog-close.png</iconset>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../mudlet.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
Brief overview of PR changes/additions
Adds a small Find menu with the shortcut CTRL+F that allows you to search in an individual document quickly, rather than searching the entire profile.

Motivation for adding to Mudlet
Document searching is ubiquitous in code editors. Even though the profile search feature CAN handle searching in the same document, it's not as convenient as being able to CTRL+F then type a search and press enter to immediately hop to the first result, then pressing ENTER or SHIFT+ENTER to go forward and backwards through results. Additionally, many modern IDE's highlight every instance of what you've typed into the search box, giving you an easy way to scroll a script on your own, but with instances of your search made very apparent.

Other info (issues closed, discussion etc)
![image](https://user-images.githubusercontent.com/15068394/78814785-3b4dc400-799d-11ea-9c75-c8c7b16b178f.png)

Supercedes #3551