### PR TITLE
UserWindow Title shortenend to only be the name of the UserWindow

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1983,7 +1983,7 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
         dockwidget->setObjectName(QStringLiteral("dockWindow_%1_%2").arg(hostName, name));
         dockwidget->setContentsMargins(0, 0, 0, 0);
         dockwidget->setFeatures(QDockWidget::AllDockWidgetFeatures);
-        dockwidget->setWindowTitle(tr("User window - %1 - %2").arg(hostName, name));
+        dockwidget->setWindowTitle(name);
         pHost->mpConsole->mDockWidgetMap.insert(name, dockwidget);
         // It wasn't obvious but the parent passed to the TConsole constructor
         // is sliced down to a QWidget and is NOT a TDockWidget pointer:


### PR DESCRIPTION
## Brief overview of PR changes/additions
This PR shortens the UserWindow Title to be only the name of the UserWindow
#### Motivation for adding to Mudlet
Discussion about the title being to verbose at https://github.com/Mudlet/Mudlet/pull/3585
#### Other info (issues closed, discussion etc)
