### PR TITLE
Use the date instead of sha1 in ptb titles

### DIFF
--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -11,8 +11,13 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
       $Script:Commit = git rev-parse --short $Env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER-$Commit"
   } else {
-    $Script:Commit = git rev-parse --short HEAD
-    $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Commit"
+    if ($Env:MUDLET_VERSION_BUILD -eq "-ptb") {
+      $Script:Date = Get-Date -Format "yyyy.M.dd"
+      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Date"
+    } else {
+      $Script:Commit = git rev-parse --short HEAD
+      $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Commit"
+    }
   }
 }
 

--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -12,7 +12,7 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER-$Commit"
   } else {
     if ($Env:MUDLET_VERSION_BUILD -eq "-ptb") {
-      $Script:Date = Get-Date -Format "yyyy.M.dd"
+      $Script:Date = Get-Date -Format "yyyy.M.d"
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Date"
     } else {
       $Script:Commit = git rev-parse --short HEAD

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -13,8 +13,13 @@ if [ -z "${TRAVIS_TAG}" ]; then
     COMMIT=$(git rev-parse --short "${TRAVIS_PULL_REQUEST_SHA}")
     MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${TRAVIS_PULL_REQUEST}-${COMMIT}"
   else
-    COMMIT=$(git rev-parse --short HEAD)
-    MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${COMMIT}"
+    if [ "${MUDLET_VERSION_BUILD}" = "-ptb" ]; then
+      DATE=$(date +'%Y.%-m.%-d')
+      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${DATE}"
+    else
+      COMMIT=$(git rev-parse --short HEAD)
+      MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${COMMIT}"
+    fi
   fi
 fi
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Use the date instead of sha1 in ptb titles.
#### Motivation for adding to Mudlet
More understandable for most people to see if they're the latest by checking the date :)
#### Other info (issues closed, discussion etc)
Shouldn't affect version comparison as that is done on the build and dblsqd upload timestamps.