### PR TITLE
Add setFgColor for Geyser Gauges

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -141,6 +141,12 @@ function Geyser.Gauge:setAlignment(alignment)
   self.formatTable = self.text.formatTable
 end
 
+--- Sets the color of the text on the gauge
+-- @param color the color you want the text to be
+function Geyser.Gauge:setFgColor(color)
+  self.text:setFgColor(color)
+end
+
 --- Sets the text on the gauge, overwrites inherited echo function.
 -- @param text The text to set.
 function Geyser.Gauge:echo(message, color, format)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Adds passthrough for setFgColor to set the text color of a Gauge

#### Motivation for adding to Mudlet

Someone asked in the help channel on discord and I realized this hadn't been added yet

#### Other info (issues closed, discussion etc)
