### PR TITLE
Add table.collect, table.n_collect, table.matches, table.n_matches

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -149,6 +149,56 @@ function table.contains(tbl, ...)
   return false
 end
 
+--- Checks each item in a table against each other argument using string.match
+--- @param tbl table to check
+--- @param pattern1 pattern to check using string.match
+--- @param pattern2+ optional additional patterns to check
+--- @param check_keys set as true if you want to also check the keys against the patterns
+--- @returns returns a table which contains every key value pair from tbl for which the value string.matches
+---          if check_keys is passed as true, then the key value pair will be added if either the key or the value string.matches
+function table.matches(tbl, ...)
+  local tbl_type = type(tbl)
+  assert(tbl_type == "table", string.format("table.matches: bad argument #1 type (table to check using string.match as table expected, got %s)", tbl_type))
+  local patterns = {...}
+  local matches = {}
+  local check_keys
+  if type(patterns[#patterns]) == "boolean" then check_keys = table.remove(patterns) end
+  for index,pattern in ipairs(patterns) do
+    local ptype = type(pattern)
+    assert(ptype == "string", string.format("table.matches: bad argument #%d type (pattern to check items in table against as string expected, got %s)", index+1, ptype))
+    for key,value in pairs(tbl) do
+      if string.match(value, pattern) or (check_keys and string.match(key, pattern)) then
+        matches[key] = value
+      end
+    end
+  end
+  return matches
+end
+
+--- Checks each item in a table against each other argument using string.match. Returns a list
+--- @param tbl table to check
+--- @param pattern1 pattern to check using string.match
+--- @param pattern2+ optional additional patterns to check
+--- @param check_keys set as true if you want to also check the keys against the patterns
+--- @returns returns a which contains every unique value from tbl for which the value string.matches
+---          does not preserve the order or keys of the original table, but does return a table traverable using ipairs
+function table.n_matches(tbl, ...)
+  local tbl_type = type(tbl)
+  assert(tbl_type == "table", string.format("table.n_matches: bad argument #1 type (table to check using string.match as table expected, got %s)", tbl_type))
+  local patterns = {...}
+  local matches = {}
+  for index,pattern in ipairs(patterns) do
+    local ptype = type(pattern)
+    assert(ptype == "string", string.format("table.n_matches: bad argument #%d type (pattern to check items in table against as string expected, got %s)", index+1, ptype))
+    for key,value in pairs(tbl) do
+      if string.match(value, pattern) and not table.contains(matches, value) then
+        table.insert(matches, value)
+      end
+    end
+  end
+  return matches
+end
+
 
 --- Table Union.
 ---

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -165,7 +165,7 @@ function table.matches(tbl, ...)
   if type(patterns[#patterns]) == "boolean" then check_keys = table.remove(patterns) end
   for index,pattern in ipairs(patterns) do
     local ptype = type(pattern)
-    assert(ptype == "string", string.format("table.matches: bad argument #%d type (pattern to check items in table against as string expected, got %s)", index+1, ptype))
+    assert(ptype == "string", string.format("table.matches: bad argument #%d type (pattern to check as string expected, got %s)", index+1, ptype))
     for key,value in pairs(tbl) do
       if string.match(value, pattern) or (check_keys and string.match(key, pattern)) then
         matches[key] = value
@@ -189,7 +189,7 @@ function table.n_matches(tbl, ...)
   local matches = {}
   for index,pattern in ipairs(patterns) do
     local ptype = type(pattern)
-    assert(ptype == "string", string.format("table.n_matches: bad argument #%d type (pattern to check items in table against as string expected, got %s)", index+1, ptype))
+    assert(ptype == "string", string.format("table.n_matches: bad argument #%d type (pattern to check as string expected, got %s)", index+1, ptype))
     for key,value in pairs(tbl) do
       if string.match(value, pattern) and not table.contains(matches, value) then
         table.insert(matches, value)

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -149,13 +149,56 @@ function table.contains(tbl, ...)
   return false
 end
 
+--- Checks each item in a table against a provided function and returns a table of items
+--- for which the function returns true
+--- @param tbl table to collect items from
+--- @param func function which is called as func(key,value) for each item in tbl
+--- @return table of key-value pairs for which func returns true.
+function table.collect(tbl, func)
+  local tbl_type = type(tbl)
+  assert(tbl_type == "table", string.format("table.collect: bad argument #1 type (table to collect items from as table expected, got %s)", tbl_type))
+  local func_type = type(func)
+  assert(func_type == "function", string.format("table.collect: bad argument #2 type (function to run against each item in tbl as function expected, got %s)", func_type))
+  local matches = {}
+  for key,value in pairs(tbl) do
+    if func(key,value) == true then
+      matches[key] = value
+    end
+  end
+  return matches
+end
+
+--- Checks each item in a table against a provided function and returns a table of items
+--- for which the function returns true. Unlike table.collect it ignores keys and returns 
+--- a table which is guaranteed to be traversable using ipairs()
+--- @param tbl table to collect items from
+--- @param func function which is called as func(value) for each item in tbl
+--- @return table of values for which func(value) returns true. Ignores keys, traversable using ipairs
+function table.n_collect(tbl, func)
+  local tbl_type = type(tbl)
+  assert(tbl_type == "table", string.format("table.n_collect: bad argument #1 type (table to collect items from as table expected, got %s)", tbl_type))
+  local func_type = type(func)
+  assert(func_type == "function", string.format("table.n_collect: bad argument #2 type (function to run against each item in tbl as function expected, got %s)", func_type))
+  local matches = {}
+  for key,value in pairs(tbl) do
+    if func(value) == true and not table.contains(matches, value) then
+      table.insert(matches, value)
+    end
+  end
+  return matches
+end
+
+-- not LDoc: table.matches and table.n_matches below do not use table.collect
+-- or n_collect above in order to reduce the potential number of times tables 
+-- need to be looped.
+
 --- Checks each item in a table against each other argument using string.match
 --- @param tbl table to check
 --- @param pattern1 pattern to check using string.match
 --- @param pattern2+ optional additional patterns to check
 --- @param check_keys set as true if you want to also check the keys against the patterns
---- @returns returns a table which contains every key value pair from tbl for which the value string.matches
----          if check_keys is passed as true, then the key value pair will be added if either the key or the value string.matches
+--- @return returns a table which contains every key value pair from tbl for which the value string.matches
+---         if check_keys is passed as true, then the key value pair will be added if either the key or the value string.matches
 function table.matches(tbl, ...)
   local tbl_type = type(tbl)
   assert(tbl_type == "table", string.format("table.matches: bad argument #1 type (table to check using string.match as table expected, got %s)", tbl_type))
@@ -180,8 +223,8 @@ end
 --- @param pattern1 pattern to check using string.match
 --- @param pattern2+ optional additional patterns to check
 --- @param check_keys set as true if you want to also check the keys against the patterns
---- @returns returns a which contains every unique value from tbl for which the value string.matches
----          does not preserve the order or keys of the original table, but does return a table traverable using ipairs
+--- @return returns a which contains every unique value from tbl for which the value string.matches
+---         does not preserve the order or keys of the original table, but does return a table traverable using ipairs
 function table.n_matches(tbl, ...)
   local tbl_type = type(tbl)
   assert(tbl_type == "table", string.format("table.n_matches: bad argument #1 type (table to check using string.match as table expected, got %s)", tbl_type))

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -98,6 +98,142 @@ describe("Tests TableUtils.lua functions", function()
     end)
   end)
 
+  describe("table.collect(tbl, func)", function()
+    it("should collect all key-value pairs from tbl for which func(key,value) returns true", function()
+      local tbl = {
+        this = "that",
+        the = "other"
+      }
+      local func = function(key, value)
+        if string.match(value, "%a") then return true end
+      end
+      local expected = {
+        this = "that",
+        the = "other"
+      }
+      local actual = table.collect(tbl, func)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should return an empty table if no items in tbl cause func(key,value) to return true", function()
+      local tbl = {
+        this = "that",
+        the = "other"
+      }
+      local func = function(key, value)
+        if string.match(value, "%d") then return true end
+      end
+      local expected = {}
+      local actual = table.collect(tbl, func)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should have another test because the existing ones seem insufficient", function()
+      local tbl = {
+        hp = 99,
+        mana = 30,
+        endurance = 73,
+        willpower = 13
+      }
+      local func = function(key,value)
+        if value < 50 then return true end
+      end
+      local expected = {
+        mana = 30,
+        willpower = 13
+      }
+      local actual = table.collect(tbl, func)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should throw an error if you give a non-table as the first argument", function()
+      local tbl = "not a table"
+      local func = function() end
+      local errfn = function()
+        table.collect(tbl, func)
+      end
+      assert.has_error(errfn, "table.collect: bad argument #1 type (table to collect items from as table expected, got string)") 
+    end)
+
+    it("should throw an error if you give a non-function as the second argument", function()
+      local tbl = {}
+      local func = "function() end"
+      local errfn = function()
+        table.collect(tbl, func)
+      end
+      assert.has_error(errfn, "table.collect: bad argument #2 type (function to run against each item in tbl as function expected, got string)") 
+    end)
+  end)
+
+  describe("table.n_collect(tbl, func)", function()
+    it("should return a table of unique values for which func(value) returns true", function()
+      local tbl = {
+        this = "that",
+        the = "other",
+        three = 3,
+      }
+      local func = function(value)
+        if type(value) == "number" then return true end
+      end
+      local expected = { 3 }
+      local actual = table.n_collect(tbl, func)
+      assert.are.same(expected, actual)
+    end)
+    
+    it("should return an empty table if no values return true", function()
+      local tbl = {
+        this = "that",
+        the = "other"
+      }
+      local func = function(value)
+        if type(value) == "number" then return true end
+      end
+      local expected = {}
+      local actual = table.n_collect(tbl, func)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should work on lists as well as maps", function()
+      local tbl = {
+        10,
+        20,
+        25,
+        53,
+        1829,
+        1800
+      }
+      local func = function(value)
+        if value % 10 == 0 then return true end
+      end
+      local expected = {
+        10,
+        20,
+        1800
+      }
+      local actual = table.n_collect(tbl, func)
+      table.sort(actual)
+      assert.are.same(expected,actual)
+    end)
+
+    it("should throw an error if you give a non-table as the first argument", function()
+      local tbl = "not a table"
+      local func = function() end
+      local errfn = function()
+        table.n_collect(tbl, func)
+      end
+      assert.has_error(errfn, "table.n_collect: bad argument #1 type (table to collect items from as table expected, got string)") 
+    end)
+
+    it("should throw an error if you give a non-function as the second argument", function()
+      local tbl = {}
+      local func = "function() end"
+      local errfn = function()
+        table.n_collect(tbl, func)
+      end
+      assert.has_error(errfn, "table.n_collect: bad argument #2 type (function to run against each item in tbl as function expected, got string)") 
+    end)
+  end)
+
   describe("table.matches(tbl, pattern_1,[pattern_2+], [check_keys])", function()
     it("should return an empty table of no values math", function()
       local tbl = { 
@@ -175,11 +311,11 @@ describe("Tests TableUtils.lua functions", function()
       local errfn = function()
         table.matches(tbl, not_string)
       end
-      assert.has_error(errfn, "table.matches: bad argument #2 type (pattern to check items in table against as string expected, got number)")
+      assert.has_error(errfn, "table.matches: bad argument #2 type (pattern to check as string expected, got number)")
       errfn = function()
         table.matches(tbl, "a string", not_string)
       end
-      assert.has_error(errfn, "table.matches: bad argument #3 type (pattern to check items in table against as string expected, got number)")
+      assert.has_error(errfn, "table.matches: bad argument #3 type (pattern to check as string expected, got number)")
     end)
   end)
 
@@ -232,11 +368,11 @@ describe("Tests TableUtils.lua functions", function()
       local errfn = function()
         table.n_matches(tbl, not_string)
       end
-      assert.has_error(errfn, "table.n_matches: bad argument #2 type (pattern to check items in table against as string expected, got number)")
+      assert.has_error(errfn, "table.n_matches: bad argument #2 type (pattern to check as string expected, got number)")
       errfn = function()
         table.n_matches(tbl, "a string", not_string)
       end
-      assert.has_error(errfn, "table.n_matches: bad argument #3 type (pattern to check items in table against as string expected, got number)")
+      assert.has_error(errfn, "table.n_matches: bad argument #3 type (pattern to check as string expected, got number)")
     end)
   end)
 

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -98,6 +98,148 @@ describe("Tests TableUtils.lua functions", function()
     end)
   end)
 
+  describe("table.matches(tbl, pattern_1,[pattern_2+], [check_keys])", function()
+    it("should return an empty table of no values math", function()
+      local tbl = { 
+        this = "that",
+        the = "other"
+       }
+      local actual = table.matches(tbl, "%d")
+      assert.is_true(table.is_empty(actual))
+    end)
+
+    it("should return a table containing all the items which match", function()
+      local tbl = {
+        this = "that",
+        the = "other",
+        number = "1234",
+        one = "1"
+      }
+      local expected = {
+        number = "1234",
+        one = "1"
+      }
+      local actual = table.matches(tbl, "%d")
+      assert.are.same(expected, actual)
+      expected = {
+        this = "that",
+        the = "other"
+      }
+      actual = table.matches(tbl, "%a+")
+      assert.are.same(expected, actual)
+    end)
+
+    it("should check both keys and values if check_keys is true", function()
+      local tbl = {
+        hp = 50,
+        maxhp = 100,
+        mana = 300,
+        maxmana = 1000,
+      }
+      local expected = {
+        hp = 50,
+        maxhp = 100
+      }
+      local actual = table.matches(tbl, "hp", true)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should check multiple patterns if passed", function()
+      local tbl = {
+        hp = 50,
+        mana = 50,
+        wakefulness = "awake",
+        title = "Lord High Muckity",
+        name = "SuchAndSuch"
+      }
+      local expected = {
+        hp = 50,
+        mana = 50,
+        title = "Lord High Muckity"
+      }
+      local actual = table.matches(tbl, "^%d+$", "title", true)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should throw an errow if the first parameter is not a table", function()
+      local not_tbl = "not a table"
+      local errfn = function()
+        table.matches(not_tbl, "%d")
+      end
+      assert.has_error(errfn, "table.matches: bad argument #1 type (table to check using string.match as table expected, got string)") 
+    end)
+
+    it("should throw an error if the pattern passed is not a string", function()
+      local tbl = {}
+      local not_string = 4
+      local errfn = function()
+        table.matches(tbl, not_string)
+      end
+      assert.has_error(errfn, "table.matches: bad argument #2 type (pattern to check items in table against as string expected, got number)")
+      errfn = function()
+        table.matches(tbl, "a string", not_string)
+      end
+      assert.has_error(errfn, "table.matches: bad argument #3 type (pattern to check items in table against as string expected, got number)")
+    end)
+  end)
+
+  describe("table.n_matches(tbl, pattern_1,[pattern_2+])", function()
+    it("should return a list of values which string.match a given pattern", function()
+      local tbl = {
+        this = "that",
+        the = "other",
+        [1] = "blue"
+      }
+      local expected = {
+        "blue",
+        "other"
+      }
+      local actual = table.n_matches(tbl, "e")
+      table.sort(actual)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should only add any given value once", function()
+      local tbl = {
+        "this",
+        "this",
+        "that",
+        "other",
+        "something"
+      }
+      local expected = {
+        "other",
+        "something",
+        "that",
+        "this",
+      }
+      local actual = table.n_matches(tbl, "%a")
+      table.sort(actual)
+      assert.are.same(expected, actual)
+    end)
+
+    it("should error if the first argument is not a table", function()
+      local not_tbl = "not a table"
+      local errfn = function()
+        table.n_matches(not_tbl, "%d")
+      end
+      assert.has_error(errfn, "table.n_matches: bad argument #1 type (table to check using string.match as table expected, got string)")
+    end)
+
+    it("should throw an error if the pattern passed is not a string", function()
+      local tbl = {}
+      local not_string = 4
+      local errfn = function()
+        table.n_matches(tbl, not_string)
+      end
+      assert.has_error(errfn, "table.n_matches: bad argument #2 type (pattern to check items in table against as string expected, got number)")
+      errfn = function()
+        table.n_matches(tbl, "a string", not_string)
+      end
+      assert.has_error(errfn, "table.n_matches: bad argument #3 type (pattern to check items in table against as string expected, got number)")
+    end)
+  end)
+
   describe("table.contains(tbl, item)", function()
 
     it("should return true if the table has a value that matches item", function()


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Adds 4 functions
table.collect(tbl, func)
table.n_collect(tbl, func)
table.matches(tbl, pattern1, [pattern_2], [pattern_n], [check_keys])
table.n_matches(tbl, pattern1, [pattern_2], [pattern_n])

They are all used to collect values from a table which match certain criteria. The differences are:
* collect
  * loops through a table using pairs
  * passes each iteration as func(key, value)
  * keeps any values for which func(key, value) returns true
* n_collect
  * loops through a table using pairs
  * passes each iteration as func(value)
  * ignores keys entirely
  * keeps any value for which func(value) returns true
  * usable on any table, unlike table.n_filter which uses ipairs to loop the table being examined
  * here the n refers to the table returned, as it is ensured to be ipairs loopable
  * does not preserve order if used with a list
* matches 
  * preserves keys but returns a table you (almost certainly) cannot traverse with ipairs.
  * has an option to check if keys match the pattern as well, so you can retrieve a table of key-value pairs for hp items (hp, maxhp keys in a table) etc
* n_matches 
  * produces a list of unique values in tbl which match any of the patterns given to check against
  * ignores keys altogether
  * does not preserve order from the original table

#### Motivation for adding to Mudlet

I find myself using these a lot as a way to collect items from a table, especially the matches/n_matches variants. It seemed like the kind of thing which may belong in the general Mudlet API.

#### Other info (issues closed, discussion etc)

![image](https://user-images.githubusercontent.com/3660/79077748-9fd88e00-7cd1-11ea-8a32-24745e72e033.png)

