### PR TITLE
BugFix: correct usage of (void) mudlet::show_options_dialog(QString&)

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -526,7 +526,7 @@ void cTelnet::handle_socket_signal_disconnected()
 
 #if !defined(QT_NO_SSL)
     if (sslerr) {
-        mudlet::self()->show_options_dialog(QStringLiteral("Security"));
+        mudlet::self()->show_options_dialog(QStringLiteral("tab_connection"));
     }
 #endif
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3501,8 +3501,8 @@ void mudlet::show_action_dialog()
     pEditor->activateWindow();
 }
 
-
-void mudlet::show_options_dialog(QString tab)
+// tab must be the "objectName" of the tab in the preferences NOT the "titleText"
+void mudlet::show_options_dialog(const QString& tab)
 {
     Host* pHost = getActiveHost();
 
@@ -3612,7 +3612,7 @@ void mudlet::slot_update_shortcuts()
 
 void mudlet::slot_show_options_dialog()
 {
-    show_options_dialog("General");
+    show_options_dialog(QStringLiteral("tab_general"));
 }
 
 void mudlet::show_help_dialog()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -416,7 +416,7 @@ public:
     // operating without either menubar or main toolbar showing.
     bool isControlsVisible() const;
     bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
-    void show_options_dialog(QString tab);
+    void show_options_dialog(const QString& tab);
     void setInterfaceLanguage(const QString &languageCode);
     const QString& getInterfaceLanguage() const { return mInterfaceLanguage; }
     QList<QString> getAvailableTranslationCodes() const { return mTranslationsMap.keys(); }


### PR DESCRIPTION
The text supplied must be the `objectName` of the tab concerned, NOT the (translatable) title text.

Without this then an OpenSSL error on trying to connect to a MUD Server securely will not switch to the "Connection" tab on the preferences!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>