### PR TITLE
Enhance: add ability to set title for floating/dockable map window

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2531,3 +2531,18 @@ void Host::setSearchOptions(const dlgTriggerEditor::SearchOptions optionsState)
         mpEditorDialog->setSearchOptions(optionsState);
     }
 }
+
+std::pair<bool, QString> Host::setMapperTitle(const QString& title)
+{
+    if (!mpDockableMapWidget) {
+        return {false, "no floating/dockable type map window found"};
+    }
+
+    if (title.isEmpty()) {
+        mpDockableMapWidget->setWindowTitle(tr("Map - %1").arg(mHostName));
+    } else {
+        mpDockableMapWidget->setWindowTitle(title);
+    }
+
+    return {true, QString()};
+}

--- a/src/Host.h
+++ b/src/Host.h
@@ -327,6 +327,8 @@ public:
     void setPlayerRoomStyleDetails(const quint8 styleCode, const quint8 outerDiameter = 120, const quint8 innerDiameter = 70, const QColor& outerColor = QColor(), const QColor& innerColor = QColor());
     void getPlayerRoomStyleDetails(quint8& styleCode, quint8& outerDiameter, quint8& innerDiameter, QColor& outerColor, QColor& innerColor);
     void setSearchOptions(const dlgTriggerEditor::SearchOptions);
+    std::pair<bool, QString> setMapperTitle(const QString&);
+
 
     cTelnet mTelnet;
     QPointer<TConsole> mpConsole;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3640,6 +3640,29 @@ int TLuaInterpreter::setUserWindowTitle(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapWindowTitle
+int TLuaInterpreter::setMapWindowTitle(lua_State* L)
+{
+    QString title;
+    if (lua_gettop(L)) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "setMapWindowTitle: bad argument #1 type (title as string is optional, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
+        title = QString::fromUtf8(lua_tostring(L, 1));
+    }
+
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = host.setMapperTitle(title); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMiniConsole
 int TLuaInterpreter::createMiniConsole(lua_State* L)
 {
@@ -16742,6 +16765,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "deleteHTTP", TLuaInterpreter::deleteHTTP);
     lua_register(pGlobalLua, "getConnectionInfo", TLuaInterpreter::getConnectionInfo);
     lua_register(pGlobalLua, "unzipAsync", TLuaInterpreter::unzipAsync);
+    lua_register(pGlobalLua, "setMapWindowTitle", TLuaInterpreter::setMapWindowTitle);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     const auto separator = QDir::separator();

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -544,6 +544,7 @@ public:
     static int deleteHTTP(lua_State* L);
     static int getConnectionInfo(lua_State* L);
     static int unzipAsync(lua_State* L);
+    static int setMapWindowTitle(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2031,3 +2031,7 @@ end
 function resetUserWindowTitle(windowname)
   return setUserWindowTitle(windowname, "")
 end
+
+function resetMapWindowTitle()
+  return setMapWindowTitle("")
+end

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -80,6 +80,16 @@ function Geyser.Mapper:setDockPosition(pos)
   end
 end
 
+function Geyser.Mapper:setTitle(text)
+  self.titleText = text
+  return setMapWindowTitle(text)
+end
+
+function Geyser.Mapper:resetTitle()
+  self.titleText = ""
+  return resetMapWindowTitle()
+end
+
 -- Overridden constructor
 function Geyser.Mapper:new (cons, container)
   cons = cons or {}
@@ -114,6 +124,12 @@ function Geyser.Mapper:new (cons, container)
       me:get_width(), me:get_height())
     else
       openMapWidget()
+    end
+
+    if me.titleText then
+      me:setTitle(me.titleText)
+    else
+      me:resetTitle()
     end
   end
 


### PR DESCRIPTION
This provides the same sort of feature to the map widget as was applied to user windows in PR https://github.com/Mudlet/Mudlet/pull/3585.

Obviously it only works for the floating/dockable type mapper - and it will tell the user this if they try it on the embedded one.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>