### PR TITLE
Signal an mxp event as an element is received

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1548,7 +1548,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                                 _tl[i] = "printCmdLine([[" + _tl[i] + "]])";
                             }
                         }
-                        mpHost->getLuaInterpreter()->signalMXPEvent(_element.name, mxp_attrs, _tl);
+
+                        mMxpEvents.append(MxpEvent(_element.name, mxp_attrs, _tl));
 
                         mLinkStore[mLinkID] = _tl;
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1549,7 +1549,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                             }
                         }
 
-                        mMxpEvents.append(MxpEvent(_element.name, mxp_attrs, _tl));
+                        mMxpEvents.enqueue(MxpEvent(_element.name, mxp_attrs, _tl));
 
                         mLinkStore[mLinkID] = _tl;
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1502,9 +1502,11 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                             match = _rex.match(_tp, _rpos);
                         }
 
+                        QMap<QString, QString> mxp_attrs;
                         if ((_rl1.size() == _rl2.size()) && (!_rl1.empty())) {
                             for (int i = 0; i < _rl1.size(); i++) {
                                 QString _var = _rl1[i];
+                                mxp_attrs[_var] = _rl2[i];
                                 _var.prepend('&');
                                 if (_userTag || _t2.indexOf(_var) != -1) {
                                     _t2 = _t2.replace(_var, _rl2[i]);
@@ -1546,6 +1548,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                                 _tl[i] = "printCmdLine([[" + _tl[i] + "]])";
                             }
                         }
+                        mpHost->getLuaInterpreter()->signalMXPEvent(_element.name, mxp_attrs, _tl);
 
                         mLinkStore[mLinkID] = _tl;
 

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -30,6 +30,7 @@
 #include <QColor>
 #include <QDebug>
 #include <QMap>
+#include <QQueue>
 #include <QPoint>
 #include <QPointer>
 #include <QString>
@@ -46,7 +47,8 @@ class Host;
 
 class QTextCodec;
 
-class TChar {
+class TChar
+{
     friend class TBuffer;
 
 public:
@@ -81,39 +83,27 @@ public:
     TChar(const TChar&);
 
     bool operator==(const TChar&);
-    void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor)
-    {
+    void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor) {
         mFgColor = newForeGroundColor;
         mBgColor = newBackGroundColor;
     }
     // Only considers the following flags: Bold, Italic, Overline, Reverse,
     // Strikeout, Underline, does not consider Echo:
-    void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes)
-    { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
-    void setForeground(const QColor& newColor)
-    { mFgColor = newColor; }
-    void setBackground(const QColor& newColor)
-    { mBgColor = newColor; }
-    void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes)
-    {
+    void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes) { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
+    void setForeground(const QColor& newColor) { mFgColor = newColor; }
+    void setBackground(const QColor& newColor) { mBgColor = newColor; }
+    void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes) {
         setColors(newFgColor, newBgColor);
         setAllDisplayAttributes(newDisplayAttributes);
     }
 
-    const QColor& foreground() const
-    { return mFgColor; }
-    const QColor& background() const
-    { return mBgColor; }
-    AttributeFlags allDisplayAttributes() const
-    { return mFlags & TestMask; }
-    void select()
-    { mIsSelected = true; }
-    void deselect()
-    { mIsSelected = false; }
-    bool isSelected() const
-    { return mIsSelected; }
-    int linkIndex() const
-    { return mLinkIndex; }
+    const QColor& foreground() const { return mFgColor; }
+    const QColor& background() const { return mBgColor; }
+    AttributeFlags allDisplayAttributes() const { return mFlags & TestMask; }
+    void select() { mIsSelected = true; }
+    void deselect() { mIsSelected = false; }
+    bool isSelected() const { return mIsSelected; }
+    int linkIndex () const { return mLinkIndex; }
 
 private:
     QColor mFgColor;
@@ -126,13 +116,15 @@ private:
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
 
-struct TMxpElement {
+struct TMxpElement
+{
     QString name;
     QString href;
     QString hint;
 };
 
-enum TMXPMode {
+enum TMXPMode
+{
     MXP_MODE_OPEN,
     MXP_MODE_SECURE,
     MXP_MODE_LOCKED,
@@ -151,7 +143,7 @@ struct MxpEvent {
 
 class TBuffer {
     // need to use tr() on encoding names in csmEncodingTable
-Q_DECLARE_TR_FUNCTIONS(TBuffer)
+    Q_DECLARE_TR_FUNCTIONS(TBuffer)
 
     // private - a map of computer-friendly encoding names as keys,
     // values are a pair of human-friendly name + encoding data
@@ -167,31 +159,15 @@ Q_DECLARE_TR_FUNCTIONS(TBuffer)
 
 public:
     TBuffer(Host* pH);
-    QPoint insert(QPoint&,
-                  const QString& text,
-                  int,
-                  int,
-                  int,
-                  int,
-                  int,
-                  int,
-                  bool bold,
-                  bool italics,
-                  bool underline,
-                  bool strikeout);
+    QPoint insert(QPoint&, const QString& text, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout);
     bool insertInLine(QPoint& cursor, const QString& what, TChar& format);
     void expandLine(int y, int count, TChar&);
     int wrapLine(int startLine, int screenWidth, int indentSize, TChar& format);
     void log(int, int);
     int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, TChar format);
-    QString bufferToHtml(const bool showTimeStamp = false,
-                         const int row = -1,
-                         const int endColumn = -1,
-                         const int startColumn = 0,
-                         int spacePadding = 0);
-    int size()
-    { return static_cast<int>(buffer.size()); }
+    QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0,  int spacePadding = 0);
+    int size() { return static_cast<int>(buffer.size()); }
     QString& line(int n);
     int find(int line, const QString& what, int pos);
     int wrap(int);
@@ -211,34 +187,19 @@ public:
     void clear();
     QPoint getEndPos();
     void translateToPlainText(std::string& s, bool isFromServer = false);
-    void append(const QString& chunk,
-                int sub_start,
-                int sub_end,
-                const QColor& fg,
-                const QColor& bg,
-                const TChar::AttributeFlags flags = TChar::None,
-                const int linkID = 0);
+    void append(const QString& chunk, int sub_start, int sub_end, const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
     // Only the bits within TChar::TestMask are considered for formatting:
     void append(const QString& chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
-    void appendLine(const QString& chunk,
-                    const int sub_start,
-                    const int sub_end,
-                    const QColor& fg,
-                    const QColor& bg,
-                    TChar::AttributeFlags flags = TChar::None,
-                    const int linkID = 0);
-    void setWrapAt(int i)
-    { mWrapAt = i; }
-    void setWrapIndent(int i)
-    { mWrapIndent = i; }
+    void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
+    void setWrapAt(int i) { mWrapAt = i; }
+    void setWrapIndent(int i) { mWrapIndent = i; }
     void updateColors();
     TBuffer copy(QPoint&, QPoint&);
     TBuffer cut(QPoint&, QPoint&);
     void paste(QPoint&, TBuffer);
     void setBufferSize(int requestedLinesLimit, int batch);
     int getMaxBufferSize();
-    static const QList<QString> getComputerEncodingNames()
-    { return csmEncodingTable.keys(); }
+    static const QList<QString> getComputerEncodingNames() { return csmEncodingTable.keys(); }
     static const QList<QString> getFriendlyEncodingNames();
     static const QString& getComputerEncoding(const QString& encoding);
     void logRemainingOutput();
@@ -247,7 +208,7 @@ public:
     void encodingChanged(const QString&);
     static int lengthInGraphemes(const QString& text);
 
-    QList<MxpEvent> mMxpEvents;
+    QQueue<MxpEvent> mMxpEvents;
 
     std::deque<TChar> bufferLine;
     std::deque<std::deque<TChar>> buffer;
@@ -314,6 +275,7 @@ public:
     std::string mAssembleRef;
     bool mEchoingText;
 
+
 private:
     void shrinkBuffer();
     int calculateWrapPosition(int lineNumber, int begin, int end);
@@ -340,6 +302,7 @@ private:
     // ESC character followed by the ']' one:
     bool mGotOSC;
     bool mIsDefaultColor;
+
 
     QColor mBlack;
     QColor mLightBlack;

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -46,8 +46,7 @@ class Host;
 
 class QTextCodec;
 
-class TChar
-{
+class TChar {
     friend class TBuffer;
 
 public:
@@ -82,27 +81,39 @@ public:
     TChar(const TChar&);
 
     bool operator==(const TChar&);
-    void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor) {
+    void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor)
+    {
         mFgColor = newForeGroundColor;
         mBgColor = newBackGroundColor;
     }
     // Only considers the following flags: Bold, Italic, Overline, Reverse,
     // Strikeout, Underline, does not consider Echo:
-    void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes) { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
-    void setForeground(const QColor& newColor) { mFgColor = newColor; }
-    void setBackground(const QColor& newColor) { mBgColor = newColor; }
-    void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes) {
+    void setAllDisplayAttributes(const AttributeFlags newDisplayAttributes)
+    { mFlags = (mFlags & ~TestMask) | (newDisplayAttributes & TestMask); }
+    void setForeground(const QColor& newColor)
+    { mFgColor = newColor; }
+    void setBackground(const QColor& newColor)
+    { mBgColor = newColor; }
+    void setTextFormat(const QColor& newFgColor, const QColor& newBgColor, const AttributeFlags newDisplayAttributes)
+    {
         setColors(newFgColor, newBgColor);
         setAllDisplayAttributes(newDisplayAttributes);
     }
 
-    const QColor& foreground() const { return mFgColor; }
-    const QColor& background() const { return mBgColor; }
-    AttributeFlags allDisplayAttributes() const { return mFlags & TestMask; }
-    void select() { mIsSelected = true; }
-    void deselect() { mIsSelected = false; }
-    bool isSelected() const { return mIsSelected; }
-    int linkIndex () const { return mLinkIndex; }
+    const QColor& foreground() const
+    { return mFgColor; }
+    const QColor& background() const
+    { return mBgColor; }
+    AttributeFlags allDisplayAttributes() const
+    { return mFlags & TestMask; }
+    void select()
+    { mIsSelected = true; }
+    void deselect()
+    { mIsSelected = false; }
+    bool isSelected() const
+    { return mIsSelected; }
+    int linkIndex() const
+    { return mLinkIndex; }
 
 private:
     QColor mFgColor;
@@ -115,25 +126,32 @@ private:
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS(TChar::AttributeFlags)
 
-struct TMxpElement
-{
+struct TMxpElement {
     QString name;
     QString href;
     QString hint;
 };
 
-enum TMXPMode
-{
+enum TMXPMode {
     MXP_MODE_OPEN,
     MXP_MODE_SECURE,
     MXP_MODE_LOCKED,
     MXP_MODE_TEMP_SECURE
 };
 
-class TBuffer
-{
+struct MxpEvent {
+    QString name;
+    QMap<QString, QString> attrs;
+    QStringList actions;
+
+    MxpEvent(QString name, QMap<QString, QString> attrs, QStringList actions)
+            : name(name), attrs(attrs), actions(actions)
+    {}
+};
+
+class TBuffer {
     // need to use tr() on encoding names in csmEncodingTable
-    Q_DECLARE_TR_FUNCTIONS(TBuffer)
+Q_DECLARE_TR_FUNCTIONS(TBuffer)
 
     // private - a map of computer-friendly encoding names as keys,
     // values are a pair of human-friendly name + encoding data
@@ -149,15 +167,31 @@ class TBuffer
 
 public:
     TBuffer(Host* pH);
-    QPoint insert(QPoint&, const QString& text, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout);
+    QPoint insert(QPoint&,
+                  const QString& text,
+                  int,
+                  int,
+                  int,
+                  int,
+                  int,
+                  int,
+                  bool bold,
+                  bool italics,
+                  bool underline,
+                  bool strikeout);
     bool insertInLine(QPoint& cursor, const QString& what, TChar& format);
     void expandLine(int y, int count, TChar&);
     int wrapLine(int startLine, int screenWidth, int indentSize, TChar& format);
     void log(int, int);
     int skipSpacesAtBeginOfLine(const int row, const int column);
     void addLink(bool, const QString& text, QStringList& command, QStringList& hint, TChar format);
-    QString bufferToHtml(const bool showTimeStamp = false, const int row = -1, const int endColumn = -1, const int startColumn = 0,  int spacePadding = 0);
-    int size() { return static_cast<int>(buffer.size()); }
+    QString bufferToHtml(const bool showTimeStamp = false,
+                         const int row = -1,
+                         const int endColumn = -1,
+                         const int startColumn = 0,
+                         int spacePadding = 0);
+    int size()
+    { return static_cast<int>(buffer.size()); }
     QString& line(int n);
     int find(int line, const QString& what, int pos);
     int wrap(int);
@@ -177,27 +211,43 @@ public:
     void clear();
     QPoint getEndPos();
     void translateToPlainText(std::string& s, bool isFromServer = false);
-    void append(const QString& chunk, int sub_start, int sub_end, const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
+    void append(const QString& chunk,
+                int sub_start,
+                int sub_end,
+                const QColor& fg,
+                const QColor& bg,
+                const TChar::AttributeFlags flags = TChar::None,
+                const int linkID = 0);
     // Only the bits within TChar::TestMask are considered for formatting:
     void append(const QString& chunk, const int sub_start, const int sub_end, const TChar format, const int linkID = 0);
-    void appendLine(const QString& chunk, const int sub_start, const int sub_end, const QColor& fg, const QColor& bg, TChar::AttributeFlags flags = TChar::None, const int linkID = 0);
-    void setWrapAt(int i) { mWrapAt = i; }
-    void setWrapIndent(int i) { mWrapIndent = i; }
+    void appendLine(const QString& chunk,
+                    const int sub_start,
+                    const int sub_end,
+                    const QColor& fg,
+                    const QColor& bg,
+                    TChar::AttributeFlags flags = TChar::None,
+                    const int linkID = 0);
+    void setWrapAt(int i)
+    { mWrapAt = i; }
+    void setWrapIndent(int i)
+    { mWrapIndent = i; }
     void updateColors();
     TBuffer copy(QPoint&, QPoint&);
     TBuffer cut(QPoint&, QPoint&);
     void paste(QPoint&, TBuffer);
     void setBufferSize(int requestedLinesLimit, int batch);
     int getMaxBufferSize();
-    static const QList<QString> getComputerEncodingNames() { return csmEncodingTable.keys(); }
+    static const QList<QString> getComputerEncodingNames()
+    { return csmEncodingTable.keys(); }
     static const QList<QString> getFriendlyEncodingNames();
     static const QString& getComputerEncoding(const QString& encoding);
     void logRemainingOutput();
     // It would have been nice to do this with Qt's signals and slots but that
     // is apparently incompatible with using a default constructor - sigh!
-    void encodingChanged(const QString &);
+    void encodingChanged(const QString&);
     static int lengthInGraphemes(const QString& text);
 
+    QList<MxpEvent> mMxpEvents;
 
     std::deque<TChar> bufferLine;
     std::deque<std::deque<TChar>> buffer;
@@ -264,7 +314,6 @@ public:
     std::string mAssembleRef;
     bool mEchoingText;
 
-
 private:
     void shrinkBuffer();
     int calculateWrapPosition(int lineNumber, int begin, int end);
@@ -272,7 +321,7 @@ private:
     bool processUtf8Sequence(const std::string&, bool, size_t, size_t&, bool&);
     bool processGBSequence(const std::string&, bool, bool, size_t, size_t&, bool&);
     bool processBig5Sequence(const std::string&, bool, size_t, size_t&, bool&);
-    QString processSupportsRequest(const QString &attributes);
+    QString processSupportsRequest(const QString& attributes);
     void decodeSGR(const QString&);
     void decodeSGR38(const QStringList&, bool isColonSeparated = true);
     void decodeSGR48(const QStringList&, bool isColonSeparated = true);
@@ -291,7 +340,6 @@ private:
     // ESC character followed by the ']' one:
     bool mGotOSC;
     bool mIsDefaultColor;
-
 
     QColor mBlack;
     QColor mLightBlack;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1245,6 +1245,12 @@ void TConsole::printOnDisplay(std::string& incomingSocketData, const bool isFrom
     buffer.translateToPlainText(incomingSocketData, isFromServer);
     mTriggerEngineMode = false;
 
+    while (!buffer.mMxpEvents.isEmpty()) {
+        const MxpEvent &event = buffer.mMxpEvents.last();
+        mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions);
+        buffer.mMxpEvents.removeLast();
+    }
+
     double processT = mProcessingTime.elapsed();
     if (mpHost->mTelnet.mGA_Driver) {
         networkLatency->setText(QString("N:%1 S:%2").arg(mpHost->mTelnet.networkLatency, 0, 'f', 3).arg(processT / 1000, 0, 'f', 3));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1246,9 +1246,8 @@ void TConsole::printOnDisplay(std::string& incomingSocketData, const bool isFrom
     mTriggerEngineMode = false;
 
     while (!buffer.mMxpEvents.isEmpty()) {
-        const MxpEvent &event = buffer.mMxpEvents.last();
+        const MxpEvent &event = buffer.mMxpEvents.dequeue();
         mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions);
-        buffer.mMxpEvents.removeLast();
     }
 
     double processT = mProcessingTime.elapsed();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14778,6 +14778,67 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
     host.raiseEvent(event);
 }
 
+void
+TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions) {
+    lua_State *L = pGlobalLua;
+    lua_getglobal(L, "mxp");
+    if (!lua_istable(L, -1)) {
+        lua_newtable(L);
+        lua_setglobal(L, "mxp");
+        lua_getglobal(L, "mxp");
+        if (!lua_istable(L, -1)) {
+            qDebug() << "ERROR: mxp table not defined";
+            return;
+        }
+    }
+
+    lua_getfield(L, -1, type.toUtf8().toLower().constData());
+    if (!lua_istable(L, -1)) {
+        lua_getglobal(L, "mxp");
+        lua_newtable(L);
+        lua_setfield(L, -2, type.toUtf8().toLower().constData());
+        if (!lua_istable(L, -1)) {
+            qDebug() << "ERROR: 'mxp." << type << "' table not defined";
+            return;
+        }
+    }
+
+    QMapIterator<QString, QString> itr(attrs);
+    while (itr.hasNext()) {
+        itr.next();
+        lua_pushstring(L, itr.value().toUtf8().constData());
+        lua_setfield(L, -2, itr.key().toUtf8().toLower().constData());
+    }
+
+    lua_newtable(L);
+    lua_setfield(L, -2, "actions");
+    lua_getfield(L, -1, "actions");
+    for (int i = 0; i < actions.size(); i++) {
+        lua_pushstring(L, actions[i].toUtf8().constData());
+        lua_rawseti(L, -2, i);
+    }
+
+    lua_pop(L, lua_gettop(L));
+
+
+    TEvent event{};
+    QString token("mxp");
+    token.append(".");
+    token.append(type.toUtf8().toLower().constData());
+
+    event.mArgumentList.append(token);
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+
+    Host &host = getHostFromLua(L);
+    if (mudlet::debugMode) {
+        QString msg = QStringLiteral("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
+        host.mpConsole->printSystemMessage(msg);
+    }
+    host.raiseEvent(event);
+}
+
+
+
 // No documentation available in wiki - internal function
 void TLuaInterpreter::setGMCPTable(QString& key, const QString& string_data)
 {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14815,7 +14815,7 @@ TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString
     lua_getfield(L, -1, "actions");
     for (int i = 0; i < actions.size(); i++) {
         lua_pushstring(L, actions[i].toUtf8().constData());
-        lua_rawseti(L, -2, i);
+        lua_rawseti(L, -2, i + 1);
     }
 
     lua_pop(L, lua_gettop(L));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14792,15 +14792,12 @@ TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString
         }
     }
 
+    lua_newtable(L);
+    lua_setfield(L, -2, type.toUtf8().toLower().constData());
     lua_getfield(L, -1, type.toUtf8().toLower().constData());
     if (!lua_istable(L, -1)) {
-        lua_getglobal(L, "mxp");
-        lua_newtable(L);
-        lua_setfield(L, -2, type.toUtf8().toLower().constData());
-        if (!lua_istable(L, -1)) {
-            qDebug() << "ERROR: 'mxp." << type << "' table not defined";
-            return;
-        }
+        qDebug() << "ERROR: 'mxp." << type << "' table could not be defined";
+        return;
     }
 
     QMapIterator<QString, QString> itr(attrs);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -91,6 +91,7 @@ public:
     bool compile(const QString& code, QString& error, const QString& name);
     bool compileScript(const QString&);
     void setAtcpTable(const QString&, const QString&);
+    void signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions);
     void setGMCPTable(QString&, const QString&);
     void setMSSPTable(const QString&);
     void setChannel102Table(int& var, int& arg);


### PR DESCRIPTION
- Enables to use scripts to handle elements received through MXP, such as NPCs' and objects' names and properties.

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
