### PR TITLE
Prevent Adjustable Container Duplicates

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -311,12 +311,14 @@ function Adjustable.Container:createContainers()
         y = "0",
         height = "100%",
         width = "100%",
+        name = self.name.."adjLabel"
     },self)
     self.Inside = Geyser.Container:new({
         x = self.padding,
         y = self.padding*2,
         height = "-"..self.padding,
         width = "-"..self.padding,
+        name = self.name.."InsideContainer"
     },self)
 end
 
@@ -492,14 +494,14 @@ end
 --- internal function to create the Minimize/Close and the right click Menu Labels
 function Adjustable.Container:createLabels()
     self.exitLabel = Geyser.Label:new({
-        x = -(self.buttonsize * 1.4), y=4, width = self.buttonsize, height = self.buttonsize, fontSize = self.buttonFontSize
+        x = -(self.buttonsize * 1.4), y=4, width = self.buttonsize, height = self.buttonsize, fontSize = self.buttonFontSize, name = self.name.."exitLabel"
         
     },self)
     self.exitLabel:echo("<center>x</center>")
     
     
     self.minimizeLabel = Geyser.Label:new({
-        x = -(self.buttonsize * 2.6), y=4, width = self.buttonsize, height = self.buttonsize, fontSize = self.buttonFontSize
+        x = -(self.buttonsize * 2.6), y=4, width = self.buttonsize, height = self.buttonsize, fontSize = self.buttonFontSize, name = self.name.."minimizeLabel"
         
     },self)
     self.minimizeLabel:echo("<center>-</center>")

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -754,6 +754,16 @@ end
 
 --- constructor for the Adjustable Container
 function Adjustable.Container:new(cons,container)
+    -- Prevents duplicates to be created
+    -- It's still important that the name of the container is unique!
+    if cons.name then
+        if Geyser.windowList[cons.name] then
+            return Geyser.windowList[cons.name]
+        end
+        if container and container.windowList[cons.name] then
+            return container.windowList[cons.name]
+        end
+    end
     local me = self.parent:new(cons,container)
     setmetatable(me, self)
     self.__index = self


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This prevents duplicates of Adjustable containers if the same name is given.
to write code like 
```lua 
myAdjustableContainer = myAdjustableContainer or Adjustable.Container:new({name="myContainer"})
```
 shouldn't be necessary anymore.

#### Motivation for adding to Mudlet
A discussion at https://github.com/Mudlet/Mudlet/pull/3567#issuecomment-613213470
It's a very common mistake at coding lua (It happend to me very often as well)

#### Other info (issues closed, discussion etc)
It is still necessary that the name of a Geyser Element is unique.

If no name is given the old issue will still be present and duplicate will be created,
but Adjustable Container already should always have an unique name to make saving reliable.