### PR TITLE
ISO 8601 for PTB date format

### DIFF
--- a/CI/appveyor.set-build-info.ps1
+++ b/CI/appveyor.set-build-info.ps1
@@ -12,7 +12,7 @@ if ($Env:APPVEYOR_REPO_TAG -eq "false") {
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-PR$Env:APPVEYOR_PULL_REQUEST_NUMBER-$Commit"
   } else {
     if ($Env:MUDLET_VERSION_BUILD -eq "-ptb") {
-      $Script:Date = Get-Date -Format "yyyy.M.d"
+      $Script:Date = Get-Date -Format "yyyy-MM-dd"
       $Env:MUDLET_VERSION_BUILD = "$Env:MUDLET_VERSION_BUILD-$Date"
     } else {
       $Script:Commit = git rev-parse --short HEAD

--- a/CI/travis.set-build-info.sh
+++ b/CI/travis.set-build-info.sh
@@ -14,7 +14,7 @@ if [ -z "${TRAVIS_TAG}" ]; then
     MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-PR${TRAVIS_PULL_REQUEST}-${COMMIT}"
   else
     if [ "${MUDLET_VERSION_BUILD}" = "-ptb" ]; then
-      DATE=$(date +'%Y.%-m.%-d')
+      DATE=$(date +'%Y-%m-%d')
       MUDLET_VERSION_BUILD="${MUDLET_VERSION_BUILD}-${DATE}"
     else
       COMMIT=$(git rev-parse --short HEAD)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Use the ISO 8601 format for date in ptb title

#### Motivation for adding to Mudlet
Easier to read and understand through international standards

#### Other info (issues closed, discussion etc)
Before: 
`Mudlet-4.6.2-ptb-2020.4.14`
After: 
`Mudlet-4.6.2-ptb-2020-04-14`
