### PR TITLE
Add a button to manually update autocompletion data

### DIFF
--- a/.actionspanel/update-autocompletion.yml
+++ b/.actionspanel/update-autocompletion.yml
@@ -1,0 +1,4 @@
+buttons:
+  - title: Update autocompletion
+    action: "update-autocompletion"
+    description: Update autocompletion json to latest from the manual

--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'release-**'
+  repository_dispatch:
+    types: update-autocompletion
 
   schedule:
     - cron:  '0 0 * * fri'


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Add a button to manually update autocompletion data
#### Motivation for adding to Mudlet
Autocompletion is updated weekly on a Friday and we have no way of running it manually if we'd like to, as was the case with https://github.com/Mudlet/Mudlet/pull/3627.
#### Other info (issues closed, discussion etc)
If this works, a button in https://www.actionspanel.app/ should show up...