### PR TITLE
Refactor: allow alternatives for Lua libraries loaded with all profiles

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -32,6 +32,7 @@
 #include <QNetworkReply>
 #include <QPointer>
 #include <QProcess>
+#include <QQueue>
 #include <QThread>
 #include <QTimer>
 #include <edbee/texteditorwidget.h>
@@ -576,7 +577,7 @@ private:
     // The last argument is only needed if the third one is true:
     static void generateElapsedTimeTable(lua_State*, const QStringList&, const bool, const qint64 elapsedTimeMilliSeconds = 0);
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
-    void loadLuaModule(const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
+    bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
 
 
     QNetworkAccessManager* mpFileDownloader;


### PR DESCRIPTION
This allows a bit of flexibility especially as I have recently changed the library used to provide the `zip` library. After this PR the following are allowed for the following libraries:
* `zip`:
  * `lua-zip` (the "Brimworks" one that MacOs has recently been switched to to avoid a `zziplib` dependency.
  * `luazip` (the one originally by the Kepler organisation)
* `utf8`:
  * `lua-utf8` (a "Starwing" one, what we were using up to now)
  * `utf8` (an alternative version from the same GitHub repository which the user might grab instead)

This has been test and confirmed to work as I expect (particularly for `luazip` & `lua-zip` modules) on Linux.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>