### PR TITLE
Add manual buttons for the rest of actions

### DIFF
--- a/.actionspanel/buttons.yml
+++ b/.actionspanel/buttons.yml
@@ -1,4 +1,12 @@
 buttons:
   - title: Update autocompletion
-    action: "update-autocompletion"
-    description: Update autocompletion json to latest from the manual
+    action: update-autocompletion
+    description: "Update autocompletion json to latest from the manual"
+
+  - title: Update 3rdparty sources
+    action: update-3rdparty
+    description: "Update 3rdparty libraries used with Mudlet. This is: IRE Mapping script, Lua code formatter, character width algorithm, and our forks of edbee, sparkle-glue, dblsqd, qtkeychain. Note that fork updates don't check the origin repository but rather our forked version to ensure the main repo is up to date with it. When: every Friday night or manually."
+
+  - title: Update text for translators
+    action: update-translations
+    description: "Update text available in Crowdin for translation."

--- a/.actionspanel/buttons.yml
+++ b/.actionspanel/buttons.yml
@@ -5,7 +5,7 @@ buttons:
 
   - title: Update 3rdparty sources
     action: update-3rdparty
-    description: "Update 3rdparty libraries used with Mudlet. This is: IRE Mapping script, Lua code formatter, character width algorithm, and our forks of edbee, sparkle-glue, dblsqd, qtkeychain. Note that fork updates don't check the origin repository but rather our forked version to ensure the main repo is up to date with it. When: every Friday night or manually."
+    description: "Update 3rdparty libraries used with Mudlet. This is: IRE Mapping script, Lua code formatter, character width algorithm, and our forks of edbee, sparkle-glue, dblsqd, qtkeychain. Note that fork updates don't check the origin repository but rather our forked version to ensure the main repo is up to date with it."
 
   - title: Update text for translators
     action: update-translations

--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - 'release-**'
+  repository_dispatch:
+    types: update-3rdparty
 
   schedule:
-    - cron:  '0 0 * * fri'
+    - cron: '0 0 * * fri'
 
 jobs:
   update-iremapper-source:

--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -8,7 +8,7 @@ on:
     types: update-autocompletion
 
   schedule:
-    - cron:  '0 0 * * fri'
+    - cron: '0 0 * * fri'
 
 jobs:
   update-autocompletion:

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -5,7 +5,9 @@ on:
       - 'release-**'
 
   schedule:
-    - cron:  '0 0 * * fri'
+    - cron: '0 0 * * fri'
+  repository_dispatch:
+    types: update-translations
 
 jobs:
   update-and-commit-text:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Add manual buttons for the rest of actions.
#### Motivation for adding to Mudlet
So instead of finding out something went wrong with a run on Friday and not being able to trigger it again until next Friday, we can trigger it manually as needed.

Actions panel [available here](https://www.actionspanel.app/app/Mudlet/Mudlet), our [documentation here](https://wiki.mudlet.org/w/Manual:Github_Actions).
#### Other info (issues closed, discussion etc)
This is a continuation of https://github.com/Mudlet/Mudlet/pull/3646 which worked well for a single button.