### PR TITLE
prevent duplicates of windownames in Geyser.windows

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -71,7 +71,7 @@ function Geyser:add (window, cons)
   -- Don't allow duplication of same name in container
   if not self.windowList[window.name] then
     self.windowList[window.name] = window
-    table.insert(self.windows, window.name)
+    self.windows[#self.windows+1] = window.name
   end
 
   window.windowname = window.windowname or window.container.windowname or "main"

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -68,7 +68,7 @@ function Geyser:add (window, cons)
   -- Assume control of this window
   window.container = self
   
-  -- Stop duplicating of same name in container
+  -- Don't allow duplication of same name in container
   if not self.windowList[window.name] then
     self.windowList[window.name] = window
     table.insert(self.windows, window.name)

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -67,8 +67,13 @@ function Geyser:add (window, cons)
 
   -- Assume control of this window
   window.container = self
-  self.windowList[window.name] = window
-  table.insert(self.windows, window.name)
+  
+  -- Stop duplicating of same name in container
+  if not self.windowList[window.name] then
+    self.windowList[window.name] = window
+    table.insert(self.windows, window.name)
+  end
+
   window.windowname = window.windowname or window.container.windowname or "main"
   Geyser.set_constraints(window, cons, self)
   if not self.defer_updates then


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Stops duplication of the same name in Geyser.windows as discussed in https://github.com/Mudlet/Mudlet/pull/3613#issuecomment-613319739

#### Motivation for adding to Mudlet
Names need to be unique in Container windowlist.
I noticed that otherwise it could create some problems with raiseAll/lowerAll.

Also if someone uses the constraint windowname to put a container in an userwindow was problematic (even though no one uses that because there is no documentation for it)

Will also need this to be fixed for the next PR (raise/lower order) I'll open
#### Other info (issues closed, discussion etc)
