### PR TITLE
Geyser.container:raise/lower changes order in Geyser.windows

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -188,9 +188,9 @@ function Geyser.Container:raise (changeWindowIndex)
     if index == #self.container.windows then
       return
     end
-    local tempValue = self.container.windows[index + 1]
-    self.container.windows[index + 1] = self.name
-    self.container.windows[index] = tempValue
+    local tempValue = self.container.windows[index]
+    table.remove(self.container.windows, index)
+    self.container.windows[#self.container.windows+1] = tempValue
   end
 end
 
@@ -202,9 +202,9 @@ function Geyser.Container:lower (changeWindowIndex)
     if index == 1 then
       return
     end
-    local tempValue = self.container.windows[index - 1]
-    self.container.windows[index - 1] = self.name
-    self.container.windows[index] = tempValue
+    local tempValue = self.container.windows[index]
+    table.remove(self.container.windows, index)
+    table.insert(self.container.windows, 1, tempValue)
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -181,26 +181,43 @@ function Geyser.Container:show_impl()
 end
 
 --- Raises the window to the top of the z-order stack, displaying in front of all other windows
-function Geyser.Container:raise ()
-	raiseWindow(self.name)
+function Geyser.Container:raise (changeWindowIndex)
+  raiseWindow(self.name)
+  if changeWindowIndex ~= false then
+    local index = table.index_of(self.container.windows, self.name)
+    if index == #self.container.windows then
+      return
+    end
+    local tempValue = self.container.windows[index + 1]
+    self.container.windows[index + 1] = self.name
+    self.container.windows[index] = tempValue
+  end
 end
 
 --- Lowers the window to the bottom of the z-order stack, displaying behind all other windows
-function Geyser.Container:lower ()
-	lowerWindow(self.name)
+function Geyser.Container:lower (changeWindowIndex)
+  lowerWindow(self.name)
+  if changeWindowIndex ~= false then
+    local index = table.index_of(self.container.windows, self.name)
+    if index == 1 then
+      return
+    end
+    local tempValue = self.container.windows[index - 1]
+    self.container.windows[index - 1] = self.name
+    self.container.windows[index] = tempValue
+  end
 end
 
 function Geyser.Container:raiseAll(container, me)
-  me = me or true
   container = container or self
   -- raise myself
-  if me then
+  if me ~= false then
     container:raise()
   end
   local v
-  for i=1,#container.windows do
+  for i=1, #container.windows do
     v = container.windows[i]
-    container.windowList[v]:raise()
+    container.windowList[v]:raise(false)
     container.windowList[v]:raiseAll(container.windowList[v], false)
   end
 end
@@ -208,7 +225,7 @@ end
 local function createWindowTable(container)
   local v
   Geyser.Container.windowTable = Geyser.Container.windowTable or {}
-  for i=1,#container.windows do
+  for i=1, #container.windows do
     v = container.windows[i]
     Geyser.Container.windowTable[#Geyser.Container.windowTable+1] = container.windowList[v]
     createWindowTable(container.windowList[v])
@@ -219,7 +236,7 @@ function Geyser.Container:lowerAll()
   createWindowTable(self)
   -- iterate in reverse order through all elements to keep the same z-axis inside the container
   for i=#Geyser.Container.windowTable,1,-1 do
-    Geyser.Container.windowTable[i]:lower()
+    Geyser.Container.windowTable[i]:lower(false)
   end
   Geyser.Container.windowTable = nil
   self:lower()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
raising and lowering a window changes the index of the windowname in the containers container:window list.

#### Motivation for adding to Mudlet
This is needed because otherwise changes made by raise/lower are destroyed if someone uses raiseAll/lowerAll

#### Other info (issues closed, discussion etc)
There is still some discussion needed as for how to change the index.

For me it is more intuitive to change the index by +1 on raising and by -1 on lowering (and like that having a z-index) but the comment on container:raise or container:lower is suggesting that if raising a window it should put on top of the index and if lowering on the bottom.

In the end this only affects people who use raiseAll/lowerAll or Adjustable.Containers which have raiseAll activated by default (but it can be deactivated/is optional)

I hope this is somehow understandable.
