### PR TITLE
BugFix: add missing LIBS variable entry for FreeBSD (QMake only)

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -229,9 +229,11 @@ unix:!macx {
     freebsd {
         LIBS += \
 # Some OS platforms have a hyphen (I think Cygwin does as well):
-            -llua-5.1\
+            -llua-5.1 \
 # FreeBSD appends the version number to hunspell:
-            -lhunspell-1.7
+            -lhunspell-1.7 \
+# Needed for sysinfo(...) call in mudlet class:
+            -lsysinfo
 # FreeBSD (at least) supports multiple Lua versions (and 5.1 is not the default anymore):
         INCLUDEPATH += \
             /usr/local/include/lua51


### PR DESCRIPTION
The introduction of a call to `sysinfo()` in the method: `(int64_t) mudlet::getPhysicalMemoryTotal()` introduced in PR #3479 requires linking against an additional GNU compatibility (optional) library `libsysinfo` which thus needs adding to the libraries required in the project files.

This fix only applies to the qmake build - there are a couple of other changes in progress in the repository which means it is premature for me to work on that build system at the moment.

This is urgent for me as it impacts on using the development branch code for other work on FreeBSD (and the main line OSs).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>