### PR TITLE
Restore simpler getMudletInfo()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3671,7 +3671,10 @@ int TLuaInterpreter::getMudletInfo(lua_State* L)
         for (const auto& encoding : host.mTelnet.getEncodingsList()) {
             knownEncodings.append(adjustEncoding(QString(encoding)));
         }
-        knownEncodings.sort(Qt::CaseInsensitive);
+        QCollator sorter;
+        sorter.setNumericMode(true);
+        sorter.setCaseSensitivity(Qt::CaseInsensitive);
+        std::sort(knownEncodings.begin(), knownEncodings.end(), sorter);
 
         if (currentEncoding.isEmpty()) {
             currentEncoding = "\"ASCII\"";

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3657,61 +3657,37 @@ int TLuaInterpreter::getMudletInfo(lua_State* L)
 {
     Host& host = getHostFromLua(L);
 
-    QByteArrayList knownEncodings{"\"ASCII\""};
-    auto adjustEncoding = [](auto encodingName) {
-        auto originalEncoding = encodingName;
-        if (encodingName.startsWith("M_")) {
-            encodingName.remove(0, 2);
+    QStringList knownEncodings{"ASCII"};
+    QString currentEncoding{host.mTelnet.getEncoding()};
+    {
+        auto adjustEncoding = [](auto encodingName) {
+            auto originalEncoding = encodingName;
+            if (encodingName.startsWith("M_")) {
+                encodingName.remove(0, 2);
+            }
+
+            return (originalEncoding == encodingName) ? originalEncoding : QStringLiteral("%1 (%2)").arg(encodingName, originalEncoding);
+        };
+        for (const auto& encoding : host.mTelnet.getEncodingsList()) {
+            knownEncodings.append(QString(adjustEncoding(encoding)));
         }
+        knownEncodings.sort(Qt::CaseInsensitive);
 
-        return (originalEncoding == encodingName) ? "\"" + originalEncoding + "\""
-                                                  : ("\"" + encodingName + "\" (\"" + originalEncoding + "\")");
-    };
-    for (const auto& encoding : host.mTelnet.getEncodingsList()) {
-        knownEncodings.append(adjustEncoding(encoding));
+        if (currentEncoding.isEmpty()) {
+            currentEncoding = "\"ASCII\"";
+        } else {
+            currentEncoding = adjustEncoding(currentEncoding);
+        }
     }
 
-    QString encodingNames{QLatin1String(knownEncodings.join(", "))};
-    encodingNames.append(QLatin1Char('.'));
-    // Have to wrap the above message as it is going to be too wide to fit on
-    // the screen. Split it at comma+space, keeping comma and
-    // replacing space with linefeed:
-    int startLineIndex = 0;
-    const QString needle = QStringLiteral(", ");
-    const int maxLineLength = 79;
-    int endLineIndex = std::min(encodingNames.lastIndexOf(needle,startLineIndex + maxLineLength), maxLineLength);
-    // encodingNames.at(endLineIndex) should be on the last comma position in
-    // what will become the first line
-    encodingNames.replace(endLineIndex, 2, QStringLiteral(",\n"));
-    while (encodingNames.lastIndexOf(needle,startLineIndex + maxLineLength) >= 0) {
-        // There is still a "needle" in the considered part of the haystack!
-        startLineIndex = endLineIndex + 2;
-        endLineIndex = std::min(encodingNames.lastIndexOf(needle,startLineIndex + maxLineLength), startLineIndex + maxLineLength);
 
-        encodingNames.replace(endLineIndex, 2, QStringLiteral(",\n"));
-    }
 
-    QByteArray currentEncoding{host.mTelnet.getEncoding()};
-    if (currentEncoding.isEmpty()) {
-        currentEncoding = "\"ASCII\"";
-    } else {
-        currentEncoding = adjustEncoding(currentEncoding);
-    }
-    QString rawMessage{tr("============================== Mudlet Information ==============================\n"
-                          "--------------------------- Server Codec Information ---------------------------\n"
-                          "Current encoding (with internal name if different): %1\n"
-                          "Available encodings (and internal names):\n"
-                          "%2\n"
-                          "===================================== End ======================================\n",
-                          // Intentional comment to separate arguments
-                          "%1 is the current codec in use; %2 is a comma separated list of encoding names "
-                          "(which are always in Engineering English)")
-                       .arg(QLatin1String(currentEncoding),
-                            encodingNames)};
-    host.mpConsole->print(rawMessage, Qt::white, Qt::black);
+    host.postMessage(QStringLiteral("[ INFO ]  - Current encoding: %1").arg(currentEncoding));
 
-    lua_pushboolean(L, true);
-    return 1;
+    host.postMessage(QStringLiteral("[ INFO ]  - Available encodings:"));
+    host.postMessage(QStringLiteral("  %1").arg(knownEncodings.join(QStringLiteral(", "))));
+
+    return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createMiniConsole

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3669,7 +3669,7 @@ int TLuaInterpreter::getMudletInfo(lua_State* L)
             return (originalEncoding == encodingName) ? originalEncoding : QStringLiteral("%1 (%2)").arg(encodingName, originalEncoding);
         };
         for (const auto& encoding : host.mTelnet.getEncodingsList()) {
-            knownEncodings.append(QString(adjustEncoding(encoding)));
+            knownEncodings.append(adjustEncoding(QString(encoding)));
         }
         knownEncodings.sort(Qt::CaseInsensitive);
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Restore simpler getMudletInfo() that was changed by https://github.com/Mudlet/Mudlet/pull/3579 
#### Motivation for adding to Mudlet
Old:
![image](https://user-images.githubusercontent.com/110988/79924807-16dff600-8439-11ea-9334-16dee7b41d7f.png)

Restored:
![image](https://user-images.githubusercontent.com/110988/79924706-d1232d80-8438-11ea-8080-1fab467132d5.png)

The restored version is shorter and cleaner, and a normal echo function in TLuaInterpreter should not have to concern itself with doing line wrapping manually.

#### Other info (issues closed, discussion etc)
Code should follow the KISS principles. The new version gives the same information but in a lot less code.