### PR TITLE
fix: Adjustable container right click menu not disappearing after reload

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -67,10 +67,9 @@ function Geyser:add (window, cons)
 
   -- Assume control of this window
   window.container = self
-  
+  self.windowList[window.name] = window
   -- Don't allow duplication of same name in container
   if not self.windowList[window.name] then
-    self.windowList[window.name] = window
     self.windows[#self.windows+1] = window.name
   end
 

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -67,11 +67,11 @@ function Geyser:add (window, cons)
 
   -- Assume control of this window
   window.container = self
-  self.windowList[window.name] = window
   -- Don't allow duplication of same name in container
   if not self.windowList[window.name] then
     self.windows[#self.windows+1] = window.name
   end
+  self.windowList[window.name] = window
 
   window.windowname = window.windowname or window.container.windowname or "main"
   Geyser.set_constraints(window, cons, self)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revert a non essential change from https://github.com/Mudlet/Mudlet/pull/3651

#### Motivation for adding to Mudlet
This change was non essential to prevent the duplication in Geyser.windows but caused some issues.
For example the adjustable container right click menu didn't disappear anymore after reloading  of the script.

#### Other info (issues closed, discussion etc)
Duplicates in the container windowlist (container.windows) are still avoided