### PR TITLE
Enhance: force GHA Ubuntu build to update + add files to qmake project file

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,8 +64,11 @@ jobs:
     - name: (Linux) Install apt dependencies
       if: runner.os == 'Linux'
       run: |
+        sudo apt update
+        sudo apt upgrade
         # these aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0
+        sudo apt autoremove
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -65,10 +65,10 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update
-        sudo apt upgrade
+        # sudo apt upgrade
         # these aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0
-        sudo apt autoremove
+        # sudo apt autoremove
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -65,10 +65,13 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update
-        # sudo apt upgrade
-        # these aren't available or don't work well in vcpkg
+        # The above is enough to tell the OS's package system what versions
+        # of package it needs to get to install the following (so it does
+        # not error out by asking for older, no-longer available upstream
+        # versions - which was happening) whilst not burdening the run
+        # with a much more time consuming full system "upgrade".
+        # These aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0
-        # sudo apt autoremove
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1394,6 +1394,19 @@ unix:!macx {
 DISTFILES += \
     CMakeLists.txt \
     .clang-format \
+    ../.github/pr-labeler.yml \
+    ../.github/CODEOWNERS.md \
+    ../.github/CODE_OF_CONDUCT.md \
+    ../.github/CONTRIBUTING.md \
+    ../.github/FUNDING.yml \
+    ../.github/ISSUE_TEMPLATE.md \
+    ../.github/PULL_REQUEST_TEMPLATE.md \
+    ../.github/SUPPORT.md \
+    ../.github/workflows/build-mudlet.yml \
+    ../.github/workflows/update-3rdparty.yml \
+    ../.github/workflows/update-autocompletion.yml \
+    ../.github/workflows/update-translations.yml \
+    ../.github/workflows/whitespace-linter.yml \
     ../CMakeLists.txt \
     ../cmake/FindHUNSPELL.cmake \
     ../cmake/FindPCRE.cmake \


### PR DESCRIPTION
This GHA build platform was out of date and failing to run as a result.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>