### PR TITLE
Enhance: bodge support for CUF and code for (and discard) ED ESC codes

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1256,6 +1256,65 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     // We have manually disabled MXP negotiation
                     break;
 
+                case static_cast<quint8>('C'): {
+                    // A workaround for the ONE cursor movement command we CAN
+                    // emulate - the CUF Cursor forward one:
+                    // Needed for mud.durismud.com see forum message topic:
+                    // https://forums.mudlet.org/viewtopic.php?f=9&t=22887
+                    QString temp = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
+                    bool isOk = false;
+                    int spacesNeeded = temp.toInt(&isOk);
+                    if (isOk && spacesNeeded > 0) {
+                        const TChar::AttributeFlags attributeFlags =
+                                ((mIsDefaultColor ? mBold : false) ? TChar::Bold : TChar::None)
+                                | (mItalics ? TChar::Italic : TChar::None)
+                                | (mOverline ? TChar::Overline : TChar::None)
+                                | (mReverse ? TChar::Reverse : TChar::None)
+                                | (mStrikeOut ? TChar::StrikeOut : TChar::None)
+                                | (mUnderline ? TChar::Underline : TChar::None);
+
+                        // Note: we are using the background color for the
+                        // foreground color as well so that we are transparent:
+                        TChar c(mBackGroundColor, mBackGroundColor, attributeFlags);
+                        for (int spaceCount = 0; spaceCount < spacesNeeded; ++spaceCount) {
+                            mMudLine.append(QChar::Space);
+                            mMudBuffer.push_back(c);
+                        }
+                        // For debugging:
+//                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - CUF (cursor forward) sequence of form CSI" << temp << "C received, converting into " << spacesNeeded << " spaces.";
+                    } else {
+                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << temp << "C received, that is supposed to be a CUF (cursor forward) sequence but doesn't make sense, Mudlet will ignore it.";
+                    }
+
+                }
+                    break;
+
+                case static_cast<quint8>('J'): {
+                    /*
+                     * Also seen in output from mud.durismud.com see 'C' case above:
+                     * Is ED 'Erase Display' command and has three variants:
+                     * * 0 (or ommitted): clear from cursor to end of screen
+                     *   - which is a NOP for us!
+                     * * 1: clear from cursor to beginning of screen
+                     *   - which is a NWIH for us!
+                     * * 2: clear entire screen and delete all lines saved in
+                     *   scrollback buffer - which is again a NWIH for us...!
+                     */
+                    QString temp = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
+                    bool isOk = false;
+                    int argValue = temp.toInt(&isOk);
+                    if (isOk) {
+                        if (argValue >= 0 && argValue < 3) {
+                            qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - ED (erase in display) sequence of form CSI" << temp << "J received,\nrejecting as incompatible with Mudlet.";
+                        } else {
+                            qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Invalid ED (erase in display) sequence of form CSI" << temp << "J received,\nwhich Mudlet will ignore.";
+                        }
+                    } else {
+                        qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << temp << "J received, that is supposed to\nbe a ED (erase in display) sequence but it doesn't make sense, Mudlet will ignore it.";
+                    }
+                }
+                    break;
+
                 default: // Unhandled other (valid) CSI final byte sequences will end up here
                     qDebug().noquote().nospace() << "TBuffer::translateToPlainText(...) INFO - Unhandled sequence of form CSI..." << localBuffer[spanEnd] << " received, Mudlet will ignore it.";
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1261,7 +1261,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     // emulate - the CUF Cursor forward one:
                     // Needed for mud.durismud.com see forum message topic:
                     // https://forums.mudlet.org/viewtopic.php?f=9&t=22887
-                    QString temp = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
+                    const int dataLength = spanEnd - spanStart;
+                    QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
                     int spacesNeeded = temp.toInt(&isOk);
                     if (isOk && spacesNeeded > 0) {
@@ -1300,7 +1301,8 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                      * * 2: clear entire screen and delete all lines saved in
                      *   scrollback buffer - which is again a NWIH for us...!
                      */
-                    QString temp = QString(localBuffer.substr(localBufferPosition, spanEnd - spanStart).c_str());
+                    const int dataLength = spanEnd - spanStart;
+                    QByteArray temp = QByteArray::fromRawData(localBuffer.substr(localBufferPosition, dataLength).c_str(), dataLength);
                     bool isOk = false;
                     int argValue = temp.toInt(&isOk);
                     if (isOk) {


### PR DESCRIPTION
This is needed to properly display the (CP437 encoded) ANSI graphic images that Durismud { `mud.durismud.com` } on port `443` (Bad number as that is supposed to be HTTP over TLS/SSL but this Server does NOT encrypt this connection!) or `7777` which has no encryption either - uses.

Whilst the cursor forward sequence can be emulated with the insertion of a corresponding number of spaces the erase in display sequence cannot safely. The default (`0`) option is to clear the screen forward from the current cursor position - which is effectively a  no-operation for Mudlet; the other two values that are codified are:
* `1` - clear backwards from the cursor position to the top of the screen
* `2` - clear the entire screen, erase the scrollback buffer and put the cursor in the top left corner.

Neither of those behaviours are ones we can support because the screen contents do not represent just the output from the MUD Game server and it would be inappropriate for the Game server to be able to clear stuff like this.

It is worth pointing out that this MUD Game Server does not attempt to identify the Client it is connected to (it does not use the Telnet TTYPE sub-option) so for it to be sending cursor movement/screen erasure commands when it does not know that the client even supports them is totally broken in my humble opinion!

This is a result of the Forum topic: https://forums.mudlet.org/viewtopic.php?f=9&t=22887 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>