### PR TITLE
Trim apt update comment

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,12 +64,8 @@ jobs:
     - name: (Linux) Install apt dependencies
       if: runner.os == 'Linux'
       run: |
+        # Without this, installing packages might fail as the github image becomes outdated
         sudo apt update
-        # The above is enough to tell the OS's package system what versions
-        # of package it needs to get to install the following (so it does
-        # not error out by asking for older, no-longer available upstream
-        # versions - which was happening) whilst not burdening the run
-        # with a much more time consuming full system "upgrade".
         # These aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -64,7 +64,7 @@ jobs:
     - name: (Linux) Install apt dependencies
       if: runner.os == 'Linux'
       run: |
-        # Without this, installing packages might fail as the github image becomes outdated
+        # Installing packages might fail as the github image becomes outdated
         sudo apt update
         # These aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Trim apt update comment, because the old one was too long.
#### Motivation for adding to Mudlet
So people don't ignore the verbose comments in the codebase.
#### Other info (issues closed, discussion etc)
Super verbose comments are a real problem: at best, some people ignore them. At worst, others feel compelled to read them because it might contain important information and comments are meant to be read, not ignored: but reading long prose that explains too much and actually says very little is not fun.

Let's think of everyone and have comments while keeping them short and consise :star: 