### PR TITLE
Fix unreadable text by default in the background button

### DIFF
--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>692</width>
-    <height>270</height>
+    <height>370</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -631,10 +631,7 @@
         <property name="checked">
          <bool>false</bool>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
-         <property name="spacing">
-          <number>3</number>
-         </property>
+        <layout class="QGridLayout" name="gridLayout">
          <property name="leftMargin">
           <number>3</number>
          </property>
@@ -647,20 +644,21 @@
          <property name="bottomMargin">
           <number>3</number>
          </property>
-         <item>
-          <widget class="QPushButton" name="pushButtonFgColor">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_foregroundColor">
            <property name="text">
             <string>Foreground</string>
            </property>
           </widget>
          </item>
-         <item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_backgroundColor">
+           <property name="text">
+            <string>Background</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
           <widget class="QPushButton" name="pushButtonBgColor">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -668,11 +666,18 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="text">
-            <string>Background</string>
-           </property>
            <property name="flat">
             <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QPushButton" name="pushButtonFgColor">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
           </widget>
          </item>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -649,12 +649,18 @@
            <property name="text">
             <string>Foreground</string>
            </property>
+           <property name="buddy">
+            <cstring>pushButtonBgColor</cstring>
+           </property>
           </widget>
          </item>
          <item row="0" column="1">
           <widget class="QLabel" name="label_backgroundColor">
            <property name="text">
             <string>Background</string>
+           </property>
+           <property name="buddy">
+            <cstring>pushButtonFgColor</cstring>
            </property>
           </widget>
          </item>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -650,7 +650,7 @@
             <string>Foreground</string>
            </property>
            <property name="buddy">
-            <cstring>pushButtonBgColor</cstring>
+            <cstring>pushButtonFgColor</cstring>
            </property>
           </widget>
          </item>
@@ -660,12 +660,12 @@
             <string>Background</string>
            </property>
            <property name="buddy">
-            <cstring>pushButtonFgColor</cstring>
+            <cstring>pushButtonBgColor</cstring>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QPushButton" name="pushButtonBgColor">
+          <widget class="QPushButton" name="pushButtonFgColor">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -678,7 +678,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QPushButton" name="pushButtonFgColor">
+          <widget class="QPushButton" name="pushButtonBgColor">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Move the labels over buttons back into above them.
#### Motivation for adding to Mudlet
The text should be readable. Closes https://github.com/Mudlet/Mudlet/issues/3051
#### Before
![image](https://user-images.githubusercontent.com/110988/80496666-cf41f880-8969-11ea-8b4b-3b81eb93deae.png)

![image](https://user-images.githubusercontent.com/110988/80496677-d537d980-8969-11ea-8df2-ae6963507157.png)

![image](https://user-images.githubusercontent.com/110988/80496700-dc5ee780-8969-11ea-8485-63a6297fd606.png)

#### After

![Selection_093](https://user-images.githubusercontent.com/110988/80496633-c4876380-8969-11ea-957a-9e8685ab77a7.png)
