### PR TITLE
Refactor: remove some obsolete method uses

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1334,11 +1334,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     auto pen = painter.pen();
     pen.setColor(mpHost->mFgColor_2);
     pen.setWidthF(exitWidth);
-    if (mMapperUseAntiAlias) {
-        painter.setRenderHint(QPainter::Antialiasing);
-    } else {
-        painter.setRenderHint(QPainter::NonCosmeticDefaultPen);
-    }
+    painter.setRenderHint(QPainter::Antialiasing, mMapperUseAntiAlias);
     painter.setPen(pen);
 
     if (mpMap->mapLabels.contains(mAreaID)) {
@@ -2597,7 +2593,11 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                                 tl2.setAngle(normal.angle());
                                 tl2.setLength(-0.1);
                                 QPointF pi;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                                if ((line.intersects(tl, &pi) == QLineF::BoundedIntersection) || (line.intersects(tl2, &pi) == QLineF::BoundedIntersection)) {
+#else
                                 if ((line.intersect(tl, &pi) == QLineF::BoundedIntersection) || (line.intersect(tl2, &pi) == QLineF::BoundedIntersection)) {
+#endif
                                     // Choose THIS line to edit as we have
                                     // clicked close enough to it...
                                     mCustomLineSelectedRoom = room->getId();
@@ -2674,7 +2674,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 break;
             case 1:
                 mMultiSelection = false; // OK, found one room so stop
-                mMultiSelectionHighlightRoomId = mMultiSelectionSet.toList().first();
+                mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
                 mHelpMsg.clear();
                 break;
             default:
@@ -2764,7 +2764,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             if ((!mIsSelectionUsingNames) && mIsSelectionSortByNames && mIsSelectionSorting) {
                 mIsSelectionSortByNames = false;
             }
-            mMultiSelectionListWidget.sortByColumn(mIsSelectionSortByNames ? 1 : 0);
+            mMultiSelectionListWidget.sortByColumn(mIsSelectionSortByNames ? 1 : 0, Qt::AscendingOrder);
             mMultiSelectionListWidget.setSortingEnabled(mIsSelectionSorting);
             resizeMultiSelectionWidget();
             mMultiSelectionListWidget.selectAll();
@@ -3633,7 +3633,11 @@ void T2DMap::slot_setSymbol()
                 itSymbolUsed.next();
                 symbolCountsSet.insert(itSymbolUsed.value());
             }
-            QList<unsigned int> symbolCountsList = symbolCountsSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QList<unsigned int> symbolCountsList{symbolCountsSet.begin(), symbolCountsSet.end()};
+#else
+            QList<unsigned int> symbolCountsList{symbolCountsSet.toList()};
+#endif
             if (symbolCountsList.size() > 1) {
                 std::sort(symbolCountsList.begin(), symbolCountsList.end());
             }
@@ -4085,7 +4089,11 @@ void T2DMap::slot_setRoomWeight()
                 weightCountsSet.insert(itWeightsUsed.value());
             }
             // Obtains a list of those weights sorted in ascending count of used
-            QList<uint> weightCountsList = weightCountsSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QList<uint> weightCountsList{weightCountsSet.begin(), weightCountsSet.end()};
+#else
+            QList<uint> weightCountsList{weightCountsSet.toList()};
+#endif
             if (weightCountsList.size() > 1) {
                 std::sort(weightCountsList.begin(), weightCountsList.end());
             }
@@ -4259,7 +4267,11 @@ void T2DMap::slot_setArea()
             if (!(mpMap->setRoomArea(currentRoomId, newAreaId, false))) {
                 // Failed on the last of multiple room area move so do the missed
                 // out recalculations for the dirtied areas
-                QSetIterator<TArea*> itpArea = mpMap->mpRoomDB->getAreaPtrList().toSet();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                QSetIterator<TArea*> itpArea{QSet<TArea*>{mpMap->mpRoomDB->getAreaPtrList().begin(), mpMap->mpRoomDB->getAreaPtrList().end()}};
+#else
+                QSetIterator<TArea*> itpArea{mpMap->mpRoomDB->getAreaPtrList().toSet()};
+#endif
                 while (itpArea.hasNext()) {
                     TArea* pArea = itpArea.next();
                     if (pArea->mIsDirty) {
@@ -4406,7 +4418,11 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 mMultiSelectionHighlightRoomId = 0;
                 break;
             case 1:
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
+#else
                 mMultiSelectionHighlightRoomId = mMultiSelectionSet.toList().first();
+#endif
                 break;
             default:
                 getCenterSelection(); // Sets mMultiSelectionHighlightRoomId to (a) central room
@@ -4444,7 +4460,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 if ((!mIsSelectionUsingNames) && mIsSelectionSortByNames && mIsSelectionSorting) {
                     mIsSelectionSortByNames = false;
                 }
-                mMultiSelectionListWidget.sortByColumn(mIsSelectionSortByNames ? 1 : 0);
+                mMultiSelectionListWidget.sortByColumn(mIsSelectionSortByNames ? 1 : 0, Qt::AscendingOrder);
                 mMultiSelectionListWidget.setSortingEnabled(mIsSelectionSorting);
                 resizeMultiSelectionWidget();
                 mMultiSelectionListWidget.selectAll();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5932,10 +5932,18 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         QSet<QString> keysSet;
         while (itRoom.hasNext()) {
             itRoom.next();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            keysSet.unite(QSet<QString>{itRoom.value()->userData.keys().begin(), itRoom.value()->userData.keys().end()});
+#else
             keysSet.unite(itRoom.value()->userData.keys().toSet());
+#endif
         }
 
-        QStringList keys = keysSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QStringList keys{keysSet.begin(), keysSet.end()};
+#else
+        QStringList keys{keysSet.toList()};
+#endif
         if (keys.size() > 1) {
             std::sort(keys.begin(), keys.end());
         }
@@ -5957,7 +5965,11 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
             }
         }
 
-        QStringList values = valuesSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QStringList values{valuesSet.begin(), valuesSet.end()};
+#else
+        QStringList values{valuesSet.toList()};
+#endif
         if (values.size() > 1) {
             std::sort(values.begin(), values.end());
         }
@@ -5978,7 +5990,11 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
             }
         }
 
-        QList<int> roomIds = roomIdsSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QList<int> roomIds{roomIdsSet.begin(), roomIdsSet.end()};
+#else
+        QList<int> roomIds{roomIdsSet.toList()};
+#endif
         if (roomIds.size() > 1) {
             std::sort(roomIds.begin(), roomIds.end());
         }
@@ -6038,10 +6054,18 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         QSet<QString> keysSet;
         while (itArea.hasNext()) {
             itArea.next();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            keysSet.unite(QSet<QString>{itArea.value()->mUserData.keys().begin(), itArea.value()->mUserData.keys().end()});
+#else
             keysSet.unite(itArea.value()->mUserData.keys().toSet());
+#endif
         }
 
-        QStringList keys = keysSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QStringList keys{keysSet.begin(), keysSet.end()};
+#else
+        QStringList keys{keysSet.toList()};
+#endif
         if (keys.size() > 1) {
             std::sort(keys.begin(), keys.end());
         }
@@ -6063,7 +6087,11 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
             }
         }
 
-        QStringList values = valuesSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QStringList values{valuesSet.begin(), valuesSet.end()};
+#else
+        QStringList values{valuesSet.toList()};
+#endif
         if (values.size() > 1) {
             std::sort(values.begin(), values.end());
         }
@@ -6084,7 +6112,11 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
             }
         }
 
-        QList<int> areaIds = areaIdsSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QList<int> areaIds{areaIdsSet.begin(), areaIdsSet.begin()};
+#else
+        QList<int> areaIds{areaIdsSet.toList()};
+#endif
         if (areaIds.size() > 1) {
             std::sort(areaIds.begin(), areaIds.end());
         }
@@ -17898,7 +17930,12 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
     }
 
     lua_newtable(L);
-    QList<int> selectionRoomsList = pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QList<int> selectionRoomsList{pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.begin(),
+                                  pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.end()};
+#else
+    QList<int> selectionRoomsList{pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.toList()};
+#endif
     if (!selectionRoomsList.isEmpty()) {
         if (selectionRoomsList.count() > 1) {
             std::sort(selectionRoomsList.begin(), selectionRoomsList.end());
@@ -18153,7 +18190,11 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
 
     // This may stall if this is accessing the shared user dictionary and that
     // is being updated by another profile, but it should eventually return...
-    QStringList wordList = host.mpConsole->getWordSet().toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList wordList{host.mpConsole->getWordSet().begin(), host.mpConsole->getWordSet().end()};
+#else
+    QStringList wordList{host.mpConsole->getWordSet().toList()};
+#endif
     int wordCount = wordList.size();
     if (wordCount > 1) {
         QCollator sorter;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1462,7 +1462,11 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 } else {
                     QList<int> oldRoomsList;
                     ifs >> oldRoomsList;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                    pA->rooms = QSet<int>{oldRoomsList.begin(), oldRoomsList.end()};
+#else
                     pA->rooms = oldRoomsList.toSet();
+#endif
                 }
                 // Can be useful when analysing suspect map files!
                 //                qDebug() << "TMap::restore(...)" << "Area:" << areaID;

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -880,7 +880,11 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             // operation we want to perform (obtain the directions of all custom
             // exit lines and remove those which are already included in the
             // colours) is much easier to perform on a QSet rather than a QList:
-            QSet<QString> missingKeys = customLines.keys().toSet().subtract(customLinesColor.keys().toSet());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QSet<QString> missingKeys{QSet<QString>{customLines.keys().begin(), customLines.keys().end()}.subtract(QSet<QString>{customLinesColor.keys().begin(), customLinesColor.keys().end()})};
+#else
+            QSet<QString> missingKeys{customLines.keys().toSet().subtract(customLinesColor.keys().toSet())};
+#endif
             QSetIterator<QString> itMissingCustomLineColourKey(missingKeys);
             while (itMissingCustomLineColourKey.hasNext()) {
                 customLinesColor.insert(itMissingCustomLineColourKey.next(), QColor(Qt::red));
@@ -944,8 +948,13 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
     // members from to identify any rogue members before removing them:
 
     QMap<QString, int> exitWeightsCopy = exitWeights;
-    QSet<int> exitStubsCopy = exitStubs.toSet();
-    QSet<int> exitLocksCopy = exitLocks.toSet();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QSet<int> exitStubsCopy{exitStubs.begin(), exitStubs.end()};
+    QSet<int> exitLocksCopy{exitLocks.begin(), exitLocks.end()};
+#else
+    QSet<int> exitStubsCopy{exitStubs.toSet()};
+    QSet<int> exitLocksCopy{exitLocks.toSet()};
+#endif
     QMap<QString, int> doorsCopy = doors;
     QMap<QString, QList<QPointF>> customLinesCopy = customLines;
     QMap<QString, QColor> customLinesColorCopy = customLinesColor;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -637,6 +637,17 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         }
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    // Check for existance of all areas needed by rooms
+    QSet<int> areaIdSet{areaRoomMultiHash.keys().begin(), areaRoomMultiHash.keys().end()};
+
+    // START OF TASK 3
+    // Throw in the area Ids from the areaNamesMap:
+    areaIdSet.unite(QSet<int>{areaNamesMap.keys().begin(), areaNamesMap.keys().end()});
+
+    // And the area Ids used by the map labels:
+    areaIdSet.unite(QSet<int>{mpMap->mapLabels.keys().begin(), mpMap->mapLabels.keys().end()});
+#else
     // Check for existance of all areas needed by rooms
     QSet<int> areaIdSet = areaRoomMultiHash.keys().toSet();
 
@@ -646,6 +657,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
     // And the area Ids used by the map labels:
     areaIdSet.unite(mpMap->mapLabels.keys().toSet());
+#endif
 
     // Check the set of area Ids against the ones we actually have:
     QSetIterator<int> itUsedArea(areaIdSet);
@@ -912,7 +924,11 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Purges any duplicates that a QList structure DOES permit, but a QSet does NOT:
             // Exit stubs:
             unsigned int _listCount = pR->exitStubs.count();
-            QSet<int> _set = pR->exitStubs.toSet();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
+#else
+            QSet<int> _set{pR->exitStubs.toSet()};
+#endif
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     QString infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
@@ -922,11 +938,19 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(), tr("[ INFO ]  - Duplicate exit stub identifiers found in room, this is an anomaly but has been cleaned up easily."), false);
             }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            pR->exitStubs = QList<int>{_set.begin(), _set.end()};
+#else
             pR->exitStubs = _set.toList();
+#endif
 
             // Exit locks:
             _listCount = pR->exitLocks.count();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            _set = QSet<int>{pR->exitLocks.begin(), pR->exitLocks.end()};
+#else
             _set = pR->exitLocks.toSet();
+#endif
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     QString infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
@@ -936,7 +960,11 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(), tr("[ INFO ]  - Duplicate exit lock identifiers found in room, this is an anomaly but has been cleaned up easily."), false);
             }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            pR->exitLocks = QList<int>{_set.begin(), _set.end()};
+#else
             pR->exitLocks = _set.toList();
+#endif
 
             // TASK 9 IS DONE INSIDE THIS METHOD:
             pR->audit(roomRemapping, areaRemapping);
@@ -969,7 +997,12 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             }
 
             // Now compare pA->rooms to areaRoomMultiHash.values( itArea.key() )
-            QSet<int> foundRooms = areaRoomMultiHash.values(itArea.key()).toSet();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            QSet<int> foundRooms{areaRoomMultiHash.values(itArea.key()).begin(), areaRoomMultiHash.values(itArea.key()).end()};
+#else
+            QSet<int> foundRooms{areaRoomMultiHash.values(itArea.key()).toSet()};
+#endif
+
             QSetIterator<int> itFoundRoom(foundRooms);
             // Original form of code which was slower because the two sets of rooms were
             // compared TWICE:
@@ -995,7 +1028,11 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Report differences:
             if (!missingRooms.isEmpty()) {
                 QStringList roomList;
-                QList<int> missingRoomsList = missingRooms.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                QList<int> missingRoomsList{missingRooms.begin(), missingRooms.end()};
+#else
+                QList<int> missingRoomsList{missingRooms.toList()};
+#endif
                 if (missingRoomsList.size() > 1) {
                     // The on-screen listing are clearer if we sort the rooms
                     std::sort(missingRoomsList.begin(), missingRoomsList.end());
@@ -1031,7 +1068,11 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             if (!extraRooms.isEmpty()) {
                 QStringList roomList;
-                QList<int> extraRoomsList = extraRooms.toList();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                QList<int> extraRoomsList{extraRooms.begin(), extraRooms.end()};
+#else
+                QList<int> extraRoomsList{extraRooms.toList()};
+#endif
                 if (extraRoomsList.size() > 1) {
                     std::sort(extraRoomsList.begin(), extraRoomsList.end());
                 }

--- a/src/Tree.h
+++ b/src/Tree.h
@@ -134,6 +134,10 @@ Tree<T>::~Tree()
     delete mpMyChildrenList;
     if (mpParent) {
         mpParent->popChild(static_cast<T*>(this)); // tell parent about my death
+        // FIXME: std::uncaught_exception() is deprecated in C++17 and is to be
+        // removed in C++20 - and this throws out a lot of build time warnings
+        // that are currently being suppressed by a `-Wno-deprecated-declarations`
+        // but which might also be masking issues in other areas:
         if (std::uncaught_exception()) {
             std::cout << "ERROR: Hook destructed during stack rewind because of an uncaught exception." << std::endl;
         }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -370,7 +370,11 @@ void XMLimport::readMap()
     QListIterator<int> itAreaWithRooms(tempAreaRoomsHash.uniqueKeys());
     while (itAreaWithRooms.hasNext()) {
         int areaId = itAreaWithRooms.next();
-        QSet<int> areaRoomsSet = tempAreaRoomsHash.values(areaId).toSet();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        QSet<int> areaRoomsSet{tempAreaRoomsHash.values(areaId).begin(), tempAreaRoomsHash.values(areaId).end()};
+#else
+        QSet<int> areaRoomsSet{tempAreaRoomsHash.values(areaId).toSet()};
+#endif
 
         if (!mpHost->mpMap->mpRoomDB->areas.contains(areaId)) {
             // It is known for map files to have rooms with area Ids that are

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2119,7 +2119,11 @@ void dlgProfilePreferences::copyMap()
     }
 
     // Identify which, if any, of the toProfilesRoomIdMap is active and get the current room
-    QSet<Host*> activeHosts(mudlet::self()->mConsoleMap.keys().toSet());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QSet<Host*> activeHosts{mudlet::self()->mConsoleMap.keys().begin(), mudlet::self()->mConsoleMap.keys().begin()};
+#else
+    QSet<Host*> activeHosts{mudlet::self()->mConsoleMap.keys().toSet()};
+#endif
     QMap<QString, Host*> activeOtherHostMap;
     QSetIterator<Host*> itActiveHost(activeHosts);
     while (itActiveHost.hasNext()) {

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -258,7 +258,11 @@ void dlgRoomExits::save()
             exitIterator.setValue(exitIterator.value().mid(1));
         }
     }
-    QSet<QString> originalExitCmds = oldSpecialExits.values().toSet();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QSet<QString> originalExitCmds{oldSpecialExits.values().begin(), oldSpecialExits.values().end()};
+#else
+    QSet<QString> originalExitCmds{oldSpecialExits.values().toSet()};
+#endif
 
     //    pR->clearSpecialExits(); // Previous code could not change the destination
     // room of an existing special exit

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2011,7 +2011,7 @@ QSize mudlet::calcFontSize(Host* pHost, const QString& windowName)
     }
 
     auto fontMetrics = QFontMetrics(font);
-    return QSize(fontMetrics.width(QChar('W')), fontMetrics.height());
+    return QSize(fontMetrics.horizontalAdvance(QChar('W')), fontMetrics.height());
 }
 
 std::pair<bool, QString> mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout, bool autoDock, const QString& area)
@@ -4511,10 +4511,15 @@ void mudlet::playSound(const QString& s, int soundVolume)
         if (state == QMediaPlayer::StoppedState) {
             TEvent soundFinished {};
             soundFinished.mArgumentList.append("sysSoundFinished");
-            soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            soundFinished.mArgumentList.append(pPlayer->media().request().url().fileName());
+            soundFinished.mArgumentList.append(pPlayer->media().request().url().path());
+#else
             soundFinished.mArgumentList.append(pPlayer->media().canonicalUrl().fileName());
-            soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             soundFinished.mArgumentList.append(pPlayer->media().canonicalUrl().path());
+#endif
+            soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             soundFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             if (pHost) {
                 // The host may have gone away if the sound was a long one
@@ -5660,7 +5665,11 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
     // to allow for persistant editing of it as it is not possible to obtain it
     // from the Hunspell library:
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    wordSet = QSet<QString>(wordList.begin(), wordList.end());
+#else
     wordSet = wordList.toSet();
+#endif
 
 #if defined(Q_OS_WIN32)
     mudlet::self()->sanitizeUtf8Path(affixPathFileName, QStringLiteral("profile.dic"));
@@ -5711,7 +5720,12 @@ Hunhandle* mudlet::prepareSharedDictionary()
         return nullptr;
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    mWordSet_shared = QSet<QString>(wordList.begin(), wordList.end());
+#else
     mWordSet_shared = wordList.toSet();
+#endif
+
 #if defined(Q_OS_WIN32)
     mudlet::self()->sanitizeUtf8Path(affixPathFileName, QStringLiteral("profile.dic"));
     mudlet::self()->sanitizeUtf8Path(dictionaryPathFileName, QStringLiteral("profile.aff"));
@@ -5738,7 +5752,11 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
         return false;
     }
 
-    QStringList wordList(wordSet.toList());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList wordList{wordList.begin(), wordList.end()};
+#else
+    QStringList wordList{wordSet.toList()};
+#endif
 
     // This also sorts wordList as a wanted side-effect:
     int wordCount = scanWordList(wordList, graphemeCounts);

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -45,10 +45,10 @@ include(../3rdparty/communi/communi.pri)
     include(../translations/translated/updateqm.pri)
 }
 
-# disable Qt adding -Wall for us, insert it ourselves so we can add -Wno-* after.
+# disable Qt adding -Wall for us, insert it ourselves so we can add -Wno-*
+# after for some warnings that we wish to ignore:
 !msvc:CONFIG += warn_off
-# ignore unused parameters, because boost has a ton of them and that is not something we need to know.
-!msvc:QMAKE_CXXFLAGS += -Wall -Wno-deprecated -Wno-unused-local-typedefs -Wno-unused-parameter
+!msvc:QMAKE_CXXFLAGS += -Wall -Wno-deprecated
 # Before we impose OUR idea about the optimisation levels to use, remove any
 # that Qt tries to put in automatically for us for release builds, only the
 # last, ours, is supposed to apply but it can be confusing to see multiple


### PR DESCRIPTION
The `QPainter::renderHint` of `QPainter::NonCosmeticDefaultPen` is obsolete as default pens are now non-cosmetic implicitly.

`QLineF.intersect(...)` has been renamed to `QLineF.intersects(...)` in Qt 5.14.

Since Qt 5.14, range constructors are available for Qt's generic container classes and should be used in place of:
`QSet<T>::toList()` and `QList<T>::toSet()`.

Since Qt 5.13, `QTreeWidget<T>::sortByColumn(int)` has been deprecated in favour of `QTreeWidget<T>::sortByColumn(int, Qt::SortOrder)` although checking back even to Qt 4.8 I cannot find the one argument case even documented!?

Since Qt 5.11, `QFontMetrics::width(QChar)` has been deprecated in favour of `QFontMetrics::horizontalAdvance(QChar)`.

From Qt 6.0, `QMediaContent::canonicalUrl()` will be deprecated - however Qt 5.14 is already marking it as obsolete and recommends replacing it with `QMediaContent::request().url()` which was introduce in that version.

Also remove our suppression of some warning details in the QMake project file - it was only hiding the above sort of issues from us...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>