### PR TITLE
Don't update autocompletion on push to release branch

### DIFF
--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -1,9 +1,6 @@
 name: Update autocompletion in Mudlet
 
 on:
-  push:
-    branches:
-      - 'release-**'
   repository_dispatch:
     types: update-autocompletion
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't update autocompletion on push to release branch
#### Motivation for adding to Mudlet
Seemed like a good idea - but it's not in practice. The current setup of weekly + manual updates is enough.
#### Other info (issues closed, discussion etc)
