### PR TITLE
Don't udpate 3rdparty on push to release branch

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -1,8 +1,5 @@
 name: Update 3rdparty sources
 on:
-  push:
-    branches:
-      - 'release-**'
   repository_dispatch:
     types: update-3rdparty
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't udpate 3rdparty on push to release branch
#### Motivation for adding to Mudlet
Seemed like a good idea - but it's not in practice. The current setup of weekly + manual updates is enough.
#### Other info (issues closed, discussion etc)
