### PR TITLE
Fixes #3723 - MXP &text; not working as expected

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1493,6 +1493,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                                 mLinkStore[mLinkID] = _t_ref_list;
                             } else {
                                 mLinkStore[mLinkID].replaceInStrings("&TEXT", mAssembleRef.c_str(), Qt::CaseInsensitive);
+                                mHintStore[mLinkID].replaceInStrings("&TEXT", mAssembleRef.c_str(), Qt::CaseInsensitive);
                             }
                             mAssembleRef.clear();
                         }
@@ -1585,6 +1586,9 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 
 
                         mMXP_LINK_MODE = true;
+
+                        _t2 = _t2.replace("&text;", "&TEXT", Qt::CaseInsensitive);
+                        _t3 = _t3.replace("&text;", "&TEXT", Qt::CaseInsensitive);
                         if (_t2.isEmpty() || _t2.contains("&TEXT", Qt::CaseInsensitive)) {
                             mMXP_SEND_NO_REF_MODE = true;
                         }

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1492,7 +1492,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                                 _t_ref_list << _t_ref;
                                 mLinkStore[mLinkID] = _t_ref_list;
                             } else {
-                                mLinkStore[mLinkID].replaceInStrings("&TEXT", mAssembleRef.c_str());
+                                mLinkStore[mLinkID].replaceInStrings("&TEXT", mAssembleRef.c_str(), Qt::CaseInsensitive);
                             }
                             mAssembleRef.clear();
                         }
@@ -1585,7 +1585,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
 
 
                         mMXP_LINK_MODE = true;
-                        if (_t2.isEmpty() || _t2.contains("&TEXT")) {
+                        if (_t2.isEmpty() || _t2.contains("&TEXT", Qt::CaseInsensitive)) {
                             mMXP_SEND_NO_REF_MODE = true;
                         }
                         mLinkID++;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
- Fixes problem with interpolating `&text;` in standalone `<SEND>` tags

#### Motivation for adding to Mudlet
Bugfix

#### Other info (issues closed, discussion etc)
Closes #3723 

MUDs that use this construct: Age of Elements (in standalone `<send>`) and Two Towers (in custom elements)