### PR TITLE
Return table of useful things in HTTP response

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1389,6 +1389,11 @@ void Host::raiseEvent(const TEvent& pE)
             mLuaInterpreter.callEventHandler(functionsList.at(i), pE);
         }
     }
+
+    // After the event has been raised but before 'event' goes out of scope,
+    // we need to safely dereference the members of 'event' that point to
+    // values in the Lua registry
+    mLuaInterpreter.freeAllInLuaRegistry(pE);
 }
 
 void Host::postIrcMessage(const QString& a, const QString& b, const QString& c)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -63,7 +63,6 @@
 #include "post_guard.h"
 
 #include <limits>
-#include <optional>
 
 const QMap<Qt::MouseButton, QString> TLuaInterpreter::mMouseButtons = {
         {Qt::NoButton, QStringLiteral("NoButton")},           {Qt::LeftButton, QStringLiteral("LeftButton")},       {Qt::RightButton, QStringLiteral("RightButton")},

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -63,6 +63,7 @@
 #include "post_guard.h"
 
 #include <limits>
+#include <optional>
 
 const QMap<Qt::MouseButton, QString> TLuaInterpreter::mMouseButtons = {
         {Qt::NoButton, QStringLiteral("NoButton")},           {Qt::LeftButton, QStringLiteral("LeftButton")},       {Qt::RightButton, QStringLiteral("RightButton")},

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -18563,9 +18563,9 @@ std::optional<int> TLuaInterpreter::createHttpHeadersTable(QNetworkReply* reply)
     lua_newtable(L);
     for (QByteArray header : headerList) {
         // Push header key onto stack
-        lua_pushstring(L, header.toStdString().c_str());
+        lua_pushstring(L, header.constData());
         // Push header value onto stack
-        lua_pushstring(L, reply->rawHeader(header).toStdString().c_str());
+        lua_pushstring(L,  reply->rawHeader(header).constData());
         // Put key-value pair into table (now 3 deep in stack), pop stack twice
         lua_settable(L, -3);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -180,7 +180,7 @@ void TLuaInterpreter::slot_httpRequestFinished(QNetworkReply* reply)
         }
 
         if (std::optional<int> registryKey = createHttpHeadersTable(reply); registryKey.has_value()) {
-            event.mArgumentList << QString::number(registryKey.value());
+            event.mArgumentList << QString::number(*registryKey);
             event.mArgumentTypeList << ARGUMENT_TYPE_TABLE;
         }
 
@@ -302,7 +302,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
     }
 
     if (std::optional<int> registryKey = createHttpHeadersTable(reply); registryKey.has_value()) {
-        event.mArgumentList << QString::number(registryKey.value());
+        event.mArgumentList << QString::number(*registryKey);
         event.mArgumentTypeList << ARGUMENT_TYPE_TABLE;
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -18554,14 +18554,14 @@ std::optional<int> TLuaInterpreter::createHttpHeadersTable(QNetworkReply* reply)
         qDebug() << "LUA CRITICAL ERROR: no suitable Lua execution unit found.";
         return {};
     }
-    QList<QByteArray> headerList = reply->rawHeaderList();
+    const QList<QByteArray> headerList = reply->rawHeaderList();
     if (headerList.isEmpty()) {
         return {};
     }
 
     // Push table onto stack
     lua_newtable(L);
-    for (QByteArray header : qAsConst(headerList)) {
+    for (QByteArray header : headerList) {
         // Push header key onto stack
         lua_pushstring(L, header.toStdString().c_str());
         // Push header value onto stack

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -63,6 +63,7 @@
 #include "post_guard.h"
 
 #include <limits>
+#include <optional>
 
 const QMap<Qt::MouseButton, QString> TLuaInterpreter::mMouseButtons = {
         {Qt::NoButton, QStringLiteral("NoButton")},           {Qt::LeftButton, QStringLiteral("LeftButton")},       {Qt::RightButton, QStringLiteral("RightButton")},
@@ -18542,7 +18543,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
 // Internal function - Looks for headers in an http response. If it finds them,
 // it creates a table on the lua stack for the headers, pops the table from the
 // stack, puts it in the lua registry, and returns the key to where it is in
-// registery wrapped in an optional. Otherwise it returns an empty optional.
+// registery, wrapped in an optional. Otherwise it returns an empty optional.
 std::optional<int> TLuaInterpreter::createHttpHeadersTable(QNetworkReply* reply)
 {
     lua_State* L = pGlobalLua;
@@ -18551,17 +18552,17 @@ std::optional<int> TLuaInterpreter::createHttpHeadersTable(QNetworkReply* reply)
         return {};
     }
     QList<QByteArray> headerList = reply->rawHeaderList();
-    if (headerList.size() <= 0) {
+    if (headerList.isEmpty()) {
         return {};
     }
 
     // Push table onto stack
     lua_newtable(L);
-    for (QByteArray head : headerList) {
+    for (QByteArray header : qAsConst(headerList)) {
         // Push header key onto stack
-        lua_pushstring(L, head.toStdString().c_str());
+        lua_pushstring(L, header.toStdString().c_str());
         // Push header value onto stack
-        lua_pushstring(L, reply->rawHeader(head).toStdString().c_str());
+        lua_pushstring(L, reply->rawHeader(header).toStdString().c_str());
         // Put key-value pair into table (now 3 deep in stack), pop stack twice
         lua_settable(L, -3);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -542,14 +542,6 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
 
     host.raiseEvent(event);
 
-    // After the event has been raised but before 'event' goes out of scope,
-    // we need to safely dereference the members of 'event' that point to
-    // values in the Lua registry
-    for (int i = 0; i < event.mArgumentList.size(); i++) {
-        if (event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_TABLE || event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_FUNCTION)
-             host.getLuaInterpreter()->freeLuaRegistryIndex(event.mArgumentList.at(i).toInt());
-    }
-
     return 0;
 }
 
@@ -17997,6 +17989,18 @@ int TLuaInterpreter::getRowCount(lua_State* L)
 // i.e. Unrefing tables passed into TLabel's event parameters.
 void TLuaInterpreter::freeLuaRegistryIndex(int index) {
     luaL_unref(pGlobalLua, LUA_REGISTRYINDEX, index);
+}
+
+// Internal function - Looks for argument types in an 'event' that have stored
+// data in the lua registry, and frees this data.
+void TLuaInterpreter::freeAllInLuaRegistry(TEvent event)
+{
+    for (int i = 0; i < event.mArgumentList.size(); i++) {
+        if (event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_TABLE || event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_FUNCTION)
+        {
+             freeLuaRegistryIndex(event.mArgumentList.at(i).toInt());
+        }
+    }
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapSelection

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -52,7 +52,6 @@ extern "C" {
 #include <list>
 #include <string>
 #include <memory>
-#include <optional>
 
 
 class Host;
@@ -117,7 +116,8 @@ public:
     static int dirToNumber(lua_State*, int);
     void updateAnsi16ColorsInTable();
     void updateExtendedAnsiColorsInTable();
-    std::optional<int> createHttpHeadersTable(QNetworkReply*);
+    int createHttpResponseTable(QNetworkReply*);
+    void createHttpHeadersTable(lua_State*, QNetworkReply*);
 
 
     QPair<int, QString> startTempTimer(double timeout, const QString& function, const bool repeating = false);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -32,6 +32,7 @@
 #include <QMutex>
 #include <QNetworkAccessManager>
 #include <QNetworkCookieJar>
+#include <QNetworkCookie>
 #include <QNetworkReply>
 #include <QPointer>
 #include <QProcess>

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -116,6 +116,7 @@ public:
     static int dirToNumber(lua_State*, int);
     void updateAnsi16ColorsInTable();
     void updateExtendedAnsiColorsInTable();
+    std::optional<int> createHttpHeadersTable(QNetworkReply*);
 
 
     QPair<int, QString> startTempTimer(double timeout, const QString& function, const bool repeating = false);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -52,6 +52,7 @@ extern "C" {
 #include <list>
 #include <string>
 #include <memory>
+#include <optional>
 
 
 class Host;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -558,6 +558,7 @@ public:
 
     static const QMap<Qt::MouseButton, QString> mMouseButtons;
     void freeLuaRegistryIndex(int index);
+    void freeAllInLuaRegistry(TEvent);
 
 public slots:
     void slot_httpRequestFinished(QNetworkReply*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -118,6 +118,7 @@ public:
     void updateExtendedAnsiColorsInTable();
     int createHttpResponseTable(QNetworkReply*);
     void createHttpHeadersTable(lua_State*, QNetworkReply*);
+    void createCookiesTable(lua_State*, QNetworkReply*);
 
 
     QPair<int, QString> startTempTimer(double timeout, const QString& function, const bool repeating = false);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -31,6 +31,7 @@
 #include <QEvent>
 #include <QMutex>
 #include <QNetworkAccessManager>
+#include <QNetworkCookieJar>
 #include <QNetworkReply>
 #include <QPointer>
 #include <QProcess>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
This commit adds a extra parameter to all functions handling HTTP responses, and this parameter is a table of "useful things" from the HTTP response. So far, I've added two useful things: the response headers and the cookies. Here is an example of logging into our MUD, which is a POST-to-GET redirect, and then printing everything in this response table to the screen:
```lua
function onHttpGetDone(_, filename, bytesWritten, response)
  cecho(string.format("<white>Downloaded file to: <dark_green>%s<white>", filename))
  cecho(string.format("\n\n<white>Number of bytes downloaded: <dark_green>%s<white>", bytesWritten))
  for k,v in pairs(response) do
    cecho(string.format("\n\n<white>%s:", k))
    for k,v in pairs(v) do
      cecho(string.format("\n  <white>%s: <dark_green>%s", k, v))
    end
  end
end
registerAnonymousEventHandler("sysDownloadDone", onHttpGetDone)

postHTTP(
  "submit=true&uname=thisisnotmyusername&pwd=thisisnotmypassword",
  "https://login.eternalcitygame.com/login.php",
  {["Cookie"] = "biscuit=test"}
)
```
```
Downloaded file to:
Number of bytes downloaded: 0

cookies:
  pass: 9876543210
  user: thisisnotmyusername

headers:
  Content-Encoding: gzip
  Content-Type: text/html; charset=UTF-8
  Vary: Accept-Encoding
  Date: Wed, 24 Jun 2020 19:50:33 GMT
  Connection: Keep-Alive
  Keep-Alive: timeout=5, max=99
  Server: Apache/2.4.25 (Debian)
```

#### Motivation for adding to Mudlet
[Our mudlet integration for The Eternal City](https://github.com/TheEternalCitizens/mudlet-integration/) recently broke when the game developers changed the handshake we were using to login to the game. Before we could pass our credentials directly to the game after connecting, now we need to `POST /login` with our credentials and look at the result in the cookie to see what credentials we should use to login.

I'm hoping that this addition will be useful to others as well.

#### Other info (issues closed, discussion etc)
This PR can be merged whenever, but it won't be useful until we upgrade mudlet to Qt 5.15.1 to get their fix for a POST-to-GET redirect bug.
* [The Qt bug report](https://bugreports.qt.io/browse/QTBUG-84162)
* The Qt bug fix for their [dev](https://codereview.qt-project.org/c/qt/qtbase/+/303705) branch and their [5.15](https://codereview.qt-project.org/c/qt/qtbase/+/304230) branch