### PR TITLE
BugFix: repair faults introduced by #3705

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4264,7 +4264,8 @@ void T2DMap::slot_setArea()
                 // Failed on the last of multiple room area move so do the missed
                 // out recalculations for the dirtied areas
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-                QSetIterator<TArea*> itpArea{QSet<TArea*>{mpMap->mpRoomDB->getAreaPtrList().begin(), mpMap->mpRoomDB->getAreaPtrList().end()}};
+                QSet<TArea*> areaPtrsSet{mpMap->mpRoomDB->getAreaPtrList().begin(), mpMap->mpRoomDB->getAreaPtrList().end()};
+                QSetIterator<TArea*> itpArea{areaPtrsSet};
 #else
                 QSetIterator<TArea*> itpArea{mpMap->mpRoomDB->getAreaPtrList().toSet()};
 #endif

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5933,7 +5933,12 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         while (itRoom.hasNext()) {
             itRoom.next();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            keysSet.unite(QSet<QString>{itRoom.value()->userData.keys().begin(), itRoom.value()->userData.keys().end()});
+            // In the brave new world of range based initializers one must use
+            // a pair of iterators that point to the SAME thing that lasts
+            // long enough - using the output of a Qt method that returns a
+            // QList twice is not good enough and causes seg. faults...
+            QList<QString> roomDataKeysList{itRoom.value()->userData.keys()};
+            keysSet.unite(QSet<QString>{roomDataKeysList.begin(), roomDataKeysList.end()});
 #else
             keysSet.unite(itRoom.value()->userData.keys().toSet());
 #endif
@@ -6055,7 +6060,8 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         while (itArea.hasNext()) {
             itArea.next();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            keysSet.unite(QSet<QString>{itArea.value()->mUserData.keys().begin(), itArea.value()->mUserData.keys().end()});
+            QList<QString> areaDataKeysList{itArea.value()->mUserData.keys()};
+            keysSet.unite(QSet<QString>{areaDataKeysList.begin(), areaDataKeysList.end()});
 #else
             keysSet.unite(itArea.value()->mUserData.keys().toSet());
 #endif
@@ -18199,7 +18205,12 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
     // This may stall if this is accessing the shared user dictionary and that
     // is being updated by another profile, but it should eventually return...
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QStringList wordList{host.mpConsole->getWordSet().begin(), host.mpConsole->getWordSet().end()};
+    // We must keep a local reference/copy of the value returned because the
+    // returned item is a deep-copy in the case of a shared dictionary and two
+    // calls to TConsole::getWordSet() can return two different instances which
+    // is fatally dangerous if used in a range based initialiser:
+    QSet<QString> wordSet{host.mpConsole->getWordSet()};
+    QStringList wordList{wordSet.begin(), wordSet.end()};
 #else
     QStringList wordList{host.mpConsole->getWordSet().toList()};
 #endif

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -881,7 +881,11 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             // exit lines and remove those which are already included in the
             // colours) is much easier to perform on a QSet rather than a QList:
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            QSet<QString> missingKeys{QSet<QString>{customLines.keys().begin(), customLines.keys().end()}.subtract(QSet<QString>{customLinesColor.keys().begin(), customLinesColor.keys().end()})};
+            QSet<QString> missingKeys{customLines.keys().begin(), customLines.keys().end()};
+            if (!customLinesColor.isEmpty()) {
+                QSet<QString> customLinesColorKeysSet{customLinesColor.keys().begin(), customLinesColor.keys().end()};
+                missingKeys.subtract(customLinesColorKeysSet);
+            }
 #else
             QSet<QString> missingKeys{customLines.keys().toSet().subtract(customLinesColor.keys().toSet())};
 #endif

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -639,14 +639,23 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     // Check for existance of all areas needed by rooms
-    QSet<int> areaIdSet{areaRoomMultiHash.keys().begin(), areaRoomMultiHash.keys().end()};
+    QList<int> areaIdsFromRoomsList{areaRoomMultiHash.uniqueKeys()};
+    QSet<int> areaIdSet{areaIdsFromRoomsList.begin(), areaIdsFromRoomsList.end()};
 
     // START OF TASK 3
     // Throw in the area Ids from the areaNamesMap:
-    areaIdSet.unite(QSet<int>{areaNamesMap.keys().begin(), areaNamesMap.keys().end()});
+    if (!areaNamesMap.isEmpty()) {
+        QList<int> areaIdsFromAreaNamesList{areaNamesMap.keys()};
+        QSet<int> areaIdsFromAreaNamesSet{areaIdsFromAreaNamesList.begin(), areaIdsFromAreaNamesList.end()};
+        areaIdSet.unite(areaIdsFromAreaNamesSet);
+    }
 
     // And the area Ids used by the map labels:
-    areaIdSet.unite(QSet<int>{mpMap->mapLabels.keys().begin(), mpMap->mapLabels.keys().end()});
+    if (!mpMap->mapLabels.isEmpty()) {
+        QList<int> areaIdsFromLabelsList{mpMap->mapLabels.keys()};
+        QSet<int> areaIdsFromLabelsSet{areaIdsFromLabelsList.begin(), areaIdsFromLabelsList.end()};
+        areaIdSet.unite(areaIdsFromLabelsSet);
+    }
 #else
     // Check for existance of all areas needed by rooms
     QSet<int> areaIdSet = areaRoomMultiHash.keys().toSet();
@@ -925,6 +934,9 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Exit stubs:
             unsigned int _listCount = pR->exitStubs.count();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            // These next few constuction of a QSet from a QList or vice versa
+            // are probably safe as both iterators refer to the SAME instance
+            // that is persistent:
             QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
 #else
             QSet<int> _set{pR->exitStubs.toSet()};
@@ -998,7 +1010,10 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             // Now compare pA->rooms to areaRoomMultiHash.values(itArea.key())
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            QSet<int> foundRooms{areaRoomMultiHash.values(itArea.key()).begin(), areaRoomMultiHash.values(itArea.key()).end()};
+            // Have to create a local copy of the list of rooms to safely make
+            // a QSet of them:
+            QList<int> roomIdsInAreaList{areaRoomMultiHash.values(itArea.key())};
+            QSet<int> foundRooms{roomIdsInAreaList.begin(), roomIdsInAreaList.end()};
 #else
             QSet<int> foundRooms{areaRoomMultiHash.values(itArea.key()).toSet()};
 #endif

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2118,7 +2118,8 @@ void dlgProfilePreferences::copyMap()
 
     // Identify which, if any, of the toProfilesRoomIdMap is active and get the current room
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QSet<Host*> activeHosts{mudlet::self()->mConsoleMap.keys().begin(), mudlet::self()->mConsoleMap.keys().begin()};
+    QList<Host*> activeHostsList{mudlet::self()->mConsoleMap.keys()};
+    QSet<Host*> activeHosts{activeHostsList.begin(), activeHostsList.end()};
 #else
     QSet<Host*> activeHosts{mudlet::self()->mConsoleMap.keys().toSet()};
 #endif

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -259,7 +259,8 @@ void dlgRoomExits::save()
         }
     }
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QSet<QString> originalExitCmds{oldSpecialExits.values().begin(), oldSpecialExits.values().end()};
+    QList<QString> originalExitCmdsList{oldSpecialExits.values()};
+    QSet<QString> originalExitCmds{originalExitCmdsList.begin(), originalExitCmdsList.end()};
 #else
     QSet<QString> originalExitCmds{oldSpecialExits.values().toSet()};
 #endif

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5766,7 +5766,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
     }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QStringList wordList{wordList.begin(), wordList.end()};
+    QStringList wordList{wordSet.begin(), wordSet.end()};
 #else
     QStringList wordList{wordSet.toList()};
 #endif


### PR DESCRIPTION
AFAICT creating a `QSet<T>` or a `QList<T>` with a range based initialiser using the output from a Qt API method that outputs the other type of container must be done by making a local copy (I think) of the output from that API call and then providing the two iterators at the extremes of that copy. This is because such an initialisation MUST have iterators that refer to the same instance of the container and the container and its members must last long enough for the use to which it is to be put. The output from something like `QMap<T1,T2>::keys()` does not meet those requirements!

This should close #3707 .

Also fixes a copy/paste error that used the `QList<T>::begin()` for BOTH elements of a range based initialisation in: `(void) dlgProfilePreferences::copyMap()` AND one that tried to initialise itself from iterators that referred to itself rather than the container of a different type.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>