### PR TITLE
Fixes bug on TBuffer:applyLink() introduced during LinkStore refactoring

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2975,7 +2975,6 @@ bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStrin
     int x2 = P_end.x();
     int y1 = P_begin.y();
     int y2 = P_end.y();
-    bool incLinkID = false;
     int linkID = 0;
 
     // clang-format off
@@ -3002,9 +3001,8 @@ bool TBuffer::applyLink(const QPoint& P_begin, const QPoint& P_end, const QStrin
                         return true;
                     }
                 }
-                if (!incLinkID) {
-                    incLinkID = true;
-                    mLinkStore.addLinks(linkFunction, linkHint);
+                if (linkID == 0) {
+                    linkID = mLinkStore.addLinks(linkFunction, linkHint);
                 }
                 buffer.at(y).at(x++).mLinkIndex = linkID;
             }


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
I was playing with setLink() function and noticed it wasn't working properly because that I forgot to assign the return value from addLinks to linkID when extracting links and hints to TLinkStore.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
