### PR TITLE
add2 for Adjustable.Containers and changeContainer

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -578,13 +578,14 @@ end
 -- overriden add function to put every new window to the Inside container
 -- @param window derives from the original Geyser.Container:add function
 -- @param cons derives from the original Geyser.Container:add function
-function Adjustable.Container:add(window,cons)
+function Adjustable.Container:add(window, cons)
     if self.goInside then
-        self.Inside:special_add(window, cons)
+        --add2 inheritance set to true
+        self.Inside:add2(window, cons, true)
     else
-        Geyser.Container.special_add(self, window, cons)
+        --add2 inheritance set to true
+        self:add2(window, cons, true)
     end
-    window.add = Geyser.special_add
 end
 
 -- overriden show function to prevent to show the right click menu on show

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -580,10 +580,11 @@ end
 -- @param cons derives from the original Geyser.Container:add function
 function Adjustable.Container:add(window,cons)
     if self.goInside then
-        self.Inside:add(window, cons)
+        self.Inside:special_add(window, cons)
     else
-        Geyser.Container.add(self, window, cons)
+        Geyser.Container.special_add(self, window, cons)
     end
+    window.add = Geyser.special_add
 end
 
 -- overriden show function to prevent to show the right click menu on show

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -830,11 +830,11 @@ end
 
 function Adjustable.Container:new(cons,container)
     Adjustable.Container.Locale = Adjustable.Container.Locale or loadTranslations("AdjustableContainer")
-    local me = self.parent:new(cons, container)
     cons = cons or {}
+    cons.type = cons.type or "adjustablecontainer"
+    local me = self.parent:new(cons, container)
     setmetatable(me, self)
     self.__index = self
-    me.type = "adjustablecontainer"
     me.ParentMenuWidth = me.ParentMenuWidth or "102"
     me.ChildMenuWidth = me.ChildMenuWidth or "82"
     me.MenuHeight = me.MenuHeight or "22"

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -580,11 +580,19 @@ end
 -- @param cons derives from the original Geyser.Container:add function
 function Adjustable.Container:add(window, cons)
     if self.goInside then
-        --add2 inheritance set to true
-        self.Inside:add2(window, cons, true)
+        if self.useAdd2 == false then
+            self.Inside:add(window, cons)
+        else
+            --add2 inheritance set to true
+            self.Inside:add2(window, cons, true)
+        end
     else
-        --add2 inheritance set to true
-        self:add2(window, cons, true)
+        if self.useAdd2 == false then
+           Geyser.add(self, window, cons)
+        else
+            --add2 inheritance set to true
+            self:add2(window, cons, true)
+        end
     end
 end
 
@@ -649,9 +657,9 @@ function Adjustable.Container:load()
     end
 end
 
--- overridden reposition function to raise an event of the Adjustable.Container changing position/size
+--- overridden reposition function to raise an event of the Adjustable.Container changing position/size
+-- event name: "AdjustableContainerReposition" passed values (name, width, height, x, y)
 -- it also calls the shrink_title function
--- @see shrink_title
 function Adjustable.Container:reposition()
     Geyser.Container.reposition(self)
     raiseEvent("AdjustableContainerReposition", self.name, self.get_width(), self.get_height(), self.get_x(), self.get_y())
@@ -936,5 +944,20 @@ function Adjustable.Container:new(cons,container)
     end
 
     Adjustable.Container.all[me.name] = me
+    return me
+end
+
+-- Adjustable Container already uses add2 as it is essential for its functioning (especially for the autoLoad function)
+-- added this wrapper for consistency
+Adjustable.Container.new2 = Adjustable.Container.new
+
+--- Overriden constructor to use the old add 
+-- if someone really wants to use the old add for Adjustable Container
+-- use this function (not recommended)
+-- or just create elements inside the Adjustable Container with the cons useAdd2 = false
+function Adjustable.Container:oldnew(cons, container)
+    cons = cons or {}
+    cons.useAdd2 = false
+    local me = self:new(cons, container)
     return me
 end

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -328,6 +328,9 @@ function Geyser.Container:new(cons, container)
   me.name = me.name or Geyser.nameGen()
   me.windowList = {}
   me.windows = {}
+  --special hidden/auto_hidden workaround for Adjustable.Container
+  me.special_hidden = me.hidden or false
+  me.special_auto_hidden = me.auto_hidden or false
   me.hidden = false
   me.auto_hidden = false
   -- Set the metatable.

--- a/src/mudlet-lua/lua/geyser/GeyserContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserContainer.lua
@@ -328,11 +328,14 @@ function Geyser.Container:new(cons, container)
   me.name = me.name or Geyser.nameGen()
   me.windowList = {}
   me.windows = {}
-  --special hidden/auto_hidden workaround for Adjustable.Container
-  me.special_hidden = me.hidden or false
-  me.special_auto_hidden = me.auto_hidden or false
-  me.hidden = false
-  me.auto_hidden = false
+  --pass the given hidden/auto_hidden values for add2
+  if me.useAdd2 == true or (container and container.useAdd2) then
+    me.hidden = me.hidden or false
+    me.auto_hidden = me.auto_hidden or false
+  else
+    me.hidden = false
+    me.auto_hidden = false
+  end
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self
@@ -342,16 +345,28 @@ function Geyser.Container:new(cons, container)
   if not string.find(me.name, ".*Class") then
     -- If passed in a container, add me to that container
     if container then
-      container:add(me)
+      if me.useAdd2 then
+        container:add2(me)
+      else
+        container:add(me)
+      end
     else
       -- Else assume the root window is my container
-      Geyser:add(me)
+      if me.useAdd2 then
+        Geyser:add2(me)
+      else
+        Geyser:add(me)
+      end
       container=Geyser
     end
    --Create Root-Container for UserWindow and add Children
    if (container == Geyser) and (me.windowname) and (me.windowname ~= "main") then
         container = Geyser.Container:new({name=me.windowname.."Container", type = "userwindow", x=0, y=0, width="100%", height="100%"})
-        container:add(me)
+        if me.useAdd2 then
+          container:add2(me)
+        else
+          container:add(me)
+        end
         container.get_width = function()
             return getUserWindowSize(me.windowname)
         end
@@ -363,5 +378,13 @@ function Geyser.Container:new(cons, container)
   end
 
   --print("New in " .. self.name .. " : " .. me.name)
+  return me
+end
+
+--- Overridden constructor to use add2
+function Geyser.Container:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
   return me
 end

--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -256,3 +256,11 @@ function Geyser.Gauge:new (cons, container)
   --print("  New in " .. self.name .. " : " .. me.name)
   return me
 end
+
+-- Overridden constructor to use add2
+function Geyser.Gauge:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
+  return me
+end

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -79,9 +79,6 @@ function Geyser:base_add (window, cons)
   if not self.defer_updates then
     window:reposition()
   end
-  --reset special variables (relevant for add2)
-  --only relevant at creation/initialization of a new container
-  window.special_hidden , window.special_auto_hidden = "novalue", "novalue"
 end
 
 --- Add a window to the list that this container manages.
@@ -97,19 +94,25 @@ end
 --- Add a window to the list that this container manages. 
 -- This add function prevents an element to be shown if it was hidden and hides an element if the 
 -- container is hidden already
--- used by Adjustable.Container and changeContainer
+-- used by Adjustable.Container and changeContainer but can be used by any container using the new2 constructor
 -- @param window The window to add this container
 -- @param cons
 -- @param passOn manages the inheritance of this add function. If set to true this add function will be inherited by all children.
 -- @param exclude manages types which have to be excluded from overwriting their add function as they have their own
-function Geyser:add2 (window, cons, passOn, exclude)
-  passOn = passOn or self.passAdd2 or false
-  exclude = exclude or {"hbox", "VBox", "adjustablecontainer"}
+function Geyser:add2 (window, cons, passAdd2, exclude)
   cons = cons or window -- 'cons' is optional
-  local hidden, auto_hidden = window.special_hidden , window.special_auto_hidden --special variables only for creation/initialization
-  if hidden == "novalue" then -- if special_hidden is "novalue" there is no initialitation
-    hidden, auto_hidden = window.hidden, window.auto_hidden
+  -- if the element doesn't want to use add2 use add instead
+  if window.useAdd2 == false then
+    Geyser.add(self, window, cons)
+    return
   end
+  -- don't overwrite these elements add function as they already use their own add
+  exclude = exclude or {"hbox", "VBox", "adjustablecontainer"}
+
+  if passAdd2 ~= false then
+    passAdd2 = passAdd2 or self.useAdd2 or window.useAdd2 or false
+  end
+
   self:base_add(window, cons)
   -- check all hidden values and hide if they are set
   if hidden then
@@ -122,8 +125,8 @@ function Geyser:add2 (window, cons, passOn, exclude)
   if not(window.hidden or window.auto_hidden) then
     window:show()
   end
-  if passOn then
-    window.passAdd2 = true
+  if passAdd2 then
+    window.useAdd2 = true
     -- Don't overwrite hbox/vbox add functions as they have their own
     if window.add == Geyser.add and not (table.contains(exclude, window.type)) then
       window.add = window.add2
@@ -215,5 +218,6 @@ function Geyser:changeContainer (container)
     setMyWindow(self, windowname)
     setContainerWindow(self, windowname)
   end
-  container:add2(self)
+  -- use add2 without overwriting childrens add functions
+  container:add2(self, cons, false)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -89,14 +89,9 @@ end
 -- @param window The window to add this container
 -- @param cons
 -- @param passOn manages the inheritance of this add function
-function Geyser:add (window, cons, passOn)
-  inheritance = inheritance or false
+function Geyser:add (window, cons)
   self:base_add(window, cons)
   window:show()
-    -- if passOn is true Geyser.add will be inheritated by all the children added to this container. If set to true this add function will be inherited by all children.
-  if window.add == Geyser.add2 and passOn then
-    window.add = Geyser.add
-  end
 end
 
 --- Add a window to the list that this container manages. 
@@ -106,8 +101,10 @@ end
 -- @param window The window to add this container
 -- @param cons
 -- @param passOn manages the inheritance of this add function. If set to true this add function will be inherited by all children.
-function Geyser:add2 (window, cons, passOn)
-  passOn = passOn or false
+-- @param exclude manages types which have to be excluded from overwriting their add function as they have their own
+function Geyser:add2 (window, cons, passOn, exclude)
+  passOn = passOn or self.passAdd2 or false
+  exclude = exclude or {"hbox", "VBox", "adjustablecontainer"}
   cons = cons or window -- 'cons' is optional
   local hidden, auto_hidden = window.special_hidden , window.special_auto_hidden --special variables only for creation/initialization
   if hidden == "novalue" then -- if special_hidden is "novalue" there is no initialitation
@@ -125,9 +122,12 @@ function Geyser:add2 (window, cons, passOn)
   if not(window.hidden or window.auto_hidden) then
     window:show()
   end
-  -- if passOn is true Geyser.add2 will be inheritated by all the children added to this container
-  if window.add == Geyser.add and passOn then
-    window.add = window.add2
+  if passOn then
+    window.passAdd2 = true
+    -- Don't overwrite hbox/vbox add functions as they have their own
+    if window.add == Geyser.add and not (table.contains(exclude, window.type)) then
+      window.add = window.add2
+    end
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -78,8 +78,31 @@ function Geyser:add (window, cons)
   if not self.defer_updates then
     window:reposition()
   end
-  if not (window.hidden or window.auto_hidden) then
-    window:show()
+  window:show()
+  --reset special variables (relevant for Adjustable.Container)
+  window.special_hidden , window.special_auto_hidden = "novalue", "novalue"
+end
+
+--- Add a window to the list that this container manages. 
+-- This one prevents an element to be shown if it was hidden and hides an element if the 
+-- container is hidden already
+-- used by Adjustable.Container and changeContainer
+-- @param window The window to add this container
+function Geyser:special_add (window, cons)
+  cons = cons or window -- 'cons' is optional
+  local hidden, auto_hidden = window.special_hidden , window.special_auto_hidden --special variables only for initialization/reinitialization
+  if hidden == "novalue" then -- if special_hidden is "novalue" there is no initialitation
+    hidden, auto_hidden = window.hidden, window.auto_hidden
+  end
+  Geyser.add(self, window, cons)
+  if hidden then
+    window:hide()
+   end
+  if auto_hidden then
+    window:hide(true)
+  end
+  if self.hidden or self.auto_hidden then
+    window:hide(true)
   end
 end
 
@@ -167,5 +190,5 @@ function Geyser:changeContainer (container)
     setMyWindow(self, windowname)
     setContainerWindow(self, windowname)
   end
-  container:add(self)
+  container:special_add(self)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -12,7 +12,7 @@ Geyser.HBox = Geyser.Container:new({
 function Geyser.HBox:add (window, cons)
   -- VBox/HBox have their own add function therefore passing off add2 should be possible without
   -- overwriting their add functions
-  if self.container and (self.container.add == Geyser.add2 or self.container.passAdd2) then
+  if self.useAdd2 then
     Geyser.add2(self, window, cons)
   else
     Geyser.add(self, window, cons)
@@ -57,5 +57,13 @@ function Geyser.HBox:new(cons, container)
   setmetatable(me, self)
   self.__index = self
   me:reposition()
+  return me
+end
+
+--- Overridden constructor to use add2
+function Geyser.HBox:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
   return me
 end

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -10,7 +10,13 @@ Geyser.HBox = Geyser.Container:new({
 })
 
 function Geyser.HBox:add (window, cons)
-  Geyser.add(self, window, cons)
+  -- VBox/HBox have their own add function therefore passing off add2 should be possible without
+  -- overwriting their add functions
+  if self.container and (self.container.add == Geyser.add2 or self.container.passAdd2) then
+    Geyser.add2(self, window, cons)
+  else
+    Geyser.add(self, window, cons)
+  end
   if not self.defer_updates then
     self:reposition()
   end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -664,7 +664,7 @@ function Geyser.Label:new (cons, container)
     createLabel(me.windowname, me.name, me:get_x(), me:get_y(),
       me:get_width(), me:get_height(), me.fillBg)
   end
--- This only affects Adjustable Containers as for standard containers me.hidden and me.auto_hidden will always be false at creation/initialisation
+-- This only has an effect if add2 is being used as for the standard add method me.hidden and me.auto_hidden is always false at creation/initialisation
   if me.hidden or me.auto_hidden then
     hideWindow(me.name)
   end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -766,6 +766,14 @@ function Geyser.Label:new (cons, container)
   return me
 end
 
+--- Overridden constructor to use add2
+function Geyser.Label:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
+  return me
+end
+
 function fakeFunction()
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -664,7 +664,10 @@ function Geyser.Label:new (cons, container)
     createLabel(me.windowname, me.name, me:get_x(), me:get_y(),
       me:get_width(), me:get_height(), me.fillBg)
   end
-
+-- This only affects Adjustable Containers as for standard containers me.hidden and me.auto_hidden will always be false at creation/initialisation
+  if me.hidden or me.auto_hidden then
+    hideWindow(me.name)
+  end
   -- parse any given format string and set sensible defaults
   me:processFormatString(cons.format)
 

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -132,7 +132,10 @@ function Geyser.Mapper:new (cons, container)
       me:resetTitle()
     end
   end
-
+-- This only affects Adjustable Containers as for standard containers me.hidden and me.auto_hidden will always be false at creation/initialisation
+  if me.hidden or me.auto_hidden then
+    me:hide_impl()
+  end
   -- Set any defined colors
   Geyser.Color.applyColors(me)
 

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -142,3 +142,11 @@ function Geyser.Mapper:new (cons, container)
   --print(" New in " .. self.name .. " : " .. me.name)
   return me
 end
+
+--- Overridden constructor to use add2
+function Geyser.Mapper:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
+  return me
+end

--- a/src/mudlet-lua/lua/geyser/GeyserMapper.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMapper.lua
@@ -132,7 +132,7 @@ function Geyser.Mapper:new (cons, container)
       me:resetTitle()
     end
   end
--- This only affects Adjustable Containers as for standard containers me.hidden and me.auto_hidden will always be false at creation/initialisation
+-- This only has an effect if add2 is being used as for the standard add method me.hidden and me.auto_hidden is always false at creation/initialisation
   if me.hidden or me.auto_hidden then
     me:hide_impl()
   end

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -319,6 +319,11 @@ function Geyser.MiniConsole:new (cons, container)
     createMiniConsole(me.windowname,me.name, me:get_x(), me:get_y(),
     me:get_width(), me:get_height())
 
+-- This only affects Adjustable Containers as for standard containers me.hidden and me.auto_hidden will always be false at creation/initialisation
+    if me.hidden or me.auto_hidden then
+      hideWindow(me.name)
+    end
+
     -- Set any defined colors
     Geyser.Color.applyColors(me)
 

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -353,3 +353,11 @@ function Geyser.MiniConsole:new (cons, container)
   end
   return me
 end
+
+--- Overridden constructor to use add2
+function Geyser.MiniConsole:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
+  return me
+end

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -319,7 +319,7 @@ function Geyser.MiniConsole:new (cons, container)
     createMiniConsole(me.windowname,me.name, me:get_x(), me:get_y(),
     me:get_width(), me:get_height())
 
--- This only affects Adjustable Containers as for standard containers me.hidden and me.auto_hidden will always be false at creation/initialisation
+-- This only has an effect if add2 is being used as for the standard add method me.hidden and me.auto_hidden is always false at creation/initialisation
     if me.hidden or me.auto_hidden then
       hideWindow(me.name)
     end

--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -167,3 +167,11 @@ function Geyser.UserWindow:new(cons)
   me:resetWindow()
   return me
 end
+
+--- Overridden constructor to use add2
+function Geyser.UserWindow:new2 (cons)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons)
+  return me
+end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -10,7 +10,14 @@ Geyser.VBox = Geyser.Container:new({
 })
 
 function Geyser.VBox:add (window, cons)
-  Geyser.add(self, window, cons)
+  -- VBox/HBox have their own add function therefore passing off add2 should be possible without
+  -- overwriting their add functions
+  if self.container and (self.container.add == Geyser.add2 or self.container.passAdd2) then
+    Geyser.add2(self, window, cons)
+  else
+    Geyser.add(self, window, cons)
+  end
+  
   if not self.defer_updates then
     self:reposition()
   end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -12,7 +12,7 @@ Geyser.VBox = Geyser.Container:new({
 function Geyser.VBox:add (window, cons)
   -- VBox/HBox have their own add function therefore passing off add2 should be possible without
   -- overwriting their add functions
-  if self.container and (self.container.add == Geyser.add2 or self.container.passAdd2) then
+  if self.useAdd2 then
     Geyser.add2(self, window, cons)
   else
     Geyser.add(self, window, cons)
@@ -57,5 +57,13 @@ function Geyser.VBox:new(cons, container)
   local me = self.parent:new(cons, container)
   setmetatable(me, self)
   self.__index = self
+  return me
+end
+
+--- Overridden constructor to use add2
+function Geyser.VBox:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
   return me
 end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
add a new internal method for ***Geyser:add2()*** which is only used by Adjustable.Containers and changeContainer.
This ***add2*** function won't show a hidden element if added to a container and also will hide a visible element if added to a hidden container.
Only for Adjustable Containers elements can have the constraint hidden workable.
For example if a Label is added to an Adjustable Container by:
```lua
testlabel = Geyser.Label:new({name="testlabel", color="green", hidden = true}, myAdjustableContainer)
```
It will be created hidden.
#### Motivation for adding to Mudlet
closes https://github.com/Mudlet/Mudlet/issues/3728
partially fixes (only for Adjustable.Containers) https://github.com/Mudlet/Mudlet/issues/3726 
(which was a problem with autoLoad as autoLoad reloaded the container before the new elements were added)
#### Other info (issues closed, discussion etc)
This should avoid breaking old scripts and still add the functionality to Adjustable containers
