### PR TITLE
fix Geyser.Label:disable/enableClickthrough stored in variable clickthrough

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -850,11 +850,13 @@ end
 --- Sets label to no longer intercept mouse events
 function Geyser.Label:enableClickthrough()
   enableClickthrough(self.name)
+  self.clickthrough = true
 end
 
 --- Sets label to once again intercept mouse events
 function Geyser.Label:disableClickthrough()
   disableClickthrough(self.name)
+  self.clickthrough = false
 end
 
 ---


### PR DESCRIPTION
#### Brief overview of PR changes/additions
If used Label:enableClickthrough()/Label:disableClickthrough() the right value will be stored in Label.clickthrough now

#### Motivation for adding to Mudlet
It was possible to use the clickthrough value to change the property on initialization, but 
after that the value was never changed.

#### Other info (issues closed, discussion etc)
