### PR TITLE
Store the stylesheet of a geyser label as self.stylesheet

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -300,7 +300,9 @@ end
 --- Sets the style sheet of the label
 -- @param css The style sheet string
 function Geyser.Label:setStyleSheet(css)
+  css = css or self.stylesheet
   setLabelStyleSheet(self.name, css)
+  self.stylesheet = css
 end
 --- Sets the tooltip of the label
 -- @param txt the tooltip txt
@@ -758,6 +760,8 @@ function Geyser.Label:new (cons, container)
 
   -- Set clickthrough if included in constructor
   if cons.clickthrough then me:enableClickthrough() end
+
+  if me.stylesheet then me:setStyleSheet() end
 
   --print("  New in " .. self.name .. " : " .. me.name)
   return me


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Geyser.Label:setStyleSheet does not currently store the stylesheet being applied. This PR adds stylesheet as a field on Geyser.Label and sets the stylesheet if it is included at instantiation.

#### Motivation for adding to Mudlet
Someone asked if it was available, and it seems like a good idea to be able to get at the stylesheet being used. Definitely good to be able to set the stylesheet during the :new() call.

#### Other info (issues closed, discussion etc)
