### PR TITLE
Performance improvement for Geyser HBox/VBox

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -12,30 +12,29 @@ Geyser.HBox = Geyser.Container:new({
 function Geyser.HBox:add (window, cons)
   Geyser.add(self, window, cons)
   if not self.defer_updates then
-    self:reposition()
+    self:organize()
   end
 end
 
---- Responsible for placing/moving/resizing this window to the correct place/size.
--- Called on window resize events.
-function Geyser.HBox:reposition()
+--- Responsible for organizing the elements inside the HBox
+-- Called when a new element is added
+function Geyser.HBox:organize()
   self.parent:reposition()
-
-  local window_width = self:calculate_dynamic_window_size().width
+  local window_width = (self:calculate_dynamic_window_size().width / self:get_width()) * 100
   local start_x = 0
   for _, window_name in ipairs(self.windows) do
     local window = self.windowList[window_name]
-    local width = window.width
-    local height = window.height
-    window:move(start_x, 0)
+    local width = (window:get_width() / self:get_width()) * 100
+    local height = (window:get_height() / self:get_height()) * 100
+    window:move(start_x.."%", "0%")
     if window.h_policy == Geyser.Dynamic then
       width = window_width * window.h_stretch_factor
     end
     if window.v_policy == Geyser.Dynamic then
-      height = self:get_height()
+      height = 100
     end
-    window:resize(width, height)
-    start_x = start_x + window:get_width()
+    window:resize(width.."%", height.."%")
+    start_x = start_x + (window:get_width() / self:get_width()) * 100
   end
 end
 
@@ -50,6 +49,6 @@ function Geyser.HBox:new(cons, container)
   local me = self.parent:new(cons, container)
   setmetatable(me, self)
   self.__index = self
-  me:reposition()
+  me:organize()
   return me
 end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -12,30 +12,30 @@ Geyser.VBox = Geyser.Container:new({
 function Geyser.VBox:add (window, cons)
   Geyser.add(self, window, cons)
   if not self.defer_updates then
-    self:reposition()
+    self:organize()
   end
 end
 
---- Responsible for placing/moving/resizing this window to the correct place/size.
--- Called on window resize events.
-function Geyser.VBox:reposition()
+--- Responsible for organizing the elements inside the VBox
+-- Called when a new element is added
+function Geyser.VBox:organize()
   self.parent:reposition()
 
-  local window_height = self:calculate_dynamic_window_size().height
+  local window_height = (self:calculate_dynamic_window_size().height / self.get_height()) * 100
   local start_y = 0
   for _, window_name in ipairs(self.windows) do
     local window = self.windowList[window_name]
-    window:move(0, start_y)
-    local width = window.width
-    local height = window.height
+    window:move("0%", start_y.."%")
+    local width = (window:get_width() / self:get_width()) * 100
+    local height = (window:get_height() / self:get_height()) * 100
     if window.h_policy == Geyser.Dynamic then
-      width = self:get_width()
+      width = 100
     end
     if window.v_policy == Geyser.Dynamic then
       height = window_height * window.v_stretch_factor
     end
-    window:resize(width, height)
-    start_y = start_y + window:get_height()
+    window:resize(width.."%", height.."%")
+    start_y = start_y + (window:get_height() / self:get_height()) * 100
   end
 end
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Scripts/GUI with many Geyser HBox/VBox should have a noticeable performance improvement
with this PR

#### Motivation for adding to Mudlet
I always avoided HBox/VBoxes for my GUI because they had an noticeable impact in the performance of Mudlet, which I didn't notice if I just use relative\percentage values to organize my elements. 

It's also possible that my ancient laptop is the cause but it was always caused by Geyser HBoxes or VBoxes.

#### Other info (issues closed, discussion etc)
[vboxHboxTest.zip](https://github.com/Mudlet/Mudlet/files/4600128/vboxHboxTest.zip)
Download this testpackage to compare the performance on Mudlet 4.8 and this PR.
At least on my machine the performance improvement is very noticeable.


Another example is GUI for the new added Mud Carrion Fields.
On my machine if I try to resize the GUI by using the arrows (the ones from GUIFrame) everything hangs and is very slow.

On this PR resizing is as fast as someone would expect.

If no one else ever noticed performance issues just ignore this PR :sweat_smile: 