### PR TITLE
Includes missing virtual destructors

### DIFF
--- a/src/MxpTag.h
+++ b/src/MxpTag.h
@@ -56,8 +56,6 @@ class MxpNode
 public:
     enum Type { MXP_NODE_TYPE_TEXT, MXP_NODE_TYPE_START_TAG, MXP_NODE_TYPE_END_TAG };
 
-    explicit MxpNode(MxpNode::Type type) : mType(type) {}
-
     MxpNode::Type getType() const { return mType; }
 
     MxpTag* asTag() { return mType != MXP_NODE_TYPE_TEXT ? reinterpret_cast<MxpTag*>(this) : nullptr; }
@@ -76,7 +74,10 @@ public:
 
     bool isStartTag() { return mType == MXP_NODE_TYPE_START_TAG; }
 
+    virtual ~MxpNode() = default;
+
 protected:
+    explicit MxpNode(MxpNode::Type type) : mType(type) {}
     MxpNode::Type mType;
 };
 
@@ -96,12 +97,9 @@ class MxpTag : public MxpNode
 {
     friend class TMxpTagParser;
 
-protected:
-    QString name;
-
-    explicit MxpTag(MxpNode::Type type, const QString& name) : MxpNode(type), name(name) {}
-
 public:
+    virtual ~MxpTag() = default;
+
     inline const QString& getName() const { return name; }
 
     inline bool isStartTag() const { return mType == MXP_NODE_TYPE_START_TAG; }
@@ -109,6 +107,11 @@ public:
     inline bool isEndTag() const { return mType == MXP_NODE_TYPE_END_TAG; }
 
     bool isNamed(const QString& tagName) const;
+
+protected:
+    QString name;
+
+    explicit MxpTag(MxpNode::Type type, const QString& name) : MxpNode(type), name(name) {}
 };
 
 class MxpEndTag : public MxpTag

--- a/src/TMxpTagHandler.h
+++ b/src/TMxpTagHandler.h
@@ -64,6 +64,9 @@ public:
     virtual TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) { return MXP_TAG_NOT_HANDLED; }
 
     virtual ~TMxpTagHandler() = default;
+
+protected:
+    TMxpTagHandler() = default;
 };
 
 class TMxpSingleTagHandler : public TMxpTagHandler
@@ -71,9 +74,12 @@ class TMxpSingleTagHandler : public TMxpTagHandler
     QString tagName;
 
 public:
-    explicit TMxpSingleTagHandler(QString tagName) : tagName(std::move(tagName)) {}
+    virtual ~TMxpSingleTagHandler() = default;
 
     virtual bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) { return tag->isNamed(tagName); }
+
+protected:
+    explicit TMxpSingleTagHandler(QString tagName) : tagName(std::move(tagName)) {}
 };
 
 #endif //MUDLET_TMXPTAGHANDLER_H


### PR DESCRIPTION
- This is required to support deleting objects from pointers to base classes MxpNode, MxpTag and TMxpTagHandler
- Pointers to these base classes are used in TMxpProcessor, TMxpTagProcessor and TMxpElement

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Fix #3740 
