### PR TITLE
Adjust PTB main window icon

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -209,7 +209,7 @@ mudlet::mudlet()
     setAttribute(Qt::WA_DeleteOnClose);
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(version);
-    if (scmIsReleaseVersion) {
+    if (scmIsReleaseVersion || scmIsDevelopmentVersion) {
         setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet.png")));
     } else if (scmIsPublicTestVersion) {
         setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_ptb_256px.png")));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -209,7 +209,13 @@ mudlet::mudlet()
     setAttribute(Qt::WA_DeleteOnClose);
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setWindowTitle(version);
-    setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_main_48px.png")));
+    if (scmIsReleaseVersion) {
+        setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet.png")));
+    } else if (scmIsPublicTestVersion) {
+        setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_ptb_256px.png")));
+    // } else { // scmIsDevelopmentVersion, currently waiting for dev image to be created
+    //     setWindowIcon(QIcon(QStringLiteral(":/icons/mudlet_dev_256px.png")));
+    }         
     mpMainToolBar = new QToolBar(this);
     mpMainToolBar->setObjectName(QStringLiteral("mpMainToolBar"));
     mpMainToolBar->setWindowTitle(tr("Main Toolbar"));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Main window application icon in top right corner should show PTB icon in PTB build.
Some windows have special icons (color, map, irc, etc.) which are not affected by this.
Some windows already use the PTB icon (updater, etc.) as no icons were set explicitly.

#### Motivation for adding to Mudlet
Help #3766 use nice logo more often

#### Other info (issues closed, discussion etc)

This also upgrades icon resolution from 48px to 256px as was requested years ago:
Icon was first introduced in Mudlet Beta 8, built in 2009-03 as a 16px version.
It was updated to 48px in 2016-03 in aptly named #228 with extra comment:
> Icon assigned to main application and thus "Alt-Tab" icon was the lowest
> resolution icon available only 16x16 and users had noticed, changed to
> 48x48 one which is not too much better for high resolution display users
> (Mac "Retina" displays?) but is significantly improved for others.