### PR TITLE
Run macOS with C++ tests

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -84,4 +84,4 @@ jobs:
         cmakeListsTxtPath: '${{github.workspace}}/CMakeLists.txt'
         useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
-        cmakeAppendedArgs: -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
+        cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -67,7 +67,7 @@ jobs:
         # Installing packages might fail as the github image becomes outdated
         sudo apt update
         # These aren't available or don't work well in vcpkg
-        sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0
+        sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0 libqt5x11extras5
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
@@ -86,18 +86,7 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
 
-    - name: Run C++ tests
-      uses: lukka/run-cmake@v2
-      with:
-       cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
-       cmakeListsTxtPath: '${{github.workspace}}/CMakeLists.txt'
-       useVcpkgToolchainFile: true
-       buildDirectory: '${{runner.workspace}}/b/ninja'
-       buildWithCMakeArgs: --target test
-        
-
     - name: Run ctest
-      if: always()
       working-directory: '${{runner.workspace}}/b/ninja'
       run: ctest --output-on-failure
      

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -89,7 +89,7 @@ jobs:
     # Linux requires tests to be run under xvfb
     - name: Run C++ tests (Linux)
       if: runner.os == 'Linux'
-      uses: GabrielBB/xvfb-action@v1.0
+      uses: GabrielBB/xvfb-action@v1.2
       env:
         QT_DEBUG_PLUGINS: true
       with:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,4 +85,19 @@ jobs:
         useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
-        buildWithCMakeArgs: --config Debug --target test
+
+    - name: Run C++ tests
+      uses: lukka/run-cmake@v2
+      with:
+       cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+       cmakeListsTxtPath: '${{github.workspace}}/CMakeLists.txt'
+       useVcpkgToolchainFile: true
+       buildDirectory: '${{runner.workspace}}/b/ninja'
+       buildWithCMakeArgs: --target test
+        
+
+    - name: Run ctest
+      if: always()
+      run: ctest
+     
+     

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,3 +85,4 @@ jobs:
         useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
+        buildWithCMakeArgs: --config Debug --target test

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,9 +85,8 @@ jobs:
         useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
-    
+
     - name: Run C++ tests (macOS)
       if: runner.os == 'macOS'
       working-directory: '${{runner.workspace}}/b/ninja'
       run: ctest --output-on-failure
-     

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -91,7 +91,8 @@ jobs:
       run: ctest --output-on-failure
     
     - name: (Linux) Run tests
-      if: runner.os == 'Linux'
+#       if: runner.os == 'Linux'
+      if: always()
       uses: GabrielBB/xvfb-action@v1.0
       with:
         run: ${{runner.workspace}}/b/ninja/src/mudlet -profile Achaea

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,18 +85,12 @@ jobs:
         useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
-
-    - name: Run ctest
-      working-directory: '${{runner.workspace}}/b/ninja'
-      run: ctest --output-on-failure
     
-    - name: (Linux) Run tests
-#       if: runner.os == 'Linux'
-      if: always()
+    - name: Run tests
       uses: GabrielBB/xvfb-action@v1.0
       env:
         QT_DEBUG_PLUGINS: true
       with:
-        run: ${{runner.workspace}}/b/ninja/src/mudlet -profile Achaea
+        run: cd ${{runner.workspace}}/b/ninja && ctest --output-on-failure
      
      

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -94,6 +94,8 @@ jobs:
 #       if: runner.os == 'Linux'
       if: always()
       uses: GabrielBB/xvfb-action@v1.0
+      env:
+        QT_DEBUG_PLUGINS: true
       with:
         run: ${{runner.workspace}}/b/ninja/src/mudlet -profile Achaea
      

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -86,11 +86,12 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
     
-    - name: Run tests
+    - name: Run tests C++ tests
       uses: GabrielBB/xvfb-action@v1.0
       env:
         QT_DEBUG_PLUGINS: true
       with:
-        run: cd ${{runner.workspace}}/b/ninja && ctest --output-on-failure
+        working-directory: '${{runner.workspace}}/b/ninja'
+        run: ctest --output-on-failure
      
      

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -89,5 +89,11 @@ jobs:
     - name: Run ctest
       working-directory: '${{runner.workspace}}/b/ninja'
       run: ctest --output-on-failure
+    
+    - name: (Linux) Run tests
+      if: runner.os == 'Linux'
+      uses: GabrielBB/xvfb-action@v1.0
+      with:
+        run: ${{runner.workspace}}/b/ninja/src/mudlet -profile Achaea
      
      

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -98,6 +98,7 @@ jobs:
 
     - name: Run ctest
       if: always()
-      run: ctest
+      working-directory: '${{runner.workspace}}/b/ninja'
+      run: ctest --output-on-failure
      
      

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -86,16 +86,6 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
     
-    # Linux requires tests to be run under xvfb
-    - name: Run C++ tests (Linux)
-      if: runner.os == 'Linux'
-      uses: GabrielBB/xvfb-action@v1.2
-      env:
-        QT_DEBUG_PLUGINS: true
-      with:
-        working-directory: '${{runner.workspace}}/b/ninja'
-        run: ctest --output-on-failure
-     
     - name: Run C++ tests (macOS)
       if: runner.os == 'macOS'
       working-directory: '${{runner.workspace}}/b/ninja'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -86,7 +86,9 @@ jobs:
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: --target test -G Ninja -DCMAKE_PREFIX_PATH=${{runner.workspace}}/Qt/${{env.qt}}/${{matrix.compiler}}/
     
-    - name: Run tests C++ tests
+    # Linux requires tests to be run under xvfb
+    - name: Run C++ tests (Linux)
+      if: runner.os == 'Linux'
       uses: GabrielBB/xvfb-action@v1.0
       env:
         QT_DEBUG_PLUGINS: true
@@ -94,4 +96,8 @@ jobs:
         working-directory: '${{runner.workspace}}/b/ninja'
         run: ctest --output-on-failure
      
+    - name: Run C++ tests (macOS)
+      if: runner.os == 'macOS'
+      working-directory: '${{runner.workspace}}/b/ninja'
+      run: ctest --output-on-failure
      


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Run Github Actions with C++ tests on macOS. Linux [didn't work](https://github.com/Mudlet/Mudlet/runs/680977344?check_suite_focus=true) even when running under [xvfb](https://github.com/Mudlet/Mudlet/runs/681076260?check_suite_focus=true), so skipping that for now.
#### Motivation for adding to Mudlet
More testing!
#### Other info (issues closed, discussion etc)
Currently only has the MXP tests @gcms added :)