### PR TITLE
Increase echo limit to a million characters

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -186,7 +186,7 @@ void TBuffer::setBufferSize(int requestedLinesLimit, int batch)
     if (batch >= requestedLinesLimit) {
         batch = requestedLinesLimit / 10;
     }
-    // clip the maximum to something reasonable, else users will abuse this, and then complain
+    // clip the maximum to something reasonable that the machine can handle
     auto max = getMaxBufferSize();
     if (requestedLinesLimit > max) {
         qWarning().nospace() << "setBufferSize(): " << requestedLinesLimit <<

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -130,9 +130,8 @@ class TBuffer
 
     inline static const int TCHAR_IN_BYTES = sizeof(TChar);
 
-    // arbitrary limit on how many characters a single echo can accept. On an average screen,
-    // a line is usually set to wrap at 200 max
-    inline static const int MAX_CHARACTERS_PER_ECHO = 10000;
+    // limit on how many characters a single echo can accept for performance reasons
+    inline static const int MAX_CHARACTERS_PER_ECHO = 1000000;
 
 public:
     TBuffer(Host* pH);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Increase echo limit to a million characters. 
#### Motivation for adding to Mudlet
10,000 characters for a single echo was causing people to get their tables truncated.
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/3786. The limit was intended on the whole echo overall to begin with it looks like, not just the wrapped lines within.