### PR TITLE
Speed up macOS launch by 1s

### DIFF
--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -57,7 +57,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font(QStringLiteral("Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font(QStringLiteral("DejaVu Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -92,7 +92,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
-        QFont font(QStringLiteral("Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();
@@ -123,11 +123,11 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
     // clang-format off
     QString htmlHead(QStringLiteral(R"(
         <head><style type="text/css">
-        h1 { font-family: "Serif"; text-align: center; }
-        h2 { font-family: "Serif"; text-align: center; }
-        h3 { font-family: "Serif"; text-align: center; white-space: pre-wrap; }
-        h4 { font-family: "Serif"; white-space: pre-wrap; }
-        p { font-family: "Serif" }
+        h1 { font-family: "DejaVu Serif"; text-align: center; }
+        h2 { font-family: "DejaVu Serif"; text-align: center; }
+        h3 { font-family: "DejaVu Serif"; text-align: center; white-space: pre-wrap; }
+        h4 { font-family: "DejaVu Serif"; white-space: pre-wrap; }
+        p { font-family: "DejaVu Serif" }
         tt { font-family: "Monospace"; white-space: pre-wrap; }
         .container { text-align: center; }
         </style></head>

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -57,7 +57,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font(QStringLiteral("DejaVu Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font(QStringLiteral("Verdana"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -92,7 +92,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
-        QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(QStringLiteral("Verdana"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();
@@ -123,11 +123,11 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
     // clang-format off
     QString htmlHead(QStringLiteral(R"(
         <head><style type="text/css">
-        h1 { font-family: "DejaVu Serif"; text-align: center; }
-        h2 { font-family: "DejaVu Serif"; text-align: center; }
-        h3 { font-family: "DejaVu Serif"; text-align: center; white-space: pre-wrap; }
-        h4 { font-family: "DejaVu Serif"; white-space: pre-wrap; }
-        p { font-family: "DejaVu Serif" }
+        h1 { font-family: "Verdana"; text-align: center; }
+        h2 { font-family: "Verdana"; text-align: center; }
+        h3 { font-family: "Verdana"; text-align: center; white-space: pre-wrap; }
+        h4 { font-family: "Verdana"; white-space: pre-wrap; }
+        p { font-family: "Verdana" }
         tt { font-family: "Monospace"; white-space: pre-wrap; }
         .container { text-align: center; }
         </style></head>

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -57,7 +57,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font(QStringLiteral("DejaVu Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font(QStringLiteral("Serif"), fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -92,7 +92,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
-        QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(QStringLiteral("Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();
@@ -123,11 +123,11 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
     // clang-format off
     QString htmlHead(QStringLiteral(R"(
         <head><style type="text/css">
-        h1 { font-family: "DejaVu Serif"; text-align: center; }
-        h2 { font-family: "DejaVu Serif"; text-align: center; }
-        h3 { font-family: "DejaVu Serif"; text-align: center; white-space: pre-wrap; }
-        h4 { font-family: "DejaVu Serif"; white-space: pre-wrap; }
-        p { font-family: "DejaVu Serif" }
+        h1 { font-family: "Serif"; text-align: center; }
+        h2 { font-family: "Serif"; text-align: center; }
+        h3 { font-family: "Serif"; text-align: center; white-space: pre-wrap; }
+        h4 { font-family: "Serif"; white-space: pre-wrap; }
+        p { font-family: "Serif" }
         tt { font-family: "Monospace"; white-space: pre-wrap; }
         .container { text-align: center; }
         </style></head>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font("DejaVu Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font("Verdana", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
-        QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(QStringLiteral("Verdana"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font("DejaVu Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font("Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
-        QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(QStringLiteral("Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
 
         bool isWithinSpace = false;
         while (!isWithinSpace) {
-            QFont font("Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+            QFont font("DejaVu Serif", fontSize, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
             QTextLayout versionTextLayout(sourceVersionText, font, painter.device());
             versionTextLayout.beginLayout();
             // Start work in this text item
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
         // Repeat for other text, but we know it will fit at given size
         // PLACEMARKER: Date-stamp needing annual update
         QString sourceCopyrightText = QStringLiteral("©️ Mudlet makers 2008-2020");
-        QFont font(QStringLiteral("Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
+        QFont font(QStringLiteral("DejaVu Serif"), 16, QFont::Bold | QFont::Serif | QFont::PreferMatch | QFont::PreferAntialias);
         QTextLayout copyrightTextLayout(sourceCopyrightText, font, painter.device());
         copyrightTextLayout.beginLayout();
         QTextLine copyrightTextline = copyrightTextLayout.createLine();


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Mudlet on macOS was saying the following:

```
qt.qpa.fonts: Populating font family aliases took 1086 ms. Replace uses of missing font family "DejaVu Serif" with one that exists to avoid this cost. 
```

So, remove the hardcoded use of DejaVu Serif and let the OS pick a serif font for us.
#### Motivation for adding to Mudlet
Better experience for macOS players.
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/3642.