### PR TITLE
Automatically run 'find 'prompt' on start for generic mapper

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -2949,6 +2949,7 @@ function map.eventHandler(event, ...)
         config()
     elseif event == "mapOpenEvent" then
         if not help_shown and not map.save.prompt_pattern[map.character or ""] then
+            map.find_prompt()
             send("look", true)
             tempTimer(3, function() map.show_help("quick_start"); help_shown = true end)
         end


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Automatically run 'find 'prompt' on start for generic mapper. If it finds it, then it means all someone has to do is use 'start mapping' and they're good to go.
#### Motivation for adding to Mudlet
Back to focus on the [5.0 goals](https://www.mudlet.org/2019/09/mudlet-5-roadmap-focus-on-first-time-player-experience/) of being new player friendly.
#### Other info (issues closed, discussion etc)
