### PR TITLE
Add more lenient room parsing

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1753,6 +1753,7 @@ local function create_room(name, exits, dir, coords)
     -- links with other rooms as appropriate
     -- links to adjacent rooms in direction of exits if in simple mode
     if map.mapping then
+        name = map.sanitizeRoomName(name)
         map.echo("New Room: " .. name,false,false,(dir or find_portal or force_portal) and true or false)
         local newID = createRoomID()
         addRoom(newID)
@@ -2722,6 +2723,7 @@ end
 
 local function handle_exits(exits)
     local room = map.prompt.room or name_search()
+    room = map.sanitizeRoomName(room)
     exits = map.prompt.exits or exits
     exits = string.lower(exits)
     exits = string.gsub(exits,"%a+", exitmap)
@@ -2895,6 +2897,20 @@ function map.showMap(shown)
     else
         mapper:hide()
     end
+end
+
+-- some games embed an ASCII map on the same line, which messes up the room room name
+-- extract the longest continuous piece of text from the line to be the room name
+function map.sanitizeRoomName(roomtitle)
+  assert(type(roomtitle) == "string", "map.sanitizeRoomName: bad argument #1 expected room title, got "..type(roomtitle).."!")
+  if not roomtitle:match("  ") then return roomtitle end
+  
+  local parts = roomtitle:split("  ")
+  table.sort(parts, function(a,b) return #a &lt; #b end)
+  local longestpart = parts[#parts]
+  
+  local trimmed = utf8.match(longestpart, "[%w ]+"):trim()
+  return trimmed
 end
 
 function map.eventHandler(event, ...)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Ignore the ASCII maps embedded in room lines that tend to mess up the title.

![image](https://user-images.githubusercontent.com/110988/82153532-4d5a3680-9868-11ea-9f91-657d6c6748ef.png)

#### Motivation for adding to Mudlet
Generic mapper works better in more situations. 
#### Other info (issues closed, discussion etc)
`map.sanitizeRoomName()` is a globally-available function so it can be overwritten with a custom algorithm if needed.