### PR TITLE
Don't translate time units in the Timer UI

### DIFF
--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -247,7 +247,7 @@
       </font>
      </property>
      <property name="text">
-      <string>:</string>
+      <string notr="true">:</string>
      </property>
     </widget>
    </item>
@@ -313,7 +313,7 @@
       </font>
      </property>
      <property name="text">
-      <string>:</string>
+      <string notr="true">:</string>
      </property>
     </widget>
    </item>
@@ -382,7 +382,7 @@
       </font>
      </property>
      <property name="text">
-      <string>.</string>
+      <string notr="true">.</string>
      </property>
     </widget>
    </item>

--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -214,7 +214,7 @@
       <enum>QDateTimeEdit::HourSection</enum>
      </property>
      <property name="displayFormat">
-      <string>hh</string>
+      <string notr="true">hh</string>
      </property>
     </widget>
    </item>
@@ -280,7 +280,7 @@
       <enum>QDateTimeEdit::MinuteSection</enum>
      </property>
      <property name="displayFormat">
-      <string>mm</string>
+      <string notr="true">mm</string>
      </property>
     </widget>
    </item>
@@ -349,7 +349,7 @@
       <enum>QDateTimeEdit::SecondSection</enum>
      </property>
      <property name="displayFormat">
-      <string>ss</string>
+      <string notr="true">ss</string>
      </property>
     </widget>
    </item>
@@ -418,7 +418,7 @@
       <enum>QDateTimeEdit::MSecSection</enum>
      </property>
      <property name="displayFormat">
-      <string>zzz</string>
+      <string notr="true">zzz</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't translate time units in the Timer UI
#### Motivation for adding to Mudlet
Translating units leads to problems saving the values: https://cdn.discordapp.com/attachments/427919962561052673/711583462372540497/2020-05-17_17.10.33.mov
#### Other info (issues closed, discussion etc)
