### PR TITLE
Only install Coverity for the Coverity job

### DIFF
--- a/CI/travis.linux.install.sh
+++ b/CI/travis.linux.install.sh
@@ -14,8 +14,8 @@ luarocks install --local lua-yajl YAJL_LIBDIR="${YAJL_PATH}"
 luarocks install --local argparse
 luarocks install --local lunajson
 
-if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
-  # download coverity tool only for cron jobs
+  # download coverity tool only for cron+deploy jobs
+if [ "${TRAVIS_EVENT_TYPE}" = "cron" ] && [ "${DEPLOY}" = "deploy" ]; then
   mkdir coverity
   cd coverity
   wget https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=Mudlet%2FMudlet" -O coverity_tool.tgz


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Only install Coverity for the Coverity job
#### Motivation for adding to Mudlet
When Coverity went down for scheduled maintenance, it took all Linux jobs down, including the PTB one: https://travis-ci.com/github/Mudlet/Mudlet/builds/166630562
#### Other info (issues closed, discussion etc)
