### PR TITLE
Disable extra apt update

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -67,7 +67,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         # Installing packages might fail as the github image becomes outdated
-        sudo apt update
+        # sudo apt update
         # These aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0 libqt5x11extras5
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Github image got updated, to the 30-40s spent on `apt update` are no longer necessary. If it works like this for a while without breaking, we could keep it - otherwise if it breaks soon again let's leave it in permanently.
#### Motivation for adding to Mudlet
Quicker builds, faster feedback.
#### Other info (issues closed, discussion etc)
