### PR TITLE
Fix typo and duplication

### DIFF
--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -327,9 +327,6 @@
      <property name="toolTip">
       <string>&lt;p&gt;The &lt;b&gt;second&lt;/b&gt; part of the interval that the timer will go off at.&lt;/p&gt;</string>
      </property>
-     <property name="whatsThis">
-      <string>&lt;p&gt;The &lt;b&gt;second&lt;/b&gt; interval that the timer will go off at&lt;/p&gt;</string>
-     </property>
      <property name="autoFillBackground">
       <bool>true</bool>
      </property>
@@ -394,10 +391,7 @@
       </font>
      </property>
      <property name="toolTip">
-      <string>&lt;p&gt;The &lt;b&gt;milisecond&lt;/b&gt; part of the interval that the timer will go off at (1000 miliseconds = 1 second).&lt;/p&gt;</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;p&gt;The &lt;b&gt;milisecond&lt;/b&gt; interval that the timer will go off at (1000 miliseconds = 1 second)&lt;/p&gt;</string>
+      <string>&lt;p&gt;The &lt;b&gt;millisecond&lt;/b&gt; part of the interval that the timer will go off at (1000 milliseconds = 1 second).&lt;/p&gt;</string>
      </property>
      <property name="autoFillBackground">
       <bool>true</bool>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove typo "milLisecond" alongside (mostly) duplicated text in [whatsthis](https://doc.qt.io/qt-5/qwhatsthis.html#details)

#### Motivation for adding to Mudlet
Less burden for translators

#### Other info (issues closed, discussion etc)
Adding whatsthis next to tooltips can make sense but should be discussed in detail and then decided and spread out to the whole Mudlet application. 

As it was used here, it just duplicated the tooltip (actually less info even), and only for 2 of the 4 time units, and for nothing else in the UI. Nobody expects to find anything there, and if they do by accident, it was no improvement over the tooltip.