### PR TITLE
Report right error argument for C++ event registration

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13575,7 +13575,7 @@ int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
     }
     std::string func;
     if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "registerAnonymousEventHandler: bad argument #2 (function name as string expected, got %s)", luaL_typename(L, 1));
+        lua_pushfstring(L, "registerAnonymousEventHandler: bad argument #2 (function name as string expected, got %s)", luaL_typename(L, 2));
         return lua_error(L);
     } else {
         func = lua_tostring(L, 2);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Report right error argument for C++ event registration. In practice it doesn't matter since we have a Lua override.
#### Motivation for adding to Mudlet
Just removing a potential problem.
#### Other info (issues closed, discussion etc)
