### PR TITLE
Add an option to keep the colour when highlighting

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -418,10 +418,18 @@ END : {
                 // otherwise highlight complete expression match
                 if (i % numberOfCaptureGroups != 1) {
                     pC->selectSection(begin, length);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                     if (mBgColor != QColorConstants::Transparent) {
+#else
+                    if (mBgColor != QColor("transparent")) {
+#endif
                         pC->setBgColor(r1, g1, b1);
                     }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                     if (mFgColor != QColorConstants::Transparent) {
+#else
+                    if (mFgColor != QColor("transparent")) {
+#endif
                         pC->setFgColor(r2, g2, b2);
                     }
                 }
@@ -495,10 +503,18 @@ bool TTrigger::match_begin_of_line_substring(const QString& toMatch, const QStri
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mBgColor != QColorConstants::Transparent) {
+#else
+                if (mBgColor != QColor("transparent")) {
+#endif
                     pC->setBgColor(r1, g1, b1);
                 }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mFgColor != QColorConstants::Transparent) {
+#else
+                if (mFgColor != QColor("transparent")) {
+#endif
                     pC->setFgColor(r2, g2, b2);
                 }
             }
@@ -619,10 +635,18 @@ bool TTrigger::match_substring(const QString& toMatch, const QString& regex, int
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mBgColor != QColorConstants::Transparent) {
+#else
+                if (mBgColor != QColor("transparent")) {
+#endif
                     pC->setBgColor(r1, g1, b1);
                 }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mFgColor != QColorConstants::Transparent) {
+#else
+                if (mFgColor != QColor("transparent")) {
+#endif
                     pC->setFgColor(r2, g2, b2);
                 }
             }
@@ -734,10 +758,18 @@ bool TTrigger::match_color_pattern(int line, int regexNumber)
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mBgColor != QColorConstants::Transparent) {
+#else
+                if (mBgColor != QColor("transparent")) {
+#endif
                     pC->setBgColor(r1, g1, b1);
                 }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mFgColor != QColorConstants::Transparent) {
+#else
+                if (mFgColor != QColor("transparent")) {
+#endif
                     pC->setFgColor(r2, g2, b2);
                 }
             }
@@ -866,10 +898,18 @@ bool TTrigger::match_exact_match(const QString& toMatch, const QString& line, in
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mBgColor != QColorConstants::Transparent) {
+#else
+                if (mBgColor != QColor("transparent")) {
+#endif
                     pC->setBgColor(r1, g1, b1);
                 }
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 if (mFgColor != QColorConstants::Transparent) {
+#else
+                if (mFgColor != QColor("transparent")) {
+#endif
                     pC->setFgColor(r2, g2, b2);
                 }
             }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -418,8 +418,12 @@ END : {
                 // otherwise highlight complete expression match
                 if (i % numberOfCaptureGroups != 1) {
                     pC->selectSection(begin, length);
-                    pC->setBgColor(r1, g1, b1);
-                    pC->setFgColor(r2, g2, b2);
+                    if (mBgColor != QColorConstants::Transparent) {
+                        pC->setBgColor(r1, g1, b1);
+                    }
+                    if (mFgColor != QColorConstants::Transparent) {
+                        pC->setFgColor(r2, g2, b2);
+                    }
                 }
             } else {
                 pC->selectSection(begin, length);
@@ -491,8 +495,12 @@ bool TTrigger::match_begin_of_line_substring(const QString& toMatch, const QStri
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
-                pC->setBgColor(r1, g1, b1);
-                pC->setFgColor(r2, g2, b2);
+                if (mBgColor != QColorConstants::Transparent) {
+                    pC->setBgColor(r1, g1, b1);
+                }
+                if (mFgColor != QColorConstants::Transparent) {
+                    pC->setFgColor(r2, g2, b2);
+                }
             }
             pC->reset();
         }
@@ -611,8 +619,12 @@ bool TTrigger::match_substring(const QString& toMatch, const QString& regex, int
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
-                pC->setBgColor(r1, g1, b1);
-                pC->setFgColor(r2, g2, b2);
+                if (mBgColor != QColorConstants::Transparent) {
+                    pC->setBgColor(r1, g1, b1);
+                }
+                if (mFgColor != QColorConstants::Transparent) {
+                    pC->setFgColor(r2, g2, b2);
+                }
             }
             pC->reset();
         }
@@ -722,8 +734,12 @@ bool TTrigger::match_color_pattern(int line, int regexNumber)
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
-                pC->setBgColor(r1, g1, b1);
-                pC->setFgColor(r2, g2, b2);
+                if (mBgColor != QColorConstants::Transparent) {
+                    pC->setBgColor(r1, g1, b1);
+                }
+                if (mFgColor != QColorConstants::Transparent) {
+                    pC->setFgColor(r2, g2, b2);
+                }
             }
             pC->reset();
         }
@@ -850,8 +866,12 @@ bool TTrigger::match_exact_match(const QString& toMatch, const QString& line, in
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);
-                pC->setBgColor(r1, g1, b1);
-                pC->setFgColor(r2, g2, b2);
+                if (mBgColor != QColorConstants::Transparent) {
+                    pC->setBgColor(r1, g1, b1);
+                }
+                if (mFgColor != QColorConstants::Transparent) {
+                    pC->setFgColor(r2, g2, b2);
+                }
             }
             pC->reset();
         }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -822,12 +822,9 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             trigger.append_child("packageName").text().set(pT->mPackageName.toUtf8().constData());
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             trigger.append_child("mFgColor").text().set(pT->mFgColor == QColorConstants::Transparent ? "transparent": pT->mFgColor.name().toUtf8().constData());
-#else
-            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColor("transparent") ? "transparent": pT->mFgColor.name().toUtf8().constData());
-#endif
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             trigger.append_child("mBgColor").text().set(pT->mBgColor == QColorConstants::Transparent ? "transparent": pT->mBgColor.name().toUtf8().constData());
 #else
+            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColor("transparent") ? "transparent": pT->mFgColor.name().toUtf8().constData());
             trigger.append_child("mBgColor").text().set(pT->mBgColor == QColor("transparent") ? "transparent": pT->mBgColor.name().toUtf8().constData());
 #endif
             trigger.append_child("mSoundFile").text().set(pT->mSoundFile.toUtf8().constData());

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -820,8 +820,16 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             trigger.append_child("mStayOpen").text().set(QString::number(pT->mStayOpen).toUtf8().constData());
             trigger.append_child("mCommand").text().set(pT->mCommand.toUtf8().constData());
             trigger.append_child("packageName").text().set(pT->mPackageName.toUtf8().constData());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             trigger.append_child("mFgColor").text().set(pT->mFgColor == QColorConstants::Transparent ? "transparent": pT->mFgColor.name().toUtf8().constData());
+#else
+            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColor("transparent") ? "transparent": pT->mFgColor.name().toUtf8().constData());
+#endif
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             trigger.append_child("mBgColor").text().set(pT->mBgColor == QColorConstants::Transparent ? "transparent": pT->mBgColor.name().toUtf8().constData());
+#else
+            trigger.append_child("mBgColor").text().set(pT->mBgColor == QColor("transparent") ? "transparent": pT->mBgColor.name().toUtf8().constData());
+#endif
             trigger.append_child("mSoundFile").text().set(pT->mSoundFile.toUtf8().constData());
             trigger.append_child("colorTriggerFgColor").text().set(pT->mColorTriggerFgColor.name().toUtf8().constData());
             trigger.append_child("colorTriggerBgColor").text().set(pT->mColorTriggerBgColor.name().toUtf8().constData());

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -820,8 +820,8 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             trigger.append_child("mStayOpen").text().set(QString::number(pT->mStayOpen).toUtf8().constData());
             trigger.append_child("mCommand").text().set(pT->mCommand.toUtf8().constData());
             trigger.append_child("packageName").text().set(pT->mPackageName.toUtf8().constData());
-            trigger.append_child("mFgColor").text().set(pT->mFgColor.name().toUtf8().constData());
-            trigger.append_child("mBgColor").text().set(pT->mBgColor.name().toUtf8().constData());
+            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColorConstants::Transparent ? "transparent": pT->mFgColor.name().toUtf8().constData());
+            trigger.append_child("mBgColor").text().set(pT->mBgColor == QColorConstants::Transparent ? "transparent": pT->mBgColor.name().toUtf8().constData());
             trigger.append_child("mSoundFile").text().set(pT->mSoundFile.toUtf8().constData());
             trigger.append_child("colorTriggerFgColor").text().set(pT->mColorTriggerFgColor.name().toUtf8().constData());
             trigger.append_child("colorTriggerBgColor").text().set(pT->mColorTriggerBgColor.name().toUtf8().constData());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8855,9 +8855,9 @@ void dlgTriggerEditor::slot_editorContextMenu()
 QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bool isEnabled)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    if (color != QColorConstants::Transparent) {
+    if (color != QColorConstants::Transparent && color.isValid()) {
 #else
-    if (color != QColor("transparent")) {
+    if (color != QColor("transparent") && color.isValid()) {
 #endif
         if (isEnabled) {
             return QStringLiteral("QPushButton {color: %1; background-color: %2; }")

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4034,12 +4034,17 @@ void dlgTriggerEditor::saveTrigger()
         pT->mSoundTrigger = mpTriggersMainArea->groupBox_soundTrigger->isChecked();
         pT->setSound(mpTriggersMainArea->lineEdit_soundFile->text());
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QColor fgColor(QColorConstants::Transparent);
+        QColor bgColor(QColorConstants::Transparent);
+#else
+        QColor fgColor("transparent");
+        QColor bgColor("transparent");
+#endif
         if (!mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString().isEmpty()) {
             fgColor = QColor(mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString());
         }
         pT->setColorizerFgColor(fgColor);
-        QColor bgColor(QColorConstants::Transparent);
         if (!mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString().isEmpty()) {
             bgColor = QColor(mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString());
         }
@@ -5156,14 +5161,21 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
         mpTriggersMainArea->groupBox_triggerColorizer->setChecked(pT->isColorizerTrigger());
 
         QColor fgColor(pT->getFgColor());
-        mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, pT->isColorizerTrigger()));
-        mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, fgColor == QColorConstants::Transparent ? QStringLiteral("transparent") : fgColor.name());
-        mpTriggersMainArea->pushButtonFgColor->setText(fgColor == QColorConstants::Transparent ? tr("keep",
-             "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
         QColor bgColor(pT->getBgColor());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        bool transparentFg = fgColor == QColorConstants::Transparent;
+        bool transparentBg = bgColor == QColorConstants::Transparent;
+#else
+        bool transparentFg = fgColor == QColor("transparent");
+        bool transparentBg = bgColor == QColor("transparent");
+#endif
+        mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, pT->isColorizerTrigger()));
+        mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, transparentFg ? QStringLiteral("transparent") : fgColor.name());
+        mpTriggersMainArea->pushButtonFgColor->setText(transparentFg ? tr("keep",
+             "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
         mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(pT->getBgColor(), pT->isColorizerTrigger()));
-        mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, bgColor == QColorConstants::Transparent ? QStringLiteral("transparent") : bgColor.name());
-        mpTriggersMainArea->pushButtonBgColor->setText(bgColor == QColorConstants::Transparent ? tr("keep",
+        mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, transparentBg ? QStringLiteral("transparent") : bgColor.name());
+        mpTriggersMainArea->pushButtonBgColor->setText(transparentBg ? tr("keep",
              "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
 
         clearDocument(mpSourceEditorEdbee, pT->getScript());
@@ -8435,10 +8447,16 @@ void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
     auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString()),
                                         this,
                                         tr("Select foreground color to apply to matches"));
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     color = color.isValid() ? color : QColorConstants::Transparent;
+    bool keepColor = color == QColorConstants::Transparent;
+#else
+    color = color.isValid() ? color : QColor("transparent");
+    bool keepColor = color == QColor("transparent");
+#endif
     mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(color));
-    mpTriggersMainArea->pushButtonFgColor->setText(color == QColorConstants::Transparent ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
-    mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, color != QColorConstants::Transparent ? color.name() : QStringLiteral("transparent"));
+    mpTriggersMainArea->pushButtonFgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
+    mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, keepColor ? QStringLiteral("transparent") : color.name());
 }
 
 // Set the background color that will be applied to text that matches the trigger pattern(s)
@@ -8455,10 +8473,16 @@ void dlgTriggerEditor::slot_colorizeTriggerSetBgColor()
     auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString()),
                                         this,
                                         tr("Select background color to apply to matches"));
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     color = color.isValid() ? color : QColorConstants::Transparent;
+    bool keepColor = color == QColorConstants::Transparent;
+#else
+    color = color.isValid() ? color : QColor("transparent");
+    bool keepColor = color == QColor("transparent");
+#endif
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(color));
-    mpTriggersMainArea->pushButtonBgColor->setText(color == QColorConstants::Transparent ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
-    mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, color != QColorConstants::Transparent ? color.name() :  QStringLiteral("transparent"));
+    mpTriggersMainArea->pushButtonBgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
+    mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, keepColor ? QStringLiteral("transparent") : color.name());
 }
 
 void dlgTriggerEditor::slot_soundTrigger()
@@ -8830,7 +8854,11 @@ void dlgTriggerEditor::slot_editorContextMenu()
 
 QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bool isEnabled)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     if (color != QColorConstants::Transparent) {
+#else
+    if (color != QColor("transparent")) {
+#endif
         if (isEnabled) {
             return QStringLiteral("QPushButton {color: %1; background-color: %2; }")
                     .arg(color.lightness() > 127 ? QLatin1String("black") : QLatin1String("white"),


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Add an option to keep the colour when highlighting. This allows to select only the fore or background color.

The keep option looks good both on light and dark themes:
![Selection_626](https://user-images.githubusercontent.com/110988/82540350-3446d380-9b4f-11ea-928f-61b695225016.png)

![image](https://user-images.githubusercontent.com/110988/82540379-41fc5900-9b4f-11ea-97e7-8dc6fc1798ca.png)

#### Motivation for adding to Mudlet
Long overdue and requested by players!
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/3801

It will not build with Qt 5.11 just yet - still need to uglify code to make it compatible with older Qt versions.