### PR TITLE
sysWindowMousePress/ReleaseEvent also in UserWindows

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -582,6 +582,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 
     if (mType & (MainConsole | UserWindow)) {
         setAcceptDrops(true);
+        setMouseTracking(true);
     }
 }
 
@@ -3045,4 +3046,61 @@ std::pair<bool, QString> TConsole::setUserWindowTitle(const QString& name, const
     // as it means that the TConsole is flagged as being a user window yet
     // it does not have a TDockWidget to hold it...
     return {false, QStringLiteral("internal error: TConsole \"%1\" is marked as a user window but does not have a TDockWidget to contain it").arg(name)};
+}
+
+
+void TConsole::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const bool isPressEvent)
+{
+    TEvent mudletEvent{};
+    mudletEvent.mArgumentList.append(isPressEvent ? QStringLiteral("sysWindowMousePressEvent") : QStringLiteral("sysWindowMouseReleaseEvent"));
+    switch (event->button()) {
+    case Qt::LeftButton:    mudletEvent.mArgumentList.append(QString::number(1));   break;
+    case Qt::RightButton:   mudletEvent.mArgumentList.append(QString::number(2));   break;
+    case Qt::MidButton:     mudletEvent.mArgumentList.append(QString::number(3));   break;
+    case Qt::BackButton:    mudletEvent.mArgumentList.append(QString::number(4));   break;
+    case Qt::ForwardButton: mudletEvent.mArgumentList.append(QString::number(5));   break;
+    case Qt::TaskButton:    mudletEvent.mArgumentList.append(QString::number(6));   break;
+    case Qt::ExtraButton4:  mudletEvent.mArgumentList.append(QString::number(7));   break;
+    case Qt::ExtraButton5:  mudletEvent.mArgumentList.append(QString::number(8));   break;
+    case Qt::ExtraButton6:  mudletEvent.mArgumentList.append(QString::number(9));   break;
+    case Qt::ExtraButton7:  mudletEvent.mArgumentList.append(QString::number(10));  break;
+    case Qt::ExtraButton8:  mudletEvent.mArgumentList.append(QString::number(11));  break;
+    case Qt::ExtraButton9:  mudletEvent.mArgumentList.append(QString::number(12));  break;
+    case Qt::ExtraButton10: mudletEvent.mArgumentList.append(QString::number(13));  break;
+    case Qt::ExtraButton11: mudletEvent.mArgumentList.append(QString::number(14));  break;
+    case Qt::ExtraButton12: mudletEvent.mArgumentList.append(QString::number(15));  break;
+    case Qt::ExtraButton13: mudletEvent.mArgumentList.append(QString::number(16));  break;
+    case Qt::ExtraButton14: mudletEvent.mArgumentList.append(QString::number(17));  break;
+    case Qt::ExtraButton15: mudletEvent.mArgumentList.append(QString::number(18));  break;
+    case Qt::ExtraButton16: mudletEvent.mArgumentList.append(QString::number(19));  break;
+    case Qt::ExtraButton17: mudletEvent.mArgumentList.append(QString::number(20));  break;
+    case Qt::ExtraButton18: mudletEvent.mArgumentList.append(QString::number(21));  break;
+    case Qt::ExtraButton19: mudletEvent.mArgumentList.append(QString::number(22));  break;
+    case Qt::ExtraButton20: mudletEvent.mArgumentList.append(QString::number(23));  break;
+    case Qt::ExtraButton21: mudletEvent.mArgumentList.append(QString::number(24));  break;
+    case Qt::ExtraButton22: mudletEvent.mArgumentList.append(QString::number(25));  break;
+    case Qt::ExtraButton23: mudletEvent.mArgumentList.append(QString::number(26));  break;
+    case Qt::ExtraButton24: mudletEvent.mArgumentList.append(QString::number(27));  break;
+    default:                mudletEvent.mArgumentList.append(QString::number(0));
+    }
+    mudletEvent.mArgumentList.append(QString::number(event->x()));
+    mudletEvent.mArgumentList.append(QString::number(event->y()));
+    mudletEvent.mArgumentList.append(mConsoleName);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    mpHost->raiseEvent(mudletEvent);
+}
+
+
+void TConsole::mousePressEvent(QMouseEvent* event)
+{
+    raiseMudletMousePressOrReleaseEvent(event, true);
+}
+
+void TConsole::mouseReleaseEvent(QMouseEvent* event)
+{
+    raiseMudletMousePressOrReleaseEvent(event, false);
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -149,6 +149,7 @@ public:
     void moveCursorEnd();
     int getLastLineNumber();
     void refresh();
+    void raiseMudletMousePressOrReleaseEvent(QMouseEvent*, const bool);
     TLabel* createLabel(const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBackground, bool clickThrough = false);
     TConsole* createMiniConsole(const QString& windowname, const QString& name, int x, int y, int width, int height);
     std::pair<bool, QString> deleteLabel(const QString&);
@@ -334,6 +335,8 @@ public slots:
 protected:
     void dragEnterEvent(QDragEnterEvent*) override;
     void dropEvent(QDropEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
 
 private:
     void refreshMiniConsole() const;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -919,53 +919,11 @@ void TTextEdit::slot_popupMenu()
     mpHost->mLuaInterpreter.compileAndExecuteScript(cmd);
 }
 
-void TTextEdit::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const bool isPressEvent)
-{
-    TEvent mudletEvent{};
-    mudletEvent.mArgumentList.append(isPressEvent ? QStringLiteral("sysWindowMousePressEvent") : QStringLiteral("sysWindowMouseReleaseEvent"));
-    switch (event->button()) {
-    case Qt::LeftButton:    mudletEvent.mArgumentList.append(QString::number(1));   break;
-    case Qt::RightButton:   mudletEvent.mArgumentList.append(QString::number(2));   break;
-    case Qt::MidButton:     mudletEvent.mArgumentList.append(QString::number(3));   break;
-    case Qt::BackButton:    mudletEvent.mArgumentList.append(QString::number(4));   break;
-    case Qt::ForwardButton: mudletEvent.mArgumentList.append(QString::number(5));   break;
-    case Qt::TaskButton:    mudletEvent.mArgumentList.append(QString::number(6));   break;
-    case Qt::ExtraButton4:  mudletEvent.mArgumentList.append(QString::number(7));   break;
-    case Qt::ExtraButton5:  mudletEvent.mArgumentList.append(QString::number(8));   break;
-    case Qt::ExtraButton6:  mudletEvent.mArgumentList.append(QString::number(9));   break;
-    case Qt::ExtraButton7:  mudletEvent.mArgumentList.append(QString::number(10));  break;
-    case Qt::ExtraButton8:  mudletEvent.mArgumentList.append(QString::number(11));  break;
-    case Qt::ExtraButton9:  mudletEvent.mArgumentList.append(QString::number(12));  break;
-    case Qt::ExtraButton10: mudletEvent.mArgumentList.append(QString::number(13));  break;
-    case Qt::ExtraButton11: mudletEvent.mArgumentList.append(QString::number(14));  break;
-    case Qt::ExtraButton12: mudletEvent.mArgumentList.append(QString::number(15));  break;
-    case Qt::ExtraButton13: mudletEvent.mArgumentList.append(QString::number(16));  break;
-    case Qt::ExtraButton14: mudletEvent.mArgumentList.append(QString::number(17));  break;
-    case Qt::ExtraButton15: mudletEvent.mArgumentList.append(QString::number(18));  break;
-    case Qt::ExtraButton16: mudletEvent.mArgumentList.append(QString::number(19));  break;
-    case Qt::ExtraButton17: mudletEvent.mArgumentList.append(QString::number(20));  break;
-    case Qt::ExtraButton18: mudletEvent.mArgumentList.append(QString::number(21));  break;
-    case Qt::ExtraButton19: mudletEvent.mArgumentList.append(QString::number(22));  break;
-    case Qt::ExtraButton20: mudletEvent.mArgumentList.append(QString::number(23));  break;
-    case Qt::ExtraButton21: mudletEvent.mArgumentList.append(QString::number(24));  break;
-    case Qt::ExtraButton22: mudletEvent.mArgumentList.append(QString::number(25));  break;
-    case Qt::ExtraButton23: mudletEvent.mArgumentList.append(QString::number(26));  break;
-    case Qt::ExtraButton24: mudletEvent.mArgumentList.append(QString::number(27));  break;
-    default:                mudletEvent.mArgumentList.append(QString::number(0));
-    }
-    mudletEvent.mArgumentList.append(QString::number(event->x()));
-    mudletEvent.mArgumentList.append(QString::number(event->y()));
-    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    mpHost->raiseEvent(mudletEvent);
-}
-
 void TTextEdit::mousePressEvent(QMouseEvent* event)
 {
-    if (mpConsole->getType() == TConsole::MainConsole) {
-        raiseMudletMousePressOrReleaseEvent(event, true);
+    if (mpConsole->getType() == TConsole::MainConsole || mpConsole->getType() == TConsole::UserWindow) {
+        QMouseEvent newEvent(event->type(), mpConsole->parentWidget()->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+        mpConsole->raiseMudletMousePressOrReleaseEvent(&newEvent, true);
     }
 
     if (event->button() == Qt::LeftButton) {
@@ -1526,10 +1484,11 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mMouseTracking = false;
         mCtrlSelecting = false;
     }
-
-    if (mpConsole->getType() == TConsole::MainConsole) {
-        raiseMudletMousePressOrReleaseEvent(event, false);
-    } else if (mpConsole->getType() == TConsole::UserWindow && mpConsole->mpDockWidget && mpConsole->mpDockWidget->isFloating()) {
+    if (mpConsole->getType() == TConsole::MainConsole || mpConsole->getType() == TConsole::UserWindow) {
+        QMouseEvent newEvent(event->type(), mpConsole->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+        mpConsole->raiseMudletMousePressOrReleaseEvent(&newEvent, false);
+    }
+    if (mpConsole->getType() == TConsole::UserWindow && mpConsole->mpDockWidget && mpConsole->mpDockWidget->isFloating()) {
         // Need to take an extra step to return focus to main profile TConsole's
         // instance - using same method as TAction::execute():
         mpHost->mpConsole->activateWindow();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -921,8 +921,13 @@ void TTextEdit::slot_popupMenu()
 
 void TTextEdit::mousePressEvent(QMouseEvent* event)
 {
+    //new event to get mouse position on the parent window
+    QMouseEvent newEvent(event->type(), mpConsole->parentWidget()->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+    if (mpConsole->getType() == TConsole::SubConsole) {
+        qApp->sendEvent(mpConsole->parentWidget(), &newEvent);
+    }
+
     if (mpConsole->getType() == TConsole::MainConsole || mpConsole->getType() == TConsole::UserWindow) {
-        QMouseEvent newEvent(event->type(), mpConsole->parentWidget()->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
         mpConsole->raiseMudletMousePressOrReleaseEvent(&newEvent, true);
     }
 
@@ -1484,8 +1489,13 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         mMouseTracking = false;
         mCtrlSelecting = false;
     }
+    QMouseEvent newEvent(event->type(), mpConsole->parentWidget()->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
+
+    if (mpConsole->getType() == TConsole::SubConsole) {
+        qApp->sendEvent(mpConsole->parentWidget(), &newEvent);
+    }
+
     if (mpConsole->getType() == TConsole::MainConsole || mpConsole->getType() == TConsole::UserWindow) {
-        QMouseEvent newEvent(event->type(), mpConsole->mapFromGlobal(event->globalPos()), event->button(), event->buttons(), event->modifiers());
         mpConsole->raiseMudletMousePressOrReleaseEvent(&newEvent, false);
     }
     if (mpConsole->getType() == TConsole::UserWindow && mpConsole->mpDockWidget && mpConsole->mpDockWidget->isFloating()) {

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -132,7 +132,6 @@ private:
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
     void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
-    void raiseMudletMousePressOrReleaseEvent(QMouseEvent*, const bool);
 
     int mFontHeight;
     int mFontWidth;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR improves the sysWindowMousePress and sysWindowMouseRelease event to also work in UserWindows by adding the parameter windowname ("main" for mainWindow and the userwindow name in UserWindows)

Other changes are that x,y coordinates are now also correct if the mainWindow has a broder set, and the events also works on MiniConsoles now.

#### Motivation for adding to Mudlet
Possibility to create Labels on-click. ~~or even the possibility for a custom right-click menu (by using flyoutLabels).~~ (not good idea see comment below)

Another possibility would be to send container to a UserWindow by click.
Many other possibilities.

#### Other info (issues closed, discussion etc)
Example code for a Label which follows your mouse click (even into a (Geyser) UserWindow
```lua
function LabelTest(event, button, x, y, windowname)
  testLabel = testLabel or Geyser.Label:new({x=0, y=0, width=200, height=80, message = "following your click", color="dark_green"})
  testLabel:setAlignment("center")
  if windowname == "main" then
    testLabel:changeContainer("main")
    testLabel:move(x,y)
    testLabel:raise()
  else
    testLabel:changeContainer(Geyser.windowList[windowname.."Container"].windowList[windowname])
    testLabel:move(x,y)
    testLabel:raise()
  end
end
registerAnonymousEventHandler("sysWindowMouseReleaseEvent", "LabelTest")
```
