### PR TITLE
BugFix: process Cr+Null correctly in replays

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2519,7 +2519,7 @@ void cTelnet::slot_processReplayChunk()
                 command = "";
             }
         } else {
-            if (ch != '\r') {
+            if (ch != '\r' && ch != '\0') {
                 cleandata += ch;
             }
         }
@@ -2701,7 +2701,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                     // flash taskbar for 3 seconds on the telnet bell
                     QApplication::alert(mudlet::self(), 3000);
                 }
-                if (ch != '\r' && ch != 0) {
+                if (ch != '\r' && ch != '\0') {
                     cleandata += ch;
                 }
             }


### PR DESCRIPTION
The code that reads the replay data and replicates the behaviour of the same data being read down a TelNet link was, incorrectly, not discarding ASCII Null characters (compared to what happens for a Telnet data stream) this meant that whilst debugging an issue relating to the user of Cr+Null my replay data was causing Null characters to be sent to the `TBuffer::translateToPlainText (...)` method where it subsequently was spamming the debug outputs with warnings about being told to paint those Null characters (U+0000 codepoints)...!

For tidyness and consistency I changed the way that that same test was being written for the Telnet data version (from a test against `0` to `'\0'` - though of course they are equivalent).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>