### PR TITLE
Revise: comment out Color Trigger Debugging Message

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -718,7 +718,7 @@ bool TTrigger::match_color_pattern(int line, int regexNumber)
             auto its = captureList.begin();
             for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
                 int begin = *iti;
-                qDebug() << "TTrigger::match_color_pattern(" << line << "," << regexNumber << ") INFO - match found: " << (*its).c_str() << " size is:" << (*its).size();
+//                qDebug() << "TTrigger::match_color_pattern(" << line << "," << regexNumber << ") INFO - match found: " << (*its).c_str() << " size is:" << (*its).size();
                 std::string& s = *its;
                 int length = QString::fromStdString(s).size();
                 pC->selectSection(begin, length);


### PR DESCRIPTION
Whilst replaying some recording that were using Color Triggers I realised that the debug output was getting some spam from this message which could probably be discarded for the moment. So that it can be reactivated if needed I have commented it out rather than removing it altogether.

This was inserted in #1571 though that replaced a previous one which sent its output to `std::cout` ...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>