### PR TITLE
Refactor: remove dead code for mLF_on_GA

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -222,7 +222,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mProxyPassword(QString())
 , mIsGoingDown(false)
 , mIsProfileLoadingSequence(false)
-, mLF_ON_GA(true)
 , mNoAntiAlias(false)
 , mpEditorDialog(nullptr)
 , mpMap(new TMap(this, hostname))

--- a/src/Host.h
+++ b/src/Host.h
@@ -286,12 +286,6 @@ public:
         mTelnet.set_USE_IRE_DRIVER_BUGFIX(b);
     }
 
-    void set_LF_ON_GA(bool b)
-    {
-        mLF_ON_GA = b;
-        mTelnet.set_LF_ON_GA(b);
-    }
-
     void adjustNAWS();
 
     bool installPackage(const QString&, int);
@@ -390,7 +384,6 @@ public:
     // pushed down:
     bool mIsProfileLoadingSequence;
 
-    bool mLF_ON_GA;
     bool mNoAntiAlias;
 
     dlgTriggerEditor* mpEditorDialog;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -74,7 +74,6 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
 , mEncoding()
 , mpPostingTimer(new QTimer(this))
 , mUSE_IRE_DRIVER_BUGFIX(false)
-, mLF_ON_GA(false)
 , mCommands(0)
 , mMCCP_version_1(false)
 , mMCCP_version_2(false)
@@ -386,7 +385,6 @@ void cTelnet::connectIt(const QString& address, int port)
 {
     if (mpHost) {
         mUSE_IRE_DRIVER_BUGFIX = mpHost->mUSE_IRE_DRIVER_BUGFIX;
-        mLF_ON_GA = mpHost->mLF_ON_GA;
         mFORCE_GA_OFF = mpHost->mFORCE_GA_OFF;
 
         if (mpHost->mUseProxy && !mpHost->mProxyAddress.isEmpty() && mpHost->mProxyPort != 0) {
@@ -2533,9 +2531,7 @@ void cTelnet::slot_processReplayChunk()
                 }
             }
 
-            if (mUSE_IRE_DRIVER_BUGFIX || mLF_ON_GA) {
-                cleandata.push_back('\n'); //part of the broken IRE-driver bugfix to make up for broken \n-prepending in unsolicited lines, part #2 see line 628
-            }
+            cleandata.push_back('\n');
             recvdGA = false;
             gotPrompt(cleandata);
             cleandata = "";
@@ -2721,10 +2717,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                     gotPrompt(cleandata);
                     cleandata = "";
                 } else {
-                    if (mLF_ON_GA) //TODO: reenable option in preferences
-                    {
-                        cleandata.push_back('\n');
-                    }
+                    cleandata.push_back('\n');
                 }
             }
         } //for

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -147,7 +147,6 @@ public:
     void setAutoReconnect(bool status);
     void encodingChanged(const QByteArray&);
     void set_USE_IRE_DRIVER_BUGFIX(bool b) { mUSE_IRE_DRIVER_BUGFIX = b; }
-    void set_LF_ON_GA(bool b) { mLF_ON_GA = b; }
     void recordReplay();
     bool loadReplay(const QString&, QString* pErrMsg = nullptr);
     void loadReplayChunk();
@@ -271,7 +270,6 @@ private:
     QByteArray mEncoding;
     QTimer* mpPostingTimer;
     bool mUSE_IRE_DRIVER_BUGFIX;
-    bool mLF_ON_GA;
 
     int mCommands;
     bool mMCCP_version_1;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -668,8 +668,6 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     command_separator_lineedit->setText(pHost->mCommandSeparator);
 
     checkBox_USE_IRE_DRIVER_BUGFIX->setChecked(pHost->mUSE_IRE_DRIVER_BUGFIX);
-    //this option is changed into a forced option for GA enabled drivers as triggers wont run on prompt lines otherwise
-    //checkBox_LF_ON_GA->setChecked( pHost->mLF_ON_GA );
     checkBox_enableTextAnalyzer->setChecked(pHost->mEnableTextAnalyzer);
     checkBox_mUSE_FORCE_LF_AFTER_PROMPT->setChecked(pHost->mUSE_FORCE_LF_AFTER_PROMPT);
     USE_UNIX_EOL->setChecked(pHost->mUSE_UNIX_EOL);


### PR DESCRIPTION
Although the `(bool) cTelnet::mLF_ON_GA` is initialised to `false` it is always set to `true` by the same variable in the `Host` class - which is never unset. Therefore the execution where this is used as a condition is fixed to that for a `true` state. Thus it can be eliminated and the code cleaned up from it's removal.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>