### PR TITLE
Refactor: remove TBuffer::processSocketData(char*, int)

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2342,7 +2342,7 @@ void cTelnet::initStreamDecompressor()
     inflateInit(&mZstream);
 }
 
-int cTelnet::decompressBuffer(char*& in_buffer, int& length, char* out_buffer)
+int cTelnet::decompressBuffer(char* in_buffer, int& length, char* out_buffer)
 {
     mZstream.avail_in = length;
     mZstream.next_in = (Bytef*)in_buffer;
@@ -2555,21 +2555,14 @@ void cTelnet::handle_socket_signal_readyRead()
     }
 
     char in_buffer[100010];
-
     int amount = socket.read(in_buffer, 100000);
-    processSocketData(in_buffer, amount);
-}
-
-void cTelnet::processSocketData(char* in_buffer, int amount)
-{
-    mpHost->mInsertedMissingLF = false;
-
     char out_buffer[100010];
 
     in_buffer[amount + 1] = '\0';
     if (amount == -1) {
         return;
     }
+
     if (amount == 0) {
         return;
     }
@@ -2588,7 +2581,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
         if (mpHost->mpConsole->mRecordReplay) {
             mpHost->mpConsole->mReplayStream << timeOffset.elapsed() - lastTimeOffset;
             mpHost->mpConsole->mReplayStream << datalen;
-            mpHost->mpConsole->mReplayStream.writeRawData(&buffer[0], datalen);
+            mpHost->mpConsole->mReplayStream.writeRawData(buffer, datalen);
         }
 
         recvdGA = false;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -214,9 +214,8 @@ signals:
 private:
     cTelnet() = default;
 
-    void processSocketData(char *data, int size);
     void initStreamDecompressor();
-    int decompressBuffer(char*& in_buffer, int& length, char* out_buffer);
+    int decompressBuffer(char*, int&, char*);
     void reset();
 
     void processTelnetCommand(const std::string& command);


### PR DESCRIPTION
It really wasn't useful - it just refactored out some lines of code into a separate method for the cost of another function call...

Also fix a dodgy argument of the form (char*&) which was passing a char array anyhow.

A line `mpHost->mInsertedMissingLF = false;` is taken out by this PR but that member is never used and will be removed in another PR to be entered after this one.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>