### PR TITLE
Refactor: remove unused Host::mInsertedMissingLF boolean

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -213,7 +213,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mFORCE_GA_OFF(false)
 , mFORCE_NO_COMPRESSION(false)
 , mFORCE_SAVE_ON_EXIT(false)
-, mInsertedMissingLF(false)
 , mSslTsl(false)
 , mUseProxy(false)
 , mProxyAddress(QString())
@@ -942,7 +941,6 @@ QPair<QString, QString> Host::getSearchEngine()
 void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 {
     if (wantPrint && (!mIsRemoteEchoingActive) && mPrintCommand) {
-        mInsertedMissingLF = true;
         if (!cmd.isEmpty() || !mUSE_IRE_DRIVER_BUGFIX || mUSE_FORCE_LF_AFTER_PROMPT) {
             // used to print the terminal <LF> that terminates a telnet command
             // this is important to get the cursor position right

--- a/src/Host.h
+++ b/src/Host.h
@@ -369,7 +369,6 @@ public:
     bool mFORCE_GA_OFF;
     bool mFORCE_NO_COMPRESSION;
     bool mFORCE_SAVE_ON_EXIT;
-    bool mInsertedMissingLF;
 
     bool mSslTsl;
     bool mAutoReconnect;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2562,8 +2562,6 @@ void cTelnet::handle_socket_signal_readyRead()
 
 void cTelnet::processSocketData(char* in_buffer, int amount)
 {
-    mpHost->mInsertedMissingLF = false;
-
     char out_buffer[100010];
 
     in_buffer[amount + 1] = '\0';


### PR DESCRIPTION
This is the other PR mentioned in PR #3830 ,

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>