### PR TITLE
BugFix: attempt to fix some High and Medium Impact Coverity Issues

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -262,19 +262,27 @@ bool LuaInterface::reparentVariable(QTreeWidgetItem* newP, QTreeWidgetItem* cIte
         //FIXME: report why this fails to user
         return false;
     }
+
     if (!newParent && !oldParent) {
         //happens when we move from _G to _G
         return false;
-    } else if (!oldParent) {
+    }
+
+    if (!oldParent) {
         from = varUnit->getBase();
+        // newParent cannot be a nullptr here as we would have returned in
+        // previous if - so to won't be either:
         to = newParent;
     } else if (!newParent) {
+        // oldParent cannot be a nullptr here as we would have returned in
+        // previous if - so from won't be either:
         from = oldParent;
         to = varUnit->getBase();
     }
-    if (!from && !to) {
-        return false;
-    }
+
+    // one of from and to must not be a nullptr here - so prior test for BOTH
+    // being a nullptr here and returning false in that case was dead code.
+
     return reparentCVariable(from, to, curVar);
 }
 
@@ -374,11 +382,20 @@ bool LuaInterface::setValue(TVar* var)
     default:
         return false;
     }
-    luaL_loadstring(L, variableChangeCode.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    int error = luaL_loadstring(L, variableChangeCode.toUtf8().constData());
     if (error) {
-        QString emsg = QString::fromUtf8(lua_tostring(L, -1));
-        //FIXME: report error to user qDebug()<<"error msg"<<emsg;
+        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (parsing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << variableChangeCode << "\".";
+        return false;
+    }
+    error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    if (error) {
+        qWarning().noquote().nospace() << "LuaInterface::setValue(...) WARNING - Internal Lua (executing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << variableChangeCode << "\".";
         return false;
     }
     return true;
@@ -391,18 +408,27 @@ void LuaInterface::deleteVar(TVar* var)
     QString oldName = vars[0]->getName();
     for (int i = 1; i < vars.size(); i++) {
         if (vars[i]->getKeyType() == LUA_TNUMBER) {
-            oldName.append("[" + vars[i]->getName() + "]");
+            oldName.append(QStringLiteral("[%1]").arg(vars[i]->getName()));
         } else {
-            oldName.append(R"([")" + vars[i]->getName() + R"("])");
+            oldName.append(QStringLiteral(R"(["%1"])").arg(vars[i]->getName()));
         }
     }
     //delete it
-    oldName.append(QString(" = nil"));
-    luaL_loadstring(L, oldName.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    oldName.append(QStringLiteral(" = nil"));
+    int error = luaL_loadstring(L, oldName.toUtf8().constData());
     if (error) {
-        QString emsg = QString::fromUtf8(lua_tostring(L, -1));
-        //FIXME: report error to userqDebug()<<"error msg"<<emsg;
+        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (parsing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << oldName << "\".";
+        return;
+    }
+    error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    if (error) {
+        qWarning().noquote().nospace() << "LuaInterface::deleteVar(...) WARNING - Internal Lua (executing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << oldName << "\".";
     }
 }
 
@@ -569,21 +595,24 @@ void LuaInterface::renameVar(TVar* var)
     if (vars.size() > 1) {
         newName = vars[0]->getName();
     }
+
     for (int i = 1; i < vars.size(); i++) {
         int kType = vars[i]->getKeyType();
         if (kType == LUA_TNUMBER) {
             oldVariable.append(QStringLiteral("[%1]").arg(vars.at(i)->getName()));
             if (i < vars.size() - 1) {
-                newName.append("[" + vars[i]->getName() + "]");
+                newName.append(QStringLiteral("[%1]").arg(vars[i]->getName()));
             }
+
         } else if (kType == LUA_TTABLE) {
             renameCVar(vars);
             return;
-        } else {
-            oldVariable.append(QStringLiteral("[\"%1\"]").arg(vars.at(i)->getName()));
-            if (i < vars.size() - 1) {
-                newName.append(QStringLiteral("[\"%1\"]").arg(vars.at(i)->getName()));
-            }
+        }
+
+        // That leaves LUA_TSTRING:
+        oldVariable.append(QStringLiteral(R"(["%1"])").arg(vars.at(i)->getName()));
+        if (i < vars.size() - 1) {
+            newName.append(QStringLiteral(R"(["%1"])").arg(vars.at(i)->getName()));
         }
     }
 
@@ -595,24 +624,46 @@ void LuaInterface::renameVar(TVar* var)
         if (var->getNewKeyType() == LUA_TNUMBER) {
             newName.append(QStringLiteral("[%1]").arg(vars.last()->getNewName()));
         } else {
-            newName.append(QStringLiteral("[\"%1\"]").arg(vars.last()->getNewName()));
+            newName.append(QStringLiteral(R"(["%1"])").arg(vars.last()->getNewName()));
         }
     }
 
     auto renameCode = QStringLiteral("%1 = %2").arg(newName, oldVariable);
-    luaL_loadstring(L, renameCode.toUtf8().constData());
-    int error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    int error = luaL_loadstring(L, renameCode.toUtf8().constData());
     if (error) {
-        QString emsg = QString::fromUtf8(lua_tostring(L, -1));
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (parsing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << renameCode << "\".";
         var->clearNewName();
         return;
     }
-    //delete it
-    luaL_loadstring(L, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
     error = lua_pcall(L, 0, LUA_MULTRET, 0);
     if (error) {
-        QString emsg = QString::fromUtf8(lua_tostring(L, -1));
-        //FIXME: report error to userqDebug()<<"error msg"<<emsg;
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In copying (first) stage, internal Lua (executing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << renameCode << "\".";
+        var->clearNewName();
+        return;
+    }
+
+    //delete it
+    error = luaL_loadstring(L, oldVariable.append(QLatin1String(" = nil")).toUtf8().constData());
+    if (error) {
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (parsing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << renameCode << "\".";
+        var->clearNewName();
+        return;
+    }
+    error = lua_pcall(L, 0, LUA_MULTRET, 0);
+    if (error) {
+        qWarning().noquote().nospace() << "LuaInterface::renameVar(...) WARNING - In deleting (second) stage, internal Lua (executing) error: \""
+                                       << lua_tostring(L, -1)
+                                       << "\" in code:\n\""
+                                       << renameCode << "\".";
     }
     var->clearNewName();
 }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018-2019 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2018-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,13 +24,16 @@
 
 
 #include "Host.h"
-#include <QRegularExpression>
 #include "TConsole.h"
 #include "TSplitter.h"
 #include "TTabBar.h"
 #include "TTextEdit.h"
 #include "mudlet.h"
 
+#include "pre_guard.h"
+#include <QKeyEvent>
+#include <QRegularExpression>
+#include "post_guard.h"
 
 TCommandLine::TCommandLine(Host* pHost, TConsole* pConsole, QWidget* parent)
 : QPlainTextEdit(parent)
@@ -107,6 +110,13 @@ bool TCommandLine::event(QEvent* event)
     const Qt::KeyboardModifiers allModifiers = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier;
     if (event->type() == QEvent::KeyPress) {
         auto* ke = dynamic_cast<QKeyEvent*>(event);
+        if (!ke) {
+            // Something is wrong -
+            qCritical().noquote() << "TCommandLine::event(QEvent*) CRITICAL - a QEvent that is supposed to be a QKeyEvent is not dynmically castable to the latter - so the processing of this event "
+                                     "has been aborted - please report this to Mudlet Makers.";
+            // Indicate that we don't want to touch this event with a barge-pole!
+            return false;
+        }
 
         // Shortcut for keypad keys
         if ((ke->modifiers() & Qt::KeypadModifier) && mpKeyUnit->processDataStream(ke->key(), (int)ke->modifiers())) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5855,11 +5855,15 @@ int TLuaInterpreter::searchRoom(lua_State* L)
         if (!roomIdsFound.isEmpty()) {
             for (int i : roomIdsFound) {
                 TRoom* pR = host.mpMap->mpRoomDB->getRoom(i);
-                QString name = pR->name;
-                int roomID = pR->getId();
-                lua_pushnumber(L, roomID);
-                lua_pushstring(L, name.toUtf8().constData());
-                lua_settable(L, -3);
+                // This test is to keep Coverity happy as it thinks pR could be
+                // a nullptr in some odd situation {CID 1415023}:
+                if (pR) {
+                    QString name = pR->name;
+                    int roomID = pR->getId();
+                    lua_pushnumber(L, roomID);
+                    lua_pushstring(L, name.toUtf8().constData());
+                    lua_settable(L, -3);
+                }
             }
         }
         return 1;
@@ -7454,6 +7458,9 @@ int TLuaInterpreter::tempTimer(lua_State* L)
         }
 
         TTimer* timer = host.getTimerUnit()->getTimer(result.first);
+        Q_ASSERT_X(timer,
+                   "TLuaInterpreter::tempTimer(...)",
+                   "Got a positive result from LuaInterpreter::startTempTimer(...) but that failed to produce pointer to it from Host::mTimerUnit::getTimer(...)");
         timer->mRegisteredAnonymousLuaFunction = true;
         lua_pushlightuserdata(L, timer);
         lua_pushvalue(L, 2);
@@ -15741,7 +15748,7 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
 {
     lua_State* L = pGlobalLua;
     lua_rawgeti(L, LUA_REGISTRYINDEX, func);
-    int error;
+    int error = 0;
     if (qE) {
         // Create Lua table with QEvent data if needed
         switch (qE->type()) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -66,6 +66,11 @@ TMap::TMap(Host* pH, const QString& profileName)
 , mMapSymbolFont(QFont(QStringLiteral("Bitstream Vera Sans Mono"), 12, QFont::Normal))
 , mMapSymbolFontFudgeFactor(1.0)
 , mIsOnlyMapSymbolFontToBeUsed(false)
+// These three are actually set to values from the Host class but initialising
+// them to the same defaults here keeps Coverity happy:
+, mPlayerRoomStyle(0)
+, mPlayerRoomOuterDiameterPercentage(120)
+, mPlayerRoomInnerDiameterPercentage(70)
 , mIsFileViewingRecommended(false)
 , mpNetworkAccessManager(Q_NULLPTR)
 , mpProgressDialog(Q_NULLPTR)

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -16,9 +16,27 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
 #include "TMxpNodeBuilder.h"
 #include "TMxpTagParser.h"
 #include "TStringUtils.h"
+
+TMxpNodeBuilder::TMxpNodeBuilder(bool ignoreText)
+: mOptionIgnoreText(ignoreText)
+, mIsEndTag(false)
+, mIsInsideTag(false)
+, mIsInsideAttr(false)
+, mReadingAttrValue(false)
+, mIsInsideSequence(false)
+, mIsQuotedSequence(false)
+, mOpeningQuote('\0')
+, mSequenceHasSpaces(false)
+, mHasSequence(false)
+, mIsInsideText(false)
+, mHasNode(false)
+, mIsText(false)
+{
+}
 
 bool TMxpNodeBuilder::accept(char ch)
 {

--- a/src/TMxpNodeBuilder.h
+++ b/src/TMxpNodeBuilder.h
@@ -73,19 +73,7 @@ class TMxpNodeBuilder
     void processAttribute();
 
 public:
-    explicit TMxpNodeBuilder(bool ignoreText = false)
-    : mOptionIgnoreText(ignoreText)
-    , mIsInsideTag(false)
-    , mHasNode(false)
-    , mIsInsideAttr(false)
-    , mIsInsideSequence(false)
-    , mHasSequence(false)
-    , mIsQuotedSequence(false)
-    , mIsText(false)
-    , mIsInsideText(false)
-    , mSequenceHasSpaces(false)
-    {
-    }
+    explicit TMxpNodeBuilder(bool ignoreText = false);
 
     // returns true when a node (text/tag start/tag end) is available
     // the same char has to be input again when a match is found as it may be a boundary

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -159,20 +159,12 @@ void TimerUnit::_removeTimerRootNode(TTimer* pT)
 
 TTimer* TimerUnit::getTimer(int id)
 {
-    if (mTimerMap.find(id) != mTimerMap.end()) {
-        return mTimerMap.value(id);
-    } else {
-        return nullptr;
-    }
+    return mTimerMap.value(id);
 }
 
 TTimer* TimerUnit::getTimerPrivate(int id)
 {
-    if (mTimerMap.find(id) != mTimerMap.end()) {
-        return mTimerMap.value(id);
-    } else {
-        return nullptr;
-    }
+    return mTimerMap.value(id);
 }
 
 bool TimerUnit::registerTimer(TTimer* pT)

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -70,7 +70,6 @@ public:
 
 
     QMultiMap<QString, TTimer*> mLookupTable;
-    QMutex mTimerUnitLock;
     int statsActiveTriggers;
     int statsTriggerTotal;
     int statsTempTriggers;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -119,8 +119,6 @@ XMLexport::XMLexport( TKey * pT )
 {
 }
 
-XMLexport::~XMLexport() = default;
-
 void XMLexport::writeModuleXML(const QString& moduleName, const QString& fileName)
 {
     auto pHost = mpHost;

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -56,7 +56,6 @@ public:
     XMLexport(TAction*);
     XMLexport(TScript*);
     XMLexport(TKey*);
-    ~XMLexport();
 
     void writeHost(Host*, pugi::xml_node hostPackage);
     void writeTrigger(TTrigger*, pugi::xml_node xmlParent);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -243,8 +243,6 @@ private:
     QTextEncoder* outgoingDataEncoder;
     QString hostName;
     int hostPort;
-    double networkLatencyMin;
-    double networkLatencyMax;
     bool mWaitingForResponse;
     std::queue<int> mCommandQueue;
 
@@ -252,7 +250,9 @@ private:
 
     bool mNeedDecompression;
     std::string command;
-    bool iac, iac2, insb;
+    bool iac;
+    bool iac2;
+    bool insb;
     // Set if we have negotiated the use of the option by us:
     bool myOptionState[256];
     // Set if he has negotiated the use of the option by him:
@@ -266,7 +266,6 @@ private:
     bool triedToEnable[256];
     bool recvdGA;
 
-    int curX, curY;
     QString termType;
     QByteArray mEncoding;
     QTimer* mpPostingTimer;

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -391,6 +391,13 @@ void Discord::UpdatePresence()
         mCurrentApplicationId = applicationID;
     }
 
+    // Coverity thinks that pDiscordPresence could be a nullptr here, which
+    // would be bad {CID 1473922} so lets test for that and abort:
+    if (!pDiscordPresence) {
+        qCritical().noquote() << "Discord::UpdatePresence() CRITICAL - pDiscordPresence is unexpectedly a nullptr, unable to proceed with this procedure, please report this to Mudlet Makers!";
+        return;
+    }
+
     if (pHost->mDiscordAccessFlags & Host::DiscordSetDetail) {
         pDiscordPresence->setDetailText(mDetailTexts.value(pHost));
     } else {

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -328,8 +328,8 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else { // No valid exit on the dialogue
-        if (originalExits.value(dirCode)->destination > 0) {
-            pR->setExit(-1, dirCode); // Destination has been deleted So ensure the value for no exit is stored
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+            pR->setExit(-1, dirCode); // Destination has been deleted so ensure the value for no exit is stored
         }
         if (stub_nw->isChecked() != pR->hasExitStub(dirCode)) {
             // Does the stub exit setting differ from what is stored
@@ -357,7 +357,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_n->isChecked() != pR->hasExitStub(dirCode)) {
@@ -385,7 +385,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_ne->isChecked() != pR->hasExitStub(dirCode)) {
@@ -413,7 +413,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_up->isChecked() != pR->hasExitStub(dirCode)) {
@@ -441,7 +441,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_w->isChecked() != pR->hasExitStub(dirCode)) {
@@ -469,7 +469,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_e->isChecked() != pR->hasExitStub(dirCode)) {
@@ -497,7 +497,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_down->isChecked() != pR->hasExitStub(dirCode)) {
@@ -525,7 +525,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_sw->isChecked() != pR->hasExitStub(dirCode)) {
@@ -553,7 +553,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_s->isChecked() != pR->hasExitStub(dirCode)) {
@@ -581,7 +581,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_se->isChecked() != pR->hasExitStub(dirCode)) {
@@ -609,7 +609,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.value(dirCode)->destination > 0) {
+        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_in->isChecked() != pR->hasExitStub(dirCode)) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4572,6 +4572,7 @@ int dlgTriggerEditor::canRecast(QTreeWidgetItem* pItem, int newNameType, int new
     if (currentValueType == LUA_TFUNCTION || currentNameType == LUA_TTABLE) {
         return 0; //no recasting functions or table keys
     }
+
     if (newValueType == LUA_TTABLE && currentValueType != LUA_TTABLE) {
         //trying to change a table to something else
         if (!var->getChildren(false).empty()) {
@@ -4580,9 +4581,7 @@ int dlgTriggerEditor::canRecast(QTreeWidgetItem* pItem, int newNameType, int new
         //no children, we can do this without bad things happening
         return 1;
     }
-    if (newValueType == LUA_TTABLE && currentValueType != LUA_TTABLE) {
-        return 1; //non-table to table
-    }
+
     if (currentNameType == newNameType && currentValueType == newValueType) {
         return 2;
     }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -611,11 +611,11 @@ void GLWidget::paintGL()
                     glLoadIdentity();
                     gluLookAt(px * 0.1 + xRot, py * 0.1 + yRot, pz * 0.1 + zRot, px * 0.1, py * 0.1, pz * 0.1, 0.0, 1.0, 0.0);
                     glScalef(0.1, 0.1, 0.1);
-                    if (areaExit) {
-                        glLineWidth(1); //1/mScale+2);
-                    } else {
+                    // if (areaExit) {
+                    //    glLineWidth(1); //1/mScale+2);
+                    // } else {
                         glLineWidth(1); //1/mScale);
-                    }
+                    // }
                     if (k == mRID || ((rz == pz) && (rx == px) && (ry == py))) {
                         glDisable(GL_BLEND);
                         glEnable(GL_LIGHTING);
@@ -1022,11 +1022,11 @@ void GLWidget::paintGL()
                     glLoadIdentity();
                     gluLookAt(px * 0.1 + xRot, py * 0.1 + yRot, pz * 0.1 + zRot, px * 0.1, py * 0.1, pz * 0.1, 0.0, 1.0, 0.0);
                     glScalef(0.1, 0.1, 0.1);
-                    if (areaExit) {
-                        glLineWidth(1); //1/mScale+2);
-                    } else {
+                    // if (areaExit) {
+                    //    glLineWidth(1); //1/mScale+2);
+                    // } else {
                         glLineWidth(1); //1/mScale);
-                    }
+                    // }
                     if (k == mRID || ((rz == pz) && (rx == px) && (ry == py))) {
                         glDisable(GL_BLEND);
                         glEnable(GL_LIGHTING);


### PR DESCRIPTION
Referring to: https://scan7.coverity.com/reports.htm#v27731/p14359

Impact | CID | Type | Detail
---------|------|--------|------
High|1492499|Uninitialized scalar variable (UNINIT)|5. uninit_use: Using uninitialized value error.
High|1485860|No virtual destructor|A1. dtor_in_derived: Class `XMLimport` has a compiler-generated destructor. It is non-empty because of its field `mpHost`. A pointer to class `XMLimport` is upcast to class `QXmlStreamReader` which doesn't have a virtual destructor.
Medium|1492834|Uninitialized scalar field (UNINIT_CTOR)|2. uninit_member: Non-static class member `mIsEndTag` is not initialized in this constructor nor in any functions that it calls.
||||4. uninit_member: Non-static class member `mIsEmptyTag` is not initialized in this constructor nor in any functions that it calls.
||||6. uninit_member: Non-static class member `mReadingAttrValue` is not initialized in this constructor nor in any functions that it calls.
||||8. uninit_member: Non-static class member `mOpeningQuote` is not initialized in this constructor nor in any functions that it calls."
Medium|1488910|Uninitialized scalar field (UNINIT_CTOR)|2. uninit_member: Non-static class member `mPlayerRoomStyle` is not initialized in this constructor nor in any functions that it calls.
||||4. uninit_member: Non-static class member `mPlayerRoomOuterDiameterPercentage` is not initialized in this constructor nor in any functions that it calls.
||||6. uninit_member: Non-static class member `mPlayerRoomInnerDiameterPercentage` is not initialized in this constructor nor in any functions that it calls.
Medium|1478854|Uninitialized pointer field (UNINIT_CTOR)|4. uninit_member: Non-static class member `mpOutOfBandDataIncomingCodec` is not initialized in this constructor nor in any functions that it calls.
Medium|1468478|Unchecked return value (CHECKED_RETURN)|10. check_return: Calling `luaL_loadstring` without checking return value (as is done elsewhere 17 out of 21 times).
Medium|1468477|Unchecked return value (CHECKED_RETURN)|14. check_return: Calling `luaL_loadstring` without checking return value (as is done elsewhere 17 out of 21 times).
Medium|1468474|Unchecked return value (CHECKED_RETURN)|16. check_return: Calling `luaL_loadstring` without checking return value (as is done elsewhere 17 out of 21 times). **x 2**
Medium|1468468|Logically dead code (DEADCODE)|dead_error_line: Execution cannot reach this statement: `return 1;`
Medium|1415097|Dereference null return value (NULL_RETURNS)|8. dereference: Dereferencing timer, which is known to be `nullptr`
Medium|1415092|Identical code for different branches (IDENTICAL_BRANCHES)|"identical_branches: The same code is executed regardless of whether `areaExit` is true, because the 'then' and 'else' branches are identical. Should one of the branches be modified, or the entire 'if' statement replaced? **x 2**
Medium|1415023|Dereference null return value (NULL_RETURNS)|26. dereference: Dereferencing a pointer that might be `nullptr` `pR->name` when calling `QString`.
Medium|1414989|Explicit null dereferenced (FORWARD_NULL)|81. var_deref_op: Dereferencing null pointer `this->originalExits.value(dirCode, TExit * const(NULL))`. **x 11**
Medium|1414977|Logically dead code (DEADCODE)|dead_error_line: Execution cannot reach this statement: `return false;`.

Also removed unused:
* (int) cTelnet::curX & curY,
* (double) cTelnet::networkLatencyMin & networkLatencyMax
* (QMutex) TimerUnit::mTimerUnitLock

There are still some **High** impact issues associated with the `TMedia` and related classes but I could not grok them enough to work out how to fix them...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>