### PR TITLE
BugFix: cure setTextFormat(...) colour reversal

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -3104,3 +3104,19 @@ void TConsole::mouseReleaseEvent(QMouseEvent* event)
 {
     raiseMudletMousePressOrReleaseEvent(event, false);
 }
+
+bool TConsole::setTextFormat(const QString& name, const QColor& fgColor, const QColor& bgColor, const TChar::AttributeFlags& flags)
+{
+    if (name.isEmpty() || name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+        mFormatCurrent.setTextFormat(fgColor, bgColor, flags);
+        return true;
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (pC) {
+        pC->mFormatCurrent.setTextFormat(fgColor, bgColor, flags);
+        return true;
+    }
+
+    return false;
+}

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -219,6 +219,7 @@ public:
     QPair<quint8, TChar> getTextAttributes() const;
     QPair<quint8, TChar> getTextAttributes(const QString&) const;
     std::pair<bool, QString> setUserWindowTitle(const QString& name, const QString& text);
+    bool setTextFormat(const QString& name, const QColor& fgColor, const QColor& bgColor, const TChar::AttributeFlags& flags);
 
 
     QPointer<Host> mpHost;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5126,24 +5126,16 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
             | (strikeout ? TChar::StrikeOut : TChar::None)
             | (underline ? TChar::Underline : TChar::None);
 
-    if (windowName.isEmpty() || windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-        TConsole* pC = host.mpConsole;
-        if (Q_UNLIKELY(!pC)) {
-            lua_pushboolean(L, false);
-            lua_pushstring(L, "mudlet error: main window does not exist");
-            return 2;
-        }
-        pC->mFormatCurrent.setTextFormat(QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)),
-                                         QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)),
-                                         flags);
-        lua_pushboolean(L, true);
-    } else {
-        lua_pushboolean(L, mudlet::self()->setTextFormat(&host, windowName,
-                                                         QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)),
-                                                         QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)),
-                                                         flags));
+    if (!host.mpConsole->setTextFormat(windowName,
+                                      QColor(colorComponents.at(3), colorComponents.at(4), colorComponents.at(5)),
+                                      QColor(colorComponents.at(0), colorComponents.at(1), colorComponents.at(2)),
+                                      flags)) {
+        lua_pushboolean(L, false);
+        lua_pushfstring(L, "window \"%s\" does not exist", windowName.toUtf8().constData());
+        return 2;
     }
 
+    lua_pushboolean(L, true);
     return 1;
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2261,23 +2261,6 @@ bool mudlet::setBackgroundImage(Host* pHost, const QString& name, QString& path)
     }
 }
 
-bool mudlet::setTextFormat(Host* pHost, const QString& name, const QColor& bgColor, const QColor& fgColor, const TChar::AttributeFlags attributes)
-{
-    if (!pHost || !pHost->mpConsole) {
-        return false;
-    }
-
-    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        pC->mFormatCurrent.setTextFormat(fgColor, bgColor, attributes);
-        pC->mUpperPane->forceUpdate();
-        pC->mLowerPane->forceUpdate();
-        return true;
-    } else {
-        return false;
-    }
-}
-
 bool mudlet::setDisplayAttributes(Host* pHost, const QString& name, const TChar::AttributeFlags attributes, const bool state)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -169,7 +169,6 @@ public:
     bool pasteWindow(Host* pHost, const QString& name);
     bool setBackgroundColor(Host*, const QString& name, int r, int g, int b, int alpha);
     bool setBackgroundImage(Host*, const QString& name, QString& path);
-    bool setTextFormat(Host*, const QString& name, const QColor &bgColor, const QColor &fgColor, const TChar::AttributeFlags attributes = TChar::None);
     bool setDisplayAttributes(Host* pHost, const QString& name, const TChar::AttributeFlags attributes, const bool state);
     bool setLabelClickCallback(Host*, const QString&, const int);
     bool setLabelDoubleClickCallback(Host*, const QString&, const int);


### PR DESCRIPTION
This PR Closes #2315.

It replaces the somewhat pointless `(bool) mudlet::setTextFormat(...)` method with a method in the main `TConsole` that sends the **correct** arguments to it's own or a subsidiary console's `TBuffer` instance.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>