### PR TITLE
Fix `Adjustable.Container` pixel precision error

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -20,11 +20,11 @@ Adjustable.Container = Adjustable.Container or Geyser.Container:new({name = "Adj
 local adjustInfo = {}
 
 -- Internal function to add "%" to a value and round it
--- @param num is the value a "%" will be added to
+-- Resulting percentage has five precision points to ensure accurate 
+-- representation in pixel space.
+-- @param num Any float. For 0-100% output, use 0.0-1.0
 local function make_percent(num)
-    num = math.floor(10000*num)/100
-    num = tostring(num).."%"
-    return num
+    return string.format("%.5f%%", (num * 100))
 end
 
 -- Internal function: checks where the mouse is at on the Label


### PR DESCRIPTION
When making constraint adjustments, the existing math used to calculate new coordinates and dimensions suffers a loss in accuracy when converting to percentage-based representation rather than pixel based. For minor adjustments, this is not noticeable, but it builds up over time. For example, widening the container by dragging the left edge 100 pixels might result in the right edge moving left 5-6 pixels.

The issue is that a target pixel size or destination might have sub-pixel precision of 3-4 meaningful points but the function used to convert this value into a percentage of width or height limited the precision to two places. Unless the math was ideal in a given transformation, this always resulted in values less than they should be by fractions of a pixel.

This PR simplifies that conversion and extends the precision to five places, which makes any loss in fidelity negligible.