### PR TITLE
Don't stop running event handlers if one has an error

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -314,6 +314,7 @@ public:
     static int disableKey(lua_State* L);
     static int killKey(lua_State* L);
     static int debug(lua_State* L);
+    static int showHandlerError(lua_State* L);
     static int setWindowWrap(lua_State*);
     static int setWindowWrapIndent(lua_State*);
     static int resetFormat(lua_State*);
@@ -562,6 +563,7 @@ public slots:
 
 private:
     void logError(std::string& e, const QString&, const QString& function);
+    void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);
     bool validLuaCode(const QString &code);
     QByteArray encodeBytes(const char*);

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -841,7 +841,8 @@ do
   function dispatchEventToFunctions(event, ...)
     if handlers[event] then
       for _, func in pairs(handlers[event]) do
-        func(event, ...)
+        local success, error = pcall(func, event, ...)
+	if not success then debugc(string.format("Error running event handler for %s: %s", event, error)) end
       end
     end
   end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -842,7 +842,7 @@ do
     if handlers[event] then
       for _, func in pairs(handlers[event]) do
         local success, error = pcall(func, event, ...)
-	if not success then debugc(string.format("Error running event handler for %s: %s", event, error)) end
+        if not success then showHandlerError(event, error) end
       end
     end
   end


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't stop running event handlers if one has an error by the means of pcall.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
We can't actually raise a proper event because doing that would stop execution flow.

Maybe another function like debugc, but for errors, is worthwhile.

Possibly closes https://github.com/Mudlet/Mudlet/issues/1311 too.

![image](https://user-images.githubusercontent.com/110988/83156892-42729200-a103-11ea-84f2-59e7d2d34cbd.png)
