### PR TITLE
Ensure all anonymous event handlers try to run

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -841,7 +841,10 @@ do
   function dispatchEventToFunctions(event, ...)
     if handlers[event] then
       for _, func in pairs(handlers[event]) do
-        func(event, ...)
+        local worked, err = pcall(func, event, ...)
+        if not worked then
+          debugc(string.format("Anonymous Event Handler for event %s failed with the following error: %s", event, err))
+        end
       end
     end
   end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Wraps anonymous event handler function calls in pcall, then if the call errors displays that error for the user via debugc so that they know what happened, but don't also block further event handlers from running.

#### Motivation for adding to Mudlet
It's come up a few times now that if an anonymous event handler errors, further anonymous event handlers are not run as the loop which executes the functions is interrupted.

#### Other info (issues closed, discussion etc)
