### PR TITLE
Enhance: make multiView persistent

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2016, 2018-2019 by Stephen Lyons                   *
+ *   Copyright (C) 2013-2016, 2018-2020 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *                                                                         *
@@ -2498,6 +2498,7 @@ bool T2DMap::event(QEvent* event)
 
 void T2DMap::mousePressEvent(QMouseEvent* event)
 {
+    mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;
     if (event->buttons() & Qt::LeftButton) {
         // move map with left mouse button + ALT

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -549,6 +549,10 @@ void TCommandLine::focusInEvent(QFocusEvent* event)
 
     mpConsole->mUpperPane->forceUpdate();
     mpConsole->mLowerPane->forceUpdate();
+
+    // Make sure this profile's tab gets activated in multi-view mode:
+    mudlet::self()->activateProfile(mpHost);
+
     QPlainTextEdit::focusInEvent(event);
 }
 
@@ -820,12 +824,17 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
 
         mPopupPosition = event->pos();
         popup->popup(event->globalPos());
+        // The use of accept here prevents this event from reaching any parent
+        // widget - like the TConsole containing this TCommandLine...
         event->accept();
+        mudlet::self()->activateProfile(mpHost);
         return;
     }
 
-    // Process any other possible mousePressEvent
+    // Process any other possible mousePressEvent - which is default popup
+    // handling - and which accepts the event:
     QPlainTextEdit::mousePressEvent(event);
+    mudlet::self()->activateProfile(mpHost);
 }
 
 void TCommandLine::enterCommand(QKeyEvent* event)

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -570,6 +570,8 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         // absence of files for the first run in a new profile or from an older
         // Mudlet version:
         setProfileSpellDictionary();
+        slot_setCompactInputLine(mudlet::self()->compactInputLine());
+        connect(mudlet::self(), &mudlet::signal_setCompactInputLine, this, &TConsole::slot_setCompactInputLine, Qt::UniqueConnection);
     }
 
     // error and debug consoles inherit font of the main console
@@ -3103,4 +3105,11 @@ void TConsole::mousePressEvent(QMouseEvent* event)
 void TConsole::mouseReleaseEvent(QMouseEvent* event)
 {
     raiseMudletMousePressOrReleaseEvent(event, false);
+}
+
+void TConsole::slot_setCompactInputLine(const bool state)
+{
+    if (mpButtonMainLayer) {
+        mpButtonMainLayer->setVisible(!state);
+    }
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -570,8 +570,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         // absence of files for the first run in a new profile or from an older
         // Mudlet version:
         setProfileSpellDictionary();
-        slot_setCompactInputLine(mudlet::self()->compactInputLine());
-        connect(mudlet::self(), &mudlet::signal_setCompactInputLine, this, &TConsole::slot_setCompactInputLine, Qt::UniqueConnection);
     }
 
     // error and debug consoles inherit font of the main console
@@ -3121,11 +3119,4 @@ bool TConsole::setTextFormat(const QString& name, const QColor& fgColor, const Q
     }
 
     return false;
-}
-
-void TConsole::slot_setCompactInputLine(const bool state)
-{
-    if (mpButtonMainLayer) {
-        mpButtonMainLayer->setVisible(!state);
-    }
 }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -332,7 +332,6 @@ public slots:
     // =>"Copy Map" in another profile to inform a list of
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
-    void slot_setCompactInputLine(const bool);
 
 protected:
     void dragEnterEvent(QDragEnterEvent*) override;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -331,6 +331,7 @@ public slots:
     // =>"Copy Map" in another profile to inform a list of
     // profiles - asynchronously - to load in an updated map
     void slot_reloadMap(QList<QString>);
+    void slot_setCompactInputLine(const bool);
 
 protected:
     void dragEnterEvent(QDragEnterEvent*) override;

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -23,7 +23,7 @@
 
 
 #include "TLabel.h"
-#include "Host.h"
+#include "mudlet.h"
 
 #include "pre_guard.h"
 #include <QApplication>
@@ -88,7 +88,10 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 
     if (mpHost && mClickFunction) {
         mpHost->getLuaInterpreter()->callLabelCallbackEvent(mClickFunction, event);
+        // The use of accept() here prevents the propogation of the event to
+        // any parent, e.g. the containing TConsole
         event->accept();
+        mudlet::self()->activateProfile(mpHost);
     } else {
         QWidget::mousePressEvent(event);
     }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014, 2016, 2019 by Stephen Lyons                       *
+ *   Copyright (C) 2014, 2016, 2019-2020 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -24,7 +24,7 @@
 #include "glwidget.h"
 
 
-#include "Host.h"
+#include "mudlet.h"
 #include "TArea.h"
 #include "TRoomDB.h"
 #include "dlgMapper.h"
@@ -2155,6 +2155,7 @@ void GLWidget::resizeGL(int w, int h)
 
 void GLWidget::mousePressEvent(QMouseEvent* event)
 {
+    mudlet::self()->activateProfile(mpHost);
     if (event->buttons() & Qt::LeftButton) {
         int x = event->x();
         int y = height() - event->y(); //opengl ursprungspunkt liegt unten links

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -322,6 +322,7 @@ public:
     bool showMapAuditErrors() const { return mshowMapAuditErrors; }
     void setShowMapAuditErrors(const bool);
     bool compactInputLine() const { return mCompactInputLine; }
+    void setCompactInputLine(const bool state) { mCompactInputLine = state; }
     void createMapper(bool loadDefaultMap = true);
     void setShowIconsOnMenu(const Qt::CheckState);
 
@@ -549,7 +550,6 @@ signals:
     void signal_passwordsMigratedToSecure();
     void signal_passwordMigratedToSecure(const QString&);
     void signal_passwordsMigratedToProfiles();
-    void signal_setCompactInputLine(const bool);
 
 
 private slots:
@@ -580,7 +580,6 @@ private slots:
     void slot_report_issue();
 #endif
     void slot_toggle_compact_input_line();
-    void slot_compact_input_line(const bool);
     void slot_password_migrated_to_secure(QKeychain::Job *job);
     void slot_password_migrated_to_profile(QKeychain::Job *job);
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -323,7 +323,6 @@ public:
     bool showMapAuditErrors() const { return mshowMapAuditErrors; }
     void setShowMapAuditErrors(const bool);
     bool compactInputLine() const { return mCompactInputLine; }
-    void setCompactInputLine(const bool state) { mCompactInputLine = state; }
     void createMapper(bool loadDefaultMap = true);
     void setShowIconsOnMenu(const Qt::CheckState);
 
@@ -501,7 +500,8 @@ public slots:
     void slot_open_mappingscripts_page();
     void slot_module_clicked(QTableWidgetItem*);
     void slot_module_changed(QTableWidgetItem*);
-    void slot_multi_view();
+    void slot_multi_view(const bool);
+    void slot_toggle_multi_view();
     void slot_connection_dlg_finished(const QString& profile, bool connectOnLoad);
     void slot_timer_fires();
     void slot_send_login();
@@ -550,6 +550,7 @@ signals:
     void signal_passwordsMigratedToSecure();
     void signal_passwordMigratedToSecure(const QString&);
     void signal_passwordsMigratedToProfiles();
+    void signal_setCompactInputLine(const bool);
 
 
 private slots:
@@ -580,6 +581,7 @@ private slots:
     void slot_report_issue();
 #endif
     void slot_toggle_compact_input_line();
+    void slot_compact_input_line(const bool);
     void slot_password_migrated_to_secure(QKeychain::Job *job);
     void slot_password_migrated_to_profile(QKeychain::Job *job);
 
@@ -723,6 +725,9 @@ private:
     // Stores the translated names for the Encodings for the static and thus
     // const TBuffer::csmEncodingTable:
     QMap<QByteArray, QString> mEncodingNameMap;
+
+    // Whether multi-view is in effect (if more than one tab is present)
+    bool mMultiView;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -253,6 +253,8 @@ public:
 #if defined(Q_OS_WIN32)
     void sanitizeUtf8Path(QString& originalLocation, const QString& fileName) const;
 #endif
+    void activateProfile(Host*);
+
 
     // used by developers in everyday coding
     static const bool scmIsDevelopmentVersion;
@@ -724,7 +726,7 @@ private:
     // const TBuffer::csmEncodingTable:
     QMap<QByteArray, QString> mEncodingNameMap;
 
-    // Whether multi-view is in effect (if more than one tab is present)
+    // Whether multi-view is in effect:
     bool mMultiView;
 };
 

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -87,7 +87,7 @@
      <x>0</x>
      <y>0</y>
      <width>750</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEditor">
@@ -286,20 +286,20 @@
    </property>
   </action>
   <action name="dactionMultiView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>MultiView</string>
    </property>
-   <property name="enabled">
-     <bool>false</bool>
-   </property>
-   <property name="checkable">
-     <bool>true</bool>
-   </property>
-   <property name="checked">
-     <bool>false</bool>
-   </property>
    <property name="toolTip">
-    <string>&lt;p&gt;Enabled when multiple profiles are open, this splits the Mudlet screen to show them all at once.&lt;/p&gt;</string>
+    <string comment="Same text is used in 2 places.">&lt;p&gt;Splits the Mudlet screen to show multiple profiles at once; disabled when less than two are loaded.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionInputLine">

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -306,14 +306,8 @@
    <property name="text">
     <string>Compact input line</string>
    </property>
-   <property name="checkable">
-     <bool>true</bool>
-   </property>
-   <property name="checked">
-     <bool>false</bool>
-   </property>
    <property name="toolTip">
-    <string>&lt;p&gt;Hide or show the search area and the bottom buttons to the right of the input area on the input line for all profiles.&lt;/p&gt;</string>
+    <string>&lt;p&gt;Hide or show the search area and the bottom buttons to the right of the input area on the input line.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionDiscord">

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -289,16 +289,31 @@
    <property name="text">
     <string>MultiView</string>
    </property>
+   <property name="enabled">
+     <bool>false</bool>
+   </property>
+   <property name="checkable">
+     <bool>true</bool>
+   </property>
+   <property name="checked">
+     <bool>false</bool>
+   </property>
    <property name="toolTip">
-    <string>&lt;p&gt;Share the screen area between multiple open profiles.&lt;/p&gt;</string>
+    <string>&lt;p&gt;Enabled when multiple profiles are open, this splits the Mudlet screen to show them all at once.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionInputLine">
    <property name="text">
     <string>Compact input line</string>
    </property>
+   <property name="checkable">
+     <bool>true</bool>
+   </property>
+   <property name="checked">
+     <bool>false</bool>
+   </property>
    <property name="toolTip">
-    <string>&lt;p&gt;Hide or show the search area and the bottom buttons to the right of the input area on the input line.&lt;/p&gt;</string>
+    <string>&lt;p&gt;Hide or show the search area and the bottom buttons to the right of the input area on the input line for all profiles.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionDiscord">


### PR DESCRIPTION
~~Makes the compact input line a toggle (so now it also has constant text).~~

Makes the multi-view stay active when `<Ctrl>+<Tab>` / `<Ctrl>+Number` switching between - or clicking on the tab bars.

Also disables the (now a toggle) control for multi-view when there is less than two profiles active.

This should close #1111 #1831 #3136 #3204 ~~#2400~~, it may also improve #2099

~~It also disables dragging the tabs around so will prevent the issue mentioned in #1456 pending a fix that can also rearrange the main `TConsole`s to match.~~

Also improve layout of the Multi-view tool-tip for both the toolbar and menu instances of the control.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>