### PR TITLE
Fix slow search in code editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7198,11 +7198,16 @@ void dlgTriggerEditor::slot_source_find_next()
 
 void dlgTriggerEditor::slot_source_find_text_changed()
 {
+    auto text = mpSourceEditorFindArea->lineEdit_findText->text();
+    if (text.length() <= 2) {
+        return;
+    }
+
     auto controller = mpSourceEditorEdbee->controller();
     auto searcher = controller->textSearcher();
     controller->borderedTextRanges()->clear();
     controller->textSelection()->range(0).clearSelection();
-    searcher->setSearchTerm(mpSourceEditorFindArea->lineEdit_findText->text());
+    searcher->setSearchTerm(text);
     searcher->markAll(controller->borderedTextRanges());
     controller->update();
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix slow search in code editor - by disabling highlighting one or two letter searches, which while would be cool for completeness, bring Edbee down to its knees in larger scripts.

The issue seems to be highlighting so many matches:

![Selection_142](https://user-images.githubusercontent.com/110988/83251168-828c5000-a1a9-11ea-9790-32f5e39b772e.png)

#### Motivation for adding to Mudlet
Mudlet should be fast.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/3846.