### PR TITLE
enable Module Sync only if file is a .xml file

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -591,6 +591,10 @@ std::pair<bool, QString> Host::changeModuleSync(const QString& moduleName, const
 
     if (mInstalledModules.contains(moduleName)) {
         QStringList moduleStringList = mInstalledModules[moduleName];
+        QFileInfo moduleFile = moduleStringList[0];
+        if (!moduleFile.suffix().compare(QLatin1String("xml"), Qt::CaseInsensitive) == 0) {
+            return {false, QStringLiteral("module has to be a .xml file")};
+        }
         moduleStringList[1] = value;
         mInstalledModules[moduleName] = moduleStringList;
         return {true, QString()};

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -592,7 +592,9 @@ std::pair<bool, QString> Host::changeModuleSync(const QString& moduleName, const
     if (mInstalledModules.contains(moduleName)) {
         QStringList moduleStringList = mInstalledModules[moduleName];
         QFileInfo moduleFile = moduleStringList[0];
-        if (!moduleFile.suffix().compare(QLatin1String("xml"), Qt::CaseInsensitive) == 0) {
+        QStringList accepted_suffix;
+        accepted_suffix << "xml" << "trigger";
+        if (!accepted_suffix.contains(moduleFile.suffix().trimmed(), Qt::CaseInsensitive)) {
             return {false, QStringLiteral("module has to be a .xml file")};
         }
         moduleStringList[1] = value;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1169,7 +1169,9 @@ void mudlet::layoutModules()
             auto itemPriority = new QTableWidgetItem();
             QStringList moduleInfo = mpModuleTableHost->mInstalledModules[pModules[i]];
             QFileInfo moduleFile = moduleInfo[0];
-            if (moduleFile.suffix().compare(QLatin1String("xml"), Qt::CaseInsensitive) == 0) {
+            QStringList accepted_suffix;
+            accepted_suffix << "xml" << "trigger";
+            if (accepted_suffix.contains(moduleFile.suffix().trimmed(), Qt::CaseInsensitive)) {
                 masterModule->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
                 masterModule->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
                                                  .arg(tr("Checking this box will cause the module to be saved and <i>resynchronised</i> across all "

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1167,8 +1167,21 @@ void mudlet::layoutModules()
             auto itemEntry = new QTableWidgetItem();
             auto itemLocation = new QTableWidgetItem();
             auto itemPriority = new QTableWidgetItem();
-            masterModule->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             QStringList moduleInfo = mpModuleTableHost->mInstalledModules[pModules[i]];
+            QFileInfo moduleFile = moduleInfo[0];
+            if (moduleFile.suffix().compare(QLatin1String("xml"), Qt::CaseInsensitive) == 0) {
+                masterModule->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+                masterModule->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                                 .arg(tr("Checking this box will cause the module to be saved and <i>resynchronised</i> across all "
+                                                         "sessions that share it when the <i>Save Profile</i> button is clicked in the Editor or if it "
+                                                         "is saved at the end of the session.")));
+            } else {
+                masterModule->setFlags(Qt::NoItemFlags);
+                masterModule->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                                 .arg(tr("<b>Note:</b> <i>.zip</i> and <i>.mpackage</i> modules are currently unable to be synced<br> "
+                                                         "only <i>.xml</i> packages are able to be synchronized across profiles at the moment. ")));
+            }
+
 
             if (moduleInfo.at(1).toInt()) {
                 masterModule->setCheckState(Qt::Checked);
@@ -1176,10 +1189,7 @@ void mudlet::layoutModules()
                 masterModule->setCheckState(Qt::Unchecked);
             }
             masterModule->setText(QString());
-            masterModule->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
-                                             .arg(tr("Checking this box will cause the module to be saved and <i>resynchronised</i> across all "
-                                                     "sessions that share it when the <i>Save Profile</i> button is clicked in the Editor or if it "
-                                                     "is saved at the end of the session.")));
+
             // Although there is now no text used here this may help to make the
             // checkbox more central in the column
             masterModule->setTextAlignment(Qt::AlignCenter);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Prevents enabling of module sync if file suffix is not .xml.

#### Motivation for adding to Mudlet
Zip/mpackage files get trashed if synced
Should prevent #3310 even if I think it would be nice (in future) to be able to sync mpackage/zip files

Also discussion on Discord about how visible the Module Manager warning was.

#### Other info (issues closed, discussion etc)
