### PR TITLE
BugFix: remove forced styling of white on grey for buttons that should be left unstyled

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8874,7 +8874,7 @@ QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bo
         return QStringLiteral("QPushButton {color: %1; background-color: %2; }")
                 .arg(QLatin1String("darkGray"), disabledColor.name());
     } else {
-        return QStringLiteral("QPushButton {color: white; background-color: grey; }");
+        return QString();
     }
 }
 

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -672,8 +672,8 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="flat">
-            <bool>false</bool>
+           <property name="text">
+            <string comment="Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button">keep</string>
            </property>
           </widget>
          </item>
@@ -684,6 +684,9 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="text">
+            <string comment="Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button">keep</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
The previous code (of #3814 as amended by #3851) means that all places that use the: `(QString) dlgTriggerEditor::generateButtonStyleSheet(const QColor&, const bool)` method end up with a white text on grey background in the default, inactive state - which is not what is needed when a dark themed Desktop Environment is being used.

This PR uses the original empty string - which resets the styling to whatever the DE/OS/User stylesheet provides. So that the hard coded white text on (dark-grey) background:
![Screenshot_20200531_052134](https://user-images.githubusercontent.com/6163092/83344421-a8773900-a2fe-11ea-85e3-a3066893d404.png)
even for a DARK DE:
![Screenshot_20200531_053924](https://user-images.githubusercontent.com/6163092/83344683-1cffa700-a302-11ea-9f87-a74b3cb4e8ac.png)
returns to the more neutral shading:
![Screenshot_20200531_045939](https://user-images.githubusercontent.com/6163092/83344336-2c302600-a2fd-11ea-9ee0-01414379ffb5.png)
and:
![Screenshot_20200531_054857](https://user-images.githubusercontent.com/6163092/83344711-749e1280-a302-11ea-8b27-a091419a60d4.png)

Also a second appended commit adds the `"keep"` word to the buttons at the start (defined in the `triggers_main_area.ui` file) otherwise they do not show up until a trigger with that setting is selected...
