### PR TITLE
BugFix: attempt to solve copy selection problem

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1148,6 +1148,10 @@ void TTextEdit::slot_searchSelectionOnline()
 
 void TTextEdit::slot_copySelectionToClipboard()
 {
+    if (!establishSelectedText()) {
+        return;
+    }
+
     QString selectedText = getSelectedText();
     QClipboard* clipboard = QApplication::clipboard();
     clipboard->setText(selectedText);
@@ -1155,6 +1159,10 @@ void TTextEdit::slot_copySelectionToClipboard()
 
 void TTextEdit::slot_copySelectionToClipboardHTML()
 {
+    if (!establishSelectedText()) {
+        return;
+    }
+
     QString title;
     if (mpConsole->getType() == TConsole::CentralDebugConsole) {
         title = tr("Mudlet, debug console extract");
@@ -1220,13 +1228,6 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     // Is this a single line then we do NOT need to pad the first (and thus
     // only) line to the right:
     bool isSingleLine = (mDragStart.y() == mDragSelectionEnd.y());
-    if (mDragStart.y() < mDragSelectionEnd.y() || (mDragStart.y() == mDragSelectionEnd.y() && mDragStart.x() == mDragSelectionEnd.x())) {
-        mPA = mDragStart;
-        mPB = mDragSelectionEnd;
-    } else {
-        mPA = mDragSelectionEnd;
-        mPB = mDragStart;
-    }
     for (int y = mPA.y(), total = mPB.y(); y <= total; ++y) {
         if (y >= static_cast<int>(mpBuffer->buffer.size())) {
             return;
@@ -1252,6 +1253,33 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
     forceUpdate();
 }
 
+bool TTextEdit::establishSelectedText()
+{
+    // mPA QPoint where selection started
+    // mPB QPoint where selection ended
+
+    // if selection was made backwards swap
+    // right to left
+    if (mFontWidth <= 0 || mFontHeight <= 0) {
+        return false;
+    }
+
+    if (mSelectedRegion == QRegion(0, 0, 0, 0)) {
+        return false;
+    }
+
+    if (mScreenHeight <= 0 || mScreenWidth <= 0) {
+        mScreenHeight = height() / mFontHeight;
+        mScreenWidth = 100;
+        if (mScreenHeight <= 0) {
+            return false;
+        }
+    }
+
+    normaliseSelection();
+    return true;
+}
+
 // Technically this copies whole lines into the image even if the selection does
 // not start at the beginning of the first line or end at the last grapheme on
 // the last line.
@@ -1259,32 +1287,8 @@ void TTextEdit::slot_copySelectionToClipboardImage()
 {
     mCopyImageStartTime = std::chrono::high_resolution_clock::now();
 
-    // mPA QPoint where selection started
-    // mPB QPoint where selection ended
-
-    // if selection was made backwards swap
-    // right to left
-    if (mFontWidth <= 0 || mFontHeight <= 0) {
+    if (!establishSelectedText()) {
         return;
-    }
-
-    if (mSelectedRegion == QRegion(0, 0, 0, 0)) {
-        return;
-    }
-
-    if (mScreenHeight <= 0 || mScreenWidth <= 0) {
-        mScreenHeight = height() / mFontHeight;
-        mScreenWidth = 100;
-        if (mScreenHeight <= 0 || mScreenWidth <= 0) {
-            return;
-        }
-    }
-    if (mDragStart.y() < mDragSelectionEnd.y() || (mDragStart.y() == mDragSelectionEnd.y() && mDragStart.x() == mDragSelectionEnd.x())) {
-        mPA = mDragStart;
-        mPB = mDragSelectionEnd;
-    } else {
-        mPA = mDragSelectionEnd;
-        mPB = mDragStart;
     }
 
     // Qt says: "Maximum supported image dimension is 65500 pixels" in stdout
@@ -1381,76 +1385,40 @@ std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect re
 
 void TTextEdit::searchSelectionOnline()
 {
-    QString selectedText = getSelectedText(' ');
+    QString selectedText = getSelectedText(QChar::Space);
     QString url = QUrl::toPercentEncoding(selectedText.trimmed());
     url.prepend(mpHost->getSearchEngine().second);
     QDesktopServices::openUrl(QUrl(url));
 }
 
-QString TTextEdit::getSelectedText(char newlineChar)
+QString TTextEdit::getSelectedText(QChar newlineChar)
 {
     // mPA QPoint where selection started
     // mPB QPoint where selection ended
 
-    // if selection was made backwards swap
-    // right to left
-    normaliseSelection();
+    int startLine = std::max(0, mPA.y());
+    int endLine = std::min(mPB.y(), mpBuffer->lineBuffer.size());
+    int offset = endLine - startLine;
+    int startPos = std::max(0, mPA.x());
+    int endPos = std::min(mPB.x(), mpBuffer->lineBuffer.at(endLine).size());
+    QStringList textLines = mpBuffer->lineBuffer.mid(startLine, endLine - startLine + 1);
 
-    QString text;
-    int x, y, total;
-
-
-    if(!mpBuffer->buffer[0].size()) {
-        return text;
+    if (mPA.y() == mPB.y()) {
+        // Is a single line, so trim characters off the beginning and end
+        // according to startPos and endPos:
+        textLines[0] = textLines.at(0).mid(startPos, endPos - startPos + 1);
+    } else {
+        // replace a number of QChars at the front with a corresponding
+        // number of spaces to push the first line to the right so it lines up
+        // with the following lines:
+        textLines[0] = textLines.at(0).mid(startPos);
+        textLines[0] = QString(QChar::Space).repeated(startPos) % textLines.at(0);
+        // and chop off the required number of QChars from the end of the last
+        // line:
+        textLines[offset] = textLines.at(offset).left(1 + endPos);
     }
-    // for each selected line
-    bool isSingleLine = (mPA.y() == mPB.y());
-    // CHECKME: the <= together with the +1 in the test looks suspecious:
-    for (y = mPA.y(), total = mPB.y() + 1; y <= total; ++y) {
-        // stop if we are at the end of the buffer lines
-        if (y >= static_cast<int>(mpBuffer->buffer.size())) {
-            mSelectedRegion = QRegion(0, 0, 0, 0);
-            forceUpdate();
-            return text;
-        }
 
-        x = 0;
-        // if the selection started on this line
-        if (y == mPA.y()) {
-            // start from the column where the selection started
-            if (mpBuffer->lineBuffer.at(y).size()) {
-                if (!mpBuffer->buffer.at(y).at(0).isSelected()) {
-                    x = mPA.x();
-                }
-            }
-            if (!isSingleLine) {
-                // insert the number of spaces to push the first line to the right
-                // so it lines up with the following lines - but only if there
-                // is MORE than a single line:
-                text.append(QStringLiteral(" ").repeated(x));
-            }
-        }
-        // while we are not at the end of the buffer line
-        while (x < static_cast<int>(mpBuffer->buffer[y].size())) {
-            if (mpBuffer->buffer.at(y).at(x).isSelected()) {
-                text.append(mpBuffer->lineBuffer[y].at(x));
-            }
-            // if the selection ended on this line
-            if (y >= mPB.y()) {
-                // stop if the selection ended on this column or the buffer line is ending
-                if (x >= static_cast<int>(mpBuffer->buffer[y].size() - 1)) {
-                    mSelectedRegion = QRegion(0, 0, 0, 0);
-                    forceUpdate();
-                    return text;
-                }
-            }
-            x++;
-        }
-        // we never append the last character of a buffer line se we set our own
-        text.append(newlineChar);
-    }
-    qDebug() << "TTextEdit::getSelectedText(...) INFO - unexpectedly hit bottom of method so returning:" << text;
-    return text;
+    return textLines.join(newlineChar);
 }
 
 void TTextEdit::mouseReleaseEvent(QMouseEvent* event)

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -693,8 +693,7 @@ void TTextEdit::unHighlight()
                 mpBuffer->buffer.at(y).at(x).deselect();
             }
     }
-    mForceUpdate = true;
-    update();
+    forceUpdate();
 }
 
 // ensure that mPA is top-right and mPB is bottom-right
@@ -949,6 +948,20 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             }
         }
         unHighlight();
+        // Ensure BOTH panes are updated if the lower one is showing
+        if (mIsLowerPane) {
+            // We wouldn't be getting to here if the lower pane was not visible:
+            mpConsole->mUpperPane->forceUpdate();
+            forceUpdate();
+        } else if (!mIsTailMode) {
+            // Not in tail mode means the lower pane is also showing (and we are the
+            // upper one) - so update both:
+            forceUpdate();
+            mpConsole->mLowerPane->forceUpdate();
+        } else {
+            // We are the upper pane and the lower one is not showing
+            forceUpdate();
+        }
         mSelectedRegion = QRegion(0, 0, 0, 0);
         if (mLastClickTimer.elapsed() < 300) {
             int xind = x;
@@ -1136,8 +1149,24 @@ void TTextEdit::slot_selectAll()
 {
     mDragStart = QPoint(0, 0);
     mDragSelectionEnd = mpBuffer->getEndPos();
+    // need this to convert the above to mPA and mPB:
+    normaliseSelection();
+
     highlightSelection();
-    update();
+    // Ensure BOTH panes are updated if the lower one is showing
+    if (mIsLowerPane) {
+        // We wouldn't be getting to here if the lower pane was not visible:
+        mpConsole->mUpperPane->forceUpdate();
+        forceUpdate();
+    } else if (!mIsTailMode) {
+        // Not in tail mode means the lower pane is also showing (and we are the
+        // upper one) - so update both:
+        forceUpdate();
+        mpConsole->mLowerPane->forceUpdate();
+    } else {
+        // We are the upper pane and the lower one is not showing
+        forceUpdate();
+    }
 }
 
 void TTextEdit::slot_searchSelectionOnline()

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -122,7 +122,7 @@ private slots:
 
 private:
     void initDefaultSettings();
-    QString getSelectedText(char newlineChar = '\n');
+    QString getSelectedText(QChar newlineChar = QChar::LineFeed);
     static QString htmlCenter(const QString&);
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
@@ -131,6 +131,7 @@ private:
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
     void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
+    bool establishSelectedText();
 
     int mFontHeight;
     int mFontWidth;


### PR DESCRIPTION
We have established that the Copy as HTML and Copy as Image modes do not seem to have the problem that the plain Copy (as Text) one has. It is noticeable that the first two have the same process to select the portion of the `TBuffer` that is to be copied and that seems to be different to that of the third. So this changes the latter to use the same system that has been refactored out of the other two.

Also, since all the text we need is already in an arrangement that we can actually copy quite fast (a `QStringList`) there is no need to do a slow `QChar` by `QChar` copy of every `QChar` in the whole selection - instead we can take a copy of that section of the `TBuffer::lineBuffer` that contains the wanted lines - and then just trim off the leading `QChar`s on the first line that precede the selection stop (and replace them with spaces if it is a multi-line selection) and chop off the unwanted trailing `QChar`s on the last line... This way of doing things also avoids the complication that empty intermediate lines might not have ANY characters in them!

Also - I noted that the code in the Copy as HTML and Copy as Image that was similar to the code in the existing `normalisedSelection()` was actually faulty as when the start and end points were on the same line
(i.e. the Y values were the same), the test to see whether the points had to be swapped had an incorrect test for the X values also being the same, whereas they should have been the end point X value being less than the starting X value - as they are in the normalising method!

This should close #3285 (and possibly some other issues).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>