### PR TITLE
BugFix: prevent empty TBuffer crashes when copying

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1284,8 +1284,10 @@ void TTextEdit::slot_copySelectionToClipboardHTML()
 
 bool TTextEdit::establishSelectedText()
 {
-    // mPA QPoint where selection started
-    // mPB QPoint where selection ended
+    if (mpBuffer->lineBuffer.isEmpty()) {
+        // Prevent problems with trying to do a copy when TBuffer is empty:
+        return false;
+    }
 
     // if selection was made backwards swap
     // right to left

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1422,7 +1422,7 @@ void TTextEdit::searchSelectionOnline()
     QDesktopServices::openUrl(QUrl(url));
 }
 
-QString TTextEdit::getSelectedText(QChar newlineChar)
+QString TTextEdit::getSelectedText(const QChar& newlineChar)
 {
     // mPA QPoint where selection started
     // mPB QPoint where selection ended
@@ -1437,16 +1437,22 @@ QString TTextEdit::getSelectedText(QChar newlineChar)
     if (mPA.y() == mPB.y()) {
         // Is a single line, so trim characters off the beginning and end
         // according to startPos and endPos:
-        textLines[0] = textLines.at(0).mid(startPos, endPos - startPos + 1);
+        if (!textLines.at(0).isEmpty()) {
+            textLines[0] = textLines.at(0).mid(startPos, endPos - startPos + 1);
+        }
     } else {
         // replace a number of QChars at the front with a corresponding
         // number of spaces to push the first line to the right so it lines up
         // with the following lines:
-        textLines[0] = textLines.at(0).mid(startPos);
-        textLines[0] = QString(QChar::Space).repeated(startPos) % textLines.at(0);
+        if (!textLines.at(0).isEmpty()) {
+            textLines[0] = textLines.at(0).mid(startPos);
+            textLines[0] = QString(QChar::Space).repeated(startPos) % textLines.at(0);
+        }
         // and chop off the required number of QChars from the end of the last
         // line:
-        textLines[offset] = textLines.at(offset).left(1 + endPos);
+        if (!textLines.at(offset).isEmpty()) {
+            textLines[offset] = textLines.at(offset).left(1 + endPos);
+        }
     }
 
     return textLines.join(newlineChar);

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -122,7 +122,7 @@ private slots:
 
 private:
     void initDefaultSettings();
-    QString getSelectedText(QChar newlineChar = QChar::LineFeed);
+    QString getSelectedText(const QChar& newlineChar = QChar::LineFeed);
     static QString htmlCenter(const QString&);
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);


### PR DESCRIPTION
As requested in https://github.com/Mudlet/Mudlet/pull/3854#issuecomment-637270293 this PR should prevent any issues from trying to copy from a `TBuffer` when there is nothing in it to copy from...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>