### PR TITLE
Enhance: improve access to TTabBar elements

### DIFF
--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,6 +28,7 @@
 #include "pre_guard.h"
 #include <QStyleOption>
 #include <QPainter>
+#include <QVariant>
 #include "post_guard.h"
 
 void TStyle::drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
@@ -138,5 +139,47 @@ QSize TTabBar::tabSizeHint(int index) const
         return {s.width() - w + bw, s.height()};
     } else {
         return QTabBar::tabSizeHint(index);
+    }
+}
+
+QString& TTabBar::tabName(const int index) const
+{
+    QString result{tabData(index).toString()};
+    return result;
+}
+
+int TTabBar::tabIndex(const QString& name) const
+{
+    int index = -1;
+    if (name.isEmpty()) {
+        return index;
+    }
+    const int total = count();
+    while (++index < total) {
+        if (!tabData(index).toString().compare(name)) {
+            return index;
+        }
+    }
+    return -1;
+}
+
+void TTabBar::removeTab(int index)
+{
+    if (index >= 0 && index < count()) {
+        setTabBold(index, false);
+        setTabItalic(index, false);
+        setTabUnderline(index, false);
+        QTabBar::removeTab(index);
+    }
+}
+
+void TTabBar::removeTab(const QString& name)
+{
+    int index = tabIndex(name);
+    if (index > -1) {
+        setTabBold(index, false);
+        setTabItalic(index, false);
+        setTabUnderline(index, false);
+        QTabBar::removeTab(index);
     }
 }

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -2,7 +2,7 @@
 #define TTABBAR_H
 
 /***************************************************************************
- *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -84,6 +84,10 @@ public:
     bool tabItalic(const int index) const {return mStyle.tabItalic(index);}
     bool tabUnderline(const QString& tabName) const {return mStyle.tabUnderline(tabName);}
     bool tabUnderline(const int index) const {return mStyle.tabUnderline(index);}
+    QString& tabName(const int) const;
+    int tabIndex(const QString&) const;
+    void removeTab(const QString&);
+    void removeTab(int);
 
 private:
     // This instance of TStyle needs a pointer to a QTabBar on instantiation:


### PR DESCRIPTION
Extended the `TTabBar` class so as to return the profile name associated with a particular index and to return the index of a tab if given the name.

Also extended the inherited `QTabBar::removeTab(int)` method so as to properly clean up the `TTabBar` (and associated `TStyle`) when a profile is removed, furthermore combined things so that there is now a `QTabBar::removeTab(const QString&)` method so that a tab can be removed without having to provide the index of it in the TabBar.

This PR is a part extracted from a larger pending work which can be dealt with separately (handle closing of profiles whilst multi-playing) - it will be needed (the removing tab by name part at least) for that...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>