### PR TITLE
Patch: prevent Multiview tabs from being rearranged

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -231,7 +231,10 @@ mudlet::mudlet()
     mpTabBar->setTabsClosable(true);
     mpTabBar->setAutoHide(true);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_close_profile_requested);
-    mpTabBar->setMovable(true);
+    // TODO: Do not enable this option currently - although the user can drag
+    // the tabs the underlying main TConsoles do not move and then it means that
+    // the wrong title can be shown over the wrong window.
+    mpTabBar->setMovable(false);
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tab_changed);
     auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
This is needed until additional code is worked out as to how the order of the main `TConsole` instances in the main application window can be reordered because without this patch the tabs can be dragged so that they are no longer over the `TConsole` to which they refer - which is confusing to say the least!

This was split out of a larger PR that originally included it: https://github.com/Mudlet/Mudlet/pull/3844 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>