### PR TITLE
Add: getClipboardText and setClipboardText Lua functions

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14603,15 +14603,14 @@ int TLuaInterpreter::getClipboardText(lua_State* L)
 
 int TLuaInterpreter::setClipboardText(lua_State* L)
 {
-    if (lua_isstring(L, 1)) {
-        QClipboard* clipboard = QApplication::clipboard();
-        clipboard->setText(QString::fromUtf8(lua_tostring(L, 1)));
-        lua_pushboolean(L, true);
-        return 1;
-    } else {
-        lua_pushfstring(L, "setClipboard: bad argument #%d type (text as string expected, got %s!)", 1, luaL_typename(L, 1));
+    if (!lua_isstring(L, 1)) {
+        lua_pushfstring(L, "setClipboardText: bad argument #%d type (text as string expected, got %s!)", 1, luaL_typename(L, 1));
         return lua_error(L);
     }
+    QClipboard* clipboard = QApplication::clipboard();
+    clipboard->setText(QString::fromUtf8(lua_tostring(L, 1)));
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // No documentation available in wiki - internal function

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14594,6 +14594,7 @@ int TLuaInterpreter::getOS(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getClipboardText
 int TLuaInterpreter::getClipboardText(lua_State* L)
 {
     QClipboard* clipboard = QApplication::clipboard();
@@ -14601,6 +14602,7 @@ int TLuaInterpreter::getClipboardText(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setClipboardText
 int TLuaInterpreter::setClipboardText(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14594,6 +14594,26 @@ int TLuaInterpreter::getOS(lua_State* L)
     return 1;
 }
 
+int TLuaInterpreter::getClipboardText(lua_State* L)
+{
+    QClipboard* clipboard = QApplication::clipboard();
+    lua_pushstring(L, clipboard->text().toUtf8().constData());
+    return 1;
+}
+
+int TLuaInterpreter::setClipboardText(lua_State* L)
+{
+    if (lua_isstring(L, 1)) {
+        QClipboard* clipboard = QApplication::clipboard();
+        clipboard->setText(QString::fromUtf8(lua_tostring(L, 1)));
+        lua_pushboolean(L, true);
+        return 1;
+    } else {
+        lua_pushfstring(L, "setClipboard: bad argument #%d type (text as string expected, got %s!)", 1, luaL_typename(L, 1));
+        return lua_error(L);
+    }
+}
+
 // No documentation available in wiki - internal function
 bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
 {
@@ -16920,6 +16940,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getColumnCount", TLuaInterpreter::getColumnCount);
     lua_register(pGlobalLua, "getRowCount", TLuaInterpreter::getRowCount);
     lua_register(pGlobalLua, "getOS", TLuaInterpreter::getOS);
+    lua_register(pGlobalLua, "getClipboardText", TLuaInterpreter::getClipboardText);
+    lua_register(pGlobalLua, "setClipboardText", TLuaInterpreter::setClipboardText);
     lua_register(pGlobalLua, "getAvailableFonts", TLuaInterpreter::getAvailableFonts);
     lua_register(pGlobalLua, "tempAnsiColorTrigger", TLuaInterpreter::tempAnsiColorTrigger);
     lua_register(pGlobalLua, "setDiscordApplicationID", TLuaInterpreter::setDiscordApplicationID);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -512,6 +512,8 @@ public:
     static int getColumnCount(lua_State*);
     static int getRowCount(lua_State*);
     static int getOS(lua_State*);
+    static int getClipboardText(lua_State*);
+    static int setClipboardText(lua_State*);
     static int getAvailableFonts(lua_State* L);
     static int tempAnsiColorTrigger(lua_State*);
     static int setDiscordApplicationID(lua_State* L);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds getClipboardText and setClipboardText functions to allow scripts to interact with the clipboard.

#### Motivation for adding to Mudlet
I want to modify the clipboard from my scripts!

#### Other info (issues closed, discussion etc)
Resolves #2751, although I do agree that it's probably a good idea to investigate sanitizing clipboard contents. It seems like the ability of someone else to leverage that against you is relatively small, since there aren't many foreseeable situations where another user could send you the sort of symbols that are necessary to attack Windows machines via the clipboard, much less for you to copy them to the clipboard automatically.