### PR TITLE
Fix for case insensitivity in exit line

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -76,7 +76,7 @@ end</script>
 				<colorTriggerFgColor>#000000</colorTriggerFgColor>
 				<colorTriggerBgColor>#000000</colorTriggerBgColor>
 				<regexCodeList>
-					<string>^\s*\[\s*[Ee]xits:\s*(.*)\]</string>
+					<string>(?i)^\s*\[\s*Exits:\s*(.*)\]</string>
 					<string>^\s*There (?:is|are) \w+ (?:visible|obvious) exit[s]?:\s*(.*)</string>
 					<string>^\[?\s*(?:[Vv]isible|[Oo]bvious) (?:[Pp]ath|[Ee]xit)[s]?(?: is| are)?:?\s*(.*)\]?</string>
 					<string>^\s*You see[\w\s]* exit[s]? leading (.*)</string>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Just a simple fix to help for exit lines that read in uppercase or lowercase.
#### Motivation for adding to Mudlet
User had trouble getting map script to work due to exits line being in uppercase, the script did not account for this.
#### Other info (issues closed, discussion etc)
