### PR TITLE
BugFix: prevent crashes from recent Coverity Issue fixup

### DIFF
--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -142,7 +142,7 @@ QSize TTabBar::tabSizeHint(int index) const
     }
 }
 
-QString& TTabBar::tabName(const int index) const
+QString TTabBar::tabName(const int index) const
 {
     QString result{tabData(index).toString()};
     return result;

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -84,7 +84,7 @@ public:
     bool tabItalic(const int index) const {return mStyle.tabItalic(index);}
     bool tabUnderline(const QString& tabName) const {return mStyle.tabUnderline(tabName);}
     bool tabUnderline(const int index) const {return mStyle.tabUnderline(index);}
-    QString& tabName(const int) const;
+    QString tabName(const int) const;
     int tabIndex(const QString&) const;
     void removeTab(const QString&);
     void removeTab(int);


### PR DESCRIPTION
I was trying to be too clever and return a reference to an object. I think I might have been able to extend the life-time of the item concerned if I had made it a `const` but all in all it is simpler just to
use the normal return action that a compiler can use RVO to avoid making a unneeded copy of the item.

This will close #3868 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>