### PR TITLE
Port QStringRef to QStringView

### DIFF
--- a/src/TMxpTagParser.cpp
+++ b/src/TMxpTagParser.cpp
@@ -22,19 +22,19 @@
 #include "TStringUtils.h"
 #include <QDebug>
 
-static QStringRef stripTagAndTrim(const QString& tagText)
+static QStringView stripTagAndTrim(const QString& tagText)
 {
-    return TStringUtils::trimmedRef(TStringUtils::stripRef(tagText, '<', '>'));
+    return TStringUtils::strip(QStringView(tagText).trimmed(), '<', '>').trimmed();
 }
 
 static bool isEndTag(const QString& tagText)
 {
-    return stripTagAndTrim(tagText).startsWith("/");
+    return stripTagAndTrim(tagText).startsWith('/');
 }
 
 static bool isTag(const QString& tagString)
 {
-    return TStringUtils::isBetween(TStringUtils::trimmedRef(tagString), '<', '>');
+    return TStringUtils::isBetween(QStringView(tagString).trimmed(), '<', '>');
 }
 
 QList<QSharedPointer<MxpNode>> TMxpTagParser::parseToMxpNodeList(const QString& tagText, bool ignoreText) const
@@ -63,7 +63,7 @@ MxpTag* TMxpTagParser::parseTag(const QString& tagText) const
 
 MxpEndTag* TMxpTagParser::parseEndTag(const QString& tagText) const
 {
-    QStringRef tagContent = TStringUtils::trimmedRef(stripTagAndTrim(tagText)).mid(1);
+    QStringView tagContent = stripTagAndTrim(tagText).mid(1);
     const QStringList& parts = parseToList(tagContent);
 
     if (parts.size() > 1) {
@@ -75,7 +75,7 @@ MxpEndTag* TMxpTagParser::parseEndTag(const QString& tagText) const
 
 MxpStartTag* TMxpTagParser::parseStartTag(const QString& tagText) const
 {
-    QStringRef tagContent = TStringUtils::stripRef(tagText, '<', '>');
+    QStringView tagContent = TStringUtils::strip(tagText, '<', '>');
 
     const QStringList& parts = parseToList(tagContent);
 
@@ -104,16 +104,16 @@ MxpTagAttribute TMxpTagParser::parseAttribute(const QString& attr) const
     }
 
     const QString& name = attr.left(sepIdx);
-    const QString& value = TStringUtils::unquoteRef(attr.midRef(sepIdx + 1)).toString();
+    const QString& value = TStringUtils::unquote(QStringView(attr).mid(sepIdx + 1)).toString();
 
     return MxpTagAttribute(name, value);
 }
 QStringList TMxpTagParser::parseToList(const QString& tagText)
 {
-    return parseToList(QStringRef(&tagText));
+    return parseToList(QStringView(tagText));
 }
 
-QStringList TMxpTagParser::parseToList(const QStringRef& tagText)
+QStringList TMxpTagParser::parseToList(QStringView tagText)
 {
     QStringList result;
 
@@ -146,7 +146,7 @@ QStringList TMxpTagParser::parseToList(const QStringRef& tagText)
     return result;
 }
 
-int TMxpTagParser::readTextBlock(const QStringRef& str, int start, int end, QChar terminatingChar)
+int TMxpTagParser::readTextBlock(QStringView str, int start, int end, QChar terminatingChar)
 {
     bool inQuote = false;
     QChar curQuote = 0;

--- a/src/TMxpTagParser.h
+++ b/src/TMxpTagParser.h
@@ -1,6 +1,6 @@
 
-#ifndef MUDLET_MXPSUPPORT_CPP_TMXPTAGPARSER_H
-#define MUDLET_MXPSUPPORT_CPP_TMXPTAGPARSER_H
+#ifndef MUDLET_TMXPTAGPARSER_H
+#define MUDLET_TMXPTAGPARSER_H
 
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
@@ -32,10 +32,10 @@
 
 class TMxpTagParser
 {
-    static int readTextBlock(const QStringRef& str, int start, int end, QChar terminatingChar);
+    static int readTextBlock(QStringView str, int start, int end, QChar terminatingChar);
 
 public:
-    static QStringList parseToList(const QStringRef& tagText);
+    static QStringList parseToList(QStringView tagText);
     static QStringList parseToList(const QString& tagText);
 
     QList<QSharedPointer<MxpNode>> parseToMxpNodeList(const QString& tagText, bool ignoreText = false) const;
@@ -47,4 +47,4 @@ public:
     MxpTagAttribute parseAttribute(const QString& attr) const;
 };
 
-#endif //MUDLET_MXPSUPPORT_CPP_TMXPTAGPARSER_H
+#endif //MUDLET_TMXPTAGPARSER_H

--- a/src/TStringUtils.cpp
+++ b/src/TStringUtils.cpp
@@ -18,35 +18,14 @@
  ***************************************************************************/
 #include "TStringUtils.h"
 
-QStringRef TStringUtils::trimmedRef(const QStringRef& ref)
-{
-    int start = 0;
-    int end = ref.length();
-
-    while (start < end && ref[start].isSpace()) {
-        start++;
-    }
-
-    while (end > start && ref[end - 1].isSpace()) {
-        end--;
-    }
-
-    return QStringRef(ref.string(), ref.position() + start, end - start);
-}
-
-QStringRef TStringUtils::trimmedRef(const QString& str)
-{
-    return trimmedRef(QStringRef(&str));
-}
-
-QStringRef TStringUtils::stripRef(const QString& str, QChar start, QChar end)
+QStringView TStringUtils::strip(QStringView str, QChar start, QChar end)
 {
     int len = str.length();
     if (len > 1 && str.front() == start && str.back() == end) {
-        return str.midRef(1, len - 2);
+        return str.mid(1, len - 2);
     }
 
-    return QStringRef(&str);
+    return str;
 }
 
 bool TStringUtils::isQuote(QChar ch)
@@ -65,21 +44,17 @@ bool TStringUtils::isOneOf(QChar ch, const QString& chars)
     return false;
 }
 
-bool TStringUtils::isQuoted(const QStringRef& ref)
+bool TStringUtils::isQuoted(QStringView ref)
 {
     return TStringUtils::isQuote(ref.front()) && ref.front() == ref.back();
 }
 
-QStringRef TStringUtils::unquoteRef(const QStringRef& ref)
+QStringView TStringUtils::unquote(QStringView ref)
 {
     return isQuoted(ref) ? ref.mid(1, ref.size() - 2) : ref;
 }
-bool TStringUtils::isBetween(const QString& str, char first, char last)
-{
-    return isBetween(QStringRef(&str), first, last);
-}
 
-bool TStringUtils::isBetween(const QStringRef& str, char first, char last)
+bool TStringUtils::isBetween(QStringView str, char first, char last)
 {
     return str.front() == first && str.back() == last;
 }

--- a/src/TStringUtils.h
+++ b/src/TStringUtils.h
@@ -41,14 +41,11 @@ public:
     static bool isQuote(QChar ch);
     static bool isOneOf(QChar ch, const QString &chars);
 
-    static QStringRef trimmedRef(const QStringRef& ref);
-    static QStringRef stripRef(const QString& str, QChar start, QChar end);
+    static QStringView strip(QStringView str, QChar start, QChar end);
+    static QStringView unquote(QStringView ref);
 
-    static QStringRef unquoteRef(const QStringRef& ref);
-    static bool isBetween(const QString& str, char first, char last);
-    static bool isBetween(const QStringRef& str, char first, char last);
-    static QStringRef trimmedRef(const QString& str);
-    static bool isQuoted(const QStringRef& ref);
+    static bool isBetween(QStringView str, char first, char last);
+    static bool isQuoted(QStringView ref);
 
     static void apply(QStringList& strList, const std::function<void(QString&)>& func)
     {


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Refers to #3855

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

There are some places that uses `QStringRef::toUint` to convert part of a string to  numerical values, however QStringView doesn't support this operation.

https://github.com/Mudlet/Mudlet/blob/bf949317257a3e163e7711748172d4f591d9fd72/src/TBuffer.cpp#L2021-L2033