### PR TITLE
Bugfix: prevent build failure with libzip 1.70.0 with no version numbers

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -43,7 +43,7 @@
 // We are now using code that won't work with really old versions of libzip:
 // Unfortunately libzip 1.70 forgot to include these defines and thus broke the
 // original tests:
-#if defined(LIBZIP_VERSION_MAJOR) && defined(LIBZIP_VERSION_MAJOR) && (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
+#if defined(LIBZIP_VERSION_MAJOR) && defined(LIBZIP_VERSION_MINOR) && (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
 #error Mudlet requires a version of libzip of at least 0.11
 #endif
 

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -41,7 +41,9 @@
 #include "post_guard.h"
 
 // We are now using code that won't work with really old versions of libzip:
-#if (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
+// Unfortunately libzip 1.70 forgot to include these defines and thus broke the
+// original tests:
+#if defined(LIBZIP_VERSION_MAJOR) && defined(LIBZIP_VERSION_MAJOR) && (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
 #error Mudlet requires a version of libzip of at least 0.11
 #endif
 


### PR DESCRIPTION
As the Travis MacOs CI builds are using the latest libzip which is currently the one which doesn't have LIBZIP_MAJOR and other version numbers they were encountering a #error situation and aborting the build.

This is being fixed upstream so 1.70.1 should be okay.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>