### PR TITLE
Add spairs which iterates over any table in a sorted fashion

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -65,7 +65,35 @@ function __printTable( k, v )
   insertText("\nkey = " .. tostring(k) .. " value = " .. tostring( v )  )
 end
 
+-- originally found at https://stackoverflow.com/questions/15706270/sort-a-table-in-lua
+--- Returns a sorted iterator for a tbl. Defaults to a basic table.sort against the keys
+--@param tbl the table to iterator
+--@param[opt] order Function to use to sort table. Should accept three arguments, the table being iterated, and the two keys in the table it is comparing. Otherwise similar to table.sort
+--@usage local tbl = { Tom = 40, Mary = 50, Joe = 23 }
+--for name, thingies in spairs(tbl) do
+--  echo(string.format("%s has %d thingies\n", name, thingies))
+--end
+-- --"Joe has 23 thingies\nMary has 50 thingies\nTom has 40 thingies"
+--for name, thingies in spairs(tbl, function(t,a,b) return t[a] < t[b] end) do --iterate from lowest value to highest
+--  echo(string.format("%s has %d thingies\n", name, thingies))
+--end
+-- --"Joe has 23 thingies\nTom has 40 thingies\nMary has 50 thingies"
+function spairs(tbl, order)
+  local keys = table.keys(tbl)
+  if order then
+    table.sort(keys, function(a,b) return order(tbl, a, b) end)
+  else
+    table.sort(keys)
+  end
 
+  local i = 0
+  return function()
+    i = i + 1
+    if keys[i] then
+      return keys[i], tbl[keys[i]]
+    end
+  end
+end
 
 --- Lua debug function that prints the content of a Lua table on the screen. <br/>
 --- There are currently 3 functions with similar behaviour.

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -2,8 +2,8 @@ describe("Tests TableUtils.lua functions", function()
 
   describe("spairs", function()
     it("should sort by basic sorted keys by default", function()
-      local tbl = { Tom = 40, Mary = 50, Joe = 23 }
-      local expected = "Joe has 23 thingies\nMary has 50 thingies\nTom has 40 thingies\n"
+      local tbl = { Tom = 40, Mary = 50, Joe = 24 }
+      local expected = "Joe has 24 thingies\nMary has 50 thingies\nTom has 40 thingies\n"
       local actual = ""
       for name, thingies in spairs(tbl) do
         actual = actual .. string.format("%s has %d thingies\n", name, thingies)

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -1,5 +1,27 @@
 describe("Tests TableUtils.lua functions", function()
 
+  describe("spairs", function()
+    it("should sort by basic sorted keys by default", function()
+      local tbl = { Tom = 40, Mary = 50, Joe = 23 }
+      local expected = "Joe has 23 thingies\nMary has 50 thingies\nTom has 40 thingies\n"
+      local actual = ""
+      for name, thingies in spairs(tbl) do
+        actual = actual .. string.format("%s has %d thingies\n", name, thingies)
+      end
+      assert.are.equal(expected,actual)
+    end)
+
+    it("should sort based on a given function", function()
+      local tbl = { Tom = 40, Mary = 50, Joe = 23 }
+      local expected = "Joe has 23 thingies\nTom has 40 thingies\nMary has 50 thingies\n"
+      local actual = ""
+      for name, thingies in spairs(tbl, function(t,a,b) return t[a] < t[b] end) do --iterate from lowest value to highest
+        actual = actual .. string.format("%s has %d thingies\n", name, thingies)
+      end
+      assert.are.equal(expected, actual)
+    end)
+  end)
+
   describe("table.is_empty(tbl)", function()
     it("Should return false if the table has an entry in it", function()
       assert.is_false(table.is_empty({"one"}))


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds the spairs(tbl,order) function which works on any table like pairs(tbl) does, but allows you to influence the order the iterator runs in. 
```lua
local tbl = { Tom = 40, Mary = 50, Joe = 23 }
for name, thingies in spairs(tbl) do
  echo(string.format("%s has %d thingies\n", name, thingies))
end
 --Joe has 23 thingies
 --Mary has 50 thingies
 --Tom has 40 thingies
for name, thingies in spairs(tbl, function(t,a,b) return t[a] < t[b] end) do --iterate from lowest value to highest
  echo(string.format("%s has %d thingies\n", name, thingies))
end
 --Joe has 23 thingies
 --Tom has 40 thingies
 --Mary has 50 thingies
```
#### Motivation for adding to Mudlet
I ended up using something almost identical to this in SortBox and realized that others might want to iterate a table in a sorted fashion like this
#### Other info (issues closed, discussion etc)
Added tests for this.
Originally found this at https://stackoverflow.com/questions/15706270/sort-a-table-in-lua while researching solutions for SortBox
![image](https://user-images.githubusercontent.com/3660/84562086-92ff0780-ad1f-11ea-9475-748dcf3392e7.png)
