### PR TITLE
Update development with 4.9 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD}
                                          STREQUAL "")
   set(APP_BUILD $ENV{MUDLET_VERSION_BUILD})
 else()
-  set(APP_BUILD "")
+  set(APP_BUILD "-dev")
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,12 @@ endif()
 # IMPORTANT: To insure consistency please ensure the SAME of the first two
 # values are also assigned to the "VERSION" and "BUILD" variables in the native
 # qmake project file, which is NOW called: ./src/mudlet.pro
-set(APP_VERSION 4.8.2)
+set(APP_VERSION 4.9.0)
 if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD}
                                          STREQUAL "")
   set(APP_BUILD $ENV{MUDLET_VERSION_BUILD})
 else()
-  set(APP_BUILD "-dev")
+  set(APP_BUILD "")
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -41,7 +41,9 @@
 #include "post_guard.h"
 
 // We are now using code that won't work with really old versions of libzip:
-#if (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
+// Unfortunately libzip 1.70 forgot to include these defines and thus broke the
+// original tests:
+#if defined(LIBZIP_VERSION_MAJOR) && defined(LIBZIP_VERSION_MINOR) && (LIBZIP_VERSION_MAJOR < 1) && (LIBZIP_VERSION_MINOR < 11)
 #error Mudlet requires a version of libzip of at least 0.11
 #endif
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -105,7 +105,7 @@ isEmpty( BUILD ) {
 # "-dev" for the development build
 # "-ptb" for the public test build
 # "" for the release build
-   BUILD = ""
+   BUILD = "-dev"
 }
 
 # As the above also modifies the splash screen image (so developers get reminded

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -93,7 +93,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 4.8.2
+VERSION = 4.9.0
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment
@@ -105,7 +105,7 @@ isEmpty( BUILD ) {
 # "-dev" for the development build
 # "-ptb" for the public test build
 # "" for the release build
-   BUILD = "-dev"
+   BUILD = ""
 }
 
 # As the above also modifies the splash screen image (so developers get reminded


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Update development with 4.9 release
#### Motivation for adding to Mudlet
So development builds will now be of version 4.9.0, not 4.8.2.
#### Other info (issues closed, discussion etc)
