### PR TITLE
Fix crash loading MMP map

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -371,7 +371,8 @@ void XMLimport::readMap()
     while (itAreaWithRooms.hasNext()) {
         int areaId = itAreaWithRooms.next();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-        QSet<int> areaRoomsSet{tempAreaRoomsHash.values(areaId).begin(), tempAreaRoomsHash.values(areaId).end()};
+        auto values = tempAreaRoomsHash.values(areaId);
+        QSet<int> areaRoomsSet{values.begin(), values.end()};
 #else
         QSet<int> areaRoomsSet{tempAreaRoomsHash.values(areaId).toSet()};
 #endif


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix crash loading MMP map
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/3898.
#### Other info (issues closed, discussion etc)
Should use iterators from two different data structures, which result from calling `.values()` twice.