### PR TITLE
Fixes #3900, bug on MXP SEND tags

### DIFF
--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -40,6 +40,11 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         hints.removeFirst();
     }
 
+    // <SEND HREF="PROBE SUSPENDERS30901|BUY SUSPENDERS30901" hint="Click to see command menu">30901</SEND>
+    if (hrefs.size() > 1 && hints.size() == 1) {
+        hints = hrefs;
+    }
+
     // handle print to prompt feature PROMPT
     // <SEND "tell Zugg " PROMPT>Zugg</SEND>
     QString command = tag->hasAttribute(ATTR_PROMPT) ? QStringLiteral("printCmdLine") : QStringLiteral("send");
@@ -48,7 +53,9 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
         hrefs[i] = ctx.getEntityResolver().interpolate(hrefs[i]);
         hrefs[i] = QStringLiteral("%1([[%2]])").arg(command, hrefs[i]);
 
-        hints[i] = ctx.getEntityResolver().interpolate(hints[i]);
+        if (i < hints.size()) {
+            hints[i] = ctx.getEntityResolver().interpolate(hints[i]);
+        }
     }
 
     mLinkId = client.setLink(hrefs, hints);

--- a/test/TMxpSendTagHandlerTest.cpp
+++ b/test/TMxpSendTagHandlerTest.cpp
@@ -127,6 +127,31 @@ private slots:
         QCOMPARE(stub.mHints[0], "say I am Gandalf");
     }
 
+    void testSendHrefHintMismatch() {
+        // Example from starmourn on WARES command from NPCs
+        // <SEND HREF="PROBE SUSPENDERS30901|BUY SUSPENDERS30901" hint="Click to see command menu">30901</SEND>
+        TMxpStubContext ctx;
+        TMxpStubClient stub;
+
+        TMxpTagParser parser;
+        MxpStartTag* startTag = parser.parseStartTag(R"(<SEND HREF="PROBE SUSPENDERS30901|BUY SUSPENDERS30901" hint="Click to see command menu">)");
+        MxpEndTag* endTag = parser.parseEndTag("</SEND>");
+
+        TMxpSendTagHandler sendTagHandler;
+        TMxpTagHandler& tagHandler = sendTagHandler;
+        tagHandler.handleTag(ctx, stub, startTag);
+        tagHandler.handleContent("3091");
+        tagHandler.handleTag(ctx, stub, endTag);
+
+        QCOMPARE(stub.mHrefs.size(), 2);
+        QCOMPARE(stub.mHrefs[0], "send([[PROBE SUSPENDERS30901]])");
+        QCOMPARE(stub.mHrefs[1], "send([[BUY SUSPENDERS30901]])");
+
+        QCOMPARE(stub.mHints.size(), 2);
+        QCOMPARE(stub.mHints[0], "PROBE SUSPENDERS30901");
+        QCOMPARE(stub.mHints[1], "BUY SUSPENDERS30901");
+    }
+
 };
 
 #include "TMxpSendTagHandlerTest.moc"


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
- Bug was caused by index out of range when processing MXP SEND tags with more commands than associated hints
- The solution uses HREF instead of HINT when the number of available hints is one and smaller than the number of commands

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Issue #3900