### PR TITLE
Fix crash importing custom exit lines with Qt 5.14+

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -881,9 +881,11 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             // exit lines and remove those which are already included in the
             // colours) is much easier to perform on a QSet rather than a QList:
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            QSet<QString> missingKeys{customLines.keys().begin(), customLines.keys().end()};
+            auto customLineKeys = customLines.keys();
+            QSet<QString> missingKeys{customLineKeys.begin(), customLineKeys.end()};
             if (!customLinesColor.isEmpty()) {
-                QSet<QString> customLinesColorKeysSet{customLinesColor.keys().begin(), customLinesColor.keys().end()};
+                auto customLinesColorKeys = customLinesColor.keys();
+                QSet<QString> customLinesColorKeysSet{customLinesColorKeys.begin(), customLinesColorKeys.end()};
                 missingKeys.subtract(customLinesColorKeysSet);
             }
 #else


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix crash importing custom exit lines with Qt 5.14+
#### Motivation for adding to Mudlet
Mudlet should never crash.
#### Other info (issues closed, discussion etc)
I thought we covered all off all of the cases from the bad migration to the (bad) new Qt API, but it seems there was still one left.