### PR TITLE
Don't call Lua functions with too many arguments

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15983,7 +15983,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
     }
 
     // Lua is limited to ~50 arguments on a function
-    auto maxArguments = std::min(pE.mArgumentList.size(), 50);
+    auto maxArguments = std::min(pE.mArgumentList.size(), LUA_FUNCTION_MAX_ARGS);
     for (int i = 0; i < maxArguments; i++) {
         switch (pE.mArgumentTypeList.at(i)) {
         case ARGUMENT_TYPE_NUMBER:
@@ -16011,6 +16011,12 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
     }
 
     error = lua_pcall(L, maxArguments, LUA_MULTRET, 0);
+
+    if (mudlet::debugMode && pE.mArgumentList.size() > LUA_FUNCTION_MAX_ARGS) {
+        TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: more than " << LUA_FUNCTION_MAX_ARGS
+                                                   << " arguments passed to Lua function, exceeding Lua's limit. Trimmed arguments to " << LUA_FUNCTION_MAX_ARGS << "\n"
+                >> 0;
+    }
 
     if (error) {
         std::string err = "";

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15982,7 +15982,9 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         return false;
     }
 
-    for (int i = 0; i < pE.mArgumentList.size(); i++) {
+    // Lua is limited to ~50 arguments on a function
+    auto maxArguments = std::min(pE.mArgumentList.size(), 50);
+    for (int i = 0; i < maxArguments; i++) {
         switch (pE.mArgumentTypeList.at(i)) {
         case ARGUMENT_TYPE_NUMBER:
             lua_pushnumber(L, pE.mArgumentList.at(i).toDouble());
@@ -16008,7 +16010,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         }
     }
 
-    error = lua_pcall(L, pE.mArgumentList.size(), LUA_MULTRET, 0);
+    error = lua_pcall(L, maxArguments, LUA_MULTRET, 0);
 
     if (error) {
         std::string err = "";

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -584,6 +584,8 @@ private:
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
 
+    const int LUA_FUNCTION_MAX_ARGS = 50;
+
 
     QNetworkAccessManager* mpFileDownloader;
     std::list<std::string> mCaptureGroupList;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't call Lua functions with too many arguments.
#### Motivation for adding to Mudlet
Lua can take 50-60 max (let's go with 50 as [others](https://www.aerospike.com/docs/udf/known_limitations.html) are doing the same) arguments to a function. Trim the list off automatically.
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/2540.

This would also possibly fix other causes of `raiseEvent` crashing - perhaps it was due to too many arguments.