### PR TITLE
Client.Media: Remove Camel Case Package Requirement

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -183,7 +183,9 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
     // This is JSON
     auto json = document.object();
 
-    if (packageMessage == "Client.Media.Stop") {
+    QString package = packageMessage.toLower(); // Don't change original variable
+
+    if (package == "client.media.stop") {
         TMedia::parseJSONForMediaStop(json);
         return;
     }
@@ -192,11 +194,11 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
         return;
     }
 
-    if (packageMessage == "Client.Media.Default" || packageMessage == "Client.Media") { // Client.Media obsolete
+    if (package == "client.media.default" || package == "client.media") { // Client.Media obsolete
         TMedia::parseJSONForMediaDefault(json);
-    } else if (packageMessage == "Client.Media.Load") {
+    } else if (package == "client.media.load") {
         TMedia::parseJSONForMediaLoad(json);
-    } else if (packageMessage == "Client.Media.Play") {
+    } else if (package == "client.media.play") {
         TMedia::parseJSONForMediaPlay(json);
     }
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1887,9 +1887,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         mpHost->processDiscordGMCP(packageMessage, data);
     }
 
-    if (mpHost->mAcceptServerMedia
-        && (packageMessage.startsWith(QStringLiteral("Client.Media")) // Camel case preferred for GMCP
-            || packageMessage.startsWith(QStringLiteral("client.media")))) {
+    if (mpHost->mAcceptServerMedia && packageMessage.startsWith(QStringLiteral("Client.Media").toLower())) {
         mpHost->mpMedia->parseGMCP(packageMessage, data);
     }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1887,7 +1887,9 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         mpHost->processDiscordGMCP(packageMessage, data);
     }
 
-    if (mpHost->mAcceptServerMedia && transcodedMsg.startsWith(QStringLiteral("Client.Media"))) {
+    if (mpHost->mAcceptServerMedia
+        && (packageMessage.startsWith(QStringLiteral("Client.Media")) // Camel case preferred for GMCP
+            || packageMessage.startsWith(QStringLiteral("client.media")))) {
         mpHost->mpMedia->parseGMCP(packageMessage, data);
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes a requirement to use camel case style GMCP package names for the Client.Media namespace.  Some games (i.e. Aardwolf) have package names that are in all lower case for GMCP, so they'd like to see `client.media.default`, `client.media.load`, `client.media.play` and `client.media.stop`.  The change now allows any case.

#### Motivation for adding to Mudlet
Someone in the MUD community requested that the Client.Media specification should not force a requirement to use camel case style package names for its processing in Mudlet.

#### Other info (issues closed, discussion etc)
Tamarindo tested this at StickMUD.  It is admittedly not trivial for any of the approvers to test this, but the code changes here are really, really simple.  It does work.