### PR TITLE
Remove Default Host code from IRC

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13741,7 +13741,6 @@ int TLuaInterpreter::sendIrc(lua_State* L)
     if (!mudlet::self()->mpIrcClientMap.contains(pHost)) {
         // create a new irc client if one isn't ready.
         mudlet::self()->mpIrcClientMap[pHost] = new dlgIRC(pHost);
-        mudlet::self()->mpIrcClientMap.value(pHost)->setDefaultHostClient(false);
         mudlet::self()->mpIrcClientMap.value(pHost)->raise();
         mudlet::self()->mpIrcClientMap.value(pHost)->show();
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13741,6 +13741,7 @@ int TLuaInterpreter::sendIrc(lua_State* L)
     if (!mudlet::self()->mpIrcClientMap.contains(pHost)) {
         // create a new irc client if one isn't ready.
         mudlet::self()->mpIrcClientMap[pHost] = new dlgIRC(pHost);
+        mudlet::self()->mpIrcClientMap.value(pHost)->setDefaultHostClient(false);
         mudlet::self()->mpIrcClientMap.value(pHost)->raise();
         mudlet::self()->mpIrcClientMap.value(pHost)->show();
     }

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -45,7 +45,13 @@ QString dlgIRC::DefaultNickName = QStringLiteral("Mudlet");
 QStringList dlgIRC::DefaultChannels = QStringList() << QStringLiteral("#mudlet");
 int dlgIRC::DefaultMessageBufferLimit = 5000;
 
-dlgIRC::dlgIRC(Host* pHost) : mReadyForSending(false), mpHost(pHost), mIrcStarted(false), mInputHistoryMax(8), mConnectedHostName()
+dlgIRC::dlgIRC(Host* pHost) 
+: mReadyForSending(false)
+, mpHost(pHost)
+, mIrcStarted(false)
+, mIsDefaultIrcClient(true)
+, mInputHistoryMax(8)
+, mConnectedHostName()
 {
     mInputHistoryMax = 8;
     mInputHistoryIdxNext = 0;

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -49,7 +49,6 @@ dlgIRC::dlgIRC(Host* pHost)
 : mReadyForSending(false)
 , mpHost(pHost)
 , mIrcStarted(false)
-, mIsDefaultIrcClient(true)
 , mInputHistoryMax(8)
 , mConnectedHostName()
 {
@@ -615,9 +614,7 @@ void dlgIRC::slot_receiveMessage(IrcMessage* message)
                 if (!textToLua.isEmpty()) {
                     QString from = message->nick();
                     QString to = getMessageTarget(message, buffer->title());
-                    if (!isDefaultHostClient()) {
-                        mpHost->postIrcMessage(from, to, textToLua);
-                    }
+                    mpHost->postIrcMessage(from, to, textToLua);
                 }
             }
 
@@ -650,9 +647,7 @@ void dlgIRC::slot_nickNameChanged(const QString& nick)
     }
 
     // send a notice to Lua about the nick name change.
-    if (!isDefaultHostClient()) {
-        mpHost->postIrcMessage(mNickName, nick, tr("Your nick has changed."));
-    }
+    mpHost->postIrcMessage(mNickName, nick, tr("Your nick has changed."));
     mNickName = nick;
 
     setClientWindowTitle();
@@ -671,9 +666,7 @@ void dlgIRC::slot_joinedChannel(IrcJoinMessage* message)
 
     if (message->isOwn()) {
         QString luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
-        if (!isDefaultHostClient()) {
-            mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
-        }
+        mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
     }
 }
 
@@ -684,7 +677,7 @@ void dlgIRC::slot_partedChannel(IrcPartMessage* message)
         mChannels.removeAll(chan);
     }
 
-    if (message->isOwn() && !isDefaultHostClient()) {
+    if (message->isOwn()) {
         QString luaText = IrcMessageFormatter::formatMessage(static_cast<IrcMessage*>(message), true);
         mpHost->postIrcMessage(message->nick(), message->channel(), luaText);
     }

--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -79,8 +79,6 @@ public:
     QStringList getChannels() { return mChannels; }
     QString getConnectedHost() { return mConnectedHostName; }
     void ircRestart(bool reloadConfigs = true);
-    void setDefaultHostClient(bool isDefaultClient) { mIsDefaultIrcClient = isDefaultClient; }
-    bool isDefaultHostClient() { return mIsDefaultIrcClient; }
 
 private slots:
     void slot_onConnected();
@@ -120,7 +118,6 @@ private:
 
     Host* mpHost;
     bool mIrcStarted;
-    bool mIsDefaultIrcClient;
     IrcCompleter* completer;
     IrcCommandParser* commandParser;
     IrcBufferModel* bufferModel;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -430,9 +430,8 @@ void dlgProfilePreferences::disableHostDetails()
     // on groupBox_specialOptions:
     groupBox_specialOptions->setEnabled(false);
 
-    // it is possible to connect using the IRC client off of the
-    // "default" host even without a normal profile loaded so leave
-    // groupBox_ircOptions enabled...
+    groupBox_ircOptions->setEnabled(false);
+
     need_reconnect_for_specialoption->hide();
     groupbox_searchEngineSelection->setEnabled(false);
 
@@ -494,9 +493,9 @@ void dlgProfilePreferences::enableHostDetails()
 
     // on groupBox_specialOptions:
     groupBox_specialOptions->setEnabled(true);
-    // it is possible to connect using the IRC client off of the
-    // "default" host even without a normal profile loaded so leave
-    // groupBox_ircOptions enabled...
+
+    groupBox_ircOptions->setEnabled(true);
+
     groupbox_searchEngineSelection->setEnabled(true);
 
 #if defined(QT_NO_SSL)

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3840,7 +3840,6 @@ void mudlet::slot_irc()
 
     if (!mpIrcClientMap.contains(pHost)) {
         QPointer<dlgIRC> dlg = new dlgIRC(pHost);
-        dlg->setDefaultHostClient(false);
         mpIrcClientMap[pHost] = dlg;
     }
     mpIrcClientMap.value(pHost)->raise();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
As pointed out in issue #3704  this addresses some code that is effectively no longer used.
We don't use IRC as the main help-chat, in favor of Discord and the "Default host" IRC client can no longer be opened.

#### Motivation for adding to Mudlet
This may be impacting the sysIrcMessage callback events.

#### Other info (issues closed, discussion etc)
If this patch works, it will close #3704 
