### PR TITLE
Enhance: prevent password sniffing from sysDataSendEvent

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -450,7 +450,7 @@ void cTelnet::slot_send_login()
 void cTelnet::slot_send_pass()
 {
     if (!mpHost->getLogin().isEmpty() && !mpHost->getPass().isEmpty()) {
-        sendData(mpHost->getPass());
+        sendData(mpHost->getPass(), false);
     }
 }
 
@@ -613,16 +613,18 @@ void cTelnet::handle_socket_signal_hostFound(QHostInfo hostInfo)
 // This uses UTF-16BE encoded data but needs to be converted to the selected
 // Mud Server encoding - it should NOT contain any Telnet protocol byte
 // sequences:
-bool cTelnet::sendData(QString& data)
+bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
 {
     data.remove(QChar::LineFeed);
 
-    TEvent event {};
-    event.mArgumentList.append(QStringLiteral("sysDataSendRequest"));
-    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append(data);
-    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    mpHost->raiseEvent(event);
+    if (Q_LIKELY(permitDataSendRequestEvent)) {
+        TEvent event{};
+        event.mArgumentList.append(QStringLiteral("sysDataSendRequest"));
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        event.mArgumentList.append(data);
+        event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        mpHost->raiseEvent(event);
+    }
 
     if (mpHost->mAllowToSendCommand) {
         std::string outData;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -136,7 +136,9 @@ public:
     void reconnect();
     void disconnectIt();
     void abortConnection();
-    bool sendData(QString& data);
+    // Second argument needs to be set false when sending password to prevent
+    // it being sniffed by scripts/packages:
+    bool sendData(QString& data, bool permitDataSendRequestEvent = true);
     void setATCPVariables(const QByteArray&);
     void setGMCPVariables(const QByteArray&);
     void setMSSPVariables(const QByteArray&);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4121,30 +4121,6 @@ void mudlet::doAutoLogin(const QString& profile_name)
     enableToolbarButtons();
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// these two callbacks are called from cTelnet::handleConnectedToServer()
-void mudlet::slot_send_login()
-{
-    if (tempHostQueue.isEmpty()) {
-        return;
-    }
-    Host* pHost = tempHostQueue.dequeue();
-    QString login = pHost->getLogin();
-    pHost->mTelnet.sendData(login);
-}
-
-void mudlet::slot_send_pass()
-{
-    if (tempHostQueue.isEmpty()) {
-        return;
-    }
-    Host* pHost = tempHostQueue.dequeue();
-    QString pass = pHost->getPass();
-    pHost->mTelnet.sendData(pass);
-}
-//////////////////////////////////////////////////////////////////////////////
-
-
 void mudlet::processEventLoopHack()
 {
     QTimer::singleShot(1, this, &mudlet::processEventLoopHack_timerRun);
@@ -4239,8 +4215,6 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
     //      and one host has a slower response time as the other one, but
     //      the worst that can happen is that they have to login manually.
 
-    tempHostQueue.enqueue(pHost);
-    tempHostQueue.enqueue(pHost);
     if (connect) {
         pHost->connectToServer();
     } else {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -504,8 +504,6 @@ public slots:
     void slot_toggle_multi_view();
     void slot_connection_dlg_finished(const QString& profile, bool connectOnLoad);
     void slot_timer_fires();
-    void slot_send_login();
-    void slot_send_pass();
     void slot_replay();
     void slot_disconnect();
     void slot_notes();
@@ -604,9 +602,6 @@ private:
     QMap<QString, TConsole*> mTabMap;
     QWidget* mainPane;
 
-    QQueue<QString> tempLoginQueue;
-    QQueue<QString> tempPassQueue;
-    QQueue<Host*> tempHostQueue;
     static QPointer<mudlet> _self;
     QMap<Host*, QToolBar*> mUserToolbarMap;
     QMenu* restoreBar;


### PR DESCRIPTION
This revises `cTelnet::sendData(...)` so that it does NOT create a `sysDataSendRequest` with the password when called from: `cTelnet::slot_send_pass()` .

Also, in passing also found that similar `mudlet` class slot methods: `mudlet::::slot_send_login()` and `mudlet::::slot_send_pass()` are not used so can be pruned and then three `QQueue<QString>` in that same class are not used either.

This is an off-shoot of the recently aborted attempt to improve scripting capabilities for login and I need this in before I can redo that in a less monstrous form.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>