### PR TITLE
Skip downloading GET response if there's no file path

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -244,6 +244,24 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
     case QNetworkAccessManager::GetOperation:
         QString localFileName = downloadMap.value(reply);
         downloadMap.remove(reply);
+
+        // If the user forgot to give us a file path, we're not going to
+        // consider this an error, we're just going to skip downloading the
+        // response. Another way this could happen is the user made a POST
+        // request, and it redirected to a GET. In the case of POST requests,
+        // we don't ask the user for a file path, and so here too we will just
+        // skip downloading the response.
+        if (localFileName.isEmpty())
+        {
+            event.mArgumentList << QLatin1String("sysDownloadDone");
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << localFileName;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+            event.mArgumentList << QString::number(0);
+            event.mArgumentTypeList << ARGUMENT_TYPE_NUMBER;
+            break;
+        }
+
         QFile localFile(localFileName);
         if (!localFile.open(QFile::WriteOnly)) {
             event.mArgumentList << QLatin1String("sysDownloadError");


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Mudlet has a latent POST-to-GET redirect bug. I say _latent_ because it is hidden by a Qt bug that prevents POST-to-GET redirects. The Qt bug fix will ultimately be released in Qt version 5.15.1, and I'm hoping that we can get mudlet ready in advance. I explained the mudlet bug over [here](https://github.com/Mudlet/Mudlet/pull/3727#issuecomment-648867070):
> I've pulled the upstream Qt bug fix onto my machine and used mudlet to make a POST request that then redirects to a GET request. One problem immediately popped up. Since mudlet makes a POST request, it's unprepared to handle the GET response. Mudlet doesn't know what file path to download the contents of the GET response to, since mudlet users specify this file path **only** [when making GET requests](https://wiki.mudlet.org/w/Manual:Networking_Functions#downloadFile) but not [when making POST requests](https://wiki.mudlet.org/w/Manual:Networking_Functions#postHTTP). This manifests as a [`failureToWriteLocalFile` error](https://github.com/Mudlet/Mudlet/blob/e3f1ca65c75b7c332d3867c68fc5017a902cfcbc/src/TLuaInterpreter.cpp#L251) because mudlet tries and fails to open a file for writing at the `''` file path.

In that conversation, I proposed a few solutions, and @vadi2 said that he preferred the solution that makes mudlet skip downloading the response if the mudlet user has not specified a file path. This PR implements that solution.

To be candid, this is a change to the lua API. Right now, if a user made a GET request without specifying a file path, mudlet will trigger a `sysDownloadError` event when handling the response. If applied, this PR will make mudlet instead trigger a `sysDownloadDone` event.

#### Motivation for adding to Mudlet
Once mudlet upgrades to Qt version 5.15.1, mudlet will be capable of handling a POST-to-GET redirects, but only if we first fix this bug.

#### Other info (issues closed, discussion etc)
* [The original PR](https://github.com/Mudlet/Mudlet/pull/3727) that spawned this PR
* [The Qt bug report](https://bugreports.qt.io/browse/QTBUG-84162)
* The Qt bug fix for their [dev](https://codereview.qt-project.org/c/qt/qtbase/+/303705) branch and their [5.15](https://codereview.qt-project.org/c/qt/qtbase/+/304230) branch
* Question: is there any way I can write a useful automated test for this code?