### PR TITLE
More concise tooltip for compact input line

### DIFF
--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -313,7 +313,7 @@
      <bool>false</bool>
    </property>
    <property name="toolTip">
-    <string>&lt;p&gt;Hide or show the search area and the bottom buttons to the right of the input area on the input line for the current profile.&lt;/p&gt;</string>
+    <string>&lt;p&gt;Hide / show the search area and buttons at the bottom of the screen.&lt;/p&gt;</string>
    </property>
   </action>
   <action name="dactionDiscord">


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Change:

> Hide or show the search area and the bottom buttons to the right of the input area on the input line for the current profile.

To a more concise:

> Hide / show the search area and buttons at the bottom of the screen.
#### Motivation for adding to Mudlet
I was looking at the text in Crowdin and it is quite a mouthful, and not really relatable for most players (who aren't engineers!).

Working through the text, it was trimmed by:

> for the current profile

Not necessary to mention, because this behaviour can be easily discovered in 2 seconds by opening another profile and toggling between them.

> right of the input area on the input line

That's some duplication happening here. We also don't have buttons on the left side, so the only buttons visible _are_ already on the right.

#### Other info (issues closed, discussion etc)

Shorter is better, not longer is better.