### PR TITLE
Revise: prevent multiple connection dialogues

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -38,14 +38,14 @@
 
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 : QDialog(parent)
+, validName()
+, validUrl()
+, validPort()
 , mProfileList(QStringList())
 , offline_button(nullptr)
 , connect_button(nullptr)
 , delete_profile_lineedit(nullptr)
 , delete_button(nullptr)
-, validName()
-, validUrl()
-, validPort()
 , mDefaultGames({"3Kingdoms", "3Scapes", "Aardwolf", "Achaea", "Aetolia",
                  "Avalon.de", "BatMUD", "Clessidra", "Fierymud", "Imperian", "Luminari",
                  "Lusternia", "Materia Magica", "Midnight Sun 2", "Realms of Despair",
@@ -430,6 +430,7 @@ void dlgConnectionProfiles::slot_update_SSL_TSL_port(int state)
 
 void dlgConnectionProfiles::slot_update_name(const QString& newName)
 {
+    Q_UNUSED(newName)
     validateProfile();
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3427,13 +3427,16 @@ void mudlet::writeSettings()
 
 void mudlet::slot_show_connection_dialog()
 {
-    auto pDlg = new dlgConnectionProfiles(this);
-    connect(pDlg, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connection_dlg_finished);
-    pDlg->fillout_form();
+    if (mConnectionDialog) {
+        return;
+    }
+    mConnectionDialog = new dlgConnectionProfiles(this);
+    connect(mConnectionDialog, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connection_dlg_finished);
+    mConnectionDialog->fillout_form();
 
-    connect(pDlg, &QDialog::accepted, this, [=]() { enableToolbarButtons(); });
-    pDlg->setAttribute(Qt::WA_DeleteOnClose);
-    pDlg->show();
+    connect(mConnectionDialog, &QDialog::accepted, this, [=]() { enableToolbarButtons(); });
+    mConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);
+    mConnectionDialog->show();
 }
 
 void mudlet::show_editor_dialog()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -111,6 +111,7 @@ class TTimer;
 class TToolBar;
 class dlgIRC;
 class dlgAboutDialog;
+class dlgConnectionProfiles;
 class dlgProfilePreferences;
 
 class translation;
@@ -286,6 +287,7 @@ public:
     QPointer<dlgAboutDialog> mpAboutDlg;
     QPointer<QDialog> mpModuleDlg;
     QPointer<QDialog> mpPackageManagerDlg;
+    QPointer<dlgConnectionProfiles> mConnectionDialog;
     QMap<Host*, QPointer<dlgProfilePreferences>> mpProfilePreferencesDlgMap;
     // More modern Desktop styles no longer include icons on the buttons in
     // QDialogButtonBox buttons - but some users are using Desktops (KDE4?) that


### PR DESCRIPTION
This will close Issue: #2706.

Also fix a couple of warnings for the `dlgConnectionProfiles` class:
* an out of order initialisation list
* an unused argument in: `(void) dlgConnectionProfiles::slot_update_name(const QString&)`

This PR came about as I was reviewing #3929 and realised that there was a further enhancement I could make that would improve the new user first launch process - but it needed to be able to get a handle (or rather a pointer) to the Connection Preferences dialogue which was not available in the existing code without something like this. Closing the issue is a bonus! :grinning: 

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>