### PR TITLE
Donot resize item in HBox/VBox if not dynamic

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -42,11 +42,12 @@ function Geyser.HBox:organize()
     window:move(start_x.."%", "0%")
     if window.h_policy == Geyser.Dynamic then
       width = window_width * window.h_stretch_factor
+      window:resize(width .. "%", nil)
     end
     if window.v_policy == Geyser.Dynamic then
       height = 100
+      window:resize(nil, height .. "%")
     end
-    window:resize(width.."%", height.."%")
     start_x = start_x + width
   end
 end

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -42,13 +42,13 @@ function Geyser.HBox:organize()
     window:move(start_x.."%", "0%")
     if window.h_policy == Geyser.Dynamic then
       width = window_width * window.h_stretch_factor
-      if window.width ~= width then
+      if window.width ~= width .. "%" then
         window:resize(width .. "%", nil)
       end
     end
     if window.v_policy == Geyser.Dynamic then
       height = 100
-      if window.height ~= height then
+      if window.height ~= height .. "%" then
         window:resize(nil, height .. "%")
       end
     end

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -34,6 +34,7 @@ function Geyser.HBox:organize()
   end
   local window_width = (self:calculate_dynamic_window_size().width / self:get_width()) * 100
   local start_x = 0
+  self.contains_fixed = false
   for _, window_name in ipairs(self.windows) do
     local window = self.windowList[window_name]
     local width = (window:get_width() / self:get_width()) * 100

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -42,11 +42,15 @@ function Geyser.HBox:organize()
     window:move(start_x.."%", "0%")
     if window.h_policy == Geyser.Dynamic then
       width = window_width * window.h_stretch_factor
-      window:resize(width .. "%", nil)
+      if window.width ~= width then
+        window:resize(width .. "%", nil)
+      end
     end
     if window.v_policy == Geyser.Dynamic then
       height = 100
-      window:resize(nil, height .. "%")
+      if window.height ~= height then
+        window:resize(nil, height .. "%")
+      end
     end
     start_x = start_x + width
   end

--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -25,7 +25,6 @@ end
 --- Responsible for organizing the elements inside the HBox
 -- Called when a new element is added
 function Geyser.HBox:organize()
-  self.parent:reposition()
   -- Workaround for issue with width/height being 0 at creation
   if self:get_width() == 0 then
     self:resize("0.9px", nil)
@@ -39,6 +38,9 @@ function Geyser.HBox:organize()
     local window = self.windowList[window_name]
     local width = (window:get_width() / self:get_width()) * 100
     local height = (window:get_height() / self:get_height()) * 100
+    if window.h_policy == Geyser.Fixed or window.v_policy == Geyser.Fixed then
+      self.contains_fixed = true
+    end
     window:move(start_x.."%", "0%")
     if window.h_policy == Geyser.Dynamic then
       width = window_width * window.h_stretch_factor
@@ -53,6 +55,13 @@ function Geyser.HBox:organize()
       end
     end
     start_x = start_x + width
+  end
+end
+
+function Geyser.HBox:reposition()
+  Geyser.Container.reposition(self)
+  if self.contains_fixed then
+    self:organize()
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -26,7 +26,6 @@ end
 --- Responsible for organizing the elements inside the VBox
 -- Called when a new element is added
 function Geyser.VBox:organize()
-  self.parent:reposition()
   -- Workaround for issue with width/height being 0 at creation
   if self:get_width() == 0 then
     self:resize("0.9px", nil)

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -62,7 +62,7 @@ end
 
 function Geyser.VBox:reposition()
   Geyser.Container.reposition(self)
-  if self.contains_fixed then
+  if self.contains_fixed then -- prevent gaps when items have fixed size
     self:organize()
   end
 end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -41,6 +41,9 @@ function Geyser.VBox:organize()
     window:move("0%", start_y.."%")
     local width = (window:get_width() / self:get_width()) * 100
     local height = (window:get_height() / self:get_height()) * 100
+    if window.h_policy == Geyser.Fixed or window.v_policy == Geyser.Fixed then
+      self.contains_fixed = true
+    end
     if window.h_policy == Geyser.Dynamic then
       width = 100
       if window.width ~= width .. "%" then
@@ -54,6 +57,13 @@ function Geyser.VBox:organize()
       end
     end
     start_y = start_y + height
+  end
+end
+
+function Geyser.VBox:reposition()
+  Geyser.Container.reposition(self)
+  if self.contains_fixed then
+    self:organize()
   end
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -43,11 +43,12 @@ function Geyser.VBox:organize()
     local height = (window:get_height() / self:get_height()) * 100
     if window.h_policy == Geyser.Dynamic then
       width = 100
+      window:resize(width .. "%", nil)
     end
     if window.v_policy == Geyser.Dynamic then
       height = window_height * window.v_stretch_factor
+      window:resize(nil, height .. "%")
     end
-    window:resize(width.."%", height.."%")
     start_y = start_y + height
   end
 end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -35,6 +35,7 @@ function Geyser.VBox:organize()
   end
   local window_height = (self:calculate_dynamic_window_size().height / self:get_height()) * 100
   local start_y = 0
+  self.contains_fixed = false
   for _, window_name in ipairs(self.windows) do
     local window = self.windowList[window_name]
     window:move("0%", start_y.."%")

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -43,11 +43,15 @@ function Geyser.VBox:organize()
     local height = (window:get_height() / self:get_height()) * 100
     if window.h_policy == Geyser.Dynamic then
       width = 100
-      window:resize(width .. "%", nil)
+      if window.width ~= width then
+        window:resize(width .. "%", nil)
+      end
     end
     if window.v_policy == Geyser.Dynamic then
       height = window_height * window.v_stretch_factor
-      window:resize(nil, height .. "%")
+      if window.height ~= height then
+        window:resize(nil, height .. "%")
+      end
     end
     start_y = start_y + height
   end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -43,13 +43,13 @@ function Geyser.VBox:organize()
     local height = (window:get_height() / self:get_height()) * 100
     if window.h_policy == Geyser.Dynamic then
       width = 100
-      if window.width ~= width then
+      if window.width ~= width .. "%" then
         window:resize(width .. "%", nil)
       end
     end
     if window.v_policy == Geyser.Dynamic then
       height = window_height * window.v_stretch_factor
-      if window.height ~= height then
+      if window.height ~= height .. "%" then
         window:resize(nil, height .. "%")
       end
     end


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Right now, if you create an item with a fixed pixel height and v_policy of fixed, and add it to a VBox, then it will not visibly change size but it does get resized from that static pixel height to a % of the vbox's height which represents the same number of pixels.

This is ok, unless your vbox changes size, as now the item inside of it will change sizes to be the same percentage of the new size. With this change, the height or width is only resized if the policy actually calls for it.
#### Motivation for adding to Mudlet
I was working on an elastic version of VBox which grows or shrinks to fit its contents, but it quickly ran away as the items inside changed size, which told the vbox to get bigger, which made the items inside bigger...
#### Other info (issues closed, discussion etc)
This does involve a small performance hit the first time an item is added to an H/VBox if both h_policy and v_policy are Geyser.Dynamic, but because I guard against calling resize if the height or width is already where it should be, every change after that should result in the same or better performance as it currently has.

Given the VBox makes it the full width if h_policy is dynamic, you can also reduce this by setting the width to 100% and it won't need to resize it. Same with HBox and the v_policy/height


ORIGINALLY OPENED AS https://github.com/Mudlet/Mudlet/pull/3941 and further testing information can be found therein, but CI got out of whack so I'm recreating it.

SECOND recreation, apparently it was tracking the travis builds by branch or sha, so changed the sha with a comment and made it a new branch.
