### PR TITLE
BugFix: announce end of replays when run from replay button

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2389,9 +2389,9 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
             postMessage(tr("[ INFO ]  - Loading replay file:\n"
                            "\"%1\".")
                         .arg(name));
-            mIsReplayRunFromLua = true;
-        } else {
             mIsReplayRunFromLua = false;
+        } else {
+            mIsReplayRunFromLua = true;
         }
         replayStream.setDevice(&replayFile);
         if (QVersionNumber::fromString(QString(qVersion())) >= QVersionNumber(5, 13, 0)) {


### PR DESCRIPTION
I got the logic reversed in the original #1519 for `(bool) cTelnet::mIsReplayRunFromLua` so the ending message was not being
displayed when it should have been.

This will close #2793.

*If called from the toolbar button there will **not** be a valid pointer to a `QString` in the `TLuaIterpreter` class that is waiting for any messages from the replay starting (or error-ing our) process - so in that case the flag is not set so that when the replay is ended a message should have been posted on screen.*

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>