### PR TITLE
Add dummy functions for TTS if Mudlet was compiled with TTS disabled

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1021,3 +1021,13 @@ function packageDrop(event, fileName, suffix)
   installPackage(fileName)
 end
 registerAnonymousEventHandler("sysDropEvent", "packageDrop")
+
+-- Add dummy functions for the TTS functions if Mudlet has been compiled without them
+-- This is to prevent scripts erroring if they've been written with TTS capabilities
+-- then loaded into a Mudlet without them.
+if not ttsSpeak then --check if ttsSpeak is defined, if not then Mudlet lacks TTS capabilities.
+  local funcs = {"ttsClearQueue", "ttsGetCurrentLine", "ttsGetCurrentVoice", "ttsGetQueue", "ttsGetState", "ttsGetVoices", "ttsPause", "ttsQueue", "ttsResume", "ttsSpeak", "ttsSetPitch", "ttsSetRate", "ttsSetVolume", "ttsSetVoiceByIndex", "ttsSetVoiceByName", "ttsSkip"}
+  for _,fn in ipairs(funcs) do
+    _G[fn] = function() debugc(string.format("%s: Mudlet was compiled without TTS capabilities", fn)) end
+  end
+end


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Checks if ttsSpeak is defined, and if not define a set of dummy functions to prevent scripts which have options for TTS included from not compiling when installed.
#### Motivation for adding to Mudlet
People who compile Mudlet without TTS should be able to install packages which use the functions without errors.
#### Other info (issues closed, discussion etc)
Adds messages to the error console:
![image](https://user-images.githubusercontent.com/3660/86521351-9583e700-be1d-11ea-9a0c-cd40d07907ab.png)
