### PR TITLE
Bugfix for string.split with too many characters

### DIFF
--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -64,16 +64,22 @@ end
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.split
 function string:split(delimiter)
   delimiter = delimiter or " "
-  if delimiter == "" then return {self:match( (self:gsub(".", "(.)")) )} end
   local result = { }
-  local from = 1
-  local delim_from, delim_to = string.find( self, delimiter, from  )
-  while delim_from do
-    table.insert( result, string.sub( self, from, delim_from - 1 ) )
-    from = delim_to + 1
-    delim_from, delim_to = string.find( self, delimiter, from  )
+
+  if delimiter == "" then
+    for i = 1, #self do
+      result[i] = self:sub(i,i)
+    end
+  else
+    local from = 1
+    local delim_from, delim_to = string.find( self, delimiter, from  )
+    while delim_from do
+      table.insert( result, string.sub( self, from, delim_from - 1 ) )
+      from = delim_to + 1
+      delim_from, delim_to = string.find( self, delimiter, from  )
+    end
+    table.insert( result, string.sub( self, from  ) )
   end
-  table.insert( result, string.sub( self, from  ) )
   return result
 end
 

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -74,7 +74,7 @@ function string:split(delimiter)
     local from = 1
     local delim_from, delim_to = string.find( self, delimiter, from  )
     while delim_from do
-      table.insert( result, string.sub( self, from, delim_from - 1 ) )
+      result[#result+1] = string.sub(self, from, delim_from - 1)
       from = delim_to + 1
       delim_from, delim_to = string.find( self, delimiter, from  )
     end

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -78,7 +78,7 @@ function string:split(delimiter)
       from = delim_to + 1
       delim_from, delim_to = string.find( self, delimiter, from  )
     end
-    table.insert( result, string.sub( self, from  ) )
+    result[#result+1] = string.sub(self, from)
   end
   return result
 end


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Ran into an issue today trying to do myString:split("") with a string > 32 characters. It turns out Lua has a limit of 32 matches returned by default. I found the definition of LUA_MAXCAPTURES and it says it's arbitrary, but rather than bump the limit and potentially cause unintended issues, I just rewrote string.split for the "" case as a for loop to avoid this limit altogether.
#### Motivation for adding to Mudlet
Caused issues while writing a chyron label class trying to split a text message into individual characters.
#### Other info (issues closed, discussion etc)
![image](https://user-images.githubusercontent.com/3660/86795645-c6d9fe00-c03b-11ea-8bc6-bf15d9450378.png)
