### PR TITLE
Revise: try and identify profiles and some controls in connection dialog

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -90,9 +90,9 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     QAbstractButton* abort = dialog_buttonbox->button(QDialogButtonBox::Cancel);
     connect_button = dialog_buttonbox->addButton(tr("Connect"), QDialogButtonBox::AcceptRole);
-    connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+    connect_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
     offline_button = dialog_buttonbox->addButton(tr("Offline"), QDialogButtonBox::AcceptRole);
-    offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+    offline_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
 
     // Test and set if needed mudlet::mIsIconShownOnDialogButtonBoxes - if there
     // is already a Qt provided icon on a predefined button, this is probably
@@ -263,13 +263,13 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     profiles_tree_widget->setViewMode(QListView::IconMode);
 
-    commonTexts_loadButton_enabled_accessibilityDesc = tr("Click to load but not connect the selected profile.");
-    commonTexts_connectButton_enabled_accessibilityDesc = tr("Click to load and connect the selected profile.");
-    commonTexts_connectOrLoadButton_disabled_accessibilityDesc = tr("Need to have a valid profile name, game server address and port before this button can be enabled.");
-    commonTexts_profile_accessibilityName = tr("mud name: %1");
-    commonTexts_profile_accessibilityDesc = tr("Button to select a mud game to play, double-click it to connect and start playing it.",
-                                                    // Intentional comment to separate arguments
-                                                    "Some text to speech engines will spell out initials like MUD so stick to lower case if that is a better option");
+    btn_load_enabled_accessDesc = tr("Click to load but not connect the selected profile.");
+    btn_connect_enabled_accessDesc = tr("Click to load and connect the selected profile.");
+    btn_connOrLoad_disabled_accessDesc = tr("Need to have a valid profile name, game server address and port before this button can be enabled.");
+    item_profile_accessName = tr("mud name: %1");
+    item_profile_accessDesc = tr("Button to select a mud game to play, double-click it to connect and start playing it.",
+                                 // Intentional comment to separate arguments
+                                 "Some text to speech engines will spell out initials like MUD so stick to lower case if that is a better option");
 }
 
 // the dialog can be accepted by pressing Enter on an qlineedit; this is a safeguard against it
@@ -359,8 +359,8 @@ void dlgConnectionProfiles::slot_update_url(const QString& url)
         validUrl = false;
         offline_button->setEnabled(false);
         connect_button->setEnabled(false);
-        offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
-        connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+        offline_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
+        connect_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
         return;
     }
 
@@ -425,11 +425,11 @@ void dlgConnectionProfiles::slot_update_port(const QString& ignoreBlank)
         validPort = false;
         if (offline_button) {
             offline_button->setEnabled(false);
-            offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+            offline_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
         }
         if (connect_button) {
             connect_button->setEnabled(false);
-            connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+            connect_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
         }
         return;
     }
@@ -636,9 +636,9 @@ void dlgConnectionProfiles::slot_addProfile()
     validUrl = false;
     validPort = false;
     offline_button->setEnabled(false);
-    offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+    offline_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
     connect_button->setEnabled(false);
-    connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+    connect_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
 }
 
 // enables the deletion button once the correct text (profile name) is entered
@@ -1356,8 +1356,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1377,8 +1377,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1397,8 +1397,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1419,8 +1419,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1441,8 +1441,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1461,8 +1461,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/batmud_mud.png"));
@@ -1481,8 +1481,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1501,8 +1501,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1521,8 +1521,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1541,8 +1541,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1561,8 +1561,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1581,8 +1581,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1601,8 +1601,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1621,8 +1621,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1641,8 +1641,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1662,8 +1662,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1683,8 +1683,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1705,8 +1705,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1727,8 +1727,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1748,8 +1748,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         if (!hasCustomIcon(mudServer)) {
             profiles_tree_widget->addItem(pItem);
@@ -1771,8 +1771,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1791,8 +1791,8 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
@@ -1814,8 +1814,8 @@ void dlgConnectionProfiles::fillout_form()
         mProfileList.append(mudServer);
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
         profiles_tree_widget->addItem(pItem);
         description = getDescription(QStringLiteral("mudlet.org"), 0, mudServer);
@@ -1906,8 +1906,8 @@ void dlgConnectionProfiles::loadCustomProfile(const QString& profileName) const
 {
     auto pItem = new QListWidgetItem();
     pItem->setData(csmNameRole, profileName);
-    pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(profileName));
-    pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+    pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(profileName));
+    pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
     setCustomIcon(profileName, pItem);
     auto description = getDescription(profileName, 0, profileName);
@@ -1964,8 +1964,8 @@ void dlgConnectionProfiles::generateCustomProfile(int i, const QString& profileN
 {
     auto pItem = new QListWidgetItem();
     pItem->setData(csmNameRole, profileName);
-    pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(profileName));
-    pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+    pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(profileName));
+    pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
     profiles_tree_widget->addItem(pItem);
     QPixmap background(120, 30);
@@ -2189,8 +2189,8 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
         return false;
     }
     pItem->setData(csmNameRole, profile_name);
-    pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(profile_name));
-    pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+    pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(profile_name));
+    pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
 
     // add the new widget in
     profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -2553,12 +2553,12 @@ bool dlgConnectionProfiles::validateProfile()
             if (offline_button) {
                 offline_button->setEnabled(true);
                 offline_button->setToolTip(tr("<p>Load profile without connecting.</p>"));
-                offline_button->setAccessibleDescription(commonTexts_loadButton_enabled_accessibilityDesc);
+                offline_button->setAccessibleDescription(btn_load_enabled_accessDesc);
             }
             if (connect_button) {
                 connect_button->setEnabled(true);
                 connect_button->setToolTip(QString());
-                connect_button->setAccessibleDescription(commonTexts_connectButton_enabled_accessibilityDesc);
+                connect_button->setAccessibleDescription(btn_connect_enabled_accessDesc);
             }
             return true;
         } else {
@@ -2567,12 +2567,12 @@ bool dlgConnectionProfiles::validateProfile()
             if (offline_button) {
                 offline_button->setEnabled(false);
                 offline_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before loading.</p>"));
-                offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+                offline_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
             }
             if (connect_button) {
                 connect_button->setEnabled(false);
                 connect_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before connecting.</p>"));
-                connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+                connect_button->setAccessibleDescription(btn_connOrLoad_disabled_accessDesc);
             }
             return false;
         }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -90,7 +90,9 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 
     QAbstractButton* abort = dialog_buttonbox->button(QDialogButtonBox::Cancel);
     connect_button = dialog_buttonbox->addButton(tr("Connect"), QDialogButtonBox::AcceptRole);
+    connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
     offline_button = dialog_buttonbox->addButton(tr("Offline"), QDialogButtonBox::AcceptRole);
+    offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
 
     // Test and set if needed mudlet::mIsIconShownOnDialogButtonBoxes - if there
     // is already a Qt provided icon on a predefined button, this is probably
@@ -120,6 +122,15 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     copy_profile_toolbutton->addAction(copyProfile);
     copy_profile_toolbutton->addAction(copyProfileSettings);
     copy_profile_toolbutton->setDefaultAction(copyProfile);
+    auto widgetList = copyProfile->associatedWidgets();
+    Q_ASSERT_X(widgetList.count(), "dlgConnectionProfiles::dlgConnectionProfiles(...)", "A QWidget for copyProfile QAction not found.");
+    widgetList.first()->setAccessibleName(tr("copy profile"));
+    widgetList.first()->setAccessibleDescription(tr("copy the entire profile to new one that will require a different new name."));
+
+    widgetList = copyProfileSettings->associatedWidgets();
+    Q_ASSERT_X(widgetList.count(), "dlgConnectionProfiles::dlgConnectionProfiles(...)", "A QWidget for copyProfileSettings QAction not found.");
+    widgetList.first()->setAccessibleName(tr("copy profile settings"));
+    widgetList.first()->setAccessibleDescription(tr("copy the settings and some other parts of the profile to a new one that will require a different new name."));
 
     if (mudlet::self()->mShowIconsOnDialogs) {
         // Since I've switched to allowing the possibility of theme replacement
@@ -251,6 +262,14 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     mErrorPalette.setColor(QPalette::Base, QColor(255, 235, 235));
 
     profiles_tree_widget->setViewMode(QListView::IconMode);
+
+    commonTexts_loadButton_enabled_accessibilityDesc = tr("Click to load but not connect the selected profile.");
+    commonTexts_connectButton_enabled_accessibilityDesc = tr("Click to load and connect the selected profile.");
+    commonTexts_connectOrLoadButton_disabled_accessibilityDesc = tr("Need to have a valid profile name, game server address and port before this button can be enabled.");
+    commonTexts_profile_accessibilityName = tr("mud name: %1");
+    commonTexts_profile_accessibilityDesc = tr("Button to select a mud game to play, double-click it to connect and start playing it.",
+                                                    // Intentional comment to separate arguments
+                                                    "Some text to speech engines will spell out initials like MUD so stick to lower case if that is a better option");
 }
 
 // the dialog can be accepted by pressing Enter on an qlineedit; this is a safeguard against it
@@ -338,8 +357,10 @@ void dlgConnectionProfiles::slot_update_url(const QString& url)
 {
     if (url.isEmpty()) {
         validUrl = false;
-        offline_button->setDisabled(true);
-        connect_button->setDisabled(true);
+        offline_button->setEnabled(false);
+        connect_button->setEnabled(false);
+        offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+        connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
         return;
     }
 
@@ -403,10 +424,12 @@ void dlgConnectionProfiles::slot_update_port(const QString& ignoreBlank)
     if (ignoreBlank.isEmpty()) {
         validPort = false;
         if (offline_button) {
-            offline_button->setDisabled(true);
+            offline_button->setEnabled(false);
+            offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
         }
         if (connect_button) {
-            connect_button->setDisabled(true);
+            connect_button->setEnabled(false);
+            connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
         }
         return;
     }
@@ -612,8 +635,10 @@ void dlgConnectionProfiles::slot_addProfile()
     validName = false;
     validUrl = false;
     validPort = false;
-    offline_button->setDisabled(true);
-    connect_button->setDisabled(true);
+    offline_button->setEnabled(false);
+    offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
+    connect_button->setEnabled(false);
+    connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
 }
 
 // enables the deletion button once the correct text (profile name) is entered
@@ -621,7 +646,7 @@ void dlgConnectionProfiles::slot_deleteprofile_check(const QString& text)
 {
     QString profile = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
     if (profile != text) {
-        delete_button->setDisabled(true);
+        delete_button->setEnabled(false);
     } else {
         delete_button->setEnabled(true);
         delete_button->setFocus();
@@ -681,7 +706,7 @@ void dlgConnectionProfiles::slot_deleteProfile()
 
     delete_profile_lineedit->setPlaceholderText(profile);
     delete_profile_lineedit->setFocus();
-    delete_button->setDisabled(true);
+    delete_button->setEnabled(false);
     delete_profile_dialog->setWindowTitle(tr("Deleting '%1'").arg(profile));
 
     delete_profile_dialog->show();
@@ -1264,13 +1289,13 @@ void dlgConnectionProfiles::updateDiscordStatus()
     auto discordLoaded = mudlet::self()->mDiscord.libraryLoaded();
 
     if (!discordLoaded) {
-        discord_optin_checkBox->setDisabled(true);
+        discord_optin_checkBox->setEnabled(false);
         discord_optin_checkBox->setChecked(false);
         discord_optin_checkBox->setToolTip(tr("Discord integration not available on this platform"));
     } else if (mDiscordApplicationId.isEmpty() && !mudlet::self()->mDiscord.gameIntegrationSupported(host_name_entry->text().trimmed()).first) {
         // Disable discord support if it is not recognised by name and a
         // Application Id has not been previously entered:
-        discord_optin_checkBox->setDisabled(true);
+        discord_optin_checkBox->setEnabled(false);
         discord_optin_checkBox->setChecked(false);
         discord_optin_checkBox->setToolTip(tr("Discord integration not supported by game"));
     } else {
@@ -1331,6 +1356,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             QPixmap p(QStringLiteral(":/icons/avalon.png"));
@@ -1349,6 +1377,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/achaea_120_30.png"));
@@ -1366,6 +1397,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             QPixmap pc(QStringLiteral(":/icons/3klogo.png"));
@@ -1385,6 +1419,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             QPixmap pc(QStringLiteral(":/icons/3slogo.png"));
@@ -1404,6 +1441,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/lusternia_120_30.png"));
@@ -1421,6 +1461,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/batmud_mud.png"));
             pItem->setIcon(mi);
@@ -1438,6 +1481,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/gw2.png"));
@@ -1455,6 +1501,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/Slothmud.png"));
@@ -1472,6 +1521,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/aardwolf_mud.png"));
@@ -1489,6 +1541,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/materiaMagicaIcon"));
@@ -1506,6 +1561,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/120x30RoDLogo.png"));
@@ -1523,6 +1581,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/zombiemud.png"));
@@ -1540,6 +1601,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/aetolia_120_30.png"));
@@ -1557,6 +1621,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/imperian_120_30.png"));
@@ -1574,6 +1641,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QPixmap(QStringLiteral(":/icons/wotmudicon.png")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
@@ -1592,6 +1662,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QPixmap(QStringLiteral(":/icons/midnightsun2.png")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
@@ -1610,6 +1683,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(
@@ -1629,6 +1705,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(
@@ -1648,6 +1727,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QPixmap(QStringLiteral(":/icons/clessidra.jpg")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
@@ -1666,6 +1748,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         if (!hasCustomIcon(mudServer)) {
             profiles_tree_widget->addItem(pItem);
             mi = QIcon(QPixmap(QStringLiteral(":/icons/reinosdeleyenda_mud.png")).scaled(QSize(120, 30),
@@ -1686,6 +1771,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/fiery_mud.png"));
@@ -1703,6 +1791,9 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         if (!hasCustomIcon(mudServer)) {
             mi = QIcon(QStringLiteral(":/icons/carrionfields.png"));
@@ -1723,6 +1814,9 @@ void dlgConnectionProfiles::fillout_form()
         mProfileList.append(mudServer);
         pItem = new QListWidgetItem();
         pItem->setData(csmNameRole, mudServer);
+        pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(mudServer));
+        pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
         profiles_tree_widget->addItem(pItem);
         description = getDescription(QStringLiteral("mudlet.org"), 0, mudServer);
         if (!description.isEmpty()) {
@@ -1741,7 +1835,7 @@ void dlgConnectionProfiles::fillout_form()
 
     for (int i = 0; i < profiles_tree_widget->count(); i++) {
         const auto profile = profiles_tree_widget->item(i);
-        const auto profileName = profile->text();
+        const auto profileName = profile->data(csmNameRole).toString();
         if (profileName == QStringLiteral("Mudlet self-test")) {
             test_profile_row = i;
         }
@@ -1812,6 +1906,9 @@ void dlgConnectionProfiles::loadCustomProfile(const QString& profileName) const
 {
     auto pItem = new QListWidgetItem();
     pItem->setData(csmNameRole, profileName);
+    pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(profileName));
+    pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
     setCustomIcon(profileName, pItem);
     auto description = getDescription(profileName, 0, profileName);
     if (!description.isEmpty()) {
@@ -1867,6 +1964,9 @@ void dlgConnectionProfiles::generateCustomProfile(int i, const QString& profileN
 {
     auto pItem = new QListWidgetItem();
     pItem->setData(csmNameRole, profileName);
+    pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(profileName));
+    pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
+
     profiles_tree_widget->addItem(pItem);
     QPixmap background(120, 30);
     background.fill(Qt::transparent);
@@ -2089,6 +2189,8 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
         return false;
     }
     pItem->setData(csmNameRole, profile_name);
+    pItem->setData(Qt::AccessibleTextRole, commonTexts_profile_accessibilityName.arg(profile_name));
+    pItem->setData(Qt::AccessibleDescriptionRole, commonTexts_profile_accessibilityDesc);
 
     // add the new widget in
     profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -2451,24 +2553,26 @@ bool dlgConnectionProfiles::validateProfile()
             if (offline_button) {
                 offline_button->setEnabled(true);
                 offline_button->setToolTip(tr("<p>Load profile without connecting.</p>"));
+                offline_button->setAccessibleDescription(commonTexts_loadButton_enabled_accessibilityDesc);
             }
             if (connect_button) {
                 connect_button->setEnabled(true);
                 connect_button->setToolTip(QString());
+                connect_button->setAccessibleDescription(commonTexts_connectButton_enabled_accessibilityDesc);
             }
-
             return true;
-
         } else {
             notificationArea->show();
             notificationAreaMessageBox->show();
             if (offline_button) {
-                offline_button->setDisabled(true);
+                offline_button->setEnabled(false);
                 offline_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before loading.</p>"));
+                offline_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
             }
             if (connect_button) {
-                connect_button->setDisabled(true);
+                connect_button->setEnabled(false);
                 connect_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before connecting.</p>"));
+                connect_button->setAccessibleDescription(commonTexts_connectOrLoadButton_disabled_accessibilityDesc);
             }
             return false;
         }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -48,11 +48,11 @@ public:
 
     static const int csmNameRole{Qt::UserRole};
 
-    QString commonTexts_connectButton_enabled_accessibilityDesc;
-    QString commonTexts_loadButton_enabled_accessibilityDesc;
-    QString commonTexts_connectOrLoadButton_disabled_accessibilityDesc;
-    QString commonTexts_profile_accessibilityName;
-    QString commonTexts_profile_accessibilityDesc;
+    QString btn_connect_enabled_accessDesc;
+    QString btn_load_enabled_accessDesc;
+    QString btn_connOrLoad_disabled_accessDesc;
+    QString item_profile_accessName;
+    QString item_profile_accessDesc;
 
 signals:
     void signal_load_profile(QString profile_name, bool alsoConnect);

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -48,6 +48,12 @@ public:
 
     static const int csmNameRole{Qt::UserRole};
 
+    QString commonTexts_connectButton_enabled_accessibilityDesc;
+    QString commonTexts_loadButton_enabled_accessibilityDesc;
+    QString commonTexts_connectOrLoadButton_disabled_accessibilityDesc;
+    QString commonTexts_profile_accessibilityName;
+    QString commonTexts_profile_accessibilityDesc;
+
 signals:
     void signal_load_profile(QString profile_name, bool alsoConnect);
 

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2224,7 +2224,7 @@
                <string>Profile name</string>
               </property>
               <property name="accessibleDescription">
-               <string>A unique name for the profile but which is limited to a subset of ASCII characters only.</string>
+               <string comment="Using lower case letters for 'ASCII' may make speech synthesisers say 'askey' which is quicker than 'Aay Ess Cee Eye Eye'!">A unique name for the profile but which is limited to a subset of ascii characters only.</string>
               </property>
               <property name="readOnly">
                <bool>false</bool>
@@ -2297,7 +2297,7 @@
                <string>Game server port</string>
               </property>
               <property name="accessibleDescription">
-               <string>The port that is used together with the server name to make the connection to the Game Server. If not specified a default of 23 for &quot;Telnet&quot; connections is used. Secure connections may require a different port number.</string>
+               <string>The port that is used together with the server name to make the connection to the game server. If not specified a default of 23 for &quot;Telnet&quot; connections is used. Secure connections may require a different port number.</string>
               </property>
               <property name="text">
                <string/>
@@ -2415,7 +2415,7 @@
                <string>Character name</string>
               </property>
               <property name="accessibleDescription">
-               <string>If provided will be sent, along with password to identify the user in the Game.</string>
+               <string>If provided will be sent, along with password to identify the user in the game.</string>
               </property>
               <property name="echoMode">
                <enum>QLineEdit::Normal</enum>
@@ -2453,7 +2453,7 @@
                <string>Auto-reconnect</string>
               </property>
               <property name="accessibleDescription">
-               <string>Automatically reconnect this profile if it should become disconnected for any reason other than the user disconnecting from the Game Server.</string>
+               <string>Automatically reconnect this profile if it should become disconnected for any reason other than the user disconnecting from the game server.</string>
               </property>
               <property name="layoutDirection">
                <enum>Qt::LeftToRight</enum>
@@ -2472,7 +2472,7 @@
                <string>Password</string>
               </property>
               <property name="accessibleDescription">
-               <string>If provided will be sent, along with the character name to identify the user in the Game.</string>
+               <string>If provided will be sent, along with the character name to identify the user in the game.</string>
               </property>
               <property name="echoMode">
                <enum>QLineEdit::Password</enum>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -2220,6 +2220,12 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
+              <property name="accessibleName">
+               <string>Profile name</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>A unique name for the profile but which is limited to a subset of ASCII characters only.</string>
+              </property>
               <property name="readOnly">
                <bool>false</bool>
               </property>
@@ -2248,6 +2254,12 @@
                 <family>Bitstream Charter</family>
                 <pointsize>9</pointsize>
                </font>
+              </property>
+              <property name="accessibleName">
+               <string>Game server URL</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>The Internet host name or IP address</string>
               </property>
              </widget>
             </item>
@@ -2281,6 +2293,12 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
+              <property name="accessibleName">
+               <string>Game server port</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>The port that is used together with the server name to make the connection to the Game Server. If not specified a default of 23 for &quot;Telnet&quot; connections is used. Secure connections may require a different port number.</string>
+              </property>
               <property name="text">
                <string/>
               </property>
@@ -2297,6 +2315,12 @@
             </item>
             <item row="2" column="2">
              <widget class="QCheckBox" name="port_ssl_tsl">
+              <property name="accessibleName">
+               <string>Connect via a secure protocol</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Make Mudlet use a secure SSL/TLS protocol instead of an unencrypted one</string>
+              </property>
               <property name="layoutDirection">
                <enum>Qt::RightToLeft</enum>
               </property>
@@ -2387,6 +2411,12 @@
               <property name="toolTip">
                <string>The characters name</string>
               </property>
+              <property name="accessibleName">
+               <string>Character name</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>If provided will be sent, along with password to identify the user in the Game.</string>
+              </property>
               <property name="echoMode">
                <enum>QLineEdit::Normal</enum>
               </property>
@@ -2403,6 +2433,12 @@
               <property name="toolTip">
                <string>With this enabled, Mudlet will automatically start and connect on this profile when it is launched</string>
               </property>
+              <property name="accessibleName">
+               <string>Auto-open profile</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Automatically start this profile when Mudlet is run</string>
+              </property>
               <property name="layoutDirection">
                <enum>Qt::LeftToRight</enum>
               </property>
@@ -2413,6 +2449,12 @@
             </item>
             <item row="4" column="0" colspan="2">
              <widget class="QCheckBox" name="auto_reconnect">
+              <property name="accessibleName">
+               <string>Auto-reconnect</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Automatically reconnect this profile if it should become disconnected for any reason other than the user disconnecting from the Game Server.</string>
+              </property>
               <property name="layoutDirection">
                <enum>Qt::LeftToRight</enum>
               </property>
@@ -2425,6 +2467,12 @@
              <widget class="QLineEdit" name="character_password_entry">
               <property name="toolTip">
                <string>Characters password. Note that the password isn't encrypted in storage</string>
+              </property>
+              <property name="accessibleName">
+               <string>Password</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>If provided will be sent, along with the character name to identify the user in the Game.</string>
               </property>
               <property name="echoMode">
                <enum>QLineEdit::Password</enum>
@@ -2441,6 +2489,9 @@
               </property>
               <property name="accessibleName">
                <string>Discord integration</string>
+              </property>
+              <property name="accessibleDescription">
+               <string>Allow this profile to use Mudlet's Discord &quot;Rich Presence&quot;  features</string>
               </property>
               <property name="text">
                <string/>


### PR DESCRIPTION
Also convert all `setDisabled(state)` to `setEnabled(!state)` in the `dlgConnectionProfiles` class - using a single one instead of a mix of the two is less likely to lead to errors - and it means less effort to search for the places where something is being enabled or disabled.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>