### PR TITLE
Switch to Qt 5.15

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -17,12 +17,12 @@ jobs:
             buildname: 'ubuntu / gcc'
             triplet: x64-linux
             compiler: gcc_64
-            qt: '5.14.1'
+            qt: '5.15.2'
           - os: ubuntu-latest
             buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
-            qt: '5.14.1'
+            qt: '5.15.2'
           - os: ubuntu-latest
             buildname: 'ubuntu / qt 5.11'
             triplet: x64-linux
@@ -32,12 +32,12 @@ jobs:
             buildname: 'macos / c++ tests'
             triplet: x64-osx
             compiler: clang_64
-            qt: '5.14.1'
+            qt: '5.15.2'
           - os: windows-2019
             buildname: 'windows'
             triplet: x64-mingw-dynamic
             # compiler: flag not used in windows pipeline
-            qt: '5.14.1'
+            qt: '5.15.2'
 
     steps:
     - name: Restore Qt cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ dist: xenial
 addons:
   apt:
     sources: &add-sources
-    - sourceline: 'ppa:beineri/opt-qt-5.12.9-xenial'
+    - sourceline: 'ppa:beineri/opt-qt-5.15.2-xenial'
     - sourceline: 'ppa:ondrej/php' # more-or-less up to date libzip
     - sourceline: 'ppa:ubuntu-toolchain-r/test' # gcc 7
     packages: &common-packages
@@ -61,19 +61,19 @@ jobs:
     compiler: gcc
     env:
     - Q_OR_C_MAKE=qmake
-      QT_VERSION=512
+      QT_VERSION=515
       DEPLOY=deploy
     addons:
       apt:
         sources: *add-sources
-        packages: &qt512-packages
+        packages: &qt515-packages
         - *common-packages
-        - qt512base
-        - qt512multimedia
-        - qt512tools
-        - qt512gamepad
-        - qt512speech
-        - qt512translations
+        - qt515base
+        - qt515multimedia
+        - qt515tools
+        - qt515gamepad
+        - qt515speech
+        - qt515translations
 
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -28,7 +28,7 @@ function SetQtBaseDir([string] $logFile) {
     }
     catch
     {
-      $Env:QT_BASE_DIR = "C:\Qt\5.12.10\mingw73_32"
+      $Env:QT_BASE_DIR = "C:\Qt\5.15.2\mingw73_32"
     }
   }
   Write-Output "Using $Env:QT_BASE_DIR as QT base directory." | Tee-Object -File "$logFile" -Append

--- a/CI/qt-silent-install.qs
+++ b/CI/qt-silent-install.qs
@@ -27,7 +27,7 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent("qt.qt5.51210.win32_mingw73");
+    widget.selectComponent("qt.qt5.5152.win32_mingw73");
     widget.selectComponent("qt.tools.win32_mingw730");
 
     gui.clickButton(buttons.NextButton);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
This PR switches mudlet from building on Qt 5.12 to building on Qt 5.15.

#### Motivation for adding to Mudlet
There is a bug fix for POST-to-GET HTTP redirects on Qt 5.15.1, which is scheduled to be released in August. I'd like to see what challenges we'll be facing when upgrading to it.

#### Other info (issues closed, discussion etc)
* [The original PR](https://github.com/Mudlet/Mudlet/pull/3727) that spawned this PR
* [The Qt bug report](https://bugreports.qt.io/browse/QTBUG-84162)
* The Qt bug fix for their [dev](https://codereview.qt-project.org/c/qt/qtbase/+/303705) branch and their [5.15](https://codereview.qt-project.org/c/qt/qtbase/+/304230) branch