### PR TITLE
bugfix: generic_mapper map config errors

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -67,7 +67,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         # Installing packages might fail as the github image becomes outdated
-        sudo apt update
+        # sudo apt update
         # These aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0 libqt5x11extras5
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -67,7 +67,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         # Installing packages might fail as the github image becomes outdated
-        # sudo apt update
+        sudo apt update
         # These aren't available or don't work well in vcpkg
         sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0 libqt5x11extras5
 

--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -412,7 +412,7 @@ map.echo("Map debug set to: " .. (map.configs.debug and "on" or "off"))</script>
 				<name>Map Config Alias</name>
 				<script>-- adjust pattern to allow no argument, if no argument show general help about configs
 if not matches[2] then
-	cecho(map.help.configs)
+	cecho(map.help.config)
 else
   local startStr, endStr = string.match(matches[2],"(.*) ([%w%.]+)")
   local vals = {'on', 'off', 'true', 'false'}

--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1092,7 +1092,7 @@ map.help.recall = [[
         is stored in map.save.recall[map.character], and is remembered between
         sessions.
 ]]
-map.help.configs = [[
+map.help.config = [[
     &lt;cyan&gt;Map Config&lt;reset&gt;
         syntax: &lt;yellow&gt;map config &lt;setting&gt; &lt;optional value&gt;&lt;reset&gt;
 

--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -1092,7 +1092,7 @@ map.help.recall = [[
         is stored in map.save.recall[map.character], and is remembered between
         sessions.
 ]]
-map.help.config = [[
+map.help.configs = [[
     &lt;cyan&gt;Map Config&lt;reset&gt;
         syntax: &lt;yellow&gt;map config &lt;setting&gt; &lt;optional value&gt;&lt;reset&gt;
 


### PR DESCRIPTION
This makes calling `map config` without a specifier work as intended in the alias.

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Adds an `s` to `map.help.config` in script, which is how it is called by `map config` alias when no argument is provided.

#### Motivation for adding to Mudlet
Bug fix so `map config` and `map help` both function properly.

#### Other info (issues closed, discussion etc)
Closes #3970 