### PR TITLE
Server Data Encoding Selection via Telnet CHARSET

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -346,6 +346,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mCommandLineBgColor(Qt::black)
 , mMapperUseAntiAlias(true)
 , mFORCE_MXP_NEGOTIATION_OFF(false)
+, mFORCE_CHARSET_NEGOTIATION_OFF(false)
 , mpDockableMapWidget()
 , mEnableTextAnalyzer(false)
 , mTimerDebugOutputSuppressionInterval(QTime())

--- a/src/Host.h
+++ b/src/Host.h
@@ -538,6 +538,7 @@ public:
     QColor mCommandLineBgColor;
     bool mMapperUseAntiAlias;
     bool mFORCE_MXP_NEGOTIATION_OFF;
+    bool mFORCE_CHARSET_NEGOTIATION_OFF;
     QSet<QChar> mDoubleClickIgnore;
     QPointer<QDockWidget> mpDockableMapWidget;
     bool mEnableTextAnalyzer;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -408,6 +408,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mAcceptServerMedia") = pHost->mAcceptServerMedia ? "yes" : "no";
     host.append_attribute("mMapperUseAntiAlias") = pHost->mMapperUseAntiAlias ? "yes" : "no";
     host.append_attribute("mFORCE_MXP_NEGOTIATION_OFF") = pHost->mFORCE_MXP_NEGOTIATION_OFF ? "yes" : "no";
+    host.append_attribute("mFORCE_CHARSET_NEGOTIATION_OFF") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";
     host.append_attribute("mRoomSize") = QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData();
     host.append_attribute("mLineSize") = QString::number(pHost->mLineSize, 'f', 1).toUtf8().constData();

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -408,7 +408,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mAcceptServerMedia") = pHost->mAcceptServerMedia ? "yes" : "no";
     host.append_attribute("mMapperUseAntiAlias") = pHost->mMapperUseAntiAlias ? "yes" : "no";
     host.append_attribute("mFORCE_MXP_NEGOTIATION_OFF") = pHost->mFORCE_MXP_NEGOTIATION_OFF ? "yes" : "no";
-    host.append_attribute("mFORCE_CHARSET_NEGOTIATION_OFF") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
+    host.append_attribute("disableCharsetNegotiation") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";
     host.append_attribute("mRoomSize") = QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData();
     host.append_attribute("mLineSize") = QString::number(pHost->mLineSize, 'f', 1).toUtf8().constData();

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -408,7 +408,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mAcceptServerMedia") = pHost->mAcceptServerMedia ? "yes" : "no";
     host.append_attribute("mMapperUseAntiAlias") = pHost->mMapperUseAntiAlias ? "yes" : "no";
     host.append_attribute("mFORCE_MXP_NEGOTIATION_OFF") = pHost->mFORCE_MXP_NEGOTIATION_OFF ? "yes" : "no";
-    host.append_attribute("disableCharsetNegotiation") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
+    host.append_attribute("mFORCE_CHARSET_NEGOTIATION_OFF") = pHost->mFORCE_CHARSET_NEGOTIATION_OFF ? "yes" : "no";
     host.append_attribute("enableTextAnalyzer") = pHost->mEnableTextAnalyzer ? "yes" : "no";
     host.append_attribute("mRoomSize") = QString::number(pHost->mRoomSize, 'f', 1).toUtf8().constData();
     host.append_attribute("mLineSize") = QString::number(pHost->mLineSize, 'f', 1).toUtf8().constData();

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -907,6 +907,7 @@ void XMLimport::readHostPackage(Host* pHost)
     }
 
     pHost->mFORCE_MXP_NEGOTIATION_OFF = (attributes().value("mFORCE_MXP_NEGOTIATION_OFF") == "yes");
+    pHost->mFORCE_CHARSET_NEGOTIATION_OFF = (attributes().value("mFORCE_CHARSET_NEGOTIATION_OFF") == "yes");
     pHost->mEnableTextAnalyzer = (attributes().value("enableTextAnalyzer") == "yes");
     pHost->mRoomSize = attributes().value("mRoomSize").toString().toDouble();
     if (qFuzzyCompare(1.0 + pHost->mRoomSize, 1.0)) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -907,7 +907,7 @@ void XMLimport::readHostPackage(Host* pHost)
     }
 
     pHost->mFORCE_MXP_NEGOTIATION_OFF = (attributes().value("mFORCE_MXP_NEGOTIATION_OFF") == "yes");
-    pHost->mFORCE_CHARSET_NEGOTIATION_OFF = (attributes().value("mFORCE_CHARSET_NEGOTIATION_OFF") == "yes");
+    pHost->mFORCE_CHARSET_NEGOTIATION_OFF = (attributes().value("disableCharsetNegotiation") == "yes");
     pHost->mEnableTextAnalyzer = (attributes().value("enableTextAnalyzer") == "yes");
     pHost->mRoomSize = attributes().value("mRoomSize").toString().toDouble();
     if (qFuzzyCompare(1.0 + pHost->mRoomSize, 1.0)) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -907,7 +907,7 @@ void XMLimport::readHostPackage(Host* pHost)
     }
 
     pHost->mFORCE_MXP_NEGOTIATION_OFF = (attributes().value("mFORCE_MXP_NEGOTIATION_OFF") == "yes");
-    pHost->mFORCE_CHARSET_NEGOTIATION_OFF = (attributes().value("disableCharsetNegotiation") == "yes");
+    pHost->mFORCE_CHARSET_NEGOTIATION_OFF = (attributes().value("mFORCE_CHARSET_NEGOTIATION_OFF") == "yes");
     pHost->mEnableTextAnalyzer = (attributes().value("enableTextAnalyzer") == "yes");
     pHost->mRoomSize = attributes().value("mRoomSize").toString().toDouble();
     if (qFuzzyCompare(1.0 + pHost->mRoomSize, 1.0)) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1506,6 +1506,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                     setEncoding(acceptedCharacterSet, true);
 
                     output += CHARSET_ACCEPTED;
+                    output += payload[1]; // Separator
                     output += encodeAndCookBytes(acceptedCharacterSet.toStdString());
                 } else {
                     output += CHARSET_REJECTED;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1307,7 +1307,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 qDebug() << "Rejecting CHARSET, because FORCE CHARSET NEGOTIATION OFF is checked.";
             } else  { // We have already negotiated the use of the option by us (We WILL welcome the DO)
                 sendTelnetOption(TN_WILL, OPT_CHARSET);
-                enableCHARSET = true; // Both sides have negotiated, either side is welcome to REQUEST now
+                enableCHARSET = true; // We negotiated, either side is welcome to REQUEST now
                 qDebug() << "CHARSET enabled";
                 raiseProtocolEvent("sysProtocolEnabled", "CHARSET");
             }
@@ -1479,13 +1479,11 @@ void cTelnet::processTelnetCommand(const std::string& command)
 
             // CHARSET support per https://tools.ietf.org/html/rfc2066
             if (command[3] == CHARSET_REQUEST) {
-                // No translate table support.  Discard. 
-                if (payload.startsWith("[TTABLE]1")) {
+                if (payload.startsWith("[TTABLE]1")) { // No translate table support.  Discard.
                     payload.remove(0, 9);
                 }
 
-                // Second character is the separator.
-                QList<QByteArray> characterSetList = payload.split(payload[1]);
+                QList<QByteArray> characterSetList = payload.split(payload[1]); // Second character is the separator.
                 QByteArray acceptedCharacterSet;
 
                 if (characterSetList.size() > 0) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -997,10 +997,10 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 }
 
                 enableCHARSET = false;
-                qDebug() << "Rejecting CHARSET, because FORCE CHARSET NEGOTIATION OFF is checked.";
+                qDebug() << "Rejecting CHARSET option negotiation because it is disabled by Host::mFORCE_CHARSET_NEGOTIATION_OFF";
             } else {
                 sendTelnetOption(TN_DO, OPT_CHARSET);
-                enableCHARSET = true; // We negotiated, either side is welcome to REQUEST now
+                enableCHARSET = true; // We negotiated, the game server is welcome to REQUEST now
                 qDebug() << "CHARSET enabled";
                 raiseProtocolEvent("sysProtocolEnabled", "CHARSET");
             }
@@ -1304,10 +1304,10 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 }
 
                 enableCHARSET = false;
-                qDebug() << "Rejecting CHARSET, because FORCE CHARSET NEGOTIATION OFF is checked.";
+                qDebug() << "Rejecting CHARSET option negotiation because it is disabled by Host::mFORCE_CHARSET_NEGOTIATION_OFF";
             } else  { // We have already negotiated the use of the option by us (We WILL welcome the DO)
                 sendTelnetOption(TN_WILL, OPT_CHARSET);
-                enableCHARSET = true; // We negotiated, either side is welcome to REQUEST now
+                enableCHARSET = true; // We negotiated, the game server is welcome to REQUEST now
                 qDebug() << "CHARSET enabled";
                 raiseProtocolEvent("sysProtocolEnabled", "CHARSET");
             }
@@ -1483,13 +1483,15 @@ void cTelnet::processTelnetCommand(const std::string& command)
                     payload.remove(0, 9);
                 }
 
-                QList<QByteArray> characterSetList = payload.split(payload[1]); // Second character is the separator.
+                auto characterSetList = payload.split(payload[1]); // Second character is the separator.
                 QByteArray acceptedCharacterSet;
 
-                if (characterSetList.size() > 0) {
+                if (!characterSetList.isEmpty()) {
                     for (int i = 1; i < characterSetList.size(); ++i) {
-                        if (mAcceptableEncodings.contains(characterSetList[i]) || mAcceptableEncodings.contains(("M_" + characterSetList[i]))) {
-                            acceptedCharacterSet = characterSetList[i];
+                        QByteArray characterSet = characterSetList.at(i).toUpper();
+
+                        if (mAcceptableEncodings.contains(characterSet) || mAcceptableEncodings.contains(("M_" + characterSet))) {
+                            acceptedCharacterSet = characterSet;
                             break;
                         }
                     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -997,7 +997,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 }
 
                 enableCHARSET = false;
-                qDebug() << "Rejecting CHARSET option negotiation because it is disabled by Host::mFORCE_CHARSET_NEGOTIATION_OFF";
+                qDebug() << "Rejecting CHARSET, because Force CHARSET negotiation off is checked.";
             } else {
                 sendTelnetOption(TN_DO, OPT_CHARSET);
                 enableCHARSET = true; // We negotiated, the game server is welcome to REQUEST now
@@ -1304,7 +1304,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 }
 
                 enableCHARSET = false;
-                qDebug() << "Rejecting CHARSET option negotiation because it is disabled by Host::mFORCE_CHARSET_NEGOTIATION_OFF";
+                qDebug() << "Rejecting CHARSET, because Force CHARSET negotiation off is checked.";
             } else  { // We have already negotiated the use of the option by us (We WILL welcome the DO)
                 sendTelnetOption(TN_WILL, OPT_CHARSET);
                 enableCHARSET = true; // We negotiated, the game server is welcome to REQUEST now

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -103,6 +103,7 @@ const char OPT_TIMING_MARK = 6;
 const char OPT_TERMINAL_TYPE = 24;
 const char OPT_EOR = 25;
 const char OPT_NAWS = 31;
+const char OPT_CHARSET = 42;
 const char OPT_MSDP = 69; // http://tintin.sourceforge.net/msdp/
 const char OPT_MSSP = static_cast<char>(70); // https://tintin.sourceforge.io/protocols/mssp/
 const char OPT_COMPRESS = 85;
@@ -113,6 +114,14 @@ const char OPT_102 = 102;
 const char OPT_ATCP = static_cast<char>(200);
 const char OPT_GMCP = static_cast<char>(201);
 
+const char CHARSET_REQUEST = 1;
+const char CHARSET_ACCEPTED = 2;
+const char CHARSET_REJECTED = 3;
+const char CHARSET_TTABLE_IS = 4;
+const char CHARSET_TTABLE_REJECTED = 5;
+const char CHARSET_TTABLE_ACK = 6;
+const char CHARSET_TTABLE_NAK = 7;
+
 const char MSSP_VAR = 1;
 const char MSSP_VAL = 2;
 
@@ -122,7 +131,6 @@ const char MSDP_TABLE_OPEN = 3;
 const char MSDP_TABLE_CLOSE = 4;
 const char MSDP_ARRAY_OPEN = 5;
 const char MSDP_ARRAY_CLOSE = 6;
-
 
 class cTelnet : public QObject
 {
@@ -165,6 +173,7 @@ public:
 #endif
     QByteArray decodeBytes(const char*);
     std::string encodeAndCookBytes(const std::string&);
+    bool isCHARSETEnabled() const { return enableCHARSET; }
     bool isATCPEnabled() const { return enableATCP; }
     bool isGMCPEnabled() const { return enableGMCP; }
     bool isMSSPEnabled() const { return enableMSSP; }
@@ -282,6 +291,7 @@ private:
     QTime timeOffset;
     QTime mConnectionTime;
     int lastTimeOffset;
+    bool enableCHARSET;
     bool enableATCP;
     bool enableGMCP;
     bool enableMSSP;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -518,6 +518,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(pHost->mFORCE_MXP_NEGOTIATION_OFF);
+    mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
     acceptServerGUI->setChecked(pHost->mAcceptServerGUI);
     acceptServerMedia->setChecked(pHost->mAcceptServerMedia);
@@ -1165,6 +1166,7 @@ void dlgProfilePreferences::clearHostDetails()
     edbeePreviewWidget->textDocument()->setText(QString());
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(false);
+    mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(false);
     mMapperUseAntiAlias->setChecked(false);
     acceptServerGUI->setChecked(false);
     acceptServerMedia->setChecked(false);
@@ -2430,6 +2432,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mBorderRightWidth = rightBorderWidth->value();
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
+        pHost->mFORCE_CHARSET_NEGOTIATION_OFF = mFORCE_CHARSET_NEGOTIATION_OFF->isChecked();
         pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
         pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();
         pHost->mLogDir = mLogDirPath;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -518,7 +518,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(pHost->mFORCE_MXP_NEGOTIATION_OFF);
-    mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
+    disableCharsetNegotiation->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
     acceptServerGUI->setChecked(pHost->mAcceptServerGUI);
     acceptServerMedia->setChecked(pHost->mAcceptServerMedia);
@@ -1166,7 +1166,7 @@ void dlgProfilePreferences::clearHostDetails()
     edbeePreviewWidget->textDocument()->setText(QString());
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(false);
-    mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(false);
+    disableCharsetNegotiation->setChecked(false);
     mMapperUseAntiAlias->setChecked(false);
     acceptServerGUI->setChecked(false);
     acceptServerMedia->setChecked(false);
@@ -2432,7 +2432,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mBorderRightWidth = rightBorderWidth->value();
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
-        pHost->mFORCE_CHARSET_NEGOTIATION_OFF = mFORCE_CHARSET_NEGOTIATION_OFF->isChecked();
+        pHost->mFORCE_CHARSET_NEGOTIATION_OFF = disableCharsetNegotiation->isChecked();
         pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
         pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();
         pHost->mLogDir = mLogDirPath;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -518,7 +518,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     search_engine_combobox->setCurrentIndex(savedText == -1 ? 1 : savedText);
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(pHost->mFORCE_MXP_NEGOTIATION_OFF);
-    disableCharsetNegotiation->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
+    mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(pHost->mFORCE_CHARSET_NEGOTIATION_OFF);
     mMapperUseAntiAlias->setChecked(pHost->mMapperUseAntiAlias);
     acceptServerGUI->setChecked(pHost->mAcceptServerGUI);
     acceptServerMedia->setChecked(pHost->mAcceptServerMedia);
@@ -1166,7 +1166,7 @@ void dlgProfilePreferences::clearHostDetails()
     edbeePreviewWidget->textDocument()->setText(QString());
 
     mFORCE_MXP_NEGOTIATION_OFF->setChecked(false);
-    disableCharsetNegotiation->setChecked(false);
+    mFORCE_CHARSET_NEGOTIATION_OFF->setChecked(false);
     mMapperUseAntiAlias->setChecked(false);
     acceptServerGUI->setChecked(false);
     acceptServerMedia->setChecked(false);
@@ -2432,7 +2432,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mBorderRightWidth = rightBorderWidth->value();
         pHost->commandLineMinimumHeight = commandLineMinimumHeight->value();
         pHost->mFORCE_MXP_NEGOTIATION_OFF = mFORCE_MXP_NEGOTIATION_OFF->isChecked();
-        pHost->mFORCE_CHARSET_NEGOTIATION_OFF = disableCharsetNegotiation->isChecked();
+        pHost->mFORCE_CHARSET_NEGOTIATION_OFF = mFORCE_CHARSET_NEGOTIATION_OFF->isChecked();
         pHost->mIsNextLogFileInHtmlFormat = mIsToLogInHtml->isChecked();
         pHost->mIsLoggingTimestamps = mIsLoggingTimestamps->isChecked();
         pHost->mLogDir = mLogDirPath;

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2640,6 +2640,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="mFORCE_CHARSET_NEGOTIATION_OFF">
+            <property name="text">
+             <string>Force CHARSET negotiation off</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QLabel" name="need_reconnect_for_specialoption">
             <property name="enabled">
              <bool>true</bool>
@@ -5332,6 +5339,7 @@
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>mFORCE_MXP_NEGOTIATION_OFF</tabstop>
+  <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>
   <tabstop>comboBox_discordLargeIconPrivacy</tabstop>
   <tabstop>checkBox_discordServerAccessToDetail</tabstop>
   <tabstop>comboBox_discordSmallIconPrivacy</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2640,7 +2640,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="disableCharsetNegotiation">
+           <widget class="QCheckBox" name="mFORCE_CHARSET_NEGOTIATION_OFF">
             <property name="text">
              <string>Force CHARSET negotiation off</string>
             </property>
@@ -5339,7 +5339,7 @@
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>mFORCE_MXP_NEGOTIATION_OFF</tabstop>
-  <tabstop>disableCharsetNegotiation</tabstop>
+  <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>
   <tabstop>comboBox_discordLargeIconPrivacy</tabstop>
   <tabstop>checkBox_discordServerAccessToDetail</tabstop>
   <tabstop>comboBox_discordSmallIconPrivacy</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2640,7 +2640,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="mFORCE_CHARSET_NEGOTIATION_OFF">
+           <widget class="QCheckBox" name="disableCharsetNegotiation">
             <property name="text">
              <string>Force CHARSET negotiation off</string>
             </property>
@@ -5339,7 +5339,7 @@
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>mFORCE_MXP_NEGOTIATION_OFF</tabstop>
-  <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>
+  <tabstop>disableCharsetNegotiation</tabstop>
   <tabstop>comboBox_discordLargeIconPrivacy</tabstop>
   <tabstop>checkBox_discordServerAccessToDetail</tabstop>
   <tabstop>comboBox_discordSmallIconPrivacy</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
[Telnet CHARSET Option](https://tools.ietf.org/html/rfc2066) added to enable a game server to negotiate CHARSET with Mudlet and automatically select a server data encoding found on the Settings->General tab.  The primary use case for this is for servers to choose UTF-8 as the preferred encoding and enable emojis and characters that will support international language characters and symbols on games.  The benefit eliminates the need to guide a user through manually updating the server data encoding.

Example of how it works per the [specification](https://tools.ietf.org/html/rfc2066):

- Game server sends WILL CHARSET (42) to Mudlet client
- Mudlet client sends DO CHARSET (42) to Game server
- Game server sends SB CHARSET_REQUEST (1) [space] UTF-8 to Mudlet client
- Mudlet client validates UTF-8 is a supported encoding and selects UTF-8 to Game server
- Mudlet client sends SB CHARSET_ACCEPTED (2) to Game server
- Game server updates its encoding to UTF-8
- There is an option to force negotiation off in Settings -> Special Options.

[Mudlet Wiki](https://wiki.mudlet.org/w/Manual:Supported_Protocols#Encoding) updated.

#### Motivation for adding to Mudlet
Intuitive support for emojis and international channels on StickMUD

#### Other info (issues closed, discussion etc)

- Test: Choose StickMUD, a default game on Mudlet.  Server data encoding will shift from ASCII to UTF-8 on the login screen.
- [Telnet Binary Transmission](https://tools.ietf.org/html/rfc856) was not implemented as part of the scope.
- Transmission begins only from the server for now per advice from @vadi2.
- Thank you to @SlySven for guidance on the RFCs.