### PR TITLE
Fix typo preventing use of getFg/BgColor on non-main consoles.

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -918,7 +918,7 @@ int TLuaInterpreter::getFgColor(lua_State* L)
 {
     std::string windowName = "main";
     if (lua_gettop(L) > 0) {
-        if (lua_isstring(L, 1)) {
+        if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "getFgColor: bad argument #1 type (window name as string is optional, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         } else {
@@ -939,7 +939,7 @@ int TLuaInterpreter::getBgColor(lua_State* L)
 {
     std::string windowName = "main";
     if (lua_gettop(L) > 0) {
-        if (lua_isstring(L, 1)) {
+        if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "getBgColor: bad argument #1 type (window name as string is optional, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         } else {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes a typo that was preventing the use of getFgColor and getBgColor with any consoles besides the main console.
Currently, both functions error if you supply them with a string argument, giving you an error specifying that the string argument you provided is an invalid type, and that instead you need to supply a string argument...

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
#3976