### PR TITLE
BugFix: Fixes shortcut behavior issues caused by saving profile twice or starting mudlet with a disabled menubar

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -561,7 +561,72 @@ mudlet::mudlet()
     disconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_D);
     reconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_R);
 #endif
-    connect(this, &mudlet::signal_menuBarVisibilityChanged, this, &mudlet::slot_update_shortcuts);
+
+    triggersShortcut = new QShortcut(triggersKeySequence, this);
+    connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_editor_dialog);
+
+    showMapShortcut = new QShortcut(showMapKeySequence, this);
+    connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
+
+    inputLineShortcut = new QShortcut(inputLineKeySequence, this);
+    connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_compact_input_line);
+
+    optionsShortcut = new QShortcut(optionsKeySequence, this);
+    connect(optionsShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
+
+    notepadShortcut = new QShortcut(notepadKeySequence, this);
+    connect(notepadShortcut.data(), &QShortcut::activated, this, &mudlet::slot_notes);
+
+    packagesShortcut = new QShortcut(packagesKeySequence, this);
+    connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
+
+    modulesShortcut = new QShortcut(packagesKeySequence, this);
+    connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
+
+    multiViewShortcut = new QShortcut(multiViewKeySequence, this);
+    connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_multi_view);
+
+    connectShortcut = new QShortcut(connectKeySequence, this);
+    connect(connectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_connection_dialog);
+
+    disconnectShortcut = new QShortcut(disconnectKeySequence, this);
+    connect(disconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
+
+    reconnectShortcut = new QShortcut(reconnectKeySequence, this);
+    connect(reconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
+
+    dactionScriptEditor->setShortcut(triggersKeySequence);
+    dactionScriptEditor->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionShowMap->setShortcut(showMapKeySequence);
+    dactionShowMap->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionInputLine->setShortcut(inputLineKeySequence);
+    dactionInputLine->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionOptions->setShortcut(optionsKeySequence);
+    dactionOptions->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionNotepad->setShortcut(notepadKeySequence);
+    dactionNotepad->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionPackageManager->setShortcut(packagesKeySequence);
+    dactionPackageManager->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionModuleManager->setShortcut(modulesKeySequence);
+    dactionModuleManager->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionMultiView->setShortcut(multiViewKeySequence);
+    dactionMultiView->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionConnect->setShortcut(connectKeySequence);
+    dactionConnect->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionDisconnect->setShortcut(disconnectKeySequence);
+    dactionDisconnect->setShortcutContext(Qt::WidgetShortcut);
+
+    dactionReconnect->setShortcut(reconnectKeySequence);
+    dactionReconnect->setShortcutContext(Qt::WidgetShortcut);
 
     mpSettings = getQSettings();
     readLateSettings(*mpSettings);
@@ -3600,88 +3665,6 @@ void mudlet::show_options_dialog(const QString& tab)
     mpProfilePreferencesDlgMap.value(pHost)->setTab(tab);
     mpProfilePreferencesDlgMap.value(pHost)->raise();
     mpProfilePreferencesDlgMap.value(pHost)->show();
-}
-
-void mudlet::slot_update_shortcuts()
-{
-    if (mpMainToolBar->isVisible()) {
-        triggersShortcut = new QShortcut(triggersKeySequence, this);
-        connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_editor_dialog);
-        dactionScriptEditor->setShortcut(QKeySequence());
-
-        showMapShortcut = new QShortcut(showMapKeySequence, this);
-        connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
-        dactionShowMap->setShortcut(QKeySequence());
-
-        inputLineShortcut = new QShortcut(inputLineKeySequence, this);
-        connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_compact_input_line);
-        dactionInputLine->setShortcut(QKeySequence());
-
-        optionsShortcut = new QShortcut(optionsKeySequence, this);
-        connect(optionsShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
-        dactionOptions->setShortcut(QKeySequence());
-
-        notepadShortcut = new QShortcut(notepadKeySequence, this);
-        connect(notepadShortcut.data(), &QShortcut::activated, this, &mudlet::slot_notes);
-        dactionNotepad->setShortcut(QKeySequence());
-
-        packagesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
-        dactionPackageManager->setShortcut(QKeySequence());
-
-        modulesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
-        dactionModuleManager->setShortcut(QKeySequence());
-
-        multiViewShortcut = new QShortcut(multiViewKeySequence, this);
-        connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_multi_view);
-        dactionMultiView->setShortcut(QKeySequence());
-
-        connectShortcut = new QShortcut(connectKeySequence, this);
-        connect(connectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_connection_dialog);
-        dactionConnect->setShortcut(QKeySequence());
-
-        disconnectShortcut = new QShortcut(disconnectKeySequence, this);
-        connect(disconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
-        dactionDisconnect->setShortcut(QKeySequence());
-
-        reconnectShortcut = new QShortcut(reconnectKeySequence, this);
-        connect(reconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
-        dactionReconnect->setShortcut(QKeySequence());
-    } else {
-        triggersShortcut.clear();
-        dactionScriptEditor->setShortcut(triggersKeySequence);
-
-        showMapShortcut.clear();
-        dactionShowMap->setShortcut(showMapKeySequence);
-
-        inputLineShortcut.clear();
-        dactionInputLine->setShortcut(inputLineKeySequence);
-
-        optionsShortcut.clear();
-        dactionOptions->setShortcut(optionsKeySequence);
-
-        notepadShortcut.clear();
-        dactionNotepad->setShortcut(notepadKeySequence);
-
-        packagesShortcut.clear();
-        dactionPackageManager->setShortcut(packagesKeySequence);
-
-        modulesShortcut.clear();
-        dactionModuleManager->setShortcut(modulesKeySequence);
-
-        multiViewShortcut.clear();
-        dactionMultiView->setShortcut(multiViewKeySequence);
-
-        connectShortcut.clear();
-        dactionConnect->setShortcut(connectKeySequence);
-
-        disconnectShortcut.clear();
-        dactionDisconnect->setShortcut(disconnectKeySequence);
-
-        reconnectShortcut.clear();
-        dactionReconnect->setShortcut(reconnectKeySequence);
-    }
 }
 
 void mudlet::slot_show_options_dialog()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -565,7 +565,6 @@ private slots:
     void show_action_dialog();
     void show_key_dialog();
     void show_variable_dialog();
-    void slot_update_shortcuts();
     void slot_show_options_dialog();
 #ifdef QT_GAMEPAD_LIB
     void slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR fixes a bug that caused shortcuts to break after saving profile settings twice.

In addition to that bug, there was also a problem with the way that the shortcuts were created if you opened Mudlet with the menubar not initially enabled, causing all shortcuts to malfunction.

#### Motivation for adding to Mudlet
It sucks to have to restart to get your ALT+E and ALT+M shortcuts functioning again.

#### Other info (issues closed, discussion etc)
Resolves issue #3985.

There were two issues occurring:
1. When Mudlet opened for the first time, it was firing the `slot_update_shortcuts` function before the Icon Menu was loaded (because the visibility of the Menu was being changed while loading settings, firing the signal that was connected to the shortcut updating slot). This caused `slot_update_shortcuts` to always initialize the Dropdown Menu actions and not create the shortcuts that were supposed to be used when the Dropdown Menu wasn't loaded.
2. When `slot_update_shortcuts` was called after the Icon Menu was initialized, the first call would correctly set up the general Mudlet-wide shortcuts that were NOT dependent on the Dropdown Menu actions, but any subsequent call to it(which occurs at least once per profile preference save) would then attempt to create another of the same exact shortcut(without properly disposing of the previous one), which was then causing the shortcut to stop functioning altogether. I'm not entirely sure of why, mechanically, the duplication of the shortcut was causing the previous shortcut and any future clones to fail, but it was reliably doing that upon saving the profile preferences twice.

I've removed the `slot_update_shortcuts` entirely and have moved the initialization of the shortcuts to an appropriate part of the `mudlet()` constructor. Additionally, I'm setting up the Dropdown Menu Action-based versions of the shortcuts with the correct keysequences to properly display the shortcuts in the menu, but I've set the shortcutContext of the shortcuts in a manner that avoids the Qt error for having ambiguous shortcuts.

With these changes in place, the shortcuts are now working for me reliably, 100% of the time, regardless of if I have loaded the Dropdown Menu since starting Mudlet or not.