### PR TITLE
Add Geyser.MiniConsole:display()

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -296,6 +296,19 @@ function Geyser.MiniConsole:resetAutoWrap()
   setWindowWrap(self.name, self.wrapAt)
 end
 
+--- The same as Mudlet's base display(), but outputs to the miniconsole instead of the main window.
+function Geyser.MiniConsole:display(...)
+  local arg = {...}
+  arg.n = table.maxn(arg)
+  if arg.n > 1 then
+    for i = 1, arg.n do
+      self:display(arg[i])
+    end
+  else
+    self:echo((prettywrite(arg[1], '  ') or 'nil') .. '\n')
+  end
+end
+
 -- Save a reference to our parent constructor
 Geyser.MiniConsole.parent = Geyser.Window
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Works like display(), but outputs to the Geyser Miniconsole instead of the main window

#### Motivation for adding to Mudlet
@Eraene mentioned in Discord that they wished they could use display() on a miniconsole. Since you can't really tell if an argument to display() is meant to be displayed or the name of a window, adding it to Geyser.MiniConsole seemed the best way

#### Other info (issues closed, discussion etc)

![image](https://user-images.githubusercontent.com/3660/88137815-5e9e2700-cbba-11ea-8a00-e2217c60af42.png)
