### PR TITLE
Zoom via mouse wheel: keep the position under the cursor in place

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1242,8 +1242,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
         return;
     }
 
-    int ox;
-    int oy;
+    qreal ox;
+    qreal oy;
     if (mRoomID != playerRoomId && mShiftMode) {
         mShiftMode = false;
     }
@@ -4617,7 +4617,33 @@ void T2DMap::wheelEvent(QWheelEvent* e)
         mPick = false;
         int oldZoom = xyzoom;
         xyzoom = qMax(3, xyzoom + delta);
+
+
         if (oldZoom != xyzoom) {
+            const float widgetWidth = width();
+            const float widgetHeight = height();
+            float xs = 1.0;
+            float ys = 1.0;
+            if (widgetWidth > 10 && widgetHeight > 10) {
+                if (widgetWidth > widgetHeight)
+                    xs = (widgetWidth / widgetHeight);
+                else
+                    ys = (widgetHeight / widgetWidth);
+            }
+
+            // mouse pos within the widget
+            QPointF pos = e->position();
+
+            // Position of the mouse within the map, scaled -1 .. +1
+            // i.e. if the mouse is in the center, nothing changes
+            const float dx = 2.0 * pos.x() / widgetWidth - 1.0;
+            const float dy = 2.0 * pos.y() / widgetHeight - 1.0;
+
+            // now shift the origin by that, scaled by the difference in
+            // zoom factors. Thus the point under the mouse stays in place.
+            mOx += dx * (oldZoom - xyzoom) / 2.0 * xs;
+            mOy += dy * (oldZoom - xyzoom) / 2.0 * ys;
+
             flushSymbolPixmapCache();
             update();
         }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4608,16 +4608,15 @@ void T2DMap::wheelEvent(QWheelEvent* e)
 
     // int delta = e->delta() / 8 / 15; // Deprecated in Qt 5.x ...!
     int delta = e->angleDelta().y() / (8 * 15);
-    if (e->modifiers() & Qt::ControlModifier) { // Increase rate 10-fold if control key down - it makes scrolling through
+    if (e->modifiers() & Qt::ControlModifier) { // Increase rate if control key down - it makes scrolling through
                                                 // a large number of items in a listwidget's contents easier AND this make it
                                                 // easier to zoom in and out on LARGE area maps
-        delta *= 10;
+        delta *= 5;
     }
     if (delta != 0) {
         mPick = false;
-        int oldZoom = xyzoom;
-        xyzoom = qMax(3, xyzoom + delta);
-
+        qreal oldZoom = xyzoom;
+        xyzoom = qMax(3.0, xyzoom * pow(1.07, delta));
 
         if (oldZoom != xyzoom) {
             const float widgetWidth = width();
@@ -4658,10 +4657,10 @@ void T2DMap::wheelEvent(QWheelEvent* e)
     return;
 }
 
-void T2DMap::setMapZoom(int zoom)
+void T2DMap::setMapZoom(qreal zoom)
 {
-    int oldZoom = xyzoom;
-    xyzoom = qMax(3, zoom);
+    qreal oldZoom = xyzoom;
+    xyzoom = qMax(3.0, zoom);
     if (oldZoom != xyzoom) {
         flushSymbolPixmapCache();
         update();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4632,7 +4632,11 @@ void T2DMap::wheelEvent(QWheelEvent* e)
             }
 
             // mouse pos within the widget
-            QPointF pos = e->position();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            const QPointF pos = e->position();
+#else
+            const QPoint pos = mapFromGlobal(e->globalPos());
+#endif
 
             // Position of the mouse within the map, scaled -1 .. +1
             // i.e. if the mouse is in the center, nothing changes

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -56,7 +56,7 @@ public:
     Q_DISABLE_COPY(T2DMap)
     explicit T2DMap(QWidget* parent = nullptr);
     void paintMap();
-    void setMapZoom(int zoom);
+    void setMapZoom(qreal zoom);
     QColor getColor(int id);
     void init();
     void exportAreaImage(int);
@@ -86,7 +86,7 @@ public:
 
     TMap* mpMap;
     QPointer<Host> mpHost;
-    int xyzoom;
+    qreal xyzoom;
     int mRX;
     int mRY;
     QPoint mPHighlight;

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -130,8 +130,8 @@ public:
     double eSize;
     int mRoomID;
     int mAreaID;
-    int mOx;
-    int mOy;
+    qreal mOx;
+    qreal mOy;
     int mOz;
     bool mShiftMode;
     bool mShowInfo;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9845,13 +9845,13 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMapZoom
 int TLuaInterpreter::setMapZoom(lua_State* L)
 {
-    int zoom = 3;
+    qreal zoom = 3.0;
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setMapZoom: wrong argument type");
         lua_error(L);
         return 1;
     } else {
-        zoom = lua_tointeger(L, 1);
+        zoom = lua_tonumber(L, 1);
     }
     Host& host = getHostFromLua(L);
     if (host.mpMap) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Mouse wheel zooming (2D view) previously kept the current map center in place. Thus there's no way to move around in the map other than using the left/right/up/down buttons, which is painful.

Now the position under the cursor is kept in place. Thus you can easily and quickly look at some other map region -- zoom out, move mouse to region of interest, zoom in.

#### Motivation for adding to Mudlet
Obvious ;-)
