### PR TITLE
NAWS width handling & reporting

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -734,7 +734,7 @@ bool cTelnet::socketOutRaw(std::string& data)
 
 void cTelnet::setDisplayDimensions()
 {
-    int x = mpHost->mWrapAt;
+    int x = (mpHost->mScreenWidth < mpHost->mWrapAt) ? mpHost->mScreenWidth : mpHost->mWrapAt;
     int y = mpHost->mScreenHeight;
     if (myOptionState[static_cast<size_t>(OPT_NAWS)]) {
         std::string s;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2384,6 +2384,7 @@ void dlgProfilePreferences::slot_save_and_exit()
             pHost->setUserDictionaryOptions(true, false);
         }
         pHost->mWrapAt = wrap_at_spinBox->value();
+        pHost->adjustNAWS();
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mPrintCommand = show_sent_text_checkbox->isChecked();
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
@@ -2451,7 +2452,6 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mSslIgnoreExpired = checkBox_expired->isChecked();
         pHost->mSslIgnoreSelfSigned = checkBox_self_signed->isChecked();
         pHost->mSslIgnoreAll = checkBox_ignore_all->isChecked();
-
 
         if (pMudlet->mConsoleMap.contains(pHost)) {
             pMudlet->mConsoleMap[pHost]->changeColors();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Updated the width handling and reporting frequency of the [NAWS (Negotiate About Window Size)](https://tools.ietf.org/html/rfc1073) protocol in Mudlet.  There is no change to main window height reporting.  There is a change to main window width reporting.  There is also a change to the frequency of reporting.

Before the change, the width of the window was reported as the wrap value set in "Settings->Main Display -> Wrap lines at" (default is 100 characters).  After the change, when the width of the main window is less than the wrap value characters, the width of the main window will be reported.  The functionality that freezes the width of the window to be the wrap value remains the same when the width value is greater than or equal to the wrap value.

Before the change, when the "Settings->Main Display -> Wrap lines at" was adjusted, the new width was not sent as an update to NAWS negotiated servers.  After the change, any update to "Settings->Main Display -> Wrap lines at" will trigger an update to NAWS negotiated servers.

#### Motivation for adding to Mudlet

- Tamarindo was adding NAWS handling into StickMUD aligned with some accessibility support and noticed how the NAWS width was always caught on the wrap value.
- Reports width to NAWS when the window is smaller than the wrap value set in "Settings->Main Display -> Wrap lines at".

#### Other info (issues closed, discussion etc)

- Resolves Issue [#748](https://github.com/Mudlet/Mudlet/issues/748) reported by @vadi2.