### PR TITLE
Emit the debug console's output to standard error

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,6 @@
 /qrc_mudlet_alpha.cpp
+/.qmake.stash
+/kwallet_interface.h
+/kwallet_interface.cpp
+/moc_predefs.h
+

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7109,6 +7109,7 @@ int TLuaInterpreter::debug(lua_State* L)
         // n == 1
         luaDebugText = QStringLiteral(" %1").arg(QString::fromUtf8(lua_tostring(L, 1)));
     }
+    qWarning() << luaDebugText;
     luaDebugText.append(QChar::LineFeed);
 
     if (host.mpEditorDialog) {


### PR DESCRIPTION
The debug console only has a couple of lines, and scrolling it back is painful, esp. if you want to figure out why your script runs into an endless loop.
    
This simple one-line patch also emits the debug console's content to standard error which can be captured in a file or in the system terminal's scrollback buffer.
