### PR TITLE
Add MXP Sound Tag Handler

### DIFF
--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -105,3 +105,8 @@ TLinkStore& TMxpMudlet::getLinkStore()
 {
     return mpHost->mpConsole->getLinkStore();
 }
+
+void TMxpMudlet::playMedia(TMediaData& mediaData)
+{
+    mpHost->mpMedia->playMedia(mediaData);
+}

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -21,6 +21,7 @@
 
 #include "TEntityResolver.h"
 #include "TLinkStore.h"
+#include "TMedia.h"
 #include "TMxpClient.h"
 #include "TMxpEvent.h"
 
@@ -96,6 +97,8 @@ public:
 
     void enqueueMxpEvent(MxpStartTag* tag);
     TLinkStore& getLinkStore();
+
+    void playMedia(TMediaData& mediaData);
 };
 
 #endif //MUDLET_TMXPMUDLET_H

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *   Copyright (C) 2020 by Mike Conley - sousesider@gmail.com              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "TMxpSoundTagHandler.h"
+#include "TMxpClient.h"
+#include "TMedia.h"
+bool TMxpSoundTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
+{
+    return tag->isNamed("SOUND") || tag->isNamed("MUSIC");
+}
+TMxpTagHandlerResult TMxpColorTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
+{// <sound FName="mm_door_close1.*" [V=100] [L=1] [P=50] [T="misc"] [U="https://www.example.com/sounds/"]>
+    TMediaData mediaData {};
+
+	if (tag->isNamed("MUSIC")) {
+		mediaData.setMediaType(TMediaData::MediaTypeMusic);
+
+		QString musicContinue = tag->getAttributeByNameOrIndex("C", 1)
+	    if (!musicContinue.isEmpty()) {
+	        if (musicContinue.toInt() == 0) {
+	            mediaData.setMediaContinue(TMediaData::MediaContinueRestart);
+	        } else {
+	            mediaData.setMediaContinue(TMediaData::MediaContinueDefault);
+	        }
+	    }
+	} else {
+		mediaData.setMediaType(TMediaData::MediaTypeSound);
+	}
+
+    mediaData.setMediaFile(tag->getAttributeByNameOrIndex("FName", 0));
+
+	QString volume = tag->getAttributeByNameOrIndex("V", 1)
+    if (!volume.isEmpty()) {
+    	mediaData.setMediaVolume(volume.toInt());
+
+        if (mediaData.getMediaVolume() == TMediaData::MediaVolumePreload) {
+            // Support preloading
+        } else if (mediaData.getMediaVolume() > TMediaData::MediaVolumeMax) {
+            mediaData.setMediaVolume(TMediaData::MediaVolumeMax);
+        } else if (mediaData.getMediaVolume() < TMediaData::MediaVolumeMin) {
+            mediaData.setMediaVolume(TMediaData::MediaVolumeMin);
+        }
+    }
+
+	QString loops = tag->getAttributeByNameOrIndex("L", 1)
+    if (!loops.isEmpty()) {
+    	mediaData.setMediaLoops(loops.toInt());
+
+        if (mediaData.getMediaLoops() < TMediaData::MediaLoopsRepeat || mediaData.getMediaLoops() == 0) {
+            mediaData.setMediaLoops(TMediaData::MediaLoopsDefault);
+        }
+    }
+
+	QString priority = tag->getAttributeByNameOrIndex("P", 1)
+    if (!priority.isEmpty()) {
+    	mediaData.setMediaPriority(priority.toInt());
+
+        if (mediaData.getMediaPriority() > TMediaData::MediaPriorityMax) {
+            mediaData.setMediaPriority(TMediaData::MediaPriorityMax);
+        } else if (mediaData.getMediaPriority() < TMediaData::MediaPriorityMin) {
+            mediaData.setMediaPriority(TMediaData::MediaPriorityMin);
+        }
+    }
+
+	QString tag = tag->getAttributeByNameOrIndex("T", 1)
+    if (!tag.isEmpty()) {
+    	mediaData.setMediaTag(tag.toLower());
+    }
+
+	QString url = tag->getAttributeByNameOrIndex("U", 1)
+    if (!url.isEmpty()) {
+    	mediaData.setMediaUrl(url);
+    }
+
+    client->mpMedia->playMedia(mediaData);
+
+    return MXP_TAG_HANDLED;
+}

--- a/src/TMxpSoundTagHandler.h
+++ b/src/TMxpSoundTagHandler.h
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *   Copyright (C) 2020 by Mike Conley - sousesider[at]gmail.com           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#ifndef MUDLET_TMXPSOUNDTAGHANDLER_H
+#define MUDLET_TMXPSOUNDTAGHANDLER_H
+
+#include "TMxpTagHandler.h"
+
+// <sound FName="mm_door_close1.*" [V=100] [L=1] [P=50] [T="misc"] [U="https://www.example.com/sounds/"]>
+class TMxpSoundTagHandler : public TMxpTagHandler
+{
+public:
+    bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override;
+
+    TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
+};
+#include "TMxpTagHandler.h"
+#endif //MUDLET_TMXPSOUNDTAGHANDLER_H

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -734,7 +734,7 @@ bool cTelnet::socketOutRaw(std::string& data)
 
 void cTelnet::setDisplayDimensions()
 {
-    int x = mpHost->mWrapAt;
+    int x = (mpHost->mScreenWidth < mpHost->mWrapAt) ? mpHost->mScreenWidth : mpHost->mWrapAt;
     int y = mpHost->mScreenHeight;
     if (myOptionState[static_cast<size_t>(OPT_NAWS)]) {
         std::string s;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2384,6 +2384,7 @@ void dlgProfilePreferences::slot_save_and_exit()
             pHost->setUserDictionaryOptions(true, false);
         }
         pHost->mWrapAt = wrap_at_spinBox->value();
+        pHost->adjustNAWS();
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mPrintCommand = show_sent_text_checkbox->isChecked();
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
@@ -2451,7 +2452,6 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mSslIgnoreExpired = checkBox_expired->isChecked();
         pHost->mSslIgnoreSelfSigned = checkBox_self_signed->isChecked();
         pHost->mSslIgnoreAll = checkBox_ignore_all->isChecked();
-
 
         if (pMudlet->mConsoleMap.contains(pHost)) {
             pMudlet->mConsoleMap[pHost]->changeColors();

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -542,6 +542,7 @@ SOURCES += \
     TMxpNodeBuilder.cpp \
     TMxpProcessor.cpp \
     TMxpSendTagHandler.cpp \
+    TMxpSoundTagHandler.cpp \
     TMxpSupportTagHandler.cpp \
     MxpTag.cpp \
     TMxpTagHandler.cpp \
@@ -647,6 +648,7 @@ HEADERS += \
     TMxpNodeBuilder.h \
     TMxpProcessor.h \
     TMxpSendTagHandler.h \
+    TMxpSoundTagHandler.h \
     MxpTag.h \
     TMxpTagHandler.h \
     TMxpTagParser.h \


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Add support for Mud Sound Protocol (MSP) through Mudlet's Mud eXtension Protocol (MXP) by linking with the existing functionality already in Mudlet that supports MSP. 

<SOUND FName="ouch.wav" V=50 L=2 P=80 T="combat" U="http://www.example.com/sounds/">

#### Motivation for adding to Mudlet

User breakone9r from the Mudlet Discord has been working on Materia Magica integration and they need MXP MSP support.

#### Other info (issues closed, discussion etc)

I don't know why my NAWS commits are showing up in this PR too, sorry about that.