### PR TITLE
Bugfix: handling of Big5 encodings for ambiguous E Asian auto-widening

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1951,17 +1951,17 @@ void Host::setWideAmbiguousEAsianGlyphs(const Qt::CheckState state)
 {
     bool localState = false;
     bool needToEmit = false;
-    const QString encoding(mTelnet.getEncoding());
+    const QByteArray encoding(mTelnet.getEncoding());
 
     QMutexLocker locker(& mLock);
     if (state == Qt::PartiallyChecked) {
         // Set things automatically
         mAutoAmbigousWidthGlyphsSetting = true;
 
-        if (encoding == QLatin1String("GBK")
-            || encoding == QLatin1String("GB18030")
-            || encoding == QLatin1String("Big5")
-            || encoding == QLatin1String("Big5-HKSCS")) {
+        if (encoding == "GBK"
+            || encoding == "GB18030"
+            || encoding == "BIG5"
+            || encoding == "BIG5-HKSCS") {
 
             // Need to use wide width for ambiguous characters
             if (!mWideAmbigousWidthGlyphs) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1749,10 +1749,10 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
     }
     QByteArray data{lua_tostring(L, 1)};
 
-    QString currentEncoding = host.mTelnet.getEncoding();
+    QByteArray currentEncoding = host.mTelnet.getEncoding();
     if (dataIsUtf8Encoded) {
         // We can convert the data from a QByteArray to a QString:
-        if (currentEncoding == QStringLiteral("UTF-8")) {
+        if (currentEncoding == "UTF-8") {
             // Simple case: the encoding is already what we are using:
             std::string dataStdString{data.toStdString()};
             host.mpConsole->printOnDisplay(dataStdString);
@@ -1764,12 +1764,12 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
             // We need to transcode it from UTF-8 into the current Game Server
             // encoding - this can fail if it includes any characters (as UTF-8)
             // that the game encoding cannot convey:
-        auto* pDataCodec = QTextCodec::codecForName(currentEncoding.toLatin1().constData());
+        auto* pDataCodec = QTextCodec::codecForName(currentEncoding);
         auto* pDataEncoder = pDataCodec->makeEncoder(QTextCodec::IgnoreHeader);
-        if (!(currentEncoding.isEmpty() || currentEncoding == QStringLiteral("ASCII"))) {
+        if (!(currentEncoding.isEmpty() || currentEncoding == "ASCII")) {
             if (!pDataCodec->canEncode(dataQString)) {
                 lua_pushnil(L);
-                lua_pushfstring(L, "cannot send \"%s\" as it contains one or more characters that cannot be conveyed in the current game server encoding of \"%s\"", data.constData(), currentEncoding.toLatin1().constData());
+                lua_pushfstring(L, "cannot send \"%s\" as it contains one or more characters that cannot be conveyed in the current game server encoding of \"%s\"", data.constData(), currentEncoding);
                 return 2;
             }
 
@@ -3685,16 +3685,18 @@ int TLuaInterpreter::getMudletInfo(lua_State* L)
     Host& host = getHostFromLua(L);
 
     QStringList knownEncodings{"ASCII"};
+    // cTelnet::getEncoding() returns a QByteArray NOT a QString:
     QString currentEncoding{host.mTelnet.getEncoding()};
     {
         auto adjustEncoding = [](auto encodingName) {
             auto originalEncoding = encodingName;
-            if (encodingName.startsWith("M_")) {
+            if (encodingName.startsWith(QStringLiteral("M_"))) {
                 encodingName.remove(0, 2);
             }
 
             return (originalEncoding == encodingName) ? originalEncoding : QStringLiteral("%1 (%2)").arg(encodingName, originalEncoding);
         };
+        // cTelnet::getEncodingsList() returns a QByteArrayList NOT a QStringList/QList<QString>:
         for (const auto& encoding : host.mTelnet.getEncodingsList()) {
             knownEncodings.append(adjustEncoding(QString(encoding)));
         }
@@ -3704,13 +3706,11 @@ int TLuaInterpreter::getMudletInfo(lua_State* L)
         std::sort(knownEncodings.begin(), knownEncodings.end(), sorter);
 
         if (currentEncoding.isEmpty()) {
-            currentEncoding = "\"ASCII\"";
+            currentEncoding = QStringLiteral("\"ASCII\"");
         } else {
             currentEncoding = adjustEncoding(currentEncoding);
         }
     }
-
-
 
     host.postMessage(QStringLiteral("[ INFO ]  - Current encoding: %1").arg(currentEncoding));
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1769,7 +1769,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
         if (!(currentEncoding.isEmpty() || currentEncoding == "ASCII")) {
             if (!pDataCodec->canEncode(dataQString)) {
                 lua_pushnil(L);
-                lua_pushfstring(L, "cannot send \"%s\" as it contains one or more characters that cannot be conveyed in the current game server encoding of \"%s\"", data.constData(), currentEncoding);
+                lua_pushfstring(L, "cannot send \"%s\" as it contains one or more characters that cannot be conveyed in the current game server encoding of \"%s\"", data.constData(), currentEncoding.constData());
                 return 2;
             }
 


### PR DESCRIPTION
When the preference that controlled the E. Asian widening was set to "Auto" the Server encoding was not being correctly detected as the wrong `QByteArray` strings were being checked against the currently selected Game Server encoding setting. This would mean that both the variants that Mudlet offered would be using the "Normal"/"Narrow" wide for such ambiguous graphemes rather than the "Wide" that was intended.

Also, there were some places in the `TLuaInterpreter` class where the encoding details were being treated as `QString`s rather than the `QByteArray` that is used specifically to match up with Qt's own usage, and avoid the whole `QStringLiteral(...)`/`QObject::tr(...)` wrapper issue that arises from the use of `QString`...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>