### PR TITLE
Adjustable.Container save/load in UserWindow

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -620,6 +620,7 @@ function Adjustable.Container:save()
     mytable.padding = self.padding
     mytable.hidden = self.hidden
     mytable.auto_hidden = self.auto_hidden
+    mytable.windowname = self.windowname
     if not(io.exists(getMudletHomeDir().."/AdjustableContainer/")) then lfs.mkdir(getMudletHomeDir().."/AdjustableContainer/") end
     table.save(getMudletHomeDir().."/AdjustableContainer/"..self.name..".lua", mytable)
 end
@@ -631,6 +632,12 @@ function Adjustable.Container:load()
 
     if io.exists(getMudletHomeDir().."/AdjustableContainer/"..self.name..".lua") then
         table.load(getMudletHomeDir().."/AdjustableContainer/"..self.name..".lua", mytable)
+    end
+
+    mytable.windowname = mytable.windowname or "main"
+    -- send Adjustable Container to a UserWindow if saved there
+    if self.windowname ~= mytable.windowname then
+        self:changeContainer(Geyser.windowList[mytable.windowname.."Container"].windowList[mytable.windowname])
     end
 
     self.lockStyle = mytable.lockStyle or self.lockStyle


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adjustable.Container will re/appear in UserWindow if saved there.

#### Motivation for adding to Mudlet
Missing of this feature, which can be very helpful if someone brought the container to an userwindow by 
:changeContainer.
There were also the issue that if someone saved the container in an userwindow the container became very big at the next start/loading

#### Other info (issues closed, discussion etc)
