### PR TITLE
BugFix: handle floating toolbars with no DockArea set

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -465,7 +465,10 @@ void ActionUnit::constructToolbar(TAction* pA, TToolBar* pTB)
     pTB->setTitleBarWidget(nullptr);
     pTB->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     if (pA->mLocation == 4) {
-        mudlet::self()->addDockWidget(pA->mToolbarLastDockArea, pTB);
+        if (pA->mToolbarLastDockArea == Qt::NoDockWidgetArea) {
+            qWarning() << "ActionUnit::constructToolbar(TAction*, TToolBar*) WARNING - no last dockarea was set for the TAction (\"" << pA->mName << "\"), for this toolbar forcing it to the Left one!";
+        }
+        mudlet::self()->addDockWidget(((pA->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pA->mToolbarLastDockArea : Qt::LeftDockWidgetArea), pTB);
         if (pA->mToolbarLastFloatingState) {
             pTB->setFloating(true);
             QPoint pos = QPoint(pA->mPosX, pA->mPosY);


### PR DESCRIPTION
I discovered I had a problem with this when working on something else with an existing profile. The result was that the toolbar concerned was not added to the main window. This PR forces a resolution to this by reapplying the toolbar to the default left DockWidgetArea if no previous one seemed to be set.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>