### PR TITLE
BugFix: prevent Segmentation Faults when closing profile with toolbars

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1966,8 +1966,15 @@ void mudlet::commitLayoutUpdates()
     while (itHostToolbarsList.hasNext()) {
         itHostToolbarsList.next();
         for (auto pToolBar : itHostToolbarsList.value()) {
-            if (Q_LIKELY(pToolBar) && pToolBar->property("layoutChanged").toBool()) {
-                pToolBar->setProperty("layoutChanged", QVariant(false));
+            // Under some circumstances there is NOT a
+            // pToolBar->property("layoutChanged") and examining that
+            // non-existant variant to see if it was true or false causes seg. faults!
+            if (Q_LIKELY(pToolBar)) {
+                if (Q_UNLIKELY(!pToolBar->property("layoutChanged").isValid())) {
+                    qWarning().nospace().noquote() << "mudlet::commitLayoutUpdates() WARNING - was about to check for \"layoutChanged\" meta-property on a toolbar without that property!";
+                } else if (pToolBar->property("layoutChanged").toBool()) {
+                    pToolBar->setProperty("layoutChanged", QVariant(false));
+                }
             }
         }
         itHostToolbarsList.remove();


### PR DESCRIPTION
I was getting this error when closing one profile with a (now floating, may not have been initially - or visa-versa) tool-bar when multi-playing. Not sure of the exact cause (other than the toolbar did NOT have a particular {meta}property - but was trying to convert the non-existent `QVariant` that would represent it to a Boolean value) but this should prevent a fatal application crash should it occur again...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>