### PR TITLE
Introduce purgeMediaCache() [MCMP & MSP]

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7263,11 +7263,11 @@ int TLuaInterpreter::receiveMSP(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#purgeAllMediaFiles
-int TLuaInterpreter::purgeAllMediaFiles(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#purgeMediaCache
+int TLuaInterpreter::purgeMediaCache(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    host.mTelnet.purgeAllMediaFiles();
+    host.mTelnet.purgeMediaCache();
     lua_pushboolean(L, true);
     return 1;
 }
@@ -16885,7 +16885,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "tempBeginOfLineTrigger", TLuaInterpreter::tempBeginOfLineTrigger);
     lua_register(pGlobalLua, "tempExactMatchTrigger", TLuaInterpreter::tempExactMatchTrigger);
     lua_register(pGlobalLua, "receiveMSP", TLuaInterpreter::receiveMSP);
-    lua_register(pGlobalLua, "purgeAllMediaFiles", TLuaInterpreter::purgeAllMediaFiles);
+    lua_register(pGlobalLua, "purgeMediaCache", TLuaInterpreter::purgeMediaCache);
     lua_register(pGlobalLua, "sendGMCP", TLuaInterpreter::sendGMCP);
     lua_register(pGlobalLua, "roomExists", TLuaInterpreter::roomExists);
     lua_register(pGlobalLua, "addRoom", TLuaInterpreter::addRoom);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7263,6 +7263,15 @@ int TLuaInterpreter::receiveMSP(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#purgeAllMediaFiles
+int TLuaInterpreter::purgeAllMediaFiles(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    host.mTelnet.purgeAllMediaFiles();
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#sendGMCP
 int TLuaInterpreter::sendGMCP(lua_State* L)
 {
@@ -16876,6 +16885,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "tempBeginOfLineTrigger", TLuaInterpreter::tempBeginOfLineTrigger);
     lua_register(pGlobalLua, "tempExactMatchTrigger", TLuaInterpreter::tempExactMatchTrigger);
     lua_register(pGlobalLua, "receiveMSP", TLuaInterpreter::receiveMSP);
+    lua_register(pGlobalLua, "purgeAllMediaFiles", TLuaInterpreter::purgeAllMediaFiles);
     lua_register(pGlobalLua, "sendGMCP", TLuaInterpreter::sendGMCP);
     lua_register(pGlobalLua, "roomExists", TLuaInterpreter::roomExists);
     lua_register(pGlobalLua, "addRoom", TLuaInterpreter::addRoom);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -450,7 +450,7 @@ public:
     static int sendATCP(lua_State*);
     static int sendGMCP(lua_State*);
     static int receiveMSP(lua_State*);
-    static int purgeAllMediaFiles(lua_State*);
+    static int purgeMediaCache(lua_State*);
     static int saveMap(lua_State* L);
     static int loadMap(lua_State* L);
     static int setExitStub(lua_State* L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -450,6 +450,7 @@ public:
     static int sendATCP(lua_State*);
     static int sendGMCP(lua_State*);
     static int receiveMSP(lua_State*);
+    static int purgeAllMediaFiles(lua_State*);
     static int saveMap(lua_State* L);
     static int loadMap(lua_State* L);
     static int setExitStub(lua_State* L);

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -203,13 +203,13 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
     }
 }
 
-bool TMedia::purgeAllMediaFiles()
+bool TMedia::purgeMediaCache()
 {
     QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
     QDir mediaDir(mediaPath);
 
     if (!mediaDir.mkpath(mediaPath)) {
-        qWarning() << QStringLiteral("TMedia::purgeAllMediaFiles() WARNING - Not able to reference directory: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
+        qWarning() << QStringLiteral("TMedia::purgeMediaCache() WARNING - Not able to reference directory: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
         return false;
     }
 

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -202,9 +202,35 @@ void TMedia::parseGMCP(QString& packageMessage, QString& gmcp)
         TMedia::parseJSONForMediaPlay(json);
     }
 }
+
+bool TMedia::purgeAllMediaFiles()
+{
+    QString mediaPath = mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName());
+    QDir mediaDir(mediaPath);
+
+    if (!mediaDir.mkpath(mediaPath)) {
+        qWarning() << QStringLiteral("TMedia::purgeAllMediaFiles() WARNING - Not able to reference directory: %1").arg(mudlet::getMudletPath(mudlet::profileMediaPath, mpHost->getName()));
+        return false;
+    }
+
+    TMedia::stopAllMediaPlayers();
+    mediaDir.removeRecursively();
+    return true;
+}
 // End Public
 
 // Private
+void TMedia::stopAllMediaPlayers()
+{
+    QList<TMediaPlayer> mTMediaPlayerList = (mMSPSoundList + mMSPMusicList + mGMCPSoundList + mGMCPMusicList);
+    QListIterator<TMediaPlayer> itTMediaPlayer(mTMediaPlayerList);
+
+    while (itTMediaPlayer.hasNext()) {
+        TMediaPlayer pPlayer = itTMediaPlayer.next();
+        pPlayer.getMediaPlayer()->stop();
+    }
+}
+
 QUrl TMedia::parseUrl(TMediaData& mediaData)
 {
     QUrl url;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -213,7 +213,7 @@ bool TMedia::purgeMediaCache()
         return false;
     }
 
-    TMedia::stopAllMediaPlayers();
+    stopAllMediaPlayers();
     mediaDir.removeRecursively();
     return true;
 }

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -127,8 +127,10 @@ public:
     void playMedia(TMediaData& mediaData);
     void stopMedia(TMediaData& mediaData);
     void parseGMCP(QString& packageMessage, QString& gmcp);
+    bool purgeAllMediaFiles();
 
 private:
+    void stopAllMediaPlayers();
     QUrl parseUrl(TMediaData& mediaData);
     static bool isValidUrl(QUrl& url);
     static bool isFileRelative(TMediaData& mediaData);

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -127,7 +127,7 @@ public:
     void playMedia(TMediaData& mediaData);
     void stopMedia(TMediaData& mediaData);
     void parseGMCP(QString& packageMessage, QString& gmcp);
-    bool purgeAllMediaFiles();
+    bool purgeMediaCache();
 
 private:
     void stopAllMediaPlayers();

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2155,9 +2155,9 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
     mpHost->mpMedia->playMedia(mediaData);
 }
 
-bool cTelnet::purgeAllMediaFiles()
+bool cTelnet::purgeMediaCache()
 {
-    return mpHost->mpMedia->purgeAllMediaFiles();
+    return mpHost->mpMedia->purgeMediaCache();
 }
 
 void cTelnet::setChannel102Variables(const QString& msg)

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2011,7 +2011,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         mpHost->processDiscordGMCP(packageMessage, data);
     }
 
-    if (mpHost->mAcceptServerMedia && packageMessage.startsWith(QStringLiteral("Client.Media").toLower())) {
+    if (mpHost->mAcceptServerMedia && packageMessage.toLower().startsWith(QStringLiteral("client.media"))) {
         mpHost->mpMedia->parseGMCP(packageMessage, data);
     }
 
@@ -2153,6 +2153,11 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
     }
 
     mpHost->mpMedia->playMedia(mediaData);
+}
+
+bool cTelnet::purgeAllMediaFiles()
+{
+    return mpHost->mpMedia->purgeAllMediaFiles();
 }
 
 void cTelnet::setChannel102Variables(const QString& msg)

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -151,6 +151,7 @@ public:
     void setGMCPVariables(const QByteArray&);
     void setMSSPVariables(const QByteArray&);
     void setMSPVariables(const QByteArray&);
+    bool purgeAllMediaFiles();
     void atcpComposerCancel();
     void atcpComposerSave(QString);
     void setDisplayDimensions();

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -151,7 +151,7 @@ public:
     void setGMCPVariables(const QByteArray&);
     void setMSSPVariables(const QByteArray&);
     void setMSPVariables(const QByteArray&);
-    bool purgeAllMediaFiles();
+    bool purgeMediaCache();
     void atcpComposerCancel();
     void atcpComposerSave(QString);
     void setDisplayDimensions();

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -264,6 +264,7 @@
     "prefix": "prefix(text, [writingFunction], [foregroundColor], [backgroundColor], [windowName])",
     "print": "print(text, some more text, ...)",
     "printCmdLine": "printCmdLine(text)",
+    "purgeAllMediaFiles": "purgeAllMediaFiles()",
     "putHTTP": "putHTTP(dataToSend, url, headersTable, file)",
     "raiseEvent": "raiseEvent(event_name, arg-1, … arg-n)",
     "raiseGlobalEvent": "raiseGlobalEvent(event_name, arg-1, … arg-n)",

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -264,7 +264,7 @@
     "prefix": "prefix(text, [writingFunction], [foregroundColor], [backgroundColor], [windowName])",
     "print": "print(text, some more text, ...)",
     "printCmdLine": "printCmdLine(text)",
-    "purgeAllMediaFiles": "purgeAllMediaFiles()",
+    "purgeMediaCache": "purgeMediaCache()",
     "putHTTP": "putHTTP(dataToSend, url, headersTable, file)",
     "raiseEvent": "raiseEvent(event_name, arg-1, … arg-n)",
     "raiseGlobalEvent": "raiseGlobalEvent(event_name, arg-1, … arg-n)",


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Purge all media file stored in the media cache within a given Mudlet profile (media used with MCMP and MSP protocols). As game developers update the media files on their games, this enables the media folder inside the profile to be cleared so that the media files could be refreshed to the latest update(s).

How to use it:

- Instruct a player to type `lua purgeMediaCache()` on the command line, OR
- Distribute a trigger, button or other feature for their profile to call `purgeMediaCache()`

Submitted by Tamarindo @ StickMUD

**Special note**: This solves a critical bug for MCMP in src/ctelnet.cpp where MCMP will not play if the package name is not in all in lower case.  This was the result of another PR before the 4.9.2 release and is not present in production, yet.

#### Motivation for adding to Mudlet
Requested by Jane of Stillborn (@crystaleyes23) 

#### Other info (issues closed, discussion etc)
Closes #4035.  This clears out subdirectories of `media` as well.  Similar code used to remove profiles.

To test this, log into StickMUD, hear music as you move room to room, enter `lua purgeMediaCache()` on the command line.  

Future enhancement(s):

- Add a button to the Settings menus inside Mudlet with some "Are you sure you want to delete all the media for this profile?" dialog boxes to gather confirmation.  Not now, keep this simple.