### PR TITLE
Allow text color manipulation by StyleSheet on Geyser.Labels

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -54,8 +54,13 @@ function Geyser.Label:echo(message, color, format)
   if not fs then
     fs = tostring(self.fontSize)
   end
+  if color == "nocolor" then
+    color = [[ style=" ]]
+  else
+    color = [[ style="color: ]] .. Geyser.Color.hex(self.fgColor) .. "; "
+  end
   fs = "font-size: " .. fs .. "pt; "
-  message = [[<div ]] .. alignment .. [[ style="color: ]] .. Geyser.Color.hex(self.fgColor) .. "; " .. fs ..
+  message = [[<div ]] .. alignment .. color .. fs ..
   [[">]] .. message .. [[</div>]]
   echo(self.name, message)
 end

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -21,7 +21,7 @@ Geyser.Label.scrollH = {}
 --- Prints a message to the window.  All parameters are optional and if not
 -- specified will use the last set value.
 -- @param message The message to print. Can contain html formatting.
--- @param color The color to use.
+-- @param color The color to use. If no color formatting is needed it is possible to use 'nocolor' which allows color formatting by using :setStyleSheet
 -- @param format A format list to use. 'c' - center, 'l' - left, 'r' - right,  'b' - bold, 'i' - italics, 'u' - underline, 's' - strikethrough,  '##' - font size.  For example, "cb18" specifies center bold 18pt font be used.  Order doesn't matter.
 function Geyser.Label:echo(message, color, format)
   message = message or self.message
@@ -57,11 +57,17 @@ function Geyser.Label:echo(message, color, format)
   if color == "nocolor" then
     color = [[ style=" ]]
   else
-    color = [[ style="color: ]] .. Geyser.Color.hex(self.fgColor) .. "; "
+    color = [[ style="color: ]] .. Geyser.Color.hex(self.fgColor) .. [[; ]]
   end
   fs = "font-size: " .. fs .. "pt; "
   message = [[<div ]] .. alignment .. color .. fs ..
   [[">]] .. message .. [[</div>]]
+  echo(self.name, message)
+end
+
+--- raw Echo without formatting/handholding stuff that Geyser.Label:echo() does
+-- @param message The message to print. Can contain html formatting.
+function Geyser.Label:rawEcho(message)
   echo(self.name, message)
 end
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Removes colorstyling in Geyser.Label if color is set to "nocolor" in order to make it possible to
change the text-color by setting a new Geyser.Label stylesheet.

This is currently not possible (even if no color is set)

#### Motivation for adding to Mudlet
This is in use already as workaround by Adjustable.Container right click menu and so I thought there may 
be other people who could need this as well, as it is nice to be able to change the text color by hovering the Label.

#### Other info (issues closed, discussion etc)
Example how to use it:
```lua
testLabel = testLabel or Geyser.Label:new({name = "TestLabel",font = "BitStream Vera Sans", fontSize = 15})
testLabel:echo("Hello!" , "nocolor")
testLabel:setStyleSheet("QLabel:!hover{color:red;} QLabel:hover{color:yellow;}") -- Changes text color to yellow if hovered
```
