### PR TITLE
fix autodock always true for Geyser.UserWindow

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserUserWindow.lua
@@ -118,7 +118,9 @@ function Geyser.UserWindow:new(cons)
 
   me.restoreLayout = me.restoreLayout or false
   me.docked = me.docked or false
-  me.autoDock = me.autoDock or true
+  if not (me.autoDock == false) then
+    me.autoDock = true
+  end
   me.dockPosition = me.dockPosition or "r"
 
   if me.restoreLayout then


### PR DESCRIPTION
#### Brief overview of PR changes/additions
autoDock was always true at initialization even if set to false.
This should work now as expected.