### PR TITLE
BugFix: repair failure to load Lua modules from profile directory

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -591,6 +591,7 @@ private:
     static void generateElapsedTimeTable(lua_State*, const QStringList&, const bool, const qint64 elapsedTimeMilliSeconds = 0);
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
+    void insertNativeSeparatorsFunction(lua_State* L);
 
     const int LUA_FUNCTION_MAX_ARGS = 50;
 

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -105,16 +105,6 @@ end
 function handleWindowResizeEvent()
 end
 
-function toNativeSeparators(rawPath)
-  if package.config:sub(1,1) == '\\' then
-    return string.gsub(rawPath, '/', '\\')
-  end
-
-  assert((package.config:sub(1,1) == '/'), "package path directory separator is neither '\\' nor '/' and cannot be handled")
-
-  return string.gsub(rawPath, '\\', '/')
-end
-
 local packages = {
   "StringUtils.lua",
   "TableUtils.lua",


### PR DESCRIPTION
This was introduced by PR #3889 which was using a function defined in the LuaGlobal.lua file before it was loaded! The function definition has been moved to be within the TLuaInterpreter class C++ code and, as it is now present in two places, refactored out to a helper method so it can be loaded into both the main and the lua code formatter Lua interpreters.

This should close #4047.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>