### PR TITLE
Geyser.Label rightClick menu

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -463,6 +463,7 @@ end
 function Adjustable.Container:createRightClickMenu()
     self.adjLabel:createRightClickMenu(
         {MenuItems = {"lockLabel", "minLabel", "saveLabel", "loadLabel", "attLabel", {"att1","att2","att3","att4"}, "lockStylesLabel",{}, "customItemsLabel",{}},
+        Style = self.menuStyleMode,
         MenuStyle = self.menustyle,
         MenuWidth = self.ParentMenuWidth,
         MenuWidth2 = self.ChildMenuWidth,
@@ -486,6 +487,11 @@ function Adjustable.Container:echoRightClickMenu()
             self[v]:echo(self[v].txt, "nocolor")
         end
     end
+end
+
+function Adjustable.Container:changeMenuStyle(mode)
+    self.menuStyleMode = mode
+    self.adjLabel:styleMenuItems(self.menuStyleMode)
 end
 
 -- overriden add function to put every new window to the Inside container
@@ -756,19 +762,19 @@ function Adjustable.Container:new(cons,container)
     local me = self.parent:new(cons, container)
     setmetatable(me, self)
     self.__index = self
-    me.ParentMenuWidth = me.ParentMenuWidth or 102
-    me.ChildMenuWidth = me.ChildMenuWidth or 82
-    me.MenuHeight = me.MenuHeight or 22
-    me.MenuFontSize = me.MenuFontSize or 8
-    me.buttonsize = me.buttonsize or 15
-    me.buttonFontSize = me.buttonFontSize or 8
+    me.ParentMenuWidth = me.ParentMenuWidth or "102"
+    me.ChildMenuWidth = me.ChildMenuWidth or "82"
+    me.MenuHeight = me.MenuHeight or "22"
+    me.MenuFontSize = me.MenuFontSize or "8"
+    me.buttonsize = me.buttonsize or "15"
+    me.buttonFontSize = me.buttonFontSize or "8"
     me.padding = me.padding or 10
 
     me.adjLabelstyle = me.adjLabelstyle or [[
     background-color: rgba(0,0,0,100%);
     border: 4px double green;
     border-radius: 4px;]]
-    me.menustyle = me.menustyle or [[QLabel::hover{ background-color: rgba(0,150,255,100%); color: white;} QLabel::!hover{color: black; background-color: rgba(240,240,240,100%);} QLabel{ font-size:]]..me.MenuFontSize..[[pt;}]]
+    me.menuStyleMode = "light"
     me.buttonstyle= me.buttonstyle or [[
     QLabel{ border-radius: 7px; background-color: rgba(255,30,30,100%);}
     QLabel::hover{ background-color: rgba(255,0,0,50%);}

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -424,7 +424,7 @@ local function createMenus(self, parent, name, func)
     local label = self.adjLabel
     local menuTxt = self.Locale[name] and self.Locale[name].message or name
     label:addMenuLabel(name, parent)
-    label:configMenuLabel(parent.."."..name, "echo", menuTxt, "nocolor")
+    label:findMenuElement(parent.."."..name):echo(menuTxt, "nocolor")
     label:setMenuAction(parent.."."..name, func, self, name)
 end
 
@@ -460,6 +460,7 @@ function Adjustable.Container:createLabels()
     self.minimizeLabel:echo("<center>-</center>")
 end
 
+-- internal function to create the right click menu
 function Adjustable.Container:createRightClickMenu()
     self.adjLabel:createRightClickMenu(
         {MenuItems = {"lockLabel", "minLabel", "saveLabel", "loadLabel", "attLabel", {"att1","att2","att3","att4"}, "lockStylesLabel",{}, "customItemsLabel",{}},
@@ -481,6 +482,7 @@ function Adjustable.Container:createRightClickMenu()
     end
 end
 
+-- internal function to set the text on the right click menu labels
 function Adjustable.Container:echoRightClickMenu()
     for k,v in ipairs(self.adjLabel.rightClickMenu.MenuItems) do
         if type(v) == "string" then
@@ -489,6 +491,9 @@ function Adjustable.Container:echoRightClickMenu()
     end
 end
 
+--- function to change the right click menu style
+-- there are 2 styles: dark and light
+--@param mode the style mode (dark or light)
 function Adjustable.Container:changeMenuStyle(mode)
     self.menuStyleMode = mode
     self.adjLabel:styleMenuItems(self.menuStyleMode)

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -72,15 +72,6 @@ local function shrink_title(lbl)
     lbl.adjLabel:echo(titleText, lbl.titleTxtColor, "l")
 end
 
--- Internal function: plain Echo which allows text manipulation by stylesheets
--- @param self the menu label itself
--- @param text the text to be shown on the menu label
-local function pEcho(self, text)
-    if text then
-        echo(self.name, text)
-    end
-end
-
 --- function to give your adjustable container a new title
 -- @param text new title text
 -- @param color title text color
@@ -91,22 +82,11 @@ function Adjustable.Container:setTitle(text, color)
     shrink_title(self)
 end
 
--- internal function to change the layout of the rightClick menu if we are at the right edge
--- @param labelNest Nested Labels
--- @param fdir flying direction of the label
-local function changeMenuLayout(labelNest, fdir)
-    if not labelNest then return end
-    for k,v in pairs (labelNest) do
-        v.flyDir  = fdir
-        changeMenuLayout(v.nestedLabels, fdir)
-    end
-end
 
 -- internal function to handle the onClick event of main Adjustable.Container Label
 -- @param label the main Adjustable.Container Label
 -- @param event the onClick event and its informations
 function Adjustable.Container:onClick(label, event)
-    closeAllLevels(self.rCLabel)
     if label.cursorShape == "OpenHand" then
         label:setCursor("ClosedHand")
     end
@@ -122,40 +102,19 @@ function Adjustable.Container:onClick(label, event)
     if event.button == "RightButton" then
         --if not in the Geyser main window attach Label is not needed and will be removed
         if self.container ~= Geyser and table.index_of(self.rCLabel.nestedLabels, self.attLabel) then
-            table.remove(self.rCLabel.nestedLabels, table.index_of(self.rCLabel.nestedLabels, self.attLabel))
+            label:hideMenuLabel("attLabel")
             -- if we are back to the Geyser main window attach Label will be readded
         elseif self.container == Geyser and not table.index_of(self.rCLabel.nestedLabels, self.attLabel) then
-            table.insert(self.rCLabel.nestedLabels, table.index_of(self.rCLabel.nestedLabels, self.lockStylesLabel)-1, self.attLabel)
-            self.attLabel:changeContainer(Geyser)
+            label:showMenuLabel("attLabel") 
         end
 
         if table.index_of(self.rCLabel.nestedLabels, self.customItemsLabel) and not self.customItemsLabel.nestedLabels then
-            table.remove(self.rCLabel.nestedLabels, table.index_of(self.rCLabel.nestedLabels, self.customItemsLabel))
-        elseif self.rCLabel.nestedLabels[#self.rCLabel.nestedLabels] ~= self.customItemsLabel and self.customItemsLabel.nestedLabels then
-            self.rCLabel.nestedLabels[#self.rCLabel.nestedLabels + 1] = self.customItemsLabel
+            label:hideMenuLabel("customItemsLabel")
+        else
+            label:showMenuLabel("customItemsLabel") 
         end
-
-        if self.rCLabel.windowname ~= self.customItemsLabel.windowname then
-            if self.rCLabel.windowname == "main" then
-                self.customItemsLabel:changeContainer(Geyser)
-            else
-                self.customItemsLabel:changeContainer(Geyser.windowList[self.windowname.."Container"].windowList[self.windowname])
-            end
-        end
-
-        local winw = getUserWindowSize(self.windowname)
-        local mousepos = self:get_x() + event.x
-        local maxdiff = self.ParentMenuWidth + self.ChildMenuWidth
-        local diff = winw - mousepos
-        local flyDir = self.rCLabel.nestedLabels[1].flyDir
-        if diff <= maxdiff and flyDir == "R"then
-            changeMenuLayout(self.rCLabel.nestedLabels, "L")
-        elseif diff > maxdiff and flyDir == "L" then
-            changeMenuLayout(self.rCLabel.nestedLabels, "R")
-        end
-        self.rCLabel:move(event.x, event.y)
-        doNestShow(self.rCLabel)
     end
+    label:onRightClick(event)
 end
 
 -- internal function to handle the onRelease event of main Adjustable.Container Label
@@ -457,39 +416,16 @@ function Adjustable.Container:restore()
     end
 end
 
--- internal function to style all labels in a labelnest
--- recursively iterates through all the labelNests
--- @param self the container itself
--- @param labelNest the given LabelNest
-local function recursiveStyle(self, labelNest)
-    if not labelNest then return end
-    for k,v in pairs (labelNest) do
-        v:setStyleSheet(self.menustyle)
-        pEcho(v, v.txt)
-        recursiveStyle(self, v.nestedLabels)
-    end
-end
-
 -- internal function to create the menu labels for lockstyle and custom items
 -- @param self the container itself
 -- @param menu name of the menu
 -- @param onClick function which will be executed onClick
-local function createMenus(self, menu, onClick)
-    self[menu.."l"] = {}
-    self[menu.."Nr"] = self[menu.."Nr"] or 1
-    if not self[menu] then return end
-    for i = self[menu.."Nr"], #self[menu] do
-        local name = self[menu][i][1]
-        local menuTxt = self.Locale[name] and self.Locale[name].message or name
-        self[menu.."l"][i] = self[menu.."Label"]:addChild({
-            width = self.ChildMenuWidth, height = self.MenuHeight, flyOut=true, layoutDir="RV", name = self.name..menu..name
-        })
-        self[menu.."l"][i].txt = [[<center>]]..menuTxt
-        self[menu.."l"][i]:setClickCallback(onClick, self, i, name)
-    end
-    recursiveStyle(self, self[menu.."Label"].nestedLabels)
-    self[menu.."Nr"] = #self[menu]
-
+local function createMenus(self, parent, name, func)
+    local label = self.adjLabel
+    local menuTxt = self.Locale[name] and self.Locale[name].message or name
+    label:addMenuLabel(name, parent)
+    label:configMenuLabel(parent.."."..name, "echo", menuTxt, "nocolor")
+    label:setMenuAction(parent.."."..name, func, self, name)
 end
 
 -- internal function: Handler for the onEnter event of the attach menu
@@ -502,7 +438,7 @@ function Adjustable.Container:onEnterAtt()
             self.att[i]:changeContainer(Geyser)
         end
         self.att[i].flyDir = self.attLabel.flyDir
-        pEcho(self.att[i], "<center>"..self.Locale[attm[i]].message)
+        self.att[i]:echo("<center>"..self.Locale[attm[i]].message, "nocolor")
         self.att[i]:setClickCallback("Adjustable.Container.attachToBorder", self, attm[i])
         self.attLabel.nestedLabels[#self.attLabel.nestedLabels+1] = self.att[i]
     end
@@ -522,57 +458,34 @@ function Adjustable.Container:createLabels()
 
     },self)
     self.minimizeLabel:echo("<center>-</center>")
-
-    -- create a label with a nestable=true property to say that it can nest labels
-    self.rCLabel = Geyser.Label:new({
-    width = "0", height = "0", nestable=true, name = self.name.."rCLabel",
-    message="<center>Clicky clicky</center>"}, self)
-
-    self.lockLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight, name = self.name.."lockLabel",
-        layoutDir="RV", flyOut=true
-    })
-
-    self.minLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight, name = self.name.."minLabel",
-        layoutDir="RV", flyOut=true
-
-    })
-
-    self.saveLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight, name = self.name.."saveLabel",
-        layoutDir="RV", flyOut=true
-    })
-
-    self.loadLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight, name = self.name.."loadLabel",
-        layoutDir="RV", flyOut=true
-    })
-
-    self.attLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight, nestable = true, flyOut=true, layoutDir="RV", name = self.name.."attLabel"
-    })
-
-    for i=1,4 do
-        self.att[i] = self.attLabel:addChild({
-            width = self.ChildMenuWidth, height = self.MenuHeight, layoutDir="RV", name = self.name.."att"..i
-        })
-    end
-
-    self.lockStylesLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight,  nestable = true, flyOut=true, layoutDir="RV", name = self.name.."lockStylesLabel"
-    })
-    createMenus(self, "lockStyles", "Adjustable.Container.lockContainer")
-
-    self.customItemsLabel = self.rCLabel:addChild({
-        width = self.ParentMenuWidth, height = self.MenuHeight, nestable = true, flyOut=true, layoutDir="RV", name = self.name.."customItemsLabel"
-    })
-
 end
 
--- internal function to apply menustyle on all nested Labels
-function Adjustable.Container:styleLabels()
-    recursiveStyle(self, self.rCLabel.nestedLabels)
+function Adjustable.Container:createRightClickMenu()
+    self.adjLabel:createRightClickMenu(
+        {MenuItems = {"lockLabel", "minLabel", "saveLabel", "loadLabel", "attLabel", {"att1","att2","att3","att4"}, "lockStylesLabel",{}, "customItemsLabel",{}},
+        MenuStyle = self.menustyle,
+        MenuWidth = self.ParentMenuWidth,
+        MenuWidth2 = self.ChildMenuWidth,
+        MenuHeight = self.MenuHeight,
+        MenuFormat = "l"..self.MenuFontSize,
+        MenuFormat2 = "c"..self.MenuFontSize,
+        }
+        )
+    self.rCLabel = self.adjLabel.rightClickMenu
+    for k,v in pairs(self.rCLabel.MenuLabels) do
+        self[k] = v
+    end
+    for k,v in ipairs(self.rCLabel.MenuLabels["attLabel"].MenuItems) do
+        self.att[k] = self.rCLabel.MenuLabels["attLabel"].MenuLabels[v]
+    end
+end
+
+function Adjustable.Container:echoRightClickMenu()
+    for k,v in ipairs(self.adjLabel.rightClickMenu.MenuItems) do
+        if type(v) == "string" then
+            self[v]:echo(self[v].txt, "nocolor")
+        end
+    end
 end
 
 -- overriden add function to put every new window to the Inside container
@@ -777,7 +690,7 @@ function Adjustable.Container:newLockStyle(name, func)
     self.lockStyles[#self.lockStyles + 1] = {name, func}
     self.lockStyles[name] = self.lockStyles[#self.lockStyles]
     if self.lockStylesLabel then
-        createMenus(self, "lockStyles", "Adjustable.Container.lockContainer")
+        createMenus(self, "lockStylesLabel", name, "Adjustable.Container.lockContainer")
     end
 end
 
@@ -791,7 +704,7 @@ function Adjustable.Container:newCustomItem(name, func)
     end
     self.customItems[#self.customItems + 1] = {name, func}
     self.customItems[name] = self.customItems[#self.customItems]
-    createMenus(self, "customItems", "Adjustable.Container.customMenu")
+    createMenus(self, "customItemsLabel", name, "Adjustable.Container.customMenu")
 end
 --- enablesAutoSave normally only used internally
 -- only useful if autoSave was set to false before
@@ -843,12 +756,12 @@ function Adjustable.Container:new(cons,container)
     local me = self.parent:new(cons, container)
     setmetatable(me, self)
     self.__index = self
-    me.ParentMenuWidth = me.ParentMenuWidth or "102"
-    me.ChildMenuWidth = me.ChildMenuWidth or "82"
-    me.MenuHeight = me.MenuHeight or "22"
-    me.MenuFontSize = me.MenuFontSize or "8"
-    me.buttonsize = me.buttonsize or "15"
-    me.buttonFontSize = me.buttonFontSize or "8"
+    me.ParentMenuWidth = me.ParentMenuWidth or 102
+    me.ChildMenuWidth = me.ChildMenuWidth or 82
+    me.MenuHeight = me.MenuHeight or 22
+    me.MenuFontSize = me.MenuFontSize or 8
+    me.buttonsize = me.buttonsize or 15
+    me.buttonFontSize = me.buttonFontSize or 8
     me.padding = me.padding or 10
 
     me.adjLabelstyle = me.adjLabelstyle or [[
@@ -861,10 +774,12 @@ function Adjustable.Container:new(cons,container)
     QLabel::hover{ background-color: rgba(255,0,0,50%);}
     ]]
 
-    me:globalLockStyles()
     me:createContainers()
     me.att = me.att or {}
     me:createLabels()
+    me:createRightClickMenu()
+
+    me:globalLockStyles()
     me.minimized =  me.minimized or false
     me.locked =  me.locked or false
 
@@ -880,14 +795,11 @@ function Adjustable.Container:new(cons,container)
     me.adjLabel:setStyleSheet(me.adjLabelstyle)
     me.exitLabel:setStyleSheet(me.buttonstyle)
     me.minimizeLabel:setStyleSheet(me.buttonstyle)
-
-    me.rCLabel:setStyleSheet([[background-color: rgba(255,255,255,0%);]])
-    me:styleLabels()
-
+    me:echoRightClickMenu()
+    
     me.adjLabel:setClickCallback("Adjustable.Container.onClick",me, me.adjLabel)
     me.adjLabel:setReleaseCallback("Adjustable.Container.onRelease",me, me.adjLabel)
     me.adjLabel:setMoveCallback("Adjustable.Container.onMove",me, me.adjLabel)
-
     me.minLabel:setClickCallback("Adjustable.Container.onClickMin", me)
     me.saveLabel:setClickCallback("Adjustable.Container.onClickSave", me)
     me.lockLabel:setClickCallback("Adjustable.Container.onClickL", me)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Gives Geyser.Labels the possibility to have a right-click menu.
New functions:
```lua
testLabel:createRightClickMenu(cons)
```
Different cons option can style/size/format different levels of the menu.
The right click menu elements itself are given in a table of strings (**MenuItems**) which will be the names of the Labels.
Sub-tables of tables are then used to create the next menu level.
```lua 
testLabel:setMenuAction(name or parent.name as string, function, args)
 -- can be used the same way as setClickCallback
-- only one parent is needed and the name is then given like "parentname.elementname"
-- see example below
```

All the menu-labels are saved in ```testlabel.rightClickMenu.MenuLabels``` and subdirectories (for deeper levels) which can make them a bit difficult to access if special styling options per label or echoing alternative text and so on is needed.
Therefore it can be easier to use a new function to directly access the right-click menu labels by:
```lua
testLabel:findMenuElement(name or parent.name):myfunc(myargs)
```
See example below.

Additionally with this PR as Adjustable Container also use this right click menu it is now possible to change their right click menu style (darkmode or lightmode) by using:
```lua
myAdjustableContainer:changeMenuStyle(mode) -- mode is "dark" or "light"
```

#### Motivation for adding to Mudlet
Adjustable.Container has a right click menu for a long time now. I thought maybe other people want to use it as well.
And it seems also useful to standardize/simplify the way to make a right-click menu

#### Other info (issues closed, discussion etc)

(Ugly) example to show all the possibilities and different styling options.
```lua
testLabel = testLabel or Geyser.Label:new({name = "TestLabel", message = "Please right click!", format = "cb15", x=10, y=10, width ="30%", height = "15%", color = "purple"}, testAdjCont)
-- ugly showcase with different styles in different levels
-- the numbers show the deepnes of the level for example Style is the default style but then Style3 is for Labels in level 3 of deepness
testLabel:createRightClickMenu(
                              {MenuItems = {"This", "is",{"Level 2","Have",{"Fun"}}, "a", "rightClick",{"Menu"}}, 
                              Style = "Light", 
                              Style3 = "Dark", 
                              MenuWidth2 = 80, 
                              MenuWidth3 = 180, 
                              MenuFormat1 = "l10",
                              MenuStyle2 = [[QLabel::hover{ background-color: rgba(0,255,150,100%); color: white;} QLabel::!hover{color: brown; background-color: rgba(100,240,240,100%);} ]]}
                              )

-- use the label directly. This is the label with the name "right click"
testLabel.rightClickMenu.MenuLabels["rightClick"]:setAlignment("c")

-- use config label to get to the label settings. in this case the Label "Level2" 
-- its parent is the label "is"
testLabel:findMenuElement("is.Level 2"):echo([[<font size="5" face="Noto Emoji">⚓</font> Level 2]])

-- works like setClickCallback can use directly a function or give function and args by string
testLabel:setMenuAction("This", function() echo("Hello\n") end )

-- if a label has a parent it needs to be given in the name. divided by a .
testLabel:setMenuAction("rightClick.Menu", "display", "Test" )

-- no matter how deep the level is only one parent needs to be given
testLabel:setMenuAction("Have.Fun", function(event) echo("\nEVENT:") display(event) end )
```
