### PR TITLE
add custom Input/Command lines

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -25,6 +25,7 @@
 
 #include "Host.h"
 #include "TConsole.h"
+#include "TEvent.h"
 #include "TSplitter.h"
 #include "TTabBar.h"
 #include "TTextEdit.h"
@@ -50,6 +51,7 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
 , mpSystemSuggestionsList()
 , mpUserSuggestionsList()
 , mType(type)
+, mCommandLineName("main")
 {
     setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);
@@ -584,6 +586,7 @@ void TCommandLine::adjustHeight()
     }
     int _baseHeight = fontH * lines;
     int _height = _baseHeight + fontH;
+
     if (_height < mpHost->commandLineMinimumHeight) {
         _height = mpHost->commandLineMinimumHeight;
     }
@@ -849,9 +852,22 @@ void TCommandLine::enterCommand(QKeyEvent* event)
     mTabCompletionTyped.clear();
 
     QStringList _l = _t.split(QChar::LineFeed);
-    for (int i = 0; i < _l.size(); i++) {
-        mpHost->send(_l[i]);
-    }
+
+        for (int i = 0; i < _l.size(); i++) {
+            if (mType != SubCommandLine) {
+            mpHost->send(_l[i]);
+            } else {
+                TEvent mudletEvent{};
+                mudletEvent.mArgumentList.append(QLatin1String("sysCmdLineEvent"));
+                mudletEvent.mArgumentList.append(mCommandLineName);
+                mudletEvent.mArgumentList.append(_l[i]);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                mudletEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+                mpHost->raiseEvent(mudletEvent);
+            }
+        }
+
     if (!toPlainText().isEmpty()) {
         mHistoryBuffer = 0;
         setPalette(mRegularPalette);

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -35,7 +35,7 @@
 #include <QRegularExpression>
 #include "post_guard.h"
 
-TCommandLine::TCommandLine(Host* pHost, TConsole* pConsole, QWidget* parent)
+TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole, QWidget* parent)
 : QPlainTextEdit(parent)
 , mpHost(pHost)
 , mpKeyUnit(pHost->getKeyUnit())
@@ -49,6 +49,7 @@ TCommandLine::TCommandLine(Host* pHost, TConsole* pConsole, QWidget* parent)
 , mUserDictionarySuggestionsCount()
 , mpSystemSuggestionsList()
 , mpUserSuggestionsList()
+, mType(type)
 {
     setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);
@@ -570,6 +571,9 @@ void TCommandLine::focusOutEvent(QFocusEvent* event)
 
 void TCommandLine::adjustHeight()
 {
+    if (mType == SubCommandLine) {
+        return;
+    }
     int lines = document()->size().height();
     int fontH = QFontMetrics(mpHost->getDisplayFont()).height();
     if (lines < 1) {

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -46,12 +46,13 @@ public:
         UnknownType = 0x0,     // Should not be encountered but left as a trap value
         MainCommandLine = 0x1, // One per profile
         SubCommandLine = 0x2,  // Overlaid on top of MainConsole instance, should be uniquely named in pool of SubCommandLine/SubConsole/UserWindow/Buffers AND Labels
+        ConsoleCommandLine = 0x4,  // Integrated in MiniConsoles
     };
 
     Q_DECLARE_FLAGS(CommandLineType, CommandLineTypeFlag)
 
     Q_DISABLE_COPY(TCommandLine)
-    TCommandLine(Host*, CommandLineType type = UnknownType, TConsole* pConsole = nullptr, QWidget* parent = nullptr);
+    explicit TCommandLine(Host*, CommandLineType type = UnknownType, TConsole* pConsole = nullptr, QWidget* parent = nullptr);
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
     void recheckWholeLine();

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -59,7 +59,7 @@ public:
     void clearMarksOnWholeLine();
     void setAction(const int);
     void resetAction();
-    void releaseFunc(const int, const int );
+    void releaseFunc(const int, const int);
     CommandLineType getType() const { return mType; }
 
     int mActionFunction = 0;

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -57,8 +57,12 @@ public:
     void focusOutEvent(QFocusEvent*) override;
     void recheckWholeLine();
     void clearMarksOnWholeLine();
+    void setAction(const int);
+    void resetAction();
+    void releaseFunc(const int, const int );
     CommandLineType getType() const { return mType; }
 
+    int mActionFunction = 0;
     QPalette mRegularPalette;
     QString mCommandLineName;
 

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -42,13 +42,21 @@ class TCommandLine : public QPlainTextEdit //QLineEdit
     Q_OBJECT
 
 public:
+    enum CommandLineTypeFlag {
+        UnknownType = 0x0,     // Should not be encountered but left as a trap value
+        MainCommandLine = 0x1, // One per profile
+        SubCommandLine = 0x2,  // Overlaid on top of MainConsole instance, should be uniquely named in pool of SubCommandLine/SubConsole/UserWindow/Buffers AND Labels
+    };
+
+    Q_DECLARE_FLAGS(CommandLineType, CommandLineTypeFlag)
+
     Q_DISABLE_COPY(TCommandLine)
-    TCommandLine(Host*, TConsole*, QWidget*);
+    TCommandLine(Host*, CommandLineType type = UnknownType, TConsole* pConsole = nullptr, QWidget* parent = nullptr);
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
     void recheckWholeLine();
     void clearMarksOnWholeLine();
-
+    CommandLineType getType() const { return mType; }
 
     QPalette mRegularPalette;
 
@@ -65,7 +73,7 @@ private:
     void adjustHeight();
     void processNormalKey(QEvent*);
     bool keybindingMatched(QKeyEvent*);
-
+    CommandLineType mType;
 
     QPointer<Host> mpHost;
     KeyUnit* mpKeyUnit;
@@ -98,5 +106,7 @@ private:
     void spellCheckWord(QTextCursor& c);
     bool handleCtrlTabChange(QKeyEvent* key, int tabNumber);
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(TCommandLine::CommandLineType)
 
 #endif // MUDLET_TCOMMANDLINE_H

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -59,6 +59,7 @@ public:
     CommandLineType getType() const { return mType; }
 
     QPalette mRegularPalette;
+    QString mCommandLineName;
 
 
 private:

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2423,7 +2423,7 @@ std::pair<bool, QString> TConsole::createMapper(const QString& windowname, int x
     return {true, QString()};
 }
 
-std::pair<bool, QString> TConsole::createCommandLine(const QString& windowname, const QString& name,int x, int y, int width, int height)
+std::pair<bool, QString> TConsole::createCommandLine(const QString& windowname, const QString& name, int x, int y, int width, int height)
 {
     if (name.isEmpty()) {
         return {false, QLatin1String("a commandLine cannot have an empty string as its name")};

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -648,9 +648,10 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
     mpMainDisplay->move(mMainFrameLeftWidth, mMainFrameTopHeight);
 
-    if (mType & (CentralDebugConsole|ErrorConsole|SubConsole|UserWindow)) {
+    if (mType & (CentralDebugConsole|ErrorConsole)) {
         layerCommandLine->hide();
-    } else {
+     // do nothing for SubConsole or UserWindows
+    } else if (mType & (!SubConsole|!UserWindow)) {
         //layerCommandLine->move(0,mpMainFrame->height()-layerCommandLine->height());
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -330,7 +330,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layerCommandLine->setMaximumHeight(31);
     layerCommandLine->setMinimumHeight(31);
 
-    auto layoutLayer2 = new QHBoxLayout(layerCommandLine);
+    layoutLayer2 = new QHBoxLayout(layerCommandLine);
     layoutLayer2->setMargin(0);
     layoutLayer2->setSpacing(0);
 
@@ -1904,6 +1904,27 @@ bool TConsole::setMiniConsoleFontSize(int size)
 
     refreshMiniConsole();
     return true;
+}
+
+void TConsole::setMiniConsoleCmdVisible(bool isVisible)
+{
+    QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    // create MiniConsole commandline if it's not existing
+    if (!mpCommandLine) {
+        mpCommandLine = new TCommandLine(mpHost, mpCommandLine->ConsoleCommandLine, this, mpMainDisplay);
+        mpCommandLine->setContentsMargins(0, 0, 0, 0);
+        mpCommandLine->setSizePolicy(sizePolicy);
+        mpCommandLine->setFocusPolicy(Qt::StrongFocus);
+        // put this CommandLine in the mainConsoles SubCommandLineMap
+        // name is the console name
+        mpHost->mpConsole->mSubCommandLineMap[mConsoleName] = mpCommandLine;
+        mpCommandLine->mCommandLineName = mConsoleName;
+        mpCommandLine->setObjectName(mConsoleName);
+        layoutLayer2->addWidget(mpCommandLine);
+    }
+    mpButtonMainLayer->setVisible(false);
+    layerCommandLine->setVisible(isVisible);
+    mpCommandLine->setVisible(isVisible);
 }
 
 void TConsole::refreshMiniConsole() const

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2423,25 +2423,27 @@ std::pair<bool, QString> TConsole::createMapper(const QString& windowname, int x
     return {true, QString()};
 }
 
-std::pair<bool, QString> TConsole::createCommandLine(const QString& windowname, const QString& name, int x, int y, int width, int height)
+std::pair<bool, QString> TConsole::createCommandLine(const QString& windowname, const QString& name,int x, int y, int width, int height)
 {
     if (name.isEmpty()) {
         return {false, QLatin1String("a commandLine cannot have an empty string as its name")};
     }
 
-    auto pC = mSubCommandLineMap.value(name);
+    auto pN = mSubCommandLineMap.value(name);
     auto pW = mDockWidgetMap.value(windowname);
-    if (!pC) {
+
+    if (!pN) {
         if (!pW) {
-            pC = new TCommandLine(mpHost, mpCommandLine->SubCommandLine, this, mpMainFrame);
+            pN = new TCommandLine(mpHost, mpCommandLine->SubCommandLine, this, mpMainFrame);
         } else {
-            pC = new TCommandLine(mpHost, mpCommandLine->SubCommandLine, this, pW->widget());
+            pN = new TCommandLine(mpHost, mpCommandLine->SubCommandLine, this, pW->widget());
         }
-        mSubCommandLineMap[name] = pC;
-        pC->setObjectName(name);
-        pC->resize(width, height);
-        pC->move(x, y);
-        pC->show();
+        mSubCommandLineMap[name] = pN;
+        pN->mCommandLineName = name;
+        pN->setObjectName(name);
+        pN->resize(width, height);
+        pN->move(x, y);
+        pN->show();
         return {true, QString()};
     }
     return {false, QLatin1String("couldn't create commandLine")};

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -32,6 +32,7 @@
 
 #include "pre_guard.h"
 #include <QDataStream>
+#include <QHBoxLayout>
 #include <QFile>
 #include <QPointer>
 #include <QTextStream>
@@ -136,6 +137,7 @@ public:
     void setBgColor(int, int, int);
     void setBgColor(const QColor&);
     void setScrollBarVisible(bool);
+    void setMiniConsoleCmdVisible(bool);
     void changeColors();
     TConsole* createBuffer(const QString& name);
     void scrollDown(int lines);
@@ -237,6 +239,7 @@ public:
     QToolButton* emergencyStop;
     QWidget* layer;
     QWidget* layerCommandLine;
+    QHBoxLayout* layoutLayer2;
     QWidget* layerEdit;
     QColor mBgColor;
     int mButtonState;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -109,6 +109,7 @@ public:
 
     int getColumnNumber();
     std::pair<bool, QString> createMapper(const QString &windowname, int, int, int, int);
+    std::pair<bool, QString> createCommandLine(const QString &windowname, const QString &name, int, int, int, int);
 
     void setWrapAt(int pos)
     {
@@ -257,6 +258,7 @@ public:
     int mIndentCount;
     QMap<QString, TConsole*> mSubConsoleMap;
     QMap<QString, TDockWidget*> mDockWidgetMap;
+    QMap<QString, TCommandLine*> mSubCommandLineMap;
     QMap<QString, TLabel*> mLabelMap;
     QFile mLogFile;
     QString mLogFileName;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4138,6 +4138,76 @@ int TLuaInterpreter::createMapper(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createCommandLine
+int TLuaInterpreter::createCommandLine(lua_State* L)
+{
+    QString commandLineName;
+    QString windowName = QLatin1String("main");
+    int n = lua_gettop(L);
+    int x, y, width, height, counter;
+    counter = 1;
+
+    if (n > 5 && lua_type(L, 1) != LUA_TSTRING) {
+        lua_pushfstring(L, "createCommandLine: bad argument #1 type (parent window name as string expected, got %s!)", luaL_typename(L, 1));
+        return lua_error(L);
+    }
+    if (n > 5 && lua_type(L, 1) == LUA_TSTRING) {
+        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        counter++;
+        if (windowName == "main") {
+            // QString::compare is zero for a match on the "default"
+            // case so clear the variable - to flag this as the main
+            // window case - as is the case for an empty string
+            windowName.clear();
+        }
+    }
+
+    if (lua_type(L, counter) != LUA_TSTRING) {
+        lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandLine name as string expected, got %s!)", counter, luaL_typename(L, counter));
+        return lua_error(L);
+    } else {
+        commandLineName = QString::fromUtf8(lua_tostring(L, counter));
+        counter++;
+    }
+
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandline x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
+        return lua_error(L);
+    } else {
+        x = lua_tonumber(L, counter);
+        counter++;
+    }
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandline y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
+        return lua_error(L);
+    } else {
+        y = lua_tonumber(L, counter);
+        counter++;
+    }
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandline width as number expected, got %s!)", counter, luaL_typename(L, counter));
+        return lua_error(L);
+    } else {
+        width = lua_tonumber(L, counter);
+        counter++;
+    }
+    if (!lua_isnumber(L, counter)) {
+        lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandline height as number expected, got %s!)", counter, luaL_typename(L, counter));
+        return lua_error(L);
+    } else {
+        height = lua_tonumber(L, counter);
+    }
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = host.mpConsole->createCommandLine(windowName, commandLineName, x, y, width, height); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#createBuffer
 int TLuaInterpreter::createBuffer(lua_State* L)
 {
@@ -16889,6 +16959,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getRoomExits", TLuaInterpreter::getRoomExits);
     lua_register(pGlobalLua, "lockRoom", TLuaInterpreter::lockRoom);
     lua_register(pGlobalLua, "createMapper", TLuaInterpreter::createMapper);
+    lua_register(pGlobalLua, "createCommandLine", TLuaInterpreter::createCommandLine);
     lua_register(pGlobalLua, "getMainConsoleWidth", TLuaInterpreter::getMainConsoleWidth);
     lua_register(pGlobalLua, "resetProfile", TLuaInterpreter::resetProfile);
     lua_register(pGlobalLua, "printCmdLine", TLuaInterpreter::printCmdLine);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2618,6 +2618,48 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrollBar
+int TLuaInterpreter::enableCommandLine(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString windowName;
+    if (n == 1) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "enableCommandLine: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            lua_error(L);
+            return 1;
+        } else {
+            windowName = lua_tostring(L, 1);
+        }
+    }
+
+    Host& host = getHostFromLua(L);
+
+    mudlet::self()->setMiniConsoleCmdVisible(&host, windowName, true);
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrollBar
+int TLuaInterpreter::disableCommandLine(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString windowName;
+    if (n == 1) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "disableCommandLine: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            lua_error(L);
+            return 1;
+        } else {
+            windowName = lua_tostring(L, 1);
+        }
+    }
+
+    Host& host = getHostFromLua(L);
+
+    mudlet::self()->setMiniConsoleCmdVisible(&host, windowName, false);
+    return 0;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#replace
 int TLuaInterpreter::replace(lua_State* L)
 {
@@ -16992,6 +17034,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setConsoleBufferSize", TLuaInterpreter::setConsoleBufferSize);
     lua_register(pGlobalLua, "enableScrollBar", TLuaInterpreter::enableScrollBar);
     lua_register(pGlobalLua, "disableScrollBar", TLuaInterpreter::disableScrollBar);
+    lua_register(pGlobalLua, "enableCommandLine", TLuaInterpreter::enableCommandLine);
+    lua_register(pGlobalLua, "disableCommandLine", TLuaInterpreter::disableCommandLine);
     lua_register(pGlobalLua, "startLogging", TLuaInterpreter::startLogging);
     lua_register(pGlobalLua, "calcFontSize", TLuaInterpreter::calcFontSize);
     lua_register(pGlobalLua, "permRegexTrigger", TLuaInterpreter::permRegexTrigger);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -415,6 +415,8 @@ public:
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);
     static int disableScrollBar(lua_State*);
+    static int enableCommandLine(lua_State*);
+    static int disableCommandLine(lua_State*);
     static int enableClickthrough(lua_State* L);
     static int disableClickthrough(lua_State* L);
     static int startLogging(lua_State* L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -113,6 +113,7 @@ public:
     void adjustCaptureGroups(int x, int a);
     void clearCaptureGroups();
     bool callEventHandler(const QString& function, const TEvent& pE);
+    bool callCmdLineAction(const int func, QString);
     bool callLabelCallbackEvent(const int func, const QEvent* qE = nullptr);
     static QString dirToString(lua_State*, int);
     static int dirToNumber(lua_State*, int);
@@ -362,6 +363,8 @@ public:
     static int setBackgroundImage(lua_State*);
     static int setBackgroundColor(lua_State*);
     static int setLabelClickCallback(lua_State*);
+    static int setCmdLineAction(lua_State*);
+    static int resetCmdLineAction(lua_State*);
     static int getImageSize(lua_State*);
     static int setLabelDoubleClickCallback(lua_State*);
     static int setLabelReleaseCallback(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -251,6 +251,7 @@ public:
     static int searchRoom(lua_State*);
     static int resetProfile(lua_State*);
     static int createMapper(lua_State*);
+    static int createCommandLine(lua_State*);
     static int sendTelnetChannel102(lua_State* L);
     static int isPrompt(lua_State* L);
     static int feedTriggers(lua_State*);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2146,7 +2146,7 @@ function setLabelCursor(labelname, cursorShape)
 end
 
 
---These functions ensure backward compatibility for the setLabelCallback functions
+--These functions ensure backward compatibility for the setActionCallback functions
 --unpack function which also returns the nil values
 -- the arg_table (arg) saves the number of arguments in n -> arg_table.n (arg.n)
 function unpack_w_nil (arg_table, counter)
@@ -2157,15 +2157,18 @@ function unpack_w_nil (arg_table, counter)
   return arg_table[counter], unpack_w_nil(arg_table, counter + 1)
 end
 
-local function setLabelCallback(callbackFunc, labelname, func, ...)
+-- This wrapper gives callback functions the possibility to be used like
+-- setCallBackFunction (name,function as string,args)
+-- it is used by setLabelCallBack functions and setCmdLineAction
+local function setActionCallback(callbackFunc, name, func, ...)
   local nr = arg.n + 1
   arg.n = arg.n + 1
   if type(func) == "string" then
     func = loadstring("return "..func.."(...)")
   end
-  assert(type(func) == 'function', '<setLabelCallback: bad argument #2 type (function expected, got '..type(func)..'!)>')
+  assert(type(func) == 'function', '<setActionCallback: bad argument #2 type (function expected, got '..type(func)..'!)>')
   if nr > 1 then
-    return callbackFunc(labelname, 
+    return callbackFunc(name, 
     function(event) 
       if not event then 
         arg.n = nr - 1 
@@ -2174,42 +2177,47 @@ local function setLabelCallback(callbackFunc, labelname, func, ...)
       func(unpack_w_nil(arg)) 
     end )
   end 
-  callbackFunc(labelname, func) 
+  callbackFunc(name, func) 
 end
 
 local setLC = setLC or setLabelClickCallback
 function setLabelClickCallback (...)
-  setLabelCallback(setLC, ...)
+  setActionCallback(setLC, ...)
 end
 
 local setLDC = setLDC or setLabelDoubleClickCallback
 function setLabelDoubleClickCallback (...)
-  setLabelCallback(setLDC, ...)
+  setActionCallback(setLDC, ...)
 end
 
 local setLRC = setLRC or setLabelReleaseCallback
 function setLabelReleaseCallback(...)
-  setLabelCallback(setLRC, ...)
+  setActionCallback(setLRC, ...)
 end
 
 local setLMC = setLMC or setLabelMoveCallback
 function setLabelMoveCallback(...)
-  setLabelCallback(setLMC, ...)
+  setActionCallback(setLMC, ...)
 end
 
 local setLWC = setLWC or setLabelWheelCallback
 function setLabelWheelCallback(...)
-  setLabelCallback(setLWC, ...)
+  setActionCallback(setLWC, ...)
 end
 
 local setOnE = setOnE or setLabelOnEnter
 function setLabelOnEnter(...)
-  setLabelCallback(setOnE, ...)
+  setActionCallback(setOnE, ...)
 end
 
 local setOnL = setOnL or setLabelOnLeave
 function setLabelOnLeave(...)
-  setLabelCallback(setOnL,...)
+  setActionCallback(setOnL,...)
+end
+
+local setCmdLA = setCmdLA or setCmdLineAction
+function setCmdLineAction(...)
+  setActionCallback(setCmdLA,...)
 end
 
 function resetUserWindowTitle(windowname)

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2149,7 +2149,7 @@ end
 --These functions ensure backward compatibility for the setLabelCallback functions
 --unpack function which also returns the nil values
 -- the arg_table (arg) saves the number of arguments in n -> arg_table.n (arg.n)
-local function unpack_w_nil (arg_table, counter)
+function unpack_w_nil (arg_table, counter)
   counter = counter or 1
   if counter >= arg_table.n then
     return arg_table[counter]

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -127,6 +127,7 @@ local packages = {
   "geyser/GeyserVBox.lua",
   "geyser/GeyserUserWindow.lua",
   "geyser/GeyserAdjustableContainer.lua",
+  "geyser/GeyserCommandLine.lua",
 
   -- TODO probably don't need to load this file
   "geyser/GeyserTests.lua",

--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -44,7 +44,7 @@ end
 -- appended as the final argument (see @{sysCmdLineEvent}) and also in Geyser.Label
 -- the setClickCallback events
 -- @param func The function to use.
--- @param ... Parameters to pass to the function. Must be strings or numbers.
+-- @param ... Parameters to pass to the function.
 function Geyser.CommandLine:setAction(func, ...)
   arg.n = arg.n + 1
   local oldarg = arg
@@ -59,12 +59,12 @@ function Geyser.CommandLine:setAction(func, ...)
     if self.name == name then 
       arg[arg.n] = text
       func(unpack_w_nil(arg))
-    end 
+    end
   end
   
   self.actionId = registerAnonymousEventHandler("sysCmdLineEvent", actionFunc)
   self.action = func
-  self.actionArgs = { oldarg }
+  self.actionArgs = {unpack_w_nil(oldarg)}
 end
 
 -- Overridden constructor

--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -46,25 +46,16 @@ end
 -- @param func The function to use.
 -- @param ... Parameters to pass to the function.
 function Geyser.CommandLine:setAction(func, ...)
-  arg.n = arg.n + 1
-  local oldarg = arg
-  if self.actionId then
-    killAnonymousEventHandler(self.actionId)
-  end
-  if type(func) == "string" then
-    func = loadstring("return "..func.."(...)")
-  end
-  
-  local actionFunc = function (event, name, text) 
-    if self.name == name then 
-      arg[arg.n] = text
-      func(unpack_w_nil(arg))
-    end
-  end
-  
-  self.actionId = registerAnonymousEventHandler("sysCmdLineEvent", actionFunc)
-  self.action = func
-  self.actionArgs = {unpack_w_nil(oldarg)}
+  setCmdLineAction(self.name, func, ...)
+  self.actionFunc = func
+  self.actionArgs = { ... }
+end
+
+--- Resets the action the command will be send to the game
+function Geyser.CommandLine:resetAction()
+  resetCmdLineAction(self.name)
+  self.actionFunc = nil
+  self.actionArgs = nil
 end
 
 -- Overridden constructor

--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -1,0 +1,43 @@
+--------------------------------------
+-- --
+-- The Geyser Layout Manager by guy --
+--  CommandLine support by Edru     --
+-- --
+--------------------------------------
+
+--- Represents a commandLine primitive
+-- @class table
+-- @name Geyser.CommandLine
+-- @field wrapAt Where line wrapping occurs. Default is 300 characters.
+Geyser.CommandLine = Geyser.Window:new({
+  name = "CommandLineClass"
+})
+
+
+-- Save a reference to our parent constructor
+Geyser.CommandLine.parent = Geyser.Window
+
+-- Overridden constructor
+function Geyser.CommandLine:new (cons, container)
+  cons = cons or {}
+  cons.type = cons.type or "commandLine"
+
+  -- Call parent's constructor
+  local me = self.parent:new(cons, container)
+  me.windowname = me.windowname or me.container.windowname or "main"
+
+  -- Set the metatable.
+  setmetatable(me, self)
+  self.__index = self
+
+  createCommandLine(me.windowname, me.name, me:get_x(), me:get_y(), me:get_width(), me:get_height())
+  return me
+end
+
+--- Overridden constructor to use add2
+function Geyser.CommandLine:new2 (cons, container)
+  cons = cons or {}
+  cons.useAdd2 = true
+  local me = self:new(cons, container)
+  return me
+end

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -96,6 +96,72 @@ function Geyser.MiniConsole:disableScrollBar()
   disableScrollBar(self.name)
 end
 
+-- Start commandLine functions
+--- Enables the scroll bar for this window
+-- @param isVisible boolean to set visibility.
+function Geyser.MiniConsole:enableCommandLine()
+  enableCommandLine(self.name)
+end
+
+--- Disables the scroll bar for this window
+-- @param isVisible boolean to set visibility.
+function Geyser.MiniConsole:disableCommandLine()
+  disableCommandLine(self.name)
+end
+
+--- Sets an action to be used when text is send in this commandline. When this
+-- function is called by the event system, text the commandline sends will be 
+-- appended as the final argument (see @{sysCmdLineEvent}) and also in Geyser.Label
+-- the setClickCallback events
+-- @param func The function to use.
+-- @param ... Parameters to pass to the function.
+function Geyser.MiniConsole:setCmdAction(func, ...)
+  arg.n = arg.n + 1
+  local oldarg = arg
+  if self.actionId then
+    killAnonymousEventHandler(self.actionId)
+  end
+  if type(func) == "string" then
+    func = loadstring("return "..func.."(...)")
+  end
+  
+  local actionFunc = function (event, name, text) 
+    if self.name == name then 
+      arg[arg.n] = text
+      func(unpack_w_nil(arg))
+    end
+  end
+  
+  self.actionId = registerAnonymousEventHandler("sysCmdLineEvent", actionFunc)
+  self.action = func
+  self.actionArgs = {unpack_w_nil(oldarg)}
+end
+
+
+--- Clears the cmdLine
+-- see: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearCmdLine
+function Geyser.MiniConsole:clearCmd()
+  clearCmdLine(self.name)
+end
+
+--- prints text to the commandline and clears text if there was one previously
+-- see: https://wiki.mudlet.org/w/Manual:Lua_Functions#printCmdLine(text)
+function Geyser.MiniConsole:printCmd(text)
+  printCmdLine(self.name, text)
+end
+
+--- appends text to the commandline
+-- see: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendCmdLine
+function Geyser.MiniConsole:appendCmd(text)
+  appendCmdLine(self.name, text)
+end
+
+--- returns the text in the commandline
+-- see: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCmdLine
+function Geyser.MiniConsole:getCmdLine()
+  return getCmdLine(self.name)
+end
+
 --- Sets bold status for this miniconsole
 -- @param bool True for bolded
 function Geyser.MiniConsole:setBold(bool)
@@ -324,7 +390,6 @@ function Geyser.MiniConsole:new (cons, container)
   -- Set the metatable.
   setmetatable(me, self)
   self.__index = self
-
   -----------------------------------------------------------
   -- Now create the MiniConsole using primitives
   if not string.find(me.name, ".*Class") then

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -116,27 +116,17 @@ end
 -- @param func The function to use.
 -- @param ... Parameters to pass to the function.
 function Geyser.MiniConsole:setCmdAction(func, ...)
-  arg.n = arg.n + 1
-  local oldarg = arg
-  if self.actionId then
-    killAnonymousEventHandler(self.actionId)
-  end
-  if type(func) == "string" then
-    func = loadstring("return "..func.."(...)")
-  end
-  
-  local actionFunc = function (event, name, text) 
-    if self.name == name then 
-      arg[arg.n] = text
-      func(unpack_w_nil(arg))
-    end
-  end
-  
-  self.actionId = registerAnonymousEventHandler("sysCmdLineEvent", actionFunc)
-  self.action = func
-  self.actionArgs = {unpack_w_nil(oldarg)}
+  setCmdLineAction(self.name, func, ...)
+  self.actionFunc = func
+  self.actionArgs = { ... }
 end
 
+--- Resets the action the command will be send to the game
+function Geyser.MiniConsole:resetCmdAction()
+  resetCmdLineAction(self.name)
+  self.actionFunc = nil
+  self.actionArgs = nil
+end
 
 --- Clears the cmdLine
 -- see: https://wiki.mudlet.org/w/Manual:Lua_Functions#clearCmdLine

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2592,7 +2592,7 @@ std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windownam
         }
         return {true, QString()};
     } else if (pN) {
-        pN->setParent(pN);
+        pN->setParent(pW);
         pN->move(x1, y1);
         if (show) {
             pN->show();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2305,7 +2305,7 @@ bool mudlet::setDisplayAttributes(Host* pHost, const QString& name, const TChar:
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     if (pC) {
         // Set or reset all the specified attributes (but leave others unchanged)
-        pC->mFormatCurrent.setAllDisplayAttributes((pC->mFormatCurrent.allDisplayAttributes() &~(attributes)) | (state ? attributes : TChar::None));
+        pC->mFormatCurrent.setAllDisplayAttributes((pC->mFormatCurrent.allDisplayAttributes() & ~(attributes)) | (state ? attributes : TChar::None));
         pC->buffer.applyAttribute(pC->P_begin, pC->P_end, attributes, state);
         pC->mUpperPane->forceUpdate();
         pC->mLowerPane->forceUpdate();
@@ -2351,6 +2351,7 @@ bool mudlet::showWindow(Host* pHost, const QString& name)
 
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     auto pL = pHost->mpConsole->mLabelMap.value(name);
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
     // check labels first as they are shown/hidden more often
     if (pL) {
         pL->show();
@@ -2365,6 +2366,11 @@ bool mudlet::showWindow(Host* pHost, const QString& name)
         } else {
             return pHost->mpConsole->showWindow(name);
         }
+    }
+
+    if (pN) {
+        pN->show();
+        return true;
     }
 
     return false;
@@ -2393,6 +2399,8 @@ bool mudlet::hideWindow(Host* pHost, const QString& name)
 
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     auto pL = pHost->mpConsole->mLabelMap.value(name);
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
+
     // check labels first as they are shown/hidden more often
     if (pL) {
         pL->hide();
@@ -2404,6 +2412,11 @@ bool mudlet::hideWindow(Host* pHost, const QString& name)
             pD->update();
         }
         return pHost->mpConsole->hideWindow(name);
+    }
+
+    if (pN) {
+        pN->hide();
+        return true;
     }
 
     return false;
@@ -2418,25 +2431,35 @@ bool mudlet::resizeWindow(Host* pHost, const QString& name, int x1, int y1)
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     auto pD = pHost->mpConsole->mDockWidgetMap.value(name);
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
+
     if (pL) {
         pL->resize(x1, y1);
         return true;
-    } else if (pC) {
-        if (pD) {
-            if (!pD->isFloating()) {
-                // Can't resize a docked window...?
-                return false;
-            } else {
-                pD->resize(x1, y1);
-                return true;
-            }
-        } else {
-            pC->resize(x1, y1);
-            return true;
-        }
-    } else {
-        return false;
     }
+
+    if (pC && !pD) {
+        // NOT a floatable/dockable "user window"
+        pC->resize(x1, y1);
+        return true;
+    }
+
+    if (pC && pD) {
+        if (!pD->isFloating()) {
+            // Undock a docked window
+            pD->setFloating(true);
+        }
+
+        pD->resize(x1, y1);
+        return true;
+    }
+
+    if (pN) {
+        pN->resize(x1, y1);
+        return true;
+    }
+
+    return false;
 }
 
 bool mudlet::setConsoleBufferSize(Host* pHost, const QString& name, int x1, int y1)
@@ -2498,6 +2521,8 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
     auto pD = pHost->mpConsole->mDockWidgetMap.value(name);
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
+
     if (pL) {
         pL->move(x1, y1);
         return true;
@@ -2521,6 +2546,11 @@ bool mudlet::moveWindow(Host* pHost, const QString& name, int x1, int y1)
         return true;
     }
 
+    if (pN) {
+        pN->move(x1, y1);
+        return true;
+    }
+
     return false;
 }
 
@@ -2535,6 +2565,7 @@ std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windownam
     auto pD = pHost->mpConsole->mDockWidgetMap.value(windowname);
     auto pW = pHost->mpConsole->mpMainFrame;
     auto pM = pHost->mpConsole->mpMapper;
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
 
     if (!pD && windowname.toLower() != QLatin1String("main")) {
         return {false, QStringLiteral("Window \"%1\" not found.").arg(windowname)};
@@ -2558,6 +2589,13 @@ std::pair<bool, QString> mudlet::setWindow(Host* pHost, const QString& windownam
         pC->mOldY = y1;
         if (show) {
             pC->show();
+        }
+        return {true, QString()};
+    } else if (pN) {
+        pN->setParent(pN);
+        pN->move(x1, y1);
+        if (show) {
+            pN->show();
         }
         return {true, QString()};
     } else if (pM && name.toLower() == QLatin1String("mapper")) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2497,6 +2497,21 @@ bool mudlet::setScrollBarVisible(Host* pHost, const QString& name, bool isVisibl
     }
 }
 
+bool mudlet::setMiniConsoleCmdVisible(Host* pHost, const QString& name, bool isVisible)
+{
+    if (!pHost || !pHost->mpConsole) {
+        return false;
+    }
+
+    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
+    if (pC) {
+        pC->setMiniConsoleCmdVisible(isVisible);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 bool mudlet::resetFormat(Host* pHost, QString& name)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2716,6 +2716,32 @@ bool mudlet::closeWindow(Host* pHost, const QString& name)
     return false;
 }
 
+bool mudlet::setCmdLineAction(Host* pHost, const QString& name, const int func)
+{
+    if (!pHost || !pHost->mpConsole) {
+        return false;
+    }
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
+    if (pN) {
+        pN->setAction(func);
+        return true;
+    }
+    return false;
+}
+
+bool mudlet::resetCmdLineAction(Host* pHost, const QString& name)
+{
+    if (!pHost || !pHost->mpConsole) {
+        return false;
+    }
+    auto pN = pHost->mpConsole->mSubCommandLineMap.value(name);
+    if (pN) {
+        pN->resetAction();
+        return true;
+    }
+    return false;
+}
+
 bool mudlet::setLabelClickCallback(Host* pHost, const QString& name, const int func)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -233,6 +233,7 @@ public:
     bool replayStart();
     bool setConsoleBufferSize(Host* pHost, const QString& name, int x1, int y1);
     bool setScrollBarVisible(Host* pHost, const QString& name, bool isVisible);
+    bool setMiniConsoleCmdVisible(Host* pHost, const QString& name, bool isVisible);
     bool setClickthrough(Host* pHost, const QString& name, bool clickthrough);
     void replayOver();
     void showEvent(QShowEvent* event) override;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -171,6 +171,8 @@ public:
     bool setBackgroundColor(Host*, const QString& name, int r, int g, int b, int alpha);
     bool setBackgroundImage(Host*, const QString& name, QString& path);
     bool setDisplayAttributes(Host* pHost, const QString& name, const TChar::AttributeFlags attributes, const bool state);
+    bool setCmdLineAction(Host*, const QString&, const int);
+    bool resetCmdLineAction(Host*, const QString&);
     bool setLabelClickCallback(Host*, const QString&, const int);
     bool setLabelDoubleClickCallback(Host*, const QString&, const int);
     bool setLabelReleaseCallback(Host*, const QString&, const int);

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -869,6 +869,7 @@ LUA_GEYSER.files = \
     $${PWD}/mudlet-lua/lua/geyser/Geyser.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserColor.lua \
+    $${PWD}/mudlet-lua/lua/geyser/GeyserCommandLine.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserContainer.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserGauge.lua \
     $${PWD}/mudlet-lua/lua/geyser/GeyserGeyser.lua \


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds the possibility for creating own custom commandlines and or activating commandlines which are integrated in miniconsoles by using:
```createCommandLine([windowname], name, x, y, width, height)```

or for the integrated ones miniconsole
```enableCommandLine(miniconsole_name)```

By this also different commandline functions and resetProfile() needed adjusting to accommodate this.

(adding optional commandlineName parameter)
```clearCmdLine([commandlineName])```
```printCmdLine([commandlineName], text)```
```appendCmdLine([commandlineName], text)```
```getCmdLine([commandlineName])```

```moveWindow, resizeWindow, raiseWindow, lowerWindow, setWindow``` also works for the not integrated commandLines

**For the integrated commandlines the name is just the same as their miniconsole name.**

Unaltered this commandlines just work as the main commandline and send the command directly to the game.
It is possible to attach an action to the command similar to the setLabelCallback events by using:
```setCmdLineAction(commandLineName, function, args```
to reset to the previous state:
```resetCmdLineAction(commandLineName)```

Geyser wrapper is:
```Geyser.CommandLine```
with the standard Geyser.Window function and wrapper for:
```mycommandline:clear() ---clearCmdLine wrapper```
```mycommandline:print()```
```mycommandline:append()```
```mycommandline:getText()```

A Geyser wrapper for setCmdLineAction ```mycommandline:setAction(func, args)``` was also added usage is the same as for clickcallbackevents
```lua
mycommandline:setAction(function(text) echo("My CommandLine Text:  "..text.."\n") end)
```
or 
```lua
function testfunction(myarg, text)
  echo(myarg..text.."\n")
end
mycommandline:setAction("testfunction","My CommandLine Text:")
```
For direct example usage see below.

Geyser wrapper for MiniConsole is:
```myminiconsole:enableCommandLine()```
```myminiconsole:disableCommandLine()```
```myminiconsole:setCmdAction()```
...


#### Motivation for adding to Mudlet
fix #1897

#### Other info (issues closed, discussion etc)
I used the same method what was used for consoles (with different mTypes as SubConsoles) by dividing command line in main command line and sub command lines.



Example code 2 Geyser.MiniConsoles with enabled commandline

```lua
testadjustablecontainer = testadjustablecontainer or Adjustable.Container:new({name = "TestContainer"})
testminiconsole = testminiconsole or Geyser.MiniConsole:new({name = "TestMiniconsole", x = 0, y = 0, width = "100%", height = "100%"}, testadjustablecontainer)
testminiconsole:enableCommandLine()
testminiconsole:setCmdAction(function(text) testminiconsole:echo("First CommandLine: "..text.."\n") end)


testadjustablecontainer2 = testadjustablecontainer2 or Adjustable.Container:new({name = "TestContainer2"})
testminiconsole2 = testminiconsole2 or Geyser.MiniConsole:new({name = "TestMiniconsole2", x = 0, y = 0, width = "100%", height = "100%"}, testadjustablecontainer2)
testminiconsole2:enableCommandLine()
testminiconsole2:setCmdAction(function(text) testminiconsole2:echo("Second CommandLine: "..text.."\n") end)
```

The example above:
![commandLine](https://user-images.githubusercontent.com/60551052/91665238-52c84d80-eaf4-11ea-971e-114142cebb7d.gif)

Another example:
A Geyser.CommandLine in an Geyser.Label the input changes the color of the Label. For example use "red" as input or <100,100,100>
```lua
-- use double of calcFontSize height as commandline height
-- Geyser.CommandLines don't resize automatically
local w,h = calcFontSize()
testadjustablecontainer3 = testadjustablecontainer3 or Adjustable.Container:new({name = "TestContainer3"})
testLabel = testLabel or Geyser.Label:new({name = "testLabel", x = 0, y = 0, width = "100%", height = "-"..h*2}, testadjustablecontainer3)
testCommandLine = testCommandLine or Geyser.CommandLine:new({name ="testcommandline" ,x=0, y="-30", width="100%", height = h*2}, testadjustablecontainer3)
testCommandLine:setAction(
function(text)
  if Geyser.Color.parse(text) then 
    testLabel:setColor(text) 
  end
end)
```


