### PR TITLE
Math in Geyser constraints

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -75,7 +75,7 @@ function Geyser:base_add (window, cons)
   self.windowList[window.name] = window
 
   window.windowname = window.windowname or window.container.windowname or "main"
-  Geyser.set_constraints(window, cons, self)
+  Geyser.Container.set_constraints(window, cons)
   if not self.defer_updates then
     window:reposition()
   end

--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -75,7 +75,7 @@ function Geyser:base_add (window, cons)
   self.windowList[window.name] = window
 
   window.windowname = window.windowname or window.container.windowname or "main"
-  Geyser.Container.set_constraints(window, cons)
+  Geyser.set_constraints(window, cons, self)
   if not self.defer_updates then
     window:reposition()
   end

--- a/src/mudlet-lua/lua/geyser/GeyserSetConstraints.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserSetConstraints.lua
@@ -18,6 +18,10 @@ function Geyser.set_constraints (window, cons, container)
   os.setlocale("C", "numeric")
   -- If container is nil then by default it is the dimensions of the main window
   container = container or Geyser
+  local con_x = container.get_x()
+  local con_y = container.get_y()
+  local con_width = container.get_width()
+  local con_height = container.get_height()
 
   -- GENERATE CONSTRAINT AWARE POSITIONING FUNCTIONS
   -- Parse the position constraints to generate functions that will get
@@ -27,75 +31,82 @@ function Geyser.set_constraints (window, cons, container)
   -- needed by width and height.
   for _, v in ipairs { "x", "y", "width", "height" } do
     local getter = "get_" .. v -- name of the function to calculate the
-
+    local num
     -- if passed a number assume pixels are meant
     if type(cons[v]) == "number" then
       cons[v] = string.format("%dpx", cons[v])
     end
 
+    -- if passed as function which returns numbers assume pixels are meant
+    if type(cons[v]) == "function" then
+      num = string.format("%dpx", cons[v]())
+    end    
+    num = num or cons[v]
+
     -- Parse the constraint
-    if string.find(cons[v], "%%") then
+    if string.find(num, "%%") then
       -- This handles dimensions as a percentage of the container.
       -- Negative percentages are converted to the equivalent positive.
       --------------------------------------------------------------
 
       -- scale is a value between 0 and 1
-      local scale = tonumber((string.gsub(cons[v], "%%", ""))) / 100.0
-      if scale < 0 then
+      -- offset is always in pixel
+      local scale, offset = string.match(num,"([%+%-%d%p]+)%%%s*([%+%-%d%p]*)")
+      local negative = string.find(scale, "-") or false -- detect "negative" 0
+      scale = tonumber(scale) / 100.0
+      offset = tonumber(offset) or 0
+      if negative then
         scale = 1 + scale
       end
       local dim = ""
       local min, max = 0, 0
 
       if v == "x" then
-        min = "container.get_x()"
-        max = "container.get_width()"
+        min = con_x
+        max = con_width
       elseif v == "width" then
-        max = "container.get_width()"
+        max = con_width
       elseif v == "y" then
-        min = "container.get_y()"
-        max = "container.get_height()"
+        min = con_y
+        max = con_height
       else
-        max = "container.get_height()"
+        max = con_height
       end
 
       -- Define the getter function
       -- Heiko: on European locales this leads to compile errors because
       --        scale will be "0,5" instead of "0.5"-> syntax error
-      --        Need to find out if there's more such cases in Geyse
       --        Need to find out if there's more such cases in Geyser
-      h_scale = tostring(scale)
-      local src = "local self,container = ...  return function () return " .. min .. " + (" .. h_scale .. " * " .. max .. ") end"
 
       -- compile the getter
-      window[getter] = assert(loadstring(src, "getter for " .. v))(window, container)
+      window[getter] = function() return min + (scale * max) + offset end
 
     else
       -- This handles absolute positioning and character positioning
       -- Negative values indicated positioning from the anti-origin.
-      -- Pre: cons[v] must contain "px" or "c"
+      -- Pre: num must contain "px" or "c"
       --------------------------------------------------------------
 
       -- Create default values
       local x_mult, y_mult = 1, 1 -- by default assume not "c"
-      local negative = string.find(cons[v], "-") or false -- detect "negative" 0
+      local negative = string.find(num, "-") or false -- detect "negative" 0
 
       -- As is, font size is considered a constraint
-      if string.find(cons[v], "c") then
+      if string.find(num, "c") then
         x_mult, y_mult = calcFontSize(window.fontSize)
       end
 
-      local pos = tonumber((string.gsub(cons[v], "%a", "")))
+      local pos = tonumber((string.gsub(num, "%a", "")))
       local max = 0
       local min = 0
 
       if v == "x" then
-        min = "container.get_x()"
+        min = con_x
         pos = x_mult * pos
       elseif v == "width" then
         pos = x_mult * pos
       elseif v == "y" then
-        min = "container.get_y()"
+        min = con_y
         pos = y_mult * pos
       else
         pos = y_mult * pos
@@ -104,27 +115,24 @@ function Geyser.set_constraints (window, cons, container)
       -- Treat negative values differently
       if negative then
         if v == "x" then
-          min = "container.get_x()"
-          max = "container.get_width()"
+          min = con_x
+          max = con_width
         elseif v == "width" then
-          min = "container.get_x()"
-          max = "container.get_width()"
-          pos = string.format("(%d - self:get_x())", pos)
+          min = con_x
+          max = con_width
+          pos = pos - window:get_x()
         elseif v == "y" then
-          min = "container.get_y()"
-          max = "container.get_height()"
+          min = con_y
+          max = con_height
         else -- v == "height"
-          min = "container.get_y()"
-          max = "container.get_height()"
-          pos = string.format("(%d - self:get_y())", pos)
+          min = con_y
+          max = con_height
+          pos = pos - window:get_y()
         end
       end
 
-      -- Define the getter function
-      local src = "local self, container = ... return function () return " .. max .. " + " .. min .. " + " .. pos .. " end"
-
       -- compile the getter
-      window[getter] = assert(loadstring(src, "getter for " .. v))(window, container)
+      window[getter] = function() return max + min + pos end
     end
 
     -- Here the actual value of the dimension is set according to the

--- a/src/mudlet-lua/lua/geyser/GeyserSetConstraints.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserSetConstraints.lua
@@ -36,8 +36,9 @@ function Geyser.set_constraints (window, cons, container)
     end
     
     -- if passed as function which returns numbers assume pixels are meant
+    -- give num the value 0 and let the function define the value
     if type(cons[v]) == "function" then
-      num = string.format("%dpx", cons[v]())
+      num = 0
     end    
     num = num or cons[v]
     
@@ -56,7 +57,7 @@ function Geyser.set_constraints (window, cons, container)
       if negative then
         scale = 1 + scale
       end
-
+      
       local min, max = "return_zero", "return_zero"
       
       if v == "x" then
@@ -98,10 +99,16 @@ function Geyser.set_constraints (window, cons, container)
         x_mult, y_mult = calcFontSize(window.fontSize)
       end
       
-      local pos = tonumber((string.gsub(num, "%a", "")))
       local pos_func = "return_zero"
       local max = "return_zero"
       local min = "return_zero"
+      local func = function() return 0 end
+      local pos = tonumber((string.gsub(num, "%a", "")))
+      
+      -- give func the function value if a function is given
+      if type(cons[v]) == "function" then
+        func = cons[v]
+      end
       
       if v == "x" then
         min = "get_x"
@@ -138,7 +145,7 @@ function Geyser.set_constraints (window, cons, container)
       window[getter] = function(self, my_container)
         my_container = container
         self = window
-        return my_container[max]() + my_container[min]() + pos - self[pos_func]()
+        return my_container[max]() + my_container[min]() + pos + func() - self[pos_func]()
       end
     end
     


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR adds function to Geyser.set_constraints which allow additional option for resizing/moving.
Percentage values are allowed to have an offset.
For example:
```lua
Label1:move("50%-16px","50%+10px")
```
Also functions which return a number are allowed. for example:
```lua
-- center Label2 on Label1 (Label1 is Label2s container)
local center_x = function() return Label1.get_width()/2-Label2.get_width()/2 end
local center_y = function() return Label1.get_height()/2-Label2.get_height()/2 end
Label2:move(center_x, center_y) -- moves Label2 to the center of Label1 and even if Label1
-- changes size Label2 stays in the center
```
#### Motivation for adding to Mudlet
Some special situation where this is needed, 
and a discussion about centering a Label on a Label on Discord.

#### Other info (issues closed, discussion etc)
By removing the **loadstring** functions this PR also increases Geysers performance.

