### PR TITLE
fix HBox/VBox dissapearing if in a container with size 0

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserHBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserHBox.lua
@@ -25,20 +25,19 @@ end
 --- Responsible for organizing the elements inside the HBox
 -- Called when a new element is added
 function Geyser.HBox:organize()
+  local self_height = self:get_height()
+  local self_width = self:get_width()
   -- Workaround for issue with width/height being 0 at creation
-  if self:get_width() == 0 then
-    self:resize("0.9px", nil)
-  end
-  if self:get_height() == 0 then
-    self:resize(nil, "0.9px")
-  end
-  local window_width = (self:calculate_dynamic_window_size().width / self:get_width()) * 100
+  self_height = self_height <= 0 and 0.9 or self_height
+  self_width = self_width <= 0 and 0.9 or self_width
+
+  local window_width = (self:calculate_dynamic_window_size().width / self_width) * 100
   local start_x = 0
   self.contains_fixed = false
   for _, window_name in ipairs(self.windows) do
     local window = self.windowList[window_name]
-    local width = (window:get_width() / self:get_width()) * 100
-    local height = (window:get_height() / self:get_height()) * 100
+    local width = (window:get_width() / self_width) * 100
+    local height = (window:get_height() / self_height) * 100
     if window.h_policy == Geyser.Fixed or window.v_policy == Geyser.Fixed then
       self.contains_fixed = true
     end

--- a/src/mudlet-lua/lua/geyser/GeyserVBox.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserVBox.lua
@@ -26,21 +26,20 @@ end
 --- Responsible for organizing the elements inside the VBox
 -- Called when a new element is added
 function Geyser.VBox:organize()
+  local self_height = self:get_height()
+  local self_width = self:get_width()
   -- Workaround for issue with width/height being 0 at creation
-  if self:get_width() == 0 then
-    self:resize("0.9px", nil)
-  end
-  if self:get_height() == 0 then
-    self:resize(nil, "0.9px")
-  end
-  local window_height = (self:calculate_dynamic_window_size().height / self:get_height()) * 100
+  self_height = self_height <= 0 and 0.9 or self_height
+  self_width = self_width <= 0 and 0.9 or self_width
+  
+  local window_height = (self:calculate_dynamic_window_size().height / self_height) * 100
   local start_y = 0
   self.contains_fixed = false
   for _, window_name in ipairs(self.windows) do
     local window = self.windowList[window_name]
     window:move("0%", start_y.."%")
-    local width = (window:get_width() / self:get_width()) * 100
-    local height = (window:get_height() / self:get_height()) * 100
+    local width = (window:get_width() / self_width) * 100
+    local height = (window:get_height() / self_height) * 100
     if window.h_policy == Geyser.Fixed or window.v_policy == Geyser.Fixed then
       self.contains_fixed = true
     end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
HBox/VBox with one or more fixed elements where disappearing (without any error-message) if container was set to 0. 
Resize the container didn't let them reappear.

This Pr fixes that
#### Motivation for adding to Mudlet
Fix this issue.

#### Other info (issues closed, discussion etc)
This code created the issue which is fixed with this PR.

```lua
testcontainer = Geyser.Container:new({name = "testcontainer"})
testVBox = Geyser.VBox:new({name = "testVBox", x=0, y=0, width="100%", height="100%"},testcontainer)
label1 = Geyser.Label:new({name = "label1", color ="green"},testVBox)
label2 = Geyser.Label:new({name = "label2", color ="red"},testVBox)
label3 = Geyser.Label:new({name = "label3", color ="yellow", height=150, h_policy=Geyser.Fixed,},testVBox)
testcontainer:resize(0,0) -- Elements dissapear
testcontainer:resize(300,300) -- Elements don't reappear (no error message)
```  