### PR TITLE
BugFix: allow color changes mid-MBCS

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2100,12 +2100,84 @@ void TConsole::setBgColor(const QColor& newColor)
     mLowerPane->forceUpdate();
 }
 
+std::pair<bool, QString> TConsole::setSplitBgColor(const QString& name, const QColor& newColor)
+{
+    if (name.isEmpty() || !name.compare(QLatin1String("main"))) {
+        return setSplitBgColor(newColor);
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (pC) {
+        return pC->setSplitBgColor(newColor);
+    }
+
+    return {false, QStringLiteral("mini-console, user window or buffer \"%1\" not found").arg(name)};
+}
+
+std::pair<bool, QString> TConsole::setSplitBgColor(const QColor& newColor)
+{
+    if (buffer.applySplitBgColor(P_begin, newColor)) {
+        mUpperPane->forceUpdate();
+        mLowerPane->forceUpdate();
+        return {true, QString()};
+    }
+    return {false, QLatin1String("invalid character position")};
+}
+
 void TConsole::setFgColor(const QColor& newColor)
 {
     mFormatCurrent.setForeground(newColor);
     buffer.applyFgColor(P_begin, P_end, newColor);
     mUpperPane->forceUpdate();
     mLowerPane->forceUpdate();
+}
+
+std::pair<bool, QString> TConsole::setSplitFgColor(const QString& name, const QColor& newColor)
+{
+    if (name.isEmpty() || !name.compare(QLatin1String("main"))) {
+        return setSplitFgColor(newColor);
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (pC) {
+        return pC->setSplitFgColor(newColor);
+    }
+
+    return {false, QStringLiteral("mini-console, user window or buffer \"%1\" not found").arg(name)};
+}
+
+std::pair<bool, QString> TConsole::setSplitFgColor(const QColor& newColor)
+{
+    if (buffer.applySplitFgColor(P_begin, newColor)) {
+        mUpperPane->forceUpdate();
+        mLowerPane->forceUpdate();
+        return {true, QString()};
+    }
+    return {false, QLatin1String("invalid character position")};
+}
+
+std::pair<bool, QString> TConsole::resetSplitFormat(const QString& name)
+{
+    if (name.isEmpty() || !name.compare(QLatin1String("main"))) {
+        return resetSplitFormat();
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (pC) {
+        return pC->resetSplitFormat();
+    }
+
+    return {false, QStringLiteral("mini-console, user window or buffer \"%1\" not found").arg(name)};
+}
+
+std::pair<bool, QString> TConsole::resetSplitFormat()
+{
+    auto result = buffer.resetSplitFormat(P_begin);
+    if (result.first) {
+        mUpperPane->forceUpdate();
+        mLowerPane->forceUpdate();
+    }
+    return result;
 }
 
 void TConsole::setScrollBarVisible(bool isVisible)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -132,8 +132,14 @@ public:
     void skipLine();
     void setFgColor(int, int, int);
     void setFgColor(const QColor&);
+    std::pair<bool, QString> setSplitFgColor(const QString&, const QColor&);
+    std::pair<bool, QString> setSplitFgColor(const QColor&);
     void setBgColor(int, int, int);
     void setBgColor(const QColor&);
+    std::pair<bool, QString> setSplitBgColor(const QString&, const QColor&);
+    std::pair<bool, QString> setSplitBgColor(const QColor&);
+    std::pair<bool, QString> resetSplitFormat(const QString&);
+    std::pair<bool, QString> resetSplitFormat();
     void setScrollBarVisible(bool);
     void changeColors();
     TConsole* createBuffer(const QString& name);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1049,6 +1049,50 @@ int TLuaInterpreter::getTextFormat(lua_State* L)
     lua_settable(L, -3);
     lua_settable(L, -3);
 
+    if (result.second.splitFormatted()) {
+        lua_pushstring(L, "splitFormat");
+        lua_newtable(L);
+        // Not sure if this is needed or not:
+//        const TChar additionalAttributes{result.second.secondary()};
+//        const TChar::AttributeFlags additionalFormat{additionalAttributes.allDisplayAttributes()};
+//        lua_pushstring(L, "bold");
+//        lua_pushboolean(L, additionalFormat & TChar::Bold);
+//        lua_settable(L, -3);
+
+        QColor leftForeground(result.second.secondary().foreground());
+        lua_pushstring(L, "foreground");
+        lua_newtable(L);
+        lua_pushnumber(L, 1);
+        lua_pushnumber(L, leftForeground.red());
+        lua_settable(L, -3);
+
+        lua_pushnumber(L, 2);
+        lua_pushnumber(L, leftForeground.green());
+        lua_settable(L, -3);
+
+        lua_pushnumber(L, 3);
+        lua_pushnumber(L, leftForeground.blue());
+        lua_settable(L, -3);
+        lua_settable(L, -3);
+
+        QColor leftBackground(result.second.secondary().background());
+        lua_pushstring(L, "background");
+        lua_newtable(L);
+        lua_pushnumber(L, 1);
+        lua_pushnumber(L, leftBackground.red());
+        lua_settable(L, -3);
+
+        lua_pushnumber(L, 2);
+        lua_pushnumber(L, leftBackground.green());
+        lua_settable(L, -3);
+
+        lua_pushnumber(L, 3);
+        lua_pushnumber(L, leftBackground.blue());
+        lua_settable(L, -3);
+        lua_settable(L, -3);
+        lua_settable(L, -3);
+    }
+
     return 1;
 }
 
@@ -11988,6 +12032,63 @@ int TLuaInterpreter::setFgColor(lua_State* L)
     return 0;
 }
 
+// Documentation (pending): https://wiki.mudlet.org/w/Manual:Lua_Functions#setSplitFgColor
+int TLuaInterpreter::setSplitFgColor(lua_State* L)
+{
+    int s = 0;
+    int n = lua_gettop(L);
+    QString windowName;
+    if (n > 3) {
+        if (!lua_isstring(L, ++s)) {
+            lua_pushfstring(L, "setSplitFgColor: bad argument #%d type (window name as string is optional, got %s!)", s, luaL_typename(L, s));
+            return lua_error(L);
+        }
+        windowName = QString::fromUtf8(lua_tostring(L, s));
+    }
+
+    if (!lua_isnumber(L, ++s)) {
+        lua_pushfstring(L, "setSplitFgColor: bad argument #%d type (red component value as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+    int red = lua_tointeger(L, s);
+    if (red < 0 || red >  255) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "the color's red component value %d is outside of the valid range (0 to 255)", red);
+        return 2;
+    }
+
+    if (!lua_isnumber(L, ++s)) {
+        lua_pushfstring(L, "setSplitFgColor: bad argument #%d type (green component value as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+    int green = lua_tointeger(L, s);
+    if (green < 0 || green >  255) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "the color's green component value %d is outside of the valid range (0 to 255)", green);
+        return 2;
+    }
+
+    if (!lua_isnumber(L, ++s)) {
+        lua_pushfstring(L, "setSplitFgColor: bad argument #%d type (blue component value as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+    int blue = lua_tointeger(L, s);
+    if (blue < 0 || blue >  255) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "the color's blue component value %d is outside of the valid range (0 to 255)", blue);
+        return 2;
+    }
+
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = host.mpConsole->setSplitFgColor(windowName, QColor(red, green, blue)); !success) {
+        lua_pushnil(L);
+        lua_pushstring(L, message.toUtf8().constData());
+        return 2;
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBgColor
 int TLuaInterpreter::setBgColor(lua_State* L)
 {
@@ -12049,6 +12150,85 @@ int TLuaInterpreter::setBgColor(lua_State* L)
         mudlet::self()->setBgColor(&host, windowName, luaRed, luaGreen, luaBlue);
     }
     return 0;
+}
+
+// Documentation (pending): https://wiki.mudlet.org/w/Manual:Lua_Functions#setSplitBgColor
+int TLuaInterpreter::setSplitBgColor(lua_State* L)
+{
+    int s = 0;
+    int n = lua_gettop(L);
+    QString windowName;
+    if (n > 3) {
+        if (!lua_isstring(L, ++s)) {
+            lua_pushfstring(L, "setSplitBgColor: bad argument #%d type (window name as string is optional, got %s!)", s, luaL_typename(L, s));
+            return lua_error(L);
+        }
+        windowName = QString::fromUtf8(lua_tostring(L, s));
+    }
+
+    if (!lua_isnumber(L, ++s)) {
+        lua_pushfstring(L, "setSplitBgColor: bad argument #%d type (red component value as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+    int red = lua_tointeger(L, s);
+    if (red < 0 || red >  255) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "the color's red component value %d is outside of the valid range (0 to 255)", red);
+        return 2;
+    }
+
+    if (!lua_isnumber(L, ++s)) {
+        lua_pushfstring(L, "setSplitBgColor: bad argument #%d type (green component value as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+    int green = lua_tointeger(L, s);
+    if (green < 0 || green >  255) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "the color's green component value %d is outside of the valid range (0 to 255)", green);
+        return 2;
+    }
+
+    if (!lua_isnumber(L, ++s)) {
+        lua_pushfstring(L, "setSplitBgColor: bad argument #%d type (blue component value as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+    int blue = lua_tointeger(L, s);
+    if (blue < 0 || blue >  255) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "the color's blue component value %d is outside of the valid range (0 to 255)", blue);
+        return 2;
+    }
+
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = host.mpConsole->setSplitBgColor(windowName, QColor(red, green, blue)); !success) {
+        lua_pushnil(L);
+        lua_pushstring(L, message.toUtf8().constData());
+        return 2;
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation (pending): https://wiki.mudlet.org/w/Manual:Lua_Functions#resetSplitFormat
+int TLuaInterpreter::resetSplitFormat(lua_State* L)
+{
+    QString windowName;
+    if (lua_gettop(L)) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "resetSplitFormat: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
+        windowName = QString::fromUtf8(lua_tostring(L, 1));
+    }
+
+    Host& host = getHostFromLua(L);
+    if (auto [success, message] = host.mpConsole->resetSplitFormat(windowName); !success) {
+        lua_pushnil(L);
+        lua_pushstring(L, message.toUtf8().constData());
+        return 2;
+    }
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#insertLink
@@ -16708,6 +16888,9 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "replace", TLuaInterpreter::replace);
     lua_register(pGlobalLua, "setBgColor", TLuaInterpreter::setBgColor);
     lua_register(pGlobalLua, "setFgColor", TLuaInterpreter::setFgColor);
+    lua_register(pGlobalLua, "setSplitBgColor", TLuaInterpreter::setSplitBgColor);
+    lua_register(pGlobalLua, "setSplitFgColor", TLuaInterpreter::setSplitFgColor);
+    lua_register(pGlobalLua, "resetSplitFormat", TLuaInterpreter::resetSplitFormat);
     lua_register(pGlobalLua, "tempTimer", TLuaInterpreter::tempTimer);
     lua_register(pGlobalLua, "tempTrigger", TLuaInterpreter::tempTrigger);
     lua_register(pGlobalLua, "tempRegexTrigger", TLuaInterpreter::tempRegexTrigger);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -269,6 +269,9 @@ public:
     static int hasFocus(lua_State* L);
     static int setFgColor(lua_State* L);
     static int setBgColor(lua_State* L);
+    static int setSplitFgColor(lua_State*);
+    static int setSplitBgColor(lua_State*);
+    static int resetSplitFormat(lua_State*);
     static int tempTimer(lua_State* L);
     static int closeMudlet(lua_State* L);
     static int loadWindowLayout(lua_State* L);

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2018 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2015, 2018, 2020 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
@@ -59,7 +60,7 @@ public:
     void drawBackground(QPainter&, const QRect&, const QColor&) const;
     uint getGraphemeBaseCharacter(const QString& str) const;
     void drawLine(QPainter& painter, int lineNumber, int rowOfScreen) const;
-    int drawGrapheme(QPainter &painter, const QPoint &cursor, const QString &c, int column, TChar &style) const;
+    int drawGrapheme(QPainter &painter, const QPoint &cursor, const QString &c, int column, const TChar &style) const;
     void showNewLines();
     void forceUpdate();
     void needUpdate(int, int);


### PR DESCRIPTION
This commit is about allowing the fore/back ground colors to be different in the left and right halves of a grapheme - by enabling a second format to be stored as part of a single `TChar` instance - and handling the additions needed to display this.

It adds new Lua API functions
* `setSplitFgColor([windowName ,] red, green, blue)`
* `setSplitBgColor([windowName ,] red, green, blue)`
* `resetSplitFormat([windowName])`
which act on the FIRST character in the current selection to change the colours used for the LEFT side of that grapheme. This is so that the majority of the existing codebase can be agnostic to the extra colours on such characters - only the `getTextFormat()` function will return extra data in a 'splitFormat' sub-table, namely extra `foreground` and `background` colour component tables.

Note: This is only half of the solution to #3939 the other half is to parse the colour codes from between the two bytes that make up a DBCS encoded grapheme in a (usually) Big5 encoded MUD/MOO server output data stream. It is my intention to append that to this PR when I have it done.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>