### PR TITLE
Ignore Qt Creator autosave files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ qrc_*.cpp
 *.dmg
 *.app
 *.qm
+*.autosave
 mudlet
 
 # ignore macOS apps in general, but keep the Autoupdater from Sparkle


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Ignore Qt Creator autosave files.
#### Motivation for adding to Mudlet
Just helps a bit against tripping up, and we don't need these files in Git anyhow.
#### Other info (issues closed, discussion etc)
https://github.com/Mudlet/Mudlet/pull/4063#issuecomment-690460971