### PR TITLE
fix issue with focus and resize of MiniConsoles when using custom command lines

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -571,6 +571,14 @@ void TCommandLine::focusOutEvent(QFocusEvent* event)
     QPlainTextEdit::focusOutEvent(event);
 }
 
+void TCommandLine::hideEvent(QHideEvent* event)
+{
+    if (hasFocus()) {
+        mudlet::self()->mpCurrentActiveHost->mpConsole->mpCommandLine->setFocus();
+    }
+    QPlainTextEdit::hideEvent(event);
+}
+
 void TCommandLine::adjustHeight()
 {
     int lines = document()->size().height();
@@ -598,13 +606,11 @@ void TCommandLine::adjustHeight()
     if (_height > height() || _height < height()) {
         mpConsole->layerCommandLine->setMinimumHeight(_height);
         mpConsole->layerCommandLine->setMaximumHeight(_height);
-        if (mType == MainCommandLine) {
-            int x = mpConsole->width();
-            int y = mpConsole->height();
-            QSize s = QSize(x, y);
-            QResizeEvent event(s, s);
-            QApplication::sendEvent(mpConsole, &event);
-        }
+        int x = mpConsole->width();
+        int y = mpConsole->height();
+        QSize s = QSize(x, y);
+        QResizeEvent event(s, s);
+        QApplication::sendEvent(mpConsole, &event);
     }
 }
 

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -55,6 +55,7 @@ public:
     explicit TCommandLine(Host*, CommandLineType type = UnknownType, TConsole* pConsole = nullptr, QWidget* parent = nullptr);
     void focusInEvent(QFocusEvent*) override;
     void focusOutEvent(QFocusEvent*) override;
+    void hideEvent(QHideEvent*) override;
     void recheckWholeLine();
     void clearMarksOnWholeLine();
     void setAction(const int);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -635,7 +635,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int y = event->size().height();
 
 
-    if (mType & (MainConsole|Buffer|SubConsole) && mpCommandLine && !mpCommandLine->isHidden()) {
+    if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -635,7 +635,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int y = event->size().height();
 
 
-    if (mType & (MainConsole|Buffer)) {
+    if (mType & (MainConsole|Buffer|SubConsole) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
         mpBaseHFrame->resize(x, y);
@@ -1926,6 +1926,10 @@ void TConsole::setMiniConsoleCmdVisible(bool isVisible)
     mpButtonMainLayer->setVisible(false);
     layerCommandLine->setVisible(isVisible);
     mpCommandLine->setVisible(isVisible);
+    //resizes miniconsole if command line gets enabled/disabled
+    QSize s = QSize(width(), height());
+    QResizeEvent event(s, s);
+    QApplication::sendEvent(this, &event);
 }
 
 void TConsole::refreshMiniConsole() const


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Command lines in MiniConsoles didn't resize the MiniConsole as expected which means that the last lines of text were always hidden under the command line.

+ if the command line was in focus while hidden there was strange behavior as the command line was still working even if not visible or the focus was jumping to the  Mudlet Connect button instead of as expected to the main command line.

This PR fixes this issues

#### Motivation for adding to Mudlet
fix issues before the release

#### Other info (issues closed, discussion etc)
