### PR TITLE
Fix multi-line trigger in generic mapper

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -192,7 +192,7 @@ end</script>
 				<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>Exit Line Trigger</name>
 					<script>map.prompt.exits = map.prompt.exits .. ", " .. string.trim(matches[2])
-setTriggerStayOpen("Multi-Line Exits Trigger",1)</script>
+setTriggerStayOpen("English Multi-Line Exits Trigger",1)</script>
 					<triggerType>0</triggerType>
 					<conditonLineDelta>0</conditonLineDelta>
 					<mStayOpen>0</mStayOpen>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix multi-line trigger in generic mapper to work as expected - the trigger was renamed, but the function calling it wasn't.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/4074.