### PR TITLE
fix mapper breaks dragging if mouse passes over it (in Adjustable.Container or GUIFrame)

### DIFF
--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -59,7 +59,6 @@ public:
     void enterEvent(QEvent*) override;
     void setClickThrough(bool clickthrough);
 
-    bool forwardEventToMapper(QEvent*);
 
     QPointer<Host> mpHost;
     int mClickFunction = 0;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adjustable.Container and GUIFrame had strange behaviour if mouse passed over mapper.
For example the release event never occurred.

#### Motivation for adding to Mudlet
fix #2499

#### Other info (issues closed, discussion etc)
I got rid of the workaround made in #1401 as it doesn't seem to be needed anymore.

Wasn't able to reproduce https://github.com/Mudlet/Mudlet/issues/764 even by testing the code provided in
https://github.com/Mudlet/Mudlet/issues/764#issuecomment-306572655

Behavior if mapper and label share space seems to be exactly as in Mudlet 4.9.1