### PR TITLE
Revise: add build details in development QApplication::ApplicationVersion

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,11 +154,30 @@ int main(int argc, char* argv[])
     app->setOrganizationName(QStringLiteral("Mudlet"));
 
     if (mudlet::scmIsPublicTestVersion) {
+#if defined(Q_OS_WIN64)
+        // Only defined on 64-bit windows
+        app->setApplicationName(QStringLiteral("Mudlet(x64) Public Test Build"));
+#elif defined(Q_OS_WIN32)
+        // Defined on both 32 and 64-bit windows
+        app->setApplicationName(QStringLiteral("Mudlet(x32) Public Test Build"));
+#else
         app->setApplicationName(QStringLiteral("Mudlet Public Test Build"));
-        app->setApplicationVersion(APP_VERSION APP_BUILD);
+#endif
     } else {
+#if defined(Q_OS_WIN64)
+        // Only defined on 64-bit windows
+        app->setApplicationName(QStringLiteral("Mudlet(x64)"));
+#elif defined(Q_OS_WIN32)
+        // Defined on both 32 and 64-bit windows
+        app->setApplicationName(QStringLiteral("Mudlet(x32)"));
+#else
         app->setApplicationName(QStringLiteral("Mudlet"));
+#endif
+    }
+    if (mudlet::scmIsReleaseVersion) {
         app->setApplicationVersion(APP_VERSION);
+    } else {
+        app->setApplicationVersion(APP_VERSION APP_BUILD);
     }
 
     QCommandLineParser parser;


### PR DESCRIPTION
Also add indication of bitness in `QApplication::ApplicationName` for Windows builds.

There is currently a small glitch in the code that sets the Qt `ApplicationName` and `ApplicationVersion` in that the *build* text is only inserted in PTB versions but not development ones. As well as fixing that this PR also adds a bitness to the ApplicationName for all Windows builds so that it should be easier to tell them apart once I get building 64-bit ones into the CI/Build process.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>