### PR TITLE
Fix PTB build generation

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -33,7 +33,7 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
 } else {
   if ($Script:PublicTestBuild) {
 
-    $commitDate = Get-Date -date $(git show -s --format=%as)
+    $commitDate = Get-Date -date $(git show -s --format=%cs)
     $yesterdaysDate = $(Get-Date).AddDays(-1).Date
     if ($commitDate -lt $yesterdaysDate) {
       Write-Output "=== No new commits, aborting public test build generation ==="

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -33,7 +33,7 @@ if { [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${DEPLOY}" = "deploy" ]; } ||
   fi
 
   # get commit date now before we check out an change into another git repository
-  commitDate=$(git show -s --format=%as | tr -d '-')
+  commitDate=$(git show -s --format=%cs | tr -d '-')
   yesterdaysDate=$(date -d "yesterday" '+%F' | tr -d '-')
 
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -32,6 +32,10 @@ if { [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${DEPLOY}" = "deploy" ]; } ||
     exit
   fi
 
+  # get commit date now before we check out an change into another git repository
+  commitDate=$(git show -s --format=%as | tr -d '-')
+  yesterdaysDate=$(date -d "yesterday" '+%F' | tr -d '-')
+
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
   cd "${TRAVIS_BUILD_DIR}/../installers/generic-linux"
@@ -53,9 +57,6 @@ if { [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${DEPLOY}" = "deploy" ]; } ||
                    "https://make.mudlet.org/snapshots/Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" -O - -q)
   else # ptb/release build
     if [ "${public_test_build}" == "true" ]; then
-
-      commitDate=$(git show -s --format=%as | tr -d '-')
-      yesterdaysDate=$(date -d "yesterday" '+%F' | tr -d '-')
 
       if [[ "$commitDate" -lt "$yesterdaysDate" ]]; then
         echo "== No new commits, aborting public test build generation =="

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -10,7 +10,7 @@ fi
 if [ "${DEPLOY}" = "deploy" ]; then
 
   # get commit date now before we check out an change into another git repository
-  commitDate=$(git show -s --format=%as | tr -d '-')
+  commitDate=$(git show -s --format=%cs | tr -d '-')
   yesterdaysDate=$(date -v-1d '+%F' | tr -d '-')
 
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -8,6 +8,11 @@ fi
 
 # we deploy only certain builds
 if [ "${DEPLOY}" = "deploy" ]; then
+
+  # get commit date now before we check out an change into another git repository
+  commitDate=$(git show -s --format=%as | tr -d '-')
+  yesterdaysDate=$(date -v-1d '+%F' | tr -d '-')
+
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
   cd "${TRAVIS_BUILD_DIR}/../installers/osx"
@@ -51,9 +56,6 @@ if [ "${DEPLOY}" = "deploy" ]; then
   else # ptb/release build
     app="${TRAVIS_BUILD_DIR}/build/Mudlet.app"
     if [ "${public_test_build}" == "true" ]; then
-
-      commitDate=$(git show -s --format=%as | tr -d '-')
-      yesterdaysDate=$(date -v-1d '+%F' | tr -d '-')
 
       if [[ "$commitDate" -lt "$yesterdaysDate" ]]; then
         echo "== No new commits, aborting public test build generation =="


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
This moves the calculation of the commit of the last commit a bit earlier to make sure, we are still in the main git repository. Before this change, the commit date of the installers repo was used.

#### Motivation for adding to Mudlet
So we have our public test builds again

#### Other info (issues closed, discussion etc)
fixes #4052 