### PR TITLE
fix links clickable on the whole console width

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -714,10 +714,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
         return;
     }
 
+    bool isOutOffBound = false;
     int lineIndex = std::max(0, (event->y() / mFontHeight) + imageTopLine());
-    int tCharIndex = convertMouseXToBufferX(event->x(), lineIndex);
+    int tCharIndex = convertMouseXToBufferX(event->x(), lineIndex, &isOutOffBound);
 
-    updateTextCursor(event, lineIndex, tCharIndex);
+    updateTextCursor(event, lineIndex, tCharIndex, isOutOffBound);
 
     if (!mMouseTracking) {
         return;
@@ -781,11 +782,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
     mDragSelectionEnd = cursorLocation;
 }
 
-void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex)
+void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffBound)
 {
     if (lineIndex < static_cast<int>(mpBuffer->buffer.size())) {
         if (tCharIndex < static_cast<int>(mpBuffer->buffer[lineIndex].size())) {
-            if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex()) {
+            if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex() && !isOutOffBound) {
                 setCursor(Qt::PointingHandCursor);
                 QStringList tooltip = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex());
                 QToolTip::showText(event->globalPos(), tooltip.join("\n"));
@@ -803,7 +804,7 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
 // If a pointer to a boolean is provided as a third argument then it will
 // be set to true if the mouse is positioned over a visible time stamp
 // and left unchanged otherwise.
-int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOverTimeStamp) const
+int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOutOffBound, bool* isOverTimeStamp) const
 {
     if (lineNumber >= 0 && lineNumber < mpBuffer->lineBuffer.size()) {
         // Line number is (should be) within range of lines in the
@@ -864,6 +865,7 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bo
         }
 
         //        qDebug().nospace().noquote() << "TTextEdit::convertMouseXToBufferX(" << mouseX << ", " << lineNumber << ") INFO - falling out of bottom of for loop and returning: " << indexOfLastChar << " !";
+        *isOutOffBound = true;
         return std::max(0, indexOfLastChar);
     }
 
@@ -909,16 +911,17 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             mCtrlSelecting = true;
         }
 
+        bool isOutOffBound = false;
         if (!mCtrlSelecting && mShowTimeStamps) {
             bool isOverTimeStamp = false;
-            x = convertMouseXToBufferX(event->x(), y, &isOverTimeStamp);
+            x = convertMouseXToBufferX(event->x(), y, &isOutOffBound, &isOverTimeStamp);
             if (isOverTimeStamp) {
                 // If we have clicked on the timestamp then emulate the effect
                 // of control clicking - i.e. select the WHOLE line:
                 mCtrlSelecting = true;
             }
         } else {
-            x = convertMouseXToBufferX(event->x(), y);
+            x = convertMouseXToBufferX(event->x(), y, &isOutOffBound);
         }
 
         if (mCtrlSelecting) {
@@ -935,7 +938,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         }
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
-            if (x < static_cast<int>(mpBuffer->buffer[y].size())) {
+            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffBound) {
                 if (mpBuffer->buffer.at(y).at(x).linkIndex()) {
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QString func;
@@ -1023,11 +1026,11 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
     if (event->button() == Qt::RightButton) {
         int y = (event->y() / mFontHeight) + imageTopLine();
         y = std::max(y, 0);
-
-        int x = convertMouseXToBufferX(event->x(), y);
+        bool isOutOffBound = false;
+        int x = convertMouseXToBufferX(event->x(), y, &isOutOffBound);
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
-            if (x < static_cast<int>(mpBuffer->buffer[y].size())) {
+            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffBound) {
                 if (mpBuffer->buffer.at(y).at(x).linkIndex()) {
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QStringList hint = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(y).at(x).linkIndex());

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -714,11 +714,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
         return;
     }
 
-    bool isOutOffbounds = false;
+    bool isOutOfbounds = false;
     int lineIndex = std::max(0, (event->y() / mFontHeight) + imageTopLine());
-    int tCharIndex = convertMouseXToBufferX(event->x(), lineIndex, &isOutOffbounds);
+    int tCharIndex = convertMouseXToBufferX(event->x(), lineIndex, &isOutOfbounds);
 
-    updateTextCursor(event, lineIndex, tCharIndex, isOutOffbounds);
+    updateTextCursor(event, lineIndex, tCharIndex, isOutOfbounds);
 
     if (!mMouseTracking) {
         return;
@@ -782,11 +782,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
     mDragSelectionEnd = cursorLocation;
 }
 
-void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffbounds)
+void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOfbounds)
 {
     if (lineIndex < static_cast<int>(mpBuffer->buffer.size())) {
         if (tCharIndex < static_cast<int>(mpBuffer->buffer[lineIndex].size())) {
-            if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex() && !isOutOffbounds) {
+            if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex() && !isOutOfbounds) {
                 setCursor(Qt::PointingHandCursor);
                 QStringList tooltip = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex());
                 QToolTip::showText(event->globalPos(), tooltip.join("\n"));
@@ -804,7 +804,7 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
 // If a pointer to a boolean is provided as a third argument then it will
 // be set to true if the mouse is positioned over a visible time stamp
 // and left unchanged otherwise.
-int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOutOffbounds, bool* isOverTimeStamp) const
+int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOutOfbounds, bool* isOverTimeStamp) const
 {
     if (lineNumber >= 0 && lineNumber < mpBuffer->lineBuffer.size()) {
         // Line number is (should be) within range of lines in the
@@ -865,7 +865,7 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bo
         }
 
         //        qDebug().nospace().noquote() << "TTextEdit::convertMouseXToBufferX(" << mouseX << ", " << lineNumber << ") INFO - falling out of bottom of for loop and returning: " << indexOfLastChar << " !";
-        *isOutOffbounds = true;
+        *isOutOfbounds = true;
         return std::max(0, indexOfLastChar);
     }
 
@@ -911,17 +911,17 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             mCtrlSelecting = true;
         }
 
-        bool isOutOffbounds = false;
+        bool isOutOfbounds = false;
         if (!mCtrlSelecting && mShowTimeStamps) {
             bool isOverTimeStamp = false;
-            x = convertMouseXToBufferX(event->x(), y, &isOutOffbounds, &isOverTimeStamp);
+            x = convertMouseXToBufferX(event->x(), y, &isOutOfbounds, &isOverTimeStamp);
             if (isOverTimeStamp) {
                 // If we have clicked on the timestamp then emulate the effect
                 // of control clicking - i.e. select the WHOLE line:
                 mCtrlSelecting = true;
             }
         } else {
-            x = convertMouseXToBufferX(event->x(), y, &isOutOffbounds);
+            x = convertMouseXToBufferX(event->x(), y, &isOutOfbounds);
         }
 
         if (mCtrlSelecting) {
@@ -938,7 +938,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         }
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
-            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffbounds) {
+            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOfbounds) {
                 if (mpBuffer->buffer.at(y).at(x).linkIndex()) {
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QString func;
@@ -1026,11 +1026,11 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
     if (event->button() == Qt::RightButton) {
         int y = (event->y() / mFontHeight) + imageTopLine();
         y = std::max(y, 0);
-        bool isOutOffbounds = false;
-        int x = convertMouseXToBufferX(event->x(), y, &isOutOffbounds);
+        bool isOutOfbounds = false;
+        int x = convertMouseXToBufferX(event->x(), y, &isOutOfbounds);
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
-            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffbounds) {
+            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOfbounds) {
                 if (mpBuffer->buffer.at(y).at(x).linkIndex()) {
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QStringList hint = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(y).at(x).linkIndex());

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -714,11 +714,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
         return;
     }
 
-    bool isOutOffBound = false;
+    bool isOutOffbounds = false;
     int lineIndex = std::max(0, (event->y() / mFontHeight) + imageTopLine());
-    int tCharIndex = convertMouseXToBufferX(event->x(), lineIndex, &isOutOffBound);
+    int tCharIndex = convertMouseXToBufferX(event->x(), lineIndex, &isOutOffbounds);
 
-    updateTextCursor(event, lineIndex, tCharIndex, isOutOffBound);
+    updateTextCursor(event, lineIndex, tCharIndex, isOutOffbounds);
 
     if (!mMouseTracking) {
         return;
@@ -782,11 +782,11 @@ void TTextEdit::mouseMoveEvent(QMouseEvent* event)
     mDragSelectionEnd = cursorLocation;
 }
 
-void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffBound)
+void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffbounds)
 {
     if (lineIndex < static_cast<int>(mpBuffer->buffer.size())) {
         if (tCharIndex < static_cast<int>(mpBuffer->buffer[lineIndex].size())) {
-            if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex() && !isOutOffBound) {
+            if (mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex() && !isOutOffbounds) {
                 setCursor(Qt::PointingHandCursor);
                 QStringList tooltip = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(lineIndex).at(tCharIndex).linkIndex());
                 QToolTip::showText(event->globalPos(), tooltip.join("\n"));
@@ -804,7 +804,7 @@ void TTextEdit::updateTextCursor(const QMouseEvent* event, int lineIndex, int tC
 // If a pointer to a boolean is provided as a third argument then it will
 // be set to true if the mouse is positioned over a visible time stamp
 // and left unchanged otherwise.
-int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOutOffBound, bool* isOverTimeStamp) const
+int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bool* isOutOffbounds, bool* isOverTimeStamp) const
 {
     if (lineNumber >= 0 && lineNumber < mpBuffer->lineBuffer.size()) {
         // Line number is (should be) within range of lines in the
@@ -865,7 +865,7 @@ int TTextEdit::convertMouseXToBufferX(const int mouseX, const int lineNumber, bo
         }
 
         //        qDebug().nospace().noquote() << "TTextEdit::convertMouseXToBufferX(" << mouseX << ", " << lineNumber << ") INFO - falling out of bottom of for loop and returning: " << indexOfLastChar << " !";
-        *isOutOffBound = true;
+        *isOutOffbounds = true;
         return std::max(0, indexOfLastChar);
     }
 
@@ -911,17 +911,17 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             mCtrlSelecting = true;
         }
 
-        bool isOutOffBound = false;
+        bool isOutOffbounds = false;
         if (!mCtrlSelecting && mShowTimeStamps) {
             bool isOverTimeStamp = false;
-            x = convertMouseXToBufferX(event->x(), y, &isOutOffBound, &isOverTimeStamp);
+            x = convertMouseXToBufferX(event->x(), y, &isOutOffbounds, &isOverTimeStamp);
             if (isOverTimeStamp) {
                 // If we have clicked on the timestamp then emulate the effect
                 // of control clicking - i.e. select the WHOLE line:
                 mCtrlSelecting = true;
             }
         } else {
-            x = convertMouseXToBufferX(event->x(), y, &isOutOffBound);
+            x = convertMouseXToBufferX(event->x(), y, &isOutOffbounds);
         }
 
         if (mCtrlSelecting) {
@@ -938,7 +938,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         }
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
-            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffBound) {
+            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffbounds) {
                 if (mpBuffer->buffer.at(y).at(x).linkIndex()) {
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QString func;
@@ -1026,11 +1026,11 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
     if (event->button() == Qt::RightButton) {
         int y = (event->y() / mFontHeight) + imageTopLine();
         y = std::max(y, 0);
-        bool isOutOffBound = false;
-        int x = convertMouseXToBufferX(event->x(), y, &isOutOffBound);
+        bool isOutOffbounds = false;
+        int x = convertMouseXToBufferX(event->x(), y, &isOutOffbounds);
 
         if (y < static_cast<int>(mpBuffer->buffer.size())) {
-            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffBound) {
+            if (x < static_cast<int>(mpBuffer->buffer[y].size()) && !isOutOffbounds) {
                 if (mpBuffer->buffer.at(y).at(x).linkIndex()) {
                     QStringList command = mpBuffer->mLinkStore.getLinks(mpBuffer->buffer.at(y).at(x).linkIndex());
                     QStringList hint = mpBuffer->mLinkStore.getHints(mpBuffer->buffer.at(y).at(x).linkIndex());

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -127,10 +127,10 @@ private:
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;
-    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOverTimeStamp = nullptr) const;
+    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOffBound = nullptr, bool *isOverTimeStamp = nullptr) const;
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
-    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex);
+    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffBound);
     bool establishSelectedText();
 
     int mFontHeight;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -127,10 +127,10 @@ private:
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;
-    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOffbounds, bool *isOverTimeStamp = nullptr) const;
+    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOfbounds, bool *isOverTimeStamp = nullptr) const;
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
-    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffbounds);
+    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOfbounds);
     bool establishSelectedText();
 
     int mFontHeight;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -127,7 +127,7 @@ private:
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;
-    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOffBound = nullptr, bool *isOverTimeStamp = nullptr) const;
+    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOffBound, bool *isOverTimeStamp = nullptr) const;
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
     void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffBound);

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -127,10 +127,10 @@ private:
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);
     std::pair<bool, int> drawTextForClipboard(QPainter& p, QRect r, int lineOffset) const;
-    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOffBound, bool *isOverTimeStamp = nullptr) const;
+    int convertMouseXToBufferX(const int mouseX, const int lineNumber, bool *isOutOffbounds, bool *isOverTimeStamp = nullptr) const;
     int getGraphemeWidth(uint unicode) const;
     void normaliseSelection();
-    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffBound);
+    void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOffbounds);
     bool establishSelectedText();
 
     int mFontHeight;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
If a link where at the edge it was clickable on the whole right console width.
See example in #3888 

This PR prevents that by checking if the mouse-position is out of the right bound of the buffer.

#### Motivation for adding to Mudlet
fix #3888 

