### PR TITLE
ansi2string to strip ansi colors from a string

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1739,6 +1739,14 @@ local grayscaleComponents = {
 }
 
 local ansiPattern = rex.new("\\e\\[([0-9;]+?)m")
+
+-- function for converting a raw ANSI string into plain strings
+function ansi2string(text)
+  assert(type(text) == 'string', 'ansi2string: bad argument #1 type (expected string, got '..type(text)..'!)')
+  local result = rex.gsub(text, ansiPattern, "")
+  return result
+end
+
 -- function for converting a raw ANSI string into something decho can process
 -- italics and underline not currently supported since decho doesn't support them
 -- bold is emulated so it is supported, up to an extent


### PR DESCRIPTION
#### Brief overview of PR changes/additions
does essentially what ansi2decho does but without adding the decho tags
example from wiki
```lua
local replaced = ansi2string('\27[0;1;36;40mYou say in a baritone voice, "Test."\27[0;37;40m')
-- 'replaced' should now contain You say in a baritone voice, "Test."
print(replaced)
```
 
#### Motivation for adding to Mudlet
fix #3195 

