### PR TITLE
Use upper pane height for page scroll

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -444,7 +444,7 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_PageUp:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
-                mpConsole->scrollUp(mpHost->mScreenHeight);
+                mpConsole->scrollUp(mpConsole->mUpperPane->mScreenHeight);
                 ke->accept();
                 return true;
 
@@ -457,7 +457,7 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_PageDown:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
-                mpConsole->scrollDown(mpHost->mScreenHeight);
+                mpConsole->scrollDown(mpConsole->mUpperPane->mScreenHeight);
                 ke->accept();
                 return true;
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -444,7 +444,7 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_PageUp:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
-                mpConsole->scrollUp(mpConsole->mUpperPane->mScreenHeight);
+                mpConsole->scrollUp(mpConsole->mUpperPane->getScreenHeight());
                 ke->accept();
                 return true;
 
@@ -457,7 +457,7 @@ bool TCommandLine::event(QEvent* event)
 
         case Qt::Key_PageDown:
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
-                mpConsole->scrollDown(mpConsole->mUpperPane->mScreenHeight);
+                mpConsole->scrollDown(mpConsole->mUpperPane->getScreenHeight());
                 ke->accept();
                 return true;
 

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -83,6 +83,7 @@ public:
     int bufferScrollDown(int lines);
 // Not used:    void setConsoleFgColor(int r, int g, int b) { mFgColor = QColor(r, g, b); }
     void setConsoleBgColor(int r, int g, int b, int a ) { mBgColor = QColor(r, g, b, a); }
+    int getScreenHeight() { return mScreenHeight; }
     void searchSelectionOnline();
     int getColumnCount();
     int getRowCount();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This PR uses the upper pane for the page scrolls

#### Motivation for adding to Mudlet
Discussion on Discord
and it probably really makes sense as the scrollbar also depends on the upper pane.
