### PR TITLE
Add test for ansi2string and correct regex for ansi

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1738,7 +1738,7 @@ local grayscaleComponents = {
   [23] = 255
 }
 
-local ansiPattern = rex.new("\\e\\[([0-9;]+?)m")
+local ansiPattern = rex.new("\\e\\[([0-9:;]+?)m")
 
 -- function for converting a raw ANSI string into plain strings
 function ansi2string(text)

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -117,6 +117,15 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
 
   end)
 
+  describe("Tests the functionality of ansi2string()", function()
+    it("should return the string fed into it with ansi codes removed", function()
+      local original = '\27[38;5;179;48;5;230mYou say in a baritone voice, "Test."\27[0;37;40m'
+      local expected = 'You say in a baritone voice, "Test."'
+      local actual = ansi2string(original)
+      assert.equals(expected, actual)
+    end)
+  end)
+
   describe("Tests the functionality of setHexFgColor()", function()
 
     it("Should convert hex string correctly", function()


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
* Adds test for ansi2string 
* Adjusts ansi regex to catch ansi which uses `;` and `:`, especially since someone insisted our `*2ansi` functions use : as the delimiter. =)

#### Motivation for adding to Mudlet
ansi2* should work on ansi produced by our *2ansi functions. And we should add a test for functions like ansi2string which are easily tested using busted.

#### Other info (issues closed, discussion etc)
