### PR TITLE
Fix right-click menu and image copy

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -296,7 +296,8 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     splitter->setSizePolicy(sizePolicy);
     splitter->setOrientation(Qt::Vertical);
     splitter->setHandleWidth(3);
-    auto styleSheet = QStringLiteral("background-color: rgba(0,0,0,0)");
+    //QSplitter covers the background if not set to transparent and a new AppStyleSheet is set for example by DarkTheme
+    auto styleSheet = QStringLiteral("QSplitter { background-color: rgba(0,0,0,0) }");
     splitter->setStyleSheet(styleSheet);
     splitter->setParent(layer);
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1448,7 +1448,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
 // (and thus doesn't mess up any of the caches)
 std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect rectangle, int lineOffset) const
 {
-    painter.setCompositionMode(QPainter::CompositionMode_Source);
+    painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
     if (mpConsole->getType() == TConsole::MainConsole) {
         painter.setFont(mpHost->getDisplayFont());
         painter.setRenderHint(QPainter::TextAntialiasing, !mpHost->mNoAntiAlias);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1419,7 +1419,7 @@ void TTextEdit::slot_copySelectionToClipboardImage()
     auto widthpx = std::min(65500, largestLine);
     auto rect = QRect(mPA.x(), mPA.y(), widthpx, heightpx);
     auto pixmap = QPixmap(widthpx, heightpx);
-    pixmap.fill(palette().base().color());
+    pixmap.fill(mBgColor);
 
     QPainter painter(&pixmap);
     if (!painter.isActive()) {


### PR DESCRIPTION
#### Motivation for adding to Mudlet
#4064 changed image copy to have a transparent background and the right click menu had 
black text on black or invisible background.

This PR should fix these issues.
