### PR TITLE
Fix typo in mapper's area box warning

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -355,7 +355,7 @@ void dlgMapper::resetAreaComboBoxToPlayerRoomArea()
                 qDebug() << "dlgResetAreaComboBoxTolayerRoomArea() warning: player room area name not valid.";
             }
         } else {
-            qDebug() << "dlgResetAreaComboBoxTolayerRoomArea() warning: player room area valid.";
+            qDebug() << "dlgResetAreaComboBoxTolayerRoomArea() warning: player room area not valid.";
         }
     } else {
         qDebug() << "dlgResetAreaComboBoxTolayerRoomArea() warning: player room not valid.";


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix typo in mapper's area box warning
#### Motivation for adding to Mudlet
An error that makes sense.
#### Other info (issues closed, discussion etc)
