### PR TITLE
Add option to stop highlighting History

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -191,6 +191,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mAlertOnNewData(true)
 , mAllowToSendCommand(true)
 , mAutoClearCommandLineAfterSend(false)
+, mUnHighlightHistory(false)
 , mBlockScriptCompile(true)
 , mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -191,7 +191,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mAlertOnNewData(true)
 , mAllowToSendCommand(true)
 , mAutoClearCommandLineAfterSend(false)
-, mUnHighlightHistory(false)
+, mHighlightHistory(true)
 , mBlockScriptCompile(true)
 , mBlockStopWatchCreation(true)
 , mEchoLuaErrors(false)

--- a/src/Host.h
+++ b/src/Host.h
@@ -337,6 +337,7 @@ public:
     bool mAlertOnNewData;
     bool mAllowToSendCommand;
     bool mAutoClearCommandLineAfterSend;
+    bool mUnHighlightHistory;
     // Set in constructor and used in (bool) TScript::setScript(const QString&)
     // to prevent compilation of the script that was being set therein, cleared
     // after the main TConsole for a new profile has been created during the

--- a/src/Host.h
+++ b/src/Host.h
@@ -337,7 +337,7 @@ public:
     bool mAlertOnNewData;
     bool mAllowToSendCommand;
     bool mAutoClearCommandLineAfterSend;
-    bool mUnHighlightHistory;
+    bool mHighlightHistory;
     // Set in constructor and used in (bool) TScript::setScript(const QString&)
     // to prevent compilation of the script that was being set therein, cleared
     // after the main TConsole for a new profile has been created during the

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -372,6 +372,9 @@ bool TCommandLine::event(QEvent* event)
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
                 historyDown(ke);
+                if (mpHost->mUnHighlightHistory){
+                    moveCursor(QTextCursor::End);
+                }
                 ke->accept();
                 return true;
 
@@ -406,6 +409,9 @@ bool TCommandLine::event(QEvent* event)
                 // If EXACTLY Up is pressed without modifiers (special case for
                 // macOs - also sets KeyPad modifier)
                 historyUp(ke);
+                if (mpHost->mUnHighlightHistory){
+                    moveCursor(QTextCursor::End);
+                }
                 ke->accept();
                 return true;
 
@@ -1017,7 +1023,7 @@ void TCommandLine::historyDown(QKeyEvent* event)
     if (mHistoryList.empty()) {
         return;
     }
-    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0)) {
+    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || mpHost->mUnHighlightHistory) {
         mHistoryBuffer--;
         if (mHistoryBuffer >= mHistoryList.size()) {
             mHistoryBuffer = mHistoryList.size() - 1;
@@ -1043,7 +1049,7 @@ void TCommandLine::historyUp(QKeyEvent* event)
     if (mHistoryList.empty()) {
         return;
     }
-    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0)) {
+    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || mpHost->mUnHighlightHistory) {
         if (toPlainText().size() != 0) {
             mHistoryBuffer++;
         }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -372,7 +372,7 @@ bool TCommandLine::event(QEvent* event)
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
                 historyDown(ke);
-                if (mpHost->mUnHighlightHistory){
+                if (!mpHost->mHighlightHistory){
                     moveCursor(QTextCursor::End);
                 }
                 ke->accept();
@@ -409,7 +409,7 @@ bool TCommandLine::event(QEvent* event)
                 // If EXACTLY Up is pressed without modifiers (special case for
                 // macOs - also sets KeyPad modifier)
                 historyUp(ke);
-                if (mpHost->mUnHighlightHistory){
+                if (!mpHost->mHighlightHistory){
                     moveCursor(QTextCursor::End);
                 }
                 ke->accept();
@@ -1023,7 +1023,7 @@ void TCommandLine::historyDown(QKeyEvent* event)
     if (mHistoryList.empty()) {
         return;
     }
-    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || mpHost->mUnHighlightHistory) {
+    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || !mpHost->mHighlightHistory) {
         mHistoryBuffer--;
         if (mHistoryBuffer >= mHistoryList.size()) {
             mHistoryBuffer = mHistoryList.size() - 1;
@@ -1049,7 +1049,7 @@ void TCommandLine::historyUp(QKeyEvent* event)
     if (mHistoryList.empty()) {
         return;
     }
-    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || mpHost->mUnHighlightHistory) {
+    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || !mpHost->mHighlightHistory) {
         if (toPlainText().size() != 0) {
             mHistoryBuffer++;
         }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -371,7 +371,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     // that can be expressed solely with the Latin1 character encoding so that
     // can be used compared to the more complex Utf8 one needed otherwise:
     host.append_attribute("autoClearCommandLineAfterSend") = pHost->mAutoClearCommandLineAfterSend ? "yes" : "no";
-    host.append_attribute("unHighlightHistory") = pHost->mUnHighlightHistory ? "yes" : "no";
+    host.append_attribute("HighlightHistory") = pHost->mHighlightHistory ? "yes" : "no";
     host.append_attribute("printCommand") = pHost->mPrintCommand ? "yes" : "no";
     host.append_attribute("USE_IRE_DRIVER_BUGFIX") = pHost->mUSE_IRE_DRIVER_BUGFIX ? "yes" : "no";
     host.append_attribute("mUSE_FORCE_LF_AFTER_PROMPT") = pHost->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no";

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -371,6 +371,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     // that can be expressed solely with the Latin1 character encoding so that
     // can be used compared to the more complex Utf8 one needed otherwise:
     host.append_attribute("autoClearCommandLineAfterSend") = pHost->mAutoClearCommandLineAfterSend ? "yes" : "no";
+    host.append_attribute("unHighlightHistory") = pHost->mUnHighlightHistory ? "yes" : "no";
     host.append_attribute("printCommand") = pHost->mPrintCommand ? "yes" : "no";
     host.append_attribute("USE_IRE_DRIVER_BUGFIX") = pHost->mUSE_IRE_DRIVER_BUGFIX ? "yes" : "no";
     host.append_attribute("mUSE_FORCE_LF_AFTER_PROMPT") = pHost->mUSE_FORCE_LF_AFTER_PROMPT ? "yes" : "no";

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -766,7 +766,6 @@ void XMLimport::readHostPackage()
 void XMLimport::readHostPackage(Host* pHost)
 {
     pHost->mAutoClearCommandLineAfterSend = (attributes().value("autoClearCommandLineAfterSend") == "yes");
-    pHost->mHighlightHistory = !(attributes().value("HighlightHistory") == "no");
     pHost->mPrintCommand = (attributes().value("printCommand") == "yes");
     pHost->set_USE_IRE_DRIVER_BUGFIX(attributes().value("USE_IRE_DRIVER_BUGFIX") == "yes");
     pHost->mUSE_FORCE_LF_AFTER_PROMPT = (attributes().value("mUSE_FORCE_LF_AFTER_PROMPT") == "yes");
@@ -774,6 +773,11 @@ void XMLimport::readHostPackage(Host* pHost)
     pHost->getKeyUnit()->mRunAllKeyMatches = (attributes().value("runAllKeyMatches") == "yes");
     pHost->mNoAntiAlias = (attributes().value("mNoAntiAlias") == "yes");
     pHost->mEchoLuaErrors = (attributes().value("mEchoLuaErrors") == "yes");
+    if (attributes().hasAttribute("HighlightHistory")) {
+        pHost->mHighlightHistory = attributes().value("HighlightHistory") == "yes";
+    } else {
+        pHost->mHighlightHistory = true;
+    }
     if (attributes().hasAttribute("AmbigousWidthGlyphsToBeWide")) {
         const QStringRef ambiguousWidthSetting(attributes().value("AmbigousWidthGlyphsToBeWide"));
         if (ambiguousWidthSetting == QStringLiteral("yes")) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -766,7 +766,7 @@ void XMLimport::readHostPackage()
 void XMLimport::readHostPackage(Host* pHost)
 {
     pHost->mAutoClearCommandLineAfterSend = (attributes().value("autoClearCommandLineAfterSend") == "yes");
-    pHost->mUnHighlightHistory = (attributes().value("unHighlightHistory") == "yes");
+    pHost->mHighlightHistory = !(attributes().value("HighlightHistory") == "no");
     pHost->mPrintCommand = (attributes().value("printCommand") == "yes");
     pHost->set_USE_IRE_DRIVER_BUGFIX(attributes().value("USE_IRE_DRIVER_BUGFIX") == "yes");
     pHost->mUSE_FORCE_LF_AFTER_PROMPT = (attributes().value("mUSE_FORCE_LF_AFTER_PROMPT") == "yes");

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -766,6 +766,7 @@ void XMLimport::readHostPackage()
 void XMLimport::readHostPackage(Host* pHost)
 {
     pHost->mAutoClearCommandLineAfterSend = (attributes().value("autoClearCommandLineAfterSend") == "yes");
+    pHost->mUnHighlightHistory = (attributes().value("unHighlightHistory") == "yes");
     pHost->mPrintCommand = (attributes().value("printCommand") == "yes");
     pHost->set_USE_IRE_DRIVER_BUGFIX(attributes().value("USE_IRE_DRIVER_BUGFIX") == "yes");
     pHost->mUSE_FORCE_LF_AFTER_PROMPT = (attributes().value("mUSE_FORCE_LF_AFTER_PROMPT") == "yes");

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -665,6 +665,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     show_sent_text_checkbox->setChecked(pHost->mPrintCommand);
     auto_clear_input_line_checkbox->setChecked(pHost->mAutoClearCommandLineAfterSend);
+    checkBox_highlightHistory->setChecked(pHost->mUnHighlightHistory);
     command_separator_lineedit->setText(pHost->mCommandSeparator);
 
     checkBox_USE_IRE_DRIVER_BUGFIX->setChecked(pHost->mUSE_IRE_DRIVER_BUGFIX);
@@ -2388,6 +2389,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mPrintCommand = show_sent_text_checkbox->isChecked();
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
+        pHost->mUnHighlightHistory = checkBox_highlightHistory->isChecked();
         pHost->mCommandSeparator = command_separator_lineedit->text();
         pHost->mAcceptServerGUI = acceptServerGUI->isChecked();
         pHost->mAcceptServerMedia = acceptServerMedia->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -665,7 +665,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     show_sent_text_checkbox->setChecked(pHost->mPrintCommand);
     auto_clear_input_line_checkbox->setChecked(pHost->mAutoClearCommandLineAfterSend);
-    checkBox_highlightHistory->setChecked(pHost->mUnHighlightHistory);
+    checkBox_unHighlightHistory->setChecked(pHost->mUnHighlightHistory);
     command_separator_lineedit->setText(pHost->mCommandSeparator);
 
     checkBox_USE_IRE_DRIVER_BUGFIX->setChecked(pHost->mUSE_IRE_DRIVER_BUGFIX);
@@ -2389,7 +2389,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mPrintCommand = show_sent_text_checkbox->isChecked();
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
-        pHost->mUnHighlightHistory = checkBox_highlightHistory->isChecked();
+        pHost->mUnHighlightHistory = checkBox_unHighlightHistory->isChecked();
         pHost->mCommandSeparator = command_separator_lineedit->text();
         pHost->mAcceptServerGUI = acceptServerGUI->isChecked();
         pHost->mAcceptServerMedia = acceptServerMedia->isChecked();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -665,7 +665,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     show_sent_text_checkbox->setChecked(pHost->mPrintCommand);
     auto_clear_input_line_checkbox->setChecked(pHost->mAutoClearCommandLineAfterSend);
-    checkBox_unHighlightHistory->setChecked(pHost->mUnHighlightHistory);
+    checkBox_highlightHistory->setChecked(pHost->mHighlightHistory);
     command_separator_lineedit->setText(pHost->mCommandSeparator);
 
     checkBox_USE_IRE_DRIVER_BUGFIX->setChecked(pHost->mUSE_IRE_DRIVER_BUGFIX);
@@ -2389,7 +2389,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();
         pHost->mPrintCommand = show_sent_text_checkbox->isChecked();
         pHost->mAutoClearCommandLineAfterSend = auto_clear_input_line_checkbox->isChecked();
-        pHost->mUnHighlightHistory = checkBox_unHighlightHistory->isChecked();
+        pHost->mHighlightHistory = checkBox_highlightHistory->isChecked();
         pHost->mCommandSeparator = command_separator_lineedit->text();
         pHost->mAcceptServerGUI = acceptServerGUI->isChecked();
         pHost->mAcceptServerMedia = acceptServerMedia->isChecked();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -496,6 +496,16 @@
            </widget>
           </item>
           <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBox_highlightHistory">
+            <property name="toolTip">
+             <string>&lt;p&gt;Don't highlight history&lt;/p&gt;&lt;p&gt;&lt;i&gt;This disables the automatic highlighting of the history&lt;/i&gt;&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Stop highlighting history</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
            <widget class="QCheckBox" name="checkBox_runAllKeyBindings">
             <property name="toolTip">
              <string>&lt;p&gt;Check all Key-bindings against key-presses.&lt;/p&gt;&lt;p&gt;&lt;i&gt;Versions of Mudlet prior to &lt;b&gt;3.9.0&lt;/b&gt; would stop checking after the first matching combination of&lt;/i&gt; KeyCode &lt;i&gt;and&lt;/i&gt; KeyModifier &lt;i&gt;was found and then send the command and/or run the script of that Key-binding only.  This&lt;/i&gt; per-profile &lt;i&gt;option tells Mudlet to check and run the remaining matches; but, to retain compatibility with previous versions, defaults to the &lt;b&gt;un&lt;/b&gt;-checked state.&lt;/i&gt;&lt;/p&gt;</string>
@@ -505,7 +515,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" alignment="Qt::AlignRight">
+          <item row="3" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_commandSeparator">
             <property name="toolTip">
              <string/>
@@ -518,14 +528,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QLineEdit" name="command_separator_lineedit">
             <property name="placeholderText">
              <string>Enter text to separate commands with or leave blank to disable</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" alignment="Qt::AlignRight">
+          <item row="4" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_commandLineMinimumHeight">
             <property name="text">
              <string>Command line minimum height in pixels:</string>
@@ -535,7 +545,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1" alignment="Qt::AlignLeft">
+          <item row="4" column="1" alignment="Qt::AlignLeft">
            <widget class="QSpinBox" name="commandLineMinimumHeight">
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -496,12 +496,12 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBox_unHighlightHistory">
+           <widget class="QCheckBox" name="checkBox_highlightHistory">
             <property name="toolTip">
-             <string>&lt;p&gt;Stop automatic history highlighting&lt;/p&gt;&lt;p&gt;&lt;i&gt;This disables the automatic highlighting of the history&lt;/i&gt;&lt;/p&gt;</string>
+             <string>&lt;p&gt;Hightlight History&lt;/p&gt;&lt;p&gt;&lt;i&gt;highlights your input line text if scrolling through your history&lt;/i&gt;&lt;/p&gt;</string>
             </property>
             <property name="text">
-             <string>Stop highlighting history</string>
+             <string>Highlight History</string>
             </property>
            </widget>
           </item>
@@ -5270,7 +5270,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>USE_UNIX_EOL</tabstop>
   <tabstop>auto_clear_input_line_checkbox</tabstop>
   <tabstop>show_sent_text_checkbox</tabstop>
-  <tabstop>checkBox_unHighlightHistory</tabstop>
+  <tabstop>checkBox_highlightHistory</tabstop>
   <tabstop>checkBox_runAllKeyBindings</tabstop>
   <tabstop>command_separator_lineedit</tabstop>
   <tabstop>commandLineMinimumHeight</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -496,9 +496,9 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBox_highlightHistory">
+           <widget class="QCheckBox" name="checkBox_unHighlightHistory">
             <property name="toolTip">
-             <string>&lt;p&gt;Don't highlight history&lt;/p&gt;&lt;p&gt;&lt;i&gt;This disables the automatic highlighting of the history&lt;/i&gt;&lt;/p&gt;</string>
+             <string>&lt;p&gt;Stop automatic history highlighting&lt;/p&gt;&lt;p&gt;&lt;i&gt;This disables the automatic highlighting of the history&lt;/i&gt;&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Stop highlighting history</string>
@@ -5270,7 +5270,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>USE_UNIX_EOL</tabstop>
   <tabstop>auto_clear_input_line_checkbox</tabstop>
   <tabstop>show_sent_text_checkbox</tabstop>
-  <tabstop>checkBox_highlightHistory</tabstop>
+  <tabstop>checkBox_unHighlightHistory</tabstop>
   <tabstop>checkBox_runAllKeyBindings</tabstop>
   <tabstop>command_separator_lineedit</tabstop>
   <tabstop>commandLineMinimumHeight</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -5268,8 +5268,9 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>pushButton_whereToLog</tabstop>
   <tabstop>pushButton_resetLogDir</tabstop>
   <tabstop>USE_UNIX_EOL</tabstop>
-  <tabstop>show_sent_text_checkbox</tabstop>
   <tabstop>auto_clear_input_line_checkbox</tabstop>
+  <tabstop>show_sent_text_checkbox</tabstop>
+  <tabstop>checkBox_highlightHistory</tabstop>
   <tabstop>checkBox_runAllKeyBindings</tabstop>
   <tabstop>command_separator_lineedit</tabstop>
   <tabstop>commandLineMinimumHeight</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -498,10 +498,10 @@
           <item row="1" column="1">
            <widget class="QCheckBox" name="checkBox_highlightHistory">
             <property name="toolTip">
-             <string>&lt;p&gt;Hightlight History&lt;/p&gt;&lt;p&gt;&lt;i&gt;highlights your input line text if scrolling through your history&lt;/i&gt;&lt;/p&gt;</string>
+             <string>Highlights your input line text when scrolling through your history for easy cancellation</string>
             </property>
             <property name="text">
-             <string>Highlight History</string>
+             <string>Highlight history</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds an option in the settings menu to stop highlighting history.

#### Motivation for adding to Mudlet
several discussions in 
fix #4113 
fix #1682

#### Other info (issues closed, discussion etc)
If activated autocomplete as described in https://github.com/Mudlet/Mudlet/issues/4113#issuecomment-701540284 won't work (tab autocomplete still works as expected)

But as I already mentioned in that issue I think that is acceptable as people who activate this option didn't use/care about that way of autocomplete.