### PR TITLE
setCmdLineStyleSheet to change the command line stylesheet

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -590,7 +590,7 @@ void TCommandLine::adjustHeight()
         }
         return;
     }
-    int fontH = QFontMetrics(mpHost->getDisplayFont()).height();
+    int fontH = QFontMetrics(font()).height();
     if (lines < 1) {
         lines = 1;
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -658,6 +658,25 @@ std::pair<bool, QString> TConsole::setUserWindowStyleSheet(const QString& name, 
 }
 
 
+std::pair<bool, QString> TConsole::setCmdLineStyleSheet(const QString& name, const QString& styleSheet)
+{
+    if (name.isEmpty()) {
+        return {false, QStringLiteral("a command-line cannot have an empty string as its name")};
+    }
+
+    if (name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+        mpHost->mpConsole->mpCommandLine->setStyleSheet(styleSheet);
+        return {true, QString()};
+    }
+
+    auto pN = mSubCommandLineMap.value(name);
+    if (pN) {
+        pN->setStyleSheet(styleSheet);
+        return {true, QString()};
+    }
+    return {false, QStringLiteral("command-line name \"%1\" not found").arg(name)};
+}
+
 void TConsole::resizeEvent(QResizeEvent* event)
 {
     if (mType & (MainConsole|Buffer)) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1224,7 +1224,7 @@ void TConsole::changeColors()
     } else if (mType == MainConsole) {
         if (mpCommandLine) {
             auto styleSheet = mpCommandLine->styleSheet();
-            mpCommandLine->setStyleSheet("");
+            mpCommandLine->setStyleSheet(QString());
             QPalette pal;
             pal.setColor(QPalette::Text, mpHost->mCommandLineFgColor); //QColor(0,0,192));
             pal.setColor(QPalette::Highlight, QColor(0, 0, 192));

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -660,11 +660,7 @@ std::pair<bool, QString> TConsole::setUserWindowStyleSheet(const QString& name, 
 
 std::pair<bool, QString> TConsole::setCmdLineStyleSheet(const QString& name, const QString& styleSheet)
 {
-    if (name.isEmpty()) {
-        return {false, QStringLiteral("a command-line cannot have an empty string as its name")};
-    }
-
-    if (name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+    if (name.isEmpty() || !name.compare(QStringLiteral("main"))) {
         mpHost->mpConsole->mpCommandLine->setStyleSheet(styleSheet);
         return {true, QString()};
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1223,6 +1223,8 @@ void TConsole::changeColors()
         }
     } else if (mType == MainConsole) {
         if (mpCommandLine) {
+            auto styleSheet = mpCommandLine->styleSheet();
+            mpCommandLine->setStyleSheet("");
             QPalette pal;
             pal.setColor(QPalette::Text, mpHost->mCommandLineFgColor); //QColor(0,0,192));
             pal.setColor(QPalette::Highlight, QColor(0, 0, 192));
@@ -1230,6 +1232,7 @@ void TConsole::changeColors()
             pal.setColor(QPalette::Base, mpHost->mCommandLineBgColor); //QColor(255,255,225));
             mpCommandLine->setPalette(pal);
             mpCommandLine->mRegularPalette = pal;
+            mpCommandLine->setStyleSheet(styleSheet);
         }
         if (mpHost->mNoAntiAlias) {
             mpHost->setDisplayFontStyle(QFont::NoAntialias);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -93,6 +93,7 @@ public:
     void echoLink(const QString& text, QStringList& func, QStringList& hint, bool customFormat = false);
     void setLabelStyleSheet(std::string& buf, std::string& sh);
     std::pair<bool, QString> setUserWindowStyleSheet(const QString& name, const QString& userWindowStyleSheet);
+    std::pair<bool, QString> setCmdLineStyleSheet(const QString& name, const QString& styleSheet);
     void copy();
     void cut();
     void paste();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5147,6 +5147,38 @@ int TLuaInterpreter::resetCmdLineAction(lua_State* L){
     }
 }
 
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCmdLineStyleSheet
+int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString name = "main";
+    if (n > 1) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "setCmdLineStyleSheet: bad argument #1 type (userwindow name as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
+        name = QString::fromUtf8(lua_tostring(L, 1));
+    }
+    if (!lua_isstring(L, n)) {
+        lua_pushfstring(L, "setCmdLineStyleSheet: bad argument #%s type (StyleSheet as string expected, got %s!)", n, luaL_typename(L, n));
+        return lua_error(L);
+    }
+
+    QString styleSheet{QString::fromUtf8(lua_tostring(L, n))};
+    Host& host = getHostFromLua(L);
+
+    if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {
+        lua_pushnil(L);
+        lua_pushfstring(L, message.toUtf8().constData());
+        return 2;
+    }
+
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+
 // No documentation available in wiki - internal function
 int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
 {
@@ -17206,6 +17238,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setBackgroundColor", TLuaInterpreter::setBackgroundColor);
     lua_register(pGlobalLua, "setCmdLineAction", TLuaInterpreter::setCmdLineAction);
     lua_register(pGlobalLua, "resetCmdLineAction", TLuaInterpreter::resetCmdLineAction);
+    lua_register(pGlobalLua, "setCmdLineStyleSheet", TLuaInterpreter::setCmdLineStyleSheet);
     lua_register(pGlobalLua, "setLabelClickCallback", TLuaInterpreter::setLabelClickCallback);
     lua_register(pGlobalLua, "setLabelDoubleClickCallback", TLuaInterpreter::setLabelDoubleClickCallback);
     lua_register(pGlobalLua, "setLabelReleaseCallback", TLuaInterpreter::setLabelReleaseCallback);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2697,7 +2697,7 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrollBar
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableCommandLine
 int TLuaInterpreter::enableCommandLine(lua_State* L)
 {
     int n = lua_gettop(L);
@@ -2718,7 +2718,7 @@ int TLuaInterpreter::enableCommandLine(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableScrollBar
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#disableCommandLine
 int TLuaInterpreter::disableCommandLine(lua_State* L)
 {
     int n = lua_gettop(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5155,7 +5155,7 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
     QString name = "main";
     if (n > 1) {
         if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "setCmdLineStyleSheet: bad argument #1 type (userwindow name as string expected, got %s!)", luaL_typename(L, 1));
+            lua_pushfstring(L, "setCmdLineStyleSheet: bad argument #1 type (command line name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
         name = QString::fromUtf8(lua_tostring(L, 1));

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -365,6 +365,7 @@ public:
     static int setLabelClickCallback(lua_State*);
     static int setCmdLineAction(lua_State*);
     static int resetCmdLineAction(lua_State*);
+    static int setCmdLineStyleSheet(lua_State*);
     static int getImageSize(lua_State*);
     static int setLabelDoubleClickCallback(lua_State*);
     static int setLabelReleaseCallback(lua_State*);

--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -39,6 +39,14 @@ function Geyser.CommandLine:getText()
   return getCmdLine(self.name)
 end
 
+--- Sets the style sheet of the command-line
+-- @param css The style sheet string
+function Geyser.CommandLine:setStyleSheet(css)
+  css = css or self.stylesheet
+  setCmdLineStyleSheet(self.name, css)
+  self.stylesheet = css
+end
+
 --- Sets an action to be used when text is send in this commandline. When this
 -- function is called by the event system, text the commandline sends will be 
 -- appended as the final argument (see @{sysCmdLineEvent}) and also in Geyser.Label
@@ -72,6 +80,11 @@ function Geyser.CommandLine:new (cons, container)
   self.__index = self
   
   createCommandLine(me.windowname, me.name, me:get_x(), me:get_y(), me:get_width(), me:get_height())
+  
+  if me.stylesheet then 
+    me:setStyleSheet()
+  end
+  
   return me
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -152,6 +152,14 @@ function Geyser.MiniConsole:getCmdLine()
   return getCmdLine(self.name)
 end
 
+--- Sets the style sheet of the command-line
+-- @param css The style sheet string
+function Geyser.MiniConsole:setCmdLineStyleSheet(css)
+  css = css or self.cmdLineStylesheet
+  setCmdLineStyleSheet(self.name, css)
+  self.cmdLineStylesheet = css
+end
+
 --- Sets bold status for this miniconsole
 -- @param bool True for bolded
 function Geyser.MiniConsole:setBold(bool)
@@ -430,6 +438,14 @@ function Geyser.MiniConsole:new (cons, container)
       me:enableAutoWrap()
     elseif cons.wrapAt then
       me:setWrap(cons.wrapAt)
+    end
+    if me.commandLine then
+      me:enableCommandLine()
+    else
+      me:disableCommandLine()
+    end
+    if me.cmdLineStylesheet and me.commandLine then
+      me:setCmdLineStyleSheet()
     end
     --print("  New in " .. self.name .. " : " .. me.name)
   end

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -97,13 +97,13 @@ function Geyser.MiniConsole:disableScrollBar()
 end
 
 -- Start commandLine functions
---- Enables the scroll bar for this window
+--- Enables the command-line for this window
 -- @param isVisible boolean to set visibility.
 function Geyser.MiniConsole:enableCommandLine()
   enableCommandLine(self.name)
 end
 
---- Disables the scroll bar for this window
+--- Disables the command-line for this window
 -- @param isVisible boolean to set visibility.
 function Geyser.MiniConsole:disableCommandLine()
   disableCommandLine(self.name)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Allows to change the stylesheet of a command line (also of the main command line) which means the command line
can have different bg/fg colors or a different font/fontsize
new functions is
```lua
setCmdLineStyleSheet([cmdName]) -- cmdname is optional use "main" or nil for main command line
``` 
Geyser wrapper:
Geyser.CommandLines
```lua
myCmdLine:setStyleSheet(css)
```
Geyser.MiniConsoles (works also for Geyser.UserWindows)
```lua
myMiniConsole:setCmdLineStyleSheet(css)
```

#### Motivation for adding to Mudlet
https://github.com/Mudlet/Mudlet/pull/4055#pullrequestreview-483102165
Command lines can have different styles/fonts/font-size/colors

#### Other info (issues closed, discussion etc)
(ugly) example:
```lua
setCmdLineStyleSheet([[font-size: 18pt; color:white; background: blue; font-family: "Arial"; border: 2px solid silver]])
```
move the command line over:
(from https://wiki.mudlet.org/w/Manual:Scripting#How_to_move_the_command_line_over.3F)
```lua
setCmdLineStyleSheet([[
    QPlainTextEdit{
    padding-left: 100px; /* change 100 to your number */
    background-color:black;
    }]])
-- use QPlainTextEdit to prevent the style to bleed over to the command-line right click menu
```