### PR TITLE
Align max regex trigger and alias capture groups for match and match_all

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -24,6 +24,7 @@
 
 
 #include "Host.h"
+#include "TConsole.h"
 #include "TDebug.h"
 #include "mudlet.h"
 
@@ -105,11 +106,11 @@ bool TAlias::match(const QString& toMatch)
     int rc, i;
     std::list<std::string> captureList;
     std::list<int> posList;
-    int ovector[300]; // 100 capture groups max (can be increase nbGroups=1/3 ovector
+    int ovector[MAX_CAPTURE_GROUPS * 3];
 
     //cout <<" LINE="<<subject<<endl;
     if (mRegexCode.size() > 0) {
-        rc = pcre_exec(re.data(), nullptr, subject, subject_length, 0, 0, ovector, 100);
+        rc = pcre_exec(re.data(), nullptr, subject, subject_length, 0, 0, ovector, MAX_CAPTURE_GROUPS * 3);
     } else {
         goto MUD_ERROR;
     }
@@ -117,7 +118,10 @@ bool TAlias::match(const QString& toMatch)
     if (rc < 0) {
         goto MUD_ERROR;
     } else if (rc == 0) {
-        qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Alias Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
+        }
+        qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
     } else {
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::cyan), QColor(Qt::black)) << "Alias name=" << mName << "(" << mRegexCode << ") matched.\n" >> 0;
@@ -172,7 +176,7 @@ bool TAlias::match(const QString& toMatch)
             options = PCRE_NOTEMPTY | PCRE_ANCHORED;
         }
 
-        rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, 30);
+        rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, MAX_CAPTURE_GROUPS * 3);
         if (rc == PCRE_ERROR_NOMATCH) {
             if (options == 0) {
                 break;
@@ -182,7 +186,10 @@ bool TAlias::match(const QString& toMatch)
         } else if (rc < 0) {
             goto END;
         } else if (rc == 0) {
-            qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
+            if (mpHost->mpEditorDialog) {
+                mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Alias Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
+            }
+            qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
         }
 
         for (i = 0; i < rc; i++) {

--- a/src/TAlias.h
+++ b/src/TAlias.h
@@ -35,6 +35,7 @@
 
 class Host;
 
+#define MAX_CAPTURE_GROUPS 33
 
 class TAlias : public Tree<TAlias>
 {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -294,17 +294,17 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
     int rc, i;
     std::list<std::string> captureList;
     std::list<int> posList;
-    int ovector[300]; // 100 capture groups max (can be increase nbGroups=1/3 ovector
+    int ovector[MAX_CAPTURE_GROUPS * 3];
 
-    rc = pcre_exec(re.data(), nullptr, subject, subject_length, 0, 0, ovector, 99);
+    rc = pcre_exec(re.data(), nullptr, subject, subject_length, 0, 0, ovector, MAX_CAPTURE_GROUPS * 3);
 
     if (rc < 0) {
         return false;
     } else if (rc == 0) {
         if (mpHost->mpEditorDialog) {
-            mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] Cannot handle matches. Too many capture groups.\n"), QColor(255, 128, 0), QColor(Qt::black));
+            mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
         }
-        qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for 33 captured substrings\n";
+        qDebug() << QStringLiteral("CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %1 captured substrings").arg(MAX_CAPTURE_GROUPS);
     } else {
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::blue), QColor(Qt::black)) << "Trigger name=" << mName << "(" << mRegexCodeList.value(regexNumber) << ") matched.\n" >> 0;
@@ -360,7 +360,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
             options = PCRE_NOTEMPTY | PCRE_ANCHORED;
         }
 
-        rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, 99);
+        rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, MAX_CAPTURE_GROUPS * 3);
 
         if (rc == PCRE_ERROR_NOMATCH) {
             if (options == 0) {
@@ -372,9 +372,9 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
             goto END;
         } else if (rc == 0) {
             if (mpHost->mpEditorDialog) {
-                mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] Cannot handle matches. Too many capture groups.\n"), QColor(255, 128, 0), QColor(Qt::black));
+                mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
             }
-            qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for 33 captured substrings\n";
+            qDebug() << QStringLiteral("CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %1 captured substrings").arg(MAX_CAPTURE_GROUPS);
         }
 
         for (i = 0; i < rc; i++) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -296,12 +296,15 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
     std::list<int> posList;
     int ovector[300]; // 100 capture groups max (can be increase nbGroups=1/3 ovector
 
-    rc = pcre_exec(re.data(), nullptr, subject, subject_length, 0, 0, ovector, 100);
+    rc = pcre_exec(re.data(), nullptr, subject, subject_length, 0, 0, ovector, 99);
 
     if (rc < 0) {
         return false;
     } else if (rc == 0) {
-        qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
+        if (mpHost->mpEditorDialog) {
+            mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] Cannot handle matches. Too many capture groups.\n"), QColor(255, 128, 0), QColor(Qt::black));
+        }
+        qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for 33 captured substrings\n";
     } else {
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::blue), QColor(Qt::black)) << "Trigger name=" << mName << "(" << mRegexCodeList.value(regexNumber) << ") matched.\n" >> 0;
@@ -357,7 +360,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
             options = PCRE_NOTEMPTY | PCRE_ANCHORED;
         }
 
-        rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, 30);
+        rc = pcre_exec(re.data(), nullptr, subject, subject_length, start_offset, options, ovector, 99);
 
         if (rc == PCRE_ERROR_NOMATCH) {
             if (options == 0) {
@@ -368,7 +371,10 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         } else if (rc < 0) {
             goto END;
         } else if (rc == 0) {
-            qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %d captured substrings\n";
+            if (mpHost->mpEditorDialog) {
+                mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] Cannot handle matches. Too many capture groups.\n"), QColor(255, 128, 0), QColor(Qt::black));
+            }
+            qDebug() << "CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for 33 captured substrings\n";
         }
 
         for (i = 0; i < rc; i++) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -304,7 +304,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         if (mpHost->mpEditorDialog) {
             mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
         }
-        qDebug() << QStringLiteral("CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %1 captured substrings").arg(MAX_CAPTURE_GROUPS);
+        qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
     } else {
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::blue), QColor(Qt::black)) << "Trigger name=" << mName << "(" << mRegexCodeList.value(regexNumber) << ") matched.\n" >> 0;
@@ -374,7 +374,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
             if (mpHost->mpEditorDialog) {
                 mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
             }
-            qDebug() << QStringLiteral("CRITICAL ERROR: SHOULD NOT HAPPEN->pcre_info() got wrong num of cap groups ovector only has room for %1 captured substrings").arg(MAX_CAPTURE_GROUPS);
+            qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
         }
 
         for (i = 0; i < rc; i++) {

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -51,6 +51,7 @@ class TMatchState;
 #define REGEX_LINE_SPACER 5
 #define REGEX_COLOR_PATTERN 6
 #define REGEX_PROMPT 7
+#define MAX_CAPTURE_GROUPS 33
 
 
 struct TColorTable


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Regex Triggers had a (non-documented?) limit of 33 capture groups for the first match but if match_all is active every successive
match had a limit of 10 capture group.
This PR aligns both to be at 33 capture group max and an error will be printed to the error console if the limit is reached.

#### Motivation for adding to Mudlet
fix #4121

#### Other info (issues closed, discussion etc)
I change the last parameter for pcre_exec to 99 as described at https://man7.org/linux/man-pages/man3/pcre_exec.3.html 
ovecsize is (or should be) a multiple of 3
