### PR TITLE
Temporarily take out signing Windows executables

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -93,7 +93,7 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
   }
 
   # fails silently if the nupkg file is not found
-  .\squirrel.windows\tools\Squirrel --releasify $nupkg_path --releaseDir C:\projects\squirreloutput --loadingGif C:\projects\installers\windows\splash-installing-2x.png --no-msi --setupIcon C:\projects\installers\windows\mudlet_main_48px.ico -n "/a /f C:\projects\installers\windows\code-signing-certificate.p12 /p $Env:signing_password /fd sha256 /tr http://timestamp.digicert.com /td sha256"
+  .\squirrel.windows\tools\Squirrel --releasify $nupkg_path --releaseDir C:\projects\squirreloutput --loadingGif C:\projects\installers\windows\splash-installing-2x.png --no-msi --setupIcon C:\projects\installers\windows\mudlet_main_48px.ico
 
   Write-Output "=== Removing old directory content of release folder ==="
   Remove-Item -Recurse -Force $Env:APPVEYOR_BUILD_FOLDER\src\release\*


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Temporarily take out signing Windows executables.
#### Motivation for adding to Mudlet
So we can build PTBs again. 
#### Other info (issues closed, discussion etc)
We will restore the signing once we get a certificate and we don't need to store it as a comment because we can always look at git history to revert it.

Not sure how happy will the update process be with an unsigned executable, but lets try it!