### PR TITLE
Sub-console cleanup

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2598,3 +2598,13 @@ void Host::setCompactInputLine(const bool state)
         }
     }
 }
+
+QPointer<TConsole> Host::findConsole(QString name)
+{
+    if (name.isEmpty() or name == "main") {
+        return mpConsole;
+    } else {
+        return mpConsole->mSubConsoleMap.value(name);
+    }
+}
+

--- a/src/Host.h
+++ b/src/Host.h
@@ -329,7 +329,7 @@ public:
     bool debugShowAllProblemCodepoints() const { return mDebugShowAllProblemCodepoints; }
     void setCompactInputLine(const bool state);
     bool getCompactInputLine() const { return mCompactInputLine; }
-
+    QPointer<TConsole> findConsole(QString name);
 
     cTelnet mTelnet;
     QPointer<TConsole> mpConsole;

--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -45,7 +45,7 @@ int LuaInterface::onPanic(lua_State* L)
 {
     QString error = "Lua Panic, No error information";
     if (lua_isstring(L, -1)) {
-        error = QString::fromUtf8(lua_tostring(L, -1));
+        error = lua_tostring(L, -1);
         //there's never anything but the error on the stack, nothing to report
     }
     //FIXME: report error to user qDebug()<<"PANIC ERROR:"<<error;
@@ -689,7 +689,7 @@ QString LuaInterface::getValue(TVar* var)
         if (vType == LUA_TBOOLEAN) {
             value = lua_toboolean(L, -1) == 0 ? QLatin1String("false") : QLatin1String("true");
         } else if (vType == LUA_TNUMBER || vType == LUA_TSTRING) {
-            value = QString::fromUtf8(lua_tostring(L, -1));
+            value = lua_tostring(L, -1);
         }
         lua_pop(L, pCount);
         return value;
@@ -712,7 +712,7 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
             lrefs.append(keyName.toInt());
             var->setReference(true);
         } else {
-            keyName = QString::fromUtf8(lua_tostring(L, -1));
+            keyName = lua_tostring(L, -1);
             if (kType == LUA_TFUNCTION && keyName.isEmpty()) {
                 //we lost the reference
                 keyName = QString::number(luaL_ref(L, LUA_REGISTRYINDEX));
@@ -758,7 +758,7 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
             }
         } else if (vType == LUA_TSTRING || vType == LUA_TNUMBER) {
             lua_pushvalue(L, -1);
-            valueName = QString::fromUtf8(lua_tostring(L, -1));
+            valueName = lua_tostring(L, -1);
             var->setValue(valueName);
             lua_pop(L, 1);
         } else if (vType == LUA_TBOOLEAN) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -637,8 +637,8 @@ Host* TConsole::getHost()
 
 void TConsole::setLabelStyleSheet(std::string& buf, std::string& sh)
 {
-    QString key = QString::fromUtf8(buf.c_str());
-    QString sheet = sh.c_str();
+    QString key{buf.c_str()};
+    QString sheet{sh.c_str()};
     if (mLabelMap.find(key) != mLabelMap.end()) {
         QLabel* pC = mLabelMap[key];
         if (!pC) {
@@ -1845,7 +1845,7 @@ void TConsole::selectCurrentLine()
 
 void TConsole::selectCurrentLine(std::string& buf)
 {
-    QString key = QString::fromUtf8(buf.c_str());
+    QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         selectCurrentLine();
         return;
@@ -1907,7 +1907,7 @@ std::list<int> TConsole::_getBgColor()
 
 std::list<int> TConsole::getFgColor(std::string& buf)
 {
-    QString key = QString::fromUtf8(buf.c_str());
+    QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return _getFgColor();
     }
@@ -1921,7 +1921,7 @@ std::list<int> TConsole::getFgColor(std::string& buf)
 
 std::list<int> TConsole::getBgColor(std::string& buf)
 {
-    QString key = QString::fromUtf8(buf.c_str());
+    QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return _getBgColor();
     }
@@ -1960,7 +1960,7 @@ QPair<quint8, TChar> TConsole::getTextAttributes(const QString& name) const
 
 void TConsole::luaWrapLine(std::string& buf, int line)
 {
-    QString key = QString::fromUtf8(buf.c_str());
+    QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         _luaWrapLine(line);
         return;
@@ -2077,7 +2077,7 @@ QString TConsole::getCurrentLine()
 
 QString TConsole::getCurrentLine(std::string& buf)
 {
-    QString key = QString::fromUtf8(buf.c_str());
+    QString key = buf.c_str();
     if (key.isEmpty() || key == QLatin1String("main")) {
         return getCurrentLine();
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -370,14 +370,12 @@ int TLuaInterpreter::Wait(lua_State* L)
     int n = lua_gettop(L);
     if (n != 1) {
         lua_pushstring(L, "Wait: wrong number of arguments");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "Wait: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaSleepMsec = lua_tointeger(L, 1);
 
@@ -570,8 +568,7 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
                             "function, or nil expected, got a %s!)",
                             i,
                             luaL_typename(L, -1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
     }
 
@@ -604,8 +601,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
     int n = lua_gettop(L);
     if (!n) {
         lua_pushstring(L, "raiseGlobalEvent: missing argument #1 (eventName as, probably, a string expected!)");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     TEvent event {};
@@ -636,8 +632,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
                             "expected, got a %s!)",
                             i,
                             luaL_typename(L, i));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
     }
 
@@ -668,8 +663,7 @@ int TLuaInterpreter::selectString(lua_State* L)
     if (lua_gettop(L) > 2) {
         if (!lua_isstring(L, s)) {
             lua_pushfstring(L, R"(selectString: bad argument #%d type (window name as string, is optional {defaults to "main" if omitted}, got %s!))", s, luaL_typename(L, s));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         // We cannot yet properly handle non-ASCII windows names but we will eventually!
         windowName = QString::fromUtf8(lua_tostring(L, s));
@@ -678,8 +672,7 @@ int TLuaInterpreter::selectString(lua_State* L)
 
     if (!lua_isstring(L, s)) {
         lua_pushfstring(L, "selectString: bad argument #%d type (text to select as string expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString searchText = QString::fromUtf8(lua_tostring(L, s));
     // CHECK: Do we need to qualify this for a non-blank string?
@@ -687,8 +680,7 @@ int TLuaInterpreter::selectString(lua_State* L)
 
     if (!lua_isnumber(L, s)) {
         lua_pushfstring(L, "selectString: bad argument #%d type (match count as number {1 for first} expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     qint64 numOfMatch = lua_tointeger(L, s);
 
@@ -1449,8 +1441,7 @@ int TLuaInterpreter::addMapMenu(lua_State* L)
     QStringList menuList;
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "addMapMenu: wrong first argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString uniqueName = lua_tostring(L, 1);
 
@@ -1480,8 +1471,7 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "removeMapMenu: wrong first argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString uniqueName = lua_tostring(L, 1);
 
@@ -1563,15 +1553,13 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
     QStringList actionInfo;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "addMapEvent: bad argument #1 type (uniquename as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString uniqueName = QString::fromUtf8(lua_tostring(L, 1));
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "addMapEvent: bad argument #2 type (event name as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     actionInfo << QString::fromUtf8(lua_tostring(L, 2));
 
@@ -1606,8 +1594,7 @@ int TLuaInterpreter::removeMapEvent(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "removeMapEvent: wrong first argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString displayName = lua_tostring(L, 1);
 
@@ -1674,8 +1661,7 @@ int TLuaInterpreter::centerview(lua_State* L)
     int roomId;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "centerview: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         roomId = lua_tointeger(L, 1);
     }
@@ -1875,15 +1861,13 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "setWindowWrap: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setWindowWrap: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaFrom = lua_tointeger(L, 2);
 
@@ -1901,15 +1885,13 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "setWindowWrapIndent: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setWindowWrapIndent: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaFrom = lua_tointeger(L, 2);
 
@@ -2529,8 +2511,7 @@ int TLuaInterpreter::moveCursor(lua_State* L)
     if (n > 2) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "moveCursor: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, s);
         s++;
@@ -2538,16 +2519,14 @@ int TLuaInterpreter::moveCursor(lua_State* L)
 
     if (!lua_isnumber(L, s)) {
         lua_pushstring(L, "moveCursor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaFrom = lua_tointeger(L, s);
     s++;
 
     if (!lua_isnumber(L, s)) {
         lua_pushstring(L, "moveCursor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaTo = lua_tointeger(L, s);
 
@@ -2570,8 +2549,7 @@ int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
     if (n > 2) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "setConsoleBufferSize: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, s);
         s++;
@@ -2579,16 +2557,14 @@ int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
 
     if (!lua_isnumber(L, s)) {
         lua_pushstring(L, "setConsoleBufferSize: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaFrom = lua_tointeger(L, s);
     s++;
 
     if (!lua_isnumber(L, s)) {
         lua_pushstring(L, "setConsoleBufferSize: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaTo = lua_tointeger(L, s);
 
@@ -2610,8 +2586,7 @@ int TLuaInterpreter::enableScrollBar(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "enableScrollBar: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, 1);
     }
@@ -2630,8 +2605,7 @@ int TLuaInterpreter::disableScrollBar(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "disableScrollBar: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, 1);
     }
@@ -2650,8 +2624,7 @@ int TLuaInterpreter::enableCommandLine(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "enableCommandLine: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, 1);
     }
@@ -2670,8 +2643,7 @@ int TLuaInterpreter::disableCommandLine(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "disableCommandLine: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, 1);
     }
@@ -2689,8 +2661,7 @@ int TLuaInterpreter::replace(lua_State* L)
     int s = 1;
     if (!lua_isstring(L, s)) {
         lua_pushstring(L, "replace: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, s);
     s++;
@@ -2699,8 +2670,7 @@ int TLuaInterpreter::replace(lua_State* L)
     if (n > 1) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "replace: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = text;
         text = lua_tostring(L, s);
@@ -2722,8 +2692,7 @@ int TLuaInterpreter::deleteLine(lua_State* L)
     if (lua_gettop(L) == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushstring(L, "deleteLine: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, 1);
     }
@@ -2778,22 +2747,19 @@ int TLuaInterpreter::setExitStub(lua_State* L)
     //args:room id, direction (as given by the #define direction table), status
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setExitStub: Need a room number as first argument");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tonumber(L, 1);
 
     int dirType = dirToNumber(L, 2);
     if (!dirType) {
         lua_pushstring(L, "setExitStub: Need a dir number as 2nd argument");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (!lua_isboolean(L, 3)) {
         lua_pushstring(L, "setExitStub: Need a true/false for third argument");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool status = lua_toboolean(L, 3);
 
@@ -2804,13 +2770,11 @@ int TLuaInterpreter::setExitStub(lua_State* L)
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         lua_pushstring(L, "setExitStub: RoomId doesn't exist");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     if (dirType > 12 || dirType < 1) {
         lua_pushstring(L, "setExitStub: dirType must be between 1 and 12");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     pR->setExitStub(dirType, status);
     return 0;
@@ -2823,16 +2787,14 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     int roomsGiven = 0;
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "connectExitStub: Need a room number as first argument");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tonumber(L, 1);
 
     int dirType = dirToNumber(L, 2);
     if (!dirType) {
         lua_pushstring(L, "connectExitStub: Need a direction number (or room id) as 2nd argument");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     if (!lua_isnumber(L, 3) && !lua_isstring(L, 3)) {
         roomsGiven = 0;
@@ -2842,8 +2804,7 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
         dirType = dirToNumber(L, 3);
         if (!dirType) {
             lua_pushstring(L, "connectExitStub: Invalid direction entered.");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
     }
     Host& host = getHostFromLua(L);
@@ -2853,28 +2814,24 @@ int TLuaInterpreter::connectExitStub(lua_State* L)
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
         lua_pushstring(L, "connectExitStub: RoomId doesn't exist");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     if (!pR->exitStubs.contains(dirType)) {
         lua_pushstring(L, "connectExitStub: ExitStub doesn't exist");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     if (roomsGiven) {
         TRoom* pR_to = host.mpMap->mpRoomDB->getRoom(toRoom);
         if (!pR_to) {
             lua_pushstring(L, "connectExitStub: toRoom doesn't exist");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         Host& host = getHostFromLua(L);
         lua_pushboolean(L, host.mpMap->setExit(roomId, toRoom, dirType));
     } else {
         if (!pR->exitStubs.contains(dirType)) {
             lua_pushstring(L, "connectExitStub: ExitStub doesn't exist");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         host.mpMap->connectExitStub(roomId, dirType);
         // Nothing has yet been put onto stack for a LUA return value in this case,
@@ -2897,8 +2854,7 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getExitStubs: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tonumber(L, 1);
 
@@ -2938,8 +2894,7 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getExitStubs1: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tonumber(L, 1);
 
@@ -2972,8 +2927,7 @@ int TLuaInterpreter::getModulePath(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "getModulePath: Module be be a string");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString moduleName = lua_tostring(L, 1);
 
@@ -2992,8 +2946,7 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "getModulePriority: Module be be a string");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString moduleName = lua_tostring(L, 1);
 
@@ -3004,8 +2957,7 @@ int TLuaInterpreter::getModulePriority(lua_State* L)
         return 1;
     } else {
         lua_pushstring(L, "getModulePriority: Module doesn't exist");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     return 0;
 }
@@ -3015,15 +2967,13 @@ int TLuaInterpreter::setModulePriority(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "setModulePriority: bad argument #1 type (module name as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString moduleName = lua_tostring(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushfstring(L, "setModulePriority: bad argument #2 type (module priority as number expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int modulePriority = lua_tonumber(L, 2);
 
@@ -3050,8 +3000,7 @@ int TLuaInterpreter::loadMap(lua_State* L)
                             "loadMap: bad argument #1 type (Map pathFile as string is optional {loads last\n"
                             "stored map if omitted}, got %s!)",
                             luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         location = QString::fromUtf8(lua_tostring(L, 1));
     }
@@ -3084,8 +3033,7 @@ int TLuaInterpreter::enableTimer(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "enableTimer: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3100,8 +3048,7 @@ int TLuaInterpreter::disableTimer(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "disableTimer: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3161,8 +3108,7 @@ int TLuaInterpreter::enableAlias(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "enableAlias: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3177,8 +3123,7 @@ int TLuaInterpreter::disableAlias(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "disableAlias: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3193,8 +3138,7 @@ int TLuaInterpreter::killAlias(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "killAlias: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3208,8 +3152,7 @@ int TLuaInterpreter::enableTrigger(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "enableTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3224,8 +3167,7 @@ int TLuaInterpreter::disableTrigger(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "disableTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3296,8 +3238,7 @@ int TLuaInterpreter::killTimer(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "killTimer: killTimer requires a string ID");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3311,8 +3252,7 @@ int TLuaInterpreter::killTrigger(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "killTrigger: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -3739,8 +3679,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "createMiniConsole: bad argument #1 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
     if (isMain(windowName)) {
@@ -3751,8 +3690,7 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
     if (!lua_isnumber(L, 2)) {
         if (!lua_isstring(L, 2)) {
             lua_pushfstring(L, "createMiniConsole: bad argument #2 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 2));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         name = lua_tostring(L, 2);
     } else {
@@ -3763,32 +3701,28 @@ int TLuaInterpreter::createMiniConsole(lua_State* L)
 
     if (!lua_isnumber(L, counter)) {
         lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole x-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int x = lua_tonumber(L, counter);
     counter++;
 
     if (!lua_isnumber(L, counter)) {
         lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole y-coordinate as number expected, got %s!)", counter, luaL_typename(L, counter));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int y = lua_tonumber(L, counter);
     counter++;
 
     if (!lua_isnumber(L, counter)) {
         lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole width as number expected, got %s!)", counter, luaL_typename(L, counter));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int width = lua_tonumber(L, counter);
     counter++;
 
     if (!lua_isnumber(L, counter)) {
         lua_pushfstring(L, "createMiniConsole: bad argument #%d type (miniconsole height as number expected, got %s!)", counter, luaL_typename(L, counter));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int height = lua_tonumber(L, counter);
 
@@ -4201,8 +4135,7 @@ int TLuaInterpreter::createBuffer(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "createBuffer: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -4233,8 +4166,7 @@ int TLuaInterpreter::closeUserWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "closeUserWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -4249,8 +4181,7 @@ int TLuaInterpreter::hideUserWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "hideWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -4467,22 +4398,19 @@ int TLuaInterpreter::resizeWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "resizeWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "resizeWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double x1 = lua_tonumber(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "resizeWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double y1 = lua_tonumber(L, 3);
 
@@ -4497,22 +4425,19 @@ int TLuaInterpreter::moveWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "moveWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "moveWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double x1 = lua_tonumber(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "moveWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double y1 = lua_tonumber(L, 3);
 
@@ -4638,15 +4563,13 @@ int TLuaInterpreter::setMainWindowSize(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setMainWindowSize: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int x1 = lua_tonumber(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setMainWindowSize: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int y1 = lua_tonumber(L, 2);
 
@@ -4811,8 +4734,7 @@ int TLuaInterpreter::startLogging(lua_State* L)
 
     if (!lua_isboolean(L, 1)) {
         lua_pushfstring(L, "startLogging: bad argument #1 type (turn logging on/off, as boolean expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool logOn = lua_toboolean(L, 1);
 
@@ -4862,15 +4784,13 @@ int TLuaInterpreter::setBackgroundImage(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "setBackgroundImage: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "setBackgroundImage: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString name = lua_tostring(L, 2);
 
@@ -5270,8 +5190,7 @@ int TLuaInterpreter::raiseWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "raiseWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = QString::fromUtf8(lua_tostring(L, 1));
 
@@ -5285,8 +5204,7 @@ int TLuaInterpreter::lowerWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "lowerWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = QString::fromUtf8(lua_tostring(L, 1));
 
@@ -5300,8 +5218,7 @@ int TLuaInterpreter::showUserWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "showWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 1);
 
@@ -5350,15 +5267,13 @@ int TLuaInterpreter::setRoomName(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setRoomName: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setRoomName: bad argument #2 type (room name as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString name = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -5387,8 +5302,7 @@ int TLuaInterpreter::getRoomName(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getRoomName: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
@@ -5408,15 +5322,13 @@ int TLuaInterpreter::setRoomWeight(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setRoomWeight: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setRoomWeight: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int w = lua_tonumber(L, 2);
 
@@ -5558,8 +5470,7 @@ int TLuaInterpreter::roomLocked(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "roomLocked: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
@@ -5579,15 +5490,13 @@ int TLuaInterpreter::lockRoom(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "lockRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     if (!lua_isboolean(L, 2)) {
         lua_pushstring(L, "lockRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool b = lua_toboolean(L, 2);
 
@@ -5608,22 +5517,19 @@ int TLuaInterpreter::lockExit(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "lockExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     int dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushstring(L, "lockExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (!lua_isboolean(L, 3)) {
         lua_pushstring(L, "lockExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool b = lua_toboolean(L, 3);
 
@@ -5641,29 +5547,25 @@ int TLuaInterpreter::lockSpecialExit(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "lockSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "lockSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int to = lua_tonumber(L, 2);
 
     if (!lua_isstring(L, 3)) {
         lua_pushstring(L, "lockSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString dir = lua_tostring(L, 3);
 
     if (!lua_isboolean(L, 4)) {
         lua_pushstring(L, "lockSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool b = lua_toboolean(L, 4);
 
@@ -5681,22 +5583,19 @@ int TLuaInterpreter::hasSpecialExitLock(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "hasSpecialExitLock: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "hasSpecialExitLock: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int to = lua_tonumber(L, 2);
 
     if (!lua_isstring(L, 3)) {
         lua_pushstring(L, "hasSpecialExitLock: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString dir = lua_tostring(L, 3);
 
@@ -5714,16 +5613,14 @@ int TLuaInterpreter::hasExitLock(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "hasExitLock: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
     int dir = dirToNumber(L, 2);
     if (!dir) {
         lua_pushstring(L, "hasExitLock: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     Host& host = getHostFromLua(L);
@@ -5740,8 +5637,7 @@ int TLuaInterpreter::getRoomExits(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getRoomExits: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tonumber(L, 1);
 
@@ -5879,21 +5775,18 @@ int TLuaInterpreter::searchRoom(lua_State* L)
                         exactMatch = lua_toboolean(L, 3);
                     } else {
                         lua_pushfstring(L, R"(searchRoom: bad argument #3 type ("exact match" as boolean is optional, got %s!))", luaL_typename(L, 3));
-                        lua_error(L);
-                        return 1;
+                        return lua_error(L);
                     }
                 }
             } else {
                 lua_pushfstring(L, R"(searchRoom: bad argument #2 type ("case sensitive" as boolean is optional, got %s!))", luaL_typename(L, 2));
-                lua_error(L);
-                return 1;
+                return lua_error(L);
             }
         }
         room = QString::fromUtf8(lua_tostring(L, 1));
     } else {
         lua_pushfstring(L, R"(searchRoom: bad argument #1 ("room name" as string expected, got %s!))", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (gotRoomID) {
@@ -5958,16 +5851,14 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
     if (lua_gettop(L)) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, R"(searchRoomUserData: bad argument #1 ("key" as string is optional, got %s!))", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         key = QString::fromUtf8(lua_tostring(L, 1));
 
         if (lua_gettop(L) > 1) {
             if (!lua_isstring(L, 2)) {
                 lua_pushfstring(L, R"(searchRoomUserData: bad argument #2 ("value" as string is optional, got %s!))", luaL_typename(L, 2));
-                lua_error(L);
-                return 1;
+                return lua_error(L);
             }
             value = QString::fromUtf8(lua_tostring(L, 2));
         }
@@ -6083,16 +5974,14 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
     if (lua_gettop(L)) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, R"(searchAreaUserData: bad argument #1 ("key" as string is optional, got %s!))", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         key = QString::fromUtf8(lua_tostring(L, 1));
 
         if (lua_gettop(L) > 1) {
             if (!lua_isstring(L, 2)) {
                 lua_pushfstring(L, R"(searchAreaUserData: bad argument #2 ("value" as string is optional, got %s!))", luaL_typename(L, 2));
-                lua_error(L);
-                return 1;
+                return lua_error(L);
             }
             value = QString::fromUtf8(lua_tostring(L, 2));
         }
@@ -6239,8 +6128,7 @@ int TLuaInterpreter::getAreaRooms(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getAreaRooms: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tonumber(L, 1);
 
@@ -6293,8 +6181,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
     if (n > 1) {
         if (!lua_isboolean(L, 2)) {
             lua_pushfstring(L, "getAreaExits: bad argument #2 type (full data wanted as boolean is optional, got %s!)", luaL_typename(L, 2));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         isFullDataRequired = lua_toboolean(L, 2);
     }
@@ -6354,8 +6241,7 @@ int TLuaInterpreter::getRoomWeight(lua_State* L)
     if (lua_gettop(L) > 0) {
         if (!lua_isnumber(L, 1)) {
             lua_pushstring(L, "getRoomWeight: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         roomId = lua_tonumber(L, 1);
     } else {
@@ -6376,8 +6262,7 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "gotoRoom: bad argument #1 type (target room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int targetRoomId = lua_tonumber(L, 1);
 
@@ -6410,15 +6295,13 @@ int TLuaInterpreter::getPath(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getPath: bad argument #1 type (starting room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int originRoomId = lua_tonumber(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushfstring(L, "getPath: bad argument #2 type (target room id as number expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int targetRoomId = lua_tonumber(L, 2);
 
@@ -6460,8 +6343,7 @@ int TLuaInterpreter::deselect(lua_State* L)
     if (lua_gettop(L) > 0) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, R"(deselect: bad argument #1 type (window name as string, is optional {defaults to "main" if omitted}, got %s!))", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         // We cannot yet properly handle non-ASCII windows names but we will eventually!
         windowName = QString::fromUtf8(lua_tostring(L, 1));
@@ -6491,8 +6373,7 @@ int TLuaInterpreter::resetFormat(lua_State* L)
     if (lua_gettop(L) > 0) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, R"(resetFormat: bad argument #1 type (window name as string, is optional {defaults to "main" if omitted}, got %s!))", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         // We cannot yet properly handle non-ASCII windows names but we will eventually!
         windowName = QString::fromUtf8(lua_tostring(L, 1));
@@ -6526,15 +6407,13 @@ int TLuaInterpreter::echoUserWindow(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "echoUserWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "echoUserWindow: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 2);
 
@@ -6610,8 +6489,7 @@ int TLuaInterpreter::playSoundFile(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "playSoundFile: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString sound = lua_tostring(L, 1);
 
@@ -6657,8 +6535,7 @@ int TLuaInterpreter::getLastLineNumber(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "getLastLineNumber: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
@@ -6706,16 +6583,14 @@ int TLuaInterpreter::setTriggerStayOpen(lua_State* L)
     if (lua_gettop(L) > 1) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "setTriggerStayOpen: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, s);
         s++;
     }
     if (!lua_isnumber(L, s)) {
         lua_pushstring(L, "setTriggerStayOpen: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double b = lua_tonumber(L, s);
 
@@ -6732,8 +6607,7 @@ int TLuaInterpreter::setLink(lua_State* L)
     if (lua_gettop(L) > 2) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "setLink: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, s);
         s++;
@@ -6741,16 +6615,14 @@ int TLuaInterpreter::setLink(lua_State* L)
 
     if (!lua_isstring(L, s)) {
         lua_pushstring(L, "setLink: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString linkFunction = lua_tostring(L, s);
     s++;
 
     if (!lua_isstring(L, s)) {
         lua_pushstring(L, "setLink: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString linkHint = lua_tostring(L, s);
     s++;
@@ -6781,24 +6653,21 @@ int TLuaInterpreter::setPopup(lua_State* L)
     if (n > 4) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "setPopup: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, s);
         s++;
     }
     if (!lua_isstring(L, s)) {
         lua_pushstring(L, "setPopup: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString txt = lua_tostring(L, s);
     s++;
 
     if (!lua_istable(L, s)) {
         lua_pushstring(L, "setPopup: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     lua_pushnil(L);
     while (lua_next(L, s) != 0) {
@@ -6814,8 +6683,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
 
     if (!lua_istable(L, s)) {
         lua_pushstring(L, "setPopup: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     lua_pushnil(L);
     while (lua_next(L, s) != 0) {
@@ -6832,8 +6700,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
     Host& host = getHostFromLua(L);
     if (_commandList.size() != _hintList.size()) {
         lua_pushstring(L, "Error: command list size and hint list size do not match cannot create popup");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (isMain(windowName)) {
@@ -6864,8 +6731,7 @@ int TLuaInterpreter::setBold(lua_State* L)
 
     if (!lua_isboolean(L, ++s)) {
         lua_pushfstring(L, "setBold: bad argument #%d type (enable bold attribute as boolean expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool isAttributeEnabled = lua_toboolean(L, s);
 
@@ -6905,8 +6771,7 @@ int TLuaInterpreter::setItalics(lua_State* L)
 
     if (!lua_isboolean(L, ++s)) {
         lua_pushfstring(L, "setItalics: bad argument #%d type (enable italic attribute as boolean expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool isAttributeEnabled = lua_toboolean(L, s);
 
@@ -6946,8 +6811,7 @@ int TLuaInterpreter::setOverline(lua_State* L)
 
     if (!lua_isboolean(L, ++s)) {
         lua_pushfstring(L, "setOverline: bad argument #%d type (enable underline attribute as boolean expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool isAttributeEnabled = lua_toboolean(L, s);
 
@@ -6987,8 +6851,7 @@ int TLuaInterpreter::setReverse(lua_State* L)
 
     if (!lua_isboolean(L, ++s)) {
         lua_pushfstring(L, "setReverse: bad argument #%d type (enable underline attribute as boolean expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool isAttributeEnabled = lua_toboolean(L, s);
 
@@ -7028,8 +6891,7 @@ int TLuaInterpreter::setStrikeOut(lua_State* L)
 
     if (!lua_isboolean(L, ++s)) {
         lua_pushfstring(L, "setStrikeOut: bad argument #%d type (enable strikeout attribute as boolean expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool isAttributeEnabled = lua_toboolean(L, s);
 
@@ -7069,8 +6931,7 @@ int TLuaInterpreter::setUnderline(lua_State* L)
 
     if (!lua_isboolean(L, ++s)) {
         lua_pushfstring(L, "setUnderline: bad argument #%d type (enable underline attribute as boolean expected, got %s!)", s, luaL_typename(L, s));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool isAttributeEnabled = lua_toboolean(L, s);
 
@@ -7126,15 +6987,13 @@ int TLuaInterpreter::showHandlerError(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "showHandlerError: bad argument #1 type (event name as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString event = QString::fromUtf8(lua_tostring(L, 1));
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "showHandlerError: bad argument #2 type (error message as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString error = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -7147,8 +7006,7 @@ int TLuaInterpreter::hideToolBar(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "hideToolBar: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
@@ -7162,8 +7020,7 @@ int TLuaInterpreter::showToolBar(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "showToolBar: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
@@ -7431,8 +7288,7 @@ int TLuaInterpreter::getUserWindowSize(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getUserWindowSize: bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString windowName = lua_tostring(L, 1);
 
@@ -8081,22 +7937,19 @@ int TLuaInterpreter::tempButton(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "tempButton: wrong first arg");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     toolbar = lua_tostring(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "tempButton: wrong second arg");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString name = lua_tostring(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "tempButton: wrong third arg");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int orientation = lua_tonumber(L, 3);
 
@@ -8187,22 +8040,19 @@ int TLuaInterpreter::tempButtonToolbar(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "tempButtonToolbar: wrong first arg");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     name = lua_tostring(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "tempButtonToolbar: wrong first arg");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int location = lua_tonumber(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "tempButtonToolbar: wrong first arg");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int orientation = lua_tonumber(L, 3);
 
@@ -8311,15 +8161,13 @@ int TLuaInterpreter::exists(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "exists: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString name = lua_tostring(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "exists: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString type = lua_tostring(L, 2);
 
@@ -8855,15 +8703,13 @@ int TLuaInterpreter::invokeFileDialog(lua_State* L)
 {
     if (!lua_isboolean(L, 1)) {
         lua_pushstring(L, "invokeFileDialog: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool luaDir = lua_toboolean(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "invokeFileDialog: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString title = lua_tostring(L, 2);
 
@@ -8940,22 +8786,19 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setBorderColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaRed = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setBorderColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaGreen = lua_tointeger(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "setBorderColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int luaBlue = lua_tointeger(L, 3);
 
@@ -8973,29 +8816,25 @@ int TLuaInterpreter::setRoomCoordinates(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setRoomCoordinates: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setRoomCoordinates: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int x = lua_tointeger(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "setRoomCoordinates: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int y = lua_tointeger(L, 3);
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "setRoomCoordinates: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int z = lua_tointeger(L, 4);
 
@@ -9009,36 +8848,31 @@ int TLuaInterpreter::setCustomEnvColor(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setCustomEnvColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setCustomEnvColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int r = lua_tointeger(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "setCustomEnvColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int g = lua_tointeger(L, 3);
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "setCustomEnvColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int b = lua_tointeger(L, 4);
 
     if (!lua_isnumber(L, 5)) {
         lua_pushstring(L, "setCustomEnvColor: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int alpha = lua_tointeger(L, 5);
 
@@ -9103,14 +8937,12 @@ int TLuaInterpreter::setAreaName(lua_State* L)
                         "setAreaName: bad argument #1 type (area id as number or area name as string\n"
                         "expected, got %s!)",
                         luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setAreaName: bad argument #2 type (area name as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString newName = QString::fromUtf8(lua_tostring(L, 2)).trimmed();
     // Now allow non-Ascii names but eliminate any leading or trailing spaces
@@ -9181,8 +9013,7 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
                             "getRoomAreaName: bad argument #1 type (area id as number or area name as string\n"
                             "expected, got %s!)",
                             luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         name = QString::fromUtf8(lua_tostring(L, 1));
     } else {
@@ -9218,8 +9049,7 @@ int TLuaInterpreter::addAreaName(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "addAreaName: bad argument #1 type (area name as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString name = QString::fromUtf8(lua_tostring(L, 1)).trimmed();
 
@@ -9308,8 +9138,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
                         "deleteArea: bad argument #1 type (area Id as number or area name as string\n"
                         "expected, got %s!)",
                         luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     bool result = false;
@@ -9342,8 +9171,7 @@ int TLuaInterpreter::deleteRoom(lua_State* L)
         }
     } else {
         lua_pushstring(L, "deleteRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     Host& host = getHostFromLua(L);
@@ -9356,23 +9184,20 @@ int TLuaInterpreter::setExit(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int from = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int to = lua_tointeger(L, 2);
 
     int dir = dirToNumber(L, 3);
     if (!dir) {
         lua_pushstring(L, "setExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     Host& host = getHostFromLua(L);
@@ -9386,8 +9211,7 @@ int TLuaInterpreter::getRoomCoordinates(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getRoomCoordinates: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
@@ -9411,8 +9235,7 @@ int TLuaInterpreter::getRoomArea(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getRoomArea: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
@@ -9431,8 +9254,7 @@ int TLuaInterpreter::roomExists(lua_State* L)
 {
     if (!lua_isnumber(L, 1) || !lua_isstring(L, 1)) {
         lua_pushstring(L, "roomExists: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
@@ -9451,8 +9273,7 @@ int TLuaInterpreter::addRoom(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "addRoom: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
@@ -9483,7 +9304,7 @@ int TLuaInterpreter::createRoomID(lua_State* L)
                             "createRoomID: bad argument #1 type (minimum room Id as number is optional,\n"
                             "got %s!)",
                             luaL_typename(L, 1));
-            lua_error(L);
+            return lua_error(L);
         } else {
             int minId = lua_tointeger(L, 1);
             if (minId < 1) {
@@ -9507,8 +9328,7 @@ int TLuaInterpreter::unHighlightRoom(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "unHighlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
@@ -9533,71 +9353,61 @@ int TLuaInterpreter::highlightRoom(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int fgr = lua_tointeger(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int fgg = lua_tointeger(L, 3);
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int fgb = lua_tointeger(L, 4);
 
     if (!lua_isnumber(L, 5)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int bgr = lua_tointeger(L, 5);
 
     if (!lua_isnumber(L, 6)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int bgg = lua_tointeger(L, 6);
 
     if (!lua_isnumber(L, 7)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int bgb = lua_tointeger(L, 7);
 
     if (!lua_isnumber(L, 8)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float radius = lua_tonumber(L, 8);
 
     if (!lua_isnumber(L, 9)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int alpha1 = lua_tointeger(L, 9);
 
     if (!lua_isnumber(L, 10)) {
         lua_pushstring(L, "highlightRoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int alpha2 = lua_tointeger(L, 10);
 
@@ -9634,109 +9444,94 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     int args = lua_gettop(L);
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float posx = lua_tonumber(L, 3);
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float posy = lua_tonumber(L, 4);
 
     if (!lua_isnumber(L, 5)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float posz = lua_tonumber(L, 5);
 
     if (!lua_isnumber(L, 6)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int fgr = lua_tointeger(L, 6);
 
     if (!lua_isnumber(L, 7)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int fgg = lua_tointeger(L, 7);
 
     if (!lua_isnumber(L, 8)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int fgb = lua_tointeger(L, 8);
 
     if (!lua_isnumber(L, 9)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int bgr = lua_tointeger(L, 9);
 
     if (!lua_isnumber(L, 10)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int bgg = lua_tointeger(L, 10);
 
     if (!lua_isnumber(L, 11)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int bgb = lua_tointeger(L, 11);
 
     if (args > 11) {
         if (!lua_isnumber(L, 12)) {
             lua_pushstring(L, "createMapLabel: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         zoom = lua_tonumber(L, 12);
 
         if (!lua_isnumber(L, 13)) {
             lua_pushstring(L, "createMapLabel: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         fontSize = lua_tointeger(L, 13);
 
         if (args > 13) {
             if (!lua_isboolean(L, 14)) {
                 lua_pushstring(L, "createMapLabel: wrong argument type");
-                lua_error(L);
-                return 1;
+                return lua_error(L);
             }
             showOnTop = lua_toboolean(L, 14);
         }
         if (args > 14) {
             if (!lua_isboolean(L, 15)) {
                 lua_pushstring(L, "createMapLabel: wrong argument type");
-                lua_error(L);
-                return 1;
+                return lua_error(L);
             }
             noScaling = lua_toboolean(L, 15);
         }
@@ -9754,8 +9549,7 @@ int TLuaInterpreter::setMapZoom(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setMapZoom: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     qreal zoom = lua_tonumber(L, 1);
 
@@ -9777,64 +9571,55 @@ int TLuaInterpreter::createMapImageLabel(lua_State* L)
     // N/U:     int args = lua_gettop(L);
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString text = lua_tostring(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float posx = lua_tonumber(L, 3);
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float posy = lua_tonumber(L, 4);
 
     if (!lua_isnumber(L, 5)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float posz = lua_tonumber(L, 5);
 
     if (!lua_isnumber(L, 6)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float width = lua_tonumber(L, 6);
 
     if (!lua_isnumber(L, 7)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float height = lua_tonumber(L, 7);
 
     if (!lua_isnumber(L, 8)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     float zoom = lua_tonumber(L, 8);
 
     if (!lua_isboolean(L, 9)) {
         lua_pushstring(L, "createMapImageLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool showOnTop = lua_toboolean(L, 9);
 
@@ -9856,8 +9641,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
     TRoom* pR;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setDoor: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
     pR = host.mpMap->mpRoomDB->getRoom(roomId);
@@ -9869,8 +9653,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setDoor: bad argument #2 type (door command as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString exitCmd = QString::fromUtf8(lua_tostring(L, 2));
     if (exitCmd.compare(QStringLiteral("n")) && exitCmd.compare(QStringLiteral("e")) && exitCmd.compare(QStringLiteral("s")) && exitCmd.compare(QStringLiteral("w"))
@@ -9928,8 +9711,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
                         "setDoor: bad argument #3 type (door type as number expected {0=\"none\",\n"
                         "1=\"open\", 2=\"closed\", 3=\"locked\"}, got %s!)",
                         luaL_typename(L, 3));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int doorStatus = lua_tointeger(L, 3);
     if (doorStatus < 0 || doorStatus > 3) {
@@ -9965,8 +9747,7 @@ int TLuaInterpreter::getDoors(lua_State* L)
     TRoom* pR;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getDoors: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     roomId = lua_tointeger(L, 1);
     pR = host.mpMap->mpRoomDB->getRoom(roomId);
@@ -10196,8 +9977,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
                                     tind,
                                     (tind == 1 ? "red" : (tind == 2 ? "green" : "blue")),
                                     luaL_typename(L, -1));
-                    lua_error(L);
-                    return 1;
+                    return lua_error(L);
                 }
 
                 qint64 component = lua_tonumber(L, -1);
@@ -10402,8 +10182,7 @@ int TLuaInterpreter::getExitWeights(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getExitWeights: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomID = lua_tointeger(L, 1);
 
@@ -10426,15 +10205,13 @@ int TLuaInterpreter::deleteMapLabel(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "deleteMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "deleteMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int labelID = lua_tointeger(L, 2);
 
@@ -10448,8 +10225,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getMapLabels: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
@@ -10473,16 +10249,14 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
     QString labelText;
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
     int labelId = -1;
     if (!lua_isstring(L, 2) && !lua_isnumber(L, 2)) {
         lua_pushstring(L, "getMapLabel: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     if (lua_isnumber(L, 2)) {
         labelId = lua_tointeger(L, 2);
@@ -10522,8 +10296,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
                 lua_settable(L, -3);
             } else {
                 lua_pushstring(L, "getMapLabel: labelId doesn't exist");
-                lua_error(L);
-                return 1;
+                return lua_error(L);
             }
         } else {
             QMapIterator<int, TMapLabel> it(host.mpMap->mapLabels[area]);
@@ -10572,22 +10345,19 @@ int TLuaInterpreter::addSpecialExit(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "addSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id_from = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "addSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id_to = lua_tointeger(L, 2);
 
     if (!lua_isstring(L, 3)) {
         lua_pushstring(L, "addSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString dir = lua_tostring(L, 3);
 
@@ -10606,15 +10376,13 @@ int TLuaInterpreter::removeSpecialExit(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "removeSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "removeSpecialExit: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString dir = lua_tostring(L, 2);
 
@@ -10638,8 +10406,7 @@ int TLuaInterpreter::clearRoomUserData(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "clearRoomUserData: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
 
@@ -10675,15 +10442,13 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
                         "clearRoomUserDataItem: bad argument #1 type (room id as number expected,\n"
                         "got %s!)",
                         luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, R"(clearRoomUserDataItem: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString key = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -10721,8 +10486,7 @@ int TLuaInterpreter::clearAreaUserData(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "clearAreaUserData: bad argument #1 type (area id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int areaId = lua_tointeger(L, 1);
 
@@ -10754,15 +10518,13 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "clearAreaUserDataItem: bad argument #1 type (area id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int areaId = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, R"(clearAreaUserDataItem: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString key = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -10814,8 +10576,7 @@ int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, R"(clearMapUserDataItem: bad argument #1 type ("key" as string expected, got %s!))", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString key = QString::fromUtf8(lua_tostring(L, 1));
     if (key.isEmpty()) {
@@ -10832,8 +10593,7 @@ int TLuaInterpreter::clearSpecialExits(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "clearSpecialExits: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id_from = lua_tointeger(L, 1);
 
@@ -10850,8 +10610,7 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getSpecialExits: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id_from = lua_tointeger(L, 1);
 
@@ -10894,8 +10653,7 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getSpecialExitsSwap: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id_from = lua_tointeger(L, 1);
 
@@ -10936,8 +10694,7 @@ int TLuaInterpreter::getRoomEnv(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getRoomEnv: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomID = lua_tointeger(L, 1);
 
@@ -10962,15 +10719,13 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getRoomUserData: bad argument #1 (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "getRoomUserData: bad argument #2 (key as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString key = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -10981,8 +10736,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
                             "getRoomUserData: bad argument #3 (enableFullErrorReporting as boolean {default\n"
                             "= false} is optional, got %s!)",
                             luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         isBackwardCompatibilityRequired = !lua_toboolean(L, 3);
     }
@@ -11019,16 +10773,14 @@ int TLuaInterpreter::getAreaUserData(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getAreaUserData: bad argument #1 (area id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int areaId = lua_tointeger(L, 1);
 
     QString key;
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "getAreaUserData: bad argument #2 (key as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     key = QString::fromUtf8(lua_tostring(L, 2));
     if (key.isEmpty()) {
@@ -11078,8 +10830,7 @@ int TLuaInterpreter::getMapUserData(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getMapUserData: bad argument #1 (key as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString key = QString::fromUtf8(lua_tostring(L, 1));
 
@@ -11105,23 +10856,20 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setRoomUserData: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, R"(setRoomUserData: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString key = QString::fromUtf8(lua_tostring(L, 2));
     // Ideally should reject empty keys but this could break existing scripts so we can't
 
     if (!lua_isstring(L, 3)) {
         lua_pushfstring(L, R"(setRoomUserData: bad argument #3 type ("value" as string expected, got %s!))", luaL_typename(L, 3));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString value = QString::fromUtf8(lua_tostring(L, 3));
 
@@ -11142,16 +10890,14 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setAreaUserData: bad argument #1 type (area id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int areaId = lua_tointeger(L, 1);
 
     QString key;
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, R"(setAreaUserData: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     key = QString::fromUtf8(lua_tostring(L, 2));
     if (key.isEmpty()) {
@@ -11164,8 +10910,7 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
 
     if (!lua_isstring(L, 3)) {
         lua_pushfstring(L, R"(setAreaUserData: bad argument #3 type ("value" as string expected, got %s!))", luaL_typename(L, 3));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString value = QString::fromUtf8(lua_tostring(L, 3));
 
@@ -11201,8 +10946,7 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
     QString key;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, R"(setMapUserData: bad argument #1 type ("key" as string expected, got %s!))", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     key = QString::fromUtf8(lua_tostring(L, 1));
     if (key.isEmpty()) {
@@ -11213,8 +10957,7 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, R"(setMapUserData: bad argument #2 type ("value" as string expected, got %s!))", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString value = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -11235,8 +10978,7 @@ int TLuaInterpreter::getRoomUserDataKeys(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getRoomUserDataKeys: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
 
@@ -11270,8 +11012,7 @@ int TLuaInterpreter::getAllRoomUserData(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getAllRoomUserData: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int roomId = lua_tointeger(L, 1);
 
@@ -11307,8 +11048,7 @@ int TLuaInterpreter::getAllAreaUserData(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "getAllAreaUserData: bad argument #1 type (area id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int areaId = lua_tointeger(L, 1);
 
@@ -11362,15 +11102,13 @@ int TLuaInterpreter::downloadFile(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "downloadFile: bad argument #1 type (local filename as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString localFile = QString::fromUtf8(lua_tostring(L, 1));
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "downloadFile: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString urlString = QString::fromUtf8(lua_tostring(L, 2));
 
@@ -11414,8 +11152,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
     int id;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "setRoomArea: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     id = lua_tointeger(L, 1);
     if (!host.mpMap->mpRoomDB->getRoomIDList().contains(id)) {
@@ -11459,8 +11196,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
                         "setRoomArea: bad argument #2 type (area Id as number or area name as string\n"
                         "expected, got %s!)",
                         luaL_typename(L, 2));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     // Can set the room to an area which does not have a TArea instance but does
@@ -11489,8 +11225,7 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
     //will reset the room area to our void area
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "resetRoomArea: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int id = lua_tointeger(L, 1);
 
@@ -11586,29 +11321,25 @@ int TLuaInterpreter::getRoomsByPosition(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "getRoomsByPosition: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "getRoomsByPosition: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int x = lua_tointeger(L, 2);
 
     if (!lua_isnumber(L, 3)) {
         lua_pushstring(L, "getRoomsByPosition: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int y = lua_tointeger(L, 3);
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "getRoomsByPosition: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int z = lua_tointeger(L, 4);
 
@@ -11661,15 +11392,13 @@ int TLuaInterpreter::setGridMode(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "setGridMode: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int area = lua_tointeger(L, 1);
 
     if (!lua_isboolean(L, 2)) {
         lua_pushstring(L, "setGridMode: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     bool gridMode = lua_toboolean(L, 2);
 
@@ -11869,8 +11598,7 @@ int TLuaInterpreter::insertLink(lua_State* L)
     }
     if (sL.size() < 4) {
         lua_pushstring(L, "insertLink: wrong number of params or wrong type of params");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     QString _name(sL[0]);
@@ -11904,24 +11632,21 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     if (n >= 4) {
         if (!lua_isstring(L, s)) {
             lua_pushstring(L, "insertPopup: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, s);
         s++;
     }
     if (!lua_isstring(L, s)) {
         lua_pushstring(L, "insertPopup: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString txt = lua_tostring(L, s);
     s++;
 
     if (!lua_istable(L, s)) {
         lua_pushstring(L, "insertPopup: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     lua_pushnil(L);
     while (lua_next(L, s) != 0) {
@@ -11937,8 +11662,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
 
     if (!lua_istable(L, s)) {
         lua_pushstring(L, "insertPopup: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     lua_pushnil(L);
     while (lua_next(L, s) != 0) {
@@ -11959,8 +11683,7 @@ int TLuaInterpreter::insertPopup(lua_State* L)
     Host& host = getHostFromLua(L);
     if (_commandList.size() != _hintList.size()) {
         lua_pushstring(L, "Error: command list size and hint list size do not match cannot create popup");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     if (isMain(windowName)) {
@@ -12013,8 +11736,7 @@ int TLuaInterpreter::insertHTML(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "insertHTML: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString sendText = lua_tostring(L, 1);
 
@@ -12028,8 +11750,7 @@ int TLuaInterpreter::addSupportedTelnetOption(lua_State* L)
 {
     if (!lua_isnumber(L, 1)) {
         lua_pushstring(L, "addSupportedTelnetOption: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int option = lua_tointeger(L, 1);
 
@@ -12268,8 +11989,7 @@ int TLuaInterpreter::setMergeTables(lua_State* L)
     for (int i = 1; i <= n; i++) {
         if (!lua_isstring(L, i)) {
             lua_pushfstring(L, "setMergeTables: bad argument #%d (string expected, got %s)", i, luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         modulesList << QString(lua_tostring(L, i));
     }
@@ -12313,8 +12033,7 @@ int TLuaInterpreter::openUrl(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "openUrl: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString url = lua_tostring(L, 1);
 
@@ -12327,15 +12046,13 @@ int TLuaInterpreter::setLabelStyleSheet(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushstring(L, "setLabelStyleSheet: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     std::string label = lua_tostring(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "setLabelStyleSheet: wrong argument type");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     std::string markup = lua_tostring(L, 2);
 
@@ -12418,8 +12135,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         qWarning() << "TLuaInterpreter::getMudletVersion(): ERROR: Version data not correctly set on compilation,\n"
                    << "   is the VERSION value in the project file present?";
         lua_pushstring(L, "getMudletVersion: sorry, version information not available.");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     bool ok = true;
@@ -12439,8 +12155,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         qWarning("TLuaInterpreter::getMudletVersion(): ERROR: Version data not correctly parsed,\n"
                  "   was the VERSION value in the project file correct at compilation time?");
         lua_pushstring(L, "getMudletVersion: sorry, version information corrupted.");
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     int n = lua_gettop(L);
@@ -12448,7 +12163,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushstring(L, "getMudletVersion: wrong argument type.");
-            lua_error(L);
+            return lua_error(L);
         } else {
             QString tidiedWhat = QString(lua_tostring(L, 1)).toLower().trimmed();
             if (tidiedWhat.contains("major")) {
@@ -12483,7 +12198,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
                 lua_pushstring(L,
                                "getMudletVersion: takes one (optional) argument:\n"
                                "   \"major\", \"minor\", \"revision\", \"build\", \"string\" or \"table\".");
-                lua_error(L);
+                return lua_error(L);
             }
         }
     } else if (n == 0) {
@@ -12504,7 +12219,7 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         lua_pushstring(L,
                        "getMudletVersion: only takes one (optional) argument:\n"
                        "   \"major\", \"minor\", \"revision\", \"build\", \"string\" or \"table\".");
-        lua_error(L);
+        return lua_error(L);
     }
     return 1;
 }
@@ -13143,8 +12858,7 @@ int TLuaInterpreter::appendBuffer(lua_State* L)
     if (n > 0) {
         if (!lua_isstring(L, 1)) {
             lua_pushstring(L, "appendBuffer: wrong argument type");
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = lua_tostring(L, 1);
     }
@@ -13403,7 +13117,7 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
                         "setDefaultAreaVisible: bad argument #1 type (isToShowDefaultArea as boolean\n"
                         "expected, got %s!)",
                         luaL_typename(L, 1));
-        lua_error(L);
+        return lua_error(L);
     } else {
         bool isToShowDefaultArea = lua_toboolean(L, 1);
         if (host.mpMap->mpMapper) {
@@ -13843,8 +13557,7 @@ int TLuaInterpreter::ttsSpeak(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "ttsSpeak: bad argument #%1 type (text to say as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     QString textToSay;
@@ -13895,8 +13608,7 @@ int TLuaInterpreter::ttsSetRate(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "ttsSetRate: bad argument #1 type (rate as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double rate = lua_tonumber(L, 1);
 
@@ -13927,8 +13639,7 @@ int TLuaInterpreter::ttsSetPitch(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "ttsSetPitch: bad argument #1 type (pitch as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double pitch = lua_tonumber(L, 1);
 
@@ -13959,8 +13670,7 @@ int TLuaInterpreter::ttsSetVolume(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "ttsSetVolume: bad argument #1 type (volume as number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     double volume = lua_tonumber(L, 1);
 
@@ -14045,8 +13755,7 @@ int TLuaInterpreter::ttsSetVoiceByName(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "ttsSetVoiceByName: bad argument #1 type (voice as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     QString nextVoice = QString(lua_tostring(L, 1));
 
@@ -14078,8 +13787,7 @@ int TLuaInterpreter::ttsSetVoiceByIndex(lua_State* L)
 
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "ttsSetVoiceByIndex: bad argument #1 type (voice as index number expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
     int index = lua_tonumber(L, 1);
 
@@ -14155,8 +13863,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
 
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "ttsQueueText: bad argument #1 type (input as string expected, got %s!)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     }
 
     QString inputText = lua_tostring(L, 1);
@@ -14165,8 +13872,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
     if (lua_gettop(L) > 1) {
         if (!lua_isnumber(L, 2)) {
             lua_pushfstring(L, "ttsQueueText: bad argument #2 type (index as number expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
 
         index = lua_tonumber(L, 2);
@@ -14211,8 +13917,7 @@ int TLuaInterpreter::ttsGetQueue(lua_State* L)
     if (lua_gettop(L) > 0) {
         if (!lua_isnumber(L, 1)) {
             lua_pushfstring(L, "ttsGetQueue: bad argument #1 type (index as number expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
 
         int index = lua_tonumber(L, 1);
@@ -14266,8 +13971,7 @@ int TLuaInterpreter::ttsClearQueue(lua_State* L)
     if (lua_gettop(L) > 0) {
         if (!lua_isnumber(L, 1)) {
             lua_pushfstring(L, "ttsClearQueue: bad argument #1 type (index as number expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
 
         int index = lua_tonumber(L, 1);
@@ -17812,8 +17516,7 @@ int TLuaInterpreter::alert(lua_State* L)
     if (lua_gettop(L) > 0) {
         if (!lua_isnumber(L, 1)) {
             lua_pushfstring(L, "alert: bad argument #1 type (alert duration in seconds as number expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         luaAlertDuration = lua_tonumber(L, 1);
 
@@ -17856,8 +17559,7 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
         windowName = QStringLiteral("main");
     } else if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getColumnCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
@@ -17889,8 +17591,7 @@ int TLuaInterpreter::getRowCount(lua_State* L)
         windowName = QStringLiteral("main");
     } else if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "getRowCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
-        lua_error(L);
-        return 1;
+        return lua_error(L);
     } else {
         windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
@@ -17982,8 +17683,7 @@ int TLuaInterpreter::enableClickthrough(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "enableClickthrough: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
@@ -18002,8 +17702,7 @@ int TLuaInterpreter::disableClickthrough(lua_State* L)
     if (n == 1) {
         if (!lua_isstring(L, 1)) {
             lua_pushfstring(L, "disableClickthrough: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            lua_error(L);
-            return 1;
+            return lua_error(L);
         }
         windowName = QString::fromUtf8(lua_tostring(L, 1));
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -429,7 +429,7 @@ QString TLuaInterpreter::dirToString(lua_State* L, int position)
         }
 
     } else if (lua_isstring(L, position)) {
-        QString direction(QString::fromUtf8(lua_tostring(L, position)));
+        QString direction{lua_tostring(L, position)};
         if (!direction.compare(QLatin1String("n"), Qt::CaseInsensitive) || !direction.compare(QLatin1String("north"), Qt::CaseInsensitive)) {
             return QLatin1String("n");
         } else if (!direction.compare(QLatin1String("e"), Qt::CaseInsensitive) || !direction.compare(QLatin1String("east"), Qt::CaseInsensitive)) {
@@ -543,7 +543,7 @@ int TLuaInterpreter::raiseEvent(lua_State* L)
             event.mArgumentTypeList.prepend(ARGUMENT_TYPE_NUMBER);
             lua_pop(L, 1);
         } else if (lua_isstring(L, -1)) {
-            event.mArgumentList.prepend(QString::fromUtf8(lua_tostring(L, -1)));
+            event.mArgumentList.prepend(lua_tostring(L, -1));
             event.mArgumentTypeList.prepend(ARGUMENT_TYPE_STRING);
             lua_pop(L, 1);
         } else if (lua_isboolean(L, -1)) {
@@ -618,7 +618,7 @@ int TLuaInterpreter::raiseGlobalEvent(lua_State* L)
             event.mArgumentList.append(QString::number(lua_tonumber(L, i)));
             event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
         } else if (lua_isstring(L, i)) {
-            event.mArgumentList.append(QString::fromUtf8(lua_tostring(L, i)));
+            event.mArgumentList.append(lua_tostring(L, i));
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         } else if (lua_isboolean(L, i)) {
             event.mArgumentList.append(QString::number(lua_toboolean(L, i)));
@@ -666,7 +666,7 @@ int TLuaInterpreter::selectString(lua_State* L)
             return lua_error(L);
         }
         // We cannot yet properly handle non-ASCII windows names but we will eventually!
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
         s++;
     }
 
@@ -674,7 +674,7 @@ int TLuaInterpreter::selectString(lua_State* L)
         lua_pushfstring(L, "selectString: bad argument #%d type (text to select as string expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
-    QString searchText = QString::fromUtf8(lua_tostring(L, s));
+    QString searchText{lua_tostring(L, s)};
     // CHECK: Do we need to qualify this for a non-blank string?
     s++;
 
@@ -1146,7 +1146,7 @@ int TLuaInterpreter::getLines(lua_State* L)
             lua_pushfstring(L, "getLines: bad argument #%d type (mini console, user window or buffer name as string expected {may be omitted for the \"main\" console}, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isnumber(L, ++s)) {
@@ -1191,7 +1191,7 @@ int TLuaInterpreter::loadRawFile(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString replayFileName = QString::fromUtf8(lua_tostring(L, 1));
+    QString replayFileName{lua_tostring(L, 1)};
     if (replayFileName.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L, "a blank string is not a valid replay file name");
@@ -1220,7 +1220,7 @@ int TLuaInterpreter::setProfileIcon(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString iconPath = QString::fromUtf8(lua_tostring(L, 1));
+    QString iconPath{lua_tostring(L, 1)};
     if (iconPath.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L, "a blank string is not a valid icon file location");
@@ -1289,7 +1289,7 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
         lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #1 type (miniconsole name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString windowName = QString::fromUtf8(lua_tostring(L, 1));
+    QString windowName{lua_tostring(L, 1)};
 
     if (!lua_isnumber(L, 2)) {
         lua_pushfstring(L, "setMiniConsoleFontSize: bad argument #2 type (font size as number expected, got %s!)", luaL_typename(L, 2));
@@ -1320,7 +1320,7 @@ int TLuaInterpreter::setConsoleBackgroundImage(lua_State* L)
             lua_pushfstring(L, "setConsoleBackgroundImage: bad argument #1 type (console name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
         counter++;
     }
 
@@ -1328,7 +1328,7 @@ int TLuaInterpreter::setConsoleBackgroundImage(lua_State* L)
         lua_pushfstring(L, "setConsoleBackgroundImage: bad argument #%d type (image path as string expected, got %s!)", counter, luaL_typename(L, counter));
         return lua_error(L);
     }
-    imgPath = QString::fromUtf8(lua_tostring(L, counter));
+    imgPath = lua_tostring(L, counter);
     counter++;
 
     if (n > 2 || (counter == 2 && n > 1)) {
@@ -1367,7 +1367,7 @@ int TLuaInterpreter::resetConsoleBackgroundImage(lua_State* L)
             lua_pushfstring(L, "resetConsoleBackgroundImage: bad argument #1 type (console name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
     }
 
     Host* host = &getHostFromLua(L);
@@ -1394,7 +1394,7 @@ int TLuaInterpreter::getLineNumber(lua_State* L)
             lua_pushfstring(L, "getLineNumber: bad argument #%d type (window name as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (isMain(windowName)) {
@@ -1555,27 +1555,27 @@ int TLuaInterpreter::addMapEvent(lua_State* L)
         lua_pushfstring(L, "addMapEvent: bad argument #1 type (uniquename as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString uniqueName = QString::fromUtf8(lua_tostring(L, 1));
+    QString uniqueName{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "addMapEvent: bad argument #2 type (event name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    actionInfo << QString::fromUtf8(lua_tostring(L, 2));
+    actionInfo << lua_tostring(L, 2);
 
     if (!lua_isstring(L, 3)) {
         actionInfo << QString();
     } else {
-        actionInfo << QString::fromUtf8(lua_tostring(L, 3));
+        actionInfo << lua_tostring(L, 3);
     }
     if (!lua_isstring(L, 4)) {
         actionInfo << uniqueName;
     } else {
-        actionInfo << QString::fromUtf8(lua_tostring(L, 4));
+        actionInfo << lua_tostring(L, 4);
     }
     //variable number of arguments
     for (int i = 5; i <= lua_gettop(L); i++) {
-        actionInfo << QString::fromUtf8(lua_tostring(L, i));
+        actionInfo << lua_tostring(L, i);
     }
     qDebug() << actionInfo;
     Host& host = getHostFromLua(L);
@@ -1791,7 +1791,7 @@ int TLuaInterpreter::feedTriggers(lua_State* L)
             lua_pushboolean(L, true);
             return 1;
         }
-        auto dataQString = QString::fromUtf8(data);
+        QString dataQString{data};
         // else
             // We need to transcode it from UTF-8 into the current Game Server
             // encoding - this can fail if it includes any characters (as UTF-8)
@@ -1927,7 +1927,7 @@ int TLuaInterpreter::getColumnNumber(lua_State* L)
             lua_pushfstring(L, "getColumnNumber: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
 
         int result = 0;
         if (windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
@@ -1970,7 +1970,7 @@ int TLuaInterpreter::getStopWatchTime(lua_State* L)
         }
 
     } else {
-        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        QString name{lua_tostring(L, 1)};
         // Using an empty string will return the first unnamed stopwatch:
         watchId = host.findStopWatchId(name);
         if (!watchId) {
@@ -2009,7 +2009,7 @@ int TLuaInterpreter::createStopWatch(lua_State* L)
             autoStart = lua_toboolean(L, s);
         } else if (lua_type(L, s) == LUA_TSTRING) {
             autoStart = false;
-            name = QString::fromUtf8(lua_tostring(L, 1));
+            name = lua_tostring(L, 1);
         } else if (lua_type(L, s) == LUA_TNIL) {
             ; // fallthrough for compatibility with old-style stopwatches in case createStopWatch(nil) is passed
             // note that 'nil' will still count towards the stack's gettop amount
@@ -2065,7 +2065,7 @@ int TLuaInterpreter::stopStopWatch(lua_State* L)
         }
 
     } else {
-        QString name = QString::fromUtf8(lua_tostring(L, 1));
+        QString name{lua_tostring(L, 1)};
         QPair<bool, QString> result = host.stopStopWatch(name);
         if (!result.first) {
             lua_pushnil(L);
@@ -2128,7 +2128,7 @@ int TLuaInterpreter::startStopWatch(lua_State* L)
         return 1;
     }
 
-    QPair<bool, QString> result = host.startStopWatch(QString::fromUtf8(lua_tostring(L, 1)));
+    QPair<bool, QString> result = host.startStopWatch(lua_tostring(L, 1));
     if (!result.first) {
         lua_pushnil(L);
         lua_pushstring(L, result.second.toUtf8().constData());
@@ -2160,7 +2160,7 @@ int TLuaInterpreter::resetStopWatch(lua_State* L)
         return 1;
     }
 
-    QPair<bool, QString> result = host.resetStopWatch(QString::fromUtf8(lua_tostring(L, 1)));
+    QPair<bool, QString> result = host.resetStopWatch(lua_tostring(L, 1));
     if (!result.first) {
         lua_pushnil(L);
         lua_pushstring(L, result.second.toUtf8().constData());
@@ -2180,7 +2180,7 @@ std::tuple<bool, int> TLuaInterpreter::getWatchId(lua_State* L, Host& h)
         return std::make_tuple(true, static_cast<int>(lua_tointeger(L, 1)));
     }
 
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
     // Using an empty string will return the first unnamed stopwatch:
     int watchId = h.findStopWatchId(name);
     if (!watchId) {
@@ -2299,14 +2299,14 @@ int TLuaInterpreter::setStopWatchName(lua_State* L)
         watchId = static_cast<int>(lua_tointeger(L, 1));
     } else {
         // Using an empty string will return the first unnamed stopwatch:
-        currentName = QString::fromUtf8(lua_tostring(L, 1));
+        currentName = lua_tostring(L, 1);
     }
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setStopWatchName: bad argument #2 type (stopwatch new name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString newName = QString::fromUtf8(lua_tostring(L, 2));
+    QString newName{lua_tostring(L, 2)};
 
     QPair<bool, QString> result;
     if (currentName.isNull()) {
@@ -2437,7 +2437,7 @@ int TLuaInterpreter::selectSection(lua_State* L)
             lua_pushfstring(L, "selectSection: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
         s++;
     }
     if (!lua_isnumber(L, s)) {
@@ -2480,7 +2480,7 @@ int TLuaInterpreter::getSelection(lua_State* L)
             lua_pushfstring(L, "getSelection: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
     }
     if (isMain(windowName)) {
         std::tie(valid, text, start, length) = host.mpConsole->getSelection();
@@ -2719,7 +2719,7 @@ int TLuaInterpreter::saveMap(lua_State* L)
                             luaL_typename(L, 1));
             return lua_error(L);
         }
-        location = QString::fromUtf8(lua_tostring(L, 1));
+        location = lua_tostring(L, 1);
         if (lua_gettop(L) > 1) {
             if (!lua_isnumber(L, 2)) {
                 lua_pushfstring(L,
@@ -3000,7 +3000,7 @@ int TLuaInterpreter::loadMap(lua_State* L)
                             luaL_typename(L, 1));
             return lua_error(L);
         }
-        location = QString::fromUtf8(lua_tostring(L, 1));
+        location = lua_tostring(L, 1);
     }
 
     bool isOk = false;
@@ -3063,7 +3063,7 @@ int TLuaInterpreter::enableKey(lua_State* L)
         lua_pushfstring(L, "enableKey: bad argument #1 type (key name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString keyName = QString::fromUtf8(lua_tostring(L, 1));
+    QString keyName{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     bool error = host.getKeyUnit()->enableKey(keyName);
@@ -3078,7 +3078,7 @@ int TLuaInterpreter::disableKey(lua_State* L)
         lua_pushfstring(L, "disableKey: bad argument #1 type (key name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString keyName = QString::fromUtf8(lua_tostring(L, 1));
+    QString keyName{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     bool error = host.getKeyUnit()->disableKey(keyName);
@@ -3093,7 +3093,7 @@ int TLuaInterpreter::killKey(lua_State* L)
         lua_pushfstring(L, "killKey: bad argument #1 type (key name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString keyName = QString::fromUtf8(lua_tostring(L, 1));
+    QString keyName{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     bool error = host.getKeyUnit()->killKey(keyName);
@@ -3182,7 +3182,7 @@ int TLuaInterpreter::enableScript(lua_State* L)
         lua_pushfstring(L, "enableScript: bad argument #1 type (script name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
@@ -3210,7 +3210,7 @@ int TLuaInterpreter::disableScript(lua_State* L)
         lua_pushfstring(L, "disableScript: bad argument #1 type (script name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
@@ -3276,7 +3276,7 @@ int TLuaInterpreter::remainingTime(lua_State* L)
         timerId = lua_tointeger(L, 1);
         result = host.getTimerUnit()->remainingTime(static_cast<int>(timerId));
     } else {
-        timerName = QString::fromUtf8(lua_tostring(L, 1));
+        timerName = lua_tostring(L, 1);
         result = host.getTimerUnit()->remainingTime(timerName);
     }
 
@@ -3330,7 +3330,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
 
     QString saveToDir;
     if (lua_isstring(L, 1)) {
-        saveToDir = QString::fromUtf8(lua_tostring(L, 1));
+        saveToDir = lua_tostring(L, 1);
     }
 
     std::tuple<bool, QString, QString> result = host.saveProfile(saveToDir);
@@ -3358,14 +3358,14 @@ int TLuaInterpreter::setFont(lua_State* L)
             lua_pushfstring(L, "setFont: bad argument #%d type for the optional window name - expected string, got %s!", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isstring(L, ++s)) {
         lua_pushfstring(L, "setFont: bad argument #%d type (name as string expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
-    QString font = QString::fromUtf8(lua_tostring(L, s));
+    QString font{lua_tostring(L, s)};
 
 #if defined(Q_OS_LINUX)
     // On Linux ensure that emojis are displayed in colour even if this font
@@ -3417,7 +3417,7 @@ int TLuaInterpreter::getFont(lua_State* L)
             lua_pushfstring(L, "getFont: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
 
         if (isMain(windowName)) {
             font = pHost->mpConsole->mUpperPane->fontInfo().family();
@@ -3454,7 +3454,7 @@ int TLuaInterpreter::setFontSize(lua_State* L)
                             luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     int size;
@@ -3510,7 +3510,7 @@ int TLuaInterpreter::getFontSize(lua_State* L)
             lua_pushfstring(L, "getFontSize: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
 
         if (isMain(windowName)) {
             rval = pHost->getDisplayFont().pointSize();
@@ -3537,7 +3537,7 @@ int TLuaInterpreter::openUserWindow(lua_State* L)
         lua_pushfstring(L, "openUserWindow:  bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     bool loadLayout = true, autoDock = true;
     if (n > 1) {
@@ -3561,7 +3561,7 @@ int TLuaInterpreter::openUserWindow(lua_State* L)
             lua_pushfstring(L, "openUserWindow: bad argument #4 type (area as string expected, got %s!)", luaL_typename(L, 4));
             return lua_error(L);
         }
-        area = QString::fromUtf8(lua_tostring(L, 4));
+        area = lua_tostring(L, 4);
     }
 
     Host& host = getHostFromLua(L);
@@ -3583,7 +3583,7 @@ int TLuaInterpreter::setUserWindowTitle(lua_State* L)
         lua_pushfstring(L, "setUserWindowTitle: bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     QString title;
     if (lua_gettop(L) > 1) {
@@ -3591,7 +3591,7 @@ int TLuaInterpreter::setUserWindowTitle(lua_State* L)
             lua_pushfstring(L, "setUserWindowTitle: bad argument #2 type (title as string is optional, got %s!)", luaL_typename(L, 2));
             return lua_error(L);
         }
-        title = QString::fromUtf8(lua_tostring(L, 2));
+        title = lua_tostring(L, 2);
     }
 
     Host& host = getHostFromLua(L);
@@ -3614,7 +3614,7 @@ int TLuaInterpreter::setMapWindowTitle(lua_State* L)
             lua_pushfstring(L, "setMapWindowTitle: bad argument #1 type (title as string is optional, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        title = QString::fromUtf8(lua_tostring(L, 1));
+        title = lua_tostring(L, 1);
     }
 
     Host& host = getHostFromLua(L);
@@ -3746,11 +3746,11 @@ int TLuaInterpreter::createLabel(lua_State* L)
         return lua_error(L);
     }
     if ((lua_type(L, 1) == LUA_TSTRING) && (lua_type(L, 2) == LUA_TSTRING)) {
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
-        labelName = QString::fromUtf8(lua_tostring(L, 2));
+        windowName = lua_tostring(L, 1);
+        labelName = lua_tostring(L, 2);
         createLabelUserWindow(L, windowName, labelName);
     } else if ((lua_type(L, 1) == LUA_TSTRING) && (lua_type(L, 2) == LUA_TNUMBER)) {
-        labelName = QString::fromUtf8(lua_tostring(L, 1));
+        labelName = lua_tostring(L, 1);
         createLabelMainWindow(L, labelName);
     } else {
         lua_pushfstring(L, "createLabel: bad argument #2 type (label name as string or label x-coordinate as number expected, got %s!)", luaL_typename(L, 2));
@@ -3897,7 +3897,7 @@ int TLuaInterpreter::deleteLabel(lua_State* L)
         lua_pushfstring(L, "deleteLabel: bad argument #1 type (label name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString labelName{QString::fromUtf8(lua_tostring(L, 1))};
+    QString labelName{lua_tostring(L, 1)};
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.mpConsole->deleteLabel(labelName); !success) {
         lua_pushnil(L);
@@ -3924,8 +3924,8 @@ int TLuaInterpreter::setLabelToolTip(lua_State* L)
         return lua_error(L);
     }
 
-    QString labelName{QString::fromUtf8(lua_tostring(L, 1))};
-    QString labelToolTip{QString::fromUtf8(lua_tostring(L, 2))};
+    QString labelName{lua_tostring(L, 1)};
+    QString labelToolTip{lua_tostring(L, 2)};
     double duration = lua_tonumber(L, 3);
     Host& host = getHostFromLua(L);
 
@@ -3950,7 +3950,7 @@ int TLuaInterpreter::setLabelCursor(lua_State* L)
         return lua_error(L);
     }
 
-    QString labelName{QString::fromUtf8(lua_tostring(L, 1))};
+    QString labelName{lua_tostring(L, 1)};
     int labelCursor = lua_tonumber(L, 2);
     Host& host = getHostFromLua(L);
 
@@ -3990,8 +3990,8 @@ int TLuaInterpreter::setLabelCustomCursor(lua_State* L)
         hotY = lua_tonumber(L, 4);
     }
 
-    QString labelName{QString::fromUtf8(lua_tostring(L, 1))};
-    QString pixmapLocation{QString::fromUtf8(lua_tostring(L, 2))};
+    QString labelName{lua_tostring(L, 1)};
+    QString pixmapLocation{lua_tostring(L, 2)};
     Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setLabelCustomCursor(labelName, pixmapLocation, hotX, hotY); !success) {
@@ -4074,7 +4074,7 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
         return lua_error(L);
     }
     if (n > 5 && lua_type(L, 1) == LUA_TSTRING) {
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
         counter++;
         if (isMain(windowName)) {
             // createCommandLine only accepts the empty name as the main window
@@ -4086,7 +4086,7 @@ int TLuaInterpreter::createCommandLine(lua_State* L)
         lua_pushfstring(L, "createCommandLine: bad argument #%d type (commandLine name as string expected, got %s!)", counter, luaL_typename(L, counter));
         return lua_error(L);
     }
-    QString commandLineName = QString::fromUtf8(lua_tostring(L, counter));
+    QString commandLineName{lua_tostring(L, counter)};
     counter++;
 
     if (!lua_isnumber(L, counter)) {
@@ -4456,13 +4456,13 @@ int TLuaInterpreter::setWindow(lua_State* L)
         lua_pushfstring(L, "setWindow: bad argument #1 type (parent windowname as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString windowname = QString::fromUtf8(lua_tostring(L, 1));
+    QString windowname{lua_tostring(L, 1)};
 
     if (lua_type(L, 2) != LUA_TSTRING) {
         lua_pushfstring(L, "setWindow: bad argument #2 type (element name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 2));
+    QString name{lua_tostring(L, 2)};
 
     if (n > 2) {
         if (!lua_isnumber(L, 3)) {
@@ -4504,7 +4504,7 @@ int TLuaInterpreter::openMapWidget(lua_State* L)
             lua_pushfstring(L, "openMapWidget: bad argument #1 type (area as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        area = QString::fromUtf8(lua_tostring(L, 1));
+        area = lua_tostring(L, 1);
     }
     if (n > 1) {
         area = QStringLiteral("f");
@@ -4589,7 +4589,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
 
     int s = 1;
     if (lua_isstring(L, s) && !lua_isnumber(L, s)) {
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
 
         if (!lua_isnumber(L, ++s)) {
             lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (red value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));
@@ -4692,7 +4692,7 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
             return lua_error(L);
         }
 
-        auto font = QFont(QString::fromUtf8(lua_tostring(L, 2)), static_cast<int> (lua_tonumber(L, 1)), QFont::Normal);
+        auto font = QFont(lua_tostring(L, 2), static_cast<int> (lua_tonumber(L, 1)), QFont::Normal);
         auto fontMetrics = QFontMetrics(font);
         size = QSize(fontMetrics.averageCharWidth(), fontMetrics.height());
 
@@ -4712,7 +4712,7 @@ int TLuaInterpreter::calcFontSize(lua_State* L)
         lua_pushfstring(L, "calcFontSize: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    windowName = QString::fromUtf8(lua_tostring(L, 1));
+    windowName = lua_tostring(L, 1);
     size = mudlet::self()->calcFontSize(pHost, windowName);
 
     if (size.width() <= -1) {
@@ -4805,7 +4805,7 @@ int TLuaInterpreter::getImageSize(lua_State* L)
         lua_pushfstring(L, "getImageSize: bad argument #1 type (image location as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString imageLocation = QString::fromUtf8(lua_tostring(L, 1));
+    QString imageLocation{lua_tostring(L, 1)};
     if (imageLocation.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L, "bad argument #1 value (image location cannot be an empty string)");
@@ -4830,7 +4830,7 @@ int TLuaInterpreter::setCmdLineAction(lua_State* L){
         lua_pushfstring(L, "setCmdLineAction: bad argument #1 type (command line name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
     if (name.isEmpty()) {
         lua_pushnil(L);
         lua_pushfstring(L, "setCmdAction: bad argument #1 value (command line name cannot be an empty string.)");
@@ -4865,7 +4865,7 @@ int TLuaInterpreter::resetCmdLineAction(lua_State* L){
         lua_pushfstring(L, "resetCmdLineAction: bad argument #1 type (command line name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
     if (name.isEmpty()) {
         lua_pushnil(L);
         lua_pushfstring(L, "resetCmdAction: bad argument #1 value (command line name cannot be an empty string.)");
@@ -4895,14 +4895,14 @@ int TLuaInterpreter::setCmdLineStyleSheet(lua_State* L)
             lua_pushfstring(L, "setCmdLineStyleSheet: bad argument #1 type (command line name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
     }
     if (!lua_isstring(L, n)) {
         lua_pushfstring(L, "setCmdLineStyleSheet: bad argument #%s type (StyleSheet as string expected, got %s!)", n, luaL_typename(L, n));
         return lua_error(L);
     }
 
-    QString styleSheet{QString::fromUtf8(lua_tostring(L, n))};
+    QString styleSheet{lua_tostring(L, n)};
     Host& host = getHostFromLua(L);
 
     if (auto [success, message] = host.mpConsole->setCmdLineStyleSheet(name, styleSheet); !success) {
@@ -4925,7 +4925,7 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         lua_pushfstring(L, "%s: bad argument #1 type (label name as string expected, got %s!)", funcName.toUtf8().constData(), luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString labelName = QString::fromUtf8(lua_tostring(L, 1));
+    QString labelName{lua_tostring(L, 1)};
     if (labelName.isEmpty()) {
         lua_pushnil(L);
         lua_pushfstring(L, "%s: bad argument #1 value (label name cannot be an empty string.)", funcName.toUtf8().constData());
@@ -5027,7 +5027,7 @@ int TLuaInterpreter::setTextFormat(lua_State* L)
                         s, luaL_typename(L, s));
         return lua_error(L);
     }
-    QString windowName = QString::fromUtf8(lua_tostring(L, s));
+    QString windowName{lua_tostring(L, s)};
 
     QVector<int> colorComponents(6); // 0-2 RGB background, 3-5 RGB foreground
     if (!lua_isnumber(L, ++s)) {
@@ -5190,7 +5190,7 @@ int TLuaInterpreter::raiseWindow(lua_State* L)
         lua_pushstring(L, "raiseWindow: wrong argument type");
         return lua_error(L);
     }
-    QString windowName = QString::fromUtf8(lua_tostring(L, 1));
+    QString windowName{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->raiseWindow(windowName));
@@ -5204,7 +5204,7 @@ int TLuaInterpreter::lowerWindow(lua_State* L)
         lua_pushstring(L, "lowerWindow: wrong argument type");
         return lua_error(L);
     }
-    QString windowName = QString::fromUtf8(lua_tostring(L, 1));
+    QString windowName{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.mpConsole->lowerWindow(windowName));
@@ -5273,7 +5273,7 @@ int TLuaInterpreter::setRoomName(lua_State* L)
         lua_pushfstring(L, "setRoomName: bad argument #2 type (room name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 2));
+    QString name{lua_tostring(L, 2)};
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
     if (pR) {
@@ -5414,7 +5414,7 @@ int TLuaInterpreter::setRoomIDbyHash(lua_State* L)
         lua_pushfstring(L, "setRoomIDbyHash: bad argument #2 type (hash as string expected, got %s)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString hash = QString::fromUtf8(lua_tostring(L, 2));
+    QString hash{lua_tostring(L, 2)};
     Host& host = getHostFromLua(L);
     if (host.mpMap->mpRoomDB->roomIDToHash.contains(id)) {
         host.mpMap->mpRoomDB->hashToRoomID.remove(host.mpMap->mpRoomDB->roomIDToHash[id]);
@@ -5434,7 +5434,7 @@ int TLuaInterpreter::getRoomIDbyHash(lua_State* L)
         lua_pushfstring(L, "getRoomIDbyHash: bad argument #1 type (hash as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString hash = QString::fromUtf8(lua_tostring(L, 1));
+    QString hash{lua_tostring(L, 1)};
     Host& host = getHostFromLua(L);
     int retID = host.mpMap->mpRoomDB->hashToRoomID.value(hash, -1);
     lua_pushnumber(L, retID);
@@ -5781,7 +5781,7 @@ int TLuaInterpreter::searchRoom(lua_State* L)
                 return lua_error(L);
             }
         }
-        room = QString::fromUtf8(lua_tostring(L, 1));
+        room = lua_tostring(L, 1);
     } else {
         lua_pushfstring(L, R"(searchRoom: bad argument #1 ("room name" as string expected, got %s!))", luaL_typename(L, 1));
         return lua_error(L);
@@ -5851,14 +5851,14 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
             lua_pushfstring(L, R"(searchRoomUserData: bad argument #1 ("key" as string is optional, got %s!))", luaL_typename(L, 1));
             return lua_error(L);
         }
-        key = QString::fromUtf8(lua_tostring(L, 1));
+        key = lua_tostring(L, 1);
 
         if (lua_gettop(L) > 1) {
             if (!lua_isstring(L, 2)) {
                 lua_pushfstring(L, R"(searchRoomUserData: bad argument #2 ("value" as string is optional, got %s!))", luaL_typename(L, 2));
                 return lua_error(L);
             }
-            value = QString::fromUtf8(lua_tostring(L, 2));
+            value = lua_tostring(L, 2);
         }
     }
 
@@ -5974,14 +5974,14 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
             lua_pushfstring(L, R"(searchAreaUserData: bad argument #1 ("key" as string is optional, got %s!))", luaL_typename(L, 1));
             return lua_error(L);
         }
-        key = QString::fromUtf8(lua_tostring(L, 1));
+        key = lua_tostring(L, 1);
 
         if (lua_gettop(L) > 1) {
             if (!lua_isstring(L, 2)) {
                 lua_pushfstring(L, R"(searchAreaUserData: bad argument #2 ("value" as string is optional, got %s!))", luaL_typename(L, 2));
                 return lua_error(L);
             }
-            value = QString::fromUtf8(lua_tostring(L, 2));
+            value = lua_tostring(L, 2);
         }
     }
 
@@ -6344,7 +6344,7 @@ int TLuaInterpreter::deselect(lua_State* L)
             return lua_error(L);
         }
         // We cannot yet properly handle non-ASCII windows names but we will eventually!
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
         if (windowName == QLatin1String("main")) {
             // This matches the identifier for the main window - so make it
             // appear so by emptying it...
@@ -6374,7 +6374,7 @@ int TLuaInterpreter::resetFormat(lua_State* L)
             return lua_error(L);
         }
         // We cannot yet properly handle non-ASCII windows names but we will eventually!
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
         if (windowName == QLatin1String("main")) {
             // This matches the identifier for the main window - so make it
             // appear so by emptying it...
@@ -6432,7 +6432,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
             lua_pushfstring(L, "setAppStyleSheet: bad argument #%d type (style sheet as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        styleSheet = QString::fromUtf8(lua_tostring(L, s));
+        styleSheet = lua_tostring(L, s);
     }
 
     if (n > 1) {
@@ -6440,7 +6440,7 @@ int TLuaInterpreter::setAppStyleSheet(lua_State* L)
             lua_pushfstring(L, "setAppStyleSheet: bad argument #%d type (tag as string is optional, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        tag = QString::fromUtf8(lua_tostring(L, s));
+        tag = lua_tostring(L, s);
     }
 
     Host& host = getHostFromLua(L);
@@ -6465,7 +6465,7 @@ int TLuaInterpreter::setProfileStyleSheet(lua_State* L)
         lua_pushfstring(L, "setProfileStyleSheet: bad argument #1 type (style sheet as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    styleSheet = QString::fromUtf8(lua_tostring(L, 1));
+    styleSheet = lua_tostring(L, 1);
 
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, mudlet::self()->setProfileStyleSheet(&host, styleSheet));
@@ -6724,7 +6724,7 @@ int TLuaInterpreter::setBold(lua_State* L)
                             s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isboolean(L, ++s)) {
@@ -6764,7 +6764,7 @@ int TLuaInterpreter::setItalics(lua_State* L)
                             s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isboolean(L, ++s)) {
@@ -6804,7 +6804,7 @@ int TLuaInterpreter::setOverline(lua_State* L)
                             s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isboolean(L, ++s)) {
@@ -6844,7 +6844,7 @@ int TLuaInterpreter::setReverse(lua_State* L)
                             s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isboolean(L, ++s)) {
@@ -6884,7 +6884,7 @@ int TLuaInterpreter::setStrikeOut(lua_State* L)
                             s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isboolean(L, ++s)) {
@@ -6924,7 +6924,7 @@ int TLuaInterpreter::setUnderline(lua_State* L)
                             s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isboolean(L, ++s)) {
@@ -6963,11 +6963,11 @@ int TLuaInterpreter::debug(lua_State* L)
     QString luaDebugText;
     if (n > 1) {
         for (int i = 0; i < n; ++i) {
-            luaDebugText += QStringLiteral(" (%1) %2").arg(QString::number(i + 1), QString::fromUtf8(lua_tostring(L, i + 1)));
+            luaDebugText += QStringLiteral(" (%1) %2").arg(QString::number(i + 1), lua_tostring(L, i + 1));
         }
     } else {
         // n == 1
-        luaDebugText = QStringLiteral(" %1").arg(QString::fromUtf8(lua_tostring(L, 1)));
+        luaDebugText = QStringLiteral(" %1").arg(lua_tostring(L, 1));
     }
     luaDebugText.append(QChar::LineFeed);
 
@@ -6987,13 +6987,13 @@ int TLuaInterpreter::showHandlerError(lua_State* L)
         lua_pushfstring(L, "showHandlerError: bad argument #1 type (event name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString event = QString::fromUtf8(lua_tostring(L, 1));
+    QString event{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "showHandlerError: bad argument #2 type (error message as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString error = QString::fromUtf8(lua_tostring(L, 2));
+    QString error{lua_tostring(L, 2)};
 
     host.mLuaInterpreter.logEventError(event, error);
     return 0;
@@ -7352,7 +7352,7 @@ int TLuaInterpreter::tempTimer(lua_State* L)
         lua_pushfstring(L, "tempTimer: bad argument #2 type (script or function name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString luaCode = QString::fromUtf8(lua_tostring(L, 2));
+    QString luaCode{lua_tostring(L, 2)};
     if (lua_isboolean(L, 3)) {
         repeating = lua_toboolean(L, 3);
     }
@@ -7379,7 +7379,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
         lua_pushfstring(L, "tempExactMatchTrigger: bad argument #1 type (exact match pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString exactMatchPattern = QString::fromUtf8(lua_tostring(L, 1));
+    QString exactMatchPattern{lua_tostring(L, 1)};
 
     if (lua_isnumber(L, 3)) {
         expirationCount = lua_tonumber(L, 3);
@@ -7392,7 +7392,7 @@ int TLuaInterpreter::tempExactMatchTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString::fromUtf8(lua_tostring(L, 2)), expirationCount);
+        triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString(lua_tostring(L, 2)), expirationCount);
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempExactMatchTrigger(exactMatchPattern, QString(), expirationCount);
 
@@ -7422,7 +7422,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
         lua_pushfstring(L, "tempBeginOfLineTrigger: bad argument #1 type (pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString pattern = QString::fromUtf8(lua_tostring(L, 1));
+    QString pattern{lua_tostring(L, 1)};
 
         if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7435,7 +7435,7 @@ int TLuaInterpreter::tempBeginOfLineTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
+        triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString(lua_tostring(L, 2)), expiryCount);
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempBeginOfLineTrigger(pattern, QString(), expiryCount);
 
@@ -7467,7 +7467,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
         lua_pushfstring(L, "tempTrigger: bad argument #1 type (substring pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    substringPattern = QString::fromUtf8(lua_tostring(L, 1));
+    substringPattern = lua_tostring(L, 1);
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -7479,7 +7479,7 @@ int TLuaInterpreter::tempTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
+        triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString(lua_tostring(L, 2)), expiryCount);
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempTrigger(substringPattern, QString(), expiryCount);
 
@@ -7517,7 +7517,7 @@ int TLuaInterpreter::tempPromptTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        triggerID = pLuaInterpreter->startTempPromptTrigger(QString::fromUtf8(lua_tostring(L, 1)), expiryCount);
+        triggerID = pLuaInterpreter->startTempPromptTrigger(QString(lua_tostring(L, 1)), expiryCount);
     } else if (lua_isfunction(L, 1)) {
         triggerID = pLuaInterpreter->startTempPromptTrigger(QString(), expiryCount);
 
@@ -7632,7 +7632,7 @@ int TLuaInterpreter::tempColorTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 3)) {
-        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString::fromUtf8(lua_tostring(L, 3)), expiryCount);
+        triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString(lua_tostring(L, 3)), expiryCount);
     } else if (lua_isfunction(L, 3)) {
         triggerID = pLuaInterpreter->startTempColorTrigger(foregroundColor, backgroundColor, QString(), expiryCount);
 
@@ -7667,7 +7667,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
     int value;
 
     if (lua_isstring(L, 1)) {
-        code = QString::fromUtf8(lua_tostring(L, 1));
+        code = lua_tostring(L, 1);
     } else if (lua_isfunction(L, 1)) {
         // leave code as a null QString()
     } else {
@@ -7760,7 +7760,7 @@ int TLuaInterpreter::tempLineTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 3)) {
-        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString::fromUtf8(lua_tostring(L, 3)), expiryCount);
+        triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString(lua_tostring(L, 3)), expiryCount);
     } else if (lua_isfunction(L, 3)) {
         triggerID = pLuaInterpreter->startTempLineTrigger(from, howMany, QString(), expiryCount);
 
@@ -7809,7 +7809,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         return lua_error(L);
     }
 
-    QString triggerName = QString::fromUtf8(lua_tostring(L, 1));
+    QString triggerName{lua_tostring(L, 1)};
     bool multiLine = lua_tonumber(L, 4);
 
     bool colorTrigger;
@@ -7851,7 +7851,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     bool playSound;
     if (lua_isstring(L, 11)) {
         playSound = true;
-        soundFile = QString::fromUtf8(lua_tostring(L, 11));
+        soundFile = lua_tostring(L, 11);
     } else {
         playSound = false;
     }
@@ -7870,7 +7870,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         }
     }
 
-    QString pattern = QString::fromUtf8(lua_tostring(L, 2));
+    QString pattern{lua_tostring(L, 2)};
     QStringList regexList;
     QList<int> propertyList;
     TTrigger* pP = host.getTriggerUnit()->findTrigger(triggerName);
@@ -7908,7 +7908,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 3)) {
-        pT->setScript(QString::fromUtf8(lua_tostring(L, 3)));
+        pT->setScript(lua_tostring(L, 3));
     } else if (lua_isfunction(L, 3)) {
         pT->setScript(QString());
 
@@ -8003,13 +8003,13 @@ int TLuaInterpreter::setButtonStyleSheet(lua_State* L)
         lua_pushfstring(L, "setButtonStyleSheet: bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setButtonStyleSheet: bad argument #2 type (css as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString css = QString::fromUtf8(lua_tostring(L, 2));
+    QString css{lua_tostring(L, 2)};
 
     Host& host = getHostFromLua(L);
     auto actionsList = host.getActionUnit()->findActionsByName(name);
@@ -8100,7 +8100,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
         lua_pushfstring(L, "tempRegexTrigger: bad argument #1 type (regex pattern as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString regexPattern = QString::fromUtf8(lua_tostring(L, 1));
+    QString regexPattern{lua_tostring(L, 1)};
 
     if (lua_isnumber(L, 3)) {
         expiryCount = lua_tonumber(L, 3);
@@ -8113,7 +8113,7 @@ int TLuaInterpreter::tempRegexTrigger(lua_State* L)
     }
 
     if (lua_isstring(L, 2)) {
-        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString::fromUtf8(lua_tostring(L, 2)), expiryCount);
+        triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, lua_tostring(L, 2), expiryCount);
     } else if (lua_isfunction(L, 2)) {
         triggerID = pLuaInterpreter->startTempRegexTrigger(regexPattern, QString(), expiryCount);
 
@@ -8139,14 +8139,14 @@ int TLuaInterpreter::tempAlias(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString regex = QString::fromUtf8(lua_tostring(L, 1));
+    QString regex{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "tempAlias: bad argument #2 type (lua script as string expected, got %s!)",
                         luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString script = QString::fromUtf8(lua_tostring(L, 2));
+    QString script{lua_tostring(L, 2)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8197,7 +8197,7 @@ int TLuaInterpreter::isActive(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "isActive: bad argument #1 type (item type as string expected, got %s!)",
@@ -8206,7 +8206,7 @@ int TLuaInterpreter::isActive(lua_State* L)
     }
     // Although we only use 4 ASCII strings the user may not enter a purely
     // ASCII value which we might have to report...
-    QString type = QString::fromUtf8(lua_tostring(L, 2));
+    QString type{lua_tostring(L, 2)};
 
     Host& host = getHostFromLua(L);
     int cnt = 0;
@@ -8272,28 +8272,28 @@ int TLuaInterpreter::permAlias(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permAlias: bad argument #2 type (alias group/parent as string expected, got %s!)",
                         luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+    QString parent{lua_tostring(L, 2)};
 
     if (!lua_isstring(L, 3)) {
         lua_pushfstring(L, "permAlias: bad argument #3 type (regexp pattern as string expected, got %s!)",
                         luaL_typename(L, 3));
         return lua_error(L);
     }
-    QString regex = QString::fromUtf8(lua_tostring(L, 3));
+    QString regex{lua_tostring(L, 3)};
 
     if (!lua_isstring(L, 4)) {
         lua_pushfstring(L, "permAlias: bad argument #4 type (lua script as string expected, got %s!)",
                         luaL_typename(L, 4));
         return lua_error(L);
     }
-    QString script = QString::fromUtf8(lua_tostring(L, 4));
+    QString script{lua_tostring(L, 4)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8310,7 +8310,7 @@ int TLuaInterpreter::getScript(lua_State* L)
         lua_pushfstring(L, "getScript: bad argument #1 type (script name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (n > 1) {
         if (!lua_isnumber(L, 2)) {
@@ -8345,13 +8345,13 @@ int TLuaInterpreter::setScript(lua_State* L)
         lua_pushfstring(L, "setScript: bad argument #1 type (script name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "setScript: bad argument #2 type (script lua code as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString luaCode = QString::fromUtf8(lua_tostring(L, 2));
+    QString luaCode{lua_tostring(L, 2)};
 
     if (n > 2) {
         if (!lua_isnumber(L, 3)) {
@@ -8382,19 +8382,19 @@ int TLuaInterpreter::permScript(lua_State* L)
         lua_pushfstring(L, "permScript: bad argument #1 type (script name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permScript: bad argument #2 type (script parent name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+    QString parent{lua_tostring(L, 2)};
 
     if (!lua_isstring(L, 3)) {
         lua_pushfstring(L, "permScript: bad argument #3 type (script as string expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
-    QString luaCode = QString::fromUtf8(lua_tostring(L, 3));
+    QString luaCode{lua_tostring(L, 3)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8416,13 +8416,13 @@ int TLuaInterpreter::permTimer(lua_State* L)
         lua_pushfstring(L, "permTimer: bad argument #1 type (timer name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permTimer: bad argument #2 type (timer parent name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+    QString parent{lua_tostring(L, 2)};
 
     if (!lua_isnumber(L, 3)) {
         lua_pushfstring(L, "permTimer: bad argument #3 type (time in seconds as {maybe decimal} number expected, got %s!)", luaL_typename(L, 3));
@@ -8434,7 +8434,7 @@ int TLuaInterpreter::permTimer(lua_State* L)
         lua_pushfstring(L, "permTimer: bad argument #4 type (script as string expected, got %s!)", luaL_typename(L, 4));
         return lua_error(L);
     }
-    QString luaCode = QString::fromUtf8(lua_tostring(L, 4));
+    QString luaCode{lua_tostring(L, 4)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8457,14 +8457,14 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permSubstringTrigger: bad argument #2 type (trigger parent as string expected, got %s!)",
                         luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+    QString parent{lua_tostring(L, 2)};
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8476,7 +8476,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
     while (lua_next(L, 3) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            regList << QString::fromUtf8(lua_tostring(L, -1));
+            regList << lua_tostring(L, -1);
         }
         // removes value, but keeps key for next iteration
         lua_pop(L, 1);
@@ -8487,7 +8487,7 @@ int TLuaInterpreter::permSubstringTrigger(lua_State* L)
                         luaL_typename(L, 4));
         return lua_error(L);
     }
-    QString script = QString::fromUtf8(lua_tostring(L, 4));
+    QString script{lua_tostring(L, 4)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8507,19 +8507,19 @@ int TLuaInterpreter::permPromptTrigger(lua_State* L)
         lua_pushfstring(L, "permPromptTrigger: bad argument #1 type (trigger name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    triggerName = QString::fromUtf8(lua_tostring(L, 1));
+    triggerName = lua_tostring(L, 1);
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permPromptTrigger: bad argument #2 type (parent trigger name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    parentName = QString::fromUtf8(lua_tostring(L, 2));
+    parentName = lua_tostring(L, 2);
 
     if (!lua_isstring(L, 3)) {
         lua_pushfstring(L, "permPromptTrigger: bad argument #3 type (code to run as string expected, got %s!)", luaL_typename(L, 3));
         return lua_error(L);
     }
-    luaFunction = QString::fromUtf8(lua_tostring(L, 3));
+    luaFunction = lua_tostring(L, 3);
 
     triggerID = pLuaInterpreter->startPermPromptTrigger(triggerName, parentName, luaFunction);
     lua_pushnumber(L, triggerID);
@@ -8535,13 +8535,13 @@ int TLuaInterpreter::permKey(lua_State* L)
         lua_pushfstring(L, "permKey: bad argument #1 type (key name as string expected, got %s!)", luaL_typename(L, argIndex));
         return lua_error(L);
     }
-    QString keyName = QString::fromUtf8(lua_tostring(L, argIndex));
+    QString keyName{lua_tostring(L, argIndex)};
 
     if (!lua_isstring(L, ++argIndex)) {
         lua_pushfstring(L, "permKey: bad argument #2 type (key parent group as string expected, got %s!)", luaL_typename(L, argIndex));
         return lua_error(L);
     }
-    QString parentGroup = QString::fromUtf8(lua_tostring(L, argIndex));
+    QString parentGroup{lua_tostring(L, argIndex)};
 
     int keyModifier = Qt::NoModifier;
     if (lua_gettop(L) > 4) {
@@ -8562,7 +8562,7 @@ int TLuaInterpreter::permKey(lua_State* L)
         lua_pushfstring(L, "permKey: bad argument #%d type (lua script as string expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
     }
-    QString luaFunction = QString::fromUtf8(lua_tostring(L, argIndex));
+    QString luaFunction{lua_tostring(L, argIndex)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8595,7 +8595,7 @@ int TLuaInterpreter::tempKey(lua_State* L)
         lua_pushfstring(L, "tempKey: bad argument #%d type (lua script as string expected, got %s!)", argIndex, luaL_typename(L, argIndex));
         return lua_error(L);
     }
-    QString luaFunction = QString::fromUtf8(lua_tostring(L, argIndex));
+    QString luaFunction{lua_tostring(L, argIndex)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8612,14 +8612,14 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permBeginOfLineStringTrigger: bad argument #2 type (trigger parent as string expected, got %s!)",
                         luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+    QString parent{lua_tostring(L, 2)};
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8631,7 +8631,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
     while (lua_next(L, 3) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            regList << QString::fromUtf8(lua_tostring(L, -1));
+            regList << lua_tostring(L, -1);
         }
         // removes value, but keeps key for next iteration
         lua_pop(L, 1);
@@ -8642,7 +8642,7 @@ int TLuaInterpreter::permBeginOfLineStringTrigger(lua_State* L)
                         luaL_typename(L, 4));
         return lua_error(L);
     }
-    QString script = QString::fromUtf8(lua_tostring(L, 4));
+    QString script{lua_tostring(L, 4)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8658,14 +8658,14 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
                         luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1));
+    QString name{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "permRegexTrigger: bad argument #2 type (trigger parent as string expected, got %s!)",
                         luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString parent = QString::fromUtf8(lua_tostring(L, 2));
+    QString parent{lua_tostring(L, 2)};
 
     QStringList regList;
     if (!lua_istable(L, 3)) {
@@ -8677,7 +8677,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
     while (lua_next(L, 3) != 0) {
         // key at index -2 and value at index -1
         if (lua_type(L, -1) == LUA_TSTRING) {
-            regList << QString::fromUtf8(lua_tostring(L, -1));
+            regList << lua_tostring(L, -1);
         }
         // removes value, but keeps key for next iteration
         lua_pop(L, 1);
@@ -8688,7 +8688,7 @@ int TLuaInterpreter::permRegexTrigger(lua_State* L)
                         luaL_typename(L, 4));
         return lua_error(L);
     }
-    QString script = QString::fromUtf8(lua_tostring(L, 4));
+    QString script{lua_tostring(L, 4)};
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
@@ -8733,7 +8733,7 @@ int TLuaInterpreter::getTimestamp(lua_State* L)
             lua_pushfstring(L, "getTimestamp: bad argument #%d type (mini console, user window or buffer name as string expected {may be omitted for the \"main\" console}, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, s));
+        name = lua_tostring(L, s);
         if (name == QLatin1String("main")) {
             // clear it so it is treated as the main console below
             name.clear();
@@ -8912,7 +8912,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         //            return 2;
         //        }
     } else if (lua_isstring(L, 1)) {
-        existingName = QString::fromUtf8(lua_tostring(L, 1));
+        existingName = lua_tostring(L, 1);
         id = host.mpMap->mpRoomDB->getAreaNamesMap().key(existingName, 0);
         if (existingName.isEmpty()) {
             lua_pushnil(L);
@@ -8942,7 +8942,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         lua_pushfstring(L, "setAreaName: bad argument #2 type (area name as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString newName = QString::fromUtf8(lua_tostring(L, 2)).trimmed();
+    QString newName = QString{lua_tostring(L, 2)}.trimmed();
     // Now allow non-Ascii names but eliminate any leading or trailing spaces
 
     if (newName.isEmpty()) {
@@ -9013,7 +9013,7 @@ int TLuaInterpreter::getRoomAreaName(lua_State* L)
                             luaL_typename(L, 1));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
     } else {
         id = lua_tonumber(L, 1);
     }
@@ -9049,7 +9049,7 @@ int TLuaInterpreter::addAreaName(lua_State* L)
         lua_pushfstring(L, "addAreaName: bad argument #1 type (area name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString name = QString::fromUtf8(lua_tostring(L, 1)).trimmed();
+    QString name = QString{lua_tostring(L, 1)}.trimmed();
 
     Host& host = getHostFromLua(L);
     if ((!host.mpMap) || (!host.mpMap->mpRoomDB)) {
@@ -9113,7 +9113,7 @@ int TLuaInterpreter::deleteArea(lua_State* L)
             return 2;
         }
     } else if (lua_isstring(L, 1)) {
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
         if (name.isEmpty()) {
             lua_pushnil(L);
             lua_pushstring(L, "deleteArea: bad argument #1 value (an empty string is not a valid area name).");
@@ -9652,7 +9652,7 @@ int TLuaInterpreter::setDoor(lua_State* L)
         lua_pushfstring(L, "setDoor: bad argument #2 type (door command as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString exitCmd = QString::fromUtf8(lua_tostring(L, 2));
+    QString exitCmd{lua_tostring(L, 2)};
     if (exitCmd.compare(QStringLiteral("n")) && exitCmd.compare(QStringLiteral("e")) && exitCmd.compare(QStringLiteral("s")) && exitCmd.compare(QStringLiteral("w"))
         && exitCmd.compare(QStringLiteral("ne"))
         && exitCmd.compare(QStringLiteral("se"))
@@ -9943,7 +9943,7 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
         lua_pushfstring(L, "addCustomLine: bad argument #4 type (line style as string expected, got %s!)", luaL_typename(L, 4));
         return lua_error(L);
     }
-    QString lineStyleString = QString::fromUtf8(lua_tostring(L, 4));
+    QString lineStyleString{lua_tostring(L, 4)};
     if (!lineStyleString.compare(QLatin1String("solid line"))) {
         line_style = Qt::SolidLine;
     } else if (!lineStyleString.compare(QLatin1String("dot line"))) {
@@ -10447,7 +10447,7 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
         lua_pushfstring(L, R"(clearRoomUserDataItem: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString key = QString::fromUtf8(lua_tostring(L, 2));
+    QString key{lua_tostring(L, 2)};
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
@@ -10523,7 +10523,7 @@ int TLuaInterpreter::clearAreaUserDataItem(lua_State* L)
         lua_pushfstring(L, R"(clearAreaUserDataItem: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString key = QString::fromUtf8(lua_tostring(L, 2));
+    QString key{lua_tostring(L, 2)};
 
     TArea* pA = host.mpMap->mpRoomDB->getArea(areaId);
     if (!pA) {
@@ -10575,7 +10575,7 @@ int TLuaInterpreter::clearMapUserDataItem(lua_State* L)
         lua_pushfstring(L, R"(clearMapUserDataItem: bad argument #1 type ("key" as string expected, got %s!))", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString key = QString::fromUtf8(lua_tostring(L, 1));
+    QString key{lua_tostring(L, 1)};
     if (key.isEmpty()) {
         lua_pushnil(L);
         lua_pushfstring(L, R"(clearMapUserDataItem: bad argument #1 value ("key" can not be an empty string).)");
@@ -10724,7 +10724,7 @@ int TLuaInterpreter::getRoomUserData(lua_State* L)
         lua_pushfstring(L, "getRoomUserData: bad argument #2 (key as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString key = QString::fromUtf8(lua_tostring(L, 2));
+    QString key{lua_tostring(L, 2)};
 
     bool isBackwardCompatibilityRequired = true;
     if (lua_gettop(L) > 2) {
@@ -10779,7 +10779,7 @@ int TLuaInterpreter::getAreaUserData(lua_State* L)
         lua_pushfstring(L, "getAreaUserData: bad argument #2 (key as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    key = QString::fromUtf8(lua_tostring(L, 2));
+    key = lua_tostring(L, 2);
     if (key.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L,
@@ -10829,7 +10829,7 @@ int TLuaInterpreter::getMapUserData(lua_State* L)
         lua_pushfstring(L, "getMapUserData: bad argument #1 (key as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString key = QString::fromUtf8(lua_tostring(L, 1));
+    QString key{lua_tostring(L, 1)};
 
     if (host.mpMap->mUserData.contains(key)) {
         lua_pushstring(L, host.mpMap->mUserData.value(key).toUtf8().constData());
@@ -10861,14 +10861,14 @@ int TLuaInterpreter::setRoomUserData(lua_State* L)
         lua_pushfstring(L, R"(setRoomUserData: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString key = QString::fromUtf8(lua_tostring(L, 2));
+    QString key{lua_tostring(L, 2)};
     // Ideally should reject empty keys but this could break existing scripts so we can't
 
     if (!lua_isstring(L, 3)) {
         lua_pushfstring(L, R"(setRoomUserData: bad argument #3 type ("value" as string expected, got %s!))", luaL_typename(L, 3));
         return lua_error(L);
     }
-    QString value = QString::fromUtf8(lua_tostring(L, 3));
+    QString value{lua_tostring(L, 3)};
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (!pR) {
@@ -10896,7 +10896,7 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
         lua_pushfstring(L, R"(setAreaUserData: bad argument #2 type ("key" as string expected, got %s!))", luaL_typename(L, 2));
         return lua_error(L);
     }
-    key = QString::fromUtf8(lua_tostring(L, 2));
+    key = lua_tostring(L, 2);
     if (key.isEmpty()) {
         lua_pushnil(L);
         lua_pushstring(L,
@@ -10909,7 +10909,7 @@ int TLuaInterpreter::setAreaUserData(lua_State* L)
         lua_pushfstring(L, R"(setAreaUserData: bad argument #3 type ("value" as string expected, got %s!))", luaL_typename(L, 3));
         return lua_error(L);
     }
-    QString value = QString::fromUtf8(lua_tostring(L, 3));
+    QString value{lua_tostring(L, 3)};
 
     Host& host = getHostFromLua(L);
     if (!host.mpMap || !host.mpMap->mpRoomDB) {
@@ -10945,7 +10945,7 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
         lua_pushfstring(L, R"(setMapUserData: bad argument #1 type ("key" as string expected, got %s!))", luaL_typename(L, 1));
         return lua_error(L);
     }
-    key = QString::fromUtf8(lua_tostring(L, 1));
+    key = lua_tostring(L, 1);
     if (key.isEmpty()) {
         lua_pushnil(L);
         lua_pushfstring(L, R"(setMapUserData: bad argument #1 value ("key" is not allowed to be an empty string).)");
@@ -10956,7 +10956,7 @@ int TLuaInterpreter::setMapUserData(lua_State* L)
         lua_pushfstring(L, R"(setMapUserData: bad argument #2 type ("value" as string expected, got %s!))", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString value = QString::fromUtf8(lua_tostring(L, 2));
+    QString value{lua_tostring(L, 2)};
 
     host.mpMap->mUserData[key] = value;
     lua_pushboolean(L, true);
@@ -11101,13 +11101,13 @@ int TLuaInterpreter::downloadFile(lua_State* L)
         lua_pushfstring(L, "downloadFile: bad argument #1 type (local filename as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString localFile = QString::fromUtf8(lua_tostring(L, 1));
+    QString localFile{lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "downloadFile: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString urlString = QString::fromUtf8(lua_tostring(L, 2));
+    QString urlString{lua_tostring(L, 2)};
 
     QUrl url = QUrl::fromUserInput(urlString);
 
@@ -11175,7 +11175,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
             return 2;
         }
     } else if (lua_isstring(L, 2)) {
-        areaName = QString::fromUtf8(lua_tostring(L, 2));
+        areaName = lua_tostring(L, 2);
         // areaId will be zero if not found!
         if (areaName.isEmpty()) {
             lua_pushnil(L);
@@ -11269,7 +11269,7 @@ int TLuaInterpreter::setRoomChar(lua_State* L)
                        luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString symbol = QString::fromUtf8(lua_tostring(L, 2));
+    QString symbol{lua_tostring(L, 2)};
 
     Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(id);
@@ -11432,7 +11432,7 @@ int TLuaInterpreter::setFgColor(lua_State* L)
             lua_pushfstring(L, "setFgColor: bad argument #%d type (window name as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
     if (!lua_isnumber(L, ++s)) {
         lua_pushfstring(L, "setFgColor: bad argument #%d type (red component value as number expected, got %s!)", s, luaL_typename(L, s));
@@ -11489,7 +11489,7 @@ int TLuaInterpreter::setBgColor(lua_State* L)
 
     int s = 1;
     if (lua_isstring(L, s) && !lua_isnumber(L, s)) {
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
 
         if (!lua_isnumber(L, ++s)) {
             lua_pushfstring(L, "setBgColor: bad argument #%d type (red value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));
@@ -11704,14 +11704,14 @@ int TLuaInterpreter::insertText(lua_State* L)
             lua_pushfstring(L, "insertText: bad argument #%d type (name as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
     }
 
     if (!lua_isstring(L, ++s)) {
         lua_pushfstring(L, "insertText: bad argument #%d type (text as string expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, s));
+    QString text{lua_tostring(L, s)};
 
     if (isMain(windowName)) {
         host.mpConsole->insertText(text);
@@ -11769,7 +11769,7 @@ int TLuaInterpreter::Echo(lua_State* L)
             lua_pushfstring(L, "echo: bad argument #1 type (console name as string, is optional, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        consoleName = QString::fromUtf8(lua_tostring(L, 1));
+        consoleName = lua_tostring(L, 1);
     } else if (!n) {
         // Handle case with NO arguments
         lua_pushstring(L, "echo: bad argument #1 type (text to display as string expected, got nil!)");
@@ -11780,7 +11780,7 @@ int TLuaInterpreter::Echo(lua_State* L)
         lua_pushfstring(L, "echo: bad argument #%d type (text to display as string expected, got %s!)", n, luaL_typename(L, n));
         return lua_error(L);
     }
-    QString displayText = QString::fromUtf8(lua_tostring(L, n));
+    QString displayText{lua_tostring(L, n)};
 
     if (isMain(consoleName)) {
         host.mpConsole->buffer.mEchoingText = true;
@@ -11819,13 +11819,13 @@ int TLuaInterpreter::echoPopup(lua_State* L)
             lua_pushfstring(L, "echoPopup: bad argument #%d type (window name as string expected, got %s!)", s, luaL_typename(L, s));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, s));
+        windowName = lua_tostring(L, s);
         s++;
     }
     if (!lua_isstring(L, s)) {
         lua_pushfstring(L, "echoPopup: bad argument #%d type (text as string expected, got %s!)", s, luaL_typename(L, s));
     } else {
-        text = QString::fromUtf8(lua_tostring(L, s));
+        text = lua_tostring(L, s);
         s++;
     }
 
@@ -11903,7 +11903,7 @@ int TLuaInterpreter::echoLink(lua_State* L)
         }
         return lua_error(L);
     }
-    a1 = QString::fromUtf8(lua_tostring(L, s));
+    a1 = lua_tostring(L, s);
 
     if (n > 1) {
         if (!lua_isstring(L, ++s)) {
@@ -11914,7 +11914,7 @@ int TLuaInterpreter::echoLink(lua_State* L)
             }
             return lua_error(L);
         }
-        a2 = QString::fromUtf8(lua_tostring(L, s));
+        a2 = lua_tostring(L, s);
     }
     if (n > 2) {
         if (!lua_isstring(L, ++s)) {
@@ -11925,11 +11925,11 @@ int TLuaInterpreter::echoLink(lua_State* L)
             }
             return lua_error(L);
         }
-        a3 = QString::fromUtf8(lua_tostring(L, s));
+        a3 = lua_tostring(L, s);
     }
     if (n > 3) {
         if (lua_isstring(L, ++s)) {
-            a4 = QString::fromUtf8(lua_tostring(L, s));
+            a4 = lua_tostring(L, s);
         } else if (lua_isboolean(L, s)) {
             gotBool = true;
             useCurrentFormat = lua_toboolean(L, s);
@@ -12004,7 +12004,7 @@ int TLuaInterpreter::pasteWindow(lua_State* L)
         lua_pushfstring(L, "pasteWindow: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString window = QString::fromUtf8(lua_tostring(L, 1));
+    QString window{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     mudlet::self()->pasteWindow(&host, window);
@@ -12070,8 +12070,8 @@ int TLuaInterpreter::setUserWindowStyleSheet(lua_State* L)
         return lua_error(L);
     }
 
-    QString userWindowName{QString::fromUtf8(lua_tostring(L, 1))};
-    QString userWindowStyleSheet{QString::fromUtf8(lua_tostring(L, 2))};
+    QString userWindowName{lua_tostring(L, 1)};
+    QString userWindowStyleSheet{lua_tostring(L, 2)};
 
     Host& host = getHostFromLua(L);
 
@@ -12251,7 +12251,7 @@ int TLuaInterpreter::setDiscordApplicationID(lua_State* L)
             // Treat it as a UTF-8 string because although it is likely to be an
             // unsigned long long integer (0 to 18446744073709551615) we want to
             // be able to handle any input so we can report bad input strings back:
-            QString inputText = QString::fromUtf8(lua_tostring(L, 1)).trimmed();
+            QString inputText = QString{lua_tostring(L, 1)}.trimmed();
             if (!inputText.isEmpty()) {
                 bool isOk = false;
                 quint64 numericEquivalent = inputText.toULongLong(&isOk);
@@ -12324,7 +12324,7 @@ int TLuaInterpreter::setDiscordLargeIcon(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        pMudlet->mDiscord.setLargeImage(&host, QString::fromUtf8(lua_tostring(L, 1)).toLower());
+        pMudlet->mDiscord.setLargeImage(&host, QString{lua_tostring(L, 1)}.toLower());
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -12372,7 +12372,7 @@ int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        pMudlet->mDiscord.setLargeImageText(&host, QString::fromUtf8(lua_tostring(L, 1)));
+        pMudlet->mDiscord.setLargeImageText(&host, lua_tostring(L, 1));
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -12420,7 +12420,7 @@ int TLuaInterpreter::setDiscordSmallIcon(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        pMudlet->mDiscord.setSmallImage(&host, QString::fromUtf8(lua_tostring(L, 1)).toLower());
+        pMudlet->mDiscord.setSmallImage(&host, QString{lua_tostring(L, 1)}.toLower());
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -12468,7 +12468,7 @@ int TLuaInterpreter::setDiscordSmallIconText(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        pMudlet->mDiscord.setSmallImageText(&host, QString::fromUtf8(lua_tostring(L, 1)));
+        pMudlet->mDiscord.setSmallImageText(&host, lua_tostring(L, 1));
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -12516,7 +12516,7 @@ int TLuaInterpreter::setDiscordDetail(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        pMudlet->mDiscord.setDetailText(&host, QString::fromUtf8(lua_tostring(L, 1)));
+        pMudlet->mDiscord.setDetailText(&host, lua_tostring(L, 1));
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -12568,7 +12568,7 @@ int TLuaInterpreter::setDiscordGame(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        auto gamename = QString::fromUtf8(lua_tostring(L, 1));
+        QString gamename{lua_tostring(L, 1)};
         pMudlet->mDiscord.setDetailText(&host, tr("Playing %1").arg(gamename));
         pMudlet->mDiscord.setLargeImage(&host, gamename.toLower());
         lua_pushboolean(L, true);
@@ -12596,7 +12596,7 @@ int TLuaInterpreter::setDiscordState(lua_State* L)
     }
 
     if (lua_isstring(L, 1)) {
-        mudlet::self()->mDiscord.setStateText(&host, QString::fromUtf8(lua_tostring(L, 1)));
+        mudlet::self()->mDiscord.setStateText(&host, lua_tostring(L, 1));
         lua_pushboolean(L, true);
         return 1;
     } else {
@@ -12879,13 +12879,13 @@ int TLuaInterpreter::appendCmdLine(lua_State* L)
             lua_pushfstring(L, "appendCmdLine: bad argument #1 (command line name as string expected, got %s)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
     }
     if (!lua_isstring(L, n)) {
         lua_pushfstring(L, "appendCmdLine: bad argument #%d (text to set on command line as string expected, got %s)", n, luaL_typename(L, n));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, n));
+    QString text{lua_tostring(L, n)};
 
     Host& host = getHostFromLua(L);
     auto pN = host.mpConsole->mSubCommandLineMap.value(name);
@@ -12916,7 +12916,7 @@ int TLuaInterpreter::getCmdLine(lua_State* L)
             lua_pushfstring(L, "getCmdLine: bad argument #1 (command line name as string expected, got %s)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
     }
     Host& host = getHostFromLua(L);
     auto pN = host.mpConsole->mSubCommandLineMap.value(name);
@@ -12939,7 +12939,7 @@ int TLuaInterpreter::installPackage(lua_State* L)
         lua_pushfstring(L, "installPackage: bad argument #1 (package location path and file name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString location = QString::fromUtf8(lua_tostring(L, 1));
+    QString location{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     host.installPackage(location, 0);
@@ -12953,7 +12953,7 @@ int TLuaInterpreter::uninstallPackage(lua_State* L)
         lua_pushfstring(L, "uninstallPackage: bad argument #1 (package name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString packageName =  QString::fromUtf8(lua_tostring(L, 1));
+    QString packageName =  lua_tostring(L, 1);
 
     Host& host = getHostFromLua(L);
     host.uninstallPackage(packageName, 0);
@@ -13014,7 +13014,7 @@ int TLuaInterpreter::enableModuleSync(lua_State* L)
         lua_pushfstring(L, "enableModuleSync: bad argument #1 (module name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString module{QString::fromUtf8(lua_tostring(L, 1))};
+    QString module{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
     if (auto [success, message] = host.changeModuleSync(module, QLatin1String("1")); !success) {
@@ -13041,7 +13041,7 @@ int TLuaInterpreter::disableModuleSync(lua_State* L)
         lua_pushfstring(L, "disableModuleSync: bad argument #1 (module name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString module{QString::fromUtf8(lua_tostring(L, 1))};
+    QString module{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -13069,7 +13069,7 @@ int TLuaInterpreter::getModuleSync(lua_State* L)
         lua_pushfstring(L, "getModuleSync: bad argument #1 (module name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString module{QString::fromUtf8(lua_tostring(L, 1))};
+    QString module{lua_tostring(L, 1)};
 
     Host& host = getHostFromLua(L);
 
@@ -13170,7 +13170,7 @@ int TLuaInterpreter::expandAlias(lua_State* L)
         lua_pushfstring(L, "expandAlias: bad argument #1 type (text to parse as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString payload = QString::fromUtf8(lua_tostring(L, 1));
+    QString payload{lua_tostring(L, 1)};
 
     bool wantPrint = true;
     if (lua_gettop(L) > 1) {
@@ -13202,13 +13202,13 @@ int TLuaInterpreter::printCmdLine(lua_State* L)
             lua_pushfstring(L, "printCmdLine: bad argument #1 (command line name as string expected, got %s)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
     }
     if (!lua_isstring(L, n)) {
         lua_pushfstring(L, "printCmdLine: bad argument #%d (text to set on command line as string expected, got %s)", n, luaL_typename(L, n));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, n));
+    QString text{lua_tostring(L, n)};
 
     Host& host = getHostFromLua(L);
     auto pN = host.mpConsole->mSubCommandLineMap.value(name);
@@ -13237,7 +13237,7 @@ int TLuaInterpreter::clearCmdLine(lua_State* L)
             lua_pushfstring(L, "clearCmdLine: bad argument #1 (command line name as string expected, got %s)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        name = QString::fromUtf8(lua_tostring(L, 1));
+        name = lua_tostring(L, 1);
     }
     Host& host = getHostFromLua(L);
     auto pN = host.mpConsole->mSubCommandLineMap.value(name);
@@ -13262,7 +13262,7 @@ int TLuaInterpreter::sendRaw(lua_State* L)
         lua_pushfstring(L, "send: bad argument #1 type (command as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, 1));
+    QString text{lua_tostring(L, 1)};
 
     bool wantPrint = true;
     if (lua_gettop(L) > 1) {
@@ -13557,7 +13557,7 @@ int TLuaInterpreter::ttsSpeak(lua_State* L)
     }
 
     QString textToSay;
-    textToSay = QString::fromUtf8(lua_tostring(L, 1));
+    textToSay = lua_tostring(L, 1);
 
     speechUnit->say(textToSay);
     speechCurrent = textToSay;
@@ -14160,7 +14160,7 @@ int TLuaInterpreter::setClipboardText(lua_State* L)
         return lua_error(L);
     }
     QClipboard* clipboard = QApplication::clipboard();
-    clipboard->setText(QString::fromUtf8(lua_tostring(L, 1)));
+    clipboard->setText(lua_tostring(L, 1));
     lua_pushboolean(L, true);
     return 1;
 }
@@ -14835,7 +14835,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
                     token = token.remove(QLatin1Char('\"'));
                     script = script.replace(0, varList.front().toUtf8().size() + 3, QByteArray());
                     mpHost->processDiscordMSDP(token, script);
-                    setMSDPTable(token, QString::fromUtf8(script));
+                    setMSDPTable(token, script);
                     varList.clear();
                     script.clear();
                 }
@@ -14859,7 +14859,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
                 (textLength <= i + 1)) {
                 script.append('\"');
             }
-            varList.append(QString::fromUtf8(lastVar));
+            varList.append(lastVar);
             last = MSDP_VAL;
             break;
         case '\\':
@@ -14890,7 +14890,7 @@ void TLuaInterpreter::msdp2Lua(const char* src)
                 script.append(']');
             }
         }
-        setMSDPTable(token, QString::fromUtf8(script));
+        setMSDPTable(token, script);
     }
 }
 
@@ -15323,7 +15323,7 @@ bool TLuaInterpreter::callCmdLineAction(const int func, QString text)
         QString name = "cmd line Action";
         logError(err, name, function);
         if (mudlet::debugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << QString::fromUtf8(err.c_str()) << "\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << err.c_str() << "\n" >> 0;
         }
     }
     lua_settop(L, top);
@@ -15483,7 +15483,7 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
         QString name = "label callback event";
         logError(err, name, function);
         if (mudlet::debugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << QString::fromUtf8(err.c_str()) << "\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << err.c_str() << "\n" >> 0;
         }
     }
 
@@ -15557,7 +15557,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         QString name = "event handler function";
         logError(err, name, function);
         if (mudlet::debugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << QString::fromUtf8(err.c_str()) << "\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << err.c_str() << "\n" >> 0;
         }
     }
 
@@ -15627,14 +15627,14 @@ int TLuaInterpreter::putHTTP(lua_State* L)
         return lua_error(L);
     }
     if (lua_isstring(L, 1)) {
-        dataToPost = QString::fromUtf8(lua_tostring(L, 1));
+        dataToPost = lua_tostring(L, 1);
     }
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "putHTTP: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString urlString = QString::fromUtf8(lua_tostring(L, 2));
+    QString urlString{lua_tostring(L, 2)};
 
     QUrl url = QUrl::fromUserInput(urlString);
 
@@ -15680,7 +15680,7 @@ int TLuaInterpreter::putHTTP(lua_State* L)
         return lua_error(L);
     }
     if (lua_isstring(L, 4)) {
-        fileLocation = QString::fromUtf8(lua_tostring(L, 4));
+        fileLocation = lua_tostring(L, 4);
     }
 
     if (!fileLocation.isEmpty()) {
@@ -15716,7 +15716,7 @@ int TLuaInterpreter::getHTTP(lua_State* L)
         lua_pushfstring(L, "getHTTP: bad argument #1 type (remote url as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString urlString = QString::fromUtf8(lua_tostring(L, 1));
+    QString urlString{lua_tostring(L, 1)};
 
     QUrl url = QUrl::fromUserInput(urlString);
 
@@ -15778,14 +15778,14 @@ int TLuaInterpreter::postHTTP(lua_State* L)
         return lua_error(L);
     }
     if (lua_isstring(L, 1)) {
-        dataToPost = QString::fromUtf8(lua_tostring(L, 1));
+        dataToPost = lua_tostring(L, 1);
     }
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "postHTTP: bad argument #2 type (remote url as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString urlString = QString::fromUtf8(lua_tostring(L, 2));
+    QString urlString{lua_tostring(L, 2)};
 
     QUrl url = QUrl::fromUserInput(urlString);
     if (!url.isValid()) {
@@ -15830,8 +15830,8 @@ int TLuaInterpreter::postHTTP(lua_State* L)
         return lua_error(L);
     }
     if (lua_isstring(L, 4)) {
-            fileLocation = QString::fromUtf8(lua_tostring(L, 4));
-        }
+        fileLocation = lua_tostring(L, 4);
+    }
 
     if (!fileLocation.isEmpty()) {
         QFile file(fileLocation);
@@ -15865,7 +15865,7 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
         lua_pushfstring(L, "deleteHTTP: bad argument #1 type (remote url as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString urlString = QString::fromUtf8(lua_tostring(L, 1));
+    QString urlString{lua_tostring(L, 1)};
 
     QUrl url = QUrl::fromUserInput(urlString);
 
@@ -15935,13 +15935,13 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
         lua_pushfstring(L, "unzipAsync: bad argument #1 type (zip location as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString zipLocation {QString::fromUtf8(lua_tostring(L, 1))};
+    QString zipLocation {lua_tostring(L, 1)};
 
     if (!lua_isstring(L, 2)) {
         lua_pushfstring(L, "unzipAsync: bad argument #2 type (extract location as string expected, got %s!)", luaL_typename(L, 2));
         return lua_error(L);
     }
-    QString extractLocation {QString::fromUtf8(lua_tostring(L, 2))};
+    QString extractLocation {lua_tostring(L, 2)};
 
     QTemporaryDir temporaryDir;
     if (!temporaryDir.isValid()) {
@@ -16023,7 +16023,7 @@ QString TLuaInterpreter::getLuaString(const QString& stringName)
 
     int error = luaL_dostring(L, QStringLiteral("return %1").arg(stringName).toUtf8().constData());
     if (!error) {
-        return QString::fromUtf8(lua_tostring(L, 1));
+        return lua_tostring(L, 1);
     } else {
         return QString();
     }
@@ -16117,7 +16117,7 @@ bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QStr
     if (error) {
         QString luaErrorMsg = tr("No error message available from Lua");
         if (lua_isstring(pGlobalLua, -1)) {
-            luaErrorMsg = tr("Lua error: %1").arg(QString::fromUtf8(lua_tostring(pGlobalLua, -1)));
+            luaErrorMsg = tr("Lua error: %1").arg(lua_tostring(pGlobalLua, -1));
         }
         resultMsgsQueue.enqueue(tr("[ ERROR ] - Cannot find Lua module %1.%2%3%4",
                                    // Intentional comment to separate arguments
@@ -16870,7 +16870,7 @@ void TLuaInterpreter::initIndenterGlobals()
     if (error) {
         QString e = tr("No error message available from Lua.");
         if (lua_isstring(pIndenterState.get(), -1)) {
-            e = tr("Lua error: %1.").arg(QString::fromUtf8(lua_tostring(pIndenterState.get(), -1)));
+            e = tr("Lua error: %1.").arg(lua_tostring(pIndenterState.get(), -1));
         }
         QString msg = tr("[ ERROR ] - Cannot load code formatter, indenting functionality won't be available.\n");
         msg.append(e);
@@ -17554,7 +17554,7 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
     if (!lua_gettop(L)) {
         windowName = QStringLiteral("main");
     } else if (lua_isstring(L, 1)) {
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
     } else {
         lua_pushfstring(L, "getColumnCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
@@ -17586,7 +17586,7 @@ int TLuaInterpreter::getRowCount(lua_State* L)
     if (!lua_gettop(L)) {
         windowName = QStringLiteral("main");
     } else if (lua_isstring(L, 1)) {
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
     } else {
         lua_pushfstring(L, "getRowCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
@@ -17625,7 +17625,7 @@ void TLuaInterpreter::freeAllInLuaRegistry(TEvent event)
     for (int i = 0; i < event.mArgumentList.size(); i++) {
         if (event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_TABLE || event.mArgumentTypeList.at(i) == ARGUMENT_TYPE_FUNCTION)
         {
-             freeLuaRegistryIndex(event.mArgumentList.at(i).toInt());
+            freeLuaRegistryIndex(event.mArgumentList.at(i).toInt());
         }
     }
 }
@@ -17681,7 +17681,7 @@ int TLuaInterpreter::enableClickthrough(lua_State* L)
             lua_pushfstring(L, "enableClickthrough: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
     }
 
     Host& host = getHostFromLua(L);
@@ -17700,7 +17700,7 @@ int TLuaInterpreter::disableClickthrough(lua_State* L)
             lua_pushfstring(L, "disableClickthrough: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
             return lua_error(L);
         }
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
+        windowName = lua_tostring(L, 1);
     }
 
     Host& host = getHostFromLua(L);
@@ -17726,7 +17726,7 @@ int TLuaInterpreter::addWordToDictionary(lua_State* L)
         lua_pushfstring(L, "addWordToDictionary: bad argument #1 type (word as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, 1));
+    QString text{lua_tostring(L, 1)};
 
     QPair<bool, QString> result = host.mpConsole->addWordToSet(text);
     if (!result.first){
@@ -17755,7 +17755,7 @@ int TLuaInterpreter::removeWordFromDictionary(lua_State* L)
         lua_pushfstring(L, "removeWordFromDictionary: bad argument #1 type (word as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, 1));
+    QString text{lua_tostring(L, 1)};
 
     QPair<bool, QString> result = host.mpConsole->removeWordFromSet(text);
     if (!result.first){
@@ -17779,7 +17779,7 @@ int TLuaInterpreter::spellCheckWord(lua_State* L)
         lua_pushfstring(L, "spellCheckWord: bad argument #1 type (word as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, 1));
+    QString text{lua_tostring(L, 1)};
 
     bool useUserDictionary = false;
     if (lua_gettop(L) > 1) {
@@ -17827,7 +17827,7 @@ int TLuaInterpreter::spellSuggestWord(lua_State* L)
         lua_pushfstring(L, "spellSuggestWord: bad argument #1 type (word as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
     }
-    QString text = QString::fromUtf8(lua_tostring(L, 1));
+    QString text{lua_tostring(L, 1)};
 
     bool useUserDictionary = false;
     if (lua_gettop(L) > 1) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1658,13 +1658,11 @@ int TLuaInterpreter::centerview(lua_State* L)
         return 2;
     }
 
-    int roomId;
     if (!lua_isnumber(L, 1)) {
         lua_pushfstring(L, "centerview: bad argument #1 type (room id as number expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        roomId = lua_tointeger(L, 1);
     }
+    int roomId = lua_tointeger(L, 1);
 
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomId);
     if (pR) {
@@ -9305,16 +9303,15 @@ int TLuaInterpreter::createRoomID(lua_State* L)
                             "got %s!)",
                             luaL_typename(L, 1));
             return lua_error(L);
-        } else {
-            int minId = lua_tointeger(L, 1);
-            if (minId < 1) {
-                lua_pushnil(L);
-                lua_pushfstring(L,
-                                "createRoomID: bad argument #1 value (minimum room id %d is an optional value\n"
-                                "but if provided it must be greater than zero.)",
-                                minId);
-                return 2;
-            }
+        }
+        int minId = lua_tointeger(L, 1);
+        if (minId < 1) {
+            lua_pushnil(L);
+            lua_pushfstring(L,
+                            "createRoomID: bad argument #1 value (minimum room id %d is an optional value\n"
+                            "but if provided it must be greater than zero.)",
+                            minId);
+            return 2;
         }
         lua_pushnumber(L, host.mpMap->createNewRoomID(lua_tointeger(L, 1)));
     } else {
@@ -12164,42 +12161,41 @@ int TLuaInterpreter::getMudletVersion(lua_State* L)
         if (!lua_isstring(L, 1)) {
             lua_pushstring(L, "getMudletVersion: wrong argument type.");
             return lua_error(L);
-        } else {
-            QString tidiedWhat = QString(lua_tostring(L, 1)).toLower().trimmed();
-            if (tidiedWhat.contains("major")) {
-                lua_pushinteger(L, major);
-            } else if (tidiedWhat.contains("minor")) {
-                lua_pushinteger(L, minor);
-            } else if (tidiedWhat.contains("revision")) {
-                lua_pushinteger(L, revision);
-            } else if (tidiedWhat.contains("build")) {
-                if (build.isEmpty()) {
-                    lua_pushnil(L);
-                } else {
-                    lua_pushstring(L, build);
-                }
-            } else if (tidiedWhat.contains("string")) {
-                if (build.isEmpty()) {
-                    lua_pushstring(L, version.constData());
-                } else {
-                    lua_pushstring(L, version.append(build).constData());
-                }
-            } else if (tidiedWhat.contains("table")) {
-                lua_pushinteger(L, major);
-                lua_pushinteger(L, minor);
-                lua_pushinteger(L, revision);
-                if (build.isEmpty()) {
-                    lua_pushnil(L);
-                } else {
-                    lua_pushstring(L, build);
-                }
-                return 4;
+        }
+        QString tidiedWhat = QString(lua_tostring(L, 1)).toLower().trimmed();
+        if (tidiedWhat.contains("major")) {
+            lua_pushinteger(L, major);
+        } else if (tidiedWhat.contains("minor")) {
+            lua_pushinteger(L, minor);
+        } else if (tidiedWhat.contains("revision")) {
+            lua_pushinteger(L, revision);
+        } else if (tidiedWhat.contains("build")) {
+            if (build.isEmpty()) {
+                lua_pushnil(L);
             } else {
-                lua_pushstring(L,
-                               "getMudletVersion: takes one (optional) argument:\n"
-                               "   \"major\", \"minor\", \"revision\", \"build\", \"string\" or \"table\".");
-                return lua_error(L);
+                lua_pushstring(L, build);
             }
+        } else if (tidiedWhat.contains("string")) {
+            if (build.isEmpty()) {
+                lua_pushstring(L, version.constData());
+            } else {
+                lua_pushstring(L, version.append(build).constData());
+            }
+        } else if (tidiedWhat.contains("table")) {
+            lua_pushinteger(L, major);
+            lua_pushinteger(L, minor);
+            lua_pushinteger(L, revision);
+            if (build.isEmpty()) {
+                lua_pushnil(L);
+            } else {
+                lua_pushstring(L, build);
+            }
+            return 4;
+        } else {
+            lua_pushstring(L,
+                            "getMudletVersion: takes one (optional) argument:\n"
+                            "   \"major\", \"minor\", \"revision\", \"build\", \"string\" or \"table\".");
+            return lua_error(L);
         }
     } else if (n == 0) {
         lua_newtable(L);
@@ -13118,28 +13114,28 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
                         "expected, got %s!)",
                         luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        bool isToShowDefaultArea = lua_toboolean(L, 1);
-        if (host.mpMap->mpMapper) {
-            // If we are reenabled the display of the default area
-            // AND the mapper was showing the default area
-            // the area widget will NOT be showing the correct area name afterwards
-            bool isAreaWidgetInNeedOfResetting = false;
-            if ((!host.mpMap->mpMapper->getDefaultAreaShown()) && (isToShowDefaultArea) && (host.mpMap->mpMapper->mp2dMap->mAreaID == -1)) {
-                isAreaWidgetInNeedOfResetting = true;
-            }
+    }
+    bool isToShowDefaultArea = lua_toboolean(L, 1);
 
-            host.mpMap->mpMapper->setDefaultAreaShown(isToShowDefaultArea);
-            if (isAreaWidgetInNeedOfResetting) {
-                // Corner case fixup:
-                host.mpMap->mpMapper->showArea->setCurrentText(host.mpMap->mpRoomDB->getDefaultAreaName());
-            }
-            host.mpMap->mpMapper->mp2dMap->repaint();
-            host.mpMap->mpMapper->update();
-            lua_pushboolean(L, true);
-        } else {
-            lua_pushboolean(L, false);
+    if (host.mpMap->mpMapper) {
+        // If we are reenabled the display of the default area
+        // AND the mapper was showing the default area
+        // the area widget will NOT be showing the correct area name afterwards
+        bool isAreaWidgetInNeedOfResetting = false;
+        if ((!host.mpMap->mpMapper->getDefaultAreaShown()) && (isToShowDefaultArea) && (host.mpMap->mpMapper->mp2dMap->mAreaID == -1)) {
+            isAreaWidgetInNeedOfResetting = true;
         }
+
+        host.mpMap->mpMapper->setDefaultAreaShown(isToShowDefaultArea);
+        if (isAreaWidgetInNeedOfResetting) {
+            // Corner case fixup:
+            host.mpMap->mpMapper->showArea->setCurrentText(host.mpMap->mpRoomDB->getDefaultAreaName());
+        }
+        host.mpMap->mpMapper->mp2dMap->repaint();
+        host.mpMap->mpMapper->update();
+        lua_pushboolean(L, true);
+    } else {
+        lua_pushboolean(L, false);
     }
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -104,7 +104,7 @@ static bool isMain(const QString& name)
     return false;
 }
 
-static const char *bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s!";
+static const char *bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s)!";
 static const char *bad_window_value = "window \"%s\" not found";
 
 #define WINDOW_NAME(_L, _pos)                                                                  \

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1400,28 +1400,12 @@ int TLuaInterpreter::getLineNumber(lua_State* L)
     int s = 0;
 
     if (lua_gettop(L) > 0) { // Have more than one argument so first must be a console name
-        if (!lua_isstring(L, ++s)) {
-            lua_pushfstring(L, "getLineNumber: bad argument #%d type (window name as string expected, got %s!)", s, luaL_typename(L, s));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, s);
+        windowName = WINDOW_NAME(L, ++s);
     }
 
-    if (isMain(windowName)) {
-        lua_pushnumber(L, host.mpConsole->getLineNumber());
-        return 1;
-    } else {
-        auto[success, lineNumber] = mudlet::self()->getLineNumber(&host, windowName);
-
-        if (success) {
-            lua_pushnumber(L, lineNumber);
-            return 1;
-        } else {
-            lua_pushnil(L);
-            lua_pushfstring(L, "window \"%s\" not found", windowName.toUtf8().constData());
-            return 2;
-        }
-    }
+    auto console = CONSOLE(L, windowName);
+    lua_pushnumber(L, console->getLineNumber());
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#updateMap
@@ -1723,19 +1707,13 @@ int TLuaInterpreter::getPlayerRoom(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#copy
 int TLuaInterpreter::copy(lua_State* L)
 {
-    QString windowName = "";
-    if (lua_isstring(L, 1)) {
-        windowName = lua_tostring(L, 1);
-    } else {
-        windowName = "main";
+    QString windowName;
+    if (lua_gettop(L) > 0) {
+        windowName = WINDOW_NAME(L, 1);
     }
 
-    Host& host = getHostFromLua(L);
-    if (isMain(windowName)) {
-        host.mpConsole->copy();
-    } else {
-        mudlet::self()->copy(&host, windowName);
-    }
+    auto console = CONSOLE(L, windowName);
+    console->copy();
     return 0;
 }
 
@@ -1750,19 +1728,13 @@ int TLuaInterpreter::cut(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#paste
 int TLuaInterpreter::paste(lua_State* L)
 {
-    QString windowName = "";
-    if (lua_isstring(L, 1)) {
-        windowName = lua_tostring(L, 1);
-    } else {
-        windowName = "main";
+    QString windowName;
+    if (lua_gettop(L) > 0) {
+        windowName = WINDOW_NAME(L, 1);
     }
 
-    Host& host = getHostFromLua(L);
-    if (isMain(windowName)) {
-        host.mpConsole->paste();
-    } else {
-        mudlet::self()->pasteWindow(&host, windowName);
-    }
+    auto console = CONSOLE(L, windowName);
+    console->paste();
     return 0;
 }
 
@@ -1867,35 +1839,28 @@ int TLuaInterpreter::isPrompt(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrap
 int TLuaInterpreter::setWindowWrap(lua_State* L)
 {
-    if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "setWindowWrap: wrong argument type");
-        return lua_error(L);
+    int s = 1;
+    QString windowName;
+    if (lua_gettop(L) > 1) {
+        windowName = WINDOW_NAME(L, 1);
+        ++s;
     }
-    QString windowName = lua_tostring(L, 1);
 
-    if (!lua_isnumber(L, 2)) {
+    if (!lua_isnumber(L, s)) {
         lua_pushstring(L, "setWindowWrap: wrong argument type");
         return lua_error(L);
     }
     int luaFrom = lua_tointeger(L, 2);
 
-    Host& host = getHostFromLua(L);
-    if (isMain(windowName)) {
-        host.mpConsole->setWrapAt(luaFrom);
-    } else {
-        mudlet::self()->setWindowWrap(&host, windowName, luaFrom);
-    }
+    auto console = CONSOLE(L, windowName);
+    console->setWrapAt(luaFrom);
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapIndent
 int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
-    if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "setWindowWrapIndent: wrong argument type");
-        return lua_error(L);
-    }
-    QString windowName = lua_tostring(L, 1);
+    QString windowName = WINDOW_NAME(L, 1);
 
     if (!lua_isnumber(L, 2)) {
         lua_pushstring(L, "setWindowWrapIndent: wrong argument type");
@@ -1903,60 +1868,35 @@ int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
     }
     int luaFrom = lua_tointeger(L, 2);
 
-    Host& host = getHostFromLua(L);
-    if (isMain(windowName)) {
-        host.mpConsole->setIndentCount(luaFrom);
-    } else {
-        mudlet::self()->setWindowWrapIndent(&host, windowName, luaFrom);
-    }
+    auto console = CONSOLE(L, windowName);
+    console->setIndentCount(luaFrom);
     return 0;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLineCount
 int TLuaInterpreter::getLineCount(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-    if (lua_isstring(L, 1)) {
-        QString window = lua_tostring(L, 1);
-        lua_pushnumber(L, mudlet::self()->getLastLineNumber(&host, window) + 1);
-        return 1;
-    } else {
-        int lineNumber = host.mpConsole->getLineCount();
-        lua_pushnumber(L, lineNumber);
-        return 1;
+    QString windowName;
+    if (lua_gettop(L) > 0) {
+        windowName = WINDOW_NAME(L, 1);
     }
+
+    auto console = CONSOLE(L, windowName);
+    lua_pushnumber(L, console->getLineCount());
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getColumnNumber
 int TLuaInterpreter::getColumnNumber(lua_State* L)
 {
     QString windowName;
-    Host& host = getHostFromLua(L);
-    if (lua_gettop(L)) {
-        if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "getColumnNumber: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, 1);
-
-        int result = 0;
-        if (windowName.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-            result = host.mpConsole->getColumnNumber();
-        } else {
-            result = mudlet::self()->getColumnNumber(&host, windowName);
-        }
-        if (result == -1) {
-            lua_pushnil(L);
-            lua_pushfstring(L, "window \"%s\" does not exist", windowName.toUtf8().constData());
-            return 2;
-        } else {
-            lua_pushnumber(L, result);
-            return 1;
-        }
-    } else {
-        lua_pushnumber(L, host.mpConsole->getColumnNumber());
-        return 1;
+    if (lua_gettop(L) > 0) {
+        windowName = WINDOW_NAME(L, 1);
     }
+
+    auto console = CONSOLE(L, windowName);
+    lua_pushnumber(L, console->getColumnNumber());
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getStopWatchTime
@@ -2439,15 +2379,10 @@ int TLuaInterpreter::getStopWatches(lua_State* L)
 int TLuaInterpreter::selectSection(lua_State* L)
 {
     int s = 1;
-    int argumentsCount = lua_gettop(L);
     QString windowName;
 
-    if (argumentsCount > 2) {
-        if (!lua_isstring(L, s)) {
-            lua_pushfstring(L, "selectSection: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, s);
+    if (lua_gettop(L) > 2) {
+        windowName = WINDOW_NAME(L, 1);
         s++;
     }
     if (!lua_isnumber(L, s)) {
@@ -2465,12 +2400,8 @@ int TLuaInterpreter::selectSection(lua_State* L)
 
     Host& host = getHostFromLua(L);
 
-    int ret;
-    if (isMain(windowName)) {
-        ret = host.mpConsole->selectSection(from, to);
-    } else {
-        ret = mudlet::self()->selectSection(&host, windowName, from, to);
-    }
+    auto console = CONSOLE(L, windowName);
+    int ret = console->selectSection(from, to);
     lua_pushboolean(L, ret == -1 ? false : true);
     return 1;
 }
@@ -2482,21 +2413,12 @@ int TLuaInterpreter::getSelection(lua_State* L)
     QString text;
     int start, length;
 
-    auto& host = getHostFromLua(L);
-
     QString windowName;
     if (lua_gettop(L) > 0) {
-        if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "getSelection: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, 1);
+        windowName = WINDOW_NAME(L, 1);
     }
-    if (isMain(windowName)) {
-        std::tie(valid, text, start, length) = host.mpConsole->getSelection();
-    } else {
-        std::tie(valid, text, start, length) = mudlet::self()->getSelection(&host, windowName);
-    }
+    auto console = CONSOLE(L, windowName);
+    std::tie(valid, text, start, length) = console->getSelection();
 
     if (!valid) {
         lua_pushnil(L);
@@ -2517,11 +2439,7 @@ int TLuaInterpreter::moveCursor(lua_State* L)
     int n = lua_gettop(L);
     QString windowName;
     if (n > 2) {
-        if (!lua_isstring(L, s)) {
-            lua_pushstring(L, "moveCursor: wrong argument type");
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, s);
+        windowName = WINDOW_NAME(L, s);
         s++;
     }
 
@@ -2538,13 +2456,8 @@ int TLuaInterpreter::moveCursor(lua_State* L)
     }
     int luaTo = lua_tointeger(L, s);
 
-    Host& host = getHostFromLua(L);
-
-    if (isMain(windowName)) {
-        lua_pushboolean(L, host.mpConsole->moveCursor(luaFrom, luaTo));
-    } else {
-        lua_pushboolean(L, mudlet::self()->moveCursor(&host, windowName, luaFrom, luaTo));
-    }
+    auto console = CONSOLE(L, windowName);
+    lua_pushboolean(L, console->moveCursor(luaFrom, luaTo));
     return 1;
 }
 
@@ -2555,11 +2468,7 @@ int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
     int n = lua_gettop(L);
     QString windowName;
     if (n > 2) {
-        if (!lua_isstring(L, s)) {
-            lua_pushstring(L, "setConsoleBufferSize: wrong argument type");
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, s);
+        windowName = WINDOW_NAME(L, s);
         s++;
     }
 
@@ -2667,22 +2576,17 @@ int TLuaInterpreter::replace(lua_State* L)
 {
     int n = lua_gettop(L);
     int s = 1;
+    QString windowName;
+
+    if (n > 1) {
+        windowName = WINDOW_NAME(L, 1);
+        s++;
+    }
     if (!lua_isstring(L, s)) {
         lua_pushstring(L, "replace: wrong argument type");
         return lua_error(L);
     }
     QString text = lua_tostring(L, s);
-    s++;
-
-    QString windowName;
-    if (n > 1) {
-        if (!lua_isstring(L, s)) {
-            lua_pushstring(L, "replace: wrong argument type");
-            return lua_error(L);
-        }
-        windowName = text;
-        text = lua_tostring(L, s);
-    }
 
     Host& host = getHostFromLua(L);
     if (isMain(windowName)) {
@@ -2698,11 +2602,7 @@ int TLuaInterpreter::deleteLine(lua_State* L)
 {
     QString windowName;
     if (lua_gettop(L) == 1) {
-        if (!lua_isstring(L, 1)) {
-            lua_pushstring(L, "deleteLine: wrong argument type");
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, 1);
+        windowName = WINDOW_NAME(L, 1);
     }
 
     Host& host = getHostFromLua(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -104,6 +104,30 @@ static bool isMain(const QString& name)
     return false;
 }
 
+static const char *bad_window_type = "%s: bad argument #%d type (window name as string expected, got %s!";
+static const char *bad_window_value = "window \"%s\" not found";
+
+#define WINDOW_NAME(_L, _pos)                                                                  \
+    ({                                                                                         \
+        if (!lua_isstring(_L, _pos)) {                                                         \
+            lua_pushfstring(_L, bad_window_type, __FUNCTION__, _pos, luaL_typename(_L, _pos)); \
+            return lua_error(_L);                                                              \
+        }                                                                                      \
+        lua_tostring(_L, _pos);                                                                \
+    })
+    
+#define CONSOLE(_L, _name)                                                                     \
+    ({                                                                                         \
+        auto console = getHostFromLua(_L).findConsole(_name);                                  \
+        if (!console) {                                                                        \
+            lua_pushnil(L);                                                                    \
+            lua_pushfstring(L, bad_window_value, _name.toUtf8().constData());                  \
+            return 2;                                                                          \
+        }                                                                                      \
+        console;                                                                               \
+    })
+
+
 TLuaInterpreter::TLuaInterpreter(Host* pH, const QString& hostName, int id) : mpHost(pH), hostName(hostName), mHostID(id), purgeTimer(this)
 {
     pGlobalLua = nullptr;
@@ -661,12 +685,7 @@ int TLuaInterpreter::selectString(lua_State* L)
     int s = 1;
     QString windowName;
     if (lua_gettop(L) > 2) {
-        if (!lua_isstring(L, s)) {
-            lua_pushfstring(L, R"(selectString: bad argument #%d type (window name as string, is optional {defaults to "main" if omitted}, got %s!))", s, luaL_typename(L, s));
-            return lua_error(L);
-        }
-        // We cannot yet properly handle non-ASCII windows names but we will eventually!
-        windowName = lua_tostring(L, s);
+        windowName = WINDOW_NAME(L, 1);
         s++;
     }
 
@@ -684,32 +703,21 @@ int TLuaInterpreter::selectString(lua_State* L)
     }
     qint64 numOfMatch = lua_tointeger(L, s);
 
-    if (isMain(windowName)) {
-        lua_pushnumber(L, host.mpConsole->select(searchText, numOfMatch));
-    } else {
-        lua_pushnumber(L, mudlet::self()->selectString(&host, windowName, searchText, numOfMatch));
-    }
+    auto console = CONSOLE(L, windowName);
+    lua_pushnumber(L, console->select(searchText, numOfMatch));
     return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCurrentLine
 int TLuaInterpreter::selectCurrentLine(lua_State* L)
 {
-    std::string windowName;
+    QString windowName;
     if (lua_gettop(L) > 0) {
-        if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "selectCurrentLine: bad argument #1 type (window name as string expected, got %s!)", luaL_typename(L, 1));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, 1);
+        windowName = WINDOW_NAME(L, 1);
     }
 
-    Host& host = getHostFromLua(L);
-    if (isMain(QString::fromStdString(windowName))) {
-        host.mpConsole->selectCurrentLine();
-    } else {
-        host.mpConsole->selectCurrentLine(windowName);
-    }
+    auto console = CONSOLE(L, windowName);
+    console->selectCurrentLine();
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -109,19 +109,21 @@ static const char *bad_window_value = "window \"%s\" not found";
 
 #define WINDOW_NAME(_L, _pos)                                                                  \
     ({                                                                                         \
-        if (!lua_isstring(_L, _pos)) {                                                         \
-            lua_pushfstring(_L, bad_window_type, __FUNCTION__, _pos, luaL_typename(_L, _pos)); \
+        int pos = (_pos);                                                                      \
+        if (!lua_isstring(_L, pos)) {                                                          \
+            lua_pushfstring(_L, bad_window_type, __FUNCTION__, pos, luaL_typename(_L, pos));   \
             return lua_error(_L);                                                              \
         }                                                                                      \
-        lua_tostring(_L, _pos);                                                                \
+        lua_tostring(_L, pos);                                                                 \
     })
     
 #define CONSOLE(_L, _name)                                                                     \
     ({                                                                                         \
-        auto console = getHostFromLua(_L).findConsole(_name);                                  \
+        auto name = (_name);                                                                   \
+        auto console = getHostFromLua(_L).findConsole(name);                                   \
         if (!console) {                                                                        \
             lua_pushnil(L);                                                                    \
-            lua_pushfstring(L, bad_window_value, _name.toUtf8().constData());                  \
+            lua_pushfstring(L, bad_window_value, name.toUtf8().constData());                   \
             return 2;                                                                          \
         }                                                                                      \
         console;                                                                               \

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -17553,11 +17553,11 @@ int TLuaInterpreter::getColumnCount(lua_State* L)
     QString windowName;
     if (!lua_gettop(L)) {
         windowName = QStringLiteral("main");
-    } else if (!lua_isstring(L, 1)) {
+    } else if (lua_isstring(L, 1)) {
+        windowName = QString::fromUtf8(lua_tostring(L, 1));
+    } else {
         lua_pushfstring(L, "getColumnCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
 
     int columns;
@@ -17585,11 +17585,11 @@ int TLuaInterpreter::getRowCount(lua_State* L)
     QString windowName;
     if (!lua_gettop(L)) {
         windowName = QStringLiteral("main");
-    } else if (!lua_isstring(L, 1)) {
+    } else if (lua_isstring(L, 1)) {
+        windowName = QString::fromUtf8(lua_tostring(L, 1));
+    } else {
         lua_pushfstring(L, "getRowCount: bad argument #1 type (window name as string expected, got %s)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        windowName = QString::fromUtf8(lua_tostring(L, 1));
     }
 
     int rows;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1806,7 +1806,7 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
         transcodedMsg = mpOutOfBandDataIncomingCodec->toUnicode(msg);
     } else {
         // Message is in ASCII (though this can handle Utf-8):
-        transcodedMsg = QString::fromUtf8(msg);
+        transcodedMsg = msg;
     }
 
     QString var;
@@ -1880,7 +1880,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         transcodedMsg = mpOutOfBandDataIncomingCodec->toUnicode(msg);
     } else {
         // Message is in ASCII (though this can handle Utf-8):
-        transcodedMsg = QString::fromUtf8(msg);
+        transcodedMsg = msg;
     }
 
     QString packageMessage;
@@ -2027,7 +2027,7 @@ void cTelnet::setMSSPVariables(const QByteArray& msg)
         transcodedMsg = mpOutOfBandDataIncomingCodec->toUnicode(msg);
     } else {
         // Message is in ASCII (though this can handle Utf-8):
-        transcodedMsg = QString::fromUtf8(msg);
+        transcodedMsg = msg;
     }
 
     transcodedMsg.remove(QChar::LineFeed);
@@ -2049,7 +2049,7 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
         transcodedMsg = mpOutOfBandDataIncomingCodec->toUnicode(msg);
     } else {
         // Message is in ASCII (though this can handle Utf-8):
-        transcodedMsg = QString::fromUtf8(msg);
+        transcodedMsg = msg;
     }
 
     // MSP specification: https://www.zuggsoft.com/zmud/msp.htm#MSP%20Specification

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -267,10 +267,10 @@ void Discord::timerEvent(QTimerEvent* event)
 void Discord::handleDiscordReady(const DiscordUser* request)
 {
     Discord::smReadWriteLock.lockForWrite(); // Will block until gets lock
-    Discord::smUserName = QString::fromUtf8(request->username);
-    Discord::smUserId = QString::fromUtf8(request->userId);
-    Discord::smDiscriminator = QString::fromUtf8(request->discriminator);
-    Discord::smAvatar = QString::fromUtf8(request->avatar);
+    Discord::smUserName = request->username;
+    Discord::smUserId = request->userId;
+    Discord::smDiscriminator = request->discriminator;
+    Discord::smAvatar = request->avatar;
     Discord::smReadWriteLock.unlock();
 
 #if defined(DEBUG_DISCORD)

--- a/src/discord.h
+++ b/src/discord.h
@@ -96,18 +96,18 @@ public:
     void setPartySize(const int n) { mPartySize = n; }
     void setPartyMax(const int n) { mPartyMax = n; }
     DiscordRichPresence convert() const;
-    QString getStateText() const { return QString::fromUtf8(mState); }
-    QString getDetailText() const { return QString::fromUtf8(mDetails); }
+    QString getStateText() const { return mState; }
+    QString getDetailText() const { return mDetails; }
     int64_t getStartTimeStamp() const { return mStartTimestamp; }
     int64_t getEndTimeStamp() const { return mEndTimestamp; }
-    QString getLargeImageKey() const { return QString::fromUtf8(mLargeImageKey); }
-    QString getLargeImageText() const { return QString::fromUtf8(mLargeImageText); }
-    QString getSmallImageKey() const { return QString::fromUtf8(mSmallImageKey); }
-    QString getSmallImageText() const { return QString::fromUtf8(mSmallImageText); }
-    QString getJoinSecret() const { return QString::fromUtf8(mJoinSecret); }
-    QString getMatchSecret() const { return QString::fromUtf8(mMatchSecret); }
-    QString getSpectateSecret() const { return QString::fromUtf8(mSpectateSecret); }
-    QString getPartyId() const { return QString::fromUtf8(mPartyId); }
+    QString getLargeImageKey() const { return mLargeImageKey; }
+    QString getLargeImageText() const { return mLargeImageText; }
+    QString getSmallImageKey() const { return mSmallImageKey; }
+    QString getSmallImageText() const { return mSmallImageText; }
+    QString getJoinSecret() const { return mJoinSecret; }
+    QString getMatchSecret() const { return mMatchSecret; }
+    QString getSpectateSecret() const { return mSpectateSecret; }
+    QString getPartyId() const { return mPartyId; }
     int getPartySize() const { return mPartySize; }
     int getPartyMax() const { return mPartyMax; }
     int8_t getInstance() const { return mInstance; }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -194,7 +194,7 @@ void dlgMapper::show2dView()
     }
     if (!glWidget) {
         glWidget = new GLWidget(widget);
-        glWidget->setObjectName(QString::fromUtf8("glWidget"));
+        glWidget->setObjectName("glWidget");
 
         QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         sizePolicy.setHorizontalStretch(0);

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -156,7 +156,7 @@ bool dlgPackageExporter::writeFileToZip(const QString& archiveFileName, const QS
         displayResultMessage(tr("Failed to open file \"%1\" to place into package. Error message was: \"%2\".",
                                 // Intentional comment to separate arguments
                                 "This error message will appear when a file is to be placed into the package but the code cannot open it.")
-                             .arg(fileSystemFileName, QString::fromUtf8(zip_strerror(archive))), false);
+                             .arg(fileSystemFileName, zip_strerror(archive)), false);
         return false;
     }
 
@@ -164,7 +164,7 @@ bool dlgPackageExporter::writeFileToZip(const QString& archiveFileName, const QS
         displayResultMessage(tr("Failed to add file \"%1\" to package \"%2\". Error message was: \"%3\".",
                                 // Intentional comment to separate arguments
                                 "This error message will appear when a file is to be placed into the package but cannot be done for some reason.")
-                             .arg(archiveFileName, mPackagePathFileName, QString::fromUtf8(zip_strerror(archive))), false);
+                             .arg(archiveFileName, mPackagePathFileName, zip_strerror(archive)), false);
         return false;
     }
 
@@ -346,7 +346,7 @@ void dlgPackageExporter::slot_export_package()
             displayResultMessage(tr("Failed to open package file. Error is: \"%1\".",
                                     // Intentional comment to separate arguments
                                     "This error message is shown when the libzip library code is unable to open the file that was to be the end result of the export process. As this may be an existing file anywhere in the computer's file-system(s) it is possible that permissions on the directory or an existing file that is to be overwritten may be a source of problems here.")
-                                 .arg(QString::fromUtf8(zip_error_strerror(&error))), false);
+                                 .arg(zip_error_strerror(&error)), false);
             zip_error_fini(&error);
             isOk = false;
             // The above flag will now cause execution to drop down to the bottom of
@@ -438,7 +438,7 @@ void dlgPackageExporter::slot_export_package()
                 // added directory item in the archive or -1 on error:
                 if (zip_dir_add(archive, directoryName.toStdString().c_str(), ZIP_FL_ENC_UTF_8) == -1) {
                     displayResultMessage(tr("Failed to add directory \"%1\" to package. Error is: \"%2\".")
-                                         .arg(directoryName, QString::fromUtf8(zip_strerror(archive))), false);
+                                         .arg(directoryName, zip_strerror(archive)), false);
                     zip_close(archive);
                     isOk = false;
                 }
@@ -518,7 +518,7 @@ void dlgPackageExporter::slot_export_package()
                     displayResultMessage(tr("Failed to write files into and then close the package. Error is: \"%1\".",
                                             // Intentional comment to separate arguments
                                             "This error message is displayed at the final stage of exporting a package when all the sourced files are finally put into the archive. Unfortunately this may be the point at which something breaks because a problem was not spotted/detected in the process earlier...")
-                                         .arg(QString::fromUtf8(zip_strerror(archive))), false);
+                                         .arg(zip_strerror(archive)), false);
                     // In libzip 0.11 a function was added to clean up
                     // (deallocate) the memory associated with an archive
                     // - which would normally occur upon a successful close

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4715,7 +4715,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     // Value is: absolute path needed when extracting files
     for (zip_int64_t i = 0, total = zip_get_num_entries(archive, 0); i < total; ++i) {
         if (!zip_stat_index(archive, static_cast<zip_uint64_t>(i), 0, &zs)) {
-            QString entryInArchive(QString::fromUtf8(zs.name));
+            QString entryInArchive(zs.name);
             QString pathInArchive(entryInArchive.section(QLatin1Literal("/"), 0, -2));
             // TODO: We are supposed to validate the fields (except the
             // "valid" one itself) in zs before using them:
@@ -4750,7 +4750,7 @@ bool mudlet::unzip(const QString& archivePath, const QString& destination, const
     for (zip_int64_t i = 0, total = zip_get_num_entries(archive, 0); i < total; ++i) {
         // No need to check return value as we've already done it first time
         zip_stat_index(archive, static_cast<zip_uint64_t>(i), 0, &zs);
-        QString entryInArchive(QString::fromUtf8(zs.name));
+        QString entryInArchive(zs.name);
         if (!entryInArchive.endsWith(QLatin1Char('/'))) {
             // TODO: check that zs.size is valid ( zs.valid & ZIP_STAT_SIZE )
             zf = zip_fopen_index(archive, static_cast<zip_uint64_t>(i), 0);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Accessing a window name, and translating it to a `TConsole` instance off the current `Host`, is moved to a pair of macros. This shortens and simplifies the code and cleans up a heap of error messages.

#### Motivation for adding to Mudlet

The code needs to be simplified; there are many places which check whether a window/miniconsole name is valid, each has their own error string, and handling of nonexisting or empty names is inconsistent.

#### Other info (issues closed, discussion etc)

This patch moves the sub-window check to the `Host` class. There's some discussion whether to split `TConsole` into a `TMainConsole`, in which case it'd make more sense to do this there,

However, this patch series will move all tests to macros which start off by accessing `THost` from Lua's registry, so changing things later is trivial and will not affect this work.
