### PR TITLE
Fix finding Sparkle with CMake

### DIFF
--- a/cmake/FindSparkle.cmake
+++ b/cmake/FindSparkle.cmake
@@ -6,7 +6,7 @@ find_path(
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set SPARKLE_FOUND to TRUE if all
 # listed variables are TRUE
-find_package_handle_standard_args(SPARKLE REQUIRED_VARS SPARKLE_INCLUDE_DIR)
+find_package_handle_standard_args(Sparkle REQUIRED_VARS SPARKLE_INCLUDE_DIR)
 
 mark_as_advanced(SPARKLE_INCLUDE_DIR)
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Apply CMake's suggestion for finding Sparkle.
#### Motivation for adding to Mudlet
Fix Github Actions macOS builds, see https://github.com/Mudlet/Mudlet/pull/4143/checks?check_run_id=1229968915.
#### Other info (issues closed, discussion etc)
```
2020-10-09T06:58:52.0577150Z CMake Warning (dev) at /usr/local/Cellar/cmake/3.18.3/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
2020-10-09T06:58:52.0578690Z   The package name passed to `find_package_handle_standard_args` (SPARKLE)
2020-10-09T06:58:52.0579630Z   does not match the name of the calling package (Sparkle).  This can lead to
2020-10-09T06:58:52.0580570Z   problems in calling code that expects `find_package` result variables
2020-10-09T06:58:52.0581390Z   (e.g., `_FOUND`) to follow a certain pattern.
2020-10-09T06:58:52.0582080Z Call Stack (most recent call first):
2020-10-09T06:58:52.0582880Z   cmake/FindSparkle.cmake:9 (find_package_handle_standard_args)
2020-10-09T06:58:52.0583850Z   3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake:286 (_find_package)
2020-10-09T06:58:52.0585540Z   3rdparty/sparkle-glue/CMakeLists.txt:72 (find_package)
2020-10-09T06:58:52.0586910Z This warning is for project developers.  Use -Wno-dev to suppress it.
2020-10-09T06:58:52.0587550Z 
2020-10-09T06:58:52.0589590Z -- Could NOT find SPARKLE (missing: SPARKLE_INCLUDE_DIR) 
2020-10-09T06:58:52.0668660Z -- Configuring done
2020-10-09T06:58:52.6404790Z CMake Error at 3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake:186 (_add_executable):
2020-10-09T06:58:52.6415860Z ##[error]  Target "mudlet" links to target "Sparkle::Sparkle" but the target was not
2020-10-09T06:58:52.6419140Z   found.  Perhaps a find_package() call is missing for an IMPORTED target, or
2020-10-09T06:58:52.6419720Z   an ALIAS target is missing?
2020-10-09T06:58:52.6420100Z Call Stack (most recent call first):
2020-10-09T06:58:52.6420570Z   src/CMakeLists.txt:336 (add_executable)
2020-10-09T06:58:52.6420860Z 
2020-10-09T06:58:52.6421010Z 
2020-10-09T06:58:52.6421680Z CMake Error at 3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake:215 (_add_library):
2020-10-09T06:58:52.6424390Z ##[error]  Target "cocoa-qt-glue" links to target "Sparkle::Sparkle" but the target
2020-10-09T06:58:52.6425730Z   was not found.  Perhaps a find_package() call is missing for an IMPORTED
2020-10-09T06:58:52.6426280Z   target, or an ALIAS target is missing?
2020-10-09T06:58:52.6426690Z Call Stack (most recent call first):
2020-10-09T06:58:52.6427700Z   3rdparty/sparkle-glue/CMakeLists.txt:65 (add_library)
```