### PR TITLE
Replace remaining fromLatin1 / toLatin1 calls with their Utf8 equivalents

### DIFF
--- a/src/MxpTag.h
+++ b/src/MxpTag.h
@@ -33,7 +33,7 @@ public:
 
     MxpTagAttribute(const QString& name, const QString& value) : QPair(name, value) {}
 
-    explicit MxpTagAttribute(const QString& name) : MxpTagAttribute(name, QString::fromLatin1("")) {}
+    explicit MxpTagAttribute(const QString& name) : MxpTagAttribute(name, QStringLiteral("")) {}
 
     MxpTagAttribute() : QPair() {}
 

--- a/src/MxpTag.h
+++ b/src/MxpTag.h
@@ -33,7 +33,7 @@ public:
 
     MxpTagAttribute(const QString& name, const QString& value) : QPair(name, value) {}
 
-    explicit MxpTagAttribute(const QString& name) : MxpTagAttribute(name, QStringLiteral("")) {}
+    explicit MxpTagAttribute(const QString& name) : MxpTagAttribute(name, QString()) {}
 
     MxpTagAttribute() : QPair() {}
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -3525,7 +3525,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
             for (size_t i = 0; i < utf8SequenceLength; ++i) {
                 debugMsg.append(QStringLiteral("<%1>").arg(static_cast<quint8>(bufferData.at(pos + i)), 2, 16, QChar('0')));
             }
-            qDebug().nospace() << "    Sequence bytes are: " << debugMsg.toLatin1().constData();
+            qDebug().nospace() << "    Sequence bytes are: " << debugMsg;
 #endif
             if (isToUseReplacementMark) {
                 mMudLine.append(QChar::ReplacementCharacter);
@@ -3968,7 +3968,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
         for (size_t i = 0; i < gbSequenceLength; ++i) {
             debugMsg.append(QStringLiteral("<%1>").arg(static_cast<quint8>(bufferData.at(pos + i)), 2, 16, QChar('0')));
         }
-        qDebug().nospace() << "    Sequence bytes are: " << debugMsg.toLatin1().constData();
+        qDebug().nospace() << "    Sequence bytes are: " << debugMsg;
 #endif
         if (isToUseReplacementMark) {
             mMudLine.append(QChar::ReplacementCharacter);
@@ -4093,7 +4093,7 @@ bool TBuffer::processBig5Sequence(const std::string& bufferData, const bool isFr
         for (size_t i = 0; i < big5SequenceLength; ++i) {
             debugMsg.append(QStringLiteral("<%1>").arg(static_cast<quint8>(bufferData.at(pos + i)), 2, 16, QChar('0')));
         }
-        qDebug().nospace() << "    Invalid.  Sequence bytes are: " << debugMsg.toLatin1().constData();
+        qDebug().nospace() << "    Invalid.  Sequence bytes are: " << debugMsg;
 #endif
         if (isToUseReplacementMark) {
             mMudLine.append(QChar::ReplacementCharacter);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1544,9 +1544,9 @@ int TLuaInterpreter::getMapMenus(lua_State* L)
                     QStringList menuInfo = it.value();
                     parent = menuInfo[0];
                     display = menuInfo[1];
-                    lua_pushstring(L, it.key().toLatin1().data());
-                    lua_pushstring(L, parent.toLatin1().data());
-                    lua_pushstring(L, display.toLatin1().data());
+                    lua_pushstring(L, it.key().toUtf8().constData());
+                    lua_pushstring(L, parent.toUtf8().constData());
+                    lua_pushstring(L, display.toUtf8().constData());
                     lua_settable(L, -3);
                 }
             }
@@ -3023,7 +3023,7 @@ int TLuaInterpreter::getModulePath(lua_State* L)
     QMap<QString, QStringList> modules = host.mInstalledModules;
     if (modules.contains(moduleName)) {
         QString modPath = modules[moduleName][0];
-        lua_pushstring(L, modPath.toLatin1().data());
+        lua_pushstring(L, modPath.toUtf8().constData());
         return 1;
     }
     return 0;
@@ -8914,11 +8914,11 @@ int TLuaInterpreter::invokeFileDialog(lua_State* L)
 
     if (!luaDir) {
         QString fileName = QFileDialog::getExistingDirectory(nullptr, title, QDir::currentPath());
-        lua_pushstring(L, fileName.toLatin1().data());
+        lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     } else {
         QString fileName = QFileDialog::getOpenFileName(nullptr, title, QDir::currentPath());
-        lua_pushstring(L, fileName.toLatin1().data());
+        lua_pushstring(L, fileName.toUtf8().constData());
         return 1;
     }
 }
@@ -10458,7 +10458,7 @@ int TLuaInterpreter::getExitWeights(lua_State* L)
     if (pR) {
         QStringList keys = pR->getExitWeights().keys();
         for (int i = 0; i < keys.size(); i++) {
-            lua_pushstring(L, keys[i].toLatin1().data());
+            lua_pushstring(L, keys[i].toUtf8().constData());
             lua_pushnumber(L, pR->getExitWeight(keys[i]));
             lua_settable(L, -3);
         }
@@ -10505,7 +10505,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
         while (it.hasNext()) {
             it.next();
             lua_pushnumber(L, it.key());
-            lua_pushstring(L, it.value().text.toLatin1().data());
+            lua_pushstring(L, it.value().text.toUtf8().constData());
             lua_settable(L, -3);
         }
     }
@@ -10563,7 +10563,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
                 lua_pushnumber(L, width);
                 lua_settable(L, -3);
                 lua_pushstring(L, "Text");
-                lua_pushstring(L, text.toLatin1().data());
+                lua_pushstring(L, text.toUtf8().constData());
                 lua_settable(L, -3);
             } else {
                 lua_pushstring(L, "getMapLabel: labelId doesn't exist");
@@ -10600,7 +10600,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
                     lua_pushnumber(L, width);
                     lua_settable(L, -3);
                     lua_pushstring(L, "Text");
-                    lua_pushstring(L, text.toLatin1().data());
+                    lua_pushstring(L, text.toUtf8().constData());
                     lua_settable(L, -3);
                     lua_pushnumber(L, id);
                     lua_insert(L, -2);
@@ -10922,8 +10922,8 @@ int TLuaInterpreter::getSpecialExits(lua_State* L)
             } else {
                 exit = dir;
             }
-            lua_pushstring(L, exit.toLatin1().data());       //done to remove the prepended special exit status
-            lua_pushstring(L, exitStatus.toLatin1().data()); //done to remove the prepended special exit status
+            lua_pushstring(L, exit.toUtf8().constData());       //done to remove the prepended special exit status
+            lua_pushstring(L, exitStatus.toUtf8().constData()); //done to remove the prepended special exit status
             lua_settable(L, -3);
             lua_pushnumber(L, id_to);
             lua_insert(L, -2);
@@ -10953,7 +10953,7 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
             it.next();
             int id_to = it.key();
             QString dir = it.value();
-            // lua_pushstring(L, dir.toLatin1().data());
+            // lua_pushstring(L, dir.toUtf8().constData());
             QString exitStatus;
             QString exit;
             if (dir.size() > 0 && (dir.startsWith('0') || dir.startsWith('1'))) {
@@ -10967,7 +10967,7 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
             } else {
                 exit = dir;
             }
-            lua_pushstring(L, exit.toLatin1().data());
+            lua_pushstring(L, exit.toUtf8().constData());
             lua_pushnumber(L, id_to);
             lua_settable(L, -3);
         }
@@ -13142,7 +13142,7 @@ int TLuaInterpreter::getTime(lua_State* L)
     QDateTime time = QDateTime::currentDateTime();
     if (return_string) {
         tm = time.toString(format);
-        lua_pushstring(L, tm.toLatin1().data());
+        lua_pushstring(L, tm.toUtf8().constData());
     } else {
         QDate dt = time.date();
         QTime tm = time.time();
@@ -14270,7 +14270,7 @@ int TLuaInterpreter::ttsGetQueue(lua_State* L)
             return 1;
         }
 
-        lua_pushstring(L, speechQueue.at(index).toLatin1().constData());
+        lua_pushstring(L, speechQueue.at(index).toUtf8().constData());
         return 1;
     }
 
@@ -14399,7 +14399,7 @@ int TLuaInterpreter::setServerEncoding(lua_State* L)
     }
 
     lua_pushnil(L);
-    lua_pushfstring(L, results.second.toLatin1().constData());
+    lua_pushfstring(L, results.second.toUtf8().constData());
     return 2;
 }
 
@@ -14768,8 +14768,8 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
 {
     lua_State* L = pGlobalLua;
     lua_getglobal(L, "atcp"); //defined in LuaGlobal.lua
-    lua_pushstring(L, var.toLatin1().data());
-    lua_pushstring(L, arg.toLatin1().data());
+    lua_pushstring(L, var.toUtf8().constData());
+    lua_pushstring(L, arg.toUtf8().constData());
     lua_rawset(L, -3);
     lua_pop(L, 1);
 
@@ -18295,7 +18295,7 @@ void TLuaInterpreter::insertColorTableEntry(lua_State* L, const QColor& color, c
     lua_getfield(L, LUA_GLOBALSINDEX, "color_table");
     lua_insert(L, -2);
 
-    lua_pushstring(L, name.toLatin1().constData());
+    lua_pushstring(L, name.toUtf8().constData());
     lua_insert(L, -2);
     lua_settable(L, -3);
     lua_pop(L, 1);
@@ -18445,7 +18445,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
         lua_insert(L, -2);
 
         QString name = QStringLiteral("ansi_%1").arg(i + 16, 3, 10, QLatin1Char('0'));
-        lua_pushstring(L, name.toLatin1().constData());
+        lua_pushstring(L, name.toUtf8().constData());
         lua_insert(L, -2);
         lua_settable(L, -3);
         lua_pop(L, 1);
@@ -18502,7 +18502,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
         lua_insert(L, -2);
 
         QString name = QStringLiteral("ansi_%1").arg(i, 3, 10, QLatin1Char('0'));
-        lua_pushstring(L, name.toLatin1().constData());
+        lua_pushstring(L, name.toUtf8().constData());
         lua_insert(L, -2);
         lua_settable(L, -3);
         lua_pop(L, 1);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10953,7 +10953,6 @@ int TLuaInterpreter::getSpecialExitsSwap(lua_State* L)
             it.next();
             int id_to = it.key();
             QString dir = it.value();
-            // lua_pushstring(L, dir.toUtf8().constData());
             QString exitStatus;
             QString exit;
             if (dir.size() > 0 && (dir.startsWith('0') || dir.startsWith('1'))) {

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -34,7 +34,7 @@ class TMediaData;
 
 class TMxpMudlet : public TMxpClient
 {
-    inline static const QString scmVersion = QStringLiteral("%1%2").arg(QString::fromUtf8(APP_VERSION), QString::fromUtf8(APP_BUILD));
+    inline static const QString scmVersion = QStringLiteral(APP_VERSION APP_BUILD);
 
     Host* mpHost;
 

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -34,7 +34,7 @@ class TMediaData;
 
 class TMxpMudlet : public TMxpClient
 {
-    inline static const QString scmVersion = QStringLiteral("%1%2").arg(QString::fromLatin1(APP_VERSION), QString::fromLatin1(APP_BUILD));
+    inline static const QString scmVersion = QStringLiteral("%1%2").arg(QString::fromUtf8(APP_VERSION), QString::fromUtf8(APP_BUILD));
 
     Host* mpHost;
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -445,11 +445,11 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     QColor outerColor;
     QColor innerColor;
     pHost->getPlayerRoomStyleDetails(styleCode, outerDiameterPercentage, innerDiameterPercentage, outerColor, innerColor);
-    host.append_attribute("playerRoomPrimaryColor") = outerColor.name(QColor::HexArgb).toLatin1().constData();
-    host.append_attribute("playerRoomSecondaryColor") = innerColor.name(QColor::HexArgb).toLatin1().constData();
-    host.append_attribute("playerRoomStyle") = QString::number(styleCode).toLatin1().constData();
-    host.append_attribute("playerRoomOuterDiameter") = QString::number(outerDiameterPercentage).toLatin1().constData();
-    host.append_attribute("playerRoomInnerDiameter") = QString::number(innerDiameterPercentage).toLatin1().constData();
+    host.append_attribute("playerRoomPrimaryColor") = outerColor.name(QColor::HexArgb).toUtf8().constData();
+    host.append_attribute("playerRoomSecondaryColor") = innerColor.name(QColor::HexArgb).toUtf8().constData();
+    host.append_attribute("playerRoomStyle") = QString::number(styleCode).toUtf8().constData();
+    host.append_attribute("playerRoomOuterDiameter") = QString::number(outerDiameterPercentage).toUtf8().constData();
+    host.append_attribute("playerRoomInnerDiameter") = QString::number(innerDiameterPercentage).toUtf8().constData();
     host.append_attribute("CompactInputLine") = pHost->getCompactInputLine() ? "yes" : "no";
 
     QString ignore;
@@ -458,7 +458,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         ignore = ignore.append(it.next());
     }
     host.append_attribute("mDoubleClickIgnore") = ignore.toUtf8().constData();
-    host.append_attribute("EditorSearchOptions") = QString::number(pHost->mSearchOptions).toLatin1().constData();
+    host.append_attribute("EditorSearchOptions") = QString::number(pHost->mSearchOptions).toUtf8().constData();
     host.append_attribute("DebugShowAllProblemCodepoints") = pHost->debugShowAllProblemCodepoints() ? "yes" : "no";
 
     { // Blocked so that indentation reflects that of the XML file
@@ -561,13 +561,13 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
             if (pStopWatch->persistent()) {
                 auto stopwatch = stopwatches.append_child("stopwatch");
                 // Three QStrings used here are purely numeric so can be expressed in Latin1 encoding:
-                stopwatch.append_attribute("id") = QString::number(stopWatchId).toLatin1().constData();
+                stopwatch.append_attribute("id") = QString::number(stopWatchId).toUtf8().constData();
                 if (pStopWatch->running()) {
                     stopwatch.append_attribute("running") = "yes";
-                    stopwatch.append_attribute("effectiveStartDateTimeEpochMSecs") = QString::number(QDateTime::currentMSecsSinceEpoch() - pStopWatch->getElapsedMilliSeconds()).toLatin1().constData();
+                    stopwatch.append_attribute("effectiveStartDateTimeEpochMSecs") = QString::number(QDateTime::currentMSecsSinceEpoch() - pStopWatch->getElapsedMilliSeconds()).toUtf8().constData();
                 } else {
                     stopwatch.append_attribute("running") = "no";
-                    stopwatch.append_attribute("elapsedDateTimeMSecs") = QString::number(pStopWatch->getElapsedMilliSeconds()).toLatin1().constData();
+                    stopwatch.append_attribute("elapsedDateTimeMSecs") = QString::number(pStopWatch->getElapsedMilliSeconds()).toUtf8().constData();
                 }
                 stopwatch.append_attribute("name") = pStopWatch->name().toUtf8().constData();
             }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1760,7 +1760,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                      * Once we comply with that we can be certain that Mud
                      * Server encoding will NOT be an issue!
                      */
-                    cmd += termType.toLatin1().data();
+                    cmd += termType.toUtf8().constData();
                     cmd += TN_IAC;
                     cmd += TN_SE;
                     socketOutRaw(cmd);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2371,7 +2371,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
 
         // This settings also need to be configured, note that the only time not to
         // save the setting is on profile loading:
-        pHost->mTelnet.setEncoding(readProfileData(profile_name, QLatin1String("encoding")).toLatin1(), false);
+        pHost->mTelnet.setEncoding(readProfileData(profile_name, QStringLiteral("encoding")).toUtf8(), false);
         // Needed to ensure setting is correct on start-up:
         pHost->setWideAmbiguousEAsianGlyphs(pHost->getWideAmbiguousEAsianGlyphsControlState());
         pHost->setAutoReconnect(auto_reconnect->isChecked());

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4278,7 +4278,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
 
     // This settings also need to be configured, note that the only time not to
     // save the setting is on profile loading:
-    pHost->mTelnet.setEncoding(readProfileData(profile_name, QLatin1String("encoding")).toLatin1(), false);
+    pHost->mTelnet.setEncoding(readProfileData(profile_name, QStringLiteral("encoding")).toUtf8(), false);
 
     emit signal_hostCreated(pHost, mHostManager.getHostCount());
     slot_connection_dlg_finished(profile_name, true);


### PR DESCRIPTION
There seem to be some left-over calls to QString's `fromLatin1`/ `toLatin1` methods which should be UTF-8.

This patch fixes those.

TODO: several of these calls apply to single characters, as opposed to strings. I didn't touch those.