### PR TITLE
allow Adjustable.Container to be attached to a border at creation

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -1097,6 +1097,8 @@ function Adjustable.Container:new(cons,container)
         if Adjustable.Container.all[me.name].auto_hidden then
             me:hide(true)
         end
+        -- detach if setting at creation changed
+        Adjustable.Container.all[me.name]:detach()
     end
 
     if me.minimized then

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -999,6 +999,7 @@ end
 --@param cons.buttonstyle close and minimize buttons style
 --@param[opt=false] cons.minimized  minimized at creation?
 --@param[opt=false] cons.locked  locked at creation?
+--@param[opt=false] cons.attached  attached to a border at creation? possible borders are ("top", "bottom", "left", "right")
 --@param cons.lockLabel.txt  text of the "lock" menu item
 --@param cons.minLabel.txt  text of the "min/restore" menu item
 --@param cons.saveLabel.txt  text of the "save" menu item
@@ -1076,7 +1077,6 @@ function Adjustable.Container:new(cons,container)
     me.minimizeLabel:setClickCallback("Adjustable.Container.onClickMin", me)
     me.attLabel:setOnEnter("Adjustable.Container.onEnterAtt", me)
     me.goInside = true
-    me:adjustBorder()
     me.titleTxtColor = me.titleTxtColor or "green"
     me.titleText = me.titleText or me.name.." - Adjustable Container"
     me.titleText = "&nbsp;&nbsp; "..me.titleText
@@ -1107,6 +1107,12 @@ function Adjustable.Container:new(cons,container)
         me:lockContainer()
     end
 
+    if me.attached then
+        local attached = me.attached
+        me.attached = nil
+        me:attachToBorder(attached)
+    end
+
     -- hide/show on creation
     if cons.hidden == true then
         me:hide()
@@ -1127,6 +1133,7 @@ function Adjustable.Container:new(cons,container)
     end
 
     Adjustable.Container.all[me.name] = me
+    me:adjustBorder()
     return me
 end
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see title

#### Motivation for adding to Mudlet
lack of this functionality

#### Other info (issues closed, discussion etc)
this code
```lua
testCont = Adjustable.Container:new({name = "testCont", height = "100", y = "-100", attached = "bottom", autoLoad = false})
```
works now (edit: added autoLoad = false to avoid confusion)