### PR TITLE
Add ability to override speedwalk path generation

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -907,9 +907,9 @@ bool Host::checkForMappingScript()
     return ret;
 }
 
-bool Host::checkForSpeedwalkScript()
+bool Host::checkForCustomSpeedwalk()
 {
-    bool ret = mLuaInterpreter.check_for_speedwalkscript();
+    bool ret = mLuaInterpreter.check_for_custom_speedwalk();
     return ret;
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -907,10 +907,27 @@ bool Host::checkForMappingScript()
     return ret;
 }
 
+bool Host::checkForSpeedwalkScript()
+{
+    bool ret = mLuaInterpreter.check_for_speedwalkscript();
+    return ret;
+}
+
 void Host::startSpeedWalk()
 {
     int totalWeight = assemblePath();
     Q_UNUSED(totalWeight);
+    QString f = QStringLiteral("doSpeedWalk");
+    QString n = QString();
+    mLuaInterpreter.call(f, n);
+}
+
+void Host::startSpeedWalk(int sourceRoom, int targetRoom)
+{
+    QString sourceName = QStringLiteral("speedWalkFrom");
+    mLuaInterpreter.set_lua_integer(sourceName, sourceRoom);
+    QString targetName = QStringLiteral("speedWalkTo");
+    mLuaInterpreter.set_lua_integer(targetName, targetRoom);
     QString f = QStringLiteral("doSpeedWalk");
     QString n = QString();
     mLuaInterpreter.call(f, n);

--- a/src/Host.h
+++ b/src/Host.h
@@ -196,6 +196,7 @@ public:
     bool isClosingDown();
     unsigned int assemblePath();
     bool checkForMappingScript();
+    bool checkForSpeedwalkScript();
 
     TriggerUnit* getTriggerUnit() { return &mTriggerUnit; }
     TimerUnit* getTimerUnit() { return &mTimerUnit; }
@@ -253,6 +254,7 @@ public:
     QPair<bool, QString> resetAndRestartStopWatch(const int);
 
     void startSpeedWalk();
+    void startSpeedWalk(int sourceRoom, int targetRoom);
     void saveModules(int sync, bool backup = true);
     void reloadModule(const QString& reloadModuleName);
     std::pair<bool, QString> changeModuleSync(const QString& enableModuleName, const QLatin1String &value);

--- a/src/Host.h
+++ b/src/Host.h
@@ -196,7 +196,7 @@ public:
     bool isClosingDown();
     unsigned int assemblePath();
     bool checkForMappingScript();
-    bool checkForSpeedwalkScript();
+    bool checkForCustomSpeedwalk();
 
     TriggerUnit* getTriggerUnit() { return &mTriggerUnit; }
     TimerUnit* getTimerUnit() { return &mTimerUnit; }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -685,7 +685,10 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
     mTarget = speedWalkTargetRoomId;
     if (mpMap->mpRoomDB->getRoom(speedWalkTargetRoomId)) {
         mpMap->mTargetID = speedWalkTargetRoomId;
-        if (mpMap->findPath(speedWalkStartRoomId, speedWalkTargetRoomId)) {
+
+        if (mpHost->checkForSpeedwalkScript()) {
+            mpHost->startSpeedWalk(speedWalkStartRoomId, speedWalkTargetRoomId);
+        } else if (mpMap->findPath(speedWalkStartRoomId, speedWalkTargetRoomId)) {
             mpHost->startSpeedWalk();
         } else {
             mpHost->mpConsole->printSystemMessage(QStringLiteral("%1\n").arg(tr("Mapper: Cannot find a path from %1 to %2 using known exits.")

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -680,7 +680,7 @@ bool T2DMap::sizeFontToFitTextInRect( QFont & font, const QRectF & boundaryRect,
 }
 
 // Helper that refactors out code to start a speedwalk:
-void T2DMap::initiateSpeeWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId)
+void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId)
 {
     mTarget = speedWalkTargetRoomId;
     if (mpMap->mpRoomDB->getRoom(speedWalkTargetRoomId)) {
@@ -798,7 +798,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QPen& pen, 
             diameterPath.addEllipse(roomCenter, roomRadius, roomRadius);
             painter.drawPath(diameterPath);
 
-            initiateSpeeWalk(speedWalkStartRoomId, currentRoomId);
+            initiateSpeedWalk(speedWalkStartRoomId, currentRoomId);
         }
 
     } else {
@@ -1168,7 +1168,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QPen& pen, 
                 painter.drawPath(myPath);
 
                 mPick = false;
-                initiateSpeeWalk(speedWalkStartRoomId, it.key());
+                initiateSpeedWalk(speedWalkStartRoomId, it.key());
             }
         }
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -686,7 +686,7 @@ void T2DMap::initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWa
     if (mpMap->mpRoomDB->getRoom(speedWalkTargetRoomId)) {
         mpMap->mTargetID = speedWalkTargetRoomId;
 
-        if (mpHost->checkForSpeedwalkScript()) {
+        if (mpHost->checkForCustomSpeedwalk()) {
             mpHost->startSpeedWalk(speedWalkStartRoomId, speedWalkTargetRoomId);
         } else if (mpMap->findPath(speedWalkStartRoomId, speedWalkTargetRoomId)) {
             mpHost->startSpeedWalk();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -218,7 +218,7 @@ private:
     void drawRoom(QPainter&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const int, const float, const float, const bool);
     void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const bool showingCurrentArea, QColor& infoColor);
     void paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth);
-    void initiateSpeeWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
+    void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
 
     bool mDialogLock;
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -16042,6 +16042,17 @@ void TLuaInterpreter::set_lua_string(const QString& varName, const QString& varV
 }
 
 // No documentation available in wiki - internal function
+void TLuaInterpreter::set_lua_integer(const QString& varName, int varValue)
+{
+    lua_State* L = pGlobalLua;
+    int top = lua_gettop(L);
+
+    lua_pushnumber(L, varValue);
+    lua_setglobal(L, varName.toUtf8().constData());
+    lua_settop(L, top);
+}
+
+// No documentation available in wiki - internal function
 QString TLuaInterpreter::getLuaString(const QString& stringName)
 {
     lua_State* L = pGlobalLua;
@@ -16078,6 +16089,26 @@ int TLuaInterpreter::check_for_mappingscript()
         return 0;
     }
 
+    int r = lua_toboolean(L, -1);
+    lua_pop(L, 2);
+    return r;
+}
+
+// No documentation available in wiki - internal function
+int TLuaInterpreter::check_for_speedwalkscript()
+{
+    lua_State* L = pGlobalLua;
+    lua_getglobal(L, "mudlet");
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        return 0;
+    }
+
+    lua_getfield(L, -1, "custom_speedwalk");
+    if (!lua_isboolean(L, -1)) {
+        lua_pop(L, 2);
+        return 0;
+    }
     int r = lua_toboolean(L, -1);
     lua_pop(L, 2);
     return r;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -16095,7 +16095,7 @@ int TLuaInterpreter::check_for_mappingscript()
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::check_for_speedwalkscript()
+int TLuaInterpreter::check_for_custom_speedwalk()
 {
     lua_State* L = pGlobalLua;
     lua_getglobal(L, "mudlet");

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -105,7 +105,7 @@ public:
     void loadGlobal();
     QString getLuaString(const QString& stringName);
     int check_for_mappingscript();
-    int check_for_speedwalkscript();
+    int check_for_custom_speedwalk();
     void set_lua_integer(const QString& varName, int varValue);
     void set_lua_string(const QString& varName, const QString& varValue);
     void set_lua_table(const QString& tableName, QStringList& variableList);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -105,6 +105,8 @@ public:
     void loadGlobal();
     QString getLuaString(const QString& stringName);
     int check_for_mappingscript();
+    int check_for_speedwalkscript();
+    void set_lua_integer(const QString& varName, int varValue);
     void set_lua_string(const QString& varName, const QString& varValue);
     void set_lua_table(const QString& tableName, QStringList& variableList);
     void setCaptureGroups(const std::list<std::string>&, const std::list<int>&);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

This patch adds a `mudlet.custom_speedwalk` flag which signals Mudlet to not generate a part to the destination; instead, `doSpeedWalk` is called directly when a room is double-clicked.

#### Motivation for adding to Mudlet

Previously "doSpeedwalk" has only been called with a Mudlet-generated path. However, this approach has several limitations. For instance, dynamic conditions like "I have no lamp oil left and thus can't take the shortcut through the cavern" or "I am too sick to use the mountain path to the healer" can easily be added to the map (via userData entries) but there is no way to teach the Mudlet path finder to use them.

Also, some exits may not be in the map. The player might be required to solve a riddle to get transported from A to B, or navigate a dynamic maze, or simply find the transport. Or the destination might not be fixed, which means that Mudlet cannot find a way to the destination and thus the `doSpeedWalk` function is not called at all. A custom wayfinder script could be taught to take these issues into account.

#### Other info (issues closed, discussion etc)

A Lua-based path finder is quite fast and not hard to write. Such code would allow for other interesting commands like "go to the closest shop" or "show me a list of the three closest healers and let me pick one".