### PR TITLE
TLuaInterpreter: rename loadRawFile to loadReplay

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1175,8 +1175,8 @@ int TLuaInterpreter::getLines(lua_State* L)
     }
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadReplay - Yes, a different name!
-int TLuaInterpreter::loadRawFile(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#loadReplay
+int TLuaInterpreter::loadReplay(lua_State* L)
 {
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "loadReplay: bad argument #1 type (replay file name as string expected, got %s!)",
@@ -16321,8 +16321,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getButtonState", TLuaInterpreter::getButtonState);
     lua_register(pGlobalLua, "showToolBar", TLuaInterpreter::showToolBar);
     lua_register(pGlobalLua, "hideToolBar", TLuaInterpreter::hideToolBar);
-    lua_register(pGlobalLua, "loadRawFile", TLuaInterpreter::loadRawFile);
-    lua_register(pGlobalLua, "loadReplay", TLuaInterpreter::loadRawFile);
+    lua_register(pGlobalLua, "loadRawFile", TLuaInterpreter::loadReplay);
+    lua_register(pGlobalLua, "loadReplay", TLuaInterpreter::loadReplay);
     lua_register(pGlobalLua, "setBold", TLuaInterpreter::setBold);
     lua_register(pGlobalLua, "setItalics", TLuaInterpreter::setItalics);
     lua_register(pGlobalLua, "setOverline", TLuaInterpreter::setOverline);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -387,7 +387,7 @@ public:
     static int getButtonState(lua_State*);
     static int showToolBar(lua_State*);
     static int hideToolBar(lua_State*);
-    static int loadRawFile(lua_State*);
+    static int loadReplay(lua_State*);
     static int setBold(lua_State*);
     static int setItalics(lua_State*);
     static int setReverse(lua_State*);

--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -585,6 +585,8 @@ if false then
 
 
   --- <b><u>TODO</u></b>  loadRawFile - TLuaInterpreter::loadRawFile
+  --- in TLuaInterpreter, loadRawFile is established as an alias to
+  --- loadReplay. We override the old name to do nothing instead.
   function loadRawFile()
   end
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -5304,7 +5304,7 @@ bool mudlet::loadReplay(Host* pHost, const QString& replayFileName, QString* pEr
         // to start a replay would mess up (QFile) ctelnet::replayFile for a
         // replay already in progess in the SAME profile.  Technically there
         // could be a very small chance of a race condition if a lua call of
-        // loadRawFile happens at the same time as a file was selected for a
+        // loadReplay happens at the same time as a file was selected for a
         // replay after the toolbar/menu command to do a reaply for the same
         // profile - but the window for this is likely to be a fraction of a
         // second...


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

For historical reasons the Lua `loadReplay` function has internally been named `loadRawFile`. Rename it.

#### Motivation for adding to Mudlet

Keeping the old name (at the C level) is confusing and helps nobody.

#### Other info (issues closed, discussion etc)

In Lua the old `loadRawFile` name is already overwritten to a no-op function.