### PR TITLE
Revert x32/x64 distinction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,25 +154,9 @@ int main(int argc, char* argv[])
     app->setOrganizationName(QStringLiteral("Mudlet"));
 
     if (mudlet::scmIsPublicTestVersion) {
-#if defined(Q_OS_WIN64)
-        // Only defined on 64-bit windows
-        app->setApplicationName(QStringLiteral("Mudlet(x64) Public Test Build"));
-#elif defined(Q_OS_WIN32)
-        // Defined on both 32 and 64-bit windows
-        app->setApplicationName(QStringLiteral("Mudlet(x32) Public Test Build"));
-#else
         app->setApplicationName(QStringLiteral("Mudlet Public Test Build"));
-#endif
     } else {
-#if defined(Q_OS_WIN64)
-        // Only defined on 64-bit windows
-        app->setApplicationName(QStringLiteral("Mudlet(x64)"));
-#elif defined(Q_OS_WIN32)
-        // Defined on both 32 and 64-bit windows
-        app->setApplicationName(QStringLiteral("Mudlet(x32)"));
-#else
         app->setApplicationName(QStringLiteral("Mudlet"));
-#endif
     }
     if (mudlet::scmIsReleaseVersion) {
         app->setApplicationVersion(APP_VERSION);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Revert x32/x64 distinction
#### Motivation for adding to Mudlet
It shows up in places we didn't expect, such as the updater:


![image](https://user-images.githubusercontent.com/110988/95907068-4eea4500-0d9b-11eb-9171-173cb9f9eeed.png)

Also our players do not care if it's 32bit or 64bit, it's a pretty old distinction... 
#### Other info (issues closed, discussion etc)
