### PR TITLE
BugFix: fix a CI script error around date calculations

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -31,9 +31,9 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
 } else {
   if ($Script:PublicTestBuild) {
 
-    $commitDate = Get-Date -date $(git show -s --format=%cs)
-    $yesterdaysDate = $(Get-Date).AddDays(-1).Date
-    if ($commitDate -lt $yesterdaysDate) {
+    $COMMIT_DATE = Get-Date -date $(git show -s --format="%cs")
+    $YESTERDAY_DATE = $(Get-Date).AddDays(-1).Date
+    if ($COMMIT_DATE -lt $YESTERDAY_DATE) {
       Write-Output "=== No new commits, aborting public test build generation ==="
       exit 0
     }

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -33,8 +33,8 @@ if { [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${DEPLOY}" = "deploy" ]; } ||
   fi
 
   # get commit date now before we check out an change into another git repository
-  commitDate=$(git show -s --format=%cs | tr -d '-')
-  yesterdaysDate=$(date -d "yesterday" '+%F' | tr -d '-')
+  COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
+  YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
@@ -58,7 +58,7 @@ if { [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "${DEPLOY}" = "deploy" ]; } ||
   else # ptb/release build
     if [ "${public_test_build}" == "true" ]; then
 
-      if [[ "$commitDate" -lt "$yesterdaysDate" ]]; then
+      if [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
         echo "== No new commits, aborting public test build generation =="
         exit 0
       fi

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -10,8 +10,8 @@ fi
 if [ "${DEPLOY}" = "deploy" ]; then
 
   # get commit date now before we check out an change into another git repository
-  commitDate=$(git show -s --format=%cs | tr -d '-')
-  yesterdaysDate=$(date -v-1d '+%F' | tr -d '-')
+  COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
+  YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"
 
@@ -57,7 +57,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
     app="${TRAVIS_BUILD_DIR}/build/Mudlet.app"
     if [ "${public_test_build}" == "true" ]; then
 
-      if [[ "$commitDate" -lt "$yesterdaysDate" ]]; then
+      if [[ "${COMMIT_DATE}" -lt "${YESTERDAY_DATE}" ]]; then
         echo "== No new commits, aborting public test build generation =="
         exit 0
       fi


### PR DESCRIPTION
The MacOs build was producing an error message:
> CI/travis.osx.after_success.sh: line 60: [[: %cs: syntax error: operand expected (error token is "%cs")
> == Creating a public test build ==
> Deploying ./Mudlet PTB.app

It turns out that when using the `git show` command it is helpful to place double quotes around the format specifier - especially (but not in this case if there was spaces in the text) it isn't clear why the `%cs` was not being handled but the fact that it was mentioned in the line where the date number that it was suppose to produce was being used means that it was not being handled by the original `git show`. Anyhow, for safety's sake I have quoted it in all three CI scripts where it is used.

At the same time I have also renamed the variables that it was being stored in and tested against to the SCREAMING_SNAKE_CASE form, as that form makes bash variables a bit easier to pick out in scripts.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>