### PR TITLE
Bugfix: "echo" didn't talk to labels

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11390,8 +11390,7 @@ int TLuaInterpreter::Echo(lua_State* L)
     }
     QString displayText{lua_tostring(L, n)};
 
-    auto console = CONSOLE(L, consoleName);
-    if (console == host.mpConsole) {
+    if (isMain(consoleName)) {
         host.mpConsole->buffer.mEchoingText = true;
         host.mpConsole->echo(displayText);
         host.mpConsole->buffer.mEchoingText = false;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

The last too-big PR removed `echo`'s ability to write to labels.

#### Motivation for adding to Mudlet

obvious Bugfix

#### Other info (issues closed, discussion etc)

several came to light during preparation of this PR. To be fixed in other PRs.