### PR TITLE
Adjustable.Container deal with corrupted save files and table for save slots

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -708,6 +708,7 @@ function Adjustable.Container:save(slot, dir)
     dir = dir or self.defaultDir
     local saveDir = string.format("%s%s.lua", dir, self.name)
     local mainTable = {}
+    mainTable.slot = {}
     local mytable = {}
 
     -- check if there are already saved settings and if so load them to the mainTable
@@ -716,7 +717,7 @@ function Adjustable.Container:save(slot, dir)
     end
 
     if slot then
-        mainTable[slot] = mytable
+        mainTable.slot[slot] = mytable
     else
         mytable = mainTable
     end
@@ -748,19 +749,25 @@ end
 -- @see Adjustable.Container:save
 function Adjustable.Container:load(slot, dir)
     local mytable = {}
+    mytable.slot = {}
     assert(slot == nil or type(slot) == "string" or type(slot) == "number", "Adjustable.Container.load: bad argument #1 type (slot as string or number expected, got "..type(slot).."!)")
     assert(dir == nil or type(dir) == "string" , "Adjustable.Container.load: bad argument #2 type (directory as string expected, got "..type(dir).."!)")
     dir = dir or self.defaultDir
     local loadDir = string.format("%s%s.lua", dir, self.name)
-    if io.exists(loadDir) then
-        table.load(loadDir, mytable)
-    else
-        return "Adjustable.Container.load: Couldn't load settings from " .. loadDir
+    if not (io.exists(loadDir)) then
+        return string.format("Adjustable.Container.load: Couldn't load settings from %s", loadDir)
+    end
+
+    local ok = pcall(table.load, loadDir, mytable)
+    if not ok then
+        self:deleteSaveFile()
+        debugc(string.format("Adjustable.Container.load: Save file %s got corrupted. It was deleted so everything else can load properly.", loadDir))
+        return false
     end
 
     -- if slot settings not found load default settings
     if slot then
-        mytable = mytable[slot] or mytable
+        mytable = mytable.slot[slot] or mytable
     end
 
     mytable.windowname = mytable.windowname or "main"


### PR DESCRIPTION
#### Brief overview of PR changes/additions
If a save file was corrupted Adjustable.Container didn't load properly which could have been problematic.
This PR deals with it by using the pcall function (see https://www.lua.org/pil/8.4.html)

Also slot weren't saved in their own table which caused issue if a slot was named the same as an already existing save parameter.
For example naming a slot "width" caused the adjustable container to break.
This is now dealt with by saving all the slots in their own table.

#### Motivation for adding to Mudlet
issues with slot names and
fix #4183 
