### PR TITLE
BugFix: correct copy/paste error in Lua setHexBgColor function

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1922,7 +1922,7 @@ function setHexBgColor(windowName, colorString)
   end
 
   if #col ~= 6 then
-    error("setHexFgColor needs a 6 digit hex color code.")
+    error("setHexBgColor needs a 6 digit hex color code.")
   end
 
   local colTable = {


### PR DESCRIPTION
A one letter typo - not much to say - except that it can, as a bugfix, be included in the pending **4.10.0** release I guess, and that I encounter it whilst doing something that did have errors and was using both the foreground and background ones and it was mystifying whilst a supposedly fine *foreground* colour was generating this error!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>