### PR TITLE
Revise: fixup pan direction arrows in mapper

### DIFF
--- a/src/ui/mapper.ui
+++ b/src/ui/mapper.ui
@@ -290,7 +290,7 @@
                   </font>
                  </property>
                  <property name="text">
-                  <string>◀</string>
+                  <string>⯇</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -330,7 +330,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>▼</string>
+                  <string>⯆</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -370,7 +370,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>▲</string>
+                  <string>⯅</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -410,7 +410,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>►</string>
+                  <string>⯈</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>


### PR DESCRIPTION
On Linux we happen to use a font that we have forced the use of the Noto Color Emoji font as a substitute for - and the left pan button happens to use a grapheme that is in the Emoji font - so it gets changed to a coloured arrow whereas the other ones do not.

The rogue left arrow is provided by the Unicode codepoint: U+25C0 {BLACK LEFT-POINTING TRIANGLE} whereas the right arrow has been determined to be U+25BA {BLACK RIGHT-POINTING POINTER}. The obvious correction would be to use U+25C4 {BLACK LEFT-POINTING POINTER} however I have determined that it would be better to use a somewhat fatter (taller) glyph for ALL four directions so this commit is switching them to use the four: U+2BC5-8 {BLACK MEDIUM (UP|DOWN|LEFT|RIGHT)-POINTING TRIANGLE CENTRED}.

This will close #4211.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>