### PR TITLE
Revert "Don't clear the stack"

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14284,7 +14284,6 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
         return false;
     }
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     int error = luaL_dostring(L, code.toUtf8().constData());
     if (error != 0) {
@@ -14301,7 +14300,7 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
         logError(e, _n, _n2);
     }
 
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 
     if (error == 0) {
         return true;
@@ -14324,7 +14323,6 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
     }
 
     lua_State* L = pIndenterState.get();
-    int top = lua_gettop(L);
 
     if (!validLuaCode(code)) {
         return code;
@@ -14353,12 +14351,12 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
         QString objectName = "error in Lua code";
         QString functionName = "no debug data available";
         logError(e, objectName, functionName);
-        lua_settop(L, top);
+        lua_pop(L, lua_gettop(L));
         return code;
     }
 
     QString result = lua_tostring(L, 1);
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     return result;
 }
 
@@ -14366,7 +14364,6 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
 bool TLuaInterpreter::compileScript(const QString& code)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     int error = luaL_dostring(L, code.toUtf8().constData());
     if (error != 0) {
@@ -14383,7 +14380,7 @@ bool TLuaInterpreter::compileScript(const QString& code)
             TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA: code compiled without errors. OK\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 
     if (error == 0) {
         return true;
@@ -14396,7 +14393,6 @@ bool TLuaInterpreter::compileScript(const QString& code)
 bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QString& name)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     int error = (luaL_loadbuffer(L, code.toUtf8().constData(),
                                  strlen(code.toUtf8().constData()),
@@ -14419,7 +14415,7 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
             TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "\nLUA: code compiled without errors. OK\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 
     if (error == 0) {
         return true;
@@ -14433,10 +14429,9 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
 bool TLuaInterpreter::validLuaCode(const QString &code)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     int error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), "Lua code validation");
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 
     return error == 0;
 }
@@ -14508,13 +14503,12 @@ void TLuaInterpreter::clearCaptureGroups()
     mMultiCaptureGroupPosList.clear();
 
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     lua_newtable(L);
     lua_setglobal(L, "matches");
     lua_newtable(L);
     lua_setglobal(L, "multimatches");
 
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 }
 
 // No documentation available in wiki - internal function
@@ -14550,7 +14544,6 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
 void
 TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions) {
     lua_State *L = pGlobalLua;
-    int top = lua_gettop(L);
     lua_getglobal(L, "mxp");
     if (!lua_istable(L, -1)) {
         lua_newtable(L);
@@ -14585,7 +14578,7 @@ TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString
         lua_rawseti(L, -2, i + 1);
     }
 
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 
 
     TEvent event{};
@@ -14663,7 +14656,6 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
 {
     // key is in format of Blah.Blah or Blah.Blah.Bleh - we want to push & pre-create the tables as appropriate
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     QStringList tokenList = key.split(QLatin1Char('.'));
     if (!lua_checkstack(L, tokenList.size() + 5)) {
         return;
@@ -14828,14 +14820,13 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
             host.mTelnet.mpComposer->show();
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 }
 
 // No documentation available in wiki - internal function
 void TLuaInterpreter::parseMSSP(const QString& string_data)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     // string_data is in the format of MSSP_VAR "PLAYERS" MSSP_VAL "52" MSSP_VAR "UPTIME" MSSP_VAL "1234567890"
     // The quote characters mean that the encased word is a string, the quotes themselves are not sent.
@@ -14878,7 +14869,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             host.raiseEvent(event);
         }
 
-        lua_settop(L, top);
+        lua_pop(L, lua_gettop(L));
     }
 }
 
@@ -15049,7 +15040,6 @@ void TLuaInterpreter::setMatches(lua_State* L)
 bool TLuaInterpreter::call_luafunction(void* pT)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     lua_pushlightuserdata(L, pT);
     lua_gettable(L, LUA_REGISTRYINDEX);
     if (lua_isfunction(L, -1)) {
@@ -15075,14 +15065,14 @@ bool TLuaInterpreter::call_luafunction(void* pT)
                 TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK anonymous Lua function ran without errors\n" >> 0;
             }
         }
-        lua_settop(L, top);
+        lua_pop(L, lua_gettop(L));
+        //lua_settop(L, 0);
         if (error == 0) {
             return true;
         } else {
             return false;
         }
     } else {
-        lua_settop(L, top);
         QString _n = "error in anonymous Lua function";
         QString _n2 = "func reference not found by Lua, func cannot be called";
         std::string e = "Lua error:";
@@ -15098,7 +15088,6 @@ bool TLuaInterpreter::call_luafunction(void* pT)
 std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     lua_pushlightuserdata(L, pT);
     lua_gettable(L, LUA_REGISTRYINDEX);
@@ -15132,7 +15121,7 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
                 TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK anonymous Lua function ran without errors\n" >> 0;
             }
         }
-        lua_settop(L, top);
+        lua_pop(L, lua_gettop(L));
         //lua_settop(L, 0);
         if (error == 0) {
             return std::make_pair(true, returnValue);
@@ -15155,7 +15144,6 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
 bool TLuaInterpreter::call(const QString& function, const QString& mName, const bool muteDebugOutput)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     setMatches(L);
 
     lua_getglobal(L, function.toUtf8().constData());
@@ -15177,7 +15165,7 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
             TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK: script " << mName << " (" << function << ") ran without errors\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 
     return (error);
 }
@@ -15186,7 +15174,6 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
 std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, const QString& mName)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     bool returnValue = false;
 
     setMatches(L);
@@ -15215,7 +15202,7 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
             TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK script " << mName << " (" << function << ") ran without errors\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     if (error == 0) {
         return std::make_pair(true, returnValue);
     } else {
@@ -15311,7 +15298,6 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
 bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     if (!mMultiCaptureGroupList.empty()) {
         int k = 1;       // Lua indexes start with 1 as a general convention
@@ -15350,7 +15336,7 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
             TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK script " << mName << " (" << function << ") ran without errors\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     if (error == 0) {
         return true;
     } else {
@@ -15362,7 +15348,6 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
 std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& function, const QString& mName)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     bool returnValue = false;
 
@@ -15408,7 +15393,7 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
             TDebug(QColor(Qt::white), QColor(Qt::darkGreen)) << "LUA OK script " << mName << " (" << function << ") ran without errors\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     if (error == 0) {
         return std::make_pair(true, returnValue);
     } else {
@@ -15420,7 +15405,6 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
 bool TLuaInterpreter::callCmdLineAction(const int func, QString text)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     lua_rawgeti(L, LUA_REGISTRYINDEX, func);
     int error = 0;
     lua_pushstring(L, text.toUtf8().constData());
@@ -15438,7 +15422,7 @@ bool TLuaInterpreter::callCmdLineAction(const int func, QString text)
             TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << err.c_str() << "\n" >> 0;
         }
     }
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     return !error;
 }
 
@@ -15446,7 +15430,6 @@ bool TLuaInterpreter::callCmdLineAction(const int func, QString text)
 bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     lua_rawgeti(L, LUA_REGISTRYINDEX, func);
     int error = 0;
     if (qE) {
@@ -15599,7 +15582,7 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
         }
     }
 
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     return !error;
 }
 
@@ -15611,7 +15594,6 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
     }
 
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     int error = luaL_dostring(L, QStringLiteral("return %1").arg(function).toUtf8().constData());
     if (error) {
@@ -15673,7 +15655,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         }
     }
 
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
     return !error;
 }
 
@@ -16106,7 +16088,6 @@ int TLuaInterpreter::unzipAsync(lua_State *L)
 void TLuaInterpreter::set_lua_table(const QString& tableName, QStringList& variableList)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
     lua_newtable(L);
     for (int i = 0; i < variableList.size(); i++) {
         lua_pushnumber(L, i + 1); // Lua indexes start with 1
@@ -16114,18 +16095,17 @@ void TLuaInterpreter::set_lua_table(const QString& tableName, QStringList& varia
         lua_settable(L, -3);
     }
     lua_setglobal(L, tableName.toUtf8().constData());
-    lua_settop(L, top);
+    lua_pop(pGlobalLua, lua_gettop(pGlobalLua));
 }
 
 // No documentation available in wiki - internal function
 void TLuaInterpreter::set_lua_string(const QString& varName, const QString& varValue)
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     lua_pushstring(L, varValue.toUtf8().constData());
     lua_setglobal(L, varName.toUtf8().constData());
-    lua_settop(L, top);
+    lua_pop(pGlobalLua, lua_gettop(pGlobalLua));
 }
 
 // No documentation available in wiki - internal function
@@ -16848,7 +16828,7 @@ void TLuaInterpreter::initLuaGlobals()
     tn = "channel102";
     set_lua_table(tn, args);
 
-    lua_settop(pGlobalLua, 0);  // initial setup
+    lua_pop(pGlobalLua, lua_gettop(pGlobalLua));
 
     //FIXME make function call in destructor lua_close(L);
 }
@@ -16858,7 +16838,6 @@ void TLuaInterpreter::initLuaGlobals()
 void TLuaInterpreter::setupLanguageData()
 {
     lua_State* L = pGlobalLua;
-    int top = lua_gettop(L);
 
     // 'mudlet' global table
     lua_createtable(L, 0, 1);
@@ -16925,7 +16904,7 @@ void TLuaInterpreter::setupLanguageData()
 
     lua_setfield(L, -2, "translations");
     lua_setglobal(L, "mudlet");
-    lua_settop(L, top);
+    lua_pop(L, lua_gettop(L));
 }
 
 // No documentation available in wiki - internal function
@@ -17027,7 +17006,7 @@ void TLuaInterpreter::initIndenterGlobals()
         mpHost->postMessage(msg);
     }
 
-    lua_settop(pIndenterState.get(), 0); // initial setup
+    lua_pop(pIndenterState.get(), lua_gettop(pIndenterState.get()));
 }
 
 // No documentation available in wiki - internal function called AFTER


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This reverts commit 85f1b5, which got squashed into 6db39ec.

#### Motivation for adding to Mudlet

Fix GMCP updates breaking after some time, which is an issue that will affect a lot of players.
Other info (issues closed, discussion etc)

Fixes #4213. Keeping the stack as-is part of the PR causes problems as the stack then grows until it can't anymore.

#### Other info (issues closed, discussion etc)

This just masks thee root issue (some code not cleaning up after itself), which still needs to be found.