### PR TITLE
 mouseClickEvent event extended to include KB modifiers

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15485,6 +15485,10 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
             lua_pushnumber(L, qME->y());
             lua_setfield(L, -2, QStringLiteral("y").toUtf8().constData());
 
+            // Push modifiers()
+            lua_pushstring(L, QKeySequence(qME->modifiers()).toString().toUtf8().constData() );
+            lua_setfield(L, -2, QStringLiteral("modifiers").toUtf8().constData());
+
             error = lua_pcall(L, 1, LUA_MULTRET, 0);
             break;
         }


### PR DESCRIPTION
With SlySven's help extended the mouseClickEvent event returned to include

keyboard modifiers as a string rather than KeySequence ENUM

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Added KB modifiers to mouseClickEvent ( Issue #4218)

#### Motivation for adding to Mudlet
Allows kb meta keys to be used to alter the click event so kb/mouse combos can be used when working with events

#### Other info (issues closed, discussion etc)
