### PR TITLE
revert TText wheelEvent (try to fix macOs scroll issue)

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1691,27 +1691,18 @@ void TTextEdit::resizeEvent(QResizeEvent* event)
 
 void TTextEdit::wheelEvent(QWheelEvent* e)
 {
-    const int k = 3;
-    int deltaY = e->angleDelta().y() / (8 * 15);
-    int deltaX = e->angleDelta().x() / (8 * 15);
-    bool handled = false;
-    if (deltaY < 0) {
-        mpConsole->scrollDown(k);
-        handled = true;
-    } else if (deltaY > 0) {
+    int k = 3;
+    if (e->delta() < 0) {
+        mpConsole->scrollDown(abs(k));
+        e->accept();
+        return;
+    }
+    if (e->delta() > 0) {
         mpConsole->scrollUp(k);
-        handled = true;
+        e->accept();
+        return;
     }
-
-    if (deltaX < 0) {
-        scrollH(std::max(0, mCursorX - k));
-        handled = true;
-    } else if (deltaX > 0) {
-        scrollH(std::min(mMaxHRange, mCursorX + k));
-        handled = true;
-    }
-
-    e->setAccepted(handled);
+    e->ignore();
 }
 
 int TTextEdit::imageTopLine()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
reverts changes for the mousewheel event introduced in #4085 which allowed to scroll horizontally with
the horizontal mousewheel.
#### Motivation for adding to Mudlet
This changes caused problems with some mac hardware
fix #4205 
 
#### Other info (issues closed, discussion etc)
Using a horizontal mousewheel to scroll horizontally won't work anymore.