### PR TITLE
use setBackgroundImage for console instead of setConsoleBackgroundImage

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1299,81 +1299,6 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setConsoleBackgroundImage
-int TLuaInterpreter::setConsoleBackgroundImage(lua_State* L)
-{
-    QString windowName = QStringLiteral("main");
-    QString imgPath;
-    int mode = 1;
-    int counter = 1;
-    int n = lua_gettop(L);
-    if (n > 1 && lua_type(L, 2) == LUA_TSTRING) {
-        if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "setConsoleBackgroundImage: bad argument #1 type (console name as string expected, got %s!)", luaL_typename(L, 1));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, 1);
-        counter++;
-    }
-
-    if (!lua_isstring(L, counter)) {
-        lua_pushfstring(L, "setConsoleBackgroundImage: bad argument #%d type (image path as string expected, got %s!)", counter, luaL_typename(L, counter));
-        return lua_error(L);
-    }
-    imgPath = lua_tostring(L, counter);
-    counter++;
-
-    if (n > 2 || (counter == 2 && n > 1)) {
-        if (!lua_isnumber(L, counter)) {
-            lua_pushfstring(L, "setConsoleBackgroundImage: bad argument #%d type (mode as number expected, got %s!)", counter, luaL_typename(L, counter));
-            return lua_error(L);
-        }
-        mode = lua_tonumber(L, counter);
-    }
-
-    if (mode < 1 || mode > 4) {
-        lua_pushnil(L);
-        lua_pushfstring(L, "setConsoleBackgroundImage: %d is not a valid mode! Valid modes are 1 \"border\", 2 \"center\", 3 \"tile\", 4 \"style\")", mode);
-        return 2;
-    }
-
-    Host* host = &getHostFromLua(L);
-    if (mudlet::self()->setWindowBackgroundImage(host, windowName, imgPath, mode)) {
-        lua_pushboolean(L, true);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        lua_pushfstring(L, R"(console "%s" not found)", windowName.toUtf8().constData());
-        return 2;
-    }
-    return 0;
-}
-
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetConsoleBackgroundImage
-int TLuaInterpreter::resetConsoleBackgroundImage(lua_State* L)
-{
-    QString windowName = QStringLiteral("main");
-    int n = lua_gettop(L);
-    if (n > 0) {
-        if (!lua_isstring(L, 1)) {
-            lua_pushfstring(L, "resetConsoleBackgroundImage: bad argument #1 type (console name as string expected, got %s!)", luaL_typename(L, 1));
-            return lua_error(L);
-        }
-        windowName = lua_tostring(L, 1);
-    }
-
-    Host* host = &getHostFromLua(L);
-    if (mudlet::self()->resetWindowBackgroundImage(host, windowName)) {
-        lua_pushboolean(L, true);
-        return 1;
-    } else {
-        lua_pushnil(L);
-        lua_pushfstring(L, R"(console "%s" not found)", windowName.toUtf8().constData());
-        return 2;
-    }
-    return 0;
-}
-
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLineNumber
 int TLuaInterpreter::getLineNumber(lua_State* L)
 {
@@ -4807,21 +4732,74 @@ int TLuaInterpreter::startLogging(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBackgroundImage
 int TLuaInterpreter::setBackgroundImage(lua_State* L)
 {
-    if (!lua_isstring(L, 1)) {
-        lua_pushstring(L, "setBackgroundImage: wrong argument type");
+    QString windowName = QStringLiteral("main");
+    QString imgPath;
+    int mode = 1;
+    int counter = 1;
+    int n = lua_gettop(L);
+    if (n > 1 && lua_type(L, 2) == LUA_TSTRING) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "setBackgroundImage: bad argument #1 type (console or label name as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
+        windowName = lua_tostring(L, 1);
+        counter++;
+    }
+
+    if (!lua_isstring(L, counter)) {
+        lua_pushfstring(L, "setBackgroundImage: bad argument #%d type (image path as string expected, got %s!)", counter, luaL_typename(L, counter));
         return lua_error(L);
     }
-    QString text = lua_tostring(L, 1);
+    imgPath = lua_tostring(L, counter);
+    counter++;
 
-    if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "setBackgroundImage: wrong argument type");
-        return lua_error(L);
+    if (n > 2 || (counter == 2 && n > 1)) {
+        if (!lua_isnumber(L, counter)) {
+            lua_pushfstring(L, "setBackgroundImage: bad argument #%d type (mode as number expected, got %s!)", counter, luaL_typename(L, counter));
+            return lua_error(L);
+        }
+        mode = lua_tonumber(L, counter);
     }
-    QString name = lua_tostring(L, 2);
 
-    Host& host = getHostFromLua(L);
-    mudlet::self()->setBackgroundImage(&host, text, name);
+    if (mode < 1 || mode > 4) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "setBackgroundImage: %d is not a valid mode! Valid modes are 1 \"border\", 2 \"center\", 3 \"tile\", 4 \"style\")", mode);
+        return 2;
+    }
 
+    Host* host = &getHostFromLua(L);
+    if (mudlet::self()->setBackgroundImage(host, windowName, imgPath, mode)) {
+        lua_pushboolean(L, true);
+        return 1;
+    }
+
+    lua_pushnil(L);
+    lua_pushfstring(L, R"(console or label "%s" not found)", windowName.toUtf8().constData());
+    return 2;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resetBackgroundImage
+int TLuaInterpreter::resetBackgroundImage(lua_State* L)
+{
+    QString windowName = QStringLiteral("main");
+    int n = lua_gettop(L);
+    if (n > 0) {
+        if (!lua_isstring(L, 1)) {
+            lua_pushfstring(L, "resetBackgroundImage: bad argument #1 type (console name as string expected, got %s!)", luaL_typename(L, 1));
+            return lua_error(L);
+        }
+        windowName = lua_tostring(L, 1);
+    }
+
+    Host* host = &getHostFromLua(L);
+    if (mudlet::self()->resetBackgroundImage(host, windowName)) {
+        lua_pushboolean(L, true);
+        return 1;
+    } else {
+        lua_pushnil(L);
+        lua_pushfstring(L, R"(console "%s" not found)", windowName.toUtf8().constData());
+        return 2;
+    }
     return 0;
 }
 
@@ -16388,6 +16366,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "resizeWindow", TLuaInterpreter::resizeWindow);
     lua_register(pGlobalLua, "appendBuffer", TLuaInterpreter::appendBuffer);
     lua_register(pGlobalLua, "setBackgroundImage", TLuaInterpreter::setBackgroundImage);
+    lua_register(pGlobalLua, "resetBackgroundImage", TLuaInterpreter::resetBackgroundImage);
     lua_register(pGlobalLua, "setBackgroundColor", TLuaInterpreter::setBackgroundColor);
     lua_register(pGlobalLua, "setCmdLineAction", TLuaInterpreter::setCmdLineAction);
     lua_register(pGlobalLua, "resetCmdLineAction", TLuaInterpreter::resetCmdLineAction);
@@ -16412,8 +16391,6 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "resetProfileIcon", TLuaInterpreter::resetProfileIcon);
     lua_register(pGlobalLua, "getCurrentLine", TLuaInterpreter::getCurrentLine);
     lua_register(pGlobalLua, "setMiniConsoleFontSize", TLuaInterpreter::setMiniConsoleFontSize);
-    lua_register(pGlobalLua, "setConsoleBackgroundImage", TLuaInterpreter::setConsoleBackgroundImage);
-    lua_register(pGlobalLua, "resetConsoleBackgroundImage", TLuaInterpreter::resetConsoleBackgroundImage);
     lua_register(pGlobalLua, "selectCurrentLine", TLuaInterpreter::selectCurrentLine);
     lua_register(pGlobalLua, "spawn", TLuaInterpreter::spawn);
     lua_register(pGlobalLua, "getButtonState", TLuaInterpreter::getButtonState);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -362,6 +362,7 @@ public:
     static int closeMapWidget(lua_State*);
     static int setTextFormat(lua_State*);
     static int setBackgroundImage(lua_State*);
+    static int resetBackgroundImage(lua_State*);
     static int setBackgroundColor(lua_State*);
     static int setLabelClickCallback(lua_State*);
     static int setCmdLineAction(lua_State*);
@@ -378,8 +379,6 @@ public:
     static int getUserWindowSize(lua_State*);
     static int getMousePosition(lua_State*);
     static int setMiniConsoleFontSize(lua_State*);
-    static int setConsoleBackgroundImage(lua_State*);
-    static int resetConsoleBackgroundImage(lua_State*);
     static int setProfileIcon(lua_State*);
     static int resetProfileIcon(lua_State*);
     static int getCurrentLine(lua_State*);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2221,8 +2221,8 @@ mudlet.BgImageMode ={
   ["style"]  = 4,
 }
 
-local setConsoleBackgroundImageLayer = setConsoleBackgroundImage
-function setConsoleBackgroundImage(...)
+local setConsoleBackgroundImageLayer = setBackgroundImage
+function setBackgroundImage(...)
   local mode = arg[arg.n]
   if type(mode) == "string" then
     mode = mudlet.BgImageMode[mode] or mode

--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -224,13 +224,13 @@ end
 -- @param mode background image mode (1 "border", 2 "center", 3 "tile", 4 "style")
 function Geyser.MiniConsole:setBackgroundImage(imgPath, mode)
   self.imgPath = imgPath
-  return setConsoleBackgroundImage(self.name, imgPath, mode)
+  return setBackgroundImage(self.name, imgPath, mode)
 end
 
 --- resets the background image of this miniconsole
 function Geyser.MiniConsole:resetBackgroundImage()
   self.imgPath = nil
-  return resetConsoleBackgroundImage(self.name)
+  return resetBackgroundImage(self.name)
 end
 
 --- inserts clickable text into the miniconsole at the end of the current line.

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1986,46 +1986,6 @@ void mudlet::commitLayoutUpdates()
     }
 }
 
-bool mudlet::setWindowBackgroundImage(Host* pHost, const QString& name, const QString& imgPath, int mode)
-{
-    if (!pHost || !pHost->mpConsole) {
-        return false;
-    }
-
-    if (name.isEmpty() || name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-        pHost->mpConsole->setConsoleBackgroundImage(imgPath, mode);
-        return true;
-    }
-
-    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        pC->setConsoleBackgroundImage(imgPath, mode);
-        return true;
-    } else {
-        return false;
-    }
-}
-
-bool mudlet::resetWindowBackgroundImage(Host *pHost, const QString &name)
-{
-    if (!pHost || !pHost->mpConsole) {
-        return false;
-    }
-
-    if (name.isEmpty() || name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
-        pHost->mpConsole->resetConsoleBackgroundImage();
-        return true;
-    }
-
-    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
-    if (pC) {
-        pC->resetConsoleBackgroundImage();
-        return true;
-    } else {
-        return false;
-    }
-}
-
 bool mudlet::setWindowFont(Host* pHost, const QString& window, const QString& font)
 {
     if (!pHost || !pHost->mpConsole) {
@@ -2327,25 +2287,63 @@ bool mudlet::setBackgroundColor(Host* pHost, const QString& name, int r, int g, 
     return false;
 }
 
-bool mudlet::setBackgroundImage(Host* pHost, const QString& name, QString& path)
+bool mudlet::setBackgroundImage(Host* pHost, const QString& name, QString& imgPath, int mode)
 {
     if (!pHost || !pHost->mpConsole) {
         return false;
     }
 
+    if (QDir::homePath().contains('\\')) {
+        imgPath.replace('/', R"(\)");
+    } else {
+        imgPath.replace('\\', "/");
+    }
+
+    if (name.isEmpty() || name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+        pHost->mpConsole->setConsoleBackgroundImage(imgPath, mode);
+        return true;
+    }
+
     auto pL = pHost->mpConsole->mLabelMap.value(name);
     if (pL) {
-        if (QDir::homePath().contains('\\')) {
-            path.replace('/', R"(\)");
-        } else {
-            path.replace('\\', "/");
-        }
-        QPixmap bgPixmap(path);
+        QPixmap bgPixmap(imgPath);
         pL->setPixmap(bgPixmap);
         return true;
-    } else {
+    }
+
+    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
+    if (pC) {
+        pC->setConsoleBackgroundImage(imgPath, mode);
+        return true;
+    }
+
+    return false;
+}
+
+bool mudlet::resetBackgroundImage(Host *pHost, const QString &name)
+{
+    if (!pHost || !pHost->mpConsole) {
         return false;
     }
+
+    if (name.isEmpty() || name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
+        pHost->mpConsole->resetConsoleBackgroundImage();
+        return true;
+    }
+
+    auto pL = pHost->mpConsole->mLabelMap.value(name);
+    if (pL) {
+        pL->clear();
+        return true;
+    }
+
+    auto pC = pHost->mpConsole->mSubConsoleMap.value(name);
+    if (pC) {
+        pC->resetConsoleBackgroundImage();
+        return true;
+    }
+
+    return false;
 }
 
 bool mudlet::setDisplayAttributes(Host* pHost, const QString& name, const TChar::AttributeFlags attributes, const bool state)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -147,8 +147,6 @@ public:
     bool setWindowFont(Host*, const QString&, const QString&);
     QString getWindowFont(Host*, const QString&);
     bool setWindowFontSize(Host *, const QString &, int);
-    bool setWindowBackgroundImage(Host *, const QString&, const QString&, int);
-    bool resetWindowBackgroundImage(Host *, const QString&);
     int getFontSize(Host*, const QString&);
     QSize calcFontSize(Host* pHost, const QString& windowName);
     std::pair<bool, QString> openWindow(Host*, const QString&, bool loadLayout, bool autoDock, const QString &area);
@@ -168,7 +166,8 @@ public:
     bool clearWindow(Host*, const QString&);
     bool pasteWindow(Host* pHost, const QString& name);
     bool setBackgroundColor(Host*, const QString& name, int r, int g, int b, int alpha);
-    bool setBackgroundImage(Host*, const QString& name, QString& path);
+    bool setBackgroundImage(Host*, const QString&, QString &, int);
+    bool resetBackgroundImage(Host *, const QString&);
     bool setDisplayAttributes(Host* pHost, const QString& name, const TChar::AttributeFlags attributes, const bool state);
     bool setCmdLineAction(Host*, const QString&, const int);
     bool resetCmdLineAction(Host*, const QString&);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Shorter name and function for consoles and labels in one name

#### Motivation for adding to Mudlet
discussion on discord
simplifying usage

#### Other info (issues closed, discussion etc)
it is really important that consoles and labels don't have the same name.
But as we discussed it is planned in future to forbid duplicated of names.

Also be aware that the "mode" parameter won't have any effect on Labels but it is possible to use "setStyleSheet" on them for that kind of functionality.