### PR TITLE
FIx Lua stack corruption when parsing MSSP

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14840,7 +14840,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             QStringList payloadList = packageList[i].split(MSSP_VAL);
 
             if (payloadList.size() != 2) {
-                return;
+                continue;
             }
 
             QString msspVAR = payloadList[0];
@@ -14867,6 +14867,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
                 host.mpConsole->printSystemMessage(msg);
             }
             host.raiseEvent(event);
+            lua_settop (L, 1);
         }
 
         lua_pop(L, lua_gettop(L));


### PR DESCRIPTION
#### Brief overview of PR changes/additions

The MSSP parser corrupted the stack because the revert in #4217 killed a bugfix.

#### Motivation for adding to Mudlet

Fixes #4230

