### PR TITLE
Adjust macOS PTB check for the macOS Git version

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -10,7 +10,7 @@ fi
 if [ "${DEPLOY}" = "deploy" ]; then
 
   # get commit date now before we check out an change into another git repository
-  COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
+  COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
   git clone https://github.com/Mudlet/installers.git "${TRAVIS_BUILD_DIR}/../installers"


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Adjust macOS PTB check for the macOS Git version
#### Motivation for adding to Mudlet
So macOS PTBs aren't rebuilt daily even when there are no new changes.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/4226

Credit to @SlySven for coming up with the solution.