### PR TITLE
Install Busted for runTests in Docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,5 +22,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Lua dependencies
-RUN luarocks install luautf8 \
-    && luarocks install lua-yajl
+RUN luarocks install luautf8     \
+    && luarocks install lua-yajl \
+    && luarocks install busted


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Install Busted for runTests in Docker
#### Motivation for adding to Mudlet
So `runTests` can have it, especially in Github Codespaces.
#### Other info (issues closed, discussion etc)
`runTests` does not actually work then still, throws an error: https://github.com/Mudlet/Mudlet/issues/4249