### PR TITLE
Update Qt to use latest 5.12.9 LTS version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
   DBLSQD_PASS:
     secure: Bm5PLJjC39XmRC55RPGVP9c5CFxvWu2VorAAmu5QS38=
   matrix:
-  - QT_BASE_DIR: C:\Qt\5.13.2\mingw73_32
+  - QT_BASE_DIR: C:\Qt\5.12.9\mingw73_32
     MINGW_BASE_DIR: C:\Qt\Tools\mingw730_32
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -22,7 +22,7 @@ function SetQtBaseDir([string] $logFile) {
     }
     catch
     {
-      $Env:QT_BASE_DIR = "C:\Qt\5.13.2\mingw73_32"
+      $Env:QT_BASE_DIR = "C:\Qt\5.12.9\mingw73_32"
     }
   }
   Write-Output "Using $Env:QT_BASE_DIR as QT base directory." | Tee-Object -File "$logFile" -Append

--- a/CI/qt-silent-install.qs
+++ b/CI/qt-silent-install.qs
@@ -27,7 +27,7 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent("qt.qt5.5132.win32_mingw73");
+    widget.selectComponent("qt.qt5.5129.win32_mingw73");
     widget.selectComponent("qt.tools.win32_mingw730");
 
     gui.clickButton(buttons.NextButton);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Update Qt to use latest 5.12.9 LTS version. Can't really update to 5.15 easily because it uses a newer 81_64 mingw release and that's a bit more work to change. Using the latest LTS, unless we need features from a more modern version, seems OK.
#### Motivation for adding to Mudlet
Our windows Qt release is over a year old now and Leris ran into a crashing issue within Qt itself that seems to have been fixed.
#### Other info (issues closed, discussion etc)
