### PR TITLE
Fix translations to work in CMake builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,6 @@
 set(mudlet_RCCS mudlet.qrc)
 configure_file("${mudlet_SOURCE_DIR}/translations/translated/qm.qrc" "${mudlet_BINARY_DIR}/translations/translated/qm.qrc" COPYONLY)
 
-
 if(USE_FONTS)
   list(APPEND mudlet_RCCS mudlet_fonts_common.qrc)
   if(CMAKE_SYSTEM_NAME STREQUAL Linux)
@@ -345,6 +344,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(mudlet ${mudlet_SRCS} ${mudlet_RCCS} ${mudlet_HDRS}
                       ${mudlet_UIS})
+target_sources(mudlet PRIVATE "${mudlet_BINARY_DIR}/translations/translated/qm.qrc")
 
 set_target_properties(
   mudlet

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,8 @@
 ############################################################################
 
 set(mudlet_RCCS mudlet.qrc)
-qt5_add_resources(RES_SOURCE_FILES ../translations/translated/qm.qrc)
+configure_file("${mudlet_SOURCE_DIR}/translations/translated/qm.qrc" "${mudlet_BINARY_DIR}/translations/translated/qm.qrc" COPYONLY)
+
 
 if(USE_FONTS)
   list(APPEND mudlet_RCCS mudlet_fonts_common.qrc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@
 ############################################################################
 
 set(mudlet_RCCS mudlet.qrc)
+qt5_add_resources(RES_SOURCE_FILES ../translations/translated/qm.qrc)
 
 if(USE_FONTS)
   list(APPEND mudlet_RCCS mudlet_fonts_common.qrc)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix translations to work in CMake builds.
#### Motivation for adding to Mudlet
This also fixes translations in Linux PTB's since we use cmake for those - qmake is occupied by Coverity builds.
#### Other info (issues closed, discussion etc)
Closes #4164

Works fine:
```
vscode ➜ ~/workspace/Mudlet/build/src (fix-cmake-linux-translations ✗) $ /home/vscode/workspace/Mudlet/build/src/mudlet
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-vscode'
qt.qpa.xcb: QXcbConnection: XCB error: 148 (Unknown), sequence: 180, resource id: 0, major code: 140 (Unknown), minor code: 20
Could not find Discord library - searched in:
     "/usr/lib/x86_64-linux-gnu/qt5/plugins"
     "/home/vscode/workspace/Mudlet/build/src"
mudlet::readEarlySettings(...) INFO - Using language code "en_US" to switch to "English (UnitedStates)" locale.
mudlet::scanForMudletTranslations(":/lang") INFO - Seeking Mudlet translation files:
    found a Mudlet translation for locale code: "de_DE".
    found a Mudlet translation for locale code: "el_GR".
    found a Mudlet translation for locale code: "en_GB".
    found a Mudlet translation for locale code: "en_US".
    found a Mudlet translation for locale code: "es_ES".
    found a Mudlet translation for locale code: "fr_FR".
    found a Mudlet translation for locale code: "it_IT".
    found a Mudlet translation for locale code: "nl_NL".
    found a Mudlet translation for locale code: "pl_PL".
    found a Mudlet translation for locale code: "pt_BR".
    found a Mudlet translation for locale code: "pt_PT".
    found a Mudlet translation for locale code: "ru_RU".
    found a Mudlet translation for locale code: "tr_TR".
    found a Mudlet translation for locale code: "zh_CN".
    found a Mudlet translation for locale code: "zh_TW".
```