### PR TITLE
Fix Luarocks on OSX

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -4,7 +4,7 @@ set +e
 shopt -s expand_aliases
 #Removed boost as first item as a temporary workaroud to prevent trying to
 #upgrade to boost version 1.68.0 which has not been bottled yet...
-BREWS="cmake hunspell libzip lua51 pcre pkg-config qt5 yajl ccache pugixml luarocks"
+BREWS="luarocks cmake hunspell libzip lua51 pcre pkg-config qt5 yajl ccache pugixml"
 OUTDATED_BREWS=$(brew outdated)
 
 for i in $BREWS; do

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -62,9 +62,3 @@ gem update cocoapods
 # shellcheck disable=2139
 alias luarocks-5.1="luarocks --lua-dir='$(brew --prefix lua@5.1)'"
 luarocks-5.1 --local install lua-yajl
-
-# Echo debug Luarocks path
-luarocks-5.1 path
-
-brew install tree
-tree /usr/local/opt/lua@5.1

--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -62,3 +62,9 @@ gem update cocoapods
 # shellcheck disable=2139
 alias luarocks-5.1="luarocks --lua-dir='$(brew --prefix lua@5.1)'"
 luarocks-5.1 --local install lua-yajl
+
+# Echo debug Luarocks path
+luarocks-5.1 path
+
+brew install tree
+tree /usr/local/opt/lua@5.1


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Debug Luarocks on OSX
#### Motivation for adding to Mudlet
Needed for 4.10 release.
#### Other info (issues closed, discussion etc)
'fixed' it just by switching the order of the installs around, because this tipped me to a potential problem even though we do everything sequentially:

```
Installing luarocks

Warning: Calling `brew list` to only list formulae is deprecated! Use `brew list --formula` instead.

==> Downloading https://homebrew.bintray.com/bottles/lua-5.3.5_1.high_sierra.bottle.tar.gz

Already downloaded: /Users/travis/Library/Caches/Homebrew/downloads/d829df9cb7ee456f6d3e9d45bfafe5816030407dfa09f9b69f258e87d9dff7a0--lua-5.3.5_1.high_sierra.bottle.tar.gz

==> Downloading https://homebrew.bintray.com/bottles/luarocks-3.4.0.high_sierra.bottle.tar.gz

Already downloaded: /Users/travis/Library/Caches/Homebrew/downloads/23410845224cd1845ec953ecbab029c06e647032361912d22c78911851002181--luarocks-3.4.0.high_sierra.bottle.tar.gz

==> Installing dependencies for luarocks: lua

==> Installing luarocks dependency: lua

==> Pouring lua-5.3.5_1.high_sierra.bottle.tar.gz

Error: Operation already in progress for lua@5.1.formula

Another active Homebrew process is already using lua@5.1.formula.

Please wait for it to finish or terminate it to continue.

Attempt 1 failed.

Retrying...

 

Installing luarocks

Warning: Calling `brew list` to only list formulae is deprecated! Use `brew list --formula` instead.

==> Downloading https://homebrew.bintray.com/bottles/luarocks-3.4.0.high_sierra.bottle.tar.gz

Already downloaded: /Users/travis/Library/Caches/Homebrew/downloads/23410845224cd1845ec953ecbab029c06e647032361912d22c78911851002181--luarocks-3.4.0.high_sierra.bottle.tar.gz

==> Pouring luarocks-3.4.0.high_sierra.bottle.tar.gz

==> Caveats

LuaRocks supports multiple versions of Lua. By default it is configured

to use Lua5.3, but you can require it to use another version at runtime

with the `--lua-dir` flag, like this:



  luarocks --lua-dir=/usr/local/opt/lua@5.1 install say
```