### PR TITLE
Fix moving rooms in the 2D mapper

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4578,8 +4578,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             return;
         }
 
-        int dx = qRound((event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0) + 1.0) - room->x;
-        int dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy - 1.0) - room->y;
+        int dx = qRound((event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0)) - room->x;
+        int dy = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy) - room->y;
         QSetIterator<int> itRoom = mMultiSelectionSet;
         while (itRoom.hasNext()) {
             room = mpMap->mpRoomDB->getRoom(itRoom.next());


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When moving a room on the 2D map, the room was offset from the actual mouse position.

#### Motivation for adding to Mudlet

This displacement is rather annoying.

#### Other info (issues closed, discussion etc)

The reason for these offsets is now lost in the mists of coding history (or rather, merge squashing).


