### PR TITLE
Purge timers periodically when offline

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -46,7 +46,6 @@
 #include "dlgIRC.h"
 #include "mudlet.h"
 
-
 #include "pre_guard.h"
 #include <chrono>
 #include <QDialog>
@@ -55,6 +54,8 @@
 #include <zip.h>
 #include <memory>
 #include "post_guard.h"
+
+using namespace std::chrono;
 
 stopWatch::stopWatch()
 : mIsInitialised(false)
@@ -449,6 +450,10 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     if (mudlet::scmIsPublicTestVersion) {
         thankForUsingPTB();
     }
+
+    connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });
+    connect(&mTelnet, &cTelnet::signal_connected, this, [this](){ purgeTimer.stop(); });
+    connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_PurgeTimers);
 }
 
 Host::~Host()
@@ -1387,6 +1392,14 @@ void Host::incomingStreamProcessor(const QString& data, int line)
 {
     mTriggerUnit.processDataStream(data, line);
 
+    mTimerUnit.doCleanup();
+}
+
+// When Mudlet is running in online mode, deleted timers are cleaned up in bulk
+// on every new line. When in offline mode, new lines don't come - so they are
+// cleaned up in bulk periodically.
+void Host::slot_PurgeTimers()
+{
     mTimerUnit.doCleanup();
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -453,7 +453,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });
     connect(&mTelnet, &cTelnet::signal_connected, this, [this](){ purgeTimer.stop(); });
-    connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_PurgeTimers);
+    connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTimers);
 }
 
 Host::~Host()
@@ -1398,7 +1398,7 @@ void Host::incomingStreamProcessor(const QString& data, int line)
 // When Mudlet is running in online mode, deleted timers are cleaned up in bulk
 // on every new line. When in offline mode, new lines don't come - so they are
 // cleaned up in bulk periodically.
-void Host::slot_PurgeTimers()
+void Host::slot_purgeTimers()
 {
     mTimerUnit.doCleanup();
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -620,7 +620,7 @@ signals:
 
 private slots:
     void slot_reloadModules();
-    void slot_PurgeTimers();
+    void slot_purgeTimers();
 
 private:
     void installPackageFonts(const QString &packageName);

--- a/src/Host.h
+++ b/src/Host.h
@@ -620,6 +620,7 @@ signals:
 
 private slots:
     void slot_reloadModules();
+    void slot_PurgeTimers();
 
 private:
     void installPackageFonts(const QString &packageName);
@@ -753,6 +754,8 @@ private:
 
     // Now a per profile option this one represents the state of this profile:
     bool mCompactInputLine;
+
+    QTimer purgeTimer;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -362,6 +362,7 @@ int TimerUnit::getNewID()
 void TimerUnit::doCleanup()
 {
     QMutableSetIterator<TTimer*> itTimer(mCleanupSet);
+    qDebug() << QTime::currentTime().toString() << "deleting" << mCleanupSet.size() << "timers";
     while (itTimer.hasNext()) {
         auto pTimer = itTimer.next();
         // It is important to take the item OUT of the set before you delete

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -362,7 +362,6 @@ int TimerUnit::getNewID()
 void TimerUnit::doCleanup()
 {
     QMutableSetIterator<TTimer*> itTimer(mCleanupSet);
-    qDebug() << QTime::currentTime().toString() << "deleting" << mCleanupSet.size() << "timers";
     while (itTimer.hasNext()) {
         auto pTimer = itTimer.next();
         // It is important to take the item OUT of the set before you delete


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Purge timers periodically when offline
#### Motivation for adding to Mudlet
So Mudlet doesn't freeze or 'crash' as people say when you've had a lot of timers running while Mudlet was offline for an extended period of time.
#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/3757 
Closes https://github.com/Mudlet/Mudlet/issues/1376

Implemented as a regular timer check so we don't need to add an `if disconnected...` condition to reduce online performance.