### PR TITLE
Disable translations for mapper controls

### DIFF
--- a/src/ui/mapper.ui
+++ b/src/ui/mapper.ui
@@ -290,7 +290,7 @@
                   </font>
                  </property>
                  <property name="text">
-                  <string>⯇</string>
+                  <string notr="true">⯇</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -330,7 +330,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>⯆</string>
+                  <string notr="true">⯆</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -370,7 +370,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>⯅</string>
+                  <string notr="true">⯅</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -410,7 +410,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>⯈</string>
+                  <string notr="true">⯈</string>
                  </property>
                  <property name="autoRepeat">
                   <bool>true</bool>
@@ -456,7 +456,7 @@
                   </font>
                  </property>
                  <property name="text">
-                  <string>+</string>
+                  <string notr="true">+</string>
                  </property>
                 </widget>
                </item>
@@ -493,7 +493,7 @@
                   </font>
                  </property>
                  <property name="text">
-                  <string>-</string>
+                  <string notr="true">-</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Disable translations for mapper controls
#### Motivation for adding to Mudlet
They shouldn't be translated.
#### Other info (issues closed, discussion etc)
Knowing what comes up for translation in https://github.com/Mudlet/Mudlet/pull/4295 would be nice here.