### PR TITLE
Remove SSL deprecation warning for Qt 5.15+

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -292,7 +292,11 @@ QSslCertificate cTelnet::getPeerCertificate()
 
 QList<QSslError> cTelnet::getSslErrors()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    return socket.sslHandshakeErrors();
+#else
     return socket.sslErrors();
+#endif
 }
 #endif
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Remove SSL deprecation warning for Qt 5.15+
#### Motivation for adding to Mudlet
Compatibility with modern Qt.
#### Other info (issues closed, discussion etc)
