### PR TITLE
Fix 'keepcolor' in replace()

### DIFF
--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -267,13 +267,13 @@ if false then
 
 
 
-  --- Get the RGB values of the first character of the current selection.
+  --- Get the RGB values of the first character of the current selection, and the number of following characters with this color.
   ---
   --- @param windowName optional
   ---
   --- @usage Getting RGB component.
   ---   <pre>
-  ---   r,g,b = getBgColor(windowName)
+  ---   r,g,b,n = getBgColor(windowName)
   ---   </pre>
   ---
   --- @see getFgColor
@@ -311,19 +311,19 @@ if false then
 
 
   --- This function returns the RGB values of the color of the first character of the current selection
-  --- on mini console (window) windowName.
+  --- on mini console (window) windowName, and the number of following characters with this color.
   ---
   --- @param windowName optional - if windowName is omitted Mudlet will use the main screen.
   ---
   --- @usage
   ---   <pre>
-  ---   r,g,b = getFgColor(windowName)
+  ---   r,g,b,n = getFgColor(windowName)
   ---   </pre>
   --- @usage
   ---   <pre>
-  ---   local r,g,b
+  ---   local r,g,b,n
   ---   selectString("troll", 1)
-  ---   r,g,b = getFgColor()
+  ---   r,g,b,n = getFgColor()
   ---   if r == 255 and g == 0 and b == 0 then
   ---       echo("HELP! troll is written in red letters, the monster is aggressive!\n")
   ---   end

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1703,12 +1703,17 @@ do
     text = text or ""
 
     if keepcolor then
+      local fr,fg,fb,br,bg,bb;
       if not windowname then
-        setBgColor(getBgColor())
-        setFgColor(getFgColor())
+        br,bg,bb = getBgColor()
+        fr,fg,fb = getFgColor()
+        setBgColor(br,bg,bb)
+        setFgColor(fr,fg,fb)
       else
-        setBgColor(windowname, getBgColor(windowname))
-        setFgColor(windowname, getFgColor(windowname))
+        br,bg,bb = getBgColor(windowname)
+        fr,fg,fb = getFgColor(windowname)
+        setBgColor(windowname, br,bg,bb)
+        setFgColor(windowname, fr,fg,fb)
       end
     end
 


### PR DESCRIPTION

#### Brief overview of PR changes/additions

getFgColor/getBgColor may return more than three values. This breaks scripts which blindly call `setFgColor(getFgColor())`.

#### Motivation for adding to Mudlet

Regression fix

#### Other info (issues closed, discussion etc)

Closes #4301.

A complementary fix might be to teach `setFgColor`/`setBgColor` to tolerate a fourth numeric argument, which is fragile because they already have an optional initial argument (the window name), which is an annoying antipattern we can't easily get rid of.