### PR TITLE
IRC '/quit' no longer crashes Mudlet

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2877,7 +2877,7 @@ void Host::close()
     if (mpDlgIRC) {
         mpDlgIRC->setAttribute(Qt::WA_DeleteOnClose);
         mpDlgIRC->deleteLater();
-        mpDlgIRC.reset(nullptr);
+        mpDlgIRC = nullptr;
     }
     if (mpConsole) {
         mpConsole->close();

--- a/src/Host.h
+++ b/src/Host.h
@@ -602,7 +602,7 @@ public:
     std::unique_ptr<QNetworkProxy> mpDownloaderProxy;
     QString mProfileStyleSheet;
     dlgTriggerEditor::SearchOptions mSearchOptions;
-    QScopedPointer<dlgIRC> mpDlgIRC;
+    QPointer<dlgIRC> mpDlgIRC;
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
     QList<QString> mDockLayoutChanges;
     QList<TToolBar*> mToolbarLayoutChanges;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12850,7 +12850,7 @@ int TLuaInterpreter::sendIrc(lua_State* L)
     Host* pHost = &getHostFromLua(L);
     if (!pHost->mpDlgIRC) {
         // create a new irc client if one isn't ready.
-        pHost->mpDlgIRC.reset(new dlgIRC(pHost));
+        pHost->mpDlgIRC = new dlgIRC(pHost);
         pHost->mpDlgIRC->raise();
         pHost->mpDlgIRC->show();
     }

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -121,7 +121,7 @@ dlgIRC::~dlgIRC()
     }
 
     if (mpHost->mpDlgIRC) {
-        mpHost->mpDlgIRC.reset(nullptr);
+        mpHost->mpDlgIRC = nullptr;
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2576,7 +2576,7 @@ void mudlet::slot_irc()
     }
 
     if (!pHost->mpDlgIRC) {
-        pHost->mpDlgIRC.reset(new dlgIRC(pHost));
+        pHost->mpDlgIRC = new dlgIRC(pHost);
     }
     pHost->mpDlgIRC->raise();
     pHost->mpDlgIRC->show();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Closing the IRC window via "/quit" crashed Mudlet.

Background: Using QScopedPointer is dangerous on objects that are not *really* scoped to whatever object the scoped pointer is bound to. Specifically you can run into double-free problems because the scoped pointer isn't auto-cleared when the object is otherwise deleted and you can't do it manually either.

#### Motivation for adding to Mudlet

Don't crash when closing IRC.

#### Other info (issues closed, discussion etc)

Closes #4304.