### PR TITLE
CHARSET handles ASCII and ISO variants

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1495,7 +1495,21 @@ void cTelnet::processTelnetCommand(const std::string& command)
                     for (int i = 1; i < characterSetList.size(); ++i) {
                         QByteArray characterSet = characterSetList.at(i).toUpper();
 
-                        if (mAcceptableEncodings.contains(characterSet) || mAcceptableEncodings.contains(("M_" + characterSet))) {
+                        if (mAcceptableEncodings.contains(characterSet) ||
+                            mAcceptableEncodings.contains(("M_" + characterSet)) ||
+                            characterSet.contains(QByteArray("ASCII"))) { // Accept variants of ASCII
+                            acceptedCharacterSet = characterSet;
+                            break;
+                        }
+
+                        if (characterSet.startsWith("ISO-") &&  // Accept "ISO-####-#" variant of "ISO ####-#"
+                            mAcceptableEncodings.contains(QByteArray("ISO " + characterSet.mid(4)))) {
+                            acceptedCharacterSet = characterSet;
+                            break;
+                        }
+
+                        if (characterSet.startsWith("ISO") &&  // Accept "ISO####-#" variant of "ISO ####-#"
+                            mAcceptableEncodings.contains(QByteArray("ISO " + characterSet.mid(3)))) {
                             acceptedCharacterSet = characterSet;
                             break;
                         }
@@ -1508,7 +1522,15 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 output += OPT_CHARSET;
 
                 if (!acceptedCharacterSet.isEmpty()) {
-                    setEncoding(acceptedCharacterSet, true);
+                    if (acceptedCharacterSet.contains(QByteArray("ASCII"))) {
+                        setEncoding(QByteArray("ASCII"), true); // Force variants of ASCII to ASCII
+                    } else if (acceptedCharacterSet.startsWith("ISO-")) {
+                        setEncoding(QByteArray("ISO " + acceptedCharacterSet.mid(4)), true); // Align with TEncodingTable::csmEncodings
+                    } else if (acceptedCharacterSet.startsWith("ISO")) {
+                        setEncoding(QByteArray("ISO " + acceptedCharacterSet.mid(3)), true); // Align with TEncodingTable::csmEncodings
+                    } else {
+                        setEncoding(acceptedCharacterSet, true);
+                    }
 
                     output += CHARSET_ACCEPTED;
                     output += payload[1]; // Separator

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1508,7 +1508,8 @@ void cTelnet::processTelnetCommand(const std::string& command)
                             break;
                         }
 
-                        if (characterSet.startsWith("ISO") &&  // Accept "ISO####-#" variant of "ISO ####-#"
+                        if (!characterSet.startsWith("ISO ") &&
+                            characterSet.startsWith("ISO") &&  // Accept "ISO####-#" variant of "ISO ####-#"
                             mAcceptableEncodings.contains(QByteArray("ISO " + characterSet.mid(3)))) {
                             acceptedCharacterSet = characterSet;
                             break;
@@ -1526,7 +1527,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                         setEncoding(QByteArray("ASCII"), true); // Force variants of ASCII to ASCII
                     } else if (acceptedCharacterSet.startsWith("ISO-")) {
                         setEncoding(QByteArray("ISO " + acceptedCharacterSet.mid(4)), true); // Align with TEncodingTable::csmEncodings
-                    } else if (acceptedCharacterSet.startsWith("ISO")) {
+                    } else if (acceptedCharacterSet.startsWith("ISO") && !acceptedCharacterSet.startsWith("ISO ")) {
                         setEncoding(QByteArray("ISO " + acceptedCharacterSet.mid(3)), true); // Align with TEncodingTable::csmEncodings
                     } else {
                         setEncoding(acceptedCharacterSet, true);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

This pull request enhances the CHARSET functionality to accept a request for ASCII and also variants of the ISO encodings.  Previous to this change, Mudlet would not match on `ASCII`, `ISO-8859-1`, `ISO8859-1`, but would match on `ISO 8859-1`.  This could be tested with play.federation2.com:30003.  Perhaps the best way is to create an account there, create a character, then change the encoding manually in Settings to UTF-8.  Quit the game and connect again and it will move back to ASCII.

#### Motivation for adding to Mudlet

Resolves issues.

#### Other info (issues closed, discussion etc)

This closes #4292 and #4285. Regarding #4292, CHARSET was already working as the game mentioned there wants a UTF-8 encoding, however their login screen expects ISO 8859-1 to display some characters.  There is not evidence of the game sending requests to change to/from ISO 8859-1, however, only UTF-8.  It will be suggested to the submitter they use the option to force CHARSET off if they want to stick with ISO 8859-1.