### PR TITLE
Add Linux Clang Qt 5.14 build to Github Actions

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -13,17 +13,22 @@ jobs:
           # - os: windows-latest
           #   triplet: x64-windows
           - os: ubuntu-latest
-            buildname: 'ubuntu'
+            buildname: 'ubuntu / gcc'
             triplet: x64-linux
             compiler: gcc_64
             qt: '5.14.1'
           - os: ubuntu-latest
-            buildname: 'ubuntu / Qt 5.11'
+            buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
+            qt: '5.14.1'            
+          - os: ubuntu-latest
+            buildname: 'ubuntu / qt 5.11'
+            triplet: x64-linux
+            compiler: gcc_64
             qt: '5.11.0'
           - os: macos-latest
-            buildname: 'macos / C++ tests'
+            buildname: 'macos / c++ tests'
             triplet: x64-osx
             compiler: clang_64
             qt: '5.14.1'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -21,7 +21,7 @@ jobs:
             buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
-            qt: '5.14.1'            
+            qt: '5.14.1'
           - os: ubuntu-latest
             buildname: 'ubuntu / qt 5.11'
             triplet: x64-linux


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Add Linux Clang Qt 5.14 build to Github Actions
#### Motivation for adding to Mudlet
So we test Clang builds with latest Qt that we're using
#### Other info (issues closed, discussion etc)
Was previously supported by Travis