### PR TITLE
Build actions on push to development

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -1,6 +1,8 @@
 name: Build Mudlet
 on:
-  - pull_request
+  push:
+    branches: [master, development]
+  pull_request:
 
 jobs:
   compile-mudlet:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Build actions on push to development, as well as commits to a PR.
#### Motivation for adding to Mudlet
Try not to duplicate push/pull request builds on a single PR, but still build them when the commit lands to `development`.
#### Other info (issues closed, discussion etc)
Behaviour was changed by https://github.com/Mudlet/Mudlet/pull/4282.