### PR TITLE
Support X11 selection keyboard

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -826,6 +826,12 @@ void TTextEdit::highlightSelection()
     update(mSelectedRegion.boundingRect());
     update(newRegion);
     mSelectedRegion = newRegion;
+
+    QClipboard* clipboard = QApplication::clipboard();
+    if (clipboard->supportsSelection()) {
+        // X11 has a second clipboard that's updated on any selection
+        clipboard->setText(getSelectedText(), QClipboard::Selection);
+    }
 }
 
 void TTextEdit::unHighlight()


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

X11 has a second clipboard (used by middle click) that should be updated whenever text is selected.

#### Motivation for adding to Mudlet

Everywhere else on my Linux system, if I select text with the mouse, I can middle click to paste it.  It's
very confusing if Mudlet is different.

#### Other info (issues closed, discussion etc)
Closes https://github.com/Mudlet/Mudlet/issues/1739