### PR TITLE
Fix bug when unhighlighting during control-selection.

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -830,8 +830,6 @@ void TTextEdit::highlightSelection()
 
 void TTextEdit::unHighlight()
 {
-    normaliseSelection();
-
     // clang-format off
     for (int y = std::max(0, mPA.y()), endY = std::min((mPB.y() + 1), static_cast<int>(mpBuffer->buffer.size()));
          y < endY;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Calling `normaliseSelection` during `unHighlight()` is incorrect, because
mPA and mPB are not necessarily equal to mDragStart and
mDragSelectionEnd in any order; during control-selection, mPA and mPB
are instead the beginning/end of the corresponding line.  So without
this, unhighlighting by clicking the mouse elsewhere after control-selection
leaves some bits highlighted.

And we don't need to call normaliseSelection, because mPA and mPB are
always normalised when set.

