### PR TITLE
refactor history code into one code path

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -373,7 +373,7 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
-                historyDown(ke);
+                historyMove(false);
                 if (!mpHost->mHighlightHistory){
                     moveCursor(QTextCursor::End);
                 }
@@ -410,7 +410,7 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Up is pressed without modifiers (special case for
                 // macOs - also sets KeyPad modifier)
-                historyUp(ke);
+                historyMove(true);
                 if (!mpHost->mHighlightHistory){
                     moveCursor(QTextCursor::End);
                 }
@@ -1019,42 +1019,19 @@ void TCommandLine::handleAutoCompletion()
     mAutoCompletionCount = -1;
 }
 
-// cursor down: cycles chronologically through the command history.
-
-void TCommandLine::historyDown(QKeyEvent* event)
-{
-    if (mHistoryList.empty()) {
-        return;
-    }
-    if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || !mpHost->mHighlightHistory) {
-        mHistoryBuffer--;
-        if (mHistoryBuffer >= mHistoryList.size()) {
-            mHistoryBuffer = mHistoryList.size() - 1;
-        }
-        if (mHistoryBuffer < 0) {
-            mHistoryBuffer = 0;
-        }
-        setPlainText(mHistoryList[mHistoryBuffer]);
-        selectAll();
-        adjustHeight();
-    } else {
-        mAutoCompletionCount--;
-        handleAutoCompletion();
-    }
-}
-
-// cursor up: turns on autocompletion mode and cycles through all possible matches
+// cursor up/down: turns on autocompletion mode and cycles through all possible matches
 // In case nothing has been typed it cycles through the command history in
 // reverse order compared to cursor down.
 
-void TCommandLine::historyUp(QKeyEvent* event)
+void TCommandLine::historyMove(bool moveUp)
 {
     if (mHistoryList.empty()) {
         return;
     }
+    int shift = moveUp ? 1 : -1;
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || !mpHost->mHighlightHistory) {
         if (toPlainText().size() != 0) {
-            mHistoryBuffer++;
+            mHistoryBuffer += shift;
         }
         if (mHistoryBuffer >= mHistoryList.size()) {
             mHistoryBuffer = mHistoryList.size() - 1;
@@ -1066,7 +1043,7 @@ void TCommandLine::historyUp(QKeyEvent* event)
         selectAll();
         adjustHeight();
     } else {
-        mAutoCompletionCount++;
+        mAutoCompletionCount += shift;
         handleAutoCompletion();
     }
 }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -373,7 +373,7 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
-                historyMove(false);
+                historyMove(MOVE_DOWN);
                 if (!mpHost->mHighlightHistory){
                     moveCursor(QTextCursor::End);
                 }
@@ -410,7 +410,7 @@ bool TCommandLine::event(QEvent* event)
 #endif
                 // If EXACTLY Up is pressed without modifiers (special case for
                 // macOs - also sets KeyPad modifier)
-                historyMove(true);
+                historyMove(MOVE_UP);
                 if (!mpHost->mHighlightHistory){
                     moveCursor(QTextCursor::End);
                 }
@@ -1023,12 +1023,12 @@ void TCommandLine::handleAutoCompletion()
 // In case nothing has been typed it cycles through the command history in
 // reverse order compared to cursor down.
 
-void TCommandLine::historyMove(bool moveUp)
+void TCommandLine::historyMove(MoveDirection direction)
 {
     if (mHistoryList.empty()) {
         return;
     }
-    int shift = moveUp ? 1 : -1;
+    int shift = (direction == MOVE_UP ? 1 : -1);
     if ((textCursor().selectedText().size() == toPlainText().size()) || (toPlainText().size() == 0) || !mpHost->mHighlightHistory) {
         if (toPlainText().size() != 0) {
             mHistoryBuffer += shift;

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -41,6 +41,11 @@ class TCommandLine : public QPlainTextEdit //QLineEdit
 {
     Q_OBJECT
 
+    enum MoveDirection {
+        MOVE_UP,
+        MOVE_DOWN
+    };
+
 public:
     enum CommandLineTypeFlag {
         UnknownType = 0x0,     // Should not be encountered but left as a trap value
@@ -74,7 +79,7 @@ private:
     void handleAutoCompletion();
     void spellCheck();
     void handleTabCompletion(bool);
-    void historyMove(bool);
+    void historyMove(MoveDirection);
     void enterCommand(QKeyEvent*);
     void adjustHeight();
     void processNormalKey(QEvent*);

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -74,8 +74,7 @@ private:
     void handleAutoCompletion();
     void spellCheck();
     void handleTabCompletion(bool);
-    void historyUp(QKeyEvent*);
-    void historyDown(QKeyEvent*);
+    void historyMove(bool);
     void enterCommand(QKeyEvent*);
     void adjustHeight();
     void processNormalKey(QEvent*);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Currently, the code path for `historyUp` and `historyDown` is nearly identical: the only difference is that one uses `++` where the other uses `--`.  This merges the two functions.

#### Motivation for adding to Mudlet

I have a more substantial change to history lined up, and it would be nice to not duplicate code.


