### PR TITLE
Trim unneeded apt dependencies in Linux Actions

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -72,7 +72,7 @@ jobs:
         # Installing packages might fail as the github image becomes outdated
         sudo apt update
         # These aren't available or don't work well in vcpkg
-        sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev libxkbcommon-x11-0 libqt5x11extras5
+        sudo apt install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev
 
     - name: (Linux Clang) change compiler
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Trim unneeded apt dependencies in Linux Actions. `libxkbcommon-x11-0` is already installed automatically by https://github.com/jurplel/install-qt-action/releases/tag/v2.6.3 now, and the other one is an apt package - which I don't think meshes with the Qt install action anyway.
#### Motivation for adding to Mudlet
Quicker build times.
#### Other info (issues closed, discussion etc)
