### PR TITLE
More cleanup of TCommandLine history/entercommand

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -299,13 +299,6 @@ bool TCommandLine::event(QEvent* event)
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 // Do the normal return key stuff only if NO modifiers are used:
                 enterCommand(ke);
-                mLastCompletion.clear();
-                mUserKeptOnTyping = false;
-                if (mpHost->mAutoClearCommandLineAfterSend) {
-                    mHistoryBuffer = -1;
-                } else {
-                    mHistoryBuffer = 0;
-                }
                 ke->accept();
                 return true;
 
@@ -325,13 +318,6 @@ bool TCommandLine::event(QEvent* event)
                 // Do the "normal" return key action if no or just the keypad
                 // modifier is present:
                 enterCommand(ke);
-                mLastCompletion.clear();
-                mUserKeptOnTyping = false;
-                if (mpHost->mAutoClearCommandLineAfterSend) {
-                    mHistoryBuffer = -1;
-                } else {
-                    mHistoryBuffer = 0;
-                }
                 ke->accept();
                 return true;
 
@@ -862,6 +848,8 @@ void TCommandLine::enterCommand(QKeyEvent* event)
     mTabCompletionCount = -1;
     mAutoCompletionCount = -1;
     mTabCompletionTyped.clear();
+    mLastCompletion.clear();
+    mUserKeptOnTyping = false;
 
     QStringList _l = _t.split(QChar::LineFeed);
 
@@ -885,8 +873,10 @@ void TCommandLine::enterCommand(QKeyEvent* event)
         mHistoryList.push_front(toPlainText());
     }
     if (mpHost->mAutoClearCommandLineAfterSend) {
+        mHistoryBuffer = -1;
         clear();
     } else {
+        mHistoryBuffer = 0;
         selectAll();
     }
     adjustHeight();

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -299,18 +299,13 @@ bool TCommandLine::event(QEvent* event)
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 // Do the normal return key stuff only if NO modifiers are used:
                 enterCommand(ke);
-                mAutoCompletionCount = -1;
                 mLastCompletion.clear();
-                mTabCompletionTyped.clear();
                 mUserKeptOnTyping = false;
-                mTabCompletionCount = -1;
                 if (mpHost->mAutoClearCommandLineAfterSend) {
-                    clear();
                     mHistoryBuffer = -1;
                 } else {
                     mHistoryBuffer = 0;
                 }
-                adjustHeight();
                 ke->accept();
                 return true;
 
@@ -330,18 +325,13 @@ bool TCommandLine::event(QEvent* event)
                 // Do the "normal" return key action if no or just the keypad
                 // modifier is present:
                 enterCommand(ke);
-                mTabCompletionCount = -1;
-                mAutoCompletionCount = -1;
                 mLastCompletion.clear();
-                mTabCompletionTyped.clear();
                 mUserKeptOnTyping = false;
                 if (mpHost->mAutoClearCommandLineAfterSend) {
-                    clear();
                     mHistoryBuffer = -1;
                 } else {
                     mHistoryBuffer = 0;
                 }
-                adjustHeight();
                 ke->accept();
                 return true;
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -350,9 +350,6 @@ bool TCommandLine::event(QEvent* event)
                 // If EXACTLY Down is pressed without modifiers (special case
                 // for macOs - also sets KeyPad modifier)
                 historyMove(MOVE_DOWN);
-                if (!mpHost->mHighlightHistory){
-                    moveCursor(QTextCursor::End);
-                }
                 ke->accept();
                 return true;
 
@@ -387,9 +384,6 @@ bool TCommandLine::event(QEvent* event)
                 // If EXACTLY Up is pressed without modifiers (special case for
                 // macOs - also sets KeyPad modifier)
                 historyMove(MOVE_UP);
-                if (!mpHost->mHighlightHistory){
-                    moveCursor(QTextCursor::End);
-                }
                 ke->accept();
                 return true;
 
@@ -1020,7 +1014,11 @@ void TCommandLine::historyMove(MoveDirection direction)
             mHistoryBuffer = 0;
         }
         setPlainText(mHistoryList[mHistoryBuffer]);
-        selectAll();
+        if (mpHost->mHighlightHistory) {
+            selectAll();
+        } else {
+            moveCursor(QTextCursor::End);
+        }
         adjustHeight();
     } else {
         mAutoCompletionCount += shift;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

There was a bunch of duplicated code after the `enterCommand()` calls in TCommandLine.

This PR has three commits, which may be easier to review separately:

 - The first removes the lines that were useless; they duplicated lines already done in `enterCommand()`.
 - The second moves the lines that appear after both calls to `enterCommand()` inside the function call
 - The third is like the second, but for `historyMove`.

#### Motivation for adding to Mudlet

I have a planned PR to change the logic in dealing with the history, and want to remove duplicated code without any changes to functionality before modifying the code.

#### Other info (issues closed, discussion etc)
