### PR TITLE
Tweak dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      # ignore vcpkg as it is updated often, and this goes off commits, not releases
+      - dependency-name: "3rdparty/vcpkg"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     ignore:
       # ignore vcpkg as it is updated often, and this goes off commits, not releases
       - dependency-name: "3rdparty/vcpkg"


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Update weekly, not daily - like our current github actions.

Ignore vcpkg since it goes off every commit to `development`, which is a lot. It doesn't seem to do releases only.
#### Motivation for adding to Mudlet
Less potential spam.
#### Other info (issues closed, discussion etc)
See all options at https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates