### PR TITLE
Fix macOS Actions builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -59,6 +59,16 @@ jobs:
         submodules: true
         fetch-depth: 0
 
+    # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
+    - name: Restore from cache and run vcpkg
+      uses: lukka/run-vcpkg@v5
+      env:
+        vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-${{matrix.triplet}}-dependencies
+      with:
+        vcpkgArguments: '@${{env.vcpkgResponseFile}}'
+        vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
+        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-newkey
+
     - name: (macOS) Install homebrew dependencies
       if: runner.os == 'macOS'
       run: |
@@ -90,16 +100,6 @@ jobs:
         echo "WITH_UPDATER=no" >> $GITHUB_ENV
         echo "WITH_3DMAPPER=no" >> $GITHUB_ENV
         echo "WITH_FONTS=no" >> $GITHUB_ENV
-
-    # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
-    - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v5
-      env:
-        vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-${{matrix.triplet}}-dependencies
-      with:
-        vcpkgArguments: '@${{env.vcpkgResponseFile}}'
-        vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
-        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-newkey
 
     - name: (Linux/macOS) restore ccache
       uses: actions/cache@v2

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -91,14 +91,6 @@ jobs:
         echo "WITH_3DMAPPER=no" >> $GITHUB_ENV
         echo "WITH_FONTS=no" >> $GITHUB_ENV
 
-    - name: (Linux/macOS) restore ccache
-      uses: actions/cache@v2
-      with:
-        path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{github.sha}}
-        restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-
-      if: matrix.os != 'windows-latest'
-
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
       uses: lukka/run-vcpkg@v5
@@ -108,6 +100,14 @@ jobs:
         vcpkgArguments: '@${{env.vcpkgResponseFile}}'
         vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
         appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-newkey
+
+    - name: (Linux/macOS) restore ccache
+      uses: actions/cache@v2
+      with:
+        path: ${{runner.workspace}}/ccache
+        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{github.sha}}
+        restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-
+      if: matrix.os != 'windows-latest'
 
     - name: Build Mudlet
       uses: lukka/run-cmake@v3


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Restore ccache after vcpkg is compiled in Actions.

Compiling vcpkg with ccache leads to a weird interaction, and on macOS it thinks it's using g++10 to compile while it really should be using clang:

![image](https://user-images.githubusercontent.com/110988/98838679-e5666080-2444-11eb-9512-b34af799d8eb.png)
https://github.com/Mudlet/Mudlet/runs/1385330005#step:10:228

#### Motivation for adding to Mudlet
So macOS Actions builds work again.
#### Other info (issues closed, discussion etc)
