### PR TITLE
Draw area exit names

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1993,55 +1993,57 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     }
                     painter.drawPolyline(polyLinePoints.data(), polyLinePoints.size());
 
-                    int exitRoomId = -1;
-                    QMapIterator<int, QString> otherExitIt = room->getOtherMap();
-                    while (otherExitIt.hasNext()) {
-                        otherExitIt.next();
-                        if (otherExitIt.value().startsWith(QLatin1String("0")) || otherExitIt.value().startsWith(QLatin1String("1"))) {
-                            if (otherExitIt.value().mid(1) == itk.key()) {
+                    if (!getUserDataBool(room->userData, ROOM_UI_DONTSHOWAREAEXITNAME, false)) {
+                        int exitRoomId = -1;
+                        QMapIterator<int, QString> otherExitIt = room->getOtherMap();
+                        while (otherExitIt.hasNext()) {
+                            otherExitIt.next();
+                            if (otherExitIt.value().startsWith(QLatin1String("0")) || otherExitIt.value().startsWith(QLatin1String("1"))) {
+                                if (otherExitIt.value().mid(1) == itk.key()) {
+                                    exitRoomId = otherExitIt.key();
+                                    break;
+                                }
+                            } else if (otherExitIt.value() == itk.key()) {
                                 exitRoomId = otherExitIt.key();
                                 break;
                             }
-                        } else if (otherExitIt.value() == itk.key()) {
-                            exitRoomId = otherExitIt.key();
-                            break;
                         }
-                    }
-                    if (exitRoomId > -1) {
-                        auto pExitRoom = mpMap->mpRoomDB->getRoom(exitRoomId);
-                        if (pExitRoom && pExitRoom->getArea() != mAreaID) {
-                            QRectF rectExitAreaName(0, 0, 250, 30);
-                            QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pExitRoom->getArea());
-                            rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(8, 2, 8, 2);
+                        if (exitRoomId > -1) {
+                            auto pExitRoom = mpMap->mpRoomDB->getRoom(exitRoomId);
+                            if (pExitRoom && pExitRoom->getArea() != mAreaID) {
+                                QRectF rectExitAreaName(0, 0, 250, 30);
+                                QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pExitRoom->getArea());
+                                rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(8, 2, 8, 2);
 
-                            QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);
-                            if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y()) {    // getSouth
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
-                            }
-                            else if (abs(_p.x() - p2.x()) < 4 && _p.y() < p2.y()) {  // getNorth
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
-                            }
-                            else if (_p.x() < p2.x() && abs(_p.y() - p2.y()) < 4) {  // getWest
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
-                            }
-                            else if (_p.x() > p2.x() && abs(_p.y() - p2.y()) < 4) {  // getEast
-                                rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
-                            }
-                            else if (_p.x() < p2.x() && _p.y() < p2.y()) {  // getNorthwest
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
-                            }
-                            else if (_p.x() > p2.x() && _p.y() < p2.y()) {  // getNortheast
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
-                            }
-                            else if (_p.x() > p2.x() && _p.y() > p2.y()) {  // getSoutheast
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
-                            }
-                            else if (_p.x() < p2.x() && _p.y() > p2.y()) {  // getSouthwest
-                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
-                            }
+                                QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);
+                                if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y()) {    // getSouth
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
+                                }
+                                else if (abs(_p.x() - p2.x()) < 4 && _p.y() < p2.y()) {  // getNorth
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
+                                }
+                                else if (_p.x() < p2.x() && abs(_p.y() - p2.y()) < 4) {  // getWest
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
+                                }
+                                else if (_p.x() > p2.x() && abs(_p.y() - p2.y()) < 4) {  // getEast
+                                    rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
+                                }
+                                else if (_p.x() < p2.x() && _p.y() < p2.y()) {  // getNorthwest
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
+                                }
+                                else if (_p.x() > p2.x() && _p.y() < p2.y()) {  // getNortheast
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
+                                }
+                                else if (_p.x() > p2.x() && _p.y() > p2.y()) {  // getSoutheast
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
+                                }
+                                else if (_p.x() < p2.x() && _p.y() > p2.y()) {  // getSouthwest
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
+                                }
 
-                            painter.setPen(mpHost->mFgColor_2);
-                            painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                                painter.setPen(mpHost->mFgColor_2);
+                                painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                            }
                         }
                     }
 
@@ -2250,8 +2252,10 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 painter.setBrush(brush);
                 painter.drawPolygon(_poly);
 
-                painter.setPen(mpHost->mFgColor_2);
-                painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                if (!getUserDataBool(room->userData, ROOM_UI_DONTSHOWAREAEXITNAME, false)) {
+                    painter.setPen(mpHost->mFgColor_2);
+                    painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                }
 
                 painter.setPen(__pen);
             }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2007,32 +2007,38 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                             break;
                         }
                     }
-                    if (rID > -1)
-                    {
+                    if (rID > -1) {
                         TRoom* pE = mpMap->mpRoomDB->getRoom(rID);
-                        if (pE && pE->getArea() != mAreaID)
-                        {
+                        if (pE && pE->getArea() != mAreaID) {
                             QRectF rectExitAreaName(0, 0, 250, 30);
                             QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pE->getArea());
                             rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(15, 10, 15, 10);
 
                             QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);
-                            if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y())    // getSouth
+                            if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y()) {    // getSouth
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
-                            else if (abs(_p.x() - p2.x()) < 4 && _p.y() < p2.y())  // getNorth
+                            }
+                            else if (abs(_p.x() - p2.x()) < 4 && _p.y() < p2.y()) {  // getNorth
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
-                            else if (_p.x() < p2.x() && abs(_p.y() - p2.y()) < 4)  // getWest
+                            }
+                            else if (_p.x() < p2.x() && abs(_p.y() - p2.y()) < 4) {  // getWest
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
-                            else if (_p.x() > p2.x() && abs(_p.y() - p2.y()) < 4)  // getEast
+                            }
+                            else if (_p.x() > p2.x() && abs(_p.y() - p2.y()) < 4) {  // getEast
                                 rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
-                            else if (_p.x() < p2.x() && _p.y() < p2.y())  // getNorthwest
+                            }
+                            else if (_p.x() < p2.x() && _p.y() < p2.y()) {  // getNorthwest
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
-                            else if (_p.x() > p2.x() && _p.y() < p2.y())  // getNortheast
+                            }
+                            else if (_p.x() > p2.x() && _p.y() < p2.y()) {  // getNortheast
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
-                            else if (_p.x() > p2.x() && _p.y() > p2.y())  // getSoutheast
+                            }
+                            else if (_p.x() > p2.x() && _p.y() > p2.y()) {  // getSoutheast
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
-                            else if (_p.x() < p2.x() && _p.y() > p2.y())  // getSouthwest
+                            }
+                            else if (_p.x() < p2.x() && _p.y() > p2.y()) {  // getSouthwest
                                 rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
+                            }
 
                             painter.setPen(mpHost->mFgColor_2);
                             painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1993,25 +1993,25 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     }
                     painter.drawPolyline(polyLinePoints.data(), polyLinePoints.size());
 
-                    int rID = -1;
+                    int exitRoomId = -1;
                     QMapIterator<int, QString> otherExitIt = room->getOtherMap();
                     while (otherExitIt.hasNext()) {
                         otherExitIt.next();
                         if (otherExitIt.value().startsWith(QLatin1String("0")) || otherExitIt.value().startsWith(QLatin1String("1"))) {
                             if (otherExitIt.value().mid(1) == itk.key()) {
-                                rID = otherExitIt.key();
+                                exitRoomId = otherExitIt.key();
                                 break;
                             }
                         } else if (otherExitIt.value() == itk.key()) {
-                            rID = otherExitIt.key();
+                            exitRoomId = otherExitIt.key();
                             break;
                         }
                     }
-                    if (rID > -1) {
-                        TRoom* pE = mpMap->mpRoomDB->getRoom(rID);
-                        if (pE && pE->getArea() != mAreaID) {
+                    if (exitRoomId > -1) {
+                        auto pExitRoom = mpMap->mpRoomDB->getRoom(exitRoomId);
+                        if (pExitRoom && pExitRoom->getArea() != mAreaID) {
                             QRectF rectExitAreaName(0, 0, 250, 30);
-                            QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pE->getArea());
+                            QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pExitRoom->getArea());
                             rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(8, 2, 8, 2);
 
                             QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1993,6 +1993,52 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     }
                     painter.drawPolyline(polyLinePoints.data(), polyLinePoints.size());
 
+                    int rID = -1;
+                    QMapIterator<int, QString> otherExitIt = room->getOtherMap();
+                    while (otherExitIt.hasNext()) {
+                        otherExitIt.next();
+                        if (otherExitIt.value().startsWith(QLatin1String("0")) || otherExitIt.value().startsWith(QLatin1String("1"))) {
+                            if (otherExitIt.value().mid(1) == itk.key()) {
+                                rID = otherExitIt.key();
+                                break;
+                            }
+                        } else if (otherExitIt.value() == itk.key()) {
+                            rID = otherExitIt.key();
+                            break;
+                        }
+                    }
+                    if (rID > -1)
+                    {
+                        TRoom* pE = mpMap->mpRoomDB->getRoom(rID);
+                        if (pE && pE->getArea() != mAreaID)
+                        {
+                            QRectF rectExitAreaName(0, 0, 250, 30);
+                            QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pE->getArea());
+                            rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(15, 10, 15, 10);
+
+                            QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);
+                            if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y())    // getSouth
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
+                            else if (abs(_p.x() - p2.x()) < 4 && _p.y() < p2.y())  // getNorth
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
+                            else if (_p.x() < p2.x() && abs(_p.y() - p2.y()) < 4)  // getWest
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
+                            else if (_p.x() > p2.x() && abs(_p.y() - p2.y()) < 4)  // getEast
+                                rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
+                            else if (_p.x() < p2.x() && _p.y() < p2.y())  // getNorthwest
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
+                            else if (_p.x() > p2.x() && _p.y() < p2.y())  // getNortheast
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
+                            else if (_p.x() > p2.x() && _p.y() > p2.y())  // getSoutheast
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
+                            else if (_p.x() < p2.x() && _p.y() > p2.y())  // getSouthwest
+                                rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
+
+                            painter.setPen(mpHost->mFgColor_2);
+                            painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                        }
+                    }
+
                     if (room->customLinesArrow.value(itk.key())) {
                         QLineF l0 = QLineF(polyLinePoints.last(), polyLinePoints.at(polyLinePoints.size() - 2));
                         l0.setLength(exitWidth * 5.0);
@@ -2126,6 +2172,10 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 }
 
             } else {
+                QRectF rectExitAreaName(0, 0, 250, 30);
+                QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pE->getArea());
+                rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(15, 10, 15, 10);
+
                 __pen = painter.pen();
                 QPoint _p;
                 pen = painter.pen();
@@ -2136,27 +2186,35 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 if (room->getSouth() == rID) {
                     _line = QLine(p2.x(), p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x(), p2.y() + mRoomHeight / 2.0);
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
                 } else if (room->getNorth() == rID) {
                     _line = QLine(p2.x(), p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x(), p2.y() - mRoomHeight / 2.0);
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
                 } else if (room->getWest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y(), p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y());
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
                 } else if (room->getEast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y(), p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y());
+                    rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
                 } else if (room->getNorthwest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y() - mRoomHeight / 2.0);
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
                 } else if (room->getNortheast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y() - mRoomHeight / 2.0);
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
                 } else if (room->getSoutheast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y() + mRoomHeight / 2.0);
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
                 } else if (room->getSouthwest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y() + mRoomHeight / 2.0);
+                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
                 }
                 painter.drawLine(_line);
                 mAreaExitsList[k] = _p;
@@ -2185,6 +2243,10 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 painter.setPen(arrowPen);
                 painter.setBrush(brush);
                 painter.drawPolygon(_poly);
+
+                painter.setPen(mpHost->mFgColor_2);
+                painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+
                 painter.setPen(__pen);
             }
             // doors

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1684,6 +1684,13 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
     const float widgetWidth = width();
     const float widgetHeight = height();
 
+    const float area_miny = pArea->min_y * -1 * mRoomHeight + static_cast<float>(mRY);
+    const float area_maxy = pArea->max_y * -1 * mRoomHeight + static_cast<float>(mRY);
+    const float area_minx = pArea->min_x * mRoomWidth + static_cast<float>(mRX);
+    const float area_maxx = pArea->max_x * mRoomWidth + static_cast<float>(mRX);
+    const float area_width = abs(area_maxx - area_minx);
+    const float area_height = abs(area_maxy - area_miny);
+
     int customLineDestinationTarget = 0;
     if (mCustomLinesRoomTo > 0) {
         customLineDestinationTarget = mCustomLinesRoomTo;
@@ -2041,8 +2048,10 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                                     rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
                                 }
 
-                                painter.setPen(mpHost->mFgColor_2);
-                                painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                                if (!(xyzoom > 40 && rectExitAreaName.width() >= qMax(area_width, area_height) / 3)) {
+                                    painter.setPen(mpHost->mFgColor_2);
+                                    painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                                }
                             }
                         }
                     }
@@ -2253,8 +2262,10 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 painter.drawPolygon(_poly);
 
                 if (!getUserDataBool(room->userData, ROOM_UI_DONTSHOWAREAEXITNAME, false)) {
-                    painter.setPen(mpHost->mFgColor_2);
-                    painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                    if (!(xyzoom > 40 && rectExitAreaName.width() >= qMax(area_width, area_height) / 3)) {
+                        painter.setPen(mpHost->mFgColor_2);
+                        painter.drawText(rectExitAreaName, Qt::AlignCenter, rAreaName);
+                    }
                 }
 
                 painter.setPen(__pen);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1679,6 +1679,34 @@ void T2DMap::paintEvent(QPaintEvent* e)
     }
 }
 
+static QPointF parseOffsetString(const QString& offsetStr)
+{
+    QPointF re {0, 0};
+    QStringList posXY = offsetStr.split(" ");
+    bool ok1, ok2;
+    double posX, posY;
+
+    switch (posXY.count()) {
+        case 1:
+        // one value: treat as Y offset
+        posY = posXY[0].toDouble(&ok1);
+        if (ok1) {
+            re.setY(posY);
+        }
+        break;
+        case 2:
+        posX = posXY[0].toDouble(&ok1);
+        posY = posXY[1].toDouble(&ok2);
+        if (ok1 && ok2) {
+            re.setX(posX);
+            re.setY(posY);
+        }
+        break;
+    }
+
+    return re;
+}
+
 void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth)
 {
     const float widgetWidth = width();
@@ -2001,6 +2029,7 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                     painter.drawPolyline(polyLinePoints.data(), polyLinePoints.size());
 
                     if (!getUserDataBool(room->userData, ROOM_UI_DONTSHOWAREAEXITNAME, false)) {
+                        QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + itk.key()));
                         int exitRoomId = -1;
                         QMapIterator<int, QString> otherExitIt = room->getOtherMap();
                         while (otherExitIt.hasNext()) {
@@ -2024,28 +2053,28 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 
                                 QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);
                                 if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y()) {    // getSouth
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2 + areaExitNameOffset.x(), _p.y() + areaExitNameOffset.y());
                                 }
                                 else if (abs(_p.x() - p2.x()) < 4 && _p.y() < p2.y()) {  // getNorth
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2 + areaExitNameOffset.x(), _p.y() - rectExitAreaName.height() + areaExitNameOffset.y());
                                 }
                                 else if (_p.x() < p2.x() && abs(_p.y() - p2.y()) < 4) {  // getWest
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() + areaExitNameOffset.x(), _p.y() - rectExitAreaName.height() / 2 + areaExitNameOffset.y());
                                 }
                                 else if (_p.x() > p2.x() && abs(_p.y() - p2.y()) < 4) {  // getEast
-                                    rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
+                                    rectExitAreaName.moveTo(_p.x() + areaExitNameOffset.x() + areaExitNameOffset.x(), _p.y() - rectExitAreaName.height() / 2 + areaExitNameOffset.y());
                                 }
                                 else if (_p.x() < p2.x() && _p.y() < p2.y()) {  // getNorthwest
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75 + areaExitNameOffset.x(), _p.y() - rectExitAreaName.height() + areaExitNameOffset.y());
                                 }
                                 else if (_p.x() > p2.x() && _p.y() < p2.y()) {  // getNortheast
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25 + areaExitNameOffset.x(), _p.y() - rectExitAreaName.height() + areaExitNameOffset.y());
                                 }
                                 else if (_p.x() > p2.x() && _p.y() > p2.y()) {  // getSoutheast
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25 + areaExitNameOffset.x(), _p.y() + areaExitNameOffset.y());
                                 }
                                 else if (_p.x() < p2.x() && _p.y() > p2.y()) {  // getSouthwest
-                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
+                                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75 + areaExitNameOffset.x(), _p.y() + areaExitNameOffset.y());
                                 }
 
                                 if (!(xyzoom > 40 && rectExitAreaName.width() >= qMax(area_width, area_height) / 3)) {
@@ -2203,35 +2232,43 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 if (room->getSouth() == rID) {
                     _line = QLine(p2.x(), p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x(), p2.y() + mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() / 2, _line.p1().y());
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "south"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() / 2 + areaExitNameOffset.x(), _line.p1().y() + areaExitNameOffset.y());
                 } else if (room->getNorth() == rID) {
                     _line = QLine(p2.x(), p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x(), p2.y() - mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() / 2, _line.p1().y() - rectExitAreaName.height());
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "north"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() / 2 + areaExitNameOffset.x(), _line.p1().y() - rectExitAreaName.height() + areaExitNameOffset.y());
                 } else if (room->getWest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y(), p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y());
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width(), _line.p1().y() - rectExitAreaName.height() / 2);
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "west"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() + areaExitNameOffset.x(), _line.p1().y() - rectExitAreaName.height() / 2 + areaExitNameOffset.y());
                 } else if (room->getEast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y(), p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y());
-                    rectExitAreaName.moveTo(_line.p1().x(), _line.p1().y() - rectExitAreaName.height() / 2);
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "east"));
+                    rectExitAreaName.moveTo(_line.p1().x() + areaExitNameOffset.x(), _line.p1().y() - rectExitAreaName.height() / 2 + areaExitNameOffset.y());
                 } else if (room->getNorthwest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y() - mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.75, _line.p1().y() - rectExitAreaName.height());
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "northwest"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.75 + areaExitNameOffset.x(), _line.p1().y() - rectExitAreaName.height() + areaExitNameOffset.y());
                 } else if (room->getNortheast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y() - mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.25, _line.p1().y() - rectExitAreaName.height());
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "northeast"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.25 + areaExitNameOffset.x(), _line.p1().y() - rectExitAreaName.height() + areaExitNameOffset.y());
                 } else if (room->getSoutheast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y() + mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.25, _line.p1().y());
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "southeast"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.25 + areaExitNameOffset.x(), _line.p1().y() + areaExitNameOffset.y());
                 } else if (room->getSouthwest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y() + mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.75, _line.p1().y());
+                    QPointF areaExitNameOffset = parseOffsetString(room->userData.value(ROOM_UI_AREAEXITNAMEOFFSET + "." + "southwest"));
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.75 + areaExitNameOffset.x(), _line.p1().y() + areaExitNameOffset.y());
                 }
                 painter.drawLine(_line);
                 mAreaExitsList[k] = _p;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2012,7 +2012,7 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                         if (pE && pE->getArea() != mAreaID) {
                             QRectF rectExitAreaName(0, 0, 250, 30);
                             QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pE->getArea());
-                            rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(15, 10, 15, 10);
+                            rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(8, 2, 8, 2);
 
                             QPointF _p = polyLinePoints.last(), p2 = polyLinePoints.at(polyLinePoints.size() - 2);
                             if (abs(_p.x() - p2.x()) < 4 && _p.y() > p2.y()) {    // getSouth
@@ -2180,7 +2180,7 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             } else {
                 QRectF rectExitAreaName(0, 0, 250, 30);
                 QString rAreaName = mpMap->mpRoomDB->getAreaNamesMap().value(pE->getArea());
-                rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(15, 10, 15, 10);
+                rectExitAreaName = painter.boundingRect(rectExitAreaName, 0, rAreaName) + QMarginsF(8, 2, 8, 2);
 
                 __pen = painter.pen();
                 QPoint _p;
@@ -2192,35 +2192,35 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 if (room->getSouth() == rID) {
                     _line = QLine(p2.x(), p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x(), p2.y() + mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y());
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() / 2, _line.p1().y());
                 } else if (room->getNorth() == rID) {
                     _line = QLine(p2.x(), p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x(), p2.y() - mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() / 2, _p.y() - rectExitAreaName.height());
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() / 2, _line.p1().y() - rectExitAreaName.height());
                 } else if (room->getWest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y(), p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y());
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width(), _p.y() - rectExitAreaName.height() / 2);
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width(), _line.p1().y() - rectExitAreaName.height() / 2);
                 } else if (room->getEast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y(), p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y());
-                    rectExitAreaName.moveTo(_p.x(), _p.y() - rectExitAreaName.height() / 2);
+                    rectExitAreaName.moveTo(_line.p1().x(), _line.p1().y() - rectExitAreaName.height() / 2);
                 } else if (room->getNorthwest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y() - mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y() - rectExitAreaName.height());
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.75, _line.p1().y() - rectExitAreaName.height());
                 } else if (room->getNortheast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y() - mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y() - mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y() - rectExitAreaName.height());
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.25, _line.p1().y() - rectExitAreaName.height());
                 } else if (room->getSoutheast() == rID) {
                     _line = QLine(p2.x() + mRoomWidth, p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() + mRoomWidth / 2.0, p2.y() + mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.25, _p.y());
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.25, _line.p1().y());
                 } else if (room->getSouthwest() == rID) {
                     _line = QLine(p2.x() - mRoomWidth, p2.y() + mRoomHeight, p2.x(), p2.y());
                     _p = QPoint(p2.x() - mRoomWidth / 2.0, p2.y() + mRoomHeight / 2.0);
-                    rectExitAreaName.moveTo(_p.x() - rectExitAreaName.width() * 0.75, _p.y());
+                    rectExitAreaName.moveTo(_line.p1().x() - rectExitAreaName.width() * 0.75, _line.p1().y());
                 }
                 painter.drawLine(_line);
                 mAreaExitsList[k] = _p;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -35,6 +35,7 @@ const QString ROOM_UI_NAMEPOS = QStringLiteral("room.ui_nameOffset");
 const QString ROOM_UI_NAMEFONT = QStringLiteral("room.ui_nameFont");
 const QString ROOM_UI_NAMESIZE = QStringLiteral("room.ui_nameSize");
 const QString ROOM_UI_DONTSHOWAREAEXITNAME = QStringLiteral("room.ui_dontShowAreaExitName");
+const QString ROOM_UI_AREAEXITNAMEOFFSET = QStringLiteral("room.ui_areaExitNameOffset");
 
 TRoomDB::TRoomDB(TMap* pMap)
 : mpMap(pMap)

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -34,6 +34,7 @@ const QString ROOM_UI_SHOWNAME = QStringLiteral("room.ui_showName");
 const QString ROOM_UI_NAMEPOS = QStringLiteral("room.ui_nameOffset");
 const QString ROOM_UI_NAMEFONT = QStringLiteral("room.ui_nameFont");
 const QString ROOM_UI_NAMESIZE = QStringLiteral("room.ui_nameSize");
+const QString ROOM_UI_DONTSHOWAREAEXITNAME = QStringLiteral("room.ui_dontShowAreaExitName");
 
 TRoomDB::TRoomDB(TMap* pMap)
 : mpMap(pMap)

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -39,6 +39,7 @@ extern const QString ROOM_UI_SHOWNAME;
 extern const QString ROOM_UI_NAMEPOS;
 extern const QString ROOM_UI_NAMEFONT;  // global only
 extern const QString ROOM_UI_NAMESIZE;  // TODO
+extern const QString ROOM_UI_DONTSHOWAREAEXITNAME;
 
 class TRoomDB
 {

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -40,6 +40,7 @@ extern const QString ROOM_UI_NAMEPOS;
 extern const QString ROOM_UI_NAMEFONT;  // global only
 extern const QString ROOM_UI_NAMESIZE;  // TODO
 extern const QString ROOM_UI_DONTSHOWAREAEXITNAME;
+extern const QString ROOM_UI_AREAEXITNAMEOFFSET;
 
 class TRoomDB
 {


### PR DESCRIPTION
When a room connect to another area's room, draw the exit area name on the line end

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
To not show area names in a room:

```
-- don't show exit:
setRoomUserData(roomid, "room.ui_dontShowAreaExitName", "yes")

-- move normal exit a little bit
setRoomUserData(roomid, "room.ui_areaExitNameOffset.south", "20")
setRoomUserData(roomid, "room.ui_areaExitNameOffset.south", "20 20")
-- move special exit a little bit
setRoomUserData(roomid, "room.ui_areaExitNameOffset.northdown", "20")
setRoomUserData(roomid, "room.ui_areaExitNameOffset.northup", "20 20")
```