### PR TITLE
Allow triggering Mudlet build manually in Github Actions

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [master, development]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   compile-mudlet:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Allow triggering Mudlet build manually in Github Actions
#### Motivation for adding to Mudlet
Useful in case you don't want to submit a PR!
#### Other info (issues closed, discussion etc)
It is also possible to select which branch to run the build against in the Github UI.