### PR TITLE
Add a warning to generic mapper version

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -645,6 +645,7 @@ end</script>
 			<name>Map Script</name>
 			<packageName></packageName>
 			<script>-- Jor'Mox's Generic Map Script
+-- the script self-updates, changing this value will bring an update to all installations
 -- 12/11/2020
 local version = "2.0.19"
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Add a warning to generic mapper version
#### Motivation for adding to Mudlet
I think we all forgot the script has self-update functionality, so the version should only be changed when there's really enough things to release an update. People do get annoyed when updates come too fast.
#### Other info (issues closed, discussion etc)
