### PR TITLE
Fix Windows Appveyor builds (use Qt 5.12.10)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
   DBLSQD_PASS:
     secure: Bm5PLJjC39XmRC55RPGVP9c5CFxvWu2VorAAmu5QS38=
   matrix:
-  - QT_BASE_DIR: C:\Qt\5.12.9\mingw73_32
+  - QT_BASE_DIR: C:\Qt\5.12.10\mingw73_32
     MINGW_BASE_DIR: C:\Qt\Tools\mingw730_32
 install:
 - cd "%APPVEYOR_BUILD_FOLDER%\CI"

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -28,7 +28,7 @@ function SetQtBaseDir([string] $logFile) {
     }
     catch
     {
-      $Env:QT_BASE_DIR = "C:\Qt\5.12.9\mingw73_32"
+      $Env:QT_BASE_DIR = "C:\Qt\5.12.10\mingw73_32"
     }
   }
   Write-Output "Using $Env:QT_BASE_DIR as QT base directory." | Tee-Object -File "$logFile" -Append

--- a/CI/qt-silent-install.qs
+++ b/CI/qt-silent-install.qs
@@ -27,7 +27,7 @@ Controller.prototype.ComponentSelectionPageCallback = function() {
     var widget = gui.currentPageWidget();
 
     widget.deselectAll();
-    widget.selectComponent("qt.qt5.5129.win32_mingw73");
+    widget.selectComponent("qt.qt5.51210.win32_mingw73");
     widget.selectComponent("qt.tools.win32_mingw730");
 
     gui.clickButton(buttons.NextButton);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Change Qt from 5.12.9 to latest LTS 5.12.10, since the former is no longer is available for use in AppVeyor.
#### Motivation for adding to Mudlet
Fix Windows Appveyor builds
#### Other info (issues closed, discussion etc)
A bit of a surprise.