### PR TITLE
Remove unused PCRE16 flag

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -292,7 +292,7 @@ function InstallPcre() {
   DownloadFile "https://ftp.pcre.org/pub/pcre/pcre-8.43.zip" "pcre.zip"
   ExtractZip "pcre.zip" "pcre"
   Set-Location pcre\pcre-8.43
-  RunConfigure "--enable-utf --enable-unicode-properties --enable-pcre16 --prefix=$Env:MINGW_BASE_DIR_BASH"
+  RunConfigure "--enable-utf --enable-unicode-properties --prefix=$Env:MINGW_BASE_DIR_BASH"
   RunMake
   RunMakeInstall
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Remove unused PCRE16 flag
#### Motivation for adding to Mudlet
It was added as part of https://github.com/Mudlet/Mudlet/pull/1615/commits/52b48a8cb8ef6dae93b01ca5bb226f40b1c30b3d, but it is still not used two years later, and just lead us on a bit of a wild goose chase. It can always be added back when we'll actually need it!
#### Other info (issues closed, discussion etc)
