### PR TITLE
BugFix: ensure Map Labels for an area are deleted when it is

### DIFF
--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -349,6 +349,10 @@ bool TRoomDB::removeArea(int id)
         // This means areas.clear() is not needed during map
         // deletion
         areas.remove(id);
+        // Must also nuke any map labels in the area - otherwise auditing the
+        // map later will regenerate an unnamed area with the same Id to be the
+        // owner of them...!
+        mpMap->mapLabels.remove(id);
 
         mpMap->mMapGraphNeedsUpdate = true;
         return true;


### PR DESCRIPTION
Not doing this was causing anonymous areas with the same IDs (but no rooms) to be regenerated when the map was next audited (likely to be during the next load) so that the map labels had an area to belong to...!

This will close #4363 .

This was discussed by myself and @Kebap (Leris) in the Discord `#help` channel starting 2020/11/17T00:17Z .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>