### PR TITLE
Update autocompletion action to work again

### DIFF
--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: leafo/gh-actions-lua@v7
+    - uses: leafo/gh-actions-lua@v8
       with:
         luaVersion: "5.1.5"
     - uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Update autocompletion action to work again
#### Motivation for adding to Mudlet
So automated autocompletion updates work again
#### Other info (issues closed, discussion etc)
The install Lua action needed an update to a version that works with the new Github security policy (stemming from that environment variables thing)