### PR TITLE
Update Lua vcpkg port style

### DIFF
--- a/3rdparty/our-vcpkg-dependencies/lua/portfile.cmake
+++ b/3rdparty/our-vcpkg-dependencies/lua/portfile.cmake
@@ -1,5 +1,3 @@
-include(vcpkg_common_functions)
-
 vcpkg_download_distfile(ARCHIVE
     URLS "https://www.lua.org/ftp/lua-5.1.5.tar.gz"
     FILENAME "lua-5.1.5.tar.gz"


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Update Lua 5.1.5 vcpkg port to new requirements by vcpkg.

We use a custom one because vcpkg doesn't support version-specific installs, and they use the latest official Lua version.
#### Motivation for adding to Mudlet
Less chances of it breaking later.
#### Other info (issues closed, discussion etc)
```
   CMake Warning at scripts/cmake/vcpkg_common_functions.cmake:1 (message):
    vcpkg_common_functions has been removed and all values are automatically
    provided in all portfile.cmake invocations.  Please remove
    `include(vcpkg_common_functions)`.
  Call Stack (most recent call first):
    D:/a/Mudlet/Mudlet/3rdparty/our-vcpkg-dependencies/lua/portfile.cmake:1 (include)
    scripts/ports.cmake:136 (include)
```