### PR TITLE
Cleanup: replace deprecated std::uncaught_exception()

### DIFF
--- a/src/Tree.h
+++ b/src/Tree.h
@@ -134,11 +134,7 @@ Tree<T>::~Tree()
     delete mpMyChildrenList;
     if (mpParent) {
         mpParent->popChild(static_cast<T*>(this)); // tell parent about my death
-        // FIXME: std::uncaught_exception() is deprecated in C++17 and is to be
-        // removed in C++20 - and this throws out a lot of build time warnings
-        // that are currently being suppressed by a `-Wno-deprecated-declarations`
-        // but which might also be masking issues in other areas:
-        if (std::uncaught_exception()) {
+        if (std::uncaught_exceptions()) {
             std::cout << "ERROR: Hook destructed during stack rewind because of an uncaught exception." << std::endl;
         }
     }


### PR DESCRIPTION
`std::uncaught_exception()` was deprecated in C++17 and is to be removed in C++20.

It has been replaced by `std::uncaught_exceptions()` which returns an `int` that indicates how many exceptions are outstanding rather than the previous `true` or `false` if there is any. This is helpful in situations where exceptions could happen in exception handling code. That is a whole level of brain-ache I do not even want to think about. However it provides a perfectly suitable solution to our usage if we just drop it in as a replacement...

For me this reduces the warning count from 662 to 510 (i.e. down by 152).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

*Edited: to correct the name of the new method - it is the plural one!*