### PR TITLE
Telnet options within a subnegotiation don't work 

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -107,6 +107,7 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
 , mEncodingWarningIssued(false)
 , mEncoderFailureNoticeIssued(false)
 , mConnectViaProxy(false)
+, mIncompleteSB(false)
 {
     // initialize encoding to a sensible default - needs to be a different value
     // than that in the initialisation list so that it is processed as a change
@@ -2846,6 +2847,12 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                         command.pop_back();
                         command += TN_SE;
                         processTelnetCommand(command);
+                        if(!mIncompleteSB) {
+                            mIncompleteSB = true;
+                            qWarning(R"("TELNET: the server did not properly terminate a subnegotiation (code %02x).\nSome data loss is likely. You should ask them to fix this.)",command[2]);
+                            qWarning("");
+                        }
+
 
                         // Re-enter the state machine.
                         command = TN_IAC;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2847,7 +2847,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                         command.pop_back();
                         command += TN_SE;
                         processTelnetCommand(command);
-                        if(!mIncompleteSB) {
+                        if (!mIncompleteSB) {
                             mIncompleteSB = true;
                             qWarning(R"("TELNET: the server did not properly terminate a subnegotiation (code %02x).\nSome data loss is likely. You should ask them to fix this.)",command[2]);
                         }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2788,6 +2788,8 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                     // IAC SB COMPRESS WILL SE for MCCP v1 (unterminated invalid telnet sequence)
                     // IAC SB COMPRESS2 IAC SE for MCCP v2
                     if ((mMCCP_version_1 || mMCCP_version_2) && (!mNeedDecompression)) {
+                        // TODO this code looks ahead instead of using the state machine.
+                        // This is not a good idea.
                         char _ch = buffer[i];
                         if ((_ch == OPT_COMPRESS) || (_ch == OPT_COMPRESS2)) {
                             bool _compress = false;
@@ -2817,11 +2819,10 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                                     datalen = 0;
                                     i = -1; // end the loop, this will make i and datalen the same.
                                 }
-                                //bugfix: BenH
+                                // compressed data starts in clean state
                                 iac = false;
                                 insb = false;
                                 command = "";
-                                ////////////////
                                 goto MAIN_LOOP_END;
                             }
                         }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2849,7 +2849,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                         processTelnetCommand(command);
                         if (!mIncompleteSB) {
                             mIncompleteSB = true;
-                            qWarning(R"("TELNET: the server did not properly terminate a subnegotiation (code %02x).\nSome data loss is likely. You should ask them to fix this.)",command[2]);
+                            qWarning(R"("TELNET: the server did not properly complete a subnegotiation (code %02x).\nSome data loss is likely - please mention this problem to the game admins.)",command[2]);
                         }
 
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2829,15 +2829,28 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                     //7. inside IAC SB
 
                     command += ch;
-                    if (iac && (ch == TN_SE)) //IAC SE - end of subcommand
-                    {
+                    if (iac && (ch == TN_SE)) { //IAC SE - end of subcommand
                         processTelnetCommand(command);
                         command = "";
                         iac = false;
                         insb = false;
-                    }
-                    if (iac) {
+                    } else if (iac && (ch == TN_IAC)) { // escaped TN_IAC
+                        command.pop_back();
                         iac = false;
+                    } else if (iac) {
+                        // Telnet options within a subcommand are not supported.
+                        // We assume that the SE went missing, possibly due to a
+                        // server bug, and try to recover.
+                        // Cf. https://github.com/Mudlet/Mudlet/issues/4385
+                        command.pop_back();
+                        command += TN_SE;
+                        processTelnetCommand(command);
+
+                        // Re-enter the state machine.
+                        command = TN_IAC;
+                        iac = true;
+                        insb = false;
+                        i -= 1;
                     } else if (ch == TN_IAC) {
                         iac = true;
                     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2850,7 +2850,6 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                         if(!mIncompleteSB) {
                             mIncompleteSB = true;
                             qWarning(R"("TELNET: the server did not properly terminate a subnegotiation (code %02x).\nSome data loss is likely. You should ask them to fix this.)",command[2]);
-                            qWarning("");
                         }
 
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -319,6 +319,8 @@ private:
     // Set if the current connection is via a proxy
     bool mConnectViaProxy;
 
+    // server problem w/ not terminating IAC SB: only warn once
+    bool mIncompleteSB;
 private slots:
 #if !defined(QT_NO_SSL)
     void handle_socket_signal_sslError(const QList<QSslError> &errors);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

If the server sends a Telnet subnegotiation (like GMCP data) and doesn't properly terminate it, a lot of junk (until the next IAC SE) is passed to the GMCP-or-whatever handler. We don't want that, esp. as this silently swallows any server output until the server decides to send the next subnegotiation.

Thus, Mudlet now terminates a subnegotiation when it sees another Telnet option.

This change also fixes another previously-unreported bug: an escaped IAC within a subnegotiation was still doubled.

#### Motivation for adding to Mudlet

Improve handling of strange server bugs

#### Other info (issues closed, discussion etc)

Closes #4385.