### PR TITLE
Revise: unhide warnings in QMake builds

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -45,10 +45,6 @@ include(../3rdparty/communi/communi.pri)
     include(../translations/translated/updateqm.pri)
 }
 
-# disable Qt adding -Wall for us, insert it ourselves so we can add -Wno-*
-# after for some warnings that we wish to ignore:
-!msvc:CONFIG += warn_off
-!msvc:QMAKE_CXXFLAGS += -Wall -Wno-deprecated
 # Before we impose OUR idea about the optimisation levels to use, remove any
 # that Qt tries to put in automatically for us for release builds, only the
 # last, ours, is supposed to apply but it can be confusing to see multiple


### PR DESCRIPTION
This was concealing errors in both our and third-party's code but since we/they have/are working to clear as many warnings it makes sense to turn them back on (as it is such warnings were not being hidden for the cmake builds).

Besides, having issues being shown increases the motivation to getting them fixed... 8-)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>