### PR TITLE
Cleanup: remove some signed to unsigned int comparison warnings

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -573,7 +573,7 @@ void T2DMap::addSymbolToPixmapCache(const QString key, const bool gridMode)
     QFontMetrics mapSymbolFontMetrics = symbolPainter.fontMetrics();
     QVector<quint32> codePoints = symbolString.toUcs4();
     QVector<bool> isUsable;
-    for (uint i = 0; i < codePoints.size(); ++i) {
+    for (int i = 0; i < codePoints.size(); ++i) {
         isUsable.append(mapSymbolFontMetrics.inFontUcs4(codePoints.at(i)));
     }
 
@@ -2410,7 +2410,7 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
         infoLeftSideAvoid += mMultiSelectionListWidget.x() + mMultiSelectionListWidget.rect().width();
     }
 
-    uint infoHeight = 5 + mFontHeight; // Account for first iteration
+    int infoHeight = 5 + mFontHeight; // Account for first iteration
     QRect testRect;
     // infoRect has a 10 margin on either side and on top to widget frame.
     mMapInfoRect = QRect(infoLeftSideAvoid, 10, width() - 10 - infoLeftSideAvoid, infoHeight);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5505,7 +5505,7 @@ int TLuaInterpreter::getAllRoomEntrances(lua_State* L)
     if (entrances.count() > 1) {
         std::sort(entrances.begin(), entrances.end());
     }
-    for (uint i = 0; i < entrances.size(); i++) {
+    for (int i = 0; i < entrances.size(); i++) {
         lua_pushnumber(L, i + 1);
         lua_pushnumber(L, entrances.at(i));
         lua_settable(L, -3);

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -940,7 +940,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             // Purges any duplicates that a QList structure DOES permit, but a QSet does NOT:
             // Exit stubs:
-            unsigned int _listCount = pR->exitStubs.count();
+            int _listCount = pR->exitStubs.count();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             // These next few constuction of a QSet from a QList or vice versa
             // are probably safe as both iterators refer to the SAME instance


### PR DESCRIPTION
Nothing else to add really, and I think these are all mine from past usage of `unsigned int`s when I knew that a negative value was never going to occur but neglecting Qt's habit (reflecting wider C++ coding design) of always using signed `int`s...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>