### PR TITLE
Cleanup: replace deprecated QFontMetrics::width(...) uses

### DIFF
--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -126,8 +126,6 @@ QSize TTabBar::tabSizeHint(int index) const
         // the text to show) the (possibly Qt modified to include an
         // accelarator) actual tabText and not the profile name that we have
         // stored in the tabData:
-        // In Qt 5.11 (int) QFontMetrics::horizontalAdvance(const QString&)
-        // replaced (int) QFontMetrics::width(const QString&)
         const int w = fm.horizontalAdvance(tabText(index));
 
         QFont f = font();

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -126,7 +126,9 @@ QSize TTabBar::tabSizeHint(int index) const
         // the text to show) the (possibly Qt modified to include an
         // accelarator) actual tabText and not the profile name that we have
         // stored in the tabData:
-        const int w = fm.width(tabText(index));
+        // In Qt 5.11 (int) QFontMetrics::horizontalAdvance(const QString&)
+        // replaced (int) QFontMetrics::width(const QString&)
+        const int w = fm.horizontalAdvance(tabText(index));
 
         QFont f = font();
         f.setBold(mStyle.tabBold(index));
@@ -134,12 +136,11 @@ QSize TTabBar::tabSizeHint(int index) const
         f.setUnderline(mStyle.tabUnderline(index));
         const QFontMetrics bfm(f);
 
-        const int bw = bfm.width(tabText(index));
+        const int bw = bfm.horizontalAdvance(tabText(index));
 
         return {s.width() - w + bw, s.height()};
-    } else {
-        return QTabBar::tabSizeHint(index);
     }
+    return QTabBar::tabSizeHint(index);
 }
 
 QString TTabBar::tabName(const int index) const


### PR DESCRIPTION
In Qt 5.11 (the earliest we now support)
`(int) QFontMetrics::width(const QString&)`
was supplanted by:
`(int) QFontMetrics::horizontalAdvance(const QString&)`
and in Qt 5.14 their use is causing a deprecation warning.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>