### PR TITLE
Cleanup: replace obsoleted QTime::elapsed() with QElapsedTimer::elapsed()

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -781,8 +781,8 @@ void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)
 void LuaInterface::getVars(bool hide)
 {
     //returns the base item
-    QTime t;
-    t.start();
+    // QElapsedTimer t;
+    // t.start();
     L = interpreter->pGlobalLua;
     lua_pushnil(L);
     depth = 0;
@@ -798,5 +798,5 @@ void LuaInterface::getVars(bool hide)
     varUnit->setBase(g);
     varUnit->addVariable(g);
     iterateTable(L, LUA_GLOBALSINDEX, g, hide);
-    //FIXME: possible to keep and report? qDebug()<<"took"<<t.elapsed()<<"to get variables in";
+    // FIXME: possible to keep and report? qDebug()<<"took"<<t.elapsed()<<"to get variables in";
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -93,7 +93,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mSystemMessageFgColor(QColor(Qt::red))
 , mTriggerEngineMode(false)
 , mWrapAt(100)
-, networkLatency(new QLineEdit)
+, mpLineEdit_networkLatency(new QLineEdit)
 , mProfileName(mpHost ? mpHost->getName() : QStringLiteral("debug console"))
 , mIsPromptLine(false)
 , mUserAgreedToCloseConsole(false)
@@ -406,37 +406,37 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     logButton->setIcon(logIcon);
     connect(logButton, &QAbstractButton::pressed, this, &TConsole::slot_toggleLogging);
 
-    networkLatency->setReadOnly(true);
-    networkLatency->setSizePolicy(sizePolicy4);
-    networkLatency->setFocusPolicy(Qt::NoFocus);
-    networkLatency->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(
+    mpLineEdit_networkLatency->setReadOnly(true);
+    mpLineEdit_networkLatency->setSizePolicy(sizePolicy4);
+    mpLineEdit_networkLatency->setFocusPolicy(Qt::NoFocus);
+    mpLineEdit_networkLatency->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(
         tr("<i>N:</i> is the latency of the game server and network (aka ping, in seconds), <br>"
            "<i>S:</i> is the system processing time - how long your triggers took to process the last line(s).")));
-    networkLatency->setMaximumSize(120, 30);
-    networkLatency->setMinimumSize(120, 30);
-    networkLatency->setAutoFillBackground(true);
-    networkLatency->setContentsMargins(0, 0, 0, 0);
+    mpLineEdit_networkLatency->setMaximumSize(120, 30);
+    mpLineEdit_networkLatency->setMinimumSize(120, 30);
+    mpLineEdit_networkLatency->setAutoFillBackground(true);
+    mpLineEdit_networkLatency->setContentsMargins(0, 0, 0, 0);
     QPalette basePalette;
     basePalette.setColor(QPalette::Text, QColor(Qt::black));
     basePalette.setColor(QPalette::Base, QColor(Qt::white));
-    networkLatency->setPalette(basePalette);
-    networkLatency->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    mpLineEdit_networkLatency->setPalette(basePalette);
+    mpLineEdit_networkLatency->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
     QFont latencyFont = QFont("Bitstream Vera Sans Mono", 10, QFont::Normal);
     int width;
     int maxWidth = 120;
     width = QFontMetrics(latencyFont).boundingRect(QString("N:0.000 S:0.000")).width();
     if (width < maxWidth) {
-        networkLatency->setFont(latencyFont);
+        mpLineEdit_networkLatency->setFont(latencyFont);
     } else {
         QFont latencyFont2 = QFont("Bitstream Vera Sans Mono", 9, QFont::Normal);
         width = QFontMetrics(latencyFont2).boundingRect(QString("N:0.000 S:0.000")).width();
         if (width < maxWidth) {
-            networkLatency->setFont(latencyFont2);
+            mpLineEdit_networkLatency->setFont(latencyFont2);
         } else {
             QFont latencyFont3 = QFont("Bitstream Vera Sans Mono", 8, QFont::Normal);
             width = QFontMetrics(latencyFont3).boundingRect(QString("N:0.000 S:0.000")).width();
-            networkLatency->setFont(latencyFont3);
+            mpLineEdit_networkLatency->setFont(latencyFont3);
         }
     }
 
@@ -500,10 +500,10 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layoutButtonLayer->addWidget(replayButton, 0, 8);
     layoutButtonLayer->addWidget(logButton, 0, 9);
     layoutButtonLayer->addWidget(emergencyStop, 0, 10);
-    layoutButtonLayer->addWidget(networkLatency, 0, 11);
+    layoutButtonLayer->addWidget(mpLineEdit_networkLatency, 0, 11);
     layoutLayer2->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(layer);
-    networkLatency->setFrame(false);
+    mpLineEdit_networkLatency->setFrame(false);
     //QPalette whitePalette;
     //whitePalette.setColor( QPalette::Window, baseColor);//,255) );
     layerCommandLine->setPalette(basePalette);
@@ -1058,7 +1058,7 @@ void TConsole::setConsoleBgColor(int r, int g, int b, int a)
 
 void TConsole::printOnDisplay(std::string& incomingSocketData, const bool isFromServer)
 {
-    mProcessingTime.restart();
+    mProcessingTimer.restart();
     mTriggerEngineMode = true;
     buffer.translateToPlainText(incomingSocketData, isFromServer);
     mTriggerEngineMode = false;
@@ -1071,11 +1071,21 @@ void TConsole::printOnDisplay(std::string& incomingSocketData, const bool isFrom
         mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions);
     }
 
-    double processT = mProcessingTime.elapsed();
+    double processT = mProcessingTimer.elapsed() / 1000.0;
     if (mpHost->mTelnet.mGA_Driver) {
-        networkLatency->setText(QString("N:%1 S:%2").arg(mpHost->mTelnet.networkLatency, 0, 'f', 3).arg(processT / 1000, 0, 'f', 3));
+        mpLineEdit_networkLatency->setText(tr("N:%1 S:%2",
+                                            // intentional comment to separate arguments
+                                            "The first argument 'N' represents the 'N'etwork latency; the second 'S' the "
+                                            "'S'ystem (processing) time")
+                                                 .arg(mpHost->mTelnet.networkLatencyTime, 0, 'f', 3)
+                                                 .arg(processT, 0, 'f', 3));
     } else {
-        networkLatency->setText(QString("<no GA> S:%1").arg(processT / 1000, 0, 'f', 3));
+        mpLineEdit_networkLatency->setText(tr("<no GA> S:%1",
+                                            // intentional comment to separate arguments
+                                            "The argument 'S' represents the 'S'ystem (processing) time, in this situation "
+                                            "the Game Server is not sending \"GoAhead\" signals so we cannot deduce the "
+                                            "network latency...")
+                                                 .arg(processT, 0, 'f', 3));
     }
     // Modify the tab text if this is not the currently active host - this
     // method is only used on the "main" console so no need to filter depending

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -33,6 +33,7 @@
 
 #include "pre_guard.h"
 #include <QDataStream>
+#include <QElapsedTimer>
 #include <QHBoxLayout>
 #include <QFile>
 #include <QLabel>
@@ -244,7 +245,7 @@ public:
     QScrollBar* mpHScrollBar;
 
 
-    QTime mProcessingTime;
+    QElapsedTimer mProcessingTimer;
     bool mRecordReplay;
     QFile mReplayFile;
     QDataStream mReplayStream;
@@ -257,7 +258,7 @@ public:
     QPoint mUserCursor;
     bool mWindowIsHidden;
     int mWrapAt;
-    QLineEdit* networkLatency;
+    QLineEdit* mpLineEdit_networkLatency;
     QPoint P_begin;
     QPoint P_end;
     QString mProfileName;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6828,9 +6828,7 @@ int TLuaInterpreter::getButtonState(lua_State* L)
 int TLuaInterpreter::getNetworkLatency(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    double number;
-    number = host.mTelnet.networkLatency;
-    lua_pushnumber(L, number);
+    lua_pushnumber(L, host.mTelnet.networkLatencyTime);
     return 1;
 }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -27,6 +27,7 @@
 
 
 #include "pre_guard.h"
+#include <QElapsedTimer>
 #include <QHostAddress>
 #include <QHostInfo>
 #include <QPointer>
@@ -190,8 +191,8 @@ public:
 
     QMap<int, bool> supportedTelnetOptions;
     bool mResponseProcessed;
-    double networkLatency;
-    QTime networkLatencyTime;
+    double networkLatencyTime;
+    QElapsedTimer networkLatencyTimer;
     bool mAlertOnNewData;
     bool mGA_Driver;
     bool mFORCE_GA_OFF;
@@ -291,9 +292,9 @@ private:
     bool mIsTimerPosting;
     QTimer* mTimerLogin;
     QTimer* mTimerPass;
-    QTime timeOffset;
-    QTime mConnectionTime;
-    int lastTimeOffset;
+    QElapsedTimer mRecordingChunkTimer;
+    QElapsedTimer mConnectionTimer;
+    int mRecordLastChunkMSecTimeOffset;
     bool enableCHARSET;
     bool enableATCP;
     bool enableGMCP;


### PR DESCRIPTION
The latter has been present since Qt 4.7 and even on some Windows OSes where it may be a 32-Bit value that can overflow after nearly 50 days when the lower quality TickCounter clock is used as a fallback instead of the PerformanceCounter one this is a better bet than the `QTime` based one that will overflow (wrap) after 24 hours and will be affected by Summer-Time changes and user/system adjustment of the system clock.

Also:
* rename three elements related to timing the network latency, their original names were somewhat ambiguous:
  * `(QLineEdit*) TConsole::networkLatency` ==> `TConsole::mpLineEdit_networkLatency`
  * `(double) cTelnet::networkLatency` ==> `cTelnet::networkLatencyTime`
  * `(QTime) cTelnet::networkLatencyTime` ==> `(QElapsedTimer) cTelnet::networkLatencyTimer`
* rename some other elements in a comparable way:
  * `(QTime) cTelnet::timeOffset` ==> `(QElapsedTimer) cTelnet::mRecordingChunkTimer`
  * `(QTime) cTelnet::mConnectionTime` ==> `(QElapsedTimer) cTelnet::mConnectionTimer`
  * `(int) cTelnet::lastTimeOffset` ==> `(int) cTelnet::mRecordLastChunkMSecTimeOffset`
* simplify a C string array access - there is no need to use the address operator AND an index when referring to the start of a C array, i.e. for `char buffer[datalen]`: `&buffer[0]` is simply `buffer`!
* the display of the network latency (if available) and the system processing time is a UI feature but it was not being put through the translation system, this commit now allows for that to happen.

This should remove 12 warnings (it did on my Linux Qt 5.14.2 system).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>