### PR TITLE
Recommend squash merge of PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,7 +108,10 @@ Of course, before embarking on such a journey, [discuss with the core team](http
 
 ## Merging Pull Requests (PRs)
 
-The preferred order of [merging PRs](https://help.github.com/articles/about-pull-request-merges/) is: prefer rebase, else squash if you'd like to clean up the history before merging. Avoid doing a merge commit.
+The preferred order of [merging PRs](https://help.github.com/articles/about-pull-request-merges/) is: 
+1. Prefer _squash and merge_ for a clean history and added PR numbers for details of discussion for future comparison. 
+2. Else _rebase and merge_ if you'd like to keep the history, but know this will not link to the PR in changelog, etc.
+3. Avoid creating a _merge commit_.
 
 ## Merging auto-generated translation PRs
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Of course, before embarking on such a journey, [discuss with the core team](http
 
 The preferred order of [merging PRs](https://help.github.com/articles/about-pull-request-merges/) is: 
 1. Prefer _squash and merge_ for a clean history and added PR numbers for details of discussion for future comparison. 
-2. Else _rebase and merge_ if you'd like to keep the history, but know this will not link to the PR in changelog, etc.
+2. Else _rebase and merge_ if you'd like to keep the history, but know this will not link to the PR in PTR changelogs, etc.
 3. Avoid creating a _merge commit_.
 
 ## Merging auto-generated translation PRs

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Of course, before embarking on such a journey, [discuss with the core team](http
 
 The preferred order of [merging PRs](https://help.github.com/articles/about-pull-request-merges/) is: 
 1. Prefer _squash and merge_ for a clean history and added PR numbers for details of discussion for future comparison. 
-2. Else _rebase and merge_ if you'd like to keep the history, but know this will not link to the PR in PTR changelogs, etc.
+2. Else _rebase and merge_ if you'd like to keep the history, but know this will not link to the PR in public test builds' (PTB) changelogs, etc.
 3. Avoid creating a _merge commit_.
 
 ## Merging auto-generated translation PRs


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Prefer squash over rebase merge

#### Motivation for adding to Mudlet
When section was written in 2017, PTB and changelog were not around.
Nowadays we really like the PRs' numbers and links in the commits' titles.
Most people seem to default to squash already, hardly rebase any commits.

#### Other info (issues closed, discussion etc)
Discussion today in Discord with Vadi, SlySven and Leris
Original #940 discussion when section was added, it was never adjusted since, and even there in that 2017 discussion, both rebase and squash seemed equally fine options, just no merge commit anymore