### PR TITLE
Cleanup: prevent unused value warnings (again!)

### DIFF
--- a/src/HostManager.cpp
+++ b/src/HostManager.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016, 2018 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2016, 2018, 2020 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -95,13 +96,11 @@ void HostManager::postInterHostEvent(const Host* pHost, const TEvent& event, con
 
     int i = 0;
     QList<int> beforeSendingHost;
-    int sendingHost = -1;
     QList<int> afterSendingHost;
     while (i < hostList.size()) {
         if (hostList.at(i) && hostList.at(i) != pHost) {
             beforeSendingHost.append(i++);
         } else if (hostList.at(i) && hostList.at(i) == pHost) {
-            sendingHost = i++;
             break;
         } else {
             i++;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1238,6 +1238,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QFont& mapN
 // Revised to use a QCache to hold QPixmap * to generated images for room symbols
 void T2DMap::paintEvent(QPaintEvent* e)
 {
+    Q_UNUSED(e)
     if (!mpMap) {
         return;
     }
@@ -4670,6 +4671,7 @@ bool T2DMap::getCenterSelection()
 
 void T2DMap::exportAreaImage(int id)
 {
+    Q_UNUSED(id)
     paintMap();
 }
 

--- a/src/TAstar.h
+++ b/src/TAstar.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2010-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2015, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -100,8 +100,8 @@ public:
     astar_goal_visitor(Vertex goal) : m_goal(goal) {}
 
     template <class Graph>
-    void examine_vertex(Vertex u, Graph& g)
-    {
+    void examine_vertex(Vertex u, Graph& g) {
+        Q_UNUSED(g)
         if (u == m_goal) {
             throw found_goal();
         }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -819,6 +819,7 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
 
 void TCommandLine::enterCommand(QKeyEvent* event)
 {
+    Q_UNUSED(event)
     QString _t = toPlainText();
     mTabCompletionCount = -1;
     mAutoCompletionCount = -1;

--- a/src/TDockWidget.cpp
+++ b/src/TDockWidget.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
- *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2019-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -53,11 +53,13 @@ void TDockWidget::closeEvent(QCloseEvent* event)
 
 void TDockWidget::resizeEvent(QResizeEvent* event)
 {
+    Q_UNUSED(event)
     mpHost->setDockLayoutUpdated(widgetConsoleName);
 }
 
 void TDockWidget::moveEvent(QMoveEvent* event)
 {
+    Q_UNUSED(event)
     mpHost->setDockLayoutUpdated(widgetConsoleName);
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -724,8 +724,6 @@ int TLuaInterpreter::resetProfile(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectString
 int TLuaInterpreter::selectString(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     int s = 1;
     QString windowName;
     if (lua_gettop(L) > 2) {
@@ -1354,7 +1352,6 @@ int TLuaInterpreter::setMiniConsoleFontSize(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLineNumber
 int TLuaInterpreter::getLineNumber(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
     QString windowName;
     int s = 0;
 
@@ -2347,11 +2344,9 @@ int TLuaInterpreter::selectSection(lua_State* L)
     }
     int to = lua_tointeger(L, s);
 
-    Host& host = getHostFromLua(L);
-
     auto console = CONSOLE(L, windowName);
     int ret = console->selectSection(from, to);
-    lua_pushboolean(L, ret == -1 ? false : true);
+    lua_pushboolean(L, ret != -1);
     return 1;
 }
 
@@ -3121,6 +3116,7 @@ int TLuaInterpreter::remainingTime(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#closeMudlet
 int TLuaInterpreter::closeMudlet(lua_State* L)
 {
+    Q_UNUSED(L)
     mudlet::self()->forceClose();
     return 0;
 }
@@ -6232,6 +6228,7 @@ int TLuaInterpreter::playSoundFile(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopSounds
 int TLuaInterpreter::stopSounds(lua_State* L)
 {
+    Q_UNUSED(L)
     //doesn't take an argument
     mudlet::self()->stopSounds();
     return 0;
@@ -6412,8 +6409,6 @@ int TLuaInterpreter::setPopup(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBold
 int TLuaInterpreter::setBold(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     QString windowName;
     int s = 0;
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
@@ -6435,8 +6430,6 @@ int TLuaInterpreter::setBold(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setItalics
 int TLuaInterpreter::setItalics(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     QString windowName;
     int s = 0;
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
@@ -6458,8 +6451,6 @@ int TLuaInterpreter::setItalics(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setOverline
 int TLuaInterpreter::setOverline(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     QString windowName;
     int s = 0;
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
@@ -6481,8 +6472,6 @@ int TLuaInterpreter::setOverline(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setReverse
 int TLuaInterpreter::setReverse(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     QString windowName;
     int s = 0;
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
@@ -6504,8 +6493,6 @@ int TLuaInterpreter::setReverse(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setStrikeOut
 int TLuaInterpreter::setStrikeOut(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     QString windowName;
     int s = 0;
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
@@ -6527,8 +6514,6 @@ int TLuaInterpreter::setStrikeOut(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setUnderline
 int TLuaInterpreter::setUnderline(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
-
     QString windowName;
     int s = 0;
     if (lua_gettop(L) > 1) { // Have more than one argument so first must be a console name
@@ -11143,8 +11128,6 @@ int TLuaInterpreter::setFgColor(lua_State* L)
         return 2;
     }
 
-    Host& host = getHostFromLua(L);
-
     auto console = CONSOLE(L, windowName);
     console->setFgColor(luaRed, luaGreen, luaBlue);
     return 0;
@@ -11153,7 +11136,6 @@ int TLuaInterpreter::setFgColor(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setBgColor
 int TLuaInterpreter::setBgColor(lua_State* L)
 {
-    Host* pHost = &getHostFromLua(L);
     QString windowName;
     int r, g, b, alpha;
 
@@ -11329,7 +11311,6 @@ int TLuaInterpreter::insertPopup(lua_State* L)
         customFormat = lua_toboolean(L, s);
     }
 
-    Host& host = getHostFromLua(L);
     if (_commandList.size() != _hintList.size()) {
         lua_pushstring(L, "Error: command list size and hint list size do not match cannot create popup");
         return lua_error(L);
@@ -11343,7 +11324,6 @@ int TLuaInterpreter::insertPopup(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#insertText
 int TLuaInterpreter::insertText(lua_State* L)
 {
-    auto& host = getHostFromLua(L);
     QString windowName;
     int s = 0;
 
@@ -11497,7 +11477,6 @@ int TLuaInterpreter::echoPopup(lua_State* L)
         customFormat = lua_toboolean(L, s);
     }
 
-    Host& host = getHostFromLua(L);
     if (commandList.size() != hintList.size()) {
         lua_pushfstring(L, "echoPopup: commands and hints list aren't the same size");
         return lua_error(L);
@@ -11579,7 +11558,6 @@ int TLuaInterpreter::echoLink(lua_State* L)
         gotBool = true;
     }
 
-    Host& host = getHostFromLua(L);
     QString text;
     QString windowName;
     QStringList function;
@@ -12471,7 +12449,6 @@ int TLuaInterpreter::getEpoch(lua_State *L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#appendBuffer
 int TLuaInterpreter::appendBuffer(lua_State* L)
 {
-    Host& host = getHostFromLua(L);
     QString windowName {WINDOW_NAME(L, 1)};
 
     auto console = CONSOLE(L, windowName);
@@ -13138,6 +13115,7 @@ void TLuaInterpreter::ttsBuild()
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#ttsSkip
 int TLuaInterpreter::ttsSkip(lua_State* L)
 {
+    Q_UNUSED(L)
     TLuaInterpreter::ttsBuild();
 
     speechUnit->stop();
@@ -13490,6 +13468,7 @@ int TLuaInterpreter::ttsGetQueue(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#ttsPause
 int TLuaInterpreter::ttsPause(lua_State* L)
 {
+    Q_UNUSED(L)
     TLuaInterpreter::ttsBuild();
 
     speechUnit->pause();
@@ -13500,6 +13479,7 @@ int TLuaInterpreter::ttsPause(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#ttsResume
 int TLuaInterpreter::ttsResume(lua_State* L)
 {
+    Q_UNUSED(L)
     TLuaInterpreter::ttsBuild();
 
     speechUnit->resume();
@@ -15575,6 +15555,7 @@ QString TLuaInterpreter::getLuaString(const QString& stringName)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#handleWindowResizeEvent is using noop function publicly - compare initLuaGlobals()
 int TLuaInterpreter::noop(lua_State* L)
 {
+    Q_UNUSED(L)
     return 0;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -379,8 +379,6 @@ public:
     static int getUserWindowSize(lua_State*);
     static int getMousePosition(lua_State*);
     static int setMiniConsoleFontSize(lua_State*);
-    static int setConsoleBackgroundImage(lua_State*);
-    static int resetConsoleBackgroundImage(lua_State*);
     static int setProfileIcon(lua_State*);
     static int resetProfileIcon(lua_State*);
     static int getCurrentLine(lua_State*);

--- a/src/TMxpBRTagHandler.cpp
+++ b/src/TMxpBRTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - virginmedia.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,5 +21,8 @@
 #include "TMxpBRTagHandler.h"
 TMxpTagHandlerResult TMxpBRTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(client)
+    Q_UNUSED(tag)
     return MXP_TAG_COMMIT_LINE;
 }

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -66,11 +67,20 @@ public:
 
     virtual bool tagReceived(MxpTag* tag) { return tag->isStartTag() ? startTagReceived(tag->asStartTag()) : endTagReceived(tag->asEndTag()); }
 
-    virtual bool startTagReceived(MxpStartTag* startTag) { return true; }
+    virtual bool startTagReceived(MxpStartTag* startTag) {
+        Q_UNUSED(startTag)
+        return true;
+    }
 
-    virtual bool endTagReceived(MxpEndTag* startTag) { return true; }
+    virtual bool endTagReceived(MxpEndTag* startTag) {
+        Q_UNUSED(startTag)
+        return true;
+    }
 
-    virtual TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result) { return result; }
+    virtual TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result) {
+        Q_UNUSED(tag)
+        return result;
+    }
 };
 
 #endif //MUDLET_TMXPCLIENT_H

--- a/src/TMxpColorTagHandler.cpp
+++ b/src/TMxpColorTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,10 +22,13 @@
 #include "TMxpClient.h"
 bool TMxpColorTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(client)
     return tag->isNamed("COLOR") || tag->isNamed("C");
 }
 TMxpTagHandlerResult TMxpColorTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
     QString fg = tag->getAttributeByNameOrIndex("FORE", 0);
     QString bg = tag->getAttributeByNameOrIndex("BACK", 1);
 
@@ -34,6 +38,8 @@ TMxpTagHandlerResult TMxpColorTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 }
 TMxpTagHandlerResult TMxpColorTagHandler::handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(tag)
     client.popColor();
     return MXP_TAG_HANDLED;
 }

--- a/src/TMxpCustomElementTagHandler.cpp
+++ b/src/TMxpCustomElementTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -126,6 +127,7 @@ QString TMxpCustomElementTagHandler::mapAttributes(const TMxpElement& element, c
 }
 void TMxpCustomElementTagHandler::configFlag(TMxpClient& client, MxpStartTag* tag, const TMxpElement& el)
 {
+    Q_UNUSED(client)
     mCurrentFlagName = el.name;
     parseFlagAttributes(tag, el);
     mCurrentFlagContent.clear();

--- a/src/TMxpCustomElementTagHandler.h
+++ b/src/TMxpCustomElementTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,7 +38,10 @@ class TMxpCustomElementTagHandler : public TMxpTagHandler
     const QMap<QString, QString>& parseFlagAttributes(const MxpStartTag* tag, const TMxpElement& el);
 
 public:
-    bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override { return ctx.getElementRegistry().containsElement(tag->getName()); }
+    bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override {
+        Q_UNUSED(client)
+        return ctx.getElementRegistry().containsElement(tag->getName());
+    }
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
     TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) override;

--- a/src/TMxpElementDefinitionHandler.cpp
+++ b/src/TMxpElementDefinitionHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephem Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,6 +24,7 @@
 // <!ELEMENT element-name [definition] [ATT=attribute-list] [TAG=tag] [FLAG=flags] [OPEN] [DELETE] [EMPTY]>
 TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(client)
     if (tag->getAttributesCount() < 2) { // UNEXPECTED: element without definition nor attributes
         return MXP_TAG_NOT_HANDLED;
     }

--- a/src/TMxpElementDefinitionHandler.h
+++ b/src/TMxpElementDefinitionHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,7 +28,11 @@
 class TMxpElementDefinitionHandler : public TMxpTagHandler
 {
 public:
-    bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override { return tag->isNamed("!EL") || tag->isNamed(("!ELEMENT")); }
+    bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override {
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
+        return tag->isNamed(QStringLiteral("!EL")) || tag->isNamed(QStringLiteral("!ELEMENT"));
+    }
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
 };

--- a/src/TMxpEntityTagHandler.h
+++ b/src/TMxpEntityTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,7 +30,9 @@ class TMxpEntityTagHandler : public TMxpTagHandler
 {
 public:
     bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override {
-        return tag->isNamed("!ENTITY") || tag->isNamed("!EN");
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
+        return tag->isNamed(QStringLiteral("!ENTITY")) || tag->isNamed(QStringLiteral("!EN"));
     }
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;

--- a/src/TMxpFontTagHandler.cpp
+++ b/src/TMxpFontTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - virginmedia.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +23,7 @@
 
 TMxpTagHandlerResult TMxpFontTagHandler::handleStartTag(TMxpContext& context, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(context)
     QString fontFace = tag->getAttributeByNameOrIndex("FACE", 0);
     QString fontSize = tag->getAttributeByNameOrIndex("SIZE", 1);
     client.pushFont(fontFace, fontSize);
@@ -32,8 +34,11 @@ TMxpTagHandlerResult TMxpFontTagHandler::handleStartTag(TMxpContext& context, TM
 
     return MXP_TAG_HANDLED;
 }
+
 TMxpTagHandlerResult TMxpFontTagHandler::handleEndTag(TMxpContext& context, TMxpClient& client, MxpEndTag* tag)
 {
+    Q_UNUSED(context)
+    Q_UNUSED(tag)
     client.popFont();
     client.popColor();
 

--- a/src/TMxpFormattingTagsHandler.cpp
+++ b/src/TMxpFormattingTagsHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -16,25 +17,36 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
 #include "TMxpFormattingTagsHandler.h"
 #include "TMxpClient.h"
 
 bool TMxpFormattingTagsHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
 {
-    return tag->isNamed("B") || tag->isNamed("I") || tag->isNamed("U");
+    Q_UNUSED(ctx)
+    Q_UNUSED(client)
+
+    return tag->isNamed(QStringLiteral("B")) || tag->isNamed(QStringLiteral("I")) || tag->isNamed(QStringLiteral("U"));
 }
+
 TMxpTagHandlerResult TMxpFormattingTagsHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
+
     setAttribute(client, tag, true);
 
     return MXP_TAG_HANDLED;
 }
+
 TMxpTagHandlerResult TMxpFormattingTagsHandler::handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag)
 {
+    Q_UNUSED(ctx)
+
     setAttribute(client, tag, false);
 
     return MXP_TAG_HANDLED;
 }
+
 void TMxpFormattingTagsHandler::setAttribute(TMxpClient& client, MxpTag* tag, bool value) const
 {
     if (tag->isNamed("B")) {

--- a/src/TMxpLinkTagHandler.cpp
+++ b/src/TMxpLinkTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -16,12 +17,14 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
 #include "TMxpLinkTagHandler.h"
 #include "TMxpClient.h"
 
 // <A href=URL [hint=text] [expire=name]>
 TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
     if (tag->hasAttribute("EXPIRE")) {
         return MXP_TAG_NOT_HANDLED;
     }
@@ -39,8 +42,11 @@ TMxpTagHandlerResult TMxpLinkTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
     client.setLinkMode(true);
     return MXP_TAG_HANDLED;
 }
+
 TMxpTagHandlerResult TMxpLinkTagHandler::handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(tag)
     QStringList *links, *hints;
     if (!client.getLink(mLinkId, &links, &hints)) {
         return MXP_TAG_NOT_HANDLED;

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -71,7 +72,11 @@ public:
     const QColor& getBgColor() { return bgColors.last(); }
 
     // TODO: implement support for fonts?
-    void pushFont(const QString& fontFace, const QString& fontSize) override {}
+    void pushFont(const QString& fontFace, const QString& fontSize) override {
+        Q_UNUSED(fontFace)
+        Q_UNUSED(fontSize)
+    }
+
     void popFont() override {}
 
     int setLink(const QStringList& links, const QStringList& hints) override;
@@ -87,14 +92,22 @@ public:
     void setItalic(bool italic) override { isItalic = italic; }
     void setUnderline(bool underline) override { isUnderline = underline; }
 
-    void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override
-    {
+    void setFlag(const QString& elementName, const QMap<QString, QString>& values, const QString& content) override {
+        Q_UNUSED(elementName)
+        Q_UNUSED(values)
+        Q_UNUSED(content)
         // TODO: raise mxp event
     }
 
-    void publishEntity(const QString& name, const QString& value) override {}
+    void publishEntity(const QString& name, const QString& value) override {
+        Q_UNUSED(name)
+        Q_UNUSED(value)
+    }
 
-    void setVariable(const QString& name, const QString& value) override {}
+    void setVariable(const QString& name, const QString& value) override {
+        Q_UNUSED(name)
+        Q_UNUSED(value)
+    }
 
     TMxpTagHandlerResult tagHandled(MxpTag* tag, TMxpTagHandlerResult result) override;
 

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Mike Conley - sousesider[at]gmail.com           *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@bvirginmedia.com        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,6 +24,7 @@
 
 TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
     TMediaData mediaData {};
 
     mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);

--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -102,6 +103,8 @@ QString TMxpSendTagHandler::extractHint(MxpStartTag* tag)
 
 TMxpTagHandlerResult TMxpSendTagHandler::handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(tag)
     if (mIsHrefInContent) {
         updateHrefInLinks(client);
     }

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Mike Conley - sousesider[at]gmail.com           *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,6 +24,7 @@
 
 TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
     TMediaData mediaData {};
 
     mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);

--- a/src/TMxpTagHandler.h
+++ b/src/TMxpTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,7 +36,9 @@ class TMxpTagHandler
 public:
     virtual TMxpTagHandlerResult handleTag(TMxpContext& ctx, TMxpClient& client, MxpTag* tag);
 
-    virtual void handleContent(char ch) {}
+    virtual void handleContent(char ch) {
+        Q_UNUSED(ch)
+    }
 
     void handleContent(const QString& text)
     {
@@ -45,6 +48,8 @@ public:
     }
 
     virtual void handleTextNode(TMxpContext& ctx, TMxpClient& client, MxpTextNode* tag) {
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
         handleContent(tag->getContent());
     }
 
@@ -57,11 +62,26 @@ public:
         }
     }
 
-    virtual bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) { return true; }
+    virtual bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) {
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
+        Q_UNUSED(tag)
+        return true;
+    }
 
-    virtual TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) { return MXP_TAG_NOT_HANDLED; }
+    virtual TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) {
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
+        Q_UNUSED(tag)
+        return MXP_TAG_NOT_HANDLED;
+    }
 
-    virtual TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) { return MXP_TAG_NOT_HANDLED; }
+    virtual TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) {
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
+        Q_UNUSED(tag)
+        return MXP_TAG_NOT_HANDLED;
+    }
 
     virtual ~TMxpTagHandler() = default;
 
@@ -76,7 +96,11 @@ class TMxpSingleTagHandler : public TMxpTagHandler
 public:
     virtual ~TMxpSingleTagHandler() = default;
 
-    virtual bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) { return tag->isNamed(tagName); }
+    virtual bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) {
+        Q_UNUSED(ctx)
+        Q_UNUSED(client)
+        return tag->isNamed(tagName);
+    }
 
 protected:
     explicit TMxpSingleTagHandler(QString tagName) : tagName(std::move(tagName)) {}

--- a/src/TMxpVarTagHandler.cpp
+++ b/src/TMxpVarTagHandler.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018, 2020 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -19,16 +20,21 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
 #include "TMxpVarTagHandler.h"
 #include "TMxpClient.h"
+
 bool TMxpVarTagHandler::supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
 {
-    return tag->isNamed("VAR") || tag->isNamed("V");
+    Q_UNUSED(ctx)
+    Q_UNUSED(client)
+    return tag->isNamed(QStringLiteral("VAR")) || tag->isNamed(QStringLiteral("V"));
 }
-
 
 TMxpTagHandlerResult TMxpVarTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(client)
     mCurrentStartTag = *tag;
     mCurrentVarContent.clear();
     return MXP_TAG_HANDLED;
@@ -38,6 +44,8 @@ TMxpTagHandlerResult TMxpVarTagHandler::handleStartTag(TMxpContext& ctx, TMxpCli
 //<VAR Name [DESC=description] [PRIVATE] [PUBLISH] [DELETE] [ADD] [REMOVE]>Value</VAR>
 TMxpTagHandlerResult TMxpVarTagHandler::handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(tag)
     const QString& name = mCurrentStartTag.getAttrName(0);
     const QString& value = mCurrentVarContent;
 
@@ -47,6 +55,7 @@ TMxpTagHandlerResult TMxpVarTagHandler::handleEndTag(TMxpContext& ctx, TMxpClien
 
     return MXP_TAG_HANDLED;
 }
+
 void TMxpVarTagHandler::handleContent(char ch)
 {
     mCurrentVarContent.append(ch);

--- a/src/TMxpVersionTagHandler.cpp
+++ b/src/TMxpVersionTagHandler.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@bvirginmedia.com        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,6 +24,8 @@
 
 TMxpTagHandlerResult TMxpVersionTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
+    Q_UNUSED(ctx)
+    Q_UNUSED(tag)
     const QString& version = client.getVersion();
 
     QString payload = scmVersionString.arg(version);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018 by Stephen Lyons                        *
+ *   Copyright (C) 2014-2016, 2018, 2020 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -552,6 +552,7 @@ bool TRoom::hasExitLock(int exit)
 // 0=offen 1=zu
 bool TRoom::hasSpecialExitLock(int to, const QString& cmd)
 {
+    Q_UNUSED(cmd)
     if (other.contains(to)) {
         QMapIterator<int, QString> it(other);
         while (it.hasNext()) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -647,7 +647,7 @@ void TTextEdit::drawForeground(QPainter& painter, const QRect& r)
 
     QPoint P_topLeft = r.topLeft();
     QPoint P_bottomRight = r.bottomRight();
-    int x_topLeft = 0;
+
     int y_topLeft = P_topLeft.y();
     int x_bottomRight = P_bottomRight.x();
     int y_bottomRight = P_bottomRight.y();
@@ -2003,10 +2003,8 @@ void TTextEdit::slot_analyseSelection()
     utf8Bytes[4] = '\0';
 
     int total = 0;
-    bool isSingleLine = false;
     startColumn = mPA.x();
     if (mPA.y() == mPB.y()) {
-        isSingleLine = true;
         // The selection is from mPA.x() to mPB.x()
         endColumn = mPB.x();
         if (endColumn == -1) {

--- a/src/TToolBar.cpp
+++ b/src/TToolBar.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2017, 2019-2020 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -59,6 +60,7 @@ TToolBar::TToolBar(TAction* pA, const QString& name, QWidget* pW)
 
 void TToolBar::resizeEvent(QResizeEvent* e)
 {
+    Q_UNUSED(e)
     mpTAction->mpHost->setToolbarLayoutUpdated(this);
 }
 

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -3,7 +3,8 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
- *   Copyright (C) 2017-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2018, 2020 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -635,6 +636,7 @@ void dlgIRC::slot_onAnchorClicked(const QUrl& link)
 
 void dlgIRC::slot_nickNameRequired(const QString& reserved, QString* alt)
 {
+    Q_UNUSED(alt)
     QString newNick = QStringLiteral("%1_%2").arg(reserved, QString::number(rand() % 10000));
     ircBrowser->append(IrcMessageFormatter::formatMessage(tr("! The Nickname %1 is reserved. Automatically changing Nickname to: %2").arg(reserved, newNick)));
     connection->setNickName(newNick);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2016, 2019 by Stephen Lyons                        *
+ *   Copyright (C) 2015-2016, 2019-2020 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -254,62 +254,6 @@ void dlgMapper::show2dView()
     dim2->setToolTip(tr("3D mapper is not available in this version of Mudlet"));
 #endif
 }
-
-void dlgMapper::choseRoom(QListWidgetItem* pT)
-{
-    QString txt = pT->text();
-
-    QHashIterator<int, TRoom*> it(mpMap->mpRoomDB->getRoomMap());
-    while (it.hasNext()) {
-        it.next();
-        int i = it.key();
-        TRoom* pR = mpMap->mpRoomDB->getRoom(i);
-        if (!pR) {
-            continue;
-        }
-        if (pR->name == txt) {
-            qDebug() << "found room id=" << i;
-            mpMap->mTargetID = i;
-            if (!mpMap->findPath(mpMap->mRoomIdHash.value(mpMap->mProfileName), i)) {
-                mpHost->mpConsole->printSystemMessage(tr("Cannot find a path to this room.\n"));
-            } else {
-                mpMap->mpHost->startSpeedWalk();
-            }
-            break;
-        }
-    }
-    mpHost->mpConsole->setFocus();
-}
-
-void dlgMapper::goRoom()
-{
-    //    QString txt = roomID->text();
-    //    searchList->clear();
-    //    int id = txt.toInt();
-
-    //    if (id != 0 && mpMap->rooms.contains(id)) {
-    //        mpMap->mTargetID = id;
-    //        if (mpMap->findPath(0,0)) {
-    //            qDebug() << "glwidget: starting speedwalk path length=" << mpMap->mPathList.size();
-    //            mpMap->mpHost->startSpeedWalk();
-    //        } else {
-    //            QString msg = "Cannot find a path to this room.\n";
-    //            mpHost->mpConsole->printSystemMessage(msg);
-    //        }
-    //    } else {
-    //        QMapIterator<int, TRoom *> it(mpMap->rooms);
-    //        while (it.hasNext()) {
-    //            it.next();
-    //            int i = it.key();
-    //            if (mpMap->rooms[i]->name.contains(txt, Qt::CaseInsensitive)) {
-    //                qDebug() << "inserting match:" << i;
-    //                searchList->addItem(mpMap->rooms[i]->name);
-    //            }
-    //        }
-    //    }
-    //    mpHost->mpConsole->setFocus();
-}
-
 
 void dlgMapper::slot_roomSize(int d)
 {

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -61,8 +61,6 @@ public slots:
     void slot_toggleStrongHighlight(int v);
     void show2dView();
     void slot_togglePanel();
-    void goRoom();
-    void choseRoom(QListWidgetItem*);
     void slot_roomSize(int d);
     void slot_lineSize(int d);
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6664,6 +6664,7 @@ void dlgTriggerEditor::autoSave()
 
 void dlgTriggerEditor::enterEvent(QEvent* pE)
 {
+    Q_UNUSED(pE)
     if (mNeedUpdateData) {
         saveOpenChanges();
         treeWidget_triggers->clear();
@@ -6680,6 +6681,7 @@ void dlgTriggerEditor::enterEvent(QEvent* pE)
 
 void dlgTriggerEditor::focusInEvent(QFocusEvent* pE)
 {
+    Q_UNUSED(pE)
     if (mNeedUpdateData) {
         saveOpenChanges();
         treeWidget_triggers->clear();
@@ -8361,6 +8363,7 @@ bool dlgTriggerEditor::event(QEvent* event)
 
 void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
 {
+    Q_UNUSED(event)
     if (mpSourceEditorArea->isVisible()) {
         slot_move_source_find();
     }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -258,11 +258,6 @@ void GLWidget::topView()
     update();
 }
 
-
-void GLWidget::goRoom(const QString& s)
-{
-}
-
 void GLWidget::setScale(int angle)
 {
     mScale = 150 / ((float)angle + 300);
@@ -2249,6 +2244,7 @@ void GLWidget::mouseMoveEvent(QMouseEvent* event)
 
 void GLWidget::mouseReleaseEvent(QMouseEvent* event)
 {
+    Q_UNUSED(event)
     mPanMode = false;
 }
 

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2010-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -61,7 +61,6 @@ public slots:
     void setYDist(int angle);
     void setZDist(int angle);
     void setScale(int);
-    void goRoom(const QString&);
     void fullView();
     void singleView();
     void increaseTop();

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2017 The Communi Project                           *
  *   Copyright (C) 2017 by Fae - itsthefae@gmail.com                       *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -146,6 +147,7 @@ QString IrcMessageFormatter::formatAwayMessage(IrcAwayMessage* message, bool isF
 
 QString IrcMessageFormatter::formatInviteMessage(IrcInviteMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     if (message->isReply())
         return QObject::tr("! invited %1 to %2").arg(message->user(), message->channel());
 
@@ -154,6 +156,7 @@ QString IrcMessageFormatter::formatInviteMessage(IrcInviteMessage* message, bool
 
 QString IrcMessageFormatter::formatJoinMessage(IrcJoinMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     if (message->flags() & IrcMessage::Own)
         return QObject::tr("! You have joined %1 as %2").arg(message->channel(), message->nick());
     else
@@ -162,11 +165,13 @@ QString IrcMessageFormatter::formatJoinMessage(IrcJoinMessage* message, bool isF
 
 QString IrcMessageFormatter::formatKickMessage(IrcKickMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     return QObject::tr("! %1 kicked %2").arg(message->nick(), message->user());
 }
 
 QString IrcMessageFormatter::formatModeMessage(IrcModeMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     QString args = message->arguments().join(" ");
     if (message->isReply())
         return QObject::tr("! %1 mode is %2 %3").arg(message->target(), message->mode(), args);
@@ -207,6 +212,7 @@ QString IrcMessageFormatter::formatNamesMessage(IrcNamesMessage* message, bool i
 
 QString IrcMessageFormatter::formatNickMessage(IrcNickMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     return QObject::tr("! %1 has changed nick to %2").arg(message->oldNick(), message->newNick());
 }
 
@@ -310,12 +316,14 @@ QString IrcMessageFormatter::formatNumericMessage(IrcNumericMessage* message, bo
 
 QString IrcMessageFormatter::formatErrorMessage(IrcErrorMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     // if you change this, change ERR_ in formatNumericMessage too
     return QObject::tr("[ERROR] %1").arg(message->error());
 }
 
 QString IrcMessageFormatter::formatPartMessage(IrcPartMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     if (message->reason().isEmpty())
         return QObject::tr("! %1 has left %2").arg(message->nick(), message->channel());
     else
@@ -324,6 +332,7 @@ QString IrcMessageFormatter::formatPartMessage(IrcPartMessage* message, bool isF
 
 QString IrcMessageFormatter::formatPongMessage(IrcPongMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     quint64 msec = message->timeStamp().toMSecsSinceEpoch();
     quint64 dms = (QDateTime::currentMSecsSinceEpoch() - msec);
     const QString secs = QString().sprintf("%04.3f", (float)((float)dms / (float)1000));
@@ -354,6 +363,7 @@ QString IrcMessageFormatter::formatPrivateMessage(IrcPrivateMessage* message, bo
 
 QString IrcMessageFormatter::formatQuitMessage(IrcQuitMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     if (message->reason().isEmpty())
         return QObject::tr("! %1 has quit").arg(message->nick());
     else
@@ -383,11 +393,13 @@ QString IrcMessageFormatter::formatTopicMessage(IrcTopicMessage* message, bool i
 
 QString IrcMessageFormatter::formatUnknownMessage(IrcMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     return QObject::tr("? %2 %3 %4").arg(message->nick(), message->command(), message->parameters().join(" "));
 }
 
 QString IrcMessageFormatter::formatWhoisMessage(IrcWhoisMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     QString wData;
     wData = QObject::tr("[WHOIS] %1 is %2@%3 (%4)").arg(message->nick(), message->ident(), message->host(), message->realName());
     wData += QObject::tr("[WHOIS] %1 is connected via %2 (%3)").arg(message->nick(), message->server(), message->info());
@@ -407,6 +419,7 @@ QString IrcMessageFormatter::formatWhoisMessage(IrcWhoisMessage* message, bool i
 
 QString IrcMessageFormatter::formatWhowasMessage(IrcWhowasMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     QString wData;
     wData = QObject::tr("[WHOWAS] %1 was %2@%3 (%4)").arg(message->nick(), message->ident(), message->host(), message->realName());
     wData += QObject::tr("[WHOWAS] %1 was connected via %2 (%3)").arg(message->nick(), message->server(), message->info());
@@ -417,6 +430,7 @@ QString IrcMessageFormatter::formatWhowasMessage(IrcWhowasMessage* message, bool
 
 QString IrcMessageFormatter::formatWhoReplyMessage(IrcWhoReplyMessage* message, bool isForLua)
 {
+    Q_UNUSED(isForLua)
     QString format = QObject::tr("[WHO] %1 (%2)").arg(message->nick(), message->realName());
     if (message->isAway())
         format += QObject::tr(" - away");


### PR DESCRIPTION
Using `Q_UNUSED` will silence the warnings that CMake gives us, though we have disabled them for ages in the QMake build process.

Also remove some unused methods and variables.

Unlike the previous attempt in PR #4383 that had to be reverted by PR #4404 this does NOT remove a pair of methods from the `TTreeWidget` class that did not seem to be being called - it turns out that they override methods in the base `QTreeWidget` class and as such they will be called by Qt library code when certain things happen to the class.

This reduces the warnings count (if they are shown by the compiler) from a starting point of about 2718 down to around 696.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>