### PR TITLE
Cleanup: replace obsoleted form of QString::split(...)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1020,7 +1020,11 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
     }
     QStringList commandList;
     if (!mCommandSeparator.isEmpty()) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        commandList = cmd.split(QString(mCommandSeparator), Qt::SkipEmptyParts);
+#else
         commandList = cmd.split(QString(mCommandSeparator), QString::SkipEmptyParts);
+#endif
     } else {
         // don't split command if the command separator is blank
         commandList << cmd;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -893,7 +893,11 @@ void TCommandLine::handleTabCompletion(bool direction)
     buffer.replace(QChar(0x21af), QChar::LineFeed);
     buffer.replace(QChar::LineFeed, QChar::Space);
 
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+    QStringList wordList = buffer.split(QRegularExpression(QStringLiteral(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), Qt::SkipEmptyParts);
+#else
     QStringList wordList = buffer.split(QRegularExpression(QStringLiteral(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), QString::SkipEmptyParts);
+#endif
     if (direction) {
         mTabCompletionCount++;
     } else {

--- a/src/TMxpElementDefinitionHandler.cpp
+++ b/src/TMxpElementDefinitionHandler.cpp
@@ -46,7 +46,11 @@ TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& c
     }
 
     if (tag->hasAttribute("ATT")) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        el.attrs = tag->getAttributeValue("ATT").toLower().split(' ', Qt::SkipEmptyParts);
+#else
         el.attrs = tag->getAttributeValue("ATT").toLower().split(' ', QString::SkipEmptyParts);
+#endif
     }
 
     if (tag->hasAttribute("TAG")) {

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -490,7 +490,11 @@ void dlgIRC::slot_onTextEntered()
         lineEdit->clear();
     } else if (input.length() > 1) {
         QString error;
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        QString command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
+#else
         QString command = lineEdit->text().mid(1).split(" ", QString::SkipEmptyParts).value(0).toUpper();
+#endif
         if (commandParser->commands().contains(command))
             error = tr("[ERROR] Syntax: %1").arg(commandParser->syntax(command).replace(QStringLiteral("<"), QStringLiteral("&lt;")).replace(QStringLiteral(">"), QStringLiteral("&gt;")));
         else
@@ -791,7 +795,11 @@ QStringList dlgIRC::readIrcChannels(Host* pH)
     if (channelstr.isEmpty()) {
         channels << dlgIRC::DefaultChannels;
     } else {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        channels = channelstr.split(QStringLiteral(" "), Qt::SkipEmptyParts);
+#else
         channels = channelstr.split(QStringLiteral(" "), QString::SkipEmptyParts);
+#endif
     }
     return channels;
 }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2500,7 +2500,11 @@ void dlgProfilePreferences::slot_save_and_exit()
         }
 
         if (!newIrcChannels.isEmpty()) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+            QStringList tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
+#else
             QStringList tL = newIrcChannels.split(" ", QString::SkipEmptyParts);
+#endif
             for (QString s : tL) {
                 if (s.startsWith("#") || s.startsWith("&") || s.startsWith("+")) {
                     newChanList << s;

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -219,7 +219,11 @@ QString IrcMessageFormatter::formatNickMessage(IrcNickMessage* message, bool isF
 QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message, bool isForLua)
 {
     if (message->isReply()) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+        const QStringList params = message->content().split(" ", Qt::SkipEmptyParts);
+#else
         const QStringList params = message->content().split(" ", QString::SkipEmptyParts);
+#endif
         const QString cmd = params.value(0);
         if (cmd.toUpper() == "PING") {
             const QString secs = formatSeconds(params.value(1).toInt());


### PR DESCRIPTION
Change:
`(QStringList) QString::split(const QString&, QString::SplitBehavior,
                                                      Qt::CaseSensitivity)`
declared obsolete in Qt 5.14 with the new form:
`(QStringList) QString::split(const QString&, Qt::SplitBehavior,
                                                      Qt::CaseSensitivity)`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>