### PR TITLE
Cleanup: do not use QMultiMap::insertMulti(...) on QMultiMaps

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -65,7 +65,7 @@ void TAlias::setName(const QString& name)
         mpHost->getAliasUnit()->mLookupTable.remove(mName, this);
     }
     mName = name;
-    mpHost->getAliasUnit()->mLookupTable.insertMulti(name, this);
+    mpHost->getAliasUnit()->mLookupTable.insert(name, this);
 }
 
 bool TAlias::match(const QString& toMatch)

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -92,7 +92,7 @@ QMap<int, QMap<int, QMultiMap<int, int>>> TArea::koordinatenSystem()
         if (!kS[x].contains(y)) {
             kS[x][y] = _z;
         }
-        kS[x][y].insertMulti(z, id);
+        kS[x][y].insert(z, id);
     }
     //qDebug()<< "kS="<<kS;
     return kS;
@@ -171,62 +171,62 @@ void TArea::determineAreaExitsOfRoom(int id)
     // the list and hence the area.
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTH);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getNortheast();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHEAST);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getEast();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_EAST);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getSoutheast();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHEAST);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getSouth();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTH);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getSouthwest();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHWEST);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getWest();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_WEST);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getNorthwest();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHWEST);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getUp();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_UP);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getDown();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_DOWN);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getIn();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_IN);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     exitId = pR->getOut();
     if (exitId > 0 && !rooms.contains(exitId)) {
         QPair<int, int> p = QPair<int, int>(exitId, DIR_OUT);
-        exits.insertMulti(id, p);
+        exits.insert(id, p);
     }
     const QMap<int, QString> otherMap = pR->getOtherMap();
     QMapIterator<int, QString> it(otherMap);
@@ -237,7 +237,7 @@ void TArea::determineAreaExitsOfRoom(int id)
         if (pO) {
             if (pO->getArea() != getAreaID()) {
                 QPair<int, int> p = QPair<int, int>(pO->getId(), DIR_OTHER);
-                exits.insertMulti(id, p);
+                exits.insert(id, p);
             }
         }
     }
@@ -257,62 +257,62 @@ void TArea::determineAreaExits()
         int exitId = pR->getNorth();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTH);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getNortheast();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHEAST);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getEast();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_EAST);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getSoutheast();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHEAST);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getSouth();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTH);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getSouthwest();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_SOUTHWEST);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getWest();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_WEST);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getNorthwest();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_NORTHWEST);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getUp();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_UP);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getDown();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_DOWN);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getIn();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_IN);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         exitId = pR->getOut();
         if (exitId > 0 && !rooms.contains(exitId)) {
             QPair<int, int> p = QPair<int, int>(exitId, DIR_OUT);
-            exits.insertMulti(id, p);
+            exits.insert(id, p);
         }
         const QMap<int, QString> otherMap = pR->getOtherMap();
         QMapIterator<int, QString> it(otherMap);
@@ -323,7 +323,7 @@ void TArea::determineAreaExits()
             if (pO) {
                 if (pO->getArea() != getAreaID()) {
                     QPair<int, int> p = QPair<int, int>(pO->getId(), DIR_OTHER);
-                    exits.insertMulti(id, p);
+                    exits.insert(id, p);
                 }
             }
         }

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -68,7 +68,7 @@ void TKey::setName(const QString& name)
         mpHost->getKeyUnit()->mLookupTable.remove(mName, this);
     }
     mName = name;
-    mpHost->getKeyUnit()->mLookupTable.insertMulti(name, this);
+    mpHost->getKeyUnit()->mLookupTable.insert(name, this);
 }
 
 bool TKey::match(int key, int modifier, const bool isToMatchAll)

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -635,7 +635,7 @@ void TRoom::setSpecialExit(int to, const QString& cmd)
         }
 
         QString finalCmd = _prefix % _strippedCmd;
-        other.insertMulti(to, finalCmd);
+        other.insert(to, finalCmd);
     } else { // Clean up related data:
         customLinesArrow.remove(_strippedCmd);
         customLinesColor.remove(_strippedCmd);

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -86,7 +86,7 @@ void TTimer::setName(const QString& name)
     mName = name;
     // Merely for information if needed later:
     mpQTimer->setObjectName(QStringLiteral("timer(Host:%1)(TTimerId:%2)").arg(mpHost->getName(), name));
-    mpHost->getTimerUnit()->mLookupTable.insertMulti(name, this);
+    mpHost->getTimerUnit()->mLookupTable.insert(name, this);
 }
 
 void TTimer::setTime(QTime time)

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -134,7 +134,7 @@ void TTrigger::setName(const QString& name)
         mpHost->getTriggerUnit()->mLookupTable.remove( mName, this );
     }
     mName = name;
-    mpHost->getTriggerUnit()->mLookupTable.insertMulti(name, this);
+    mpHost->getTriggerUnit()->mLookupTable.insert(name, this);
 }
 
 static void pcre_deleter(pcre* pointer)


### PR DESCRIPTION
The `insertMulti` method is implicit on a multi-map and is deprecated now. (As is using it on `QMap`s as well - those should be converted TO `QMultiMaps` - and the same for `QHash`/`QMultiHash`es!!!)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>