### PR TITLE
Cleanup: remove use of deprecated QString::sprintf(...)

### DIFF
--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -335,8 +335,7 @@ QString IrcMessageFormatter::formatPongMessage(IrcPongMessage* message, bool isF
     Q_UNUSED(isForLua)
     quint64 msec = message->timeStamp().toMSecsSinceEpoch();
     quint64 dms = (QDateTime::currentMSecsSinceEpoch() - msec);
-    const QString secs = QString().sprintf("%04.3f", (float)((float)dms / (float)1000));
-    return QObject::tr("! %1 replied in %2 seconds").arg(message->nick(), secs);
+    return QObject::tr("! %1 replied in %2 seconds").arg(message->nick()).arg(dms / 1000.0, 4, 'f', 3, QLatin1Char('0'));
 }
 
 // Normal messages sent to channels are processed by our client as if they are private messages.


### PR DESCRIPTION
This was not recommended for use even as far back as Qt 4.8 see: https://doc.qt.io/archives/qt-4.8/qstring.html#sprintf

This commit also removes a triplet of old C-style casts where the speed improvement by using `float`s is not even justified compared to the inherent use of `double`s when a `.0` is added to a divisor in a simple maths expression!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>