### PR TITLE
CHARSET ACCEPTED does *not* include the separator.

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1551,7 +1551,6 @@ void cTelnet::processTelnetCommand(const std::string& command)
                     qDebug() << "Game changed encoding to" << value;
 
                     output += CHARSET_ACCEPTED;
-                    output += payload[1]; // Separator
                     output += encodeAndCookBytes(acceptedCharacterSet.toStdString());
                 } else {
                     output += CHARSET_REJECTED;


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Fix obvious RFC 2066 incompatibility.

#### Motivation for adding to Mudlet

There's no point (ACCEPTED only carries one charset).
Also, RFC 2066 doesn't have that.

