### PR TITLE
add getWindowWrap lua function

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1568,6 +1568,11 @@ int TConsole::getColumnNumber()
     return mUserCursor.x();
 }
 
+int TConsole::getWrapAt()
+{
+    return buffer.mWrapAt;
+}
+
 int TConsole::getLineCount()
 {
     return buffer.getLastLineNumber();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -114,6 +114,7 @@ public:
         mWrapAt = pos;
         buffer.setWrapAt(pos);
     }
+    int getWrapAt();
 
     void setIndentCount(int count)
     {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1803,6 +1803,16 @@ int TLuaInterpreter::setWindowWrap(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getWindowWrap
+int TLuaInterpreter::getWindowWrap(lua_State* L)
+{
+    QString windowName {WINDOW_NAME(L, 1)};
+
+    auto console = CONSOLE(L, windowName);
+    lua_pushnumber(L, console->getWrapAt());
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setWindowWrapIndent
 int TLuaInterpreter::setWindowWrapIndent(lua_State* L)
 {
@@ -15777,6 +15787,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "debugc", TLuaInterpreter::debug);
     lua_register(pGlobalLua, "showHandlerError", TLuaInterpreter::showHandlerError);
     lua_register(pGlobalLua, "setWindowWrap", TLuaInterpreter::setWindowWrap);
+    lua_register(pGlobalLua, "getWindowWrap", TLuaInterpreter::getWindowWrap);
     lua_register(pGlobalLua, "setWindowWrapIndent", TLuaInterpreter::setWindowWrapIndent);
     lua_register(pGlobalLua, "resetFormat", TLuaInterpreter::resetFormat);
     lua_register(pGlobalLua, "moveCursorEnd", TLuaInterpreter::moveCursorEnd);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -324,6 +324,7 @@ public:
     static int debug(lua_State* L);
     static int showHandlerError(lua_State* L);
     static int setWindowWrap(lua_State*);
+    static int getWindowWrap(lua_State*);
     static int setWindowWrapIndent(lua_State*);
     static int resetFormat(lua_State*);
     static int moveCursorEnd(lua_State*);

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -416,6 +416,7 @@
     "setUserWindowTitle": "setUserWindowTitle(windowName, text)",
     "setWindow": "setWindow(windowName, name, [Xpos, Ypos, show])",
     "setWindowWrap": "setWindowWrap(windowName, wrapAt)",
+    "getWindowWrap": "getWindowWrap(windowName)",
     "setWindowWrapIndent": "setWindowWrapIndent(windowName, wrapTo)",
     "shms": "shms(seconds, bool)",
     "showCaptureGroups": "showCaptureGroups()",

--- a/src/mudlet-lua/lua/CoreMudlet.lua
+++ b/src/mudlet-lua/lua/CoreMudlet.lua
@@ -1091,6 +1091,9 @@ if false then
   function setWindowWrap(windowName, wrapAt)
   end
 
+  --- Gets at what position in the line the console or miniconsole will start word wrap.
+  function getWindowWrap(windownName)
+  end
 
 
   --- <b><u>TODO</u></b>  setWindowWrapIndent - TLuaInterpreter::setWindowWrapIndent


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

There is option to `setWindowWrap`, but not option to retrieve its value.

#### Motivation for adding to Mudlet

I want to be able in scripts to write full-width sequences or ones that actually will fit and not be wrapped.
In my case it will decide how many columns table should have to not get wrapped.

#### Other info (issues closed, discussion etc)
I am no C++ dev, but was able to compile it locally and it seems to be working.
I took `setWindowWrap` as reference method.
