### PR TITLE
Revise: select profiles by typing the name, keep profile icons, new colors

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2279,20 +2279,12 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
 {
     QPixmap background(120, 30);
     background.fill(Qt::transparent);
-    uint hash1 = qHash(text, 0);
-    uint hash2 = qHash(text, 16381);
-    uint hash3 = qHash(text, 8191);
-    uint hash4 = qHash(text, 2053);
-    QRadialGradient shade(85 - (hash4 % 30), 5 + (hash3 % 20), 40, 35 + (hash2 % 30), 25 - (hash1 % 20));
-    uint16_t innerHue = (7 * hash1) % 360;
-    uint8_t hueDirection = (hash2 % 2) ? 1 : -1;
-    uint8_t hueSpan = (hash3 % 180);
-    QColor color0 = QColor::fromHsv(innerHue, 255, 80);
-    QColor color1 = QColor::fromHsv((innerHue + hueDirection * hueSpan) % 360, 255, 160);
-    QColor color2 = QColor::fromHsv((innerHue + 2 * hueDirection * hueSpan) % 360, 255, 255);
-    shade.setColorAt(0.0, color0);
-    shade.setColorAt(0.5, color1);
-    shade.setColorAt(1.0, color2);
+    uint hash = qHash(text);
+    QRadialGradient shade(75, 5, 40, 45, 25);
+    QColor color0(((3 * hash) % 255), ((13 * hash) % 255), ((5 * hash) % 255));
+    QColor color1((hash % 255), ((7 * hash) % 255), ((11 * hash) % 255));
+    shade.setColorAt(0, color0);
+    shade.setColorAt(1, color1);
 
     // Set to one larger than wanted so that do loop can contain the decrementor
     int fontSize = 30;
@@ -2316,14 +2308,25 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
         QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
         pt.drawPixmap(QRect(5, 5, 20, 20), pg);
         pt.setFont(font);
-        // Draw the text 4 times offset by +/-1 pixel to form a contrasting shadow:
-        pt.setPen(Qt::black);
+        // Draw the text 4 times offset by +/-1 pixel in a similar contrast
+        // (well black on a darker average icon and white on a ligher one)
+        // to form a contrasting shadow for a foreground one:
+        if ((color0.lightness() + color1.lightness()) > 255) {
+            pt.setPen(Qt::white);
+        } else {
+            pt.setPen(Qt::black);
+        }
         pt.drawText(QRect(28, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
         pt.drawText(QRect(30, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
         pt.drawText(QRect(28, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
         pt.drawText(QRect(30, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
-        // Then draw the text in white centered on top of the black ones:
-        pt.setPen(Qt::white);
+        // Then draw the text in the opposite used before to get a strong
+        // contrast:
+        if ((color0.lightness() + color1.lightness()) > 255) {
+            pt.setPen(Qt::black);
+        } else {
+            pt.setPen(Qt::white);
+        }
         pt.drawText(QRect(29, 1, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
     }
     return QIcon(background);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2320,7 +2320,7 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
         pt.drawText(QRect(30, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
         pt.drawText(QRect(28, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
         pt.drawText(QRect(30, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
-        // Then draw the text in the opposite used before to get a strong
+        // Then draw the text in the opposite color than used before to get a strong
         // contrast:
         if ((color0.lightness() + color1.lightness()) > 255) {
             pt.setPen(Qt::black);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -36,43 +36,7 @@
 #include <sstream>
 #include "post_guard.h"
 
-const QVector<QColor> dlgConnectionProfiles::csmCustomIconColors = {{QColor(0, 0, 0)},
-                                                                    {QColor::fromHsv(0, 192, 255)},
-                                                                    {QColor::fromHsv(12, 192, 255)},
-                                                                    {QColor::fromHsv(24, 192, 255)},
-                                                                    {QColor::fromHsv(36, 192, 255)},
-                                                                    {QColor::fromHsv(48, 192, 255)},
-                                                                    {QColor::fromHsv(60, 192, 255)},
-                                                                    {QColor::fromHsv(72, 192, 255)},
-                                                                    {QColor::fromHsv(84, 192, 255)},
-                                                                    {QColor(63, 63, 63)},
-                                                                    {QColor::fromHsv(96, 192, 255)},
-                                                                    {QColor::fromHsv(108, 192, 255)},
-                                                                    {QColor::fromHsv(120, 192, 255)},
-                                                                    {QColor::fromHsv(132, 192, 255)},
-                                                                    {QColor::fromHsv(144, 192, 255)},
-                                                                    {QColor::fromHsv(156, 192, 255)},
-                                                                    {QColor::fromHsv(168, 192, 255)},
-                                                                    {QColor::fromHsv(180, 192, 255)},
-                                                                    {QColor(128, 128, 128)},
-                                                                    {QColor::fromHsv(192, 192, 255)},
-                                                                    {QColor::fromHsv(204, 192, 255)},
-                                                                    {QColor::fromHsv(216, 192, 255)},
-                                                                    {QColor::fromHsv(228, 192, 255)},
-                                                                    {QColor::fromHsv(240, 192, 255)},
-                                                                    {QColor::fromHsv(252, 192, 255)},
-                                                                    {QColor::fromHsv(264, 192, 255)},
-                                                                    {QColor(192, 192, 192)},
-                                                                    {QColor::fromHsv(276, 192, 255)},
-                                                                    {QColor::fromHsv(288, 192, 255)},
-                                                                    {QColor::fromHsv(300, 192, 255)},
-                                                                    {QColor::fromHsv(312, 192, 255)},
-                                                                    {QColor::fromHsv(324, 192, 255)},
-                                                                    {QColor::fromHsv(336, 192, 255)},
-                                                                    {QColor::fromHsv(348, 192, 255)},
-                                                                    {QColor(255, 255, 255)}};
-
-dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
+dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 : QDialog(parent)
 , validName()
 , validUrl()
@@ -320,6 +284,32 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
                                  // Intentional comment to separate arguments
                                  "Some text to speech engines will spell out initials like MUD so stick to lower case if that is a better option");
 
+    // Set up some initial black/white/greys:
+    mCustomIconColors = {{QColor(0, 0, 0)},
+                         {QColor(63, 63, 63)},
+                         {QColor(128, 128, 128)},
+                         {QColor(192, 192, 192)},
+                         {QColor(255, 255, 255)}};
+
+    // Add some color ones with evenly spaced hue
+    for (quint16 i = 0; i < 360; i += 24) {
+        for (quint16 j = 0; j < 3; ++j) {
+            switch (j) {
+            case 0: {
+                mCustomIconColors.append(QColor::fromHsv(i, 255, 255));
+                break;
+            }
+            case 1: {
+                mCustomIconColors.append(QColor::fromHsv(i, 192, 255));
+                break;
+            }
+            case 2: {
+                mCustomIconColors.append(QColor::fromHsv(i, 128, 255));
+                break;
+            }
+            }
+        }
+    }
 }
 
 // the dialog can be accepted by pressing Enter on an qlineedit; this is a safeguard against it
@@ -2315,7 +2305,7 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
 {
     QPixmap background(120, 30);
     uint hash = qHash(text);
-    QColor backgroundColor = csmCustomIconColors.at((hash * 8131) % csmCustomIconColors.count());
+    QColor backgroundColor = mCustomIconColors.at((hash * 8131) % mCustomIconColors.count());
     background.fill(backgroundColor);
 
     // Set to one larger than wanted so that do loop can contain the decrementor

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -69,7 +69,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     }
     QPixmap holdPixmap;
 
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15,0))
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     holdPixmap = notificationAreaIconLabelWarning->pixmap(Qt::ReturnByValue);
 #else
     holdPixmap = notificationAreaIconLabelWarning->pixmap();
@@ -77,7 +77,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     holdPixmap.setDevicePixelRatio(5.3);
     notificationAreaIconLabelWarning->setPixmap(holdPixmap);
 
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15,0))
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     holdPixmap = notificationAreaIconLabelError->pixmap(Qt::ReturnByValue);
 #else
     holdPixmap = notificationAreaIconLabelError->pixmap();
@@ -85,7 +85,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     holdPixmap.setDevicePixelRatio(5.3);
     notificationAreaIconLabelError->setPixmap(holdPixmap);
 
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15,0))
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     holdPixmap = notificationAreaIconLabelInformation->pixmap(Qt::ReturnByValue);
 #else
     holdPixmap = notificationAreaIconLabelInformation->pixmap();
@@ -2243,7 +2243,7 @@ void dlgConnectionProfiles::setItemName(QListWidgetItem* pI, const QString& name
         font.setPointSize(--fontSize);
         QFontMetrics fm(font);
         testRect = fm.boundingRect(textRectangle, Qt::AlignCenter|Qt::TextSingleLine, name);
-    } while (fontSize > 1 && ! textRectangle.contains(testRect));
+    } while (fontSize > 1 && !textRectangle.contains(testRect));
     pI->setFont(font);
     pI->setData(csmNameRole, name);
     pI->setText(name);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -72,7 +72,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     holdPixmap = notificationAreaIconLabelWarning->pixmap(Qt::ReturnByValue);
 #else
-    holdPixmap = notificationAreaIconLabelWarning->pixmap();
+    holdPixmap = *(this->notificationAreaIconLabelWarning->pixmap());
 #endif
     holdPixmap.setDevicePixelRatio(5.3);
     notificationAreaIconLabelWarning->setPixmap(holdPixmap);
@@ -80,7 +80,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     holdPixmap = notificationAreaIconLabelError->pixmap(Qt::ReturnByValue);
 #else
-    holdPixmap = notificationAreaIconLabelError->pixmap();
+    holdPixmap = *(this->notificationAreaIconLabelError->pixmap());
 #endif
     holdPixmap.setDevicePixelRatio(5.3);
     notificationAreaIconLabelError->setPixmap(holdPixmap);
@@ -88,7 +88,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     holdPixmap = notificationAreaIconLabelInformation->pixmap(Qt::ReturnByValue);
 #else
-    holdPixmap = notificationAreaIconLabelInformation->pixmap();
+    holdPixmap = *(notificationAreaIconLabelInformation->pixmap());
 #endif
     holdPixmap.setDevicePixelRatio(5.3);
     notificationAreaIconLabelInformation->setPixmap(holdPixmap);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -69,17 +69,29 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     }
     QPixmap holdPixmap;
 
-    holdPixmap = *(this->notificationAreaIconLabelWarning->pixmap());
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15,0))
+    holdPixmap = notificationAreaIconLabelWarning->pixmap(Qt::ReturnByValue);
+#else
+    holdPixmap = notificationAreaIconLabelWarning->pixmap();
+#endif
     holdPixmap.setDevicePixelRatio(5.3);
-    this->notificationAreaIconLabelWarning->setPixmap(holdPixmap);
+    notificationAreaIconLabelWarning->setPixmap(holdPixmap);
 
-    holdPixmap = *(this->notificationAreaIconLabelError->pixmap());
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15,0))
+    holdPixmap = notificationAreaIconLabelError->pixmap(Qt::ReturnByValue);
+#else
+    holdPixmap = notificationAreaIconLabelError->pixmap();
+#endif
     holdPixmap.setDevicePixelRatio(5.3);
-    this->notificationAreaIconLabelError->setPixmap(holdPixmap);
+    notificationAreaIconLabelError->setPixmap(holdPixmap);
 
-    holdPixmap = *(this->notificationAreaIconLabelInformation->pixmap());
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15,0))
+    holdPixmap = notificationAreaIconLabelInformation->pixmap(Qt::ReturnByValue);
+#else
+    holdPixmap = notificationAreaIconLabelInformation->pixmap();
+#endif
     holdPixmap.setDevicePixelRatio(5.3);
-    this->notificationAreaIconLabelInformation->setPixmap(holdPixmap);
+    notificationAreaIconLabelInformation->setPixmap(holdPixmap);
 
     // selection mode is important. if this is not set the selection behaviour is
     // undefined. this is an undocumented qt bug, as it only shows on certain OS
@@ -271,6 +283,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
     item_profile_accessDesc = tr("Button to select a mud game to play, double-click it to connect and start playing it.",
                                  // Intentional comment to separate arguments
                                  "Some text to speech engines will spell out initials like MUD so stick to lower case if that is a better option");
+
 }
 
 // the dialog can be accepted by pressing Enter on an qlineedit; this is a safeguard against it
@@ -485,7 +498,7 @@ void dlgConnectionProfiles::slot_save_name()
 
     migrateSecuredPassword(currentProfileEditName, newProfileName);
 
-    pItem->setData(csmNameRole, newProfileName);
+    setItemName(pItem, newProfileName);
 
     QDir currentPath(mudlet::getMudletPath(mudlet::profileHomePath, currentProfileEditName));
     QDir dir;
@@ -523,77 +536,13 @@ void dlgConnectionProfiles::slot_save_name()
         Q_ASSERT_X(pRestoredItems.count() < 1, "dlgConnectionProfiles::slot_save_name", "no previously deleted Mud found with matching name when trying to restore one");
         Q_ASSERT_X(pRestoredItems.count() > 1, "dlgConnectionProfiles::slot_save_name", "multiple deleted Muds found with matching name when trying to restore one");
 
+        // As we are using QAbstractItemView::SingleSelection this will
+        // automatically unselect the previous item:
         profiles_tree_widget->setCurrentItem(pRestoredItems.first());
         slot_item_clicked(pRestoredItems.first());
     } else {
-        // code stolen from fillout_form, should be moved to its own function
-        QFont font(QStringLiteral("Bitstream Vera Sans Mono"), 1, QFont::Normal);
-        // Some uses of QFont have a third argument such as QFont::Helvetica or
-        // QFont::Courier but that is not a valid value for that argument - it
-        // is a font weight and typically only QFont::Normal or QFont::Bold is
-        // correct there (or a number 0 to 99, the two given are 50 and 75
-        // respectively)
-
-        QString sList = newProfileName;
-        QString s = newProfileName;
-        pItem->setFont(font);
-        pItem->setForeground(QColor(Qt::white));
-        profiles_tree_widget->addItem(pItem);
-        QPixmap pb(120, 30);
-        pb.fill(Qt::transparent);
-        uint hash = qHash(sList);
-        QLinearGradient shade(0, 0, 120, 30);
-        int i = row;
-        quint8 i1 = hash % 255;
-        quint8 i2 = (hash + i) % 255;
-        quint8 i3 = (i * hash) % 255;
-        quint8 i4 = (3 * hash) % 255;
-        quint8 i5 = (hash) % 255;
-        quint8 i6 = (hash / (i + 2)) % 255; // Under some corner cases i might be -1 or 0
-        shade.setColorAt(1, QColor(i1, i2, i3, 255));
-        shade.setColorAt(0, QColor(i4, i5, i6, 255));
-
-        QPainter pt(&pb);
-        pt.setCompositionMode(QPainter::CompositionMode_SourceOver);
-        pt.fillRect(QRect(0, 0, 120, 30), shade);
-        QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
-        pt.drawPixmap(QRect(5, 5, 20, 20), pg);
-
-        QFont _font;
-        QImage _pm(90, 30, QImage::Format_ARGB32_Premultiplied);
-        QPainter _pt(&_pm);
-        _pt.setCompositionMode(QPainter::CompositionMode_SourceOver);
-        int fs = 30;
-        for (; fs > 1; fs--) {
-            _pt.eraseRect(QRect(0, 0, 90, 30));
-            _pt.fillRect(QRect(0, 0, 90, 30), QColor(255, 0, 0, 10));
-            _font = QFont(QStringLiteral("DejaVu Sans"), fs, QFont::Normal);
-            _pt.setFont(_font);
-            QRect _r;
-            if ((i1 + i2 + i3 + i4 + i5 + i6) / 6 < 100) {
-                _pt.setPen(QColor(Qt::white));
-            } else {
-                _pt.setPen(QColor(Qt::black));
-            }
-            _pt.drawText(QRect(0, 0, 90, 30), Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextWordWrap, s, &_r);
-            /*
-             * if (QFontMetrics(_font).boundingRect(s).width() <= 80
-             *     && QFontMetrics(_font).boundingRect( s ).height() <= 30)
-             */
-            if (_r.width() <= 90 && _r.height() <= 30) {
-                break;
-            }
-        }
-        pt.setFont(_font);
-        QRect _r;
-        if ((i1 + i2 + i3 + i4 + i5 + i6) / 6 < 100) {
-            pt.setPen(QColor(Qt::white));
-        } else {
-            pt.setPen(QColor(Qt::black));
-        }
-        pt.drawText(QRect(30, 0, 90, 30), Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextWordWrap, s, &_r);
-        QIcon mi = QIcon(pb);
-        pItem->setIcon(mi);
+        setItemName(pItem, newProfileName);
+        pItem->setIcon(customIcon(newProfileName));
     }
 }
 
@@ -613,18 +562,17 @@ void dlgConnectionProfiles::slot_addProfile()
     if (!pItem) {
         return;
     }
-    pItem->setData(csmNameRole, newname);
+    setItemName(pItem, newname);
 
-    profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
     profiles_tree_widget->addItem(pItem);
 
     // insert newest entry on top of the list as the general sorting
     // is always newest item first -> fillout->form() filters
     // this is more practical for the user as they use the same profile most of the time
 
-    profiles_tree_widget->setItemSelected(profiles_tree_widget->currentItem(), false); // Unselect previous item
+    // As we are using QAbstractItemView::SingleSelection this will
+    // automatically unselect the previous item:
     profiles_tree_widget->setCurrentItem(pItem);
-    profiles_tree_widget->setItemSelected(pItem, true);
 
     profile_name_entry->setText(newname);
     profile_name_entry->setFocus();
@@ -1203,8 +1151,7 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
         if (profile_name == QStringLiteral("Reinos de Leyenda")) {
             val = QStringLiteral("<center><a href='https://www.reinosdeleyenda.es/'>Main website</a></center>\n"
                                  "<center><a href='https://www.reinosdeleyenda.es/foro/'>Forums</a></center>\n"
-                                 "<center><a href='https://wiki.reinosdeleyenda.es/'>Wiki</a></center>\n"
-                                 );
+                                 "<center><a href='https://wiki.reinosdeleyenda.es/'>Wiki</a></center>\n");
         }
     }
     website_entry->setText(val);
@@ -1352,13 +1299,6 @@ void dlgConnectionProfiles::fillout_form()
     }
 
     profiles_tree_widget->setIconSize(QSize(120, 30));
-    QFont font(QStringLiteral("Bitstream Vera Sans Mono"), 1, QFont::Normal);
-    // This (and setting the font color to white on a white background for an
-    // unselected widget) is a hack that minimises - but does not remove the
-    // QString assigned as the "name" of the QListWidgetItem in the constructor
-    // we use - unfortunately we currently need that text programmatically at
-    // present to identify each item - more work is needed, and is plausable, to
-    // completely resolve this. -Slysven
     QString mudServer, description;
     QListWidgetItem* pItem;
     QIcon mi;
@@ -1369,476 +1309,140 @@ void dlgConnectionProfiles::fillout_form()
     mudServer = QStringLiteral("Avalon.de");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            QPixmap p(QStringLiteral(":/icons/avalon.png"));
-            mi = QIcon(p.scaled(QSize(120, 30)));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("avalon.mud.de"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("avalon.mud.de"), 0, mudServer), QStringLiteral(":/icons/avalon.png"));
     }
 
     mudServer = QStringLiteral("Achaea");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/achaea_120_30.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("achaea.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("achaea.com"), 0, mudServer), QStringLiteral(":/icons/achaea_120_30.png"));
     }
 
     mudServer = QStringLiteral("3Kingdoms");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            QPixmap pc(QStringLiteral(":/icons/3klogo.png"));
-            QPixmap pc1 = pc.scaled(QSize(120, 30), Qt::IgnoreAspectRatio, Qt::SmoothTransformation).copy();
-            mi = QIcon(pc1);
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("3k.org"), 3000, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("3k.org"), 3000, mudServer), QStringLiteral(":/icons/3klogo.png"));
     }
 
     mudServer = QStringLiteral("3Scapes");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            QPixmap pc(QStringLiteral(":/icons/3slogo.png"));
-            QPixmap pc1 = pc.scaled(QSize(120, 30), Qt::IgnoreAspectRatio, Qt::SmoothTransformation).copy();
-            mi = QIcon(pc1);
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("3k.org"), 3200, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("3k.org"), 3200, mudServer), QStringLiteral(":/icons/3slogo.png"));
     }
 
     mudServer = QStringLiteral("Lusternia");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/lusternia_120_30.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("lusternia.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("lusternia.com"), 0, mudServer), QStringLiteral(":/icons/lusternia_120_30.png"));
     }
 
     mudServer = QStringLiteral("BatMUD");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/batmud_mud.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        profiles_tree_widget->addItem(pItem);
-        description = getDescription(QStringLiteral("batmud.bat.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("batmud.bat.org"), 0, mudServer), QStringLiteral(":/icons/batmud_mud.png"));
     }
 
     mudServer = QStringLiteral("God Wars II");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/gw2.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("godwars2.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("godwars2.org"), 0, mudServer), QStringLiteral(":/icons/gw2.png"));
     }
 
     mudServer = QStringLiteral("Slothmud");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/Slothmud.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("slothmud.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("slothmud.org"), 0, mudServer), QStringLiteral(":/icons/Slothmud.png"));
     }
 
     mudServer = QStringLiteral("Aardwolf");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/aardwolf_mud.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("aardmud.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("aardmud.org"), 0, mudServer), QStringLiteral(":/icons/aardwolf_mud.png"));
     }
 
     mudServer = QStringLiteral("Materia Magica");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/materiaMagicaIcon"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("materiamagica.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("materiamagica.com"), 0, mudServer), QStringLiteral(":/materiaMagicaIcon"));
     }
 
     mudServer = QStringLiteral("Realms of Despair");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/120x30RoDLogo.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("realmsofdespair.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("realmsofdespair.com"), 0, mudServer), QStringLiteral(":/icons/120x30RoDLogo.png"));
     }
 
     mudServer = QStringLiteral("ZombieMUD");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/zombiemud.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("zombiemud.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("zombiemud.org"), 0, mudServer), QStringLiteral(":/icons/zombiemud.png"));
     }
 
     mudServer = QStringLiteral("Aetolia");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/aetolia_120_30.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("aetolia.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("aetolia.com"), 0, mudServer), QStringLiteral(":/icons/aetolia_120_30.png"));
     }
 
     mudServer = QStringLiteral("Imperian");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/imperian_120_30.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("imperian.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("imperian.com"), 0, mudServer), QStringLiteral(":/icons/imperian_120_30.png"));
     }
 
     mudServer = QStringLiteral("WoTMUD");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QPixmap(QStringLiteral(":/icons/wotmudicon.png")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
-                                                                                Qt::SmoothTransformation).copy());
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("game.wotmud.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("game.wotmud.org"), 0, mudServer), QStringLiteral(":/icons/wotmudicon.png"));
     }
 
     mudServer = QStringLiteral("Midnight Sun 2");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QPixmap(QStringLiteral(":/icons/midnightsun2.png")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
-                                                                                  Qt::SmoothTransformation).copy());
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("midnightsun2.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("midnightsun2.org"), 0, mudServer), QStringLiteral(":/icons/midnightsun2.png"));
     }
 
     mudServer = QStringLiteral("Luminari");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(
-                    QPixmap(QStringLiteral(":/icons/luminari_icon.png")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
-                                                                                Qt::SmoothTransformation).copy());
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("luminarimud.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("luminari_icon.com"), 0, mudServer), QStringLiteral(":/icons/luminari_icon.png"));
     }
 
     mudServer = QStringLiteral("StickMUD");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(
-                    QPixmap(QStringLiteral(":/icons/stickmud_icon.jpg")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
-                                                                                Qt::SmoothTransformation).copy());
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("stickmud.com"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("stickmud.com"), 0, mudServer), QStringLiteral(":/icons/stickmud_icon.jpg"));
     }
 
     mudServer = QStringLiteral("Clessidra");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QPixmap(QStringLiteral(":/icons/clessidra.jpg")).scaled(QSize(120, 30), Qt::IgnoreAspectRatio,
-                                                                               Qt::SmoothTransformation).copy());
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("clessidra.it"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("clessidra.it"), 0, mudServer), QStringLiteral(":/icons/clessidra.jpg"));
     }
 
     mudServer = QStringLiteral("Reinos de Leyenda");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        if (!hasCustomIcon(mudServer)) {
-            profiles_tree_widget->addItem(pItem);
-            mi = QIcon(QPixmap(QStringLiteral(":/icons/reinosdeleyenda_mud.png")).scaled(QSize(120, 30),
-                                                                                         Qt::IgnoreAspectRatio,
-                                                                                         Qt::SmoothTransformation).copy());
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("reinosdeleyenda.es"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("reinosdeleyenda.es"), 0, mudServer), QStringLiteral(":/icons/reinosdeleyenda_mud.png"));
     }
 
 
     mudServer = QStringLiteral("Fierymud");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/fiery_mud.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("fierymud.org"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("fierymud.org"), 0, mudServer), QStringLiteral(":/icons/fiery_mud.png"));
     }
 
     mudServer = QStringLiteral("Carrion Fields");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/carrionfields.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("carrionfields.net"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("carrionfields.net"), 0, mudServer), QStringLiteral(":/icons/carrionfields.png"));
     }
 
     mudServer = QStringLiteral("Cleft of Dimensions");
     if (!deletedDefaultMuds.contains(mudServer)) {
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
-        profiles_tree_widget->addItem(pItem);
-        if (!hasCustomIcon(mudServer)) {
-            mi = QIcon(QStringLiteral(":/icons/cleftofdimensions.png"));
-            pItem->setIcon(mi);
-        } else {
-            setCustomIcon(mudServer, pItem);
-        }
-        description = getDescription(QStringLiteral("cleftofdimensions.net"), 0, mudServer);
-        if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
-        }
+        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("cleftofdimensions.net"), 0, mudServer), QStringLiteral(":/icons/cleftofdimensions.png"));
     }
 
 
@@ -1847,14 +1451,13 @@ void dlgConnectionProfiles::fillout_form()
     if (!deletedDefaultMuds.contains(mudServer) && !mProfileList.contains(mudServer)) {
         mProfileList.append(mudServer);
         pItem = new QListWidgetItem();
-        pItem->setData(csmNameRole, mudServer);
-        pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(mudServer));
-        pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
+        // Can't use setupMudProfile(...) here as we do not set the icon in the same way:
+        setItemName(pItem, mudServer);
 
         profiles_tree_widget->addItem(pItem);
         description = getDescription(QStringLiteral("mudlet.org"), 0, mudServer);
         if (!description.isEmpty()) {
-            pItem->setToolTip(QLatin1String("<html><head/><body><p>") % description % QLatin1String("</p></body></html>"));
+            pItem->setToolTip(QStringLiteral("<p>%1</p>").arg(description));
         }
     }
 #endif
@@ -1926,7 +1529,8 @@ void dlgConnectionProfiles::setProfileIcon() const
                 continue;
             }
 
-            generateCustomProfile(i, profileName);
+            // This will instantiate a new QListWidgetItem for the profile:
+            generateCustomProfile(profileName);
         }
     }
 }
@@ -1939,9 +1543,7 @@ bool dlgConnectionProfiles::hasCustomIcon(const QString& profileName) const
 void dlgConnectionProfiles::loadCustomProfile(const QString& profileName) const
 {
     auto pItem = new QListWidgetItem();
-    pItem->setData(csmNameRole, profileName);
-    pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(profileName));
-    pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
+    setItemName(pItem, profileName);
 
     setCustomIcon(profileName, pItem);
     auto description = getDescription(profileName, 0, profileName);
@@ -1951,7 +1553,8 @@ void dlgConnectionProfiles::loadCustomProfile(const QString& profileName) const
     profiles_tree_widget->addItem(pItem);
 }
 
-void dlgConnectionProfiles::setCustomIcon(const QString& profileName, QListWidgetItem* profile) const {
+void dlgConnectionProfiles::setCustomIcon(const QString& profileName, QListWidgetItem* profile) const
+{
     auto profileIconPath = mudlet::getMudletPath(mudlet::profileDataItemPath, profileName, QStringLiteral("profileicon"));
     auto icon = QIcon(QPixmap(profileIconPath).scaled(QSize(120, 30), Qt::IgnoreAspectRatio, Qt::SmoothTransformation).copy());
     profile->setIcon(icon);
@@ -1994,61 +1597,12 @@ void dlgConnectionProfiles::loadSecuredPassword(const QString &profile, L callba
     job->start();
 }
 
-void dlgConnectionProfiles::generateCustomProfile(int i, const QString& profileName) const
+void dlgConnectionProfiles::generateCustomProfile(const QString& profileName) const
 {
     auto pItem = new QListWidgetItem();
-    pItem->setData(csmNameRole, profileName);
-    pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(profileName));
-    pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
-
+    setItemName(pItem, profileName);
+    pItem->setIcon(customIcon(profileName));
     profiles_tree_widget->addItem(pItem);
-    QPixmap background(120, 30);
-    background.fill(Qt::transparent);
-    uint hash = qHash(profileName);
-    QLinearGradient shade(0, 0, 120, 30);
-    quint8 i1 = hash % 255;
-    quint8 i2 = (hash + i) % 255;
-    quint8 i3 = (i * hash) % 255;
-    quint8 i4 = (3 * hash) % 255;
-    quint8 i5 = (hash) % 255;
-    quint8 i6 = (hash / (i + 2)) % 255; // In the other place where this is used i might be -1 or 0
-    shade.setColorAt(1, QColor(i1, i2, i3, 255));
-    shade.setColorAt(0, QColor(i4, i5, i6, 255));
-    QPainter pt(&background);
-    pt.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    pt.fillRect(QRect(0, 0, 120, 30), shade);
-    QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
-    pt.drawPixmap(QRect(5, 5, 20, 20), pg);
-
-    QFont _font;
-    QImage _pm(90, 30, QImage::Format_ARGB32_Premultiplied);
-    QPainter _pt(&_pm);
-    _pt.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    for (int fs = 30; fs > 1; fs--) {
-        _pt.eraseRect(QRect(0, 0, 90, 30));
-        _pt.fillRect(QRect(0, 0, 90, 30), QColor(255, 0, 0, 10));
-        _font = QFont(QStringLiteral("DejaVu Sans"), fs, QFont::Normal);
-        _pt.setFont(_font);
-        QRect _r;
-        if ((i1 + i2 + i3 + i4 + i5 + i6) / 6 < 100) {
-            _pt.setPen(QColor(Qt::white));
-        } else {
-            _pt.setPen(QColor(Qt::black));
-        }
-        _pt.drawText(QRect(0, 0, 90, 30), Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextWordWrap, profileName, &_r);
-        if (_r.width() <= 90 && _r.height() <= 30) {
-            break;
-        }
-    }
-    pt.setFont(_font);
-    QRect _r;
-    if ((i1 + i2 + i3 + i4 + i5 + i6) / 6 < 100) {
-        pt.setPen(QColor(Qt::white));
-    } else {
-        pt.setPen(QColor(Qt::black));
-    }
-    pt.drawText(QRect(30, 0, 90, 30), Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextWordWrap, profileName, &_r);
-    pItem->setIcon(QIcon(background));
 }
 
 void dlgConnectionProfiles::slot_profile_menu(QPoint pos)
@@ -2222,16 +1776,11 @@ bool dlgConnectionProfiles::copyProfileWidget(QString& profile_name, QString& ol
     if (!pItem) {
         return false;
     }
-    pItem->setData(csmNameRole, profile_name);
-    pItem->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(profile_name));
-    pItem->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
+    setItemName(pItem, profile_name);
 
     // add the new widget in
-    profiles_tree_widget->setSelectionMode(QAbstractItemView::SingleSelection);
     profiles_tree_widget->addItem(pItem);
-    profiles_tree_widget->setItemSelected(profiles_tree_widget->currentItem(), false); // Unselect previous item
     profiles_tree_widget->setCurrentItem(pItem);
-    profiles_tree_widget->setItemSelected(pItem, true);
 
     profile_name_entry->setText(profile_name);
     profile_name_entry->setFocus();
@@ -2675,4 +2224,75 @@ QList<QListWidgetItem*> dlgConnectionProfiles::findData(const QListWidget& listW
         }
     }
     return results;
+}
+
+void dlgConnectionProfiles::setItemName(QListWidgetItem* pI, const QString& name) const
+{
+    if (!pI) {
+        // Avoid any problems should the supplied argument be a nullptr:
+        return;
+    }
+
+    // Set to one larger than wanted so that do loop can contain the decrementor
+    int fontSize = 11;
+    QFont font(QStringLiteral("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
+    // For an icon of size 120x30 allow another 20 underneath it for the text:
+    QRect textRectangle(0, 0, 119, 19);
+    QRect testRect;
+    do {
+        font.setPointSize(--fontSize);
+        QFontMetrics fm(font);
+        testRect = fm.boundingRect(textRectangle, Qt::AlignCenter|Qt::TextSingleLine, name);
+    } while (fontSize > 1 && ! textRectangle.contains(testRect));
+    pI->setFont(font);
+    pI->setData(csmNameRole, name);
+    pI->setText(name);
+    pI->setData(Qt::AccessibleTextRole, item_profile_accessName.arg(name));
+    pI->setData(Qt::AccessibleDescriptionRole, item_profile_accessDesc);
+}
+
+void dlgConnectionProfiles::setupMudProfile(QListWidgetItem* pItem, const QString& mudServer, const QString& serverDescription, const QString& iconFileName)
+{
+    pItem = new QListWidgetItem();
+    setItemName(pItem, mudServer);
+
+    profiles_tree_widget->addItem(pItem);
+    if (!hasCustomIcon(mudServer)) {
+        QPixmap p(iconFileName);
+        if (p.width() != 120) {
+            pItem->setIcon(p.scaled(QSize(120, 30), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+        } else {
+            pItem->setIcon(QIcon(iconFileName));
+        }
+    } else {
+        setCustomIcon(mudServer, pItem);
+    }
+    if (!serverDescription.isEmpty()) {
+        pItem->setToolTip(QStringLiteral("<p>%1</p>").arg(serverDescription));
+    }
+}
+
+QIcon dlgConnectionProfiles::customIcon(const QString& text) const
+{
+    QPixmap background(120, 30);
+    background.fill(Qt::transparent);
+    uint hash = qHash(text);
+    QRadialGradient shade(75, 5, 40, 45, 25);
+    quint8 i1 = hash % 255;
+    quint8 i2 = (7 * hash) % 255;
+    quint8 i3 = (11 * hash) % 255;
+    quint8 i4 = (3 * hash) % 255;
+    quint8 i5 = (13 * hash) % 255;
+    quint8 i6 = (5 * hash) % 255;
+    shade.setColorAt(1, QColor(i1, i2, i3, 255));
+    shade.setColorAt(0, QColor(i4, i5, i6, 255));
+
+    { // Enclosed in braces to limit lifespan of QPainter:
+        QPainter pt(&background);
+        pt.setCompositionMode(QPainter::CompositionMode_SourceOver);
+        pt.fillRect(QRect(0, 0, 120, 30), shade);
+        QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
+        pt.drawPixmap(QRect(5, 5, 20, 20), pg);
+    }
+    return QIcon(background);
 }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -36,6 +36,42 @@
 #include <sstream>
 #include "post_guard.h"
 
+const QVector<QColor> dlgConnectionProfiles::csmCustomIconColors = {{QColor(0, 0, 0)},
+                                                                    {QColor::fromHsv(0, 192, 255)},
+                                                                    {QColor::fromHsv(12, 192, 255)},
+                                                                    {QColor::fromHsv(24, 192, 255)},
+                                                                    {QColor::fromHsv(36, 192, 255)},
+                                                                    {QColor::fromHsv(48, 192, 255)},
+                                                                    {QColor::fromHsv(60, 192, 255)},
+                                                                    {QColor::fromHsv(72, 192, 255)},
+                                                                    {QColor::fromHsv(84, 192, 255)},
+                                                                    {QColor(63, 63, 63)},
+                                                                    {QColor::fromHsv(96, 192, 255)},
+                                                                    {QColor::fromHsv(108, 192, 255)},
+                                                                    {QColor::fromHsv(120, 192, 255)},
+                                                                    {QColor::fromHsv(132, 192, 255)},
+                                                                    {QColor::fromHsv(144, 192, 255)},
+                                                                    {QColor::fromHsv(156, 192, 255)},
+                                                                    {QColor::fromHsv(168, 192, 255)},
+                                                                    {QColor::fromHsv(180, 192, 255)},
+                                                                    {QColor(128, 128, 128)},
+                                                                    {QColor::fromHsv(192, 192, 255)},
+                                                                    {QColor::fromHsv(204, 192, 255)},
+                                                                    {QColor::fromHsv(216, 192, 255)},
+                                                                    {QColor::fromHsv(228, 192, 255)},
+                                                                    {QColor::fromHsv(240, 192, 255)},
+                                                                    {QColor::fromHsv(252, 192, 255)},
+                                                                    {QColor::fromHsv(264, 192, 255)},
+                                                                    {QColor(192, 192, 192)},
+                                                                    {QColor::fromHsv(276, 192, 255)},
+                                                                    {QColor::fromHsv(288, 192, 255)},
+                                                                    {QColor::fromHsv(300, 192, 255)},
+                                                                    {QColor::fromHsv(312, 192, 255)},
+                                                                    {QColor::fromHsv(324, 192, 255)},
+                                                                    {QColor::fromHsv(336, 192, 255)},
+                                                                    {QColor::fromHsv(348, 192, 255)},
+                                                                    {QColor(255, 255, 255)}};
+
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget * parent)
 : QDialog(parent)
 , validName()
@@ -2278,21 +2314,15 @@ void dlgConnectionProfiles::setupMudProfile(QListWidgetItem* pItem, const QStrin
 QIcon dlgConnectionProfiles::customIcon(const QString& text) const
 {
     QPixmap background(120, 30);
-    background.fill(Qt::transparent);
     uint hash = qHash(text);
-    QRadialGradient shade(75, 5, 40, 45, 25);
-    QColor color0(((3 * hash) % 255), ((13 * hash) % 255), ((5 * hash) % 255));
-    QColor color1((hash % 255), ((7 * hash) % 255), ((11 * hash) % 255));
-    shade.setColorAt(0, color0);
-    shade.setColorAt(1, color1);
+    QColor backgroundColor = csmCustomIconColors.at((hash * 8131) % csmCustomIconColors.count());
+    background.fill(backgroundColor);
 
     // Set to one larger than wanted so that do loop can contain the decrementor
     int fontSize = 30;
     QFont font(QStringLiteral("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
-    // For an icon of size 120x30 allow 89x29 for the text (need to take off an
-    // extra pixel to allow the text to be orbited and painted in black
-    // underneath a white top one:
-    QRect textRectangle(0, 0, 88, 28);
+    // For an icon of size 120x30 allow 89x29 for the text:
+    QRect textRectangle(0, 0, 89, 29);
     QRect testRect;
     // Really long names will be drawn very small (font size 6) with the ends clipped off:
     do {
@@ -2304,30 +2334,15 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
     { // Enclosed in braces to limit lifespan of QPainter:
         QPainter pt(&background);
         pt.setCompositionMode(QPainter::CompositionMode_SourceOver);
-        pt.fillRect(QRect(0, 0, 120, 30), shade);
         QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
         pt.drawPixmap(QRect(5, 5, 20, 20), pg);
+        if (backgroundColor.lightness() > 127) {
+            pt.setPen(Qt::black);
+        } else {
+            pt.setPen(Qt::white);
+        }
         pt.setFont(font);
-        // Draw the text 4 times offset by +/-1 pixel in a similar contrast
-        // (well black on a darker average icon and white on a ligher one)
-        // to form a contrasting shadow for a foreground one:
-        if ((color0.lightness() + color1.lightness()) > 255) {
-            pt.setPen(Qt::white);
-        } else {
-            pt.setPen(Qt::black);
-        }
-        pt.drawText(QRect(28, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
-        pt.drawText(QRect(30, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
-        pt.drawText(QRect(28, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
-        pt.drawText(QRect(30, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
-        // Then draw the text in the opposite color than used before to get a strong
-        // contrast:
-        if ((color0.lightness() + color1.lightness()) > 255) {
-            pt.setPen(Qt::black);
-        } else {
-            pt.setPen(Qt::white);
-        }
-        pt.drawText(QRect(29, 1, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
+        pt.drawText(QRect(30, 0, 90, 30), Qt::AlignCenter|Qt::TextSingleLine, text);
     }
     return QIcon(background);
 }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2279,18 +2279,28 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
 {
     QPixmap background(120, 30);
     background.fill(Qt::transparent);
-    uint hash = qHash(text);
-    QRadialGradient shade(75, 5, 40, 45, 25);
-    QColor color0(((3 * hash) % 255), ((13 * hash) % 255), ((5 * hash) % 255));
-    QColor color1((hash % 255), ((7 * hash) % 255), ((11 * hash) % 255));
-    shade.setColorAt(0, color0);
-    shade.setColorAt(1, color1);
+    uint hash1 = qHash(text, 0);
+    uint hash2 = qHash(text, 16381);
+    uint hash3 = qHash(text, 8191);
+    uint hash4 = qHash(text, 2053);
+    QRadialGradient shade(85 - (hash4 % 30), 5 + (hash3 % 20), 40, 35 + (hash2 % 30), 25 - (hash1 % 20));
+    uint16_t innerHue = (7 * hash1) % 360;
+    uint8_t hueDirection = (hash2 % 2) ? 1 : -1;
+    uint8_t hueSpan = (hash3 % 180);
+    QColor color0 = QColor::fromHsv(innerHue, 255, 80);
+    QColor color1 = QColor::fromHsv((innerHue + hueDirection * hueSpan) % 360, 255, 160);
+    QColor color2 = QColor::fromHsv((innerHue + 2 * hueDirection * hueSpan) % 360, 255, 255);
+    shade.setColorAt(0.0, color0);
+    shade.setColorAt(0.5, color1);
+    shade.setColorAt(1.0, color2);
 
     // Set to one larger than wanted so that do loop can contain the decrementor
     int fontSize = 30;
     QFont font(QStringLiteral("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
-    // For an icon of size 120x30 allow 90x30 for the text:
-    QRect textRectangle(0, 0, 89, 29);
+    // For an icon of size 120x30 allow 89x29 for the text (need to take off an
+    // extra pixel to allow the text to be orbited and painted in black
+    // underneath a white top one:
+    QRect textRectangle(0, 0, 88, 28);
     QRect testRect;
     // Really long names will be drawn very small (font size 6) with the ends clipped off:
     do {
@@ -2306,12 +2316,15 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
         QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
         pt.drawPixmap(QRect(5, 5, 20, 20), pg);
         pt.setFont(font);
-        if ((color0.lightness() + color1.lightness()) > 255) {
-            pt.setPen(Qt::black);
-        } else {
-            pt.setPen(Qt::white);
-        }
-        pt.drawText(QRect(29, 0, 90, 30), Qt::AlignCenter|Qt::TextSingleLine, text);
+        // Draw the text 4 times offset by +/-1 pixel to form a contrasting shadow:
+        pt.setPen(Qt::black);
+        pt.drawText(QRect(28, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
+        pt.drawText(QRect(30, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
+        pt.drawText(QRect(28, 2, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
+        pt.drawText(QRect(30, 0, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
+        // Then draw the text in white centered on top of the black ones:
+        pt.setPen(Qt::white);
+        pt.drawText(QRect(29, 1, 89, 29), Qt::AlignCenter|Qt::TextSingleLine, text);
     }
     return QIcon(background);
 }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2233,17 +2233,20 @@ void dlgConnectionProfiles::setItemName(QListWidgetItem* pI, const QString& name
         return;
     }
 
-    // Set to one larger than wanted so that do loop can contain the decrementor
-    int fontSize = 11;
-    QFont font(QStringLiteral("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
-    // For an icon of size 120x30 allow another 20 underneath it for the text:
-    QRect textRectangle(0, 0, 119, 19);
-    QRect testRect;
-    do {
-        font.setPointSize(--fontSize);
-        QFontMetrics fm(font);
-        testRect = fm.boundingRect(textRectangle, Qt::AlignCenter|Qt::TextSingleLine, name);
-    } while (fontSize > 1 && !textRectangle.contains(testRect));
+// This section of code not currently wanted but retained for another day
+//    // Set to one larger than wanted so that do loop can contain the decrementor
+//    int fontSize = 11;
+//    QFont font(QStringLiteral("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
+//    // For an icon of size 120x30 allow another 20 underneath it for the text:
+//    QRect textRectangle(0, 0, 119, 19);
+//    QRect testRect;
+//    do {
+//        font.setPointSize(--fontSize);
+//        QFontMetrics fm(font);
+//        testRect = fm.boundingRect(textRectangle, Qt::AlignCenter|Qt::TextSingleLine, name);
+//    } while (fontSize > 1 && !textRectangle.contains(testRect));
+
+    QFont font(QStringLiteral("Bitstream Vera Sans Mono"), 1, QFont::Normal);
     pI->setFont(font);
     pI->setData(csmNameRole, name);
     pI->setText(name);
@@ -2278,14 +2281,23 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
     background.fill(Qt::transparent);
     uint hash = qHash(text);
     QRadialGradient shade(75, 5, 40, 45, 25);
-    quint8 i1 = hash % 255;
-    quint8 i2 = (7 * hash) % 255;
-    quint8 i3 = (11 * hash) % 255;
-    quint8 i4 = (3 * hash) % 255;
-    quint8 i5 = (13 * hash) % 255;
-    quint8 i6 = (5 * hash) % 255;
-    shade.setColorAt(1, QColor(i1, i2, i3, 255));
-    shade.setColorAt(0, QColor(i4, i5, i6, 255));
+    QColor color0(((3 * hash) % 255), ((13 * hash) % 255), ((5 * hash) % 255));
+    QColor color1((hash % 255), ((7 * hash) % 255), ((11 * hash) % 255));
+    shade.setColorAt(0, color0);
+    shade.setColorAt(1, color1);
+
+    // Set to one larger than wanted so that do loop can contain the decrementor
+    int fontSize = 30;
+    QFont font(QStringLiteral("Bitstream Vera Sans Mono"), fontSize, QFont::Normal);
+    // For an icon of size 120x30 allow 90x30 for the text:
+    QRect textRectangle(0, 0, 89, 29);
+    QRect testRect;
+    // Really long names will be drawn very small (font size 6) with the ends clipped off:
+    do {
+        font.setPointSize(--fontSize);
+        QFontMetrics fm(font);
+        testRect = fm.boundingRect(textRectangle, Qt::AlignCenter|Qt::TextSingleLine, text);
+    } while (fontSize > 6 && !textRectangle.contains(testRect));
 
     { // Enclosed in braces to limit lifespan of QPainter:
         QPainter pt(&background);
@@ -2293,6 +2305,13 @@ QIcon dlgConnectionProfiles::customIcon(const QString& text) const
         pt.fillRect(QRect(0, 0, 120, 30), shade);
         QPixmap pg(QStringLiteral(":/icons/mudlet_main_32px.png"));
         pt.drawPixmap(QRect(5, 5, 20, 20), pg);
+        pt.setFont(font);
+        if ((color0.lightness() + color1.lightness()) > 255) {
+            pt.setPen(Qt::black);
+        } else {
+            pt.setPen(Qt::white);
+        }
+        pt.drawText(QRect(29, 0, 90, 30), Qt::AlignCenter|Qt::TextSingleLine, text);
     }
     return QIcon(background);
 }

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -108,6 +108,8 @@ private:
     void setItemName(QListWidgetItem*, const QString&) const;
     QIcon customIcon(const QString&) const;
 
+    static const QVector<QColor> csmCustomIconColors;
+
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has
     // to be valid, but other properties don't have to be

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -108,7 +108,6 @@ private:
     void setItemName(QListWidgetItem*, const QString&) const;
     QIcon customIcon(const QString&) const;
 
-    static const QVector<QColor> csmCustomIconColors;
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -132,6 +132,7 @@ private:
     // true for the duration of the 'Copy profile' action
     bool mCopyingProfile {};
     QString mDateTimeFormat;
+    QVector<QColor> mCustomIconColors;
 
 
 private slots:

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -94,16 +94,19 @@ private:
     bool extractSettingsFromProfile(pugi::xml_document& newProfile, const QString& copySettingsFrom);
     void saveProfileCopy(const QDir& newProfiledir, const pugi::xml_document& newProfileXml) const;
     bool copyProfileWidget(QString& profile_name, QString& oldname, QListWidgetItem*& pItem) const;
-    bool hasCustomIcon(const QString& profileName) const;
+    bool hasCustomIcon(const QString&) const;
     void setProfileIcon() const;
-    void loadCustomProfile(const QString& profileName) const;
-    void generateCustomProfile(int i, const QString& profileName) const;
-    void setCustomIcon(const QString& profileName, QListWidgetItem* profile) const;
+    void loadCustomProfile(const QString&) const;
+    void generateCustomProfile(const QString&) const;
+    void setCustomIcon(const QString&, QListWidgetItem*) const;
     template <typename L>
     void loadSecuredPassword(const QString& profile, L callback);
     void migrateSecuredPassword(const QString& oldProfile, const QString& newProfile);
     void writeSecurePassword(const QString& profile, const QString& pass) const;
     void deleteSecurePassword(const QString& profile) const;
+    void setupMudProfile(QListWidgetItem*, const QString& mudServer, const QString& serverDescription, const QString& iconFileName);
+    void setItemName(QListWidgetItem*, const QString&) const;
+    QIcon customIcon(const QString&) const;
 
     // split into 3 properties so each one can be checked individually
     // important for creation of a folder on disk, for example: name has


### PR DESCRIPTION
This is so that the keyboard selection of profiles beginning with a particular letter works again. This will close issue #4283 .

This also returns it to a readable size instead of trying to hide it by setting the font size to 1 - as that would still show something (and a font size of zero is NOT valid). Manipulating the QPalette of the `QListWidget` does not work well enough in the presence of Styles or StyleSheets to be a viable means of hiding the text underneath either.

Also in the `dlgConnection` class:
* refactor out some highly repetitive code that sets up the predefined Mud icons.
* remove warnings and adopts a change introduced into Qt 5.15 for the `QLabel::pixmap()` which now requires a `Qt::ReturnByValue` argument to prevent an obsolete code warning and to force a `QPixmap` to be returned by value and not reference...
* remove a warning about: `QListWidget::setItemSelected(QListWidgetItem*,bool)` being deprecated and switches to the recommended: `QListWidgetItem::setSelected(bool)`

Take the display of the name from the custom icon - as we now show it visibly underneath and if the user assigns their own icon the text is not shown anyway.

Change the custom icon generator so that there is NOT a dependency on the position in the list for the colours used. This means that the same name will always have the same colours - which will help the user to pick out a particular profile as it will always look the same no matter if other profiles are added or removed.

Change the colour gradient to be a radial one rather than a linear one, this makes it more *interesting* I think.

Refactor out the colour icon generator to a single method that is called from more than one place.

Closes https://github.com/Mudlet/Mudlet/issues/4288

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>