### PR TITLE
Fixup: insert missing test in TTextCodec methods

### DIFF
--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -191,7 +191,9 @@ QString TTextCodec_437::convertToUnicode(const char *in, int length, ConverterSt
     }
 
     // If we get here and headerDone is false then we need to insert the BOM
-    result += QChar::ByteOrderMark;
+    if (!headerDone) {
+        result += QChar::ByteOrderMark;
+    }
     for (int i = 0; i < length; ++i) {
         unsigned char ch = in[i];
         if (ch < 0x80) {
@@ -221,7 +223,9 @@ QString TTextCodec_667::convertToUnicode(const char *in, int length, ConverterSt
     }
 
     // If we get here and headerDone is false then we need to insert the BOM
-    result += QChar::ByteOrderMark;
+    if (!headerDone) {
+        result += QChar::ByteOrderMark;
+    }
     for (int i = 0; i < length; ++i) {
         unsigned char ch = in[i];
         if (ch < 0x80) {
@@ -251,7 +255,9 @@ QString TTextCodec_737::convertToUnicode(const char *in, int length, ConverterSt
     }
 
     // If we get here and headerDone is false then we need to insert the BOM
-    result += QChar::ByteOrderMark;
+    if (!headerDone) {
+        result += QChar::ByteOrderMark;
+    }
     for (int i = 0; i < length; ++i) {
         unsigned char ch = in[i];
         if (ch < 0x80) {
@@ -285,7 +291,9 @@ QString TTextCodec_869::convertToUnicode(const char *in, int length, ConverterSt
     }
 
     // If we get here and headerDone is false then we need to insert the BOM
-    result += QChar::ByteOrderMark;
+    if (!headerDone) {
+        result += QChar::ByteOrderMark;
+    }
     for (int i = 0; i < length; ++i) {
         unsigned char ch = in[i];
         if (ch < 0x80) {


### PR DESCRIPTION
The recent re-enabling of warnings revealed a failure to handle a check I was making in some methods that override the `[pure virtual protected]` method in: `(QString) QTextCodec::convertToUnicode(const char *chars, int len, TextCodec::ConverterState *state) const` in some codecs I implimented in the `TTextCodec` class.

As it happens I do not think the method is currently used by Mudlet, but it makes sense to fix it in case anyone uses those codecs for their own purposes. (I recall searching for ways to do these codecs and none of the examples I found online were as complete as the ones I have constructed here!)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>