### PR TITLE
Cleanup: reduce warnings from unhandled switch cases

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15020,6 +15020,9 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
             error = lua_pcall(L, 1, LUA_MULTRET, 0);
             break;
         }
+        default: {
+            // No-op - this silences warnings about unhandled QEvent types
+        }
         }
     } else {
         error = lua_pcall(L, 0, LUA_MULTRET, 0);

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -718,6 +718,13 @@ QString dlgIRC::getMessageTarget(IrcMessage* msg, const QString& bufferName)
         target = msgPrivate->target();
         break;
     }
+    default:
+        // Other message types are not expected - I hope - SlySven
+        qWarning().noquote().nospace() << "dlgIRC::getMessageTarget(..., \""
+                                       << bufferName
+                                       << "\") WARNING - message of type: "
+                                       << msg->type()
+                                       << " not explicitly handled, this needs fixing by Mudlet Makers...";
     }
     return target;
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6619,10 +6619,6 @@ void dlgTriggerEditor::slot_showSearchAreaResults(const bool isChecked)
 
 void dlgTriggerEditor::saveOpenChanges()
 {
-    if (mCurrentView == EditorViewType::cmUnknownView) {
-        return;
-    }
-
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
         saveTrigger();
@@ -6645,6 +6641,8 @@ void dlgTriggerEditor::saveOpenChanges()
     case EditorViewType::cmVarsView:
         saveVar();
         break;
+    case EditorViewType::cmUnknownView:
+        return; // Silently ignore this case
     }
 }
 
@@ -7271,6 +7269,8 @@ void dlgTriggerEditor::slot_item_selected_save(QTreeWidgetItem* pItem)
     case EditorViewType::cmVarsView:
         saveVar();
         break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_item_selected_save() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
     }
 }
 
@@ -7921,6 +7921,12 @@ void dlgTriggerEditor::slot_export()
     case EditorViewType::cmKeysView:
         exportKey(fileName);
         break;
+    case EditorViewType::cmVarsView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_export() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_export() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
+        break;
     }
 }
 
@@ -7945,9 +7951,16 @@ void dlgTriggerEditor::slot_copy_xml()
     case EditorViewType::cmKeysView:
         exportKeyToClipboard();
         break;
+    case EditorViewType::cmVarsView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_copy_xml() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_copy_xml() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
+        break;
     }
 }
 
+// FIXME: The switch cases in here need to handle EditorViewType::cmVarsView but how is not clear
 void dlgTriggerEditor::slot_paste_xml()
 {
     XMLimport reader(mpHost);
@@ -7972,6 +7985,12 @@ void dlgTriggerEditor::slot_paste_xml()
         break;
     case EditorViewType::cmKeysView:
         saveKey();
+        break;
+    case EditorViewType::cmVarsView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_paste_xml() WARNING - switch(EditorViewType) number 1 not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_paste_xml() WARNING - switch(EditorViewType) number 1 not expected to be called for \"EditorViewType::cmUnknownView!\"";
         break;
     }
 
@@ -8042,6 +8061,12 @@ void dlgTriggerEditor::slot_paste_xml()
         mpHost->getKeyUnit()->reParentKey(importedItemID, 0, parentId, parentRow, siblingRow);
         break;
     }
+    case EditorViewType::cmVarsView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_paste_xml() WARNING - switch(EditorViewType) number 2 not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_paste_xml() WARNING - switch(EditorViewType) number 2 not expected to be called for \"EditorViewType::cmUnknownView!\"";
+        break;
     }
 
     // flag for re-rendering so the new item shows up in the right spot
@@ -8103,6 +8128,12 @@ void dlgTriggerEditor::slot_paste_xml()
         treeWidget_keys->setFocus();
         break;
     }
+    case EditorViewType::cmVarsView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_paste_xml() WARNING - switch(EditorViewType) number 3 not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_paste_xml() WARNING - switch(EditorViewType) number 3 not expected to be called for \"EditorViewType::cmUnknownView!\"";
+        break;
     }
 }
 
@@ -8129,6 +8160,11 @@ void dlgTriggerEditor::slot_import()
     case EditorViewType::cmKeysView:
         saveKey();
         break;
+    case EditorViewType::cmVarsView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_import() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_import() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
     }
 
     QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
@@ -8231,6 +8267,7 @@ void dlgTriggerEditor::doCleanReset()
         runScheduledCleanReset();
     });
 }
+
 void dlgTriggerEditor::runScheduledCleanReset()
 {
     switch (mCurrentView) {
@@ -8252,6 +8289,13 @@ void dlgTriggerEditor::runScheduledCleanReset()
     case EditorViewType::cmKeysView:
         saveKey();
         break;
+    case EditorViewType::cmVarsView:
+        // FIXME: The switch in here need to handle (or at least treat correctly) the
+        // EditorViewType:cmVarsView case but how is not clear:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::runScheduledCleanReset() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmVarsView!\"";
+        break;
+    case EditorViewType::cmUnknownView:
+        qWarning().nospace().noquote() << "dlgTriggerEditor::runScheduledCleanReset() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
     }
 
     treeWidget_triggers->clear();


### PR DESCRIPTION
The absence of a `default:` to handle the unlisted cases in one `switch` was causing warnings and some explicit `QWarnings` have be put in should some not currently handled `case`s be hit in others.

This should reduce the number of compilation warnings by around 203.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>