### PR TITLE
BugFix: prevent export action from being active in Variables editor view

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -518,9 +518,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     importAction->setEnabled(true);
     connect(importAction, &QAction::triggered, this, &dlgTriggerEditor::slot_import);
 
-    QAction* exportAction = new QAction(QIcon(QStringLiteral(":/icons/export.png")), tr("Export"), this);
-    exportAction->setEnabled(true);
-    connect(exportAction, &QAction::triggered, this, &dlgTriggerEditor::slot_export);
+    mpExportAction = new QAction(QIcon(QStringLiteral(":/icons/export.png")), tr("Export"), this);
+    mpExportAction->setEnabled(true);
+    connect(mpExportAction, &QAction::triggered, this, &dlgTriggerEditor::slot_export);
 
     mProfileSaveAction = new QAction(QIcon(QStringLiteral(":/icons/document-save-all.png")), tr("Save Profile"), this);
     mProfileSaveAction->setEnabled(true);
@@ -582,7 +582,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar->addSeparator();
     toolBar->addAction(deleteTriggerAction);
     toolBar->addAction(importAction);
-    toolBar->addAction(exportAction);
+    toolBar->addAction(mpExportAction);
     toolBar->addAction(mProfileSaveAsAction);
     toolBar->addAction(mProfileSaveAction);
 
@@ -6775,6 +6775,8 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     mpVarsMainArea->setVisible(view == EditorViewType::cmVarsView);
     treeWidget_variables->setVisible(view == EditorViewType::cmVarsView);
     checkBox_displayAllVariables->setVisible(view == EditorViewType::cmVarsView);
+
+    mpExportAction->setEnabled(view != EditorViewType::cmVarsView);
 }
 
 void dlgTriggerEditor::slot_show_timers()
@@ -7882,6 +7884,10 @@ void dlgTriggerEditor::exportKeyToClipboard()
 
 void dlgTriggerEditor::slot_export()
 {
+    if (mCurrentView == EditorViewType::cmUnknownView || mCurrentView == EditorViewType::cmVarsView) {
+        return;
+    }
+
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Triggers"), QDir::currentPath(), tr("Mudlet packages (*.xml)"));
     if (fileName.isEmpty()) {
         return;
@@ -7922,11 +7928,11 @@ void dlgTriggerEditor::slot_export()
         exportKey(fileName);
         break;
     case EditorViewType::cmVarsView:
-        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_export() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmVarsView!\"";
-        break;
+        [[fallthrough]];
     case EditorViewType::cmUnknownView:
-        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_export() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
-        break;
+        // These two have already been handled so this place in the code should
+        // indeed be:
+        Q_UNREACHABLE();
     }
 }
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -484,6 +484,10 @@ private:
     QAction* mProfileSaveAction;
     QAction* mProfileSaveAsAction;
 
+    // We need to keep a record of this button as we have to disable it
+    // for the "Variables" view:
+    QAction* mpExportAction;
+
     // tracks the duration of the "Save Profile As" action so
     // autosave doesn't kick in
     bool mSavingAs;


### PR DESCRIPTION
As discovered as a result of PR #4447 this should prevent the `(void) dlgTriggerEditor::slot_export()` method from trying (and failing) to export a variable as an `.XML` package.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>