### PR TITLE
Cleanup: replace obsolete in Qt 5.15 QByteArray(char, const QString &)

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1588,7 +1588,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 return;
             }
 
-            rawData = rawData.replace(TN_BELL, QLatin1String("\\\\7"));
+            rawData = rawData.replace(TN_BELL, QByteArray("\\\\7"));
 
             // rawData is in the Mud Server's encoding, trim off the Telnet suboption
             // bytes from beginning (3) and end (2):


### PR DESCRIPTION
There are some other overloaded forms that are NOT obsoleted in this version and the one that uses a `QByteArray` for the second argument seems a sensible replacement - for all versions.

It also removes a single warning.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>