### PR TITLE
Cleanup: replace obsolete in Qt 5.15 QComboBox::activated(const QString&)

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -322,8 +322,11 @@ void T2DMap::shiftZdown()
     update();
 }
 
-
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+void T2DMap::switchArea(const QString& newAreaName)
+#else
 void T2DMap::slot_switchArea(const QString& newAreaName)
+#endif
 {
     Host* pHost = mpHost;
     if (!pHost || !mpMap) {

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -182,7 +182,7 @@ public slots:
     void shiftZdown();
 #if (QT_VERSION) < (QT_VERSION_CHECK(5, 15, 0))
     // This is ONLY used as a slot in older versions
-    void T2DMap::slot_switchArea(const QString& newAreaName)
+    void T2DMap::slot_switchArea(const QString& newAreaName);
 #endif
     void toggleShiftMode();
     void shiftUp();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -82,6 +82,11 @@ public:
     // Clears cache so new symbols are built at next paintEvent():
     void flushSymbolPixmapCache() {mSymbolPixmapCache.clear();}
     void addSymbolToPixmapCache(const QString, const bool);
+    void setPlayerRoomStyle(const int style);
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+    // This is NOT used as a slot in newer versions
+    void switchArea(const QString& newAreaName);
+#endif
 
 
     TMap* mpMap;
@@ -162,7 +167,7 @@ public:
     bool mSizeLabel;
     bool isCenterViewCall;
     QString mHelpMsg;
-    void setPlayerRoomStyle(const int style);
+
 
 public slots:
     void slot_roomSelectionChanged();
@@ -175,7 +180,10 @@ public slots:
     void slot_customLineColor();
     void shiftZup();
     void shiftZdown();
-    void slot_switchArea(const QString&);
+#if (QT_VERSION) < (QT_VERSION_CHECK(5, 15, 0))
+    // This is ONLY used as a slot in older versions
+    void T2DMap::slot_switchArea(const QString& newAreaName)
+#endif
     void toggleShiftMode();
     void shiftUp();
     void shiftDown();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -182,7 +182,7 @@ public slots:
     void shiftZdown();
 #if (QT_VERSION) < (QT_VERSION_CHECK(5, 15, 0))
     // This is ONLY used as a slot in older versions
-    void T2DMap::slot_switchArea(const QString& newAreaName);
+    void slot_switchArea(const QString& newAreaName);
 #endif
     void toggleShiftMode();
     void shiftUp();

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -96,7 +96,11 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     connect(lineSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgMapper::slot_lineSize);
     connect(roomSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgMapper::slot_roomSize);
     connect(togglePanel, &QAbstractButton::pressed, this, &dlgMapper::slot_togglePanel);
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+    connect(showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
+#else
     connect(showArea, qOverload<const QString&>(&QComboBox::activated), mp2dMap, &T2DMap::slot_switchArea);
+#endif
     connect(dim2, &QAbstractButton::pressed, this, &dlgMapper::show2dView);
     connect(showRoomIDs, &QCheckBox::stateChanged, this, &dlgMapper::slot_toggleShowRoomIDs);
     connect(showRoomNames, &QCheckBox::stateChanged, this, &dlgMapper::slot_toggleShowRoomNames);
@@ -315,3 +319,13 @@ void dlgMapper::resetAreaComboBoxToPlayerRoomArea()
         qDebug() << "dlgResetAreaComboBoxTolayerRoomArea() warning: player room not valid.";
     }
 }
+
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+// Only needed in newer Qt versions as the old SIGNAL overload that returned the
+// QString of the activated QComboBox entry has been obsoleted:
+void dlgMapper::slot_switchArea(const int index)
+{
+    const QString areaName{showArea->itemText(index)};
+    mp2dMap->switchArea(areaName);
+}
+#endif

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -63,6 +63,10 @@ public slots:
     void slot_togglePanel();
     void slot_roomSize(int d);
     void slot_lineSize(int d);
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+    // Only used in newer Qt versions
+    void slot_switchArea(const int);
+#endif
 
 private:
     TMap* mpMap;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -625,7 +625,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     config->setAutocompleteAutoShow(mpHost->mEditorAutoComplete);
     config->endChanges();
 
-    connect(comboBox_searchTerms, qOverload<const QString&>(&QComboBox::activated), this, &dlgTriggerEditor::slot_searchMudletItems);
+    connect(comboBox_searchTerms, qOverload<int>(&QComboBox::activated), this, &dlgTriggerEditor::slot_searchMudletItems);
     connect(treeWidget_triggers, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_trigger_selected);
     connect(treeWidget_triggers, &QTreeWidget::itemSelectionChanged, this, &dlgTriggerEditor::slot_tree_selection_changed);
     connect(treeWidget_keys, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_key_selected);
@@ -1321,8 +1321,12 @@ void dlgTriggerEditor::slot_item_selected_search_list(QTreeWidgetItem* pItem)
     } // End of switch()
 }
 
-void dlgTriggerEditor::slot_searchMudletItems(const QString& s)
+void dlgTriggerEditor::slot_searchMudletItems(const int index)
 {
+    if (index < 0) {
+        return;
+    }
+    const QString s{comboBox_searchTerms->itemText(index)};
     if (s.isEmpty()) {
         return;
     }

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -254,7 +254,7 @@ public slots:
     void slot_add_new();
     void slot_add_new_folder();
     void slot_toggle_active();
-    void slot_searchMudletItems(const QString&); // Was slot_search_triggers(...)
+    void slot_searchMudletItems(const int);
     void slot_item_selected_search_list(QTreeWidgetItem*);
     void slot_delete_item();
     void slot_open_source_find();


### PR DESCRIPTION
This (overloaded) signal has been obsoleted and we must use the other (overload) that returns the index of the activated item rather than the text that we were using. For the one in the 2D mapper this is slightly more fiddly as we actually need to pass the text to another class whereas the editor case is simpler as it is used within the same class so we can use the alternate form almost as easily.

This should reduce the warnings by one or two for Qt 5.15

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>