### PR TITLE
Cleanup: replace obsolete in Qt 5.15 QComboBox::AdjustToMinimumContents

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1237,7 +1237,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <bool>true</bool>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>QComboBox::AdjustToContents</enum>
             </property>
            </widget>
           </item>
@@ -2076,7 +2076,7 @@ you can use it but there could be issues with aligning columns of text</string>
                 <number>0</number>
                </property>
                <property name="sizeAdjustPolicy">
-                <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                <enum>QComboBox::AdjustToContents</enum>
                </property>
                <item>
                 <property name="text">


### PR DESCRIPTION
This `enum` value has been deprecated and `QComboBox::AdjustToContents` seems to be the best alternative. There was a second case where `QComboBox::AdjustToMinimumContentsLengthWithIcon` was used (which is still valid) but since there is no icon used in that case it seemed sensible to change it to the other usable value as well.

This seems to reduce the warnings by about 5.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>