### PR TITLE
Cleanup: replace obsolete in Qt 5.15 QModelIndex::child(int row, int col)

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -201,7 +201,11 @@ void TTreeWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int
     }
 
     if (parent.isValid()) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+        QModelIndex child = parent.model()->index(start, 0);
+#else
         QModelIndex child = parent.child(start, 0);
+#endif
         mChildID = child.data(Qt::UserRole).toInt();
         if (mChildID == 0) {
             if (parent.isValid()) {
@@ -222,7 +226,11 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
     // determine position in parent list
 
     if (mIsDropAction) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+        QModelIndex child = parent.model()->index(start, 0);
+#else
         QModelIndex child = parent.child(start, 0);
+#endif
         int parentPosition = parent.row();
         int childPosition = child.row();
         if (mChildID == 0) {


### PR DESCRIPTION
We are directed to use `QAbstractItemModel::index()` instead.

This will reduce the warnings in Qt 5.15 or later by 2.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>