### PR TITLE
Cleanup: mark some more arguments as Q_UNUSED

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -190,6 +190,8 @@ void TTreeWidget::mousePressEvent(QMouseEvent* event)
 
 void TTreeWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end)
 {
+    Q_UNUSED(end)
+
     if (parent.isValid()) {
         mOldParentID = parent.data(Qt::UserRole).toInt();
     } else {
@@ -344,6 +346,9 @@ void TTreeWidget::dropEvent(QDropEvent* event)
 
 void TTreeWidget::beginInsertRows(const QModelIndex& parent, int first, int last)
 {
+    Q_UNUSED(parent)
+    Q_UNUSED(first)
+    Q_UNUSED(last)
 }
 
 void TTreeWidget::dragMoveEvent(QDragMoveEvent* e)


### PR DESCRIPTION
These are in the (overrides for virtual) methods that were erroneously nuked in #4383 but not in the replacement #4415 - however since they are still here their unused arguments needs to be marked to eliminate warnings about them.

This should remove 4 warnings.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>