### PR TITLE
Cleanup: remove deprecated QDockWidget::AllDockWidgetFeatures

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2695,7 +2695,7 @@ std::pair<bool, QString> Host::openWindow(const QString& name, bool loadLayout, 
         dockwidget = new TDockWidget(this, name);
         dockwidget->setObjectName(QStringLiteral("dockWindow_%1_%2").arg(hostName, name));
         dockwidget->setContentsMargins(0, 0, 0, 0);
-        dockwidget->setFeatures(QDockWidget::AllDockWidgetFeatures);
+        dockwidget->setFeatures(QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable);
         dockwidget->setWindowTitle(name);
         mpConsole->mDockWidgetMap.insert(name, dockwidget);
         // It wasn't obvious but the parent passed to the TConsole constructor


### PR DESCRIPTION
This has not been recommended at least as far back as Qt 5.11 because it is incompatible with the addition of new flags (values) to the enum - as has already happened by Qt 5.11. instead one is supposed to OR all the wanted feature flags together...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>