### PR TITLE
Cleanup: adopt "Rule of Three" requirements for TChar class

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018, 2020 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -51,16 +52,6 @@
 //#define DEBUG_MXP_PROCESSING
 
 
-// Default constructor:
-TChar::TChar()
-: mFgColor(Qt::white)
-, mBgColor(Qt::black)
-, mFlags(None)
-, mIsSelected(false)
-, mLinkIndex(0)
-{
-}
-
 TChar::TChar(const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags, const int linkIndex)
 : mFgColor(fg)
 , mBgColor(bg)
@@ -106,7 +97,8 @@ bool TChar::operator==(const TChar& other)
     return true;
 }
 
-// Copy constructor:
+// Copy constructor - because it is resetting the mIsSelected flag it is NOT a
+// default copy constructor:
 TChar::TChar(const TChar& copy)
 : mFgColor(copy.mFgColor)
 , mBgColor(copy.mBgColor)
@@ -2701,7 +2693,7 @@ void TBuffer::log(int fromLine, int toLine)
 
     // record the last log call into a temporary buffer - we'll actually log
     // on the next iteration after duplication detection has run
-    lastTextToLog = std::move(linesToLog.join(QString()));
+    lastTextToLog = linesToLog.join(QString());
     lastLoggedFromLine = fromLine;
     lastloggedToLine = toLine;
 }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2017-2018 by Stephen Lyons                        *
+ *   Copyright (C) 2015, 2017-2018, 2020 by Stephen Lyons                  *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -82,10 +82,19 @@ public:
     };
     Q_DECLARE_FLAGS(AttributeFlags, AttributeFlag)
 
-    TChar();
+    // Default constructor - the default argument means it can be used with no
+    // supplied arguments, but it must NOT be marked 'explicit' so as to allow
+    // this:
+    TChar(Host* pH = nullptr);
+    // A non-default constructor:
     TChar(const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkIndex = 0);
-    TChar(Host*);
+    // User defined copy-constructor:
     TChar(const TChar&);
+    // Under the rule of three, because we have a user defined copy-constructor,
+    // we should also have a destructor and an assignment operator but they can,
+    // in this case, be default ones:
+    TChar& operator=(const TChar&) = default;
+    ~TChar() = default;
 
     bool operator==(const TChar&);
     void setColors(const QColor& newForeGroundColor, const QColor& newBackGroundColor) {


### PR DESCRIPTION
Briefly: since we have a user-defined copy constructor we need to also have an assignment operator and a destructor - though they can be default ones.

I discovered this when getting a warning when using the Clang 10 compiler on FreeBSD and found out more about it on Stack Exchange at: https://stackoverflow.com/q/51863588/4805858

Also:
* Because the action of the previous default constructor and the one that takes a `Host*` is the same if the latter is give a `nullptr` argument the former is redundant and can be removed if we default the `Host*` argument for the latter and do NOT mark it as `explicit`.
* remove the `std::move(...)` wrapper at the end of `TBuffer::log(int, int)` as it is causing Clang 10 to warn: "Moving a temporary object prevents copy elision [-Wpessimizing-move]"

FTR this PR is about producing better code...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>