### PR TITLE
Cleanup: replace obsolete in Qt 4.3 QProcess::setReadChannelMode(...)

### DIFF
--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -2,6 +2,7 @@
  *   Copyright (C) 2009 by Benjamin Lerman - mudlet@ambre.net              *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Christer Oscarsson-christer.oscarsson@gmail.com *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -62,7 +63,7 @@ TForkedProcess::TForkedProcess(TLuaInterpreter* interpreter, lua_State* L) : QPr
     connect(this, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &TForkedProcess::slotFinish);
     connect(this, &QProcess::readyReadStandardOutput, this, &TForkedProcess::slotReceivedData);
 
-    setReadChannelMode(QProcess::MergedChannels);
+    setProcessChannelMode(QProcess::MergedChannels);
     start(prog, args, QIODevice::ReadWrite);
     waitForStarted();
     running = true;


### PR DESCRIPTION
The method has been obsoleted for a *very* long time and is causing a compiler warning: "warning: 'setReadChannelMode' is deprecated: Use QProcess::setProcessChannelMode() instead [-Wdeprecated-declarations]" .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>