### PR TITLE
Cleanup: sort out class vs. struct mixup

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2012-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015, 2017-2019 by Stephen Lyons                        *
+ *   Copyright (C) 2015, 2017-2020 by Stephen Lyons                        *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -37,7 +37,6 @@
 #include <QDirIterator>
 #include <QFileDialog>
 #include <QInputDialog>
-#include <zip.h>
 #include "post_guard.h"
 
 // We are now using code that won't work with really old versions of libzip:

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2019-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,11 +27,11 @@
 
 #include "pre_guard.h"
 #include <QDialog>
+#include <zip.h>
 #include "post_guard.h"
 
 class QTreeWidget;
 class QTreeWidgetItem;
-class zip;
 
 namespace Ui {
 class dlgPackageExporter;


### PR DESCRIPTION
As the zip element is a `struct` forward declaring it as a `class` in the `dlgPackageExporter` header is confusing for the compiler and can break things, producing a compiler message such as: "warning: struct 'zip' was previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]".

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>