### PR TITLE
Cleanup: use correct default argument in multi-arg method

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4227,7 +4227,7 @@ void T2DMap::slot_setRoomWeight()
                                                           0,                                                                // int current = 0, last value in list
                                                           true,                                                             // bool editable = true
                                                           &isOk,                                                            // bool * ok = 0
-                                                          nullptr,                                                                // Qt::WindowFlags flags = 0
+                                                          Qt::WindowFlags(),                                                // Qt::WindowFlags flags = 0
                                                           Qt::ImhDigitsOnly);                                               // Qt::InputMethodHints inputMethodHints = Qt::ImhNone
             newWeight = 1;
             if (isOk) { // Don't do anything if cancel was pressed


### PR DESCRIPTION
Not sure if this was something that has been cleaned up in later Qt versions or just something that my current compiler is more rigorous about but using a `nullptr` instead of a null `Qt::WindowsFlags()` was producing a "warning: 'QFlags' is deprecated: Use default constructor instead [-Wdeprecated-declarations]" warning.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>