### PR TITLE
Cleanup: remove unused class members in LuaInterface and XMLimport

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2013 by Chris Mitchell                                  *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -31,8 +32,7 @@
 static jmp_buf buf;
 
 LuaInterface::LuaInterface(Host* pH)
-: mpHost(pH)
-, mHostID(pH->getHostID())
+: mHostID(pH->getHostID())
 , depth()
 , interpreter(pH->getLuaInterpreter())
 , L()

--- a/src/LuaInterface.h
+++ b/src/LuaInterface.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2013 by Chris Mitchell                                  *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -44,7 +45,7 @@ class QTreeWidgetItem;
 class LuaInterface
 {
 public:
-    LuaInterface(Host*);
+    explicit LuaInterface(Host*);
     ~LuaInterface();
     void iterateTable(lua_State*, int, TVar*, bool);
     void getVars(bool);
@@ -68,7 +69,6 @@ public:
     static int onPanic(lua_State*);
 
 private:
-    Host* mpHost;
     int mHostID;
     int depth;
     TLuaInterpreter* interpreter;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -54,7 +54,6 @@ XMLimport::XMLimport(Host* pH)
 , gotScript(false)
 , module(0)
 , mMaxRoomId(0)
-, mMaxAreaId(-1)
 , mVersionMajor(1) // 0 to 255
 , mVersionMinor(0) // 0 to 999 for 3 digit decimal value
 {

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2017 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2017, 2020 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2017 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -122,7 +123,6 @@ private:
     bool gotScript;
     int module;
     int mMaxRoomId;
-    int mMaxAreaId; // Could be useful when iterating through map data
     quint8 mVersionMajor;
     quint16 mVersionMinor; // Cannot be a quint8 as that only allows x.255 for the decimal
 };


### PR DESCRIPTION
The `Host*` is never actually used inside the `LuaInterface` class, only in a non-default constructor. So it does not need to be retained as a class member.

As the default is never used either we can also mark the above constructor as `explicit`...

Also `mMaxAreaId` is declared in the `XMLimport` class but although a use had been considered it is not currently used for anything.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>