### PR TITLE
Cleanup: fix bit-wise logic in an if()

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -638,9 +638,8 @@ void TConsole::resizeEvent(QResizeEvent* event)
 
     if (mType & (CentralDebugConsole|ErrorConsole)) {
         layerCommandLine->hide();
-     // do nothing for SubConsole or UserWindows
-    } else if (mType & (!SubConsole|!UserWindow)) {
-        //layerCommandLine->move(0,mpMainFrame->height()-layerCommandLine->height());
+    } else if (mType & ~(SubConsole|UserWindow)) {
+        // does nothing for SubConsole or UserWindows
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());
     }
 


### PR DESCRIPTION
Repair a couple of warnings of type: "warning: enum constant in boolean context [-Wint-in-bool-context]"

This was introduced by PR #4055 .

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>