### PR TITLE
Cleanup: sort out enum and non-enum combination warnings

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3304,7 +3304,8 @@ void mudlet::playSound(const QString& s, int soundVolume)
 
 void mudlet::setEditorTextoptions(const bool isTabsAndSpacesToBeShown, const bool isLinesAndParagraphsToBeShown)
 {
-    mEditorTextOptions = QTextOption::Flags((isTabsAndSpacesToBeShown ? QTextOption::ShowTabsAndSpaces : 0) | (isLinesAndParagraphsToBeShown ? QTextOption::ShowLineAndParagraphSeparators : 0));
+    mEditorTextOptions = QTextOption::Flags((isTabsAndSpacesToBeShown ? QTextOption::ShowTabsAndSpaces : QTextOption::Flag())
+                                           |(isLinesAndParagraphsToBeShown ? QTextOption::ShowLineAndParagraphSeparators : QTextOption::Flag()));
     emit signal_editorTextOptionsChanged(mEditorTextOptions);
 }
 


### PR DESCRIPTION
Fixes a couple of: "warning: enumeral and non-enumeral type in conditional expression [-Wextra]" warnings.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>