### PR TITLE
Fix Mudlet's buttons to act on release

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -388,7 +388,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     replayButton->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(
         tr("Record a replay.")));
     replayButton->setIcon(QIcon(QStringLiteral(":/icons/media-tape.png")));
-    connect(replayButton, &QAbstractButton::pressed, this, &TConsole::slot_toggleReplayRecording);
+    connect(replayButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleReplayRecording);
 
     logButton = new QToolButton;
     logButton->setMinimumSize(QSize(30, 30));
@@ -402,7 +402,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     logIcon.addPixmap(QPixmap(QStringLiteral(":/icons/folder-downloads.png")), QIcon::Normal, QIcon::Off);
     logIcon.addPixmap(QPixmap(QStringLiteral(":/icons/folder-downloads-red-cross.png")), QIcon::Normal, QIcon::On);
     logButton->setIcon(logIcon);
-    connect(logButton, &QAbstractButton::pressed, this, &TConsole::slot_toggleLogging);
+    connect(logButton, &QAbstractButton::clicked, this, &TConsole::slot_toggleLogging);
 
     mpLineEdit_networkLatency->setReadOnly(true);
     mpLineEdit_networkLatency->setSizePolicy(sizePolicy4);

--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -54,13 +54,13 @@ dlgColorTrigger::dlgColorTrigger(QWidget* pF, TTrigger* pT, const bool isBackGro
     buttonBox->button(QDialogButtonBox::Apply)->setToolTip(tr("Click to access all 256 ANSI colors."));
     connect(buttonBox->button(QDialogButtonBox::Apply), &QAbstractButton::clicked, this, &dlgColorTrigger::slot_moreColorsClicked);
 
-    connect(buttonBox->button(QDialogButtonBox::Ignore), &QAbstractButton::pressed, this, &dlgColorTrigger::slot_resetColorClicked);
+    connect(buttonBox->button(QDialogButtonBox::Ignore), &QAbstractButton::clicked, this, &dlgColorTrigger::slot_resetColorClicked);
     buttonBox->button(QDialogButtonBox::Ignore)->setToolTip(mudlet::htmlWrapper(mIsBackground
                                                                                 ? tr("<p>Click to make the color trigger ignore the text's background color - however chosing this for both this and the foreground is an error.</p>")
                                                                                 : tr("<p>Click to make the color trigger ignore the text's foreground color - however chosing this for both this and the background is an error.</p>")));
     // The Reset button means trigger only if the text is not set to anything
     // so is in the "default" colour - what ever THAT is:
-    connect(buttonBox->button(QDialogButtonBox::Reset), &QAbstractButton::pressed, this, &dlgColorTrigger::slot_defaultColorClicked);
+    connect(buttonBox->button(QDialogButtonBox::Reset), &QAbstractButton::clicked, this, &dlgColorTrigger::slot_defaultColorClicked);
     buttonBox->button(QDialogButtonBox::Reset)->setText(tr("Default"));
     buttonBox->button(QDialogButtonBox::Reset)->setToolTip(mudlet::htmlWrapper(mIsBackground
                                                                                 ? tr("<p>Click to make the color trigger when the text's background color has not been modified from its normal value.</p>")

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -32,8 +32,8 @@ dlgComposer::dlgComposer(Host* pH) : mpHost(pH)
     setupUi(this);
     QFont f = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 10, QFont::Normal);
     edit->setFont(f);
-    connect(saveButton, &QAbstractButton::pressed, this, &dlgComposer::save);
-    connect(cancelButton, &QAbstractButton::pressed, this, &dlgComposer::cancel);
+    connect(saveButton, &QAbstractButton::clicked, this, &dlgComposer::save);
+    connect(cancelButton, &QAbstractButton::clicked, this, &dlgComposer::cancel);
     setAttribute(Qt::WA_DeleteOnClose);
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -87,21 +87,21 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     panel->setVisible(mpHost->mShowPanel);
     connect(bubbles, &QAbstractButton::clicked, this, &dlgMapper::slot_bubbles);
     connect(showInfo, &QAbstractButton::clicked, this, &dlgMapper::slot_info);
-    connect(shiftZup, &QAbstractButton::pressed, mp2dMap, &T2DMap::shiftZup);
-    connect(shiftZdown, &QAbstractButton::pressed, mp2dMap, &T2DMap::shiftZdown);
-    connect(shiftLeft, &QAbstractButton::pressed, mp2dMap, &T2DMap::shiftLeft);
-    connect(shiftRight, &QAbstractButton::pressed, mp2dMap, &T2DMap::shiftRight);
-    connect(shiftUp, &QAbstractButton::pressed, mp2dMap, &T2DMap::shiftUp);
-    connect(shiftDown, &QAbstractButton::pressed, mp2dMap, &T2DMap::shiftDown);
+    connect(shiftZup, &QAbstractButton::clicked, mp2dMap, &T2DMap::shiftZup);
+    connect(shiftZdown, &QAbstractButton::clicked, mp2dMap, &T2DMap::shiftZdown);
+    connect(shiftLeft, &QAbstractButton::clicked, mp2dMap, &T2DMap::shiftLeft);
+    connect(shiftRight, &QAbstractButton::clicked, mp2dMap, &T2DMap::shiftRight);
+    connect(shiftUp, &QAbstractButton::clicked, mp2dMap, &T2DMap::shiftUp);
+    connect(shiftDown, &QAbstractButton::clicked, mp2dMap, &T2DMap::shiftDown);
     connect(lineSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgMapper::slot_lineSize);
     connect(roomSize, qOverload<int>(&QSpinBox::valueChanged), this, &dlgMapper::slot_roomSize);
-    connect(togglePanel, &QAbstractButton::pressed, this, &dlgMapper::slot_togglePanel);
+    connect(togglePanel, &QAbstractButton::clicked, this, &dlgMapper::slot_togglePanel);
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     connect(showArea, qOverload<int>(&QComboBox::activated), this, &dlgMapper::slot_switchArea);
 #else
     connect(showArea, qOverload<const QString&>(&QComboBox::activated), mp2dMap, &T2DMap::slot_switchArea);
 #endif
-    connect(dim2, &QAbstractButton::pressed, this, &dlgMapper::show2dView);
+    connect(dim2, &QAbstractButton::clicked, this, &dlgMapper::show2dView);
     connect(showRoomIDs, &QCheckBox::stateChanged, this, &dlgMapper::slot_toggleShowRoomIDs);
     connect(showRoomNames, &QCheckBox::stateChanged, this, &dlgMapper::slot_toggleShowRoomNames);
 
@@ -219,22 +219,22 @@ void dlgMapper::show2dView()
 
         glWidget->mpMap = mpMap;
         mpMap->mpM = mpMap->mpMapper->glWidget;
-        connect(ortho, &QAbstractButton::pressed, glWidget, &GLWidget::fullView);
-        connect(singleLevel, &QAbstractButton::pressed, glWidget, &GLWidget::singleView);
-        connect(increaseTop, &QAbstractButton::pressed, glWidget, &GLWidget::increaseTop);
-        connect(increaseBottom, &QAbstractButton::pressed, glWidget, &GLWidget::increaseBottom);
-        connect(reduceTop, &QAbstractButton::pressed, glWidget, &GLWidget::reduceTop);
-        connect(reduceBottom, &QAbstractButton::pressed, glWidget, &GLWidget::reduceBottom);
-        connect(shiftZup, &QAbstractButton::pressed, glWidget, &GLWidget::shiftZup);
-        connect(shiftZdown, &QAbstractButton::pressed, glWidget, &GLWidget::shiftZdown);
-        connect(shiftLeft, &QAbstractButton::pressed, glWidget, &GLWidget::shiftLeft);
-        connect(shiftRight, &QAbstractButton::pressed, glWidget, &GLWidget::shiftRight);
-        connect(shiftUp, &QAbstractButton::pressed, glWidget, &GLWidget::shiftUp);
-        connect(shiftDown, &QAbstractButton::pressed, glWidget, &GLWidget::shiftDown);
+        connect(ortho, &QAbstractButton::clicked, glWidget, &GLWidget::fullView);
+        connect(singleLevel, &QAbstractButton::clicked, glWidget, &GLWidget::singleView);
+        connect(increaseTop, &QAbstractButton::clicked, glWidget, &GLWidget::increaseTop);
+        connect(increaseBottom, &QAbstractButton::clicked, glWidget, &GLWidget::increaseBottom);
+        connect(reduceTop, &QAbstractButton::clicked, glWidget, &GLWidget::reduceTop);
+        connect(reduceBottom, &QAbstractButton::clicked, glWidget, &GLWidget::reduceBottom);
+        connect(shiftZup, &QAbstractButton::clicked, glWidget, &GLWidget::shiftZup);
+        connect(shiftZdown, &QAbstractButton::clicked, glWidget, &GLWidget::shiftZdown);
+        connect(shiftLeft, &QAbstractButton::clicked, glWidget, &GLWidget::shiftLeft);
+        connect(shiftRight, &QAbstractButton::clicked, glWidget, &GLWidget::shiftRight);
+        connect(shiftUp, &QAbstractButton::clicked, glWidget, &GLWidget::shiftUp);
+        connect(shiftDown, &QAbstractButton::clicked, glWidget, &GLWidget::shiftDown);
         connect(showInfo, &QAbstractButton::clicked, glWidget, &GLWidget::showInfo);
-        connect(defaultView, &QAbstractButton::pressed, glWidget, &GLWidget::defaultView);
-        connect(sideView, &QAbstractButton::pressed, glWidget, &GLWidget::sideView);
-        connect(topView, &QAbstractButton::pressed, glWidget, &GLWidget::topView);
+        connect(defaultView, &QAbstractButton::clicked, glWidget, &GLWidget::defaultView);
+        connect(sideView, &QAbstractButton::clicked, glWidget, &GLWidget::sideView);
+        connect(topView, &QAbstractButton::clicked, glWidget, &GLWidget::topView);
         connect(scale, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setScale);
         connect(xRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setXRotation);
         connect(yRot, &QAbstractSlider::valueChanged, glWidget, &GLWidget::setYRotation);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -245,7 +245,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
     connect(checkBox_showLineFeedsAndParagraphs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs);
-    connect(closeButton, &QAbstractButton::pressed, this, &dlgProfilePreferences::slot_save_and_exit);
+    connect(closeButton, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_save_and_exit);
     connect(pMudlet, &mudlet::signal_hostCreated, this, &dlgProfilePreferences::slot_handleHostAddition);
     connect(pMudlet, &mudlet::signal_hostDestroyed, this, &dlgProfilePreferences::slot_handleHostDeletion);
     // Because QComboBox::currentIndexChanged has multiple (overloaded) forms we

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -702,8 +702,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     pLineEdit_searchTerm->addAction(mpAction_searchOptions, QLineEdit::LeadingPosition);
 
-    connect(mpScriptsMainArea->toolButton_script_add_event_handler, &QAbstractButton::pressed, this, &dlgTriggerEditor::slot_script_main_area_add_handler);
-    connect(mpScriptsMainArea->toolButton_script_remove_event_handler, &QAbstractButton::pressed, this, &dlgTriggerEditor::slot_script_main_area_delete_handler);
+    connect(mpScriptsMainArea->toolButton_script_add_event_handler, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_script_main_area_add_handler);
+    connect(mpScriptsMainArea->toolButton_script_remove_event_handler, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_script_main_area_delete_handler);
 
     mpTriggersMainArea->hide();
     mpTimersMainArea->hide();
@@ -800,8 +800,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         pBox->setItemIcon(6, icon_color_trigger);
         pBox->setItemIcon(7, icon_prompt);
         connect(pBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerEditor::slot_setupPatternControls);
-        connect(pItem->pushButton_fgColor, &QAbstractButton::pressed, this, &dlgTriggerEditor::slot_color_trigger_fg);
-        connect(pItem->pushButton_bgColor, &QAbstractButton::pressed, this, &dlgTriggerEditor::slot_color_trigger_bg);
+        connect(pItem->pushButton_fgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_color_trigger_fg);
+        connect(pItem->pushButton_bgColor, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_color_trigger_bg);
         HpatternList->layout()->addWidget(pItem);
         mTriggerPatternEdit.push_back(pItem);
         pItem->mRow = i;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix Mudlet's buttons to act on release, instead of just pressed and not released yet, which is incorrect UX.
#### Motivation for adding to Mudlet
Fix a minor, but a longstanding issue that the buttons don't quite work as people expect them to.
#### Other info (issues closed, discussion etc)
