### PR TITLE
Submit Github Actions-made builds to make.mudlet.org

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -218,10 +218,11 @@ jobs:
       with:
         name: ${{env.UPLOAD_FILENAME}}
         path: ${{env.FOLDER_TO_UPLOAD}}
-        
+
     - name: Submit to make.mudlet.org
       if: env.FOLDER_TO_UPLOAD
       run: |
+        curl "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts"
         curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
       shell: bash
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -222,7 +222,7 @@ jobs:
     - name: Submit to make.mudlet.org
       if: env.FOLDER_TO_UPLOAD
       run: |
-        curl --silent https://api.github.com/repos/Mudlet/Mudlet/actions/runs/$GITHUB_RUN_ID/artifacts | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
+        curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
       shell: bash
 
     - name: (windows) Show relevant logs logs

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -214,16 +214,14 @@ jobs:
 
     - name: Upload packaged Mudlet
       uses: actions/upload-artifact@v2
-      if: env.FOLDER_TO_UPLOAD
+      if: env.UPLOAD_FILENAME
       with:
         name: ${{env.UPLOAD_FILENAME}}
         path: ${{env.FOLDER_TO_UPLOAD}}
 
     - name: Submit to make.mudlet.org
-      if: env.FOLDER_TO_UPLOAD
-      run: |
-        echo "https://make.mudlet.org/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
-        curl "https://make.mudlet.org/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
+      if: env.UPLOAD_FILENAME
+      run: curl "https://make.mudlet.org/snapshots/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
       shell: bash
 
     - name: (windows) Show relevant logs logs

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -219,6 +219,13 @@ jobs:
         name: ${{env.UPLOAD_FILENAME}}
         path: ${{env.FOLDER_TO_UPLOAD}}
 
+    - name: Submit to make.mudlet.org
+      if: env.FOLDER_TO_UPLOAD
+      run: |
+        curl "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts"
+        curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
+      shell: bash
+
     - name: (windows) Show relevant logs logs
       if: failure() && runner.os == 'Windows'
       run: |
@@ -235,15 +242,3 @@ jobs:
           echo "CMakeOutput.log: "
           cat "${{runner.workspace}}/b/ninja/CMakeFiles/CMakeOutput.log"
         }
-
-  upload-mudlet:
-    name: upload to make.mudlet.org
-    runs-on: ubuntu-20.04
-    needs: compile-mudlet
-    steps:
-      - name: Submit to make.mudlet.org
-        run: |
-          curl "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts"
-          curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("x64-linux")).archive_download_url'
-        shell: bash
-    

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -221,7 +221,7 @@ jobs:
 
     - name: Submit to make.mudlet.org
       if: env.UPLOAD_FILENAME
-      run: curl -X POST "https://make.mudlet.org/snapshots/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
+      run: curl -X POST "https://make.mudlet.org/snapshots/gha_queue.php?artifact_name=${{env.UPLOAD_FILENAME}}&unzip=1"
       shell: bash
 
     - name: (windows) Show relevant logs logs

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -219,13 +219,6 @@ jobs:
         name: ${{env.UPLOAD_FILENAME}}
         path: ${{env.FOLDER_TO_UPLOAD}}
 
-    - name: Submit to make.mudlet.org
-      if: env.FOLDER_TO_UPLOAD
-      run: |
-        curl "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts"
-        curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
-      shell: bash
-
     - name: (windows) Show relevant logs logs
       if: failure() && runner.os == 'Windows'
       run: |
@@ -242,3 +235,15 @@ jobs:
           echo "CMakeOutput.log: "
           cat "${{runner.workspace}}/b/ninja/CMakeFiles/CMakeOutput.log"
         }
+
+  upload-mudlet:
+    name: upload to make.mudlet.org
+    runs-on: ubuntu-20.04
+    needs: compile-mudlet
+    steps:
+      - name: Submit to make.mudlet.org
+        run: |
+          curl "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts"
+          curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("x64-linux")).archive_download_url'
+        shell: bash
+    

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -222,8 +222,8 @@ jobs:
     - name: Submit to make.mudlet.org
       if: env.FOLDER_TO_UPLOAD
       run: |
-        curl "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts"
-        curl --silent "${GITHUB_API_URL}/repos/Mudlet/Mudlet/actions/runs/${GITHUB_RUN_ID}/artifacts" | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
+        echo "https://make.mudlet.org/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
+        curl "https://make.mudlet.org/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
       shell: bash
 
     - name: (windows) Show relevant logs logs

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -221,7 +221,7 @@ jobs:
 
     - name: Submit to make.mudlet.org
       if: env.UPLOAD_FILENAME
-      run: curl "https://make.mudlet.org/snapshots/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
+      run: curl -X POST "https://make.mudlet.org/snapshots/gha_queue.php?aname=${{env.UPLOAD_FILENAME}}&unzip=1"
       shell: bash
 
     - name: (windows) Show relevant logs logs

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -218,6 +218,12 @@ jobs:
       with:
         name: ${{env.UPLOAD_FILENAME}}
         path: ${{env.FOLDER_TO_UPLOAD}}
+        
+    - name: Submit to make.mudlet.org
+      if: env.FOLDER_TO_UPLOAD
+      run: |
+        curl --silent https://api.github.com/repos/Mudlet/Mudlet/actions/runs/$GITHUB_RUN_ID/artifacts | jq '.artifacts[] | select(.name | endswith("${{matrix.triplet}}")).archive_download_url'
+      shell: bash
 
     - name: (windows) Show relevant logs logs
       if: failure() && runner.os == 'Windows'


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Submit Github Actions-made builds to make.mudlet.org
#### Motivation for adding to Mudlet
So Github-built Mudlet builds show up on make.mudlet.org, where anyone can download them without signing into Github and we get a nice link for any download.
#### Other info (issues closed, discussion etc)
