### PR TITLE
Cleanup: replace deprecated in Qt 5.15 date format methodology

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -931,12 +931,12 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         } else {
             ssl_issuer_label->setText(cert.issuerInfo(QSslCertificate::CommonName).join(","));
             ssl_issued_label->setText(cert.subjectInfo(QSslCertificate::CommonName).join(","));
-            ssl_expires_label->setText(cert.expiryDate().toString(Qt::LocalDate));
+            ssl_expires_label->setText(cert.expiryDate().toString(mudlet::self()->getUserLocale().dateFormat(QLocale::ShortFormat)));
             ssl_serial_label->setText(QString::fromStdString(cert.serialNumber().toStdString()));
-            checkBox_self_signed->setStyleSheet("");
-            checkBox_expired->setStyleSheet("");
-            ssl_issuer_label->setStyleSheet("");
-            ssl_expires_label->setStyleSheet("");
+            checkBox_self_signed->setStyleSheet(QString());
+            checkBox_expired->setStyleSheet(QString());
+            ssl_issuer_label->setStyleSheet(QString());
+            ssl_expires_label->setStyleSheet(QString());
 
             if (!pHost->mTelnet.getSslErrors().empty()) {
                 // handle ssl errors


### PR DESCRIPTION
Qt pointedly makes it clear that many of the formats supported by `QDate::toString(...)` will be removed in Qt 6 and that the `Qt::DateFormat` `Qt::LocalDate` should be replaced by the `QString` that `QLocale::dateFormat(QLocale::ShortFormat)` returns for the system local.

As I have arranged for the `mudlet` class to have a `getUserLocale()` method that can return a `QLocale` to match that which the user has set to be used to customise it to their Language preferences it makes sense to use that to determine the actual (short) date format string to use.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>