### PR TITLE
Cleanup: replace obsolete in Qt 5.15 QSet:toList()

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -3209,7 +3209,7 @@ void dlgProfilePreferences::generateMapGlyphDisplay()
     while (itUsedSymbol.hasNext()) {
         itUsedSymbol.next();
         QString symbol = itUsedSymbol.key();
-        QList<int> roomsWithSymbol = itUsedSymbol.value().toList();
+        QList<int> roomsWithSymbol = itUsedSymbol.value().values();
         if (roomsWithSymbol.count() > 1) {
             std::sort(roomsWithSymbol.begin(), roomsWithSymbol.end());
         }


### PR DESCRIPTION
This seems to have been missed in a previous cleanup, perhaps because it is being used on the output of a `QHash` with values that are of the form of `QSet<int>`. The Qt documentation does say: "Note: Since Qt 5.14, range constructors are available for Qt's generic container classes and should be used in place of this method." so it may be that a further change will be needed but since I have already had one or two run ins with those range constructors I do not feel the urge to dive in on that right now.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>