### PR TITLE
Cleanup: remove undesirable unsigned to signed integer comparision

### DIFF
--- a/src/TMxpTagParser.cpp
+++ b/src/TMxpTagParser.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,7 +21,10 @@
 #include "TMxpTagParser.h"
 #include "TMxpNodeBuilder.h"
 #include "TStringUtils.h"
+
+#include "pre_guard.h"
 #include <QDebug>
+#include "post_guard.h"
 
 static QStringView stripTagAndTrim(const QString& tagText)
 {
@@ -42,10 +46,10 @@ QList<QSharedPointer<MxpNode>> TMxpTagParser::parseToMxpNodeList(const QString& 
     TMxpNodeBuilder nodeBuilder(ignoreText);
 
     QList<QSharedPointer<MxpNode>> result;
-    for (int i = 0; i < tagText.length(); i++) {
-        if (nodeBuilder.accept(tagText[i].toLatin1())) {
+    for (int i = 0; i < tagText.length(); ++i) {
+        if (nodeBuilder.accept(tagText.at(i).toLatin1())) {
             result.append(QSharedPointer<MxpNode>(nodeBuilder.buildNode()));
-            i--;
+            --i;
         }
     }
 
@@ -67,7 +71,7 @@ MxpEndTag* TMxpTagParser::parseEndTag(const QString& tagText) const
     const QStringList& parts = parseToList(tagContent);
 
     if (parts.size() > 1) {
-        qDebug() << "WARN: end tag " << tagText << " has attributes";
+        qWarning().noquote().nospace() << "TMxpTagParser::parseEndTag(\"" << tagText << "\") WARNING - this end tag has attributes.";
     }
 
     return new MxpEndTag(parts.first());
@@ -82,11 +86,11 @@ MxpStartTag* TMxpTagParser::parseStartTag(const QString& tagText) const
     const QString& name = parts.first();
 
     bool isClosed = parts.back() == "/";
-    size_t attrsEndIndex = isClosed ? parts.size() - 1 : parts.size();
+    int attrsEndIndex = isClosed ? parts.size() - 1 : parts.size();
 
     QList<MxpTagAttribute> attrs;
-    for (int i = 1; i < attrsEndIndex; i++) {
-        attrs.append(parseAttribute(parts[i]));
+    for (int i = 1; i < attrsEndIndex; ++i) {
+        attrs.append(parseAttribute(parts.at(i)));
     }
 
     return new MxpStartTag(name, attrs, isClosed);
@@ -108,20 +112,21 @@ MxpTagAttribute TMxpTagParser::parseAttribute(const QString& attr) const
 
     return MxpTagAttribute(name, value);
 }
+
 QStringList TMxpTagParser::parseToList(const QString& tagText)
 {
     return parseToList(QStringView(tagText));
 }
 
-QStringList TMxpTagParser::parseToList(QStringView tagText)
+QStringList TMxpTagParser::parseToList(const QStringView tagText)
 {
     QStringList result;
 
     int start = 0;
 
     while (start < tagText.length()) {
-        if (TStringUtils::isQuote(tagText[start])) {
-            auto end = readTextBlock(tagText, start + 1, tagText.length(), tagText[start]);
+        if (TStringUtils::isQuote(tagText.at(start))) {
+            auto end = readTextBlock(tagText, start + 1, tagText.length(), tagText.at(start));
             if (start != end) {
                 result.append(tagText.mid(start + 1, end - start - 1).toString());
             }
@@ -130,7 +135,7 @@ QStringList TMxpTagParser::parseToList(QStringView tagText)
             continue;
         }
 
-        if (!tagText[start].isSpace()) {
+        if (!tagText.at(start).isSpace()) {
             auto end = readTextBlock(tagText, start, tagText.length(), ' ');
             if (start != end) {
                 result.append(tagText.mid(start, end - start).toString());
@@ -140,35 +145,35 @@ QStringList TMxpTagParser::parseToList(QStringView tagText)
             continue;
         }
 
-        start++;
+        ++start;
     }
 
     return result;
 }
 
-int TMxpTagParser::readTextBlock(QStringView str, int start, int end, QChar terminatingChar)
+int TMxpTagParser::readTextBlock(QStringView str, const int start, const int end, const QChar terminatingChar)
 {
     bool inQuote = false;
-    QChar curQuote = 0;
+    QChar curQuote = QChar::Null;
 
     int pos = start;
     while (pos < end) {
-        if (!inQuote && str[pos] == terminatingChar) {
+        if (!inQuote && str.at(pos) == terminatingChar) {
             break;
         }
 
-        if (TStringUtils::isQuote(str[pos])) {
+        if (TStringUtils::isQuote(str.at(pos))) {
             if (!inQuote) {
                 inQuote = true;
-                curQuote = str[pos];
+                curQuote = str.at(pos);
             } else {
-                if (str[pos] == curQuote) {
+                if (str.at(pos) == curQuote) {
                     inQuote = false;
                 }
             }
         }
 
-        pos++;
+        ++pos;
     }
 
     return pos;

--- a/src/TMxpTagParser.h
+++ b/src/TMxpTagParser.h
@@ -1,9 +1,9 @@
-
 #ifndef MUDLET_TMXPTAGPARSER_H
 #define MUDLET_TMXPTAGPARSER_H
 
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -32,10 +32,10 @@
 
 class TMxpTagParser
 {
-    static int readTextBlock(QStringView str, int start, int end, QChar terminatingChar);
+    static int readTextBlock(QStringView str, const int start, const int end, const QChar terminatingChar);
 
 public:
-    static QStringList parseToList(QStringView tagText);
+    static QStringList parseToList(const QStringView tagText);
     static QStringList parseToList(const QString& tagText);
 
     QList<QSharedPointer<MxpNode>> parseToMxpNodeList(const QString& tagText, bool ignoreText = false) const;


### PR DESCRIPTION
This originally was just going to convert a use of `size_t` to hold the result of a Qt class `::size()` when they use `int` - so as to avoid a warning about comparing signed and unsigned integers. However I spotted some other "improvements" that could be made in the same class by using `::at(int)` instead of `::operator[int]`; by marking unchangable things as `const` and using pre-increment rather than the slower post-increment operator.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>