### PR TITLE
Cleanup: replace obsolete in Qt 5.15 QNetworkRequest elements

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2662,12 +2662,16 @@ void mudlet::updateMudletDiscordInvite()
     QUrl url(QStringLiteral("https://discord.com/api/guilds/283581582550237184/widget.json"));
     QNetworkRequest request(url);
     request.setRawHeader(QByteArray("User-Agent"), QByteArray(QStringLiteral("Mozilla/5.0 (Mudlet/%1%2)").arg(APP_VERSION, APP_BUILD).toUtf8().constData()));
-    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
 
     QNetworkReply* getReply = manager->get(request);
 
-    connect(getReply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error), this, [=](QNetworkReply::NetworkError) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+    connect(getReply, &QNetworkReply::errorOccurred, this, [=](QNetworkReply::NetworkError) {
+#else
+    connect(getReply, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this, [=](QNetworkReply::NetworkError) {
+#endif
         qWarning() << "mudlet::updateMudletDiscordInvite() WARNING - couldn't download " << url.url() << " to update Mudlet's Discord invite link";
         getReply->deleteLater();
     });


### PR DESCRIPTION
Replace the `bool`-ean `QNetworkRequest::attribute` `QNetworkRequest::FollowRedirectsAttribute` with the `enum` `QNetworkRequest::RedirectPolicyAttribute` and set that to the equivalent `QNetworkRequest::NoLessSafeRedirectPolicy` - this has been available since Qt 5.9 so it can be applied unconditionally to our code.

Replace the overloaded signal `(void) QNetworkReply::error(QNetworkReply::NetworkError)` with the not overloaded and introduced in Qt 5.15: `(void) QNetworkReply::errorOccurred(QNetworkReply::NetworkError)` .

Also, use the special cast `qOverload<T1>(T2::method)` that Qt provides for the older overload rather than the generic (and more verbose) `static_cast` form!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>