### PR TITLE
Cleanup: replace obsolete in Qt 5.11 qrand() & qsrand()

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
- *   Copyright (C) 2014-2019 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2020 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,6 +29,7 @@
 #include <QJsonObject>
 #include <QMediaPlaylist>
 #include <QNetworkDiskCache>
+#include <QRandomGenerator>
 #include <QStandardPaths>
 #include "post_guard.h"
 
@@ -760,7 +761,7 @@ void TMedia::play(TMediaData& mediaData)
 
     if (mediaData.getMediaLoops() == TMediaData::MediaLoopsDefault) { // Play once
         if (fileNameList.size() > 1) {
-            absolutePathFileName = fileNameList.at(qrand() % fileNameList.size());
+            absolutePathFileName = fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()));
         } else {
             absolutePathFileName = fileNameList.at(0);
         }
@@ -779,7 +780,7 @@ void TMedia::play(TMediaData& mediaData)
 
         if (mediaData.getMediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
             if (fileNameList.size() > 1) {
-                absolutePathFileName = fileNameList.at(qrand() % fileNameList.size());
+                absolutePathFileName = fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()));
             } else {
                 absolutePathFileName = fileNameList.at(0);
             }
@@ -801,7 +802,7 @@ void TMedia::play(TMediaData& mediaData)
 
             for (int k = 0; k < mediaData.getMediaLoops(); k++) { // Repeat a finite number of times
                 if (fileNameList.size() > 1) {
-                    absolutePathFileName = fileNameList.at(qrand() % fileNameList.size());
+                    absolutePathFileName = fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()));
                 } else {
                     absolutePathFileName = fileNameList.at(0);
                 }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -32,6 +32,7 @@
 
 #include "pre_guard.h"
 #include <QtUiTools>
+#include <QRandomGenerator>
 #include <QSettings>
 #include <sstream>
 #include "post_guard.h"
@@ -1511,7 +1512,7 @@ void dlgConnectionProfiles::fillout_form()
         // make sure not to select the test_profile though
         if (profiles_tree_widget->count() > 1) {
             while (toselectRow == -1 || toselectRow == test_profile_row) {
-                toselectRow = qrand() % profiles_tree_widget->count();
+                toselectRow = QRandomGenerator::global()->bounded(profiles_tree_widget->count());
             }
         }
     }

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2522,8 +2522,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         }
 
         if (newIrcNick.isEmpty()) {
-            qsrand(QTime::currentTime().msec());
-            newIrcNick = QString("%1%2").arg(dlgIRC::DefaultNickName, QString::number(rand() % 10000));
+            newIrcNick = QString("%1%2").arg(dlgIRC::DefaultNickName, QString::number(QRandomGenerator::global()->bounded(10000)));
         }
 
         if (!newIrcChannels.isEmpty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,9 +333,6 @@ int main(int argc, char* argv[])
     }
     app->processEvents();
 
-    // seed random number generator (should be done once per lifetime)
-    qsrand(static_cast<quint64>(QTime::currentTime().msecsSinceStartOfDay()));
-
     QString homeDirectory = mudlet::getMudletPath(mudlet::mainPath);
     QDir dir;
     bool first_launch = false;


### PR DESCRIPTION
The replacement `QRandomGenerator` class has been around since Qt 5.10; it is also true that the original `qrand()` (needing a call to `qsrand()` once per application run to seed it) has been deprecated since Qt 5.11.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>