### PR TITLE
Cleanup: change enum from Qt::MidButton to Qt::MiddleButton

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2020,7 +2020,7 @@ void TConsole::raiseMudletMousePressOrReleaseEvent(QMouseEvent* event, const boo
     switch (event->button()) {
     case Qt::LeftButton:    mudletEvent.mArgumentList.append(QString::number(1));   break;
     case Qt::RightButton:   mudletEvent.mArgumentList.append(QString::number(2));   break;
-    case Qt::MidButton:     mudletEvent.mArgumentList.append(QString::number(3));   break;
+    case Qt::MiddleButton:  mudletEvent.mArgumentList.append(QString::number(3));   break;
     case Qt::BackButton:    mudletEvent.mArgumentList.append(QString::number(4));   break;
     case Qt::ForwardButton: mudletEvent.mArgumentList.append(QString::number(5));   break;
     case Qt::TaskButton:    mudletEvent.mArgumentList.append(QString::number(6));   break;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -67,7 +67,7 @@
 
 const QMap<Qt::MouseButton, QString> TLuaInterpreter::mMouseButtons = {
         {Qt::NoButton, QStringLiteral("NoButton")},           {Qt::LeftButton, QStringLiteral("LeftButton")},       {Qt::RightButton, QStringLiteral("RightButton")},
-        {Qt::MidButton, QStringLiteral("MidButton")},         {Qt::BackButton, QStringLiteral("BackButton")},       {Qt::ForwardButton, QStringLiteral("ForwardButton")},
+        {Qt::MiddleButton, QStringLiteral("MidButton")},      {Qt::BackButton, QStringLiteral("BackButton")},       {Qt::ForwardButton, QStringLiteral("ForwardButton")},
         {Qt::TaskButton, QStringLiteral("TaskButton")},       {Qt::ExtraButton4, QStringLiteral("ExtraButton4")},   {Qt::ExtraButton5, QStringLiteral("ExtraButton5")},
         {Qt::ExtraButton6, QStringLiteral("ExtraButton6")},   {Qt::ExtraButton7, QStringLiteral("ExtraButton7")},   {Qt::ExtraButton8, QStringLiteral("ExtraButton8")},
         {Qt::ExtraButton9, QStringLiteral("ExtraButton9")},   {Qt::ExtraButton10, QStringLiteral("ExtraButton10")}, {Qt::ExtraButton11, QStringLiteral("ExtraButton11")},

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1331,7 +1331,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         return;
     }
 
-    if (event->button() == Qt::MidButton) {
+    if (event->button() == Qt::MiddleButton) {
         mpConsole->mLowerPane->mCursorY = mpConsole->buffer.size(); //
         mpConsole->mLowerPane->hide();
         mpBuffer->mCursorY = mpBuffer->size();


### PR DESCRIPTION
The newer form is good at least as far back as Qt 5.11 but the shorter form is now being warned about in, it seems, in Qt 5.15.2 and later...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>