### PR TITLE
Cleanup: remove unused retention of method return value

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -615,7 +615,7 @@ void XMLimport::readUnknownPackage()
         }
 
         if (isStartElement()) {
-            auto result = readPackage();
+            readPackage();
         }
     }
 }


### PR DESCRIPTION
Since we do not use it in this case there is no point in storing it, as this is prompting an unused variable warning and there is not really a conceivable use for this particular case. The method is called in two other places and the result used in only one of them as well!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>