### PR TITLE
Cleanup: replace obsolete in Qt 5.11 use of QDesktopWidget

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,14 +26,14 @@
 
 #include "pre_guard.h"
 #include <chrono>
-#include <QDesktopWidget>
+#include <QCommandLineParser>
 #include <QDir>
 #if defined(Q_OS_WIN32) && !defined(INCLUDE_UPDATER)
 #include <QMessageBox>
 #endif // defined(Q_OS_WIN32) && !defined(INCLUDE_UPDATER)
 #include <QPainter>
+#include <QScreen>
 #include <QSplashScreen>
-#include <QCommandLineParser>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;
@@ -327,7 +327,15 @@ int main(int argc, char* argv[])
         copyrightTextLayout.draw(&painter, QPointF(0, 0));
     }
     QPixmap pixmap = QPixmap::fromImage(splashImage);
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
+    // Specifying the screen here seems to help to put the splash screen on the
+    // same monitor that the main application window will be put upon on first
+    // run, in some situations the two can otherwise get to be different which
+    // is misleading unhelpful to a new user...!
+    QSplashScreen splash(qApp->primaryScreen(), pixmap);
+#else
     QSplashScreen splash(pixmap);
+#endif
     if (show_splash) {
         splash.show();
     }
@@ -450,11 +458,20 @@ int main(int argc, char* argv[])
     mudlet::start();
 
     if (first_launch) {
-        // give Mudlet window decent size - most of the screen on non-HiDPI displays
-        auto desktop = qApp->desktop();
-        auto initialSpace = desktop->availableGeometry(desktop->screenNumber());
-        mudlet::self()->resize(initialSpace.width() * 3 / 4, initialSpace.height() * 3 / 4);
-        mudlet::self()->move(initialSpace.width() / 8, initialSpace.height() / 8);
+        // give Mudlet window decent size - most of the screen on non-HiDPI
+        // displays, on which ever screen it is started up on if it is a virtual
+        // multi-screen setup:
+        auto pScreen = qApp->primaryScreen();
+        // This is the coordinates of the WHOLE of the screen in pixels, for a
+        // virtual desktop - this is likely to be a subset of the virtual
+        // desktop. However it may also include parts that are used by the OS
+        // for taskbars, etc.
+        const QRect geometry = pScreen->geometry();
+        // The available size within the above that does not include the
+        // reserved parts:
+        const QSize availableSize = pScreen->availableSize();
+        mudlet::self()->resize(availableSize.width() * 3 / 4, availableSize.height() * 3 / 4);
+        mudlet::self()->move(geometry.left() + (availableSize.width() / 8), geometry.top() + availableSize.height() / 8);
     }
 
     if (show_splash) {


### PR DESCRIPTION
The whole class was declared obsolete before Qt 5.11. It seems that one is supposed to consider instead the data retrievable from `QList<QScreen*>`. Annoyingly it is made clear that `QScreen::availableGeometry()` does not produce reliable results on X11 due to a limitation on the specification.

Also:
* As of Qt 5.15 it is possible to direct the screen (monitor) to which a Splash-screen is applied, I noticed that this was not always to the same monitor to which the main Mudlet window was sent.  I have arranged for them now to both be applied to the primary screen, which definitely works for main application window but I am not so sure the splash screen follows the instruction...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>