### PR TITLE
validate permKey function argument before actually create permKey

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8243,9 +8243,9 @@ int TLuaInterpreter::permKey(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    auto validationResult = pLuaInterpreter->validLuaCode(luaFunction);
-    if(!validationResult.first) {
-        lua_pushfstring(L, "permKey: bad argument #%d type (%s)", argIndex, validationResult.second.toUtf8().constData());
+    auto [validationResult, validationMessage] = pLuaInterpreter->validLuaCode(luaFunction);
+    if(!validationResult) {
+        lua_pushfstring(L, "permKey: bad argument #%d type (%s)", argIndex, validationMessage.toUtf8().constData());
         return lua_error(L);
     }
     int keyID = pLuaInterpreter->startPermKey(keyName, parentGroup, keyCode, keyModifier, luaFunction);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13942,13 +13942,14 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
 std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString &code)
 {
     lua_State* L = pGlobalLua;
-    int error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), "Lua code validation");
+    int error = luaL_loadbuffer(L, code.toUtf8().constData(), strlen(code.toUtf8().constData()), code.toUtf8().data());
     int topElementIndex = lua_gettop(L);
-    QString e = "No error message available from Lua";
+    QString e = "";
     if (error) {
-        e = "Lua syntax error:";
         if (lua_isstring(L, topElementIndex)) {
-            e.append(lua_tostring(L, topElementIndex));
+            e = lua_tostring(L, topElementIndex);
+        } else {
+            e = "No error message available from Lua";
         }
     }
     lua_pop(L, topElementIndex);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8245,7 +8245,7 @@ int TLuaInterpreter::permKey(lua_State* L)
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
     auto validationResult = pLuaInterpreter->validLuaCode(luaFunction);
     if(!validationResult.first) {
-        lua_pushfstring(L, "permKey: bad argument #%d type (%s)", argIndex, validationResult.second.toUtf8().constData());
+        lua_pushfstring(L, "permKey: bad argument #%d (invalid Lua code: %s)", argIndex, validationResult.second.toUtf8().constData());
         return lua_error(L);
     }
     int keyID = pLuaInterpreter->startPermKey(keyName, parentGroup, keyCode, keyModifier, luaFunction);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8243,8 +8243,7 @@ int TLuaInterpreter::permKey(lua_State* L)
 
     Host& host = getHostFromLua(L);
     TLuaInterpreter* pLuaInterpreter = host.getLuaInterpreter();
-    auto [validationResult, validationMessage] = pLuaInterpreter->validLuaCode(luaFunction);
-    if (!validationResult) {
+    if (auto [validationResult, validationMessage] = pLuaInterpreter->validLuaCode(luaFunction); !validationResult) {
         lua_pushfstring(L, "permKey: bad argument #%d (invalid Lua code: %s)", argIndex, validationMessage.toUtf8().constData());
         return lua_error(L);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13938,7 +13938,8 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
 }
 
 // No documentation available in wiki - internal function
-// returns pair where first if the given Lua code is valid, false otherwise
+// returns pair where first is bool stating true the given Lua code is valid, false otherwise
+// second is empty if code is valid, error message if not valid
 std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString &code)
 {
     lua_State* L = pGlobalLua;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -596,7 +596,7 @@ private:
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);
-    bool validLuaCode(const QString &code);
+    std::pair<bool, QString> validLuaCode(const QString &code);
     QByteArray encodeBytes(const char*);
     void setMatches(lua_State* L);
     static std::pair<bool, QString> discordApiEnabled(lua_State* L, bool writeAccess = false);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Went from some TODO/FIXME comments and found this easy enough to fix.
This add validation for last argment in `permKey` which is lua code as string.
Will not create key if function is not valid lua code.

#### Motivation for adding to Mudlet

Better argument validation in `permKey`

#### Other info (issues closed, discussion etc)
Mentioned in #3539
