### PR TITLE
BugFix: correct QRegularExpression warnings on profile save

### DIFF
--- a/src/TAction.h
+++ b/src/TAction.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,7 +29,6 @@
 #include <QColor>
 #include <QIcon>
 #include <QPointer>
-#include <QRegularExpression>
 #include "post_guard.h"
 
 class Host;
@@ -111,7 +110,6 @@ public:
     QString mName;
     QString mCommandButtonUp;
     QString mCommandButtonDown;
-    QRegularExpression mRegex;
     QString mScript;
     bool mIsPushDownButton;
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -42,7 +42,6 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
-#include <QRegularExpression>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QTextBoundaryFinder>

--- a/src/TKey.h
+++ b/src/TKey.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,7 +27,6 @@
 
 #include "pre_guard.h"
 #include <QPointer>
-#include <QRegularExpression>
 #include "post_guard.h"
 
 class Host;
@@ -85,7 +84,6 @@ private:
     int mKeyModifier;
 
     QString mRegexCode;
-    QRegularExpression mRegex;
     QString mScript;
     QString mFuncName;
     QPointer<Host> mpHost;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -41,7 +41,6 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
-#include <QRegularExpression>
 #include <QScrollBar>
 #include <QShortcut>
 #include <QTextBoundaryFinder>

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -31,7 +31,6 @@
 #include "pre_guard.h"
 #include <QString>
 #include <QStringBuilder>
-#include <QRegularExpression>
 #include "post_guard.h"
 
 // Helper needed to allow Qt::PenStyle enum to be unserialised (read from file)

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -1152,7 +1152,7 @@ QStringList XMLexport::remapAnsiToColorNumber(const QStringList & patternList, c
 {
 
     QStringList results;
-    QRegularExpression regex = QRegularExpression(QStringLiteral("(^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
+    QRegularExpression regex = QRegularExpression(QStringLiteral("^ANSI_COLORS_F{(\\d+|IGNORE|DEFAULT)}_B{(\\d+|IGNORE|DEFAULT)}$"));
     QStringListIterator itPattern(patternList);
     QListIterator<int> itType(typeList);
     while (itPattern.hasNext() && itType.hasNext()) {


### PR DESCRIPTION
This was causing messages of the form: `'QRegularExpressionPrivate::doMatch(): called on an invalid QRegularExpression object'` whenever a color trigger was saved. It was due to an error in the regular expression defined in: `QStringList XMLexport::remapAnsiToColorNumber(const QStringList&, const QList<int>&)`

Also remove unneeded `#include <QRegularExpression>`  in classes that do not need it.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>