### PR TITLE
Dark mode improvement for connection dialog

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -255,7 +255,6 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
     }
 #endif
 
-    mRegularPalette.setColor(QPalette::Base, QColor(Qt::transparent));
     mReadOnlyPalette.setColor(QPalette::Base, QColor(125, 125, 125, 25));
     mOKPalette.setColor(QPalette::Base, QColor(150, 255, 150, 50));
     mErrorPalette.setColor(QPalette::Base, QColor(255, 150, 150, 50));

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -255,25 +255,10 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
     }
 #endif
 
-    mRegularPalette.setColor(QPalette::Text, QColor(0, 0, 192));
-    mRegularPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
-    mRegularPalette.setColor(QPalette::HighlightedText, QColor(Qt::white));
-    mRegularPalette.setColor(QPalette::Base, QColor(Qt::white));
-
-    mReadOnlyPalette.setColor(QPalette::Base, QColor(212, 212, 212));
-    mReadOnlyPalette.setColor(QPalette::Text, QColor(0, 0, 192));
-    mReadOnlyPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
-    mReadOnlyPalette.setColor(QPalette::HighlightedText, QColor(Qt::white));
-
-    mOKPalette.setColor(QPalette::Text, QColor(0, 0, 192));
-    mOKPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
-    mOKPalette.setColor(QPalette::HighlightedText, QColor(Qt::white));
-    mOKPalette.setColor(QPalette::Base, QColor(235, 255, 235));
-
-    mErrorPalette.setColor(QPalette::Text, QColor(0, 0, 192));
-    mErrorPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
-    mErrorPalette.setColor(QPalette::HighlightedText, QColor(Qt::white));
-    mErrorPalette.setColor(QPalette::Base, QColor(255, 235, 235));
+    mRegularPalette.setColor(QPalette::Base, QColor(Qt::transparent));
+    mReadOnlyPalette.setColor(QPalette::HighlightedText, QColor(Qt::transparent));
+    mOKPalette.setColor(QPalette::Base, QColor(200, 255, 200, 50));
+    mErrorPalette.setColor(QPalette::Base, QColor(255, 200, 200, 50));
 
     profiles_tree_widget->setViewMode(QListView::IconMode);
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -258,7 +258,7 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
     mRegularPalette.setColor(QPalette::Base, QColor(Qt::transparent));
     mReadOnlyPalette.setColor(QPalette::Base, QColor(125, 125, 125, 25));
     mOKPalette.setColor(QPalette::Base, QColor(150, 255, 150, 50));
-    mErrorPalette.setColor(QPalette::Base, QColor(150, 200, 150, 50));
+    mErrorPalette.setColor(QPalette::Base, QColor(255, 150, 150, 50));
 
     profiles_tree_widget->setViewMode(QListView::IconMode);
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -256,9 +256,9 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
 #endif
 
     mRegularPalette.setColor(QPalette::Base, QColor(Qt::transparent));
-    mReadOnlyPalette.setColor(QPalette::HighlightedText, QColor(Qt::transparent));
-    mOKPalette.setColor(QPalette::Base, QColor(200, 255, 200, 50));
-    mErrorPalette.setColor(QPalette::Base, QColor(255, 200, 200, 50));
+    mReadOnlyPalette.setColor(QPalette::Base, QColor(125, 125, 125, 25));
+    mOKPalette.setColor(QPalette::Base, QColor(150, 255, 150, 50));
+    mErrorPalette.setColor(QPalette::Base, QColor(150, 200, 150, 50));
 
     profiles_tree_widget->setViewMode(QListView::IconMode);
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Simplified pallets used for fields: profile name, host and port. They will consist only from semitransparent background.
![image](https://user-images.githubusercontent.com/3740628/103157487-7609bd80-47b3-11eb-89a1-1f99801e045b.png)
![image](https://user-images.githubusercontent.com/3740628/103157619-1f9d7e80-47b5-11eb-8bde-2e1569975033.png)

#### Motivation for adding to Mudlet

Previous state looks wrong.
![image](https://user-images.githubusercontent.com/3740628/103157469-62f6ed80-47b3-11eb-99c7-4e5489fe2985.png)

#### Other info (issues closed, discussion etc)
Calcification: This imperfect fill is present with my local builds, even before change. 