### PR TITLE
Cleanup: replace more obsolete in Qt 5.14 QNetworkRequest::canonicalUrl()

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -622,10 +622,15 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
         if (state == QMediaPlayer::StoppedState) {
             TEvent mediaFinished{};
             mediaFinished.mArgumentList.append("sysMediaFinished");
-            mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().request().url().fileName());
+            mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().request().url().path());
+#else
             mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().canonicalUrl().fileName());
-            mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().canonicalUrl().path());
+#endif
+            mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+            mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
             if (mpHost) {
@@ -649,7 +654,11 @@ TMediaPlayer TMedia::matchMediaPlayer(TMediaData& mediaData, const QString& abso
         TMediaPlayer pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+            if (pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)) { // Is the same sound or music playing?
+#else
             if (pTestPlayer.getMediaPlayer()->media().canonicalUrl().toString().endsWith(absolutePathFileName)) { // Is the same sound or music playing?
+#endif
                 pPlayer = pTestPlayer;
                 pPlayer.setMediaData(mediaData);
                 pPlayer.getMediaPlayer()->setVolume(mediaData.getMediaVolume());
@@ -679,7 +688,11 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
         TMediaPlayer pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+            if (!pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
+#else
             if (!pTestPlayer.getMediaPlayer()->media().canonicalUrl().toString().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
+#endif
                 if (pTestPlayer.getMediaData().getMediaPriority() != TMediaData::MediaPriorityNotSet && pTestPlayer.getMediaData().getMediaPriority() > maxMediaPriority) {
                     maxMediaPriority = pTestPlayer.getMediaData().getMediaPriority();
                 }
@@ -712,7 +725,11 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (!mediaData.getMediaKey().isEmpty() && !pTestPlayer.getMediaData().getMediaKey().isEmpty()
                 && mediaData.getMediaKey() == pTestPlayer.getMediaData().getMediaKey()) { // Does it have the same key?
+#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
+                if (!pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)
+#else
                 if (!pTestPlayer.getMediaPlayer()->media().canonicalUrl().toString().endsWith(absolutePathFileName)
+#endif
                     || (!mediaData.getMediaUrl().isEmpty() && !pTestPlayer.getMediaData().getMediaUrl().isEmpty()
                         && mediaData.getMediaUrl() != pTestPlayer.getMediaData().getMediaUrl())) { // Is it a different sound or music than specified?
                     TMediaData stopMediaData = pTestPlayer.getMediaData();


### PR DESCRIPTION
This should remove another 5 warnings.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>