### PR TITLE
Refactor: remove unneeded data from map file format and classes

### DIFF
--- a/src/TArea.h
+++ b/src/TArea.h
@@ -75,9 +75,6 @@ public:
     QMap<int, int> xmaxForZ;
     QMap<int, int> yminForZ;
     QMap<int, int> ymaxForZ;
-// Pointless:
-//    QMap<int, int> zminForZ;
-//    QMap<int, int> zmaxForZ;
     QList<int> zLevels; // The z-levels that ARE used, not guaranteed to be in order
     bool gridMode;
     bool isZone;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1136,7 +1136,9 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
             ofs << itL2.key(); //label ID
             TMapLabel label = itL2.value();
             ofs << label.pos;
-            ofs << label.pointer;
+            if (mSaveVersion < 21) {
+                ofs << QPointF();
+            }
             ofs << label.size;
             ofs << label.text;
             ofs << label.fgColor;
@@ -1547,7 +1549,12 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                         ifs >> __label_pos;
                         label.pos = QVector3D(__label_pos.x(), __label_pos.y(), 0);
                     }
-                    ifs >> label.pointer;
+                    if (mVersion < 21) {
+                        // There was an unused QPointF in versions prior to 21
+                        QPointF dummyPointF;
+                        ifs >> dummyPointF;
+                        Q_UNUSED(dummyPointF)
+                    }
                     ifs >> label.size;
                     ifs >> label.text;
                     ifs >> label.fgColor;
@@ -1815,7 +1822,11 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
                     ifs >> __label_pos;
                     label.pos = QVector3D(__label_pos.x(), __label_pos.y(), 0);
                 }
-                ifs >> label.pointer;
+                if (mSaveVersion < 21) {
+                    QPointF dummyPointF;
+                    ifs >> dummyPointF;
+                    Q_UNUSED(dummyPointF)
+                }
                 ifs >> label.size;
                 ifs >> label.text;
                 ifs >> label.fgColor;

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -67,7 +67,6 @@ public:
     }
 
     QVector3D pos;
-    QPointF pointer;
     QSizeF size;
     QSizeF clickSize;
     QString text;

--- a/src/TRoom.h
+++ b/src/TRoom.h
@@ -31,7 +31,6 @@
 #include <QColor>
 #include <QHash>
 #include <QMap>
-#include <QVector3D>
 #include "post_guard.h"
 
 
@@ -145,7 +144,7 @@ public:
     qreal max_y;
     QString mSymbol;
     QString name;
-    QVector3D v;
+
     QList<int> exitStubs; //contains a list of: exittype (according to defined values above)
     QMap<QString, QString> userData;
     QList<int> exitLocks;


### PR DESCRIPTION
The map file format stuff won't take effect until the next map version is enabled.

Remove unused:
* `(QPointF) TMapLabel::pointer` completely.
* `(QVector3D) TRoom::v` completely.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>