### PR TITLE
add more information to return table from getMapLabel (colors and bas…

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9991,7 +9991,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
     return 1;
 }
 
-void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, TMapLabel& label)
+void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel& label)
 {
     int x = label.pos.x();
     int y = label.pos.y();
@@ -10018,7 +10018,7 @@ void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, TMapLabel& label
     lua_pushstring(L, text.toUtf8().constData());
     lua_settable(L, -3);
     lua_pushstring(L, "Pixmap");
-    lua_pushstring(L, label.base64EncodePixmap().toUtf8().constData());
+    lua_pushstring(L, label.base64EncodePixmap().constData());
     lua_settable(L, -3);
     lua_pushstring(L, "FgColor");
     lua_newtable(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9991,7 +9991,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
     return 1;
 }
 
-void TLuaInterpreter::pushLabelPropertiesToLua(lua_State* L, TMapLabel label)
+void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, TMapLabel label)
 {
     int x = label.pos.x();
     int y = label.pos.y();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9967,30 +9967,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
         if (labelId != -1) {
             if (host.mpMap->mapLabels[area].contains(labelId)) {
                 TMapLabel label = host.mpMap->mapLabels[area][labelId];
-                int x = label.pos.x();
-                int y = label.pos.y();
-                int z = label.pos.z();
-                float height = label.size.height();
-                float width = label.size.width();
-                QString text = label.text;
-                lua_pushstring(L, "X");
-                lua_pushnumber(L, x);
-                lua_settable(L, -3);
-                lua_pushstring(L, "Y");
-                lua_pushnumber(L, y);
-                lua_settable(L, -3);
-                lua_pushstring(L, "Z");
-                lua_pushnumber(L, z);
-                lua_settable(L, -3);
-                lua_pushstring(L, "Height");
-                lua_pushnumber(L, height);
-                lua_settable(L, -3);
-                lua_pushstring(L, "Width");
-                lua_pushnumber(L, width);
-                lua_settable(L, -3);
-                lua_pushstring(L, "Text");
-                lua_pushstring(L, text.toUtf8().constData());
-                lua_settable(L, -3);
+                pushLabelPropertiesToLua(L, label);
             } else {
                 lua_pushstring(L, "getMapLabel: labelId doesn't exist");
                 return lua_error(L);
@@ -10000,33 +9977,10 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
             while (it.hasNext()) {
                 it.next();
                 if (it.value().text == labelText) {
-                    TMapLabel label = it.value();
                     lua_newtable(L);
+                    TMapLabel label = it.value();
                     int id = it.key();
-                    int x = label.pos.x();
-                    int y = label.pos.y();
-                    int z = label.pos.z();
-                    float height = label.size.height();
-                    float width = label.size.width();
-                    QString text = label.text;
-                    lua_pushstring(L, "X");
-                    lua_pushnumber(L, x);
-                    lua_settable(L, -3);
-                    lua_pushstring(L, "Y");
-                    lua_pushnumber(L, y);
-                    lua_settable(L, -3);
-                    lua_pushstring(L, "Z");
-                    lua_pushnumber(L, z);
-                    lua_settable(L, -3);
-                    lua_pushstring(L, "Height");
-                    lua_pushnumber(L, height);
-                    lua_settable(L, -3);
-                    lua_pushstring(L, "Width");
-                    lua_pushnumber(L, width);
-                    lua_settable(L, -3);
-                    lua_pushstring(L, "Text");
-                    lua_pushstring(L, text.toUtf8().constData());
-                    lua_settable(L, -3);
+                    pushLabelPropertiesToLua(L, label);
                     lua_pushnumber(L, id);
                     lua_insert(L, -2);
                     lua_settable(L, -3);
@@ -10035,6 +9989,61 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
         }
     }
     return 1;
+}
+
+void TLuaInterpreter::pushLabelPropertiesToLua(lua_State* L, TMapLabel label)
+{
+    int x = label.pos.x();
+    int y = label.pos.y();
+    int z = label.pos.z();
+    float height = label.size.height();
+    float width = label.size.width();
+    QString text = label.text;
+    lua_pushstring(L, "X");
+    lua_pushnumber(L, x);
+    lua_settable(L, -3);
+    lua_pushstring(L, "Y");
+    lua_pushnumber(L, y);
+    lua_settable(L, -3);
+    lua_pushstring(L, "Z");
+    lua_pushnumber(L, z);
+    lua_settable(L, -3);
+    lua_pushstring(L, "Height");
+    lua_pushnumber(L, height);
+    lua_settable(L, -3);
+    lua_pushstring(L, "Width");
+    lua_pushnumber(L, width);
+    lua_settable(L, -3);
+    lua_pushstring(L, "Text");
+    lua_pushstring(L, text.toUtf8().constData());
+    lua_settable(L, -3);
+    lua_pushstring(L, "Pixmap");
+    lua_pushstring(L, label.base64EncodePixmap().toUtf8().constData());
+    lua_settable(L, -3);
+    lua_pushstring(L, "FgColor");
+    lua_newtable(L);
+    lua_pushstring(L, "r");
+    lua_pushinteger(L, label.fgColor.red());
+    lua_settable(L, -3);
+    lua_pushstring(L, "g");
+    lua_pushinteger(L, label.fgColor.green());
+    lua_settable(L, -3);
+    lua_pushstring(L, "b");
+    lua_pushinteger(L, label.fgColor.blue());
+    lua_settable(L, -3);
+    lua_settable(L, -3);
+    lua_pushstring(L, "BgColor");
+    lua_newtable(L);
+    lua_pushstring(L, "r");
+    lua_pushinteger(L, label.bgColor.red());
+    lua_settable(L, -3);
+    lua_pushstring(L, "g");
+    lua_pushinteger(L, label.bgColor.green());
+    lua_settable(L, -3);
+    lua_pushstring(L, "b");
+    lua_pushinteger(L, label.bgColor.blue());
+    lua_settable(L, -3);
+    lua_settable(L, -3);
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addSpecialExit

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9991,7 +9991,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
     return 1;
 }
 
-void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, TMapLabel label)
+void TLuaInterpreter::pushMapLabelPropertiesToLua(lua_State* L, TMapLabel& label)
 {
     int x = label.pos.x();
     int y = label.pos.y();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9967,7 +9967,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
         if (labelId != -1) {
             if (host.mpMap->mapLabels[area].contains(labelId)) {
                 TMapLabel label = host.mpMap->mapLabels[area][labelId];
-                pushLabelPropertiesToLua(L, label);
+                pushMapLabelPropertiesToLua(L, label);
             } else {
                 lua_pushstring(L, "getMapLabel: labelId doesn't exist");
                 return lua_error(L);
@@ -9980,7 +9980,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
                     lua_newtable(L);
                     TMapLabel label = it.value();
                     int id = it.key();
-                    pushLabelPropertiesToLua(L, label);
+                    pushMapLabelPropertiesToLua(L, label);
                     lua_pushnumber(L, id);
                     lua_insert(L, -2);
                     lua_settable(L, -3);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -43,6 +43,7 @@
 #include <QTextToSpeech>
 #endif // QT_TEXTTOSPEECH_LIB
 #include "post_guard.h"
+#include "TMap.h"
 
 extern "C" {
 #include <lauxlib.h>
@@ -614,7 +615,7 @@ private:
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State* L);
-
+    static void pushLabelPropertiesToLua(lua_State* L, TMapLabel label);
     const int LUA_FUNCTION_MAX_ARGS = 50;
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -615,7 +615,7 @@ private:
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State* L);
-    static void pushMapLabelPropertiesToLua(lua_State* L, TMapLabel label);
+    static void pushMapLabelPropertiesToLua(lua_State* L, TMapLabel& label);
     const int LUA_FUNCTION_MAX_ARGS = 50;
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -615,7 +615,7 @@ private:
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State* L);
-    static void pushMapLabelPropertiesToLua(lua_State* L, TMapLabel& label);
+    static void pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel& label);
     const int LUA_FUNCTION_MAX_ARGS = 50;
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -615,7 +615,7 @@ private:
     static std::tuple<bool, int> getWatchId(lua_State*, Host&);
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State* L);
-    static void pushLabelPropertiesToLua(lua_State* L, TMapLabel label);
+    static void pushMapLabelPropertiesToLua(lua_State* L, TMapLabel label);
     const int LUA_FUNCTION_MAX_ARGS = 50;
 
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2585,11 +2585,10 @@ void TMap::update()
     }
 }
 
-QString TMapLabel::base64EncodePixmap()
+QByteArray TMapLabel::base64EncodePixmap() const
 {
     QBuffer buffer;
     buffer.open(QIODevice::WriteOnly);
     pix.save(&buffer, "PNG");
-    auto const encoded = buffer.data().toBase64();
-    return QString(encoded);
+    return buffer.data().toBase64();
 }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2584,3 +2584,10 @@ void TMap::update()
     }
 }
 
+QString TMapLabel::base64EncodePixmap() {
+    QBuffer buffer;
+    buffer.open(QIODevice::WriteOnly);
+    pix.save(&buffer, "PNG");
+    auto const encoded = buffer.data().toBase64();
+    return QString(encoded);
+}

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -38,6 +38,7 @@
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QPainter>
+#include <QBuffer>
 #include "post_guard.h"
 
 TMap::TMap(Host* pH, const QString& profileName)

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2584,7 +2584,8 @@ void TMap::update()
     }
 }
 
-QString TMapLabel::base64EncodePixmap() {
+QString TMapLabel::base64EncodePixmap()
+{
     QBuffer buffer;
     buffer.open(QIODevice::WriteOnly);
     pix.save(&buffer, "PNG");

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -77,7 +77,7 @@ public:
     bool showOnTop;
     bool noScaling;
 
-    QString base64EncodePixmap();
+    QByteArray base64EncodePixmap() const;
 };
 
 

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -76,6 +76,8 @@ public:
     bool highlight;
     bool showOnTop;
     bool noScaling;
+
+    QString base64EncodePixmap();
 };
 
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

`getMapLabel` will now return more complete information about label:
 - foreground color
 - background color
 - pixmap as encoded base64 image

![image](https://user-images.githubusercontent.com/3740628/103235505-a895f080-4942-11eb-95f1-18f110c75fe4.png)

![image](https://user-images.githubusercontent.com/3740628/103235475-94ea8a00-4942-11eb-8bd5-0e1a95adb4c9.png)


#### Motivation for adding to Mudlet

Mudlet Map (Reader/Browser/Explorer) can use it :)

#### Other info (issues closed, discussion etc)
closes #3981 