### PR TITLE
Select profile maps directory or profile directory when manually loading a map

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2004,7 +2004,7 @@ void dlgProfilePreferences::loadMap()
     QString fileName = QFileDialog::getOpenFileName(
                            this,
                            tr("Load Mudlet map"),
-                           mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName()),
+                           mapSaveLoadDirectory(pHost),
                            tr("Mudlet map (*.dat);;Xml map data (*.xml);;Any file (*)",
                               "Do not change extensions (in braces) as they are used programmatically"));
     if (fileName.isEmpty()) {
@@ -2051,7 +2051,7 @@ void dlgProfilePreferences::saveMap()
     }
 
     QString fileName =
-            QFileDialog::getSaveFileName(this, tr("Save Mudlet map"), QDir::homePath(), tr("Mudlet map (*.dat)", "Do not change the extension text (in braces) - it is needed programmatically!"));
+            QFileDialog::getSaveFileName(this, tr("Save Mudlet map"), mapSaveLoadDirectory(pHost), tr("Mudlet map (*.dat)", "Do not change the extension text (in braces) - it is needed programmatically!"));
     if (fileName.isEmpty()) {
         return;
     }
@@ -2078,6 +2078,12 @@ void dlgProfilePreferences::saveMap()
     mudlet::self()->setShowMapAuditErrors(showAuditErrors);
 
     QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+}
+
+QString dlgProfilePreferences::mapSaveLoadDirectory(Host* pHost) {
+    QString mapsPath = mudlet::getMudletPath(mudlet::profileMapsPath, pHost->getName());
+    QDir mapsDir = QDir(mapsPath);
+    return mapsDir.exists() ? mapsPath : mudlet::getMudletPath(mudlet::profileHomePath, pHost->getName());
 }
 
 void dlgProfilePreferences::hideActionLabel()

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -182,6 +182,7 @@ private:
     void generateDiscordTooltips();
     void hidePasswordMigrationLabel();
     void setupPasswordsMigration();
+    QString mapSaveLoadDirectory(Host* pHost);
 
     int mFontSize;
     QPointer<Host> mpHost;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Slight improvement - load map will open `maps` folder as it does now, but if maps folder is not existing, it will open profile directory instead of home directory.
Save map will have same behaviour.

#### Motivation for adding to Mudlet
It's tedious to always go to profile directory for map save and load.

#### Other info (issues closed, discussion etc)

closes https://github.com/Mudlet/Mudlet/issues/992 (although partially done already)
