### PR TITLE
Bugfix: fix seg fault on reloadModule

### DIFF
--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -235,7 +235,7 @@ bool AliasUnit::processDataStream(const QString& data)
     Lua->set_lua_string(QStringLiteral("command"), data);
     bool state = false;
     //Using copy fixes https://github.com/Mudlet/Mudlet/issues/4297
-    std::list<TAlias*> copyOfNodeList = mAliasRootNodeList;
+    auto copyOfNodeList = mAliasRootNodeList;
     for (auto alias : copyOfNodeList) {
         // = data.replace( "\n", "" );
         if (alias->match(data)) {

--- a/src/AliasUnit.cpp
+++ b/src/AliasUnit.cpp
@@ -234,7 +234,9 @@ bool AliasUnit::processDataStream(const QString& data)
     TLuaInterpreter* Lua = mpHost->getLuaInterpreter();
     Lua->set_lua_string(QStringLiteral("command"), data);
     bool state = false;
-    for (auto alias : mAliasRootNodeList) {
+    //Using copy fixes https://github.com/Mudlet/Mudlet/issues/4297
+    std::list<TAlias*> copyOfNodeList = mAliasRootNodeList;
+    for (auto alias : copyOfNodeList) {
         // = data.replace( "\n", "" );
         if (alias->match(data)) {
             state = true;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Fixes segmentation fault when reloading module from alias contained in that module.
Module is reloaded and alias pointer is accessed afterwards.

#### Motivation for adding to Mudlet

Fixes crash.

#### Other info (issues closed, discussion etc)
closes #4297

REMARK!
Not sure if this is correct way to handle that nor if it is safe to copy list like that. It fixes the issue though.

`Tree.h`
![image](https://user-images.githubusercontent.com/3740628/103353939-73a4ad80-4aaa-11eb-80ff-bb97d38f0efd.png)
