### PR TITLE
multiple package selection in package manager

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1539,7 +1539,7 @@ void mudlet::slot_uninstall_package()
     }
     auto selectedPackages = packageList->selectedItems();
     if (!selectedPackages.empty()) {
-        for(auto package : selectedPackages) {
+        for (auto package : selectedPackages) {
             pH->uninstallPackage(package->text(), 0);
         }
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1537,9 +1537,11 @@ void mudlet::slot_uninstall_package()
     if (!pH) {
         return;
     }
-    QListWidgetItem* pI = packageList->currentItem();
-    if (pI) {
-        pH->uninstallPackage(pI->text(), 0);
+    auto selectedPackages = packageList->selectedItems();
+    if (!selectedPackages.empty()) {
+        for(auto package : selectedPackages) {
+            pH->uninstallPackage(package->text(), 0);
+        }
     }
     packageList->clear();
     packageList->addItems(pH->mInstalledPackages);

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -21,7 +21,11 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QListWidget" name="packageList"/>
+       <widget class="QListWidget" name="packageList">
+        <property name="selectionMode">
+         <enum>QAbstractItemView::ExtendedSelection</enum>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QWidget" name="widget_2" native="true">


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Allows ctrl/shift selection of multiple packages in package manager.
![image](https://user-images.githubusercontent.com/3740628/103390071-ba2df280-4b12-11eb-9f3d-798d7aa36942.png)

#### Motivation for adding to Mudlet

I often caught myself trying multiselection of packages :)

#### Other info (issues closed, discussion etc)
I thought I saw some issue with that request... but can't find it.