### PR TITLE
Improve "no map loaded" message not to confuse users

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1325,7 +1325,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You don't have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%1 rooms), but we don't know where you are at the moment.").arg(mpMap->mpRoomDB->size()); 
+        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", mpMap->mpRoomDB->size())); 
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1325,7 +1325,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = mpMap->mpRoomDB->size() == 0 ? tr("Map not preset. Load map or start mapping.") : tr("Your map has %1 rooms, but you have no position set.").arg(mpMap->mpRoomDB->size()); 
+        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You don't have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%1 rooms), but we don't know where you are at the moment.").arg(mpMap->mpRoomDB->size()); 
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1325,7 +1325,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", mpMap->mpRoomDB->size())); 
+        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded with single room, but Mudlet does not know where you are at the moment.", "You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", mpMap->mpRoomDB->size()); 
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1325,7 +1325,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, tr("No map or no valid position."));
+        auto message = mpMap->mpRoomDB->size() == 0 ? tr("Map not preset. Load map or start mapping.") : tr("Your map has %1 rooms, but you have no position set.").arg(mpMap->mpRoomDB->size()); 
+        painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1325,7 +1325,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded with single room, but Mudlet does not know where you are at the moment.", "You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", mpMap->mpRoomDB->size()); 
+        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size()); 
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1219,6 +1219,8 @@ bool TMainConsole::loadMap(const QString& location)
         pHost->mpMap->pushErrorMessagesToFile(tr(R"(Loading map(1) "%1" at %2 report)").arg(location, now.toString(Qt::ISODate)), true);
     }
 
+    pHost->mpMap->update();
+
     return result;
 }
 
@@ -1315,6 +1317,8 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
         }
         return false;
     }
+
+    pHost->mpMap->update();
 
     return result;
 }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -380,7 +380,7 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded with single room, but Mudlet does not know where you are at the moment.", "You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", mpMap->mpRoomDB->size()); 
+            auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size()); 
             painter.drawText(width() / 3, height() / 2, message);
             painter.end();
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -380,7 +380,8 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            painter.drawText(width() / 3, height() / 2, "no map or no valid position on map");
+            auto message = mpMap->mpRoomDB->size() == 0 ? tr("Map not preset. Load map or start mapping.") : tr("Your map has %1 rooms, but you have no position set.").arg(mpMap->mpRoomDB->size()); 
+            painter.drawText(width() / 3, height() / 2, message);
             painter.end();
 
             glLoadIdentity();

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -380,7 +380,7 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            auto message = mpMap->mpRoomDB->size() == 0 ? tr("Map not preset. Load map or start mapping.") : tr("Your map has %1 rooms, but you have no position set.").arg(mpMap->mpRoomDB->size()); 
+            auto message = mpMap->mpRoomDB->size() == 0 ? tr("You don't have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%1 rooms), but we don't know where you are at the moment.").arg(mpMap->mpRoomDB->size()); 
             painter.drawText(width() / 3, height() / 2, message);
             painter.end();
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -380,7 +380,7 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            auto message = mpMap->mpRoomDB->size() == 0 ? tr("You don't have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%1 rooms), but we don't know where you are at the moment.").arg(mpMap->mpRoomDB->size()); 
+            auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded with single room, but Mudlet does not know where you are at the moment.", "You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", mpMap->mpRoomDB->size()); 
             painter.drawText(width() / 3, height() / 2, message);
             painter.end();
 

--- a/translations/translated/mudlet_en_US.ts
+++ b/translations/translated/mudlet_en_US.ts
@@ -5,11 +5,10 @@
     <name>GLWidget</name>
     <message numerus="yes">
         <location filename="../../src/glwidget.cpp" line="383"/>
-        <source>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</source>
-        <comment>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</comment>
+        <source>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</source>
         <translation>
-            <numerusform>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</numerusform>
-            <numerusform>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</numerusform>
+            <numerusform>You have a map loaded (one room), but Mudlet does not know where you are at the moment.</numerusform>
+            <numerusform>You have a map loaded (%n rooms), but Mudlet does not know where you are at the moment.</numerusform>
         </translation>
     </message>
 </context>
@@ -17,11 +16,10 @@
     <name>T2DMap</name>
     <message numerus="yes">
         <location filename="../../src/T2DMap.cpp" line="1328"/>
-        <source>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</source>
-        <comment>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</comment>
+        <source>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</source>
         <translation>
             <numerusform>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</numerusform>
-            <numerusform>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</numerusform>
+            <numerusform>You have a map loaded (%n rooms), but Mudlet does not know where you are at the moment.</numerusform>
         </translation>
     </message>
     <message numerus="yes">

--- a/translations/translated/mudlet_en_US.ts
+++ b/translations/translated/mudlet_en_US.ts
@@ -2,9 +2,30 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en_US" sourcelanguage="en">
 <context>
+    <name>GLWidget</name>
+    <message numerus="yes">
+        <location filename="../../src/glwidget.cpp" line="383"/>
+        <source>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</source>
+        <comment>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</comment>
+        <translation>
+            <numerusform>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</numerusform>
+            <numerusform>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
     <name>T2DMap</name>
     <message numerus="yes">
-        <location filename="../../src/T2DMap.cpp" line="2240"/>
+        <location filename="../../src/T2DMap.cpp" line="1328"/>
+        <source>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</source>
+        <comment>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</comment>
+        <translation>
+            <numerusform>You have a map loaded with single room, but Mudlet does not know where you are at the moment.</numerusform>
+            <numerusform>You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/T2DMap.cpp" line="2380"/>
         <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms
 </source>
         <comment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handlethem literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when TWO or MORE rooms are selected; %1 is the room number for which %2-%4 are the x,y and z coordinates of the room nearest the middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms selected and will ALWAYS be greater than 1 in this situation. It is provided so that non-English translations can select required plural forms as needed.</comment>
@@ -17,7 +38,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/T2DMap.cpp" line="3603"/>
+        <location filename="../../src/T2DMap.cpp" line="3691"/>
         <source>Enter the symbol to use
 for this/these %n room(s):</source>
         <comment>this is for when applying a new room symbol to one or more rooms and none have a symbol at present; use line feeds to format text into a reasonable rectangle, %n is the number of rooms involved</comment>
@@ -30,7 +51,7 @@ for these %n rooms:</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/T2DMap.cpp" line="3620"/>
+        <location filename="../../src/T2DMap.cpp" line="3708"/>
         <source>The only used symbol is &quot;%1&quot; in one or
 more of the selected %n room(s), delete this to
 clear it from all selected rooms or replace
@@ -49,7 +70,7 @@ with a new symbol to use for all the rooms:</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/T2DMap.cpp" line="3674"/>
+        <location filename="../../src/T2DMap.cpp" line="3766"/>
         <source>Choose:
  • an existing symbol from the list below (sorted by most commonly used first)
  • enter one or more graphemes (&quot;visible characters&quot;) as a new symbol
@@ -73,7 +94,7 @@ for all of the %n selected rooms:</numerusform>
 <context>
     <name>TRoomDB</name>
     <message numerus="yes">
-        <location filename="../../src/TRoomDB.cpp" line="697"/>
+        <location filename="../../src/TRoomDB.cpp" line="726"/>
         <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
  Look for further messsages related to the rooms that are supposed
  to be in this/these area(s)...</source>
@@ -89,7 +110,7 @@ for all of the %n selected rooms:</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/TRoomDB.cpp" line="704"/>
+        <location filename="../../src/TRoomDB.cpp" line="733"/>
         <source>[ ALERT ] - %n area(s) detected as missing in map: adding it/them in.
  Look for further messsages related to the rooms that is/are supposed to
  be in this/these area(s)...</source>
@@ -105,7 +126,7 @@ for all of the %n selected rooms:</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/TRoomDB.cpp" line="713"/>
+        <location filename="../../src/TRoomDB.cpp" line="742"/>
         <source>[ INFO ]  - The missing area(s) are now called:
 (ID) ==&gt; &quot;name&quot;</source>
         <comment>Making use of %n to allow quantity dependent message form 8-) !</comment>
@@ -121,7 +142,7 @@ for all of the %n selected rooms:</numerusform>
 <context>
     <name>TTrigger</name>
     <message numerus="yes">
-        <location filename="../../src/TTrigger.cpp" line="1065"/>
+        <location filename="../../src/TTrigger.cpp" line="1130"/>
         <source>Trigger name=%1 will fire %n more time(s).
 </source>
         <translation>
@@ -135,7 +156,7 @@ for all of the %n selected rooms:</numerusform>
 <context>
     <name>mudlet</name>
     <message numerus="yes">
-        <location filename="../../src/mudlet.cpp" line="4524"/>
+        <location filename="../../src/mudlet.cpp" line="3800"/>
         <source>&lt;p&gt;About Mudlet&lt;/p&gt;&lt;p&gt;&lt;i&gt;%n update(s) is/are now available!&lt;/i&gt;&lt;p&gt;</source>
         <comment>This is the tooltip text for the &apos;About&apos; Mudlet main toolbar button when it has been changed by adding a menu which now contains the original &apos;About Mudlet&apos; action and a new one to access the manual update process</comment>
         <translation>
@@ -144,7 +165,7 @@ for all of the %n selected rooms:</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/mudlet.cpp" line="4542"/>
+        <location filename="../../src/mudlet.cpp" line="3818"/>
         <source>Review %n update(s)...</source>
         <comment>Review update(s) menu item, %n is the count of how many updates are available</comment>
         <translatorcomment>Could do with the insertion of &quot;the&quot; as a second word!</translatorcomment>
@@ -154,7 +175,7 @@ for all of the %n selected rooms:</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../src/mudlet.cpp" line="4547"/>
+        <location filename="../../src/mudlet.cpp" line="3823"/>
         <source>&lt;p&gt;Review the update(s) available...&lt;/p&gt;</source>
         <comment>Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here</comment>
         <translatorcomment>As per the developer&apos;s comment it is not necessary to include the number of update in this text in English.</translatorcomment>


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

More clear message stating that either map is not loaded or it is loaded but position is not set.

![image](https://user-images.githubusercontent.com/3740628/103391549-55769600-4b1a-11eb-81aa-89ed8f64d43a.png)
![image](https://user-images.githubusercontent.com/3740628/103391560-61faee80-4b1a-11eb-9d3d-cabaa118bed9.png)


#### Motivation for adding to Mudlet

I was confused as well first time I've installed scripts and loaded map...

#### Other info (issues closed, discussion etc)
Touches a bit: https://github.com/Mudlet/Mudlet/issues/710