### PR TITLE
include generated sources in include path (VS Code config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ CMakeLists.txt.user
 #CLion
 .idea
 cmake-build-debug
+
+#VS Code
+.vscode/*.code-workspace

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,6 +1,10 @@
 {
+    "env": {
+        "myDefaultIncludePath": ["${workspaceFolder}", "${workspaceFolder}/build/src/mudlet_autogen"]
+    },
     "configurations": [
         {
+            "name": "Mudlet",
             "configurationProvider": "ms-vscode.cmake-tools"
         }
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "cmake.configureOnOpen": true
+    "cmake.configureOnOpen": true,
+    "cmake.configureSettings": {
+        "CMAKE_TOOLCHAIN_FILE": "${workspaceFolder}/3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      }
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

I've added include path to generated sources (like qt ui)

#### Motivation for adding to Mudlet

It's useful :)

#### Other info (issues closed, discussion etc)

Actually I am not fan of keeping IDE configuration in repository, since it will be getting in the way of commits if changes.
So actually I personally think it would be better to remove `vscode` directory and add it to `.gitignore`