### PR TITLE
prevent spawning new About buttons when updates are available

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3780,7 +3780,7 @@ void mudlet::slot_updateAvailable(const int updateCount)
     // Removes the normal click to activate "About Mudlet" action and move it
     // to a new menu which also contains a "goto updater" option
 
-    if(mpActionAboutWithUpdates) {
+    if (mpActionAboutWithUpdates) {
         mpMainToolBar->removeAction(mpActionAboutWithUpdates);
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3780,6 +3780,10 @@ void mudlet::slot_updateAvailable(const int updateCount)
     // Removes the normal click to activate "About Mudlet" action and move it
     // to a new menu which also contains a "goto updater" option
 
+    if(mpActionAboutWithUpdates) {
+        mpMainToolBar->removeAction(mpActionAboutWithUpdates);
+    }
+
     // First change the existing button:
     if (!qApp->testAttribute(Qt::AA_DontShowIconsInMenus)) {
         mpActionAbout->setIcon(QIcon(":/icons/mudlet_information.png"));
@@ -3806,7 +3810,7 @@ void mudlet::slot_updateAvailable(const int updateCount)
     mpButtonAbout->setText(tr("About"));
     mpButtonAbout->setPopupMode(QToolButton::InstantPopup);
     // Now insert our new button after the current QAction/QToolButton
-    mpMainToolBar->insertWidget(mpActionAbout, mpButtonAbout);
+    mpActionAboutWithUpdates = mpMainToolBar->insertWidget(mpActionAbout, mpButtonAbout);
     // And quickly pull out the old QAction/QToolButton:
     mpMainToolBar->removeAction(mpActionAbout);
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -582,6 +582,7 @@ private:
     QPointer<QAction> mpActionReplay;
 
     QPointer<QAction> mpActionAbout;
+    QPointer<QAction> mpActionAboutWithUpdates;
     QPointer<QToolButton> mpButtonAbout;
     QPointer<QAction> mpActionAliases;
     QPointer<QAction> mpActionButtons;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Prevents spawning multiple about buttons when updates are available as described in (#4306)

#### Motivation for adding to Mudlet

Bugfix

#### Other info (issues closed, discussion etc)
closes #4306