### PR TITLE
fix module xml clear on profile load

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -469,10 +469,6 @@ Host::~Host()
 
 void Host::saveModules(int sync, bool backup)
 {
-    if (mIsProfileLoadingSequence) {
-        //If we're inside of profile loading sequence modules might not be loaded yet, thus we can accidetnally clear their contents
-        return;
-    }
     QMapIterator<QString, QStringList> it(modulesToWrite);
     mModulesToSync.clear();
     QString savePath = mudlet::getMudletPath(mudlet::moduleBackupsPath);
@@ -713,6 +709,12 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
         filename_xml = QStringLiteral("%1/%2.xml").arg(directory_xml, QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd#HH-mm-ss")));
     } else {
         filename_xml = QStringLiteral("%1/%2.xml").arg(directory_xml, saveName);
+    }
+
+
+    if (mIsProfileLoadingSequence) {
+        //If we're inside of profile loading sequence modules might not be loaded yet, thus we can accidetnally clear their contents
+        return std::make_tuple(false, filename_xml, QStringLiteral("profile loading is in progress"));
     }
 
     QDir dir_xml;

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -469,6 +469,10 @@ Host::~Host()
 
 void Host::saveModules(int sync, bool backup)
 {
+    if (mIsProfileLoadingSequence) {
+        //If we're inside of profile loading sequence modules might not be loaded yet, thus we can accidetnally clear their contents
+        return;
+    }
     QMapIterator<QString, QStringList> it(modulesToWrite);
     mModulesToSync.clear();
     QString savePath = mudlet::getMudletPath(mudlet::moduleBackupsPath);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3205,7 +3205,7 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         lua_pushnil(L);
         lua_pushstring(L, message.toUtf8().constData());
         if (mudlet::debugMode) {
-            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: " << message << "\n" >> 0;
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: saveProfile: " << message << "\n" >> 0;
         }
         return 2;
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3201,8 +3201,12 @@ int TLuaInterpreter::saveProfile(lua_State* L)
         lua_pushstring(L, (std::get<1>(result).toUtf8().constData()));
         return 2;
     } else {
+        auto message = QString("Couldn't save %1 to %2 because: %3").arg(host.getName(), std::get<1>(result), std::get<2>(result));
         lua_pushnil(L);
-        lua_pushstring(L, QString("Couldn't save %1 to %2 because: %3").arg(host.getName(), std::get<1>(result), std::get<2>(result)).toUtf8().constData());
+        lua_pushstring(L, message.toUtf8().constData());
+        if (mudlet::debugMode) {
+            TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: " << message << "\n" >> 0;
+        }
         return 2;
     }
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2952,8 +2952,7 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
 
     pHost->mBlockStopWatchCreation = false;
     pHost->getScriptUnit()->compileAll();
-    pHost->mIsProfileLoadingSequence = false;
-
+    
     pHost->updateAnsi16ColorsInTable();
 
     //Load rest of modules after scripts
@@ -2969,6 +2968,8 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
     }
 
     packagesToInstallList.clear();
+
+    pHost->mIsProfileLoadingSequence = false;
 
     TEvent event {};
     event.mArgumentList.append(QLatin1String("sysLoadEvent"));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2952,7 +2952,6 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
 
     pHost->mBlockStopWatchCreation = false;
     pHost->getScriptUnit()->compileAll();
-    
     pHost->updateAnsi16ColorsInTable();
 
     //Load rest of modules after scripts


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Prevents XML module save while in profile load cycle.

#### Motivation for adding to Mudlet

XML contents of modules in sync sometimes get deleted during profile load.
Always when calling `saveProfile` during profile load

#### Other info (issues closed, discussion etc)
closes #3884
potentially might help with #4029