### PR TITLE
Improve caching in Github Actions

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -142,8 +142,8 @@ jobs:
       uses: pat-s/always-upload-cache@v2.1.3
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{github.sha}}
-        restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-
+        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}
+        restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}
       if: matrix.os != 'windows-latest'
 
     - name: (Linux/macOS) Set build info

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -152,6 +152,10 @@ jobs:
         ${{github.workspace}}/CI/travis.validate_deployment.sh
         ${{github.workspace}}/CI/travis.set-build-info.sh
 
+    - name: check ccache stats prior to build
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      run: ccache --show-stats
+
     - name: Build Mudlet
       uses: lukka/run-cmake@v3
       with:
@@ -166,6 +170,10 @@ jobs:
           -DVCPKG_APPLOCAL_DEPS=OFF
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
+
+    - name: check ccache stats post build
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      run: ccache --show-stats
 
     - name: Run C++ tests (macOS)
       if: runner.os == 'macOS'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -139,7 +139,7 @@ jobs:
         echo "WITH_FONTS=no" >> $GITHUB_ENV
 
     - name: (Linux/macOS) restore ccache
-      uses: actions/cache@v2
+      uses: pat-s/always-upload-cache@v2.1.3
       with:
         path: ${{runner.workspace}}/ccache
         key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{github.sha}}


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Always save Mudlet build cache, even if other steps fail.
#### Motivation for adding to Mudlet
Helps make builds just a little bit quicker.
#### Other info (issues closed, discussion etc)
The official Github Actions cache step does not support always saving the cache (https://github.com/actions/cache/issues/92), so use a 3rd party one instead.