### PR TITLE
BugFix: stop special exits being modified when old format maps are read

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -673,16 +673,16 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
         while (itOldSpecialExit.hasNext()) {
             itOldSpecialExit.next();
             QString cmd{itOldSpecialExit.value()};
-            if (cmd.startsWith(QLatin1Char('1'))) {
+            if (cmd.startsWith(QLatin1String("1"))) {
                 // Is locked:
                 mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());
                 mSpecialExitLocks.insert(cmd);
-            } else if (Q_LIKELY(cmd.startsWith(QLatin1Char('1')))) {
+            } else if (Q_LIKELY(cmd.startsWith(QLatin1String("0")))) {
                 // Is not locked:
                 mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());
             } else {
                 // Has no lock prefix at all
-                mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());
+                mSpecialExits.insert(cmd, itOldSpecialExit.key());
             }
         }
     }


### PR DESCRIPTION
Since #4526 was merged into the development branch 4 days ago reading of old maps (formats *before* *8*) built from Mudlet prior to 8e0f9dba7fa26d3939724d68faaa8eb5dac9c677 (merged on 2011/01/24) will chop the first character from the name/command of every special exit...

This was caused by a copy-paste error in the code that converted the older style of storing the special exits and their locked status that was used prior to that PR.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>