### PR TITLE
Do not allow `setFont` on unknown fonts

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3225,8 +3225,9 @@ int TLuaInterpreter::setFont(lua_State* L)
     QString font{lua_tostring(L, s)};
 
     if (!mudlet::self()->getAvailableFonts().contains(font)) {
-        lua_pushfstring(L, "setFont: bad argument #%d type (font '%s' is not available)", s, font.toUtf8().constData());
-        return lua_error(L);
+        lua_pushnil(L);
+        lua_pushfstring(L, "Font '%s' is not available)", font.toUtf8().constData());
+        return 2;
     }
 
 #if defined(Q_OS_LINUX)
@@ -3245,7 +3246,6 @@ int TLuaInterpreter::setFont(lua_State* L)
             lua_pushstring(L, result.second.toUtf8().constData());
             return 2;
         }
-        //console->refresh();
         console->refreshView();
     } else {
         console->setFont(font);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3226,7 +3226,7 @@ int TLuaInterpreter::setFont(lua_State* L)
 
     if (!mudlet::self()->getAvailableFonts().contains(font, Qt::CaseInsensitive)) {
         lua_pushnil(L);
-        lua_pushfstring(L, "Font '%s' is not available)", font.toUtf8().constData());
+        lua_pushfstring(L, "font '%s' is not available)", font.toUtf8().constData());
         return 2;
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3224,7 +3224,7 @@ int TLuaInterpreter::setFont(lua_State* L)
     }
     QString font{lua_tostring(L, s)};
 
-    if (!mudlet::self()->getAvailableFonts().contains(font)) {
+    if (!mudlet::self()->getAvailableFonts().contains(font, Qt::CaseInsensitive)) {
         lua_pushnil(L);
         lua_pushfstring(L, "Font '%s' is not available)", font.toUtf8().constData());
         return 2;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3224,6 +3224,11 @@ int TLuaInterpreter::setFont(lua_State* L)
     }
     QString font{lua_tostring(L, s)};
 
+    if (!mudlet::self()->getAvailableFonts().contains(font)) {
+        lua_pushfstring(L, "setFont: bad argument #%d type (font '%s' is not available)", s, font.toUtf8().constData());
+        return lua_error(L);
+    }
+
 #if defined(Q_OS_LINUX)
     // On Linux ensure that emojis are displayed in colour even if this font
     // doesn't support it:
@@ -3234,7 +3239,7 @@ int TLuaInterpreter::setFont(lua_State* L)
     auto console = CONSOLE(L, windowName);
     if (console == host.mpConsole) {
         // apply changes to main console and its while-scrolling component too.
-        auto result = host.setDisplayFont(font);
+        auto result = host.setDisplayFont(QFont(font, host.getDisplayFont().pointSize()));
         if (!result.first) {
             lua_pushboolean(L, false);
             lua_pushstring(L, result.second.toUtf8().constData());


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Calling `setFont` with unknown font type falls back to `Noto Color Emoji` on Linux, on other systems results may vary.
This just doesn't allow setting font no 'on the list' in the database (just as preferences font combo box)

Additionally it fixes issue - when calling `setFont` behaviour was very different from dialog preferences - it overriden font size and font looked off (try setting same font as you have selected to see difference).

#### Motivation for adding to Mudlet

Bugfixing.


#### Other info (issues closed, discussion etc)
closes #4159

Explanation:
![fonts issue](https://user-images.githubusercontent.com/3740628/103479706-ce524800-4dcf-11eb-8e76-0275bfb9d996.gif)
