### PR TITLE
Cleanup: apply previously version dependent fix to all

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -203,11 +203,7 @@ void TTreeWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int
     }
 
     if (parent.isValid()) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
         QModelIndex child = parent.model()->index(start, 0);
-#else
-        QModelIndex child = parent.child(start, 0);
-#endif
         mChildID = child.data(Qt::UserRole).toInt();
         if (mChildID == 0) {
             if (parent.isValid()) {
@@ -228,11 +224,7 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
     // determine position in parent list
 
     if (mIsDropAction) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
         QModelIndex child = parent.model()->index(start, 0);
-#else
-        QModelIndex child = parent.child(start, 0);
-#endif
         int parentPosition = parent.row();
         int childPosition = child.row();
         if (mChildID == 0) {


### PR DESCRIPTION
It seems that the change I proposed in #4461 does not apply at the correct Qt version breakpoint. I had set the newer code to be used from Qt 5.15. However it is still throwing up GH Actions "check" annotations which must therefore be testing with an older Qt version. Looking more deeply into the Qt code it seems that the particular method was deprecated in 5.8 and since we only now support Qt versions going back to 5.11 there is no need to keep the old code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>