### PR TITLE
[Refactor] Streamline error message creation

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -205,6 +205,8 @@ TLuaInterpreter::~TLuaInterpreter()
 // With reduced repetition like that:
 //    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", true);
 //
+// The "notOptional" parameter is optional, and will default to not-optional parameters! :)
+//
 // See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
 bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, notOptional)
 { 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -206,10 +206,10 @@ TLuaInterpreter::~TLuaInterpreter()
 //    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", true);
 //
 // See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
-bool TLuaInterpreter::verifyBool(L, functionName, pos, publicName, notOptional)
+bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, notOptional)
 { 
     if (!lua_isboolean(L, pos)) { 
-        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "boolean");
+        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "boolean");
         return lua_error(L);
     }
     return lua_toboolean(L, pos);
@@ -217,10 +217,10 @@ bool TLuaInterpreter::verifyBool(L, functionName, pos, publicName, notOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-QString TLuaInterpreter::verifyString(L, functionName, pos, publicName, notOptional)
+QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, notOptional)
 { 
     if (!lua_isstring(L, pos)) { 
-        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "string");
+        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "string");
         return lua_error(L);
     }
     return lua_tostring(L, pos);
@@ -228,10 +228,10 @@ QString TLuaInterpreter::verifyString(L, functionName, pos, publicName, notOptio
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-int TLuaInterpreter::verifyInt(L, functionName, pos, publicName, notOptional)
+int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, notOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "number");
+        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "number");
         return lua_error(L);
     }
     return lua_tointeger(L, pos);
@@ -239,10 +239,10 @@ int TLuaInterpreter::verifyInt(L, functionName, pos, publicName, notOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-float TLuaInterpreter::verifyFloat(L, functionName, pos, publicName, notOptional)
+float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, notOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "number");
+        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "number");
         return lua_error(L);
     }
     return lua_tonumber(L, pos);
@@ -250,7 +250,7 @@ float TLuaInterpreter::verifyFloat(L, functionName, pos, publicName, notOptional
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-void TLuaInterpreter::announceWrongArgumentType(L, functionName, pos, publicName, notOptional, publicType) 
+void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, notOptional, publicType) 
 { 
     if notOptional {
         lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!", 
@@ -9275,7 +9275,7 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 //        lua_pushstring(L, "createMapLabel: wrong argument type");
 //        return lua_error(L);
 //    }
-    int area = verifyInt(L, "createMapLabel", 1, "areaID");
+    int area = verifyInt(L, 1, "createMapLabel", "areaID");
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -194,16 +194,16 @@ TLuaInterpreter::~TLuaInterpreter()
 
 // No documentation available in wiki - internal function
 // Replaces a check like this:
-//    if (!lua_isboolean(L, 9)) {
+//    if (!lua_isboolean(L, 14)) {
 //        lua_pushfstring(L,
-//            "createMapLabel: bad argument #9 type (showOnTop as number expected, got %s!)",
-//            luaL_typename(L, 9));
+//            "createMapLabel: bad argument #14 type (showOnTop as boolean is optional, got %s!)",
+//            luaL_typename(L, 14));
 //        return lua_error(L);
 //    }
-//    bool showOnTop = lua_toboolean(L, 9);
+//    bool showOnTop = lua_toboolean(L, 14);
 //
 // With reduced repetition like that:
-//    bool showOnTop = getVerifiedBoolean(L, 9, "createMapLabel", "showOnTop");
+//    bool showOnTop = getVerifiedBoolean(L, 14, "createMapLabel", "showOnTop", true);
 //
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9292,7 +9292,7 @@ QString text = verifyString(L, 2, "createMapLabel", "text");
 //        return lua_error(L);
 //    }
 //    float posx = lua_tonumber(L, 3);
-    float posx = verifyFloat(L, 3, "posX", "number");
+    float posx = verifyFloat(L, 3, "createMapLabel", "posX");
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9277,19 +9277,22 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 //        lua_pushstring(L, "createMapLabel: wrong argument type");
 //        return lua_error(L);
 //    }
+//    int area = lua_tointeger(L, 1);
     int area = verifyInt(L, 1, "createMapLabel", "areaID");
 
-    if (!lua_isstring(L, 2)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    QString text = lua_tostring(L, 2);
+//    if (!lua_isstring(L, 2)) {
+//        lua_pushstring(L, "createMapLabel: wrong argument type");
+//        return lua_error(L);
+//    }
+//    QString text = lua_tostring(L, 2);
+QString text = verifyString(L, 2, "createMapLabel", "text");
 
-    if (!lua_isnumber(L, 3)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    float posx = lua_tonumber(L, 3);
+//    if (!lua_isnumber(L, 3)) {
+//        lua_pushstring(L, "createMapLabel: wrong argument type");
+//        return lua_error(L);
+//    }
+//    float posx = lua_tonumber(L, 3);
+    float posx = verifyFloat(L, 3, "posX", "number");
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
@@ -9340,11 +9343,12 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     int bgb = lua_tointeger(L, 11);
 
     if (args > 11) {
-        if (!lua_isnumber(L, 12)) {
-            lua_pushstring(L, "createMapLabel: wrong argument type");
-            return lua_error(L);
-        }
-        zoom = lua_tonumber(L, 12);
+//        if (!lua_isnumber(L, 12)) {
+//            lua_pushstring(L, "createMapLabel: wrong argument type");
+//            return lua_error(L);
+//        }
+//        zoom = lua_tonumber(L, 12);
+        zoom = verifyFloat(L, 12, "createMapLabel", "zoom", true);
 
         if (!lua_isnumber(L, 13)) {
             lua_pushstring(L, "createMapLabel: wrong argument type");
@@ -9353,11 +9357,12 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
         fontSize = lua_tointeger(L, 13);
 
         if (args > 13) {
-            if (!lua_isboolean(L, 14)) {
-                lua_pushstring(L, "createMapLabel: wrong argument type");
-                return lua_error(L);
-            }
-            showOnTop = lua_toboolean(L, 14);
+//            if (!lua_isboolean(L, 14)) {
+//                lua_pushstring(L, "createMapLabel: wrong argument type");
+//                return lua_error(L);
+//            }
+//            showOnTop = lua_toboolean(L, 14);
+            showOnTop = verifyBool(L, 14, "createMapLabel", "showOnTop", true);
         }
         if (args > 14) {
             if (!lua_isboolean(L, 15)) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9281,103 +9281,25 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     bool noScaling = true;
 
     int args = lua_gettop(L);
-//    if (!lua_isnumber(L, 1)) {
-//        lua_pushstring(L, "createMapLabel: wrong argument type");
-//        return lua_error(L);
-//    }
-//    int area = lua_tointeger(L, 1);
     int area = getVerifiedInt(L, 1, "createMapLabel", "areaID");
-
-//    if (!lua_isstring(L, 2)) {
-//        lua_pushstring(L, "createMapLabel: wrong argument type");
-//        return lua_error(L);
-//    }
-//    QString text = lua_tostring(L, 2);
-QString text = getVerifiedString(L, 2, "createMapLabel", "text");
-
-//    if (!lua_isnumber(L, 3)) {
-//        lua_pushstring(L, "createMapLabel: wrong argument type");
-//        return lua_error(L);
-//    }
-//    float posx = lua_tonumber(L, 3);
+    QString text = getVerifiedString(L, 2, "createMapLabel", "text");
     float posx = getVerifiedFloat(L, 3, "createMapLabel", "posX");
-
-    if (!lua_isnumber(L, 4)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    float posy = lua_tonumber(L, 4);
-
-    if (!lua_isnumber(L, 5)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    float posz = lua_tonumber(L, 5);
-
-    if (!lua_isnumber(L, 6)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int fgr = lua_tointeger(L, 6);
-
-    if (!lua_isnumber(L, 7)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int fgg = lua_tointeger(L, 7);
-
-    if (!lua_isnumber(L, 8)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int fgb = lua_tointeger(L, 8);
-
-    if (!lua_isnumber(L, 9)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int bgr = lua_tointeger(L, 9);
-
-    if (!lua_isnumber(L, 10)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int bgg = lua_tointeger(L, 10);
-
-    if (!lua_isnumber(L, 11)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int bgb = lua_tointeger(L, 11);
-
+    float posy = getVerifiedFloat(L, 4, "createMapLabel", "posY");
+    float posz = getVerifiedFloat(L, 5, "createMapLabel", "posZ");
+    int fgr = getVerifiedInt(L, 6, "createMapLabel", "fgRed");
+    int fgg = getVerifiedInt(L, 7, "createMapLabel", "fgGreen");
+    int fgb = getVerifiedInt(L, 8, "createMapLabel", "fgBlue");
+    int bgr = getVerifiedInt(L, 9, "createMapLabel", "bgRed");
+    int bgg = getVerifiedInt(L, 10, "createMapLabel", "bgGreen");
+    int bgb = getVerifiedInt(L, 11, "createMapLabel", "bgBlue");
     if (args > 11) {
-//        if (!lua_isnumber(L, 12)) {
-//            lua_pushstring(L, "createMapLabel: wrong argument type");
-//            return lua_error(L);
-//        }
-//        zoom = lua_tonumber(L, 12);
         zoom = getVerifiedFloat(L, 12, "createMapLabel", "zoom", true);
-
-        if (!lua_isnumber(L, 13)) {
-            lua_pushstring(L, "createMapLabel: wrong argument type");
-            return lua_error(L);
-        }
-        fontSize = lua_tointeger(L, 13);
-
+        fontSize = getVerifiedInt(L, 13, "createMapLabel", "fontSize", true);
         if (args > 13) {
-//            if (!lua_isboolean(L, 14)) {
-//                lua_pushstring(L, "createMapLabel: wrong argument type");
-//                return lua_error(L);
-//            }
-//            showOnTop = lua_toboolean(L, 14);
             showOnTop = getVerifiedBoolean(L, 14, "createMapLabel", "showOnTop", true);
         }
         if (args > 14) {
-            if (!lua_isboolean(L, 15)) {
-                lua_pushstring(L, "createMapLabel: wrong argument type");
-                return lua_error(L);
-            }
-            noScaling = lua_toboolean(L, 15);
+            noScaling = getVerifiedBoolean(L, 15, "createMapLabel", "noScaling", true);
         }
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -208,7 +208,7 @@ TLuaInterpreter::~TLuaInterpreter()
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //
 // See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
-bool TLuaInterpreter::verifyBoolean(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+bool TLuaInterpreter::verifyBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isboolean(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "boolean", isOptional);
@@ -221,7 +221,7 @@ bool TLuaInterpreter::verifyBoolean(lua_State* L, const int pos, const QString& 
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isstring(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
@@ -234,7 +234,7 @@ QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const QString
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-int TLuaInterpreter::verifyInt(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+int TLuaInterpreter::verifyInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isnumber(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
@@ -247,7 +247,7 @@ int TLuaInterpreter::verifyInt(lua_State* L, const int pos, const QString& funct
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-float TLuaInterpreter::verifyFloat(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+float TLuaInterpreter::verifyFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isnumber(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
@@ -260,7 +260,7 @@ float TLuaInterpreter::verifyFloat(lua_State* L, const int pos, const QString& f
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-void TLuaInterpreter::announceWrongArgumentType(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const QString& publicType, const bool isOptional)
+void TLuaInterpreter::announceWrongArgumentType(lua_State* L, const int pos, const char* functionName, const char* publicName, const char* publicType, const bool isOptional)
 {
     if (isOptional) {
         lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!",

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -263,10 +263,10 @@ float TLuaInterpreter::verifyFloat(lua_State* L, const int pos, const char* func
 void TLuaInterpreter::announceWrongArgumentType(lua_State* L, const int pos, const char* functionName, const char* publicName, const char* publicType, const bool isOptional)
 {
     if (isOptional) {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!",
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s!)",
             functionName, pos, publicName, publicType, luaL_typename(L, pos));
     } else {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!",
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s!)",
             functionName, pos, publicName, publicType, luaL_typename(L, pos));
     }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -205,7 +205,7 @@ TLuaInterpreter::~TLuaInterpreter()
 // With reduced repetition like that:
 //    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", true);
 //
-// See also: verifyString, verifyNumber, announceWrongArgumentType
+// See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
 bool TLuaInterpreter::verifyBool(L, functionName, pos, publicName, notOptional)
 { 
     if (!lua_isboolean(L, pos)) { 
@@ -216,7 +216,7 @@ bool TLuaInterpreter::verifyBool(L, functionName, pos, publicName, notOptional)
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool, verifyNumber, announceWrongArgumentType
+// See also: verifyBool
 QString TLuaInterpreter::verifyString(L, functionName, pos, publicName, notOptional)
 { 
     if (!lua_isstring(L, pos)) { 
@@ -227,18 +227,29 @@ QString TLuaInterpreter::verifyString(L, functionName, pos, publicName, notOptio
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool, verifyString, announceWrongArgumentType
-float TLuaInterpreter::verifyNumber(L, functionName, pos, publicName, notOptional)
+// See also: verifyBool
+int TLuaInterpreter::verifyInt(L, functionName, pos, publicName, notOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "string");
+        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "number");
+        return lua_error(L);
+    }
+    return lua_tointeger(L, pos);
+}
+
+// No documentation available in wiki - internal function
+// See also: verifyBool
+float TLuaInterpreter::verifyFloat(L, functionName, pos, publicName, notOptional)
+{ 
+    if (!lua_isnumber(L, pos)) { 
+        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "number");
         return lua_error(L);
     }
     return lua_tonumber(L, pos);
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool, verifyString, verifyNumber
+// See also: verifyBool
 void TLuaInterpreter::announceWrongArgumentType(L, functionName, pos, publicName, notOptional, publicType) 
 { 
     if notOptional {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9281,25 +9281,25 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     bool noScaling = true;
 
     int args = lua_gettop(L);
-    int area = getVerifiedInt(L, 1, "createMapLabel", "areaID");
-    QString text = getVerifiedString(L, 2, "createMapLabel", "text");
-    float posx = getVerifiedFloat(L, 3, "createMapLabel", "posX");
-    float posy = getVerifiedFloat(L, 4, "createMapLabel", "posY");
-    float posz = getVerifiedFloat(L, 5, "createMapLabel", "posZ");
-    int fgr = getVerifiedInt(L, 6, "createMapLabel", "fgRed");
-    int fgg = getVerifiedInt(L, 7, "createMapLabel", "fgGreen");
-    int fgb = getVerifiedInt(L, 8, "createMapLabel", "fgBlue");
-    int bgr = getVerifiedInt(L, 9, "createMapLabel", "bgRed");
-    int bgg = getVerifiedInt(L, 10, "createMapLabel", "bgGreen");
-    int bgb = getVerifiedInt(L, 11, "createMapLabel", "bgBlue");
+    int area = getVerifiedInt(L, 1, __func__, "areaID");
+    QString text = getVerifiedString(L, 2, __func__, "text");
+    float posx = getVerifiedFloat(L, 3, __func__, "posX");
+    float posy = getVerifiedFloat(L, 4, __func__, "posY");
+    float posz = getVerifiedFloat(L, 5, __func__, "posZ");
+    int fgr = getVerifiedInt(L, 6, __func__, "fgRed");
+    int fgg = getVerifiedInt(L, 7, __func__, "fgGreen");
+    int fgb = getVerifiedInt(L, 8, __func__, "fgBlue");
+    int bgr = getVerifiedInt(L, 9, __func__, "bgRed");
+    int bgg = getVerifiedInt(L, 10, __func__, "bgGreen");
+    int bgb = getVerifiedInt(L, 11, __func__, "bgBlue");
     if (args > 11) {
-        zoom = getVerifiedFloat(L, 12, "createMapLabel", "zoom", true);
-        fontSize = getVerifiedInt(L, 13, "createMapLabel", "fontSize", true);
+        zoom = getVerifiedFloat(L, 12, __func__, "zoom", true);
+        fontSize = getVerifiedInt(L, 13, __func__, "fontSize", true);
         if (args > 13) {
-            showOnTop = getVerifiedBoolean(L, 14, "createMapLabel", "showOnTop", true);
+            showOnTop = getVerifiedBoolean(L, 14, __func__, "showOnTop", true);
         }
         if (args > 14) {
-            noScaling = getVerifiedBoolean(L, 15, "createMapLabel", "noScaling", true);
+            noScaling = getVerifiedBoolean(L, 15, __func__, "noScaling", true);
         }
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -211,7 +211,7 @@ TLuaInterpreter::~TLuaInterpreter()
 bool TLuaInterpreter::verifyBoolean(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isboolean(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "boolean");
+        announceWrongArgumentType(L, pos, functionName, publicName, "boolean", isOptional);
         return lua_error(L);
     }
     return lua_toboolean(L, pos);
@@ -222,7 +222,7 @@ bool TLuaInterpreter::verifyBoolean(L, pos, functionName, publicName, isOptional
 QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isstring(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "string");
+        announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
         return lua_error(L);
     }
     return lua_tostring(L, pos);
@@ -233,7 +233,7 @@ QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOption
 int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "number");
+        announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
         return lua_error(L);
     }
     return lua_tointeger(L, pos);
@@ -244,7 +244,7 @@ int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "number");
+        announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional;
         return lua_error(L);
     }
     return lua_tonumber(L, pos);
@@ -252,7 +252,7 @@ float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, isOptional, publicType) 
+void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, publicType, isOptional) 
 { 
     if isOptional {
         lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!", 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -203,15 +203,15 @@ TLuaInterpreter::~TLuaInterpreter()
 //    bool showOnTop = lua_toboolean(L, 14);
 //
 // With reduced repetition like that:
-//    bool showOnTop = getVerifiedBoolean(L, 14, "createMapLabel", "showOnTop", true);
+//    bool showOnTop = getVerifiedBoolean(L, "createMapLabel", 14, "showOnTop", true);
 //
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //
 // See also: getVerifiedString, getVerifiedInt, getVerifiedFloat, announceWrongArgumentType
-bool TLuaInterpreter::getVerifiedBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+bool TLuaInterpreter::getVerifiedBoolean(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional)
 {
     if (!lua_isboolean(L, pos)) {
-        announceWrongArgumentType(L, pos, functionName, publicName, "boolean", isOptional);
+        announceWrongArgumentType(L, functionName, pos, publicName, "boolean", isOptional);
         lua_error(L);
         Q_UNREACHABLE();
         return false;
@@ -221,10 +221,10 @@ bool TLuaInterpreter::getVerifiedBoolean(lua_State* L, const int pos, const char
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-QString TLuaInterpreter::getVerifiedString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+QString TLuaInterpreter::getVerifiedString(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional)
 {
     if (!lua_isstring(L, pos)) {
-        announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
+        announceWrongArgumentType(L, functionName, pos, publicName, "string", isOptional);
         lua_error(L);
         Q_UNREACHABLE();
         return QString();
@@ -234,10 +234,10 @@ QString TLuaInterpreter::getVerifiedString(lua_State* L, const int pos, const ch
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-int TLuaInterpreter::getVerifiedInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+int TLuaInterpreter::getVerifiedInt(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional)
 {
     if (!lua_isnumber(L, pos)) {
-        announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
+        announceWrongArgumentType(L, functionName, pos, publicName, "number", isOptional);
         lua_error(L);
         Q_UNREACHABLE();
         return -1;
@@ -247,10 +247,10 @@ int TLuaInterpreter::getVerifiedInt(lua_State* L, const int pos, const char* fun
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-float TLuaInterpreter::getVerifiedFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+float TLuaInterpreter::getVerifiedFloat(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional)
 {
     if (!lua_isnumber(L, pos)) {
-        announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
+        announceWrongArgumentType(L, functionName, pos, publicName, "number", isOptional);
         lua_error(L);
         Q_UNREACHABLE();
         return 0;
@@ -260,7 +260,7 @@ float TLuaInterpreter::getVerifiedFloat(lua_State* L, const int pos, const char*
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-void TLuaInterpreter::announceWrongArgumentType(lua_State* L, const int pos, const char* functionName, const char* publicName, const char* publicType, const bool isOptional)
+void TLuaInterpreter::announceWrongArgumentType(lua_State* L, const char* functionName, const int pos, const char* publicName, const char* publicType, const bool isOptional)
 {
     if (isOptional) {
         lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s!)",

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -212,7 +212,9 @@ bool TLuaInterpreter::verifyBoolean(L, pos, functionName, publicName, isOptional
 { 
     if (!lua_isboolean(L, pos)) { 
         announceWrongArgumentType(L, pos, functionName, publicName, "boolean", isOptional);
-        return lua_error(L);
+        lua_error(L);
+        Q_UNREACHABLE();
+        return false;
     }
     return lua_toboolean(L, pos);
 }
@@ -223,7 +225,9 @@ QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOption
 { 
     if (!lua_isstring(L, pos)) { 
         announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
-        return lua_error(L);
+        lua_error(L);
+        Q_UNREACHABLE();
+        return QString;
     }
     return lua_tostring(L, pos);
 }
@@ -234,7 +238,9 @@ int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
-        return lua_error(L);
+        lua_error(L);
+        Q_UNREACHABLE();
+        return -1;
     }
     return lua_tointeger(L, pos);
 }
@@ -245,7 +251,9 @@ float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional;
-        return lua_error(L);
+        lua_error(L);
+        Q_UNREACHABLE();
+        return 0;
     }
     return lua_tonumber(L, pos);
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -208,9 +208,9 @@ TLuaInterpreter::~TLuaInterpreter()
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //
 // See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
-bool TLuaInterpreter::verifyBoolean(L, pos, functionName, publicName, isOptional)
-{ 
-    if (!lua_isboolean(L, pos)) { 
+bool TLuaInterpreter::verifyBoolean(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+{
+    if (!lua_isboolean(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "boolean", isOptional);
         return lua_error(L);
     }
@@ -219,9 +219,9 @@ bool TLuaInterpreter::verifyBoolean(L, pos, functionName, publicName, isOptional
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOptional)
-{ 
-    if (!lua_isstring(L, pos)) { 
+QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+{
+    if (!lua_isstring(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
         return lua_error(L);
     }
@@ -230,9 +230,9 @@ QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOption
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
-{ 
-    if (!lua_isnumber(L, pos)) { 
+int TLuaInterpreter::verifyInt(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+{
+    if (!lua_isnumber(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
         return lua_error(L);
     }
@@ -241,10 +241,10 @@ int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
-{ 
-    if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional;
+float TLuaInterpreter::verifyFloat(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional)
+{
+    if (!lua_isnumber(L, pos)) {
+        announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
         return lua_error(L);
     }
     return lua_tonumber(L, pos);
@@ -252,13 +252,13 @@ float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, publicType, isOptional) 
-{ 
-    if isOptional {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!", 
+void TLuaInterpreter::announceWrongArgumentType(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const QString& publicType, const bool isOptional)
+{
+    if (isOptional) {
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!",
             functionName, pos, publicName, publicType, luaL_typename(L, pos));
     } else {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!", 
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!",
             functionName, pos, publicName, publicType, luaL_typename(L, pos));
     }
 }
@@ -6146,7 +6146,7 @@ int TLuaInterpreter::auditAreas(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomWeight 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomWeight
 int TLuaInterpreter::getRoomWeight(lua_State* L)
 {
     Host& host = getHostFromLua(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9281,25 +9281,25 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     bool noScaling = true;
 
     int args = lua_gettop(L);
-    int area = getVerifiedInt(L, 1, __func__, "areaID");
-    QString text = getVerifiedString(L, 2, __func__, "text");
-    float posx = getVerifiedFloat(L, 3, __func__, "posX");
-    float posy = getVerifiedFloat(L, 4, __func__, "posY");
-    float posz = getVerifiedFloat(L, 5, __func__, "posZ");
-    int fgr = getVerifiedInt(L, 6, __func__, "fgRed");
-    int fgg = getVerifiedInt(L, 7, __func__, "fgGreen");
-    int fgb = getVerifiedInt(L, 8, __func__, "fgBlue");
-    int bgr = getVerifiedInt(L, 9, __func__, "bgRed");
-    int bgg = getVerifiedInt(L, 10, __func__, "bgGreen");
-    int bgb = getVerifiedInt(L, 11, __func__, "bgBlue");
+    int area = getVerifiedInt(L, __func__, 1, "areaID");
+    QString text = getVerifiedString(L, __func__, 2, "text");
+    float posx = getVerifiedFloat(L, __func__, 3, "posX");
+    float posy = getVerifiedFloat(L, __func__, 4, "posY");
+    float posz = getVerifiedFloat(L, __func__, 5, "posZ");
+    int fgr = getVerifiedInt(L, __func__, 6, "fgRed");
+    int fgg = getVerifiedInt(L, __func__, 7, "fgGreen");
+    int fgb = getVerifiedInt(L, __func__, 8, "fgBlue");
+    int bgr = getVerifiedInt(L, __func__, 9, "bgRed");
+    int bgg = getVerifiedInt(L, __func__, 10, "bgGreen");
+    int bgb = getVerifiedInt(L, __func__, 11, "bgBlue");
     if (args > 11) {
-        zoom = getVerifiedFloat(L, 12, __func__, "zoom", true);
-        fontSize = getVerifiedInt(L, 13, __func__, "fontSize", true);
+        zoom = getVerifiedFloat(L, __func__, 12, "zoom", true);
+        fontSize = getVerifiedInt(L, __func__, 13, "fontSize", true);
         if (args > 13) {
-            showOnTop = getVerifiedBoolean(L, 14, __func__, "showOnTop", true);
+            showOnTop = getVerifiedBoolean(L, __func__, 14, "showOnTop", true);
         }
         if (args > 14) {
-            noScaling = getVerifiedBoolean(L, 15, __func__, "noScaling", true);
+            noScaling = getVerifiedBoolean(L, __func__, 15, "noScaling", true);
         }
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -203,15 +203,15 @@ TLuaInterpreter::~TLuaInterpreter()
 //    bool showOnTop = lua_toboolean(L, 9);
 //
 // With reduced repetition like that:
-//    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", true);
+//    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", false);
 //
-// The "notOptional" parameter is optional, and will default to not-optional parameters! :)
+// The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //
 // See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
-bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, notOptional)
+bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isboolean(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "boolean");
+        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "boolean");
         return lua_error(L);
     }
     return lua_toboolean(L, pos);
@@ -219,10 +219,10 @@ bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, notOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, notOptional)
+QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isstring(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "string");
+        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "string");
         return lua_error(L);
     }
     return lua_tostring(L, pos);
@@ -230,10 +230,10 @@ QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, notOptio
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, notOptional)
+int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "number");
+        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "number");
         return lua_error(L);
     }
     return lua_tointeger(L, pos);
@@ -241,10 +241,10 @@ int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, notOptional)
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, notOptional)
+float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
-        announceWrongArgumentType(L, pos, functionName, publicName, notOptional, "number");
+        announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "number");
         return lua_error(L);
     }
     return lua_tonumber(L, pos);
@@ -252,13 +252,13 @@ float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, notOptional
 
 // No documentation available in wiki - internal function
 // See also: verifyBool
-void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, notOptional, publicType) 
+void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, isOptional, publicType) 
 { 
-    if notOptional {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!", 
+    if isOptional {
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!", 
             functionName, pos, publicName, publicType, luaL_typename(L, pos));
     } else {
-        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!", 
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!", 
             functionName, pos, publicName, publicType, luaL_typename(L, pos));
     }
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -203,12 +203,12 @@ TLuaInterpreter::~TLuaInterpreter()
 //    bool showOnTop = lua_toboolean(L, 9);
 //
 // With reduced repetition like that:
-//    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", false);
+//    bool showOnTop = verifyBoolean(L, "createMapLabel", 9, "showOnTop", false);
 //
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //
 // See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
-bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, isOptional)
+bool TLuaInterpreter::verifyBoolean(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isboolean(L, pos)) { 
         announceWrongArgumentType(L, pos, functionName, publicName, isOptional, "boolean");
@@ -218,7 +218,7 @@ bool TLuaInterpreter::verifyBool(L, pos, functionName, publicName, isOptional)
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool
+// See also: verifyBoolean
 QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isstring(L, pos)) { 
@@ -229,7 +229,7 @@ QString TLuaInterpreter::verifyString(L, pos, functionName, publicName, isOption
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool
+// See also: verifyBoolean
 int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
@@ -240,7 +240,7 @@ int TLuaInterpreter::verifyInt(L, pos, functionName, publicName, isOptional)
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool
+// See also: verifyBoolean
 float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 { 
     if (!lua_isnumber(L, pos)) { 
@@ -251,7 +251,7 @@ float TLuaInterpreter::verifyFloat(L, pos, functionName, publicName, isOptional)
 }
 
 // No documentation available in wiki - internal function
-// See also: verifyBool
+// See also: verifyBoolean
 void TLuaInterpreter::announceWrongArgumentType(L, pos, functionName, publicName, isOptional, publicType) 
 { 
     if isOptional {
@@ -9362,7 +9362,7 @@ QString text = verifyString(L, 2, "createMapLabel", "text");
 //                return lua_error(L);
 //            }
 //            showOnTop = lua_toboolean(L, 14);
-            showOnTop = verifyBool(L, 14, "createMapLabel", "showOnTop", true);
+            showOnTop = verifyBoolean(L, 14, "createMapLabel", "showOnTop", true);
         }
         if (args > 14) {
             if (!lua_isboolean(L, 15)) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -203,7 +203,7 @@ TLuaInterpreter::~TLuaInterpreter()
 //    bool showOnTop = lua_toboolean(L, 9);
 //
 // With reduced repetition like that:
-//    bool showOnTop = verifyBoolean(L, "createMapLabel", 9, "showOnTop", false);
+//    bool showOnTop = verifyBoolean(L, 9, "createMapLabel", "showOnTop");
 //
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -227,7 +227,7 @@ QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const char* f
         announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
         lua_error(L);
         Q_UNREACHABLE();
-        return QString;
+        return QString();
     }
     return lua_tostring(L, pos);
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9271,11 +9271,11 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     bool noScaling = true;
 
     int args = lua_gettop(L);
-    if (!lua_isnumber(L, 1)) {
-        lua_pushstring(L, "createMapLabel: wrong argument type");
-        return lua_error(L);
-    }
-    int area = lua_tointeger(L, 1);
+//    if (!lua_isnumber(L, 1)) {
+//        lua_pushstring(L, "createMapLabel: wrong argument type");
+//        return lua_error(L);
+//    }
+    int area = verifyInt(L, "createMapLabel", 1, "areaID");
 
     if (!lua_isstring(L, 2)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -193,6 +193,64 @@ TLuaInterpreter::~TLuaInterpreter()
 }
 
 // No documentation available in wiki - internal function
+// Replaces a check like this:
+//    if (!lua_isboolean(L, 9)) {
+//        lua_pushfstring(L,
+//            "createMapLabel: bad argument #9 type (showOnTop as number expected, got %s!)",
+//            luaL_typename(L, 1));
+//        return lua_error(L);
+//    }
+//    bool showOnTop = lua_toboolean(L, 9);
+//
+// With reduced repetition like that:
+//    bool showOnTop = verifyBool(L, "createMapLabel", 9, "showOnTop", true);
+//
+// See also: verifyString, verifyNumber, announceWrongArgumentType
+bool TLuaInterpreter::verifyBool(L, functionName, pos, publicName, notOptional)
+{ 
+    if (!lua_isboolean(L, pos)) { 
+        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "boolean");
+        return lua_error(L);
+    }
+    return lua_toboolean(L, pos);
+}
+
+// No documentation available in wiki - internal function
+// See also: verifyBool, verifyNumber, announceWrongArgumentType
+QString TLuaInterpreter::verifyString(L, functionName, pos, publicName, notOptional)
+{ 
+    if (!lua_isstring(L, pos)) { 
+        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "string");
+        return lua_error(L);
+    }
+    return lua_tostring(L, pos);
+}
+
+// No documentation available in wiki - internal function
+// See also: verifyBool, verifyString, announceWrongArgumentType
+float TLuaInterpreter::verifyNumber(L, functionName, pos, publicName, notOptional)
+{ 
+    if (!lua_isnumber(L, pos)) { 
+        announceWrongArgumentType(L, functionName, pos, publicName, notOptional, "string");
+        return lua_error(L);
+    }
+    return lua_tonumber(L, pos);
+}
+
+// No documentation available in wiki - internal function
+// See also: verifyBool, verifyString, verifyNumber
+void TLuaInterpreter::announceWrongArgumentType(L, functionName, pos, publicName, notOptional, publicType) 
+{ 
+    if notOptional {
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s expected, got %s)!", 
+            functionName, pos, publicName, publicType, luaL_typename(L, pos));
+    } else {
+        lua_pushfstring(L, "%s: bad argument #%d type (%s as %s is optional, got %s)!", 
+            functionName, pos, publicName, publicType, luaL_typename(L, pos));
+    }
+}
+
+// No documentation available in wiki - internal function
 // Raises additional sysDownloadError Events on failure to process
 // the local file, the second argument is "failureToWriteLocalFile" and besides
 // the file to be written being the third argument (as multiple downloads are

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -197,7 +197,7 @@ TLuaInterpreter::~TLuaInterpreter()
 //    if (!lua_isboolean(L, 9)) {
 //        lua_pushfstring(L,
 //            "createMapLabel: bad argument #9 type (showOnTop as number expected, got %s!)",
-//            luaL_typename(L, 1));
+//            luaL_typename(L, 9));
 //        return lua_error(L);
 //    }
 //    bool showOnTop = lua_toboolean(L, 9);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -203,12 +203,12 @@ TLuaInterpreter::~TLuaInterpreter()
 //    bool showOnTop = lua_toboolean(L, 9);
 //
 // With reduced repetition like that:
-//    bool showOnTop = verifyBoolean(L, 9, "createMapLabel", "showOnTop");
+//    bool showOnTop = getVerifiedBoolean(L, 9, "createMapLabel", "showOnTop");
 //
 // The "isOptional" parameter is optional, and will default to not-optional parameters! :)
 //
-// See also: verifyString, verifyInt, verifyFloat, announceWrongArgumentType
-bool TLuaInterpreter::verifyBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+// See also: getVerifiedString, getVerifiedInt, getVerifiedFloat, announceWrongArgumentType
+bool TLuaInterpreter::getVerifiedBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isboolean(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "boolean", isOptional);
@@ -221,7 +221,7 @@ bool TLuaInterpreter::verifyBoolean(lua_State* L, const int pos, const char* fun
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+QString TLuaInterpreter::getVerifiedString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isstring(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "string", isOptional);
@@ -234,7 +234,7 @@ QString TLuaInterpreter::verifyString(lua_State* L, const int pos, const char* f
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-int TLuaInterpreter::verifyInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+int TLuaInterpreter::getVerifiedInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isnumber(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
@@ -247,7 +247,7 @@ int TLuaInterpreter::verifyInt(lua_State* L, const int pos, const char* function
 
 // No documentation available in wiki - internal function
 // See also: verifyBoolean
-float TLuaInterpreter::verifyFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
+float TLuaInterpreter::getVerifiedFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional)
 {
     if (!lua_isnumber(L, pos)) {
         announceWrongArgumentType(L, pos, functionName, publicName, "number", isOptional);
@@ -9286,21 +9286,21 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
 //        return lua_error(L);
 //    }
 //    int area = lua_tointeger(L, 1);
-    int area = verifyInt(L, 1, "createMapLabel", "areaID");
+    int area = getVerifiedInt(L, 1, "createMapLabel", "areaID");
 
 //    if (!lua_isstring(L, 2)) {
 //        lua_pushstring(L, "createMapLabel: wrong argument type");
 //        return lua_error(L);
 //    }
 //    QString text = lua_tostring(L, 2);
-QString text = verifyString(L, 2, "createMapLabel", "text");
+QString text = getVerifiedString(L, 2, "createMapLabel", "text");
 
 //    if (!lua_isnumber(L, 3)) {
 //        lua_pushstring(L, "createMapLabel: wrong argument type");
 //        return lua_error(L);
 //    }
 //    float posx = lua_tonumber(L, 3);
-    float posx = verifyFloat(L, 3, "createMapLabel", "posX");
+    float posx = getVerifiedFloat(L, 3, "createMapLabel", "posX");
 
     if (!lua_isnumber(L, 4)) {
         lua_pushstring(L, "createMapLabel: wrong argument type");
@@ -9356,7 +9356,7 @@ QString text = verifyString(L, 2, "createMapLabel", "text");
 //            return lua_error(L);
 //        }
 //        zoom = lua_tonumber(L, 12);
-        zoom = verifyFloat(L, 12, "createMapLabel", "zoom", true);
+        zoom = getVerifiedFloat(L, 12, "createMapLabel", "zoom", true);
 
         if (!lua_isnumber(L, 13)) {
             lua_pushstring(L, "createMapLabel: wrong argument type");
@@ -9370,7 +9370,7 @@ QString text = verifyString(L, 2, "createMapLabel", "text");
 //                return lua_error(L);
 //            }
 //            showOnTop = lua_toboolean(L, 14);
-            showOnTop = verifyBoolean(L, 14, "createMapLabel", "showOnTop", true);
+            showOnTop = getVerifiedBoolean(L, 14, "createMapLabel", "showOnTop", true);
         }
         if (args > 14) {
             if (!lua_isboolean(L, 15)) {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    static bool getVerifiedBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static QString getVerifiedString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static int getVerifiedInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static float getVerifiedFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static void announceWrongArgumentType(lua_State* L, const int pos, const char* functionName, const char* publicName, const char* publicType, const bool isOptional = false);
+    static bool getVerifiedBoolean(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
+    static QString getVerifiedString(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
+    static int getVerifiedInt(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
+    static float getVerifiedFloat(lua_State* L, const char* functionName, const int pos, const char* publicName, const bool isOptional = false);
+    static void announceWrongArgumentType(lua_State* L, const char* functionName, const int pos, const char* publicName, const char* publicType, const bool isOptional = false);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    static bool verifyBoolean(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    static QString verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    static int verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    static float verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    void announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const QString&, const bool isOptional = false);
+    static bool verifyBoolean(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
+    static QString verifyString(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
+    static int verifyInt(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
+    static float verifyFloat(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
+    static void announceWrongArgumentType(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const QString& publicType, const bool isOptional = false);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,10 +597,10 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    static bool verifyBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static QString verifyString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static int verifyInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
-    static float verifyFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static bool getVerifiedBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static QString getVerifiedString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static int getVerifiedInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static float getVerifiedFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
     static void announceWrongArgumentType(lua_State* L, const int pos, const char* functionName, const char* publicName, const char* publicType, const bool isOptional = false);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -599,7 +599,8 @@ public slots:
 private:
     bool TLuaInterpreter::verifyBool(lua_State*, const QString&, const int, const QString&, const bool);
     QString TLuaInterpreter::verifyString(lua_State*, const QString&, const int, const QString&, const bool);
-    float TLuaInterpreter::verifyNumber(lua_State*, const QString&, const int, const QString&, const bool);
+    int TLuaInterpreter::verifyInt(lua_State*, const QString&, const int, const QString&, const bool);
+    float TLuaInterpreter::verifyFloat(lua_State*, const QString&, const int, const QString&, const bool);
     void TLuaInterpreter::announceWrongArgumentType(lua_State*, const QString&, const int, const QString&, const bool, const QString&);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,10 +597,10 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool verifyBoolean(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    QString verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    int verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    float verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    static bool verifyBoolean(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    static QString verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    static int verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    static float verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
     void announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const QString&, const bool isOptional = false);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    static bool verifyBoolean(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
-    static QString verifyString(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
-    static int verifyInt(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
-    static float verifyFloat(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const bool isOptional = false);
-    static void announceWrongArgumentType(lua_State* L, const int pos, const QString& functionName, const QString& publicName, const QString& publicType, const bool isOptional = false);
+    static bool verifyBoolean(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static QString verifyString(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static int verifyInt(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static float verifyFloat(lua_State* L, const int pos, const char* functionName, const char* publicName, const bool isOptional = false);
+    static void announceWrongArgumentType(lua_State* L, const int pos, const char* functionName, const char* publicName, const char* publicType, const bool isOptional = false);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool TLuaInterpreter::verifyBool(lua_State*, const QString&, const int, const QString&, const bool);
-    QString TLuaInterpreter::verifyString(lua_State*, const QString&, const int, const QString&, const bool);
-    int TLuaInterpreter::verifyInt(lua_State*, const QString&, const int, const QString&, const bool);
-    float TLuaInterpreter::verifyFloat(lua_State*, const QString&, const int, const QString&, const bool);
-    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const QString&, const int, const QString&, const bool, const QString&);
+    bool TLuaInterpreter::verifyBool(lua_State*, const int, const QString&, const QString&, const bool);
+    QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool);
+    int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool);
+    float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool);
+    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool, const QString&);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,6 +597,10 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
+    bool TLuaInterpreter::verifyBool(lua_State*, const QString&, const int, const QString&, const bool);
+    QString TLuaInterpreter::verifyString(lua_State*, const QString&, const int, const QString&, const bool);
+    float TLuaInterpreter::verifyNumber(lua_State*, const QString&, const int, const QString&, const bool);
+    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const QString&, const int, const QString&, const bool, const QString&);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool TLuaInterpreter::verifyBool(lua_State*, const int, const QString&, const QString&, const bool);
-    QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool);
-    int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool);
-    float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool);
-    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool, const QString&);
+    bool TLuaInterpreter::verifyBool(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
+    QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
+    int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
+    float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
+    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool notOptional = false, const QString&);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool TLuaInterpreter::verifyBool(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
-    QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
-    int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
-    float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool notOptional = false);
-    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool notOptional = false, const QString&);
+    bool TLuaInterpreter::verifyBool(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool isOptional = false, const QString&);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,7 +597,7 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool TLuaInterpreter::verifyBool(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    bool TLuaInterpreter::verifyBoolean(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
     QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
     int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
     float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -597,11 +597,11 @@ public slots:
     void slotDeleteSender(int, QProcess::ExitStatus);
 
 private:
-    bool TLuaInterpreter::verifyBoolean(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    QString TLuaInterpreter::verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    int TLuaInterpreter::verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    float TLuaInterpreter::verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    void TLuaInterpreter::announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool isOptional = false, const QString&);
+    bool verifyBoolean(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    QString verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    int verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    float verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
+    void announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool isOptional = false, const QString&);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -601,7 +601,7 @@ private:
     QString verifyString(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
     int verifyInt(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
     float verifyFloat(lua_State*, const int, const QString&, const QString&, const bool isOptional = false);
-    void announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const bool isOptional = false, const QString&);
+    void announceWrongArgumentType(lua_State*, const int, const QString&, const QString&, const QString&, const bool isOptional = false);
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Use dedicated functions to verify lua argument types given by users

#### Motivation for adding to Mudlet
Less repetition, more standardisation, easier readability and writability 

#### Other info (issues closed, discussion etc)
Helpful tool to tackle a probably large part of #2091

Current draft as proof of concept can be tested with createMapLabel()
https://wiki.mudlet.org/w/Manual:Lua_Functions#createMapLabel
> labelID = createMapLabel(areaID, text, posx, posy, posz, fgRed, fgGreen, fgBlue, bgRed, bgGreen, bgBlue, zoom, fontSize, showOnTop, noScaling)

edit: All arguments of this function's have been ported to new style messages.

~The following arguments have been ported to new style messages for testing of many possible style combinations:~
- ~areaID - integer~
- ~text - string~
- ~posX - float~
- ~zoom - optional float~
- ~showOnTop - optional boolean~

Try giving wrong argument types to any of these ~(and the non-listed unchanged ones)~ and see what happens.