### PR TITLE
Bugfix: `connectToServer` port was save to url slot

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5291,7 +5291,7 @@ int TLuaInterpreter::connectToServer(lua_State* L)
             return 2;
         }
 
-        result = host.writeProfileData(QLatin1String("url"), QString::number(port));
+        result = host.writeProfileData(QLatin1String("port"), QString::number(port));
         if (!result.first) {
             lua_pushnil(L);
             lua_pushfstring(L, "unable to save port number, reason: %s", result.second.toUtf8().constData());


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

FIxes bug when calling `connectToServer(host, port, true` would save port in host entry.

#### Motivation for adding to Mudlet

Bugfixing!

#### Other info (issues closed, discussion etc)
