### PR TITLE
Bugfix: more consistent validation for empty host

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2093,6 +2093,13 @@ bool dlgConnectionProfiles::validateProfile()
         QUrl check;
         QString url = host_name_entry->text().trimmed();
         check.setHost(url);
+
+        if (url.isEmpty()) {
+            host_name_entry->setPalette(mErrorPalette);
+            validUrl = false;
+            valid = false;
+        }
+
         if (!check.isValid()) {
             notificationAreaIconLabelError->show();
             notificationAreaMessageBox->setText(
@@ -2143,8 +2150,10 @@ bool dlgConnectionProfiles::validateProfile()
             }
             return true;
         } else {
-            notificationArea->show();
-            notificationAreaMessageBox->show();
+            if (!notificationAreaMessageBox->text().isEmpty()) {
+                notificationArea->show();
+                notificationAreaMessageBox->show();
+            }
             if (offline_button) {
                 offline_button->setEnabled(false);
                 offline_button->setToolTip(tr("<p>Please set a valid profile name, game server address and the game port before loading.</p>"));


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

On connection screen empty host was allowed when creating new profile or for existing profile typing in name allowed to bypass that validation.

#### Motivation for adding to Mudlet

More consistent validation.

#### Other info (issues closed, discussion etc)
