### PR TITLE
Remove no-modifier text for keybindings

### DIFF
--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -318,21 +318,13 @@ int KeyUnit::getNewID()
 QString KeyUnit::getKeyName(const Qt::Key keyCode, const Qt::KeyboardModifiers modifierCode) const
 {
     QString name;
-    if (modifierCode == Qt::NoModifier) {
-        name = tr("no modifiers + ",
-                  // Intentional comment to separate arguments
-                  "This text is added before the name of the key in a keybinding when there is "
-                  "NO modifiers. If any modifier (\"control\", etc.) is used they will be added "
-                  "instead; but they are not included in the translations. If they need to be "
-                  "translated in your language tell the Mudlet developers so that we can add them.");
-    } else {
-        name = ((modifierCode & Qt::ShiftModifier) ? "shift + " : QString())
-               % ((modifierCode & Qt::ControlModifier) ? "control + " : QString())
-               % ((modifierCode & Qt::AltModifier) ? "alt + " : QString())
-               % ((modifierCode & Qt::MetaModifier) ? "meta + " : QString())
-               % ((modifierCode & Qt::KeypadModifier) ? "keypad + " : QString())
-               % ((modifierCode & Qt::GroupSwitchModifier) ? "groupswitch + " : QString());
-    }
+    name = ((modifierCode & Qt::ShiftModifier) ? "shift + " : QString())
+         % ((modifierCode & Qt::ControlModifier) ? "control + " : QString())
+         % ((modifierCode & Qt::AltModifier) ? "alt + " : QString())
+         % ((modifierCode & Qt::MetaModifier) ? "meta + " : QString())
+         % ((modifierCode & Qt::KeypadModifier) ? "keypad + " : QString())
+         % ((modifierCode & Qt::GroupSwitchModifier) ? "groupswitch + " : QString());
+
 
     if (mKeys.contains(keyCode)) {
         return name % mKeys.value(keyCode);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
When there is no modifier in a keybinding, Mudlet shows this:

![image](https://user-images.githubusercontent.com/110988/104427651-cc347a00-5583-11eb-80a4-78138d343d26.png)

There's a couple of issues with it:
* it's obvious there's no modifier if none is shown, so it is not adding any new information
* a lot of Mudlet players won't even know what a 'modifier' is, they are not super technical

#### Motivation for adding to Mudlet
Better user experience and a less confusing Mudlet for our majority playerbase :)
#### Other info (issues closed, discussion etc)
Now looks like this:

![image](https://user-images.githubusercontent.com/110988/104427790-f7b76480-5583-11eb-814b-dc1505223c09.png)

![image](https://user-images.githubusercontent.com/110988/104427796-f9812800-5583-11eb-80a4-38ff9e00d0de.png)
