### PR TITLE
Delete Lua-side objects with timers

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14872,7 +14872,7 @@ void TLuaInterpreter::delete_luafunction(const QString& name)
         lua_setglobal(L, name.toUtf8().constData());
         lua_pop(L, lua_gettop(L));
     } else if (mudlet::debugMode) {
-        qWarning << "LUA: ERROR deleting " << name << ", it is not a function as expected";
+        qWarning() << "LUA: ERROR deleting " << name << ", it is not a function as expected";
     }
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14854,6 +14854,15 @@ bool TLuaInterpreter::call_luafunction(void* pT)
 }
 
 // No documentation available in wiki - internal function
+void TLuaInterpreter::delete_luafunction(void* pT)
+{
+    lua_State* L = pGlobalLua;
+    lua_pushlightuserdata(L, pT);
+    lua_pushnil(L);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+}
+
+// No documentation available in wiki - internal function
 // returns true if function ran without errors
 // as well as the boolean return value from the function
 std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14863,6 +14863,20 @@ void TLuaInterpreter::delete_luafunction(void* pT)
 }
 
 // No documentation available in wiki - internal function
+void TLuaInterpreter::delete_luafunction(const QString& name)
+{
+    lua_State* L = pGlobalLua;
+    lua_getglobal(L, name.toUtf8().constData());
+    if (lua_isfunction(L, -1)) {
+        lua_pushnil(L);
+        lua_setglobal(L, name.toUtf8().constData());
+        lua_pop(L, lua_gettop(L));
+    } else if (mudlet::debugMode) {
+        qWarning << "LUA: ERROR deleting " << name << ", it is not a function as expected";
+    }
+}
+
+// No documentation available in wiki - internal function
 // returns true if function ran without errors
 // as well as the boolean return value from the function
 std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -91,6 +91,7 @@ public:
     std::pair<bool, bool> callMultiReturnBool(const QString& function, const QString& mName);
     bool callConditionFunction(std::string& function, const QString& mName);
     bool call_luafunction(void* pT);
+    bool delete_luafunction(void* pT);
     std::pair<bool, bool> callLuaFunctionReturnBool(void* pT);
     double condenseMapLoad();
     bool compile(const QString& code, QString& error, const QString& name);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -92,6 +92,7 @@ public:
     bool callConditionFunction(std::string& function, const QString& mName);
     bool call_luafunction(void* pT);
     void delete_luafunction(void* pT);
+    void delete_luafunction(const QString& name);
     std::pair<bool, bool> callLuaFunctionReturnBool(void* pT);
     double condenseMapLoad();
     bool compile(const QString& code, QString& error, const QString& name);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -91,7 +91,7 @@ public:
     std::pair<bool, bool> callMultiReturnBool(const QString& function, const QString& mName);
     bool callConditionFunction(std::string& function, const QString& mName);
     bool call_luafunction(void* pT);
-    bool delete_luafunction(void* pT);
+    void delete_luafunction(void* pT);
     std::pair<bool, bool> callLuaFunctionReturnBool(void* pT);
     double condenseMapLoad();
     bool compile(const QString& code, QString& error, const QString& name);

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -71,6 +71,14 @@ TTimer::~TTimer()
     mpQTimer->stop();
     if (mpHost) {
         mpHost->getTimerUnit()->unregisterTimer(this);
+
+        if (isTemporary()) {
+            if (mScript.isEmpty()) {
+                mpHost->mLuaInterpreter.delete_luafunction(this);
+            } else {
+//                mpHost->mLuaInterpreter.compileAndExecuteScript(mScript);
+            }
+        }
     }
 
     mpQTimer->deleteLater();

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -76,7 +76,7 @@ TTimer::~TTimer()
             if (mScript.isEmpty()) {
                 mpHost->mLuaInterpreter.delete_luafunction(this);
             } else {
-//                mpHost->mLuaInterpreter.compileAndExecuteScript(mScript);
+                mpHost->mLuaInterpreter.delete_luafunction(QStringLiteral("Timer%1").arg(mName));
             }
         }
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Mudlet has already cleaned up the associated timer objects on the C++ side when deleting timers, but not on the Lua side as well. This fixes it.
#### Motivation for adding to Mudlet
Mudlet should not leak memory, even if this was a very small amount. It does build up over time if you run Mudlet for a long while.
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/4613

At the moment only functions are cleaned up, timers created with strings have the same issue ie `tempTimer(1, [[echo'hi']])` and need to be fixed.

This would apply not just to functions in timers, but in all temp* objects.