### PR TITLE
Perform timer cleanup in case of offline connection

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -454,6 +454,9 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });
     connect(&mTelnet, &cTelnet::signal_connected, this, [this](){ purgeTimer.stop(); });
     connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTimers);
+
+    // enable by default in case of offline connection; if the profile connects - timer will be disabled
+    purgeTimer.start(1min);
 }
 
 Host::~Host()
@@ -1410,6 +1413,7 @@ void Host::incomingStreamProcessor(const QString& data, int line)
 // cleaned up in bulk periodically.
 void Host::slot_purgeTimers()
 {
+    qDebug() << "timer cleanup";
     mTimerUnit.doCleanup();
 }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1413,7 +1413,6 @@ void Host::incomingStreamProcessor(const QString& data, int line)
 // cleaned up in bulk periodically.
 void Host::slot_purgeTimers()
 {
-    qDebug() << "timer cleanup";
     mTimerUnit.doCleanup();
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
https://github.com/Mudlet/Mudlet/pull/4290 added timer cleanup when Mudlet is offline - but didn't cover the case when a profile is first opened offline, without even connecting.
#### Motivation for adding to Mudlet
Always cleanup timers, when online and offline.
#### Other info (issues closed, discussion etc)
When online a timer isn't used - Mudlet instead cleans them up when the next line of data is received from the game. This is for optimal and predictable performance.