### PR TITLE
Enable PTB builds for Linux and macOS

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -4,6 +4,8 @@ on:
     branches: [master, development]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   compile-mudlet:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Enable PTB builds for Linux and macOS
#### Motivation for adding to Mudlet
So we have Public Test Builds running again and people can help us test early features
#### Other info (issues closed, discussion etc)
In theory, everything else should be in place and it will "just work", but it's hard to predict this.