### PR TITLE
Cleanup all other temp objects in the same way as timers

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -453,7 +453,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });
     connect(&mTelnet, &cTelnet::signal_connected, this, [this](){ purgeTimer.stop(); });
-    connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTimers);
+    connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTemps);
 
     // enable by default in case of offline connection; if the profile connects - timer will be disabled
     purgeTimer.start(1min);
@@ -1405,15 +1405,21 @@ void Host::incomingStreamProcessor(const QString& data, int line)
 {
     mTriggerUnit.processDataStream(data, line);
 
+    mAliasUnit.doCleanup();
     mTimerUnit.doCleanup();
+    mTriggerUnit.doCleanup();
+    mKeyUnit.doCleanup();
 }
 
-// When Mudlet is running in online mode, deleted timers are cleaned up in bulk
+// When Mudlet is running in online mode, deleted temp* objects are cleaned up in bulk
 // on every new line. When in offline mode, new lines don't come - so they are
 // cleaned up in bulk periodically.
-void Host::slot_purgeTimers()
+void Host::slot_purgeTemps()
 {
+    mAliasUnit.doCleanup();
     mTimerUnit.doCleanup();
+    mTriggerUnit.doCleanup();
+    mKeyUnit.doCleanup();
 }
 
 void Host::registerEventHandler(const QString& name, TScript* pScript)

--- a/src/Host.h
+++ b/src/Host.h
@@ -621,7 +621,7 @@ signals:
 
 private slots:
     void slot_reloadModules();
-    void slot_purgeTimers();
+    void slot_purgeTemps();
 
 private:
     void installPackageFonts(const QString &packageName);

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -95,6 +95,14 @@ TAction::~TAction()
 {
     if (mpHost) {
         mpHost->getActionUnit()->unregisterAction(this);
+
+        if (isTemporary()) {
+            if (mScript.isEmpty()) {
+                mpHost->mLuaInterpreter.delete_luafunction(this);
+            } else {
+                mpHost->mLuaInterpreter.delete_luafunction(mFuncName);
+            }
+        }
     }
 
     if (mpToolBar) {
@@ -237,15 +245,15 @@ void TAction::expandToolbar(TToolBar* pT)
         button->setStyleSheet(css);
 
         /*
-		 * CHECK: The other expandToolbar(...) has the following in this position:
-		 *       //FIXME: Heiko April 2012: only run checkbox button scripts, but run them even if unchecked
-		 *       if( action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence )
-		 *       {
-		 *          qDebug()<<"expandToolBar() name="<<action->mName<<" executing script";
-		 *          action->execute();
-		 *       }
-		 * Why does it have this and we do not? - Slysven
-		 */
+         * CHECK: The other expandToolbar(...) has the following in this position:
+         *       //FIXME: Heiko April 2012: only run checkbox button scripts, but run them even if unchecked
+         *       if( action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence )
+         *       {
+         *          qDebug()<<"expandToolBar() name="<<action->mName<<" executing script";
+         *          action->execute();
+         *       }
+         * Why does it have this and we do not? - Slysven
+         */
 
         if (action->isFolder()) {
             auto newMenu = new QMenu(pT);

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -57,6 +57,14 @@ TAlias::~TAlias()
         return;
     }
     mpHost->getAliasUnit()->unregisterAlias(this);
+
+    if (isTemporary()) {
+        if (mScript.isEmpty()) {
+            mpHost->mLuaInterpreter.delete_luafunction(this);
+        } else {
+            mpHost->mLuaInterpreter.delete_luafunction(mFuncName);
+        }
+    }
 }
 
 void TAlias::setName(const QString& name)

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -60,6 +60,14 @@ TKey::~TKey()
         return;
     }
     mpHost->getKeyUnit()->unregisterKey(this);
+
+    if (isTemporary()) {
+        if (mScript.isEmpty()) {
+            mpHost->mLuaInterpreter.delete_luafunction(this);
+        } else {
+            mpHost->mLuaInterpreter.delete_luafunction(mFuncName);
+        }
+    }
 }
 
 void TKey::setName(const QString& name)

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -76,7 +76,7 @@ TTimer::~TTimer()
             if (mScript.isEmpty()) {
                 mpHost->mLuaInterpreter.delete_luafunction(this);
             } else {
-                mpHost->mLuaInterpreter.delete_luafunction(QStringLiteral("Timer%1").arg(mName));
+                mpHost->mLuaInterpreter.delete_luafunction(mFuncName);
             }
         }
     }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -126,6 +126,14 @@ TTrigger::~TTrigger()
         return;
     }
     mpHost->getTriggerUnit()->unregisterTrigger(this);
+
+    if (isTemporary()) {
+        if (mScript.isEmpty()) {
+            mpHost->mLuaInterpreter.delete_luafunction(this);
+        } else {
+            mpHost->mLuaInterpreter.delete_luafunction(mFuncName);
+        }
+    }
 }
 
 void TTrigger::setName(const QString& name)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Cleanup all other temp objects - aliases, triggers, keys in the same way as timers - when they're deleted and you're online - on the next line, otherwise on a periodic timer.
#### Motivation for adding to Mudlet
Fixing a (small) memory leak, so Mudlet runs better if you run it for long periods of time.
#### Other info (issues closed, discussion etc)
Continuation of https://github.com/Mudlet/Mudlet/pull/4614.