### PR TITLE
Rename a few internal functions

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4969,10 +4969,10 @@ int TLuaInterpreter::lowerWindow(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showWindow -- not showUserWindow - compare initLuaGlobals()
-int TLuaInterpreter::showUserWindow(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#showWindow
+int TLuaInterpreter::showWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, "showWindow", 1, "name");
+    QString text = getVerifiedString(L, __func__, 1, "name");
     Host& host = getHostFromLua(L);
     lua_pushboolean(L, host.showWindow(text));
     return 1;
@@ -15629,7 +15629,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "raiseWindow", TLuaInterpreter::raiseWindow);
     lua_register(pGlobalLua, "lowerWindow", TLuaInterpreter::lowerWindow);
     lua_register(pGlobalLua, "hideWindow", TLuaInterpreter::hideWindow);
-    lua_register(pGlobalLua, "showWindow", TLuaInterpreter::showUserWindow);
+    lua_register(pGlobalLua, "showWindow", TLuaInterpreter::showWindow);
     lua_register(pGlobalLua, "createBuffer", TLuaInterpreter::createBuffer);
     lua_register(pGlobalLua, "createStopWatch", TLuaInterpreter::createStopWatch);
     lua_register(pGlobalLua, "getStopWatchTime", TLuaInterpreter::getStopWatchTime);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11132,8 +11132,8 @@ int TLuaInterpreter::addSupportedTelnetOption(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echo -- not Echo - compare initLuaGlobals()
-int TLuaInterpreter::Echo(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#echo
+int TLuaInterpreter::echo(lua_State* L)
 {
     Host& host = getHostFromLua(L);
 
@@ -15562,7 +15562,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "showUnzipProgress", TLuaInterpreter::showUnzipProgress); //internal function used by the package system NOT FOR USERS
     lua_register(pGlobalLua, "wait", TLuaInterpreter::Wait);
     lua_register(pGlobalLua, "expandAlias", TLuaInterpreter::expandAlias);
-    lua_register(pGlobalLua, "echo", TLuaInterpreter::Echo);
+    lua_register(pGlobalLua, "echo", TLuaInterpreter::echo);
     lua_register(pGlobalLua, "selectString", TLuaInterpreter::selectString);
     lua_register(pGlobalLua, "selectSection", TLuaInterpreter::selectSection);
     lua_register(pGlobalLua, "replace", TLuaInterpreter::replace);
@@ -16194,7 +16194,7 @@ void TLuaInterpreter::initIndenterGlobals()
     lua_pushstring(pIndenterState.get(), "SCRIPT_ID");
     lua_pushnumber(pIndenterState.get(), -2); // ID 2 is used to indicate that this is the indenter Lua interpreter
     lua_settable(pIndenterState.get(), LUA_GLOBALSINDEX);
-    lua_register(pIndenterState.get(), "echo", TLuaInterpreter::Echo);
+    lua_register(pIndenterState.get(), "echo", TLuaInterpreter::echo);
     lua_register(pIndenterState.get(), "tempTimer", TLuaInterpreter::tempTimer);
     lua_register(pIndenterState.get(), "send", TLuaInterpreter::sendRaw);
     lua_register(pIndenterState.get(), "debugc", TLuaInterpreter::debug);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4143,7 +4143,7 @@ int TLuaInterpreter::getBorderSizes(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resizeWindow -- not resizeUserWindow - compare initLuaGlobals()
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resizeWindow
 int TLuaInterpreter::resizeWindow(lua_State* L)
 {
     QString text = getVerifiedString(L, __func__, 1, "windowName");

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3930,10 +3930,10 @@ int TLuaInterpreter::closeUserWindow(lua_State* L)
     return 0;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideWindow -- not hideUserWindow - compare initLuaGlobals()
-int TLuaInterpreter::hideUserWindow(lua_State* L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#hideWindow
+int TLuaInterpreter::hideWindow(lua_State* L)
 {
-    QString text = getVerifiedString(L, "hideWindow", 1, "name");
+    QString text = getVerifiedString(L, __func__, 1, "name");
 
     Host& host = getHostFromLua(L);
     host.hideWindow(text);
@@ -15628,7 +15628,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setLabelCustomCursor", TLuaInterpreter::setLabelCustomCursor);
     lua_register(pGlobalLua, "raiseWindow", TLuaInterpreter::raiseWindow);
     lua_register(pGlobalLua, "lowerWindow", TLuaInterpreter::lowerWindow);
-    lua_register(pGlobalLua, "hideWindow", TLuaInterpreter::hideUserWindow);
+    lua_register(pGlobalLua, "hideWindow", TLuaInterpreter::hideWindow);
     lua_register(pGlobalLua, "showWindow", TLuaInterpreter::showUserWindow);
     lua_register(pGlobalLua, "createBuffer", TLuaInterpreter::createBuffer);
     lua_register(pGlobalLua, "createStopWatch", TLuaInterpreter::createStopWatch);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -268,7 +268,7 @@ public:
     static int Wait(lua_State* L);
     static int expandAlias(lua_State* L);
     static int sendRaw(lua_State* L);
-    static int Echo(lua_State* L);
+    static int echo(lua_State* L);
     static int selectString(lua_State* L); // Was select but I think it clashes with the Lua command with that name
     static int getMainConsoleWidth(lua_State* L);
     static int selectSection(lua_State* L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -343,7 +343,7 @@ public:
     static int raiseWindow(lua_State*);
     static int lowerWindow(lua_State*);
     static int showUserWindow(lua_State*);
-    static int hideUserWindow(lua_State*);
+    static int hideWindow(lua_State*);
     static int closeUserWindow(lua_State*);
     static int resizeWindow(lua_State*);
     static int createStopWatch(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -342,7 +342,7 @@ public:
     static int createBuffer(lua_State*);
     static int raiseWindow(lua_State*);
     static int lowerWindow(lua_State*);
-    static int showUserWindow(lua_State*);
+    static int showWindow(lua_State*);
     static int hideWindow(lua_State*);
     static int closeUserWindow(lua_State*);
     static int resizeWindow(lua_State*);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
rename some c++ functions to reflect their lua function names
- hideUserWindow to hideWindow 
- showUserWindow to showWindow
- Echo to echo
- resizeUserWindow was already renamed, removed comment that said otherwise

#### Motivation for adding to Mudlet
Consistency

#### Other info (issues closed, discussion etc)
As noted in #4599