### PR TITLE
Fix macOS builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         vcpkgArguments: '@${{env.vcpkgResponseFile}}'
         vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
-        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-key
+        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-cachekey
 
     - name: (macOS) Install non-vcpkg dependencies
       if: runner.os == 'macOS'


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Github Actions macOS environment was updated a couple of days ago and so vcpkg binary needs to be rebuilt - but the run-vcpk action doesn't currently account for this (https://github.com/lukka/run-vcpkg/issues/69).

Unfortunately Github Actions do not offer a way to purge the cache (https://github.com/actions/cache/issues/2), so we change the key as a workaround.
#### Motivation for adding to Mudlet
Fix macOS builds.
#### Other info (issues closed, discussion etc)
