### PR TITLE
Don't update edbee fork ourselves

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -49,46 +49,6 @@ jobs:
           commit-message: (autocommit) Updated IRE mapping script to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
-  update-edbee-fork:
-    runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: development
-          submodules: true
-          fetch-depth: 0
-
-      - name: update submodule to latest
-        run: git submodule update --remote 3rdparty/edbee-lib/
-
-      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
-      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
-      - name: check if we have any updates
-        id: getdiff
-        run: |
-          lines_changed=$(git diff --patch --unified=0 3rdparty/edbee-lib/ | wc --lines)
-          echo "$lines_changed lines changed."
-          echo ::set-output name=lines_changed::$lines_changed
-
-      - name: send in a pull request
-        uses: gr2m/create-or-update-pull-request-action@v1.x
-        if: steps.getdiff.outputs.lines_changed > 0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          title: "Update edbee to latest in our fork"
-          body: |
-            #### Brief overview of PR changes/additions
-            :crown: An automated PR to update edbee to its latest version in our fork.
-            #### Motivation for adding to Mudlet
-            Get new features, bugfixes, improvements! Stay modern.
-            #### Other info (issues closed, discussion etc)
-            _update triggered by ${{ github.ref }} ${{ github.sha }}_
-          branch: update-edbee-lib-${{ github.sha }}
-          path: 3rdparty/edbee-lib
-          commit-message: (autocommit) Updated edbee-lib submodule to latest in our fork
-          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
   update-sparkle-glue-fork:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Don't update edbee fork ourselves, because dependabot can already do it thanks to https://github.com/Mudlet/Mudlet/blob/development/.github/dependabot.yml
#### Motivation for adding to Mudlet
Less custom code that we need, good!
#### Other info (issues closed, discussion etc)
See sample PR https://github.com/Mudlet/Mudlet/pull/4632. It's even more informative than our usual PR: https://github.com/Mudlet/Mudlet/pull/4630