### PR TITLE
restore ability for miniconsoles to set a background image

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3480,9 +3480,14 @@ bool Host::setBackgroundImage(const QString& name, QString& imgPath, int mode)
         QPixmap bgPixmap(imgPath);
         pL->setPixmap(bgPixmap);
         return true;
-    } else {
-        return false;
     }
+
+    auto pC = mpConsole->mSubConsoleMap.value(name);
+    if (pC) {
+        pC->setConsoleBackgroundImage(imgPath, mode);
+        return true;
+    }
+    return false;
 }
 
 bool Host::resetBackgroundImage(const QString &name)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see Title
#### Motivation for adding to Mudlet
fix #4646
#### Other info (issues closed, discussion etc)
I think probably when refactoring the console access code in #4186 the part got lost.
@smurfix 