### PR TITLE
use QT mirror

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -60,6 +60,7 @@ jobs:
         dir: ${{runner.workspace}}
         arch: win64_mingw73 # this key is relevant only for windows
         cached: ${{steps.cache-qt.outputs.cache-hit}}
+        mirror: http://mirrors.ocf.berkeley.edu/qt/
 
     - name: Checkout Mudlet source code
       uses: actions/checkout@v2


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Repair QT install action by using mirror

#### Motivation for adding to Mudlet
download.qt.io doesn't work for over 10 hours now.

#### Other info (issues closed, discussion etc)
Official suggestion by action builder:
https://github.com/jurplel/install-qt-action#mirror
