### PR TITLE
static cast for getVerifiedFloat

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -256,7 +256,7 @@ float TLuaInterpreter::getVerifiedFloat(lua_State* L, const char* functionName, 
         Q_UNREACHABLE();
         return 0;
     }
-    return lua_tonumber(L, pos);
+    return static_cast <float> (lua_tonumber(L, pos));
 }
 
 // No documentation available in wiki - internal function


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Make getVerifiedFloat static cast the double type return of lua_tonumber.

#### Motivation for adding to Mudlet
Close #4644

#### Other info (issues closed, discussion etc)
Turns out, getVerifiedInt doesn't need static cast, because it already uses lua_tointeger.