### PR TITLE
Fix memory leak with conditions in triggers not being released on shutdown

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -122,6 +122,11 @@ TTrigger::~TTrigger()
         }
         itColorTable.remove();
     }
+
+    for (auto && [key, value] : mConditionMap) {
+        delete value;
+    }
+
     if (!mpHost) {
         return;
     }


### PR DESCRIPTION
…tdown

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix memory leak with conditions in triggers not being released on shutdown
#### Motivation for adding to Mudlet
Mudlet should not leak memory.
#### Other info (issues closed, discussion etc)
The choice of a map is weird (but it's old and it does work as we know). A better design would be to go with `unordered_set<unique_ptr<T>>`, that would really simplify things and prevent such a memory leak as this from happening by design.

While `TTrigger:match()` is unfortunately a method too big, looking through it I suspect this was the cause for the leak as per

![image](https://user-images.githubusercontent.com/110988/105199609-3a0e1200-5b3f-11eb-8ea3-3626d1281043.png)
