### PR TITLE
Fix memory leak with tracked timers in triggers not being released on shutdown

### DIFF
--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -26,6 +26,13 @@
 #include "mudlet.h"
 #include "TTimer.h"
 
+TimerUnit::~TimerUnit()
+{
+    for (auto&& timer : qAsConst(mQTimerSet)) {
+        delete timer;
+    }
+}
+
 void TimerUnit::_uninstall(TTimer* pChild, const QString& packageName)
 {
     std::list<TTimer*>* childrenList = pChild->mpMyChildrenList;

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -43,6 +43,7 @@ class TimerUnit
 
 public:
     TimerUnit(Host* pHost) : statsActiveTriggers(0), statsTriggerTotal(0), statsTempTriggers(0), mpHost(pHost), mMaxID(0), mModuleMember() {}
+    ~TimerUnit();
     void removeAllTempTimers();
     std::list<TTimer*> getTimerRootNodeList() { return mTimerRootNodeList; }
     TTimer* getTimer(int id);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Delete tracked timers when closing profile
#### Motivation for adding to Mudlet
Fix memory leak if you open/close profiles without shutting down Mudlet often
#### Other info (issues closed, discussion etc)
Fixes this leak:

```
8.14MB leaked over 761061 calls from
QHashData::allocateNode(int)
  in /tmp/.mount_MudletVSq2Ae/lib/libQt5Core.so.5
3.70MB leaked over 154084 calls from:
    QHash<>::createNode(unsigned int, QTimer* const&, QHashDummyValue const&, QHashNode<>**)
    QHash<>::insert(QTimer* const&, QHashDummyValue const&)
    QSet<>::insert(QTimer* const&)
    TTimer::TTimer(QString const&, QTime, Host*, bool)
```