### PR TITLE
Make it clearer for Mudlet newbies where trigger text goes

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -811,6 +811,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
         pItem->spinBox_lineSpacer->hide();
         pItem->label_patternNumber->setText(QString::number(i+1));
         pItem->label_patternNumber->show();
+        if (i == 0) {
+            pItem->lineEdit_pattern->setPlaceholderText(tr("Text to find (trigger pattern)"));
+        }
     }
     // force the minimum size of the scroll area for the trigger items to be one
     // and a half trigger item widgets:

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -42,26 +42,23 @@ void dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged(const int index)
 {
     label_colorIcon->setPixmap(comboBox_patternType->itemIcon(index).pixmap(15, 15));
 
-    int patternType = comboBox_patternType->currentIndex();
-    qDebug() << comboBox_patternType->itemData(0);
-    qDebug() << comboBox_patternType->itemData(0).toInt();
     const bool firstRow = comboBox_patternType->itemData(0).toInt() == 0;
     if (!firstRow) {
         return;
     }
 
-    switch (patternType) {
+    switch (comboBox_patternType->currentIndex()) {
     case REGEX_SUBSTRING:
-        lineEdit_pattern->setPlaceholderText(tr("Text to find anywhere in the line (trigger pattern)"));
+        lineEdit_pattern->setPlaceholderText(tr("Text to find (anywhere in the game output)"));
         break;
     case REGEX_PERL:
-        lineEdit_pattern->setPlaceholderText(tr("Regex pattern"));
+        lineEdit_pattern->setPlaceholderText(tr("Text to find (as a regular expression pattern)"));
         break;
     case REGEX_BEGIN_OF_LINE_SUBSTRING:
-        lineEdit_pattern->setPlaceholderText(tr("Text to find from start of of line (trigger pattern)"));
+        lineEdit_pattern->setPlaceholderText(tr("Text to find (from beginning of the line)"));
         break;
     case REGEX_EXACT_MATCH:
-        lineEdit_pattern->setPlaceholderText(tr("Exact line to match (trigger pattern)"));
+        lineEdit_pattern->setPlaceholderText(tr("Exact line to match"));
         break;
     case REGEX_LUA_CODE:
         lineEdit_pattern->setPlaceholderText(tr("Lua code to run (return true to match)"));

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -21,9 +21,11 @@
 
 
 #include "dlgTriggerPatternEdit.h"
+#include "TTrigger.h"
 
 #include "pre_guard.h"
 #include <QAction>
+#include <QDebug>
 #include "post_guard.h"
 
 dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pF)
@@ -32,10 +34,37 @@ dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pF)
 {
     // init generated dialog
     setupUi(this);
-    connect(comboBox_patternType, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged);
+    // delay the connection so the pattern type is available for the slot
+    connect(comboBox_patternType, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged, Qt::QueuedConnection);
 }
 
 void dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged(const int index)
 {
     label_colorIcon->setPixmap(comboBox_patternType->itemIcon(index).pixmap(15, 15));
+
+    int patternType = comboBox_patternType->currentIndex();
+    qDebug() << comboBox_patternType->itemData(0);
+    qDebug() << comboBox_patternType->itemData(0).toInt();
+    const bool firstRow = comboBox_patternType->itemData(0).toInt() == 0;
+    if (!firstRow) {
+        return;
+    }
+
+    switch (patternType) {
+    case REGEX_SUBSTRING:
+        lineEdit_pattern->setPlaceholderText(tr("Text to find anywhere in the line (trigger pattern)"));
+        break;
+    case REGEX_PERL:
+        lineEdit_pattern->setPlaceholderText(tr("Regex pattern"));
+        break;
+    case REGEX_BEGIN_OF_LINE_SUBSTRING:
+        lineEdit_pattern->setPlaceholderText(tr("Text to find from start of of line (trigger pattern)"));
+        break;
+    case REGEX_EXACT_MATCH:
+        lineEdit_pattern->setPlaceholderText(tr("Exact line to match (trigger pattern)"));
+        break;
+    case REGEX_LUA_CODE:
+        lineEdit_pattern->setPlaceholderText(tr("Lua code to run (return true to match)"));
+        break;
+    }
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Add a placeholder on the 1st pattern where the trigger pattern goes:

![image](https://user-images.githubusercontent.com/110988/105627597-1b0dc980-5e38-11eb-9749-9a2630285444.png)

#### Motivation for adding to Mudlet
We've seen cases where it's not obvious to new players:
![image](https://user-images.githubusercontent.com/110988/105627669-76d85280-5e38-11eb-8fe6-9b99c3438fe1.png)

#### Other info (issues closed, discussion etc)
`Text to find` was explicitly chosen because newbies to text games won't know what a `trigger pattern` is. That said `trigger pattern` is still included as an educational measure + to help veterans from other clients.

Pattern is only on the 1st one because after you fill in the first pattern, you know what the field is for, so you don't need the 'nag'.


I've tried several variants, I think this one is the best:
![image](https://user-images.githubusercontent.com/110988/105627600-1c3ef680-5e38-11eb-8f2c-04e65a40e3b2.png)

But opinions on others welcome:
![image](https://user-images.githubusercontent.com/110988/105627591-1517e880-5e38-11eb-916a-b6f383215e87.png)



