### PR TITLE
Improve caching: always save at the end of every build

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -180,7 +180,7 @@ jobs:
       uses: pat-s/always-upload-cache@v2.1.3
       with:
         path: ${{runner.workspace}}/ccache
-        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}
+        key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}-${{ github.sha }}
         restore-keys: ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.qt}}
       if: matrix.os != 'windows-latest'
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
`ccache` benefits from the cache always being saved to help populate it with even more files due to the little changes the code introduced.

Current setup only saved the cache once though and never updated it again - this'll make it always update the cache, making it more and more efficient over time - until Github automatically purges it.
#### Motivation for adding to Mudlet
Even quicker builds!
#### Other info (issues closed, discussion etc)
https://github.community/t/always-cache-files-and-save-them/18230