### PR TITLE
Update Github Actions to failsafe vcpkg version

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -69,13 +69,13 @@ jobs:
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v5
+      uses: lukka/run-vcpkg@v6
       env:
         vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-${{matrix.triplet}}-dependencies
       with:
         vcpkgArguments: '@${{env.vcpkgResponseFile}}'
         vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
-        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-aakey
+        appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-cachekey
 
     - name: (macOS) Install non-vcpkg dependencies
       if: runner.os == 'macOS'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,7 +72,7 @@ jobs:
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v5
+      uses: lukka/run-vcpkg@v6
       env:
         vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-x64-linux-dependencies
       with:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Update Github Actions to failsafe vcpkg version
#### Motivation for adding to Mudlet
So it doesn't fail when building from a cached version
#### Other info (issues closed, discussion etc)
https://github.com/lukka/run-vcpkg/issues/69#issuecomment-766477604