### PR TITLE
BugFix: correct mis-use of nullptr to denote no room symbol colour

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -771,7 +771,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QFont& mapN
     // Do we need to draw the room symbol:
     if (!(mShowRoomID && areRoomIdsLegible) && !pRoom->mSymbol.isEmpty()) {
         QColor symbolColor;
-        if (pRoom->mSymbolColor != nullptr) {
+        if (pRoom->mSymbolColor.isValid()) {
             symbolColor = pRoom->mSymbolColor;
         } else if (roomColor.lightness() > 127) {
             symbolColor = Qt::black;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10703,13 +10703,14 @@ int TLuaInterpreter::setRoomCharColor(lua_State* L)
         lua_pushnil(L);
         lua_pushfstring(L, "room with id %d does not exist", id);
         return 2;
-    } else {
-        pR->mSymbolColor = QColor(r, g, b);
-        lua_pushboolean(L, true);
-        host.mpMap->mpMapper->mp2dMap->repaint();
-        host.mpMap->mpMapper->update();
-        return 1;
     }
+
+    pR->mSymbolColor = QColor(r, g, b);
+    if (host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap) {
+        host.mpMap->mpMapper->mp2dMap->update();
+    }
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#unsetRoomCharColor
@@ -10727,13 +10728,15 @@ int TLuaInterpreter::unsetRoomCharColor(lua_State* L)
         lua_pushnil(L);
         lua_pushfstring(L, "room with id %d does not exist", id);
         return 2;
-    } else {
-        pR->mSymbolColor = nullptr;
-        lua_pushboolean(L, true);
-        host.mpMap->mpMapper->mp2dMap->repaint();
-        host.mpMap->mpMapper->update();
-        return 1;
     }
+
+    // Reset it to the default (and invalid) QColor:
+    pR->mSymbolColor = {};
+    if (host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap) {
+        host.mpMap->mpMapper->mp2dMap->update();
+    }
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getRoomCharColor

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1263,7 +1263,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
         if (mSaveVersion >= 21) {
             ofs << pR->mSymbolColor;
         } else {
-            if (pR->mSymbolColor != nullptr) {
+            if (pR->mSymbolColor.isValid()) {
                 pR->userData.insert(QLatin1String("system.fallback_symbol_color"), pR->mSymbolColor.name());
             }
         }


### PR DESCRIPTION
It seems like PR #4573 introduced a bogus use of pointer access to a `QColor` whereas the correct methodology is `QColor::isValid()` - a default constructed `QColor` is itself equivalent to an RGBA specified colour of `QColor(0,0,0,0)` and that will fail in that test. This PR fixes things so that (instead of a `nullptr` test) is used.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>