### PR TITLE
Show timestamps in normal copy as well

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -855,7 +855,7 @@ void TTextEdit::highlightSelection()
     QClipboard* clipboard = QApplication::clipboard();
     if (clipboard->supportsSelection()) {
         // X11 has a second clipboard that's updated on any selection
-        clipboard->setText(getSelectedText(), QClipboard::Selection);
+        clipboard->setText(getSelectedText(QChar::LineFeed, mShowTimeStamps), QClipboard::Selection);
     }
 }
 
@@ -1399,7 +1399,7 @@ void TTextEdit::slot_copySelectionToClipboard()
         return;
     }
 
-    QString selectedText = getSelectedText();
+    QString selectedText = getSelectedText(QChar::LineFeed, mShowTimeStamps);
     QClipboard* clipboard = QApplication::clipboard();
     clipboard->setText(selectedText);
 }
@@ -1643,12 +1643,12 @@ void TTextEdit::searchSelectionOnline()
     QDesktopServices::openUrl(QUrl(url));
 }
 
-QString TTextEdit::getSelectedText(const QChar& newlineChar)
+QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTimestamps)
 {
     // mPA QPoint where selection started
     // mPB QPoint where selection ended
     // try to prevent crash if buffer is batch deleted
-    if (mPA.y() > mpBuffer->lineBuffer.size() - 1 || mPB.y() > mpBuffer->lineBuffer.size() - 1){
+    if (mPA.y() > mpBuffer->lineBuffer.size() - 1 || mPB.y() > mpBuffer->lineBuffer.size() - 1) {
         mPA.ry() -= mpBuffer->mBatchDeleteSize;
         mPB.ry() -= mpBuffer->mBatchDeleteSize;
     }
@@ -1658,6 +1658,14 @@ QString TTextEdit::getSelectedText(const QChar& newlineChar)
     int startPos = std::max(0, mPA.x());
     int endPos = std::min(mPB.x(), (mpBuffer->lineBuffer.at(endLine).size() - 1));
     QStringList textLines = mpBuffer->lineBuffer.mid(startLine, endLine - startLine + 1);
+    if (showTimestamps) {
+        QStringList timestamps = mpBuffer->timeBuffer.mid(startLine, endLine - startLine + 1);
+        QStringList result;
+        std::transform(textLines.begin(), textLines.end(), timestamps.begin(), std::back_inserter(result),
+                       [](QString text, QString timestamp) { return timestamp.append(text); }
+        );
+        textLines = result;
+    }
 
     if (mPA.y() == mPB.y()) {
         // Is a single line, so trim characters off the beginning and end

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1661,8 +1661,8 @@ QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTime
     if (showTimestamps) {
         QStringList timestamps = mpBuffer->timeBuffer.mid(startLine, endLine - startLine + 1);
         QStringList result;
-        std::transform(textLines.begin(), textLines.end(), timestamps.begin(), std::back_inserter(result),
-                       [](QString text, QString timestamp) { return timestamp.append(text); } );
+        std::transform(textLines.cbegin(), textLines.cend(), timestamps.cbegin(), std::back_inserter(result),
+                               [](const QString& text, const QString& timestamp) { return timestamp + text; });
         textLines = result;
     }
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1662,8 +1662,7 @@ QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTime
         QStringList timestamps = mpBuffer->timeBuffer.mid(startLine, endLine - startLine + 1);
         QStringList result;
         std::transform(textLines.begin(), textLines.end(), timestamps.begin(), std::back_inserter(result),
-                       [](QString text, QString timestamp) { return timestamp.append(text); }
-        );
+                       [](QString text, QString timestamp) { return timestamp.append(text); } );
         textLines = result;
     }
 

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -132,7 +132,7 @@ private slots:
 
 private:
     void initDefaultSettings();
-    QString getSelectedText(const QChar& newlineChar = QChar::LineFeed);
+    QString getSelectedText(const QChar& newlineChar = QChar::LineFeed, const bool showTimestamps = false);
     static QString htmlCenter(const QString&);
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Timestamps are now included in the normal right-click copy option, in addition to the already existing HTML and image copy.
#### Motivation for adding to Mudlet
We thought this was already in, but wasn't. Also, consistency.
#### Other info (issues closed, discussion etc)
`std::transform` allows to easily merge the two lists of timestamps and lines together without having to do a for loop. Some nice reading:

https://tutorialspoint.dev/language/cpp/transform-c-stl-perform-operation-elements
https://www.fluentcpp.com/2017/02/13/transform-central-algorithm

Linux middle-click selection is updated as well.