### PR TITLE
BugFix: initialise mDlgRoomSymbol so that settng room symbols works again

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3557,14 +3557,14 @@ void T2DMap::slot_showSymbolSelection()
         }
     }
 
-    if (isAtLeastOneRoom && !mDlgRoomSymbol) {
-        mDlgRoomSymbol = new dlgRoomSymbol(mpHost, this);
-        mDlgRoomSymbol->init(usedSymbols, roomPtrsSet);
-        mDlgRoomSymbol->show();
-        mDlgRoomSymbol->raise();
-        connect(mDlgRoomSymbol, &dlgRoomSymbol::signal_save_symbol, this, &T2DMap::slot_setRoomSymbol);
-        connect(mDlgRoomSymbol, &QDialog::finished, this, [=]() {
-            mDlgRoomSymbol = nullptr;
+    if (isAtLeastOneRoom && !mpDlgRoomSymbol) {
+        mpDlgRoomSymbol = new dlgRoomSymbol(mpHost, this);
+        mpDlgRoomSymbol->init(usedSymbols, roomPtrsSet);
+        mpDlgRoomSymbol->show();
+        mpDlgRoomSymbol->raise();
+        connect(mpDlgRoomSymbol, &dlgRoomSymbol::signal_save_symbol, this, &T2DMap::slot_setRoomSymbol);
+        connect(mpDlgRoomSymbol, &QDialog::finished, this, [=]() {
+            mpDlgRoomSymbol = nullptr;
         });
     }
 }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -260,7 +260,7 @@ private:
 
     // Holds the QRadialGradient details to use for the player room:
     QGradientStops mPlayerRoomColorGradentStops;
-    dlgRoomSymbol* mDlgRoomSymbol;
+    dlgRoomSymbol* mpDlgRoomSymbol = nullptr;
 
 private slots:
     void slot_createRoom();


### PR DESCRIPTION
A test for this pointer being a `nullptr` is what enables a new dialogue to be made in the 2D mapper - by not initialising it in #4573 a random non-null value is found so the dialogue and thus the functionality can be virtually impossible to use.

As it is a pointer I have taken the liberty to introduce a `p` into the initial part of the name - after the `m` to indicate it is a class member.

As the defect is a regression that causes loss of functionality I am rating this as a **high** priority bug(fix) even though it does not induce any fatal termination of the application.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>