### PR TITLE
BugFix: correct missing detail (map label position) from binary map files

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1131,6 +1131,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
                 itMapLabel.next();
                 ofs << itMapLabel.key(); //label ID
                 TMapLabel label = itMapLabel.value();
+                ofs << label.pos;
                 ofs << label.size;
                 ofs << label.text;
                 ofs << label.fgColor;
@@ -1179,6 +1180,7 @@ bool TMap::serialize(QDataStream& ofs, int saveVersion)
                 itMapLabel.next();
                 ofs << itMapLabel.key(); //label ID
                 TMapLabel label = itMapLabel.value();
+                ofs << label.pos;
                 ofs << QPointF(); // dummy value - not actually used
                 ofs << label.size;
                 ofs << label.text;
@@ -1894,6 +1896,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
                     int labelId = -1;
                     ifs >> labelId;
                     TMapLabel label;
+                    ifs >> label.pos;
                     ifs >> label.size;
                     ifs >> label.text;
                     ifs >> label.fgColor;
@@ -1944,9 +1947,9 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
                 if (otherProfileVersion >= 12) {
                     ifs >> label.pos;
                 } else {
-                    QPointF __label_pos;
-                    ifs >> __label_pos;
-                    label.pos = QVector3D(__label_pos.x(), __label_pos.y(), 0);
+                    QPointF oldLabelPos;
+                    ifs >> oldLabelPos;
+                    label.pos = QVector3D(oldLabelPos);
                 }
                 QPointF dummyPointF;
                 ifs >> dummyPointF;


### PR DESCRIPTION
This will cause serious data loss (because it throws off the whole structure of the file) when reading existing files {because the label position element is not read from the file so everything after the first map label will not be at the expected offset} and writing new ones as they would not be storing the position detail rendering all map labels at the origin when read by the new code.

This defect was introduced in #4604 - ten days ago.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>