### PR TITLE
Fixes bug on parsing MXP tags with UTF8 strings

### DIFF
--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -26,73 +26,12 @@
 #include "Host.h"
 #include "TEvent.h"
 #include "mudlet.h"
+#include "TMediaData.h"
 
 #include "pre_guard.h"
 #include <QMediaPlayer>
 #include "post_guard.h"
 
-
-class TMediaData
-{
-public:
-    enum MediaProtocol { MediaProtocolMSP = 90, MediaProtocolGMCP = 201, MediaProtocolNotSet = 0 };
-
-    enum MediaType { MediaTypeSound = 1, MediaTypeMusic = 2, MediaTypeNotSet = 0 };
-
-    enum MediaVolume { MediaVolumeMax = 100, MediaVolumeHigh = 75, MediaVolumeDefault = 50, MediaVolumeLow = 25, MediaVolumeMin = 1, MediaVolumePreload = 0 };
-
-    enum MediaLoops { MediaLoopsDefault = 1, MediaLoopsRepeat = -1 };
-
-    enum MediaPriority { MediaPriorityMax = 100, MediaPriorityHigh = 75, MediaPriorityDefault = 50, MediaPriorityLow = 25, MediaPriorityMin = 1, MediaPriorityNotSet = 0 };
-
-    enum MediaContinue { MediaContinueDefault = true, MediaContinueRestart = false };
-
-    TMediaData()
-    {
-        mMediaProtocol = MediaProtocolNotSet;
-        mMediaType = MediaTypeNotSet;
-        mMediaVolume = MediaVolumeDefault;
-        mMediaLoops = MediaLoopsDefault;
-        mMediaPriority = MediaPriorityNotSet;
-        mMediaContinue = MediaContinueDefault;
-    }
-
-    int getMediaProtocol() { return mMediaProtocol; }
-    void setMediaProtocol(int mediaProtocol) { mMediaProtocol = mediaProtocol; }
-    int getMediaType() { return mMediaType; }
-    void setMediaType(int mediaType) { mMediaType = mediaType; }
-    QString getMediaFileName() { return mMediaFileName; }
-    void setMediaFileName(QString mediaFileName) { mMediaFileName = mediaFileName; }
-    int getMediaVolume() { return mMediaVolume; }
-    void setMediaVolume(int mediaVolume) { mMediaVolume = mediaVolume; }
-    int getMediaLoops() { return mMediaLoops; }
-    void setMediaLoops(int mediaLoops) { mMediaLoops = mediaLoops; }
-    int getMediaPriority() { return mMediaPriority; }
-    void setMediaPriority(int mediaPriority) { mMediaPriority = mediaPriority; }
-    bool getMediaContinue() { return mMediaContinue; }
-    void setMediaContinue(bool mediaContinue) { mMediaContinue = mediaContinue; }
-    QString getMediaTag() { return mMediaTag; }
-    void setMediaTag(QString mediaTag) { mMediaTag = mediaTag; }
-    QString getMediaUrl() { return mMediaUrl; }
-    void setMediaUrl(QString mediaUrl) { mMediaUrl = mediaUrl; }
-    QString getMediaKey() { return mMediaKey; }
-    void setMediaKey(QString mediaKey) { mMediaKey = mediaKey; }
-    QString getMediaAbsolutePathFileName() { return mMediaAbsolutePathFileName; }
-    void setMediaAbsolutePathFileName(QString mediaAbsolutePathFileName) { mMediaAbsolutePathFileName = mediaAbsolutePathFileName; }
-
-private:
-    int mMediaProtocol;
-    int mMediaType;
-    QString mMediaFileName;
-    int mMediaVolume;
-    int mMediaLoops;
-    int mMediaPriority;
-    bool mMediaContinue;
-    QString mMediaTag;
-    QString mMediaUrl;
-    QString mMediaKey;
-    QString mMediaAbsolutePathFileName;
-};
 
 class TMediaPlayer
 {

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -1,0 +1,90 @@
+#ifndef MUDLET_TMEDIA_DATA_H
+#define MUDLET_TMEDIA_DATA_H
+
+/***************************************************************************
+ *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
+ *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
+ *   Copyright (C) 2014-2019 by Stephen Lyons - slysven@virginmedia.com    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include <QString>
+
+class TMediaData
+{
+public:
+    enum MediaProtocol { MediaProtocolMSP = 90, MediaProtocolGMCP = 201, MediaProtocolNotSet = 0 };
+
+    enum MediaType { MediaTypeSound = 1, MediaTypeMusic = 2, MediaTypeNotSet = 0 };
+
+    enum MediaVolume { MediaVolumeMax = 100, MediaVolumeHigh = 75, MediaVolumeDefault = 50, MediaVolumeLow = 25, MediaVolumeMin = 1, MediaVolumePreload = 0 };
+
+    enum MediaLoops { MediaLoopsDefault = 1, MediaLoopsRepeat = -1 };
+
+    enum MediaPriority { MediaPriorityMax = 100, MediaPriorityHigh = 75, MediaPriorityDefault = 50, MediaPriorityLow = 25, MediaPriorityMin = 1, MediaPriorityNotSet = 0 };
+
+    enum MediaContinue { MediaContinueDefault = true, MediaContinueRestart = false };
+
+    TMediaData()
+    {
+        mMediaProtocol = MediaProtocolNotSet;
+        mMediaType = MediaTypeNotSet;
+        mMediaVolume = MediaVolumeDefault;
+        mMediaLoops = MediaLoopsDefault;
+        mMediaPriority = MediaPriorityNotSet;
+        mMediaContinue = MediaContinueDefault;
+    }
+
+    int getMediaProtocol() { return mMediaProtocol; }
+    void setMediaProtocol(int mediaProtocol) { mMediaProtocol = mediaProtocol; }
+    int getMediaType() { return mMediaType; }
+    void setMediaType(int mediaType) { mMediaType = mediaType; }
+    QString getMediaFileName() { return mMediaFileName; }
+    void setMediaFileName(QString mediaFileName) { mMediaFileName = mediaFileName; }
+    int getMediaVolume() { return mMediaVolume; }
+    void setMediaVolume(int mediaVolume) { mMediaVolume = mediaVolume; }
+    int getMediaLoops() { return mMediaLoops; }
+    void setMediaLoops(int mediaLoops) { mMediaLoops = mediaLoops; }
+    int getMediaPriority() { return mMediaPriority; }
+    void setMediaPriority(int mediaPriority) { mMediaPriority = mediaPriority; }
+    bool getMediaContinue() { return mMediaContinue; }
+    void setMediaContinue(bool mediaContinue) { mMediaContinue = mediaContinue; }
+    QString getMediaTag() { return mMediaTag; }
+    void setMediaTag(QString mediaTag) { mMediaTag = mediaTag; }
+    QString getMediaUrl() { return mMediaUrl; }
+    void setMediaUrl(QString mediaUrl) { mMediaUrl = mediaUrl; }
+    QString getMediaKey() { return mMediaKey; }
+    void setMediaKey(QString mediaKey) { mMediaKey = mediaKey; }
+    QString getMediaAbsolutePathFileName() { return mMediaAbsolutePathFileName; }
+    void setMediaAbsolutePathFileName(QString mediaAbsolutePathFileName) { mMediaAbsolutePathFileName = mediaAbsolutePathFileName; }
+
+private:
+    int mMediaProtocol;
+    int mMediaType;
+    QString mMediaFileName;
+    int mMediaVolume;
+    int mMediaLoops;
+    int mMediaPriority;
+    bool mMediaContinue;
+    QString mMediaTag;
+    QString mMediaUrl;
+    QString mMediaKey;
+    QString mMediaAbsolutePathFileName;
+};
+
+#endif // MUDLET_TMEDIA_DATA_H

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -18,7 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "TMedia.h"
+#include "TMediaData.h"
 #include "TMxpMusicTagHandler.h"
 #include "TMxpClient.h"
 

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -63,7 +63,7 @@ bool TMxpNodeBuilder::accept(char ch)
         }
     } else if (!mOptionIgnoreText) { // text
         mIsInsideText = true;
-        mCurrentText.append(ch);
+        mCurrentText.push_back(ch);
         return false;
     }
 
@@ -80,7 +80,7 @@ bool TMxpNodeBuilder::acceptTag(char ch)
         if (!acceptAttribute(ch)) {
             return false;
         } else {
-            if (!mCurrentAttrName.isEmpty()) {
+            if (!mCurrentAttrName.empty()) {
                 processAttribute();
             }
             resetCurrentAttribute();
@@ -97,7 +97,7 @@ bool TMxpNodeBuilder::acceptTag(char ch)
     }
 
     if (ch == '/') {
-        mIsEndTag = mCurrentTagName.isEmpty();
+        mIsEndTag = mCurrentTagName.empty();
         mIsEmptyTag = !mIsEndTag;
         return false;
     }
@@ -115,10 +115,10 @@ bool TMxpNodeBuilder::acceptTag(char ch)
 }
 void TMxpNodeBuilder::processAttribute()
 {
-    if (mCurrentTagName.isEmpty()) {
+    if (mCurrentTagName.empty()) {
         mCurrentTagName = mCurrentAttrName;
-    } else if (!mCurrentAttrName.isEmpty()) {
-        mCurrentTagAttrs.append(MxpTagAttribute(mCurrentAttrName, mCurrentAttrValue));
+    } else if (!mCurrentAttrName.empty()) {
+        mCurrentTagAttrs.append(MxpTagAttribute(mCurrentAttrName.c_str(),mCurrentAttrValue.c_str()));
     }
 }
 void TMxpNodeBuilder::resetCurrentTag()
@@ -136,7 +136,7 @@ bool TMxpNodeBuilder::acceptAttribute(char ch)
 {
     mIsInsideAttr = true;
 
-    QString& buffer = mReadingAttrValue ? mCurrentAttrValue : mCurrentAttrName;
+    std::string& buffer = mReadingAttrValue ? mCurrentAttrValue : mCurrentAttrName;
     if (!acceptSequence(ch, buffer)) {
         return false;
     }
@@ -160,7 +160,7 @@ void TMxpNodeBuilder::resetCurrentAttribute()
     mIsInsideAttr = false;
     resetCurrentSequence();
 }
-bool TMxpNodeBuilder::acceptSequence(char ch, QString& buffer)
+bool TMxpNodeBuilder::acceptSequence(char ch, std::string& buffer)
 {
     if (mHasSequence) {
         mHasSequence = false;
@@ -203,7 +203,7 @@ bool TMxpNodeBuilder::acceptSequence(char ch, QString& buffer)
 
     mSequenceHasSpaces = mSequenceHasSpaces || QChar(ch).isSpace();
 
-    buffer.append(ch);
+    buffer.push_back(ch);
     return false;
 }
 void TMxpNodeBuilder::resetCurrentSequence()
@@ -215,14 +215,14 @@ void TMxpNodeBuilder::resetCurrentSequence()
 }
 MxpTag* TMxpNodeBuilder::buildTag()
 {
-    MxpTag* result = mIsEndTag ? static_cast<MxpTag*>(new MxpEndTag(mCurrentTagName)) : static_cast<MxpTag*>(new MxpStartTag(mCurrentTagName, mCurrentTagAttrs, mIsEmptyTag));
+    MxpTag* result = mIsEndTag ? static_cast<MxpTag*>(new MxpEndTag(mCurrentTagName.c_str())) : static_cast<MxpTag*>(new MxpStartTag(mCurrentTagName.c_str(), mCurrentTagAttrs, mIsEmptyTag));
     resetCurrentTag();
 
     return result;
 }
 MxpNode* TMxpNodeBuilder::buildNode()
 {
-    MxpNode* node = mIsText ? static_cast<MxpNode*>(new MxpTextNode(mCurrentText)) : static_cast<MxpNode*>(buildTag());
+    MxpNode* node = mIsText ? static_cast<MxpNode*>(new MxpTextNode(mCurrentText.c_str())) : static_cast<MxpNode*>(buildTag());
     mCurrentText.clear();
     mHasNode = false;
     return node;

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -118,7 +118,7 @@ void TMxpNodeBuilder::processAttribute()
     if (mCurrentTagName.empty()) {
         mCurrentTagName = mCurrentAttrName;
     } else if (!mCurrentAttrName.empty()) {
-        mCurrentTagAttrs.append(MxpTagAttribute(mCurrentAttrName.c_str(),mCurrentAttrValue.c_str()));
+        mCurrentTagAttrs.append(MxpTagAttribute(mCurrentAttrName.c_str(), mCurrentAttrValue.c_str()));
     }
 }
 void TMxpNodeBuilder::resetCurrentTag()

--- a/src/TMxpNodeBuilder.h
+++ b/src/TMxpNodeBuilder.h
@@ -22,16 +22,12 @@
 #include "MxpTag.h"
 #include "TStringUtils.h"
 
-#include "pre_guard.h"
-#include <QString>
-#include "post_guard.h"
-
 class TMxpNodeBuilder
 {
     bool mOptionIgnoreText;
 
     // current tag attrs
-    QString mCurrentTagName;
+    std::string mCurrentTagName;
     QList<MxpTagAttribute> mCurrentTagAttrs;
     bool mIsEndTag;
     bool mIsEmptyTag;
@@ -39,8 +35,8 @@ class TMxpNodeBuilder
     bool mIsInsideTag;
 
     // current attr
-    QString mCurrentAttrName;
-    QString mCurrentAttrValue;
+    std::string mCurrentAttrName;
+    std::string mCurrentAttrValue;
     // parsing attr state
     bool mIsInsideAttr;
     bool mReadingAttrValue;
@@ -53,7 +49,7 @@ class TMxpNodeBuilder
     bool mHasSequence;
 
     // current text node
-    QString mCurrentText;
+    std::string mCurrentText;
 
     // text node parsing state
     bool mIsInsideText;
@@ -68,7 +64,7 @@ class TMxpNodeBuilder
     bool acceptAttribute(char ch);
     void resetCurrentAttribute();
 
-    bool acceptSequence(char ch, QString& buffer);
+    bool acceptSequence(char ch, std::string& buffer);
     void resetCurrentSequence();
     void processAttribute();
 

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -18,7 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "TMedia.h"
+#include "TMediaData.h"
 #include "TMxpSoundTagHandler.h"
 #include "TMxpClient.h"
 

--- a/src/TMxpTagParser.cpp
+++ b/src/TMxpTagParser.cpp
@@ -44,10 +44,11 @@ static bool isTag(const QString& tagString)
 QList<QSharedPointer<MxpNode>> TMxpTagParser::parseToMxpNodeList(const QString& tagText, bool ignoreText) const
 {
     TMxpNodeBuilder nodeBuilder(ignoreText);
+    std::string tagStdStr = tagText.toStdString();
 
     QList<QSharedPointer<MxpNode>> result;
     for (int i = 0; i < tagText.length(); ++i) {
-        if (nodeBuilder.accept(tagText.at(i).toLatin1())) {
+        if (nodeBuilder.accept(tagStdStr[i])) {
             result.append(QSharedPointer<MxpNode>(nodeBuilder.buildNode()));
             --i;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,5 @@ list(FILTER MXP_SOURCE EXCLUDE REGEX ".*/src/TMxpMudlet.cpp")
 add_executable(TMxpTagParserTest TMxpTagParserTest.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp ../src/MxpTag.cpp ../src/TStringUtils.cpp)
 add_test(NAME TMxpTagParserTest COMMAND TMxpTagParserTest)
 
-# https://github.com/Mudlet/Mudlet/issues/4021 added an include that made this test fail.  Entering issue to inspect the test separately; re-enable when complete.
-#add_executable(TMxpSendTagHandlerTest TMxpSendTagHandlerTest.cpp ${MXP_SOURCE} ../src/TMxpSendTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp)
-#add_test(NAME TMxpSendTagHandlerTest COMMAND TMxpSendTagHandlerTest)
+add_executable(TMxpSendTagHandlerTest TMxpSendTagHandlerTest.cpp ${MXP_SOURCE} ../src/TMxpSendTagHandler.cpp ../src/TMxpTagParser.cpp ../src/TMxpNodeBuilder.cpp)
+add_test(NAME TMxpSendTagHandlerTest COMMAND TMxpSendTagHandlerTest)

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -24,12 +24,12 @@ public:
         return mSupportedElements;
     }
 
-    virtual TMxpTagHandlerResult handleTag(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
+    TMxpTagHandlerResult handleTag(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override
     {
         return MXP_TAG_HANDLED;
     }
 
-    virtual void handleContent(char ch)
+    void handleContent(char ch) override
     {
 
     }

--- a/test/TMxpStubClient.h
+++ b/test/TMxpStubClient.h
@@ -7,6 +7,7 @@
 
 #include "TMxpContext.h"
 #include "TMxpClient.h"
+#include "TMediaData.h"
 
 class TMxpStubContext : public TMxpContext {
 public:


### PR DESCRIPTION
- TMxpTagParser was converting QChar to a single char
- TMxpNodeBuilder was converting each individual char to a QChar

<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet
Should fix #4368 

#### Other info (issues closed, discussion etc)
