### PR TITLE
BugFix: repair special exits in speedwalks with corrupt names

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -830,7 +830,7 @@ void TMap::initGraph()
                 pTargetR = mpRoomDB->getRoom(target);
                 if (pTargetR && !pTargetR->isLocked) {
                     route r;
-                    r.specialExitName = itSpecialExit.value();
+                    r.specialExitName = itSpecialExit.key();
                     r.cost = exitWeights.value(r.specialExitName, pTargetR->getWeight());
                     if (!bestRoutes.contains(target) || bestRoutes.value(target).cost > r.cost) {
                         r.direction = direction;


### PR DESCRIPTION
This is an error that slipped in as a result of #4526 and resulted in the exit room id being stored as the special exit name in the BGL graph that is built for the A* search algorithm to work on. Consquently if that route was used in a path the special exit command produced for that step was garbage which also tripped off warnings about invalid characters being sent to the MUD as an exit direction.

Thanks to @ryanstadther for bringing this to my attention!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>