### PR TITLE
Improve http error messages to make sense for the end player

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -453,11 +453,11 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         if (!localFile.open(QFile::WriteOnly)) {
             event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("failureToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't save to the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << localFileName;
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("unableToOpenLocalFileForWriting");
+            event.mArgumentList << QLatin1String("Couldn't open the destination file for writing (permission errors?)");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             break;
         }
@@ -466,11 +466,11 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         if (bytesWritten == -1) {
             event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("failureToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't save to the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << localFileName;
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("unableToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't write downloaded content into the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             break;
         }
@@ -487,7 +487,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         } else {
             event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("failureToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't save to the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << localFileName;
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -428,11 +428,11 @@ void TMedia::writeFile(QNetworkReply* reply)
         if (!localFile.open(QFile::WriteOnly)) {
             event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("failureToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't save to the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << mediaData.getMediaAbsolutePathFileName();
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("unableToOpenLocalFileForWriting");
+            event.mArgumentList << QLatin1String("Couldn't open the destination file for writing (permission errors?)");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
             reply->deleteLater();
@@ -444,11 +444,11 @@ void TMedia::writeFile(QNetworkReply* reply)
         if (bytesWritten == -1) {
             event.mArgumentList << QLatin1String("sysDownloadError");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("failureToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't save to the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << mediaData.getMediaAbsolutePathFileName();
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            event.mArgumentList << QLatin1String("unableToWriteLocalFile");
+            event.mArgumentList << QLatin1String("Couldn't write downloaded content into the destination file");
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
 
             reply->deleteLater();
@@ -473,7 +473,7 @@ void TMedia::writeFile(QNetworkReply* reply)
             } else {
                 event.mArgumentList << QLatin1String("sysDownloadError");
                 event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-                event.mArgumentList << QLatin1String("failureToWriteLocalFile");
+                event.mArgumentList << QLatin1String("Couldn't save to the destination file");
                 event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
                 event.mArgumentList << mediaData.getMediaAbsolutePathFileName();
                 event.mArgumentTypeList << ARGUMENT_TYPE_STRING;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Improve http error messages to make sense for the end player
#### Motivation for adding to Mudlet
So coders can use the error message as-is without having to worry to translate it to something the player would understand.
#### Other info (issues closed, discussion etc)
The first time I've seen someone use them - and it was someone experienced with Mudlet, @delwing, the end result didn't work out:

![image](https://user-images.githubusercontent.com/110988/106381827-d1832880-63bb-11eb-9677-14dbc459bbce.png)

I don't think the expectations that the interface is simple to use were met by Mudlet here. I understand the motivations behind a programmable error message, but it in practice it didn't work out, and it's better to be consistent with all the other messages we use which are player-friendly.