### PR TITLE
Switch text-to-speech voice when locale changes

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13138,7 +13138,24 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
 
 // No documentation available in wiki - internal function
 void TLuaInterpreter::ttsLocaleChanged(const QLocale &locale)
-{ // TODO - Tim   If current voice is not in list of available voices then set voice to first in list of available.
+{
+    QString currentVoice = speechUnit->voice().name();
+    QVector<QVoice> speechVoices = speechUnit->availableVoices();
+    int sz = speechVoices.size();
+
+    if (!sz) {
+        return;
+    }
+        
+    for (auto voice : speechVoices) {
+        if (voice.name() == currentVoice) {
+            return;
+        }
+    }
+
+    speechUnit->setVoice(speechVoices.at(0));
+
+    return;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#ttsQueue

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12876,7 +12876,7 @@ void TLuaInterpreter::ttsBuild()
     bSpeechQueueing = false;
 
     connect(speechUnit, &QTextToSpeech::stateChanged, &TLuaInterpreter::ttsStateChanged);
-
+    connect(speechUnit, &QTextToSpeech::localeChanged, &TLuaInterpreter::ttsLocaleChanged);
 
     speechUnit->setVolume(1.0);
     speechUnit->setRate(0.0);
@@ -13134,6 +13134,11 @@ void TLuaInterpreter::ttsStateChanged(QTextToSpeech::State state)
     speechCurrent = textToSay;
 
     return;
+}
+
+// No documentation available in wiki - internal function
+void TLuaInterpreter::ttsLocaleChanged(const QLocale &locale)
+{ // TODO - Tim   If current voice is not in list of available voices then set voice to first in list of available.
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#ttsQueue

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -534,6 +534,7 @@ public:
     static int ttsGetState(lua_State* L);
     static void ttsBuild();
     static void ttsStateChanged(QTextToSpeech::State state);
+    static void ttsLocaleChanged(const QLocale &locale);
 #endif // QT_TEXTTOSPEECH_LIB
     static int tempPromptTrigger(lua_State*);
     static int permPromptTrigger(lua_State*);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Switch text-to-speech voice when locale changes to one that does not offer the current voice.

#### Motivation for adding to Mudlet
If you start the program with one locale and then switch to another locale, Mudlet does not act upon the  QTextToSpeech::localeChanged() event to switch to an appropriate voice.

#### Other info (issues closed, discussion etc)
Vadi showed me that his voice was set to one that was not in the list of available voices.  ttsGetCurrentVoice() gave a string that was not in ttsGetVoices().  I was unable to manually set my voice to an unlisted one through ttsSetVoiceByName().  I believe that he may have changed locale after booting Mudlet (when it selected a voice) and before running the script (when it looked at available voices within current locale).  I saw in the docs that QTextToSpeech has an event to be notified when locale changes.