### PR TITLE
Add name capture group support for regex triggers

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13653,10 +13653,11 @@ std::pair<bool, QString> TLuaInterpreter::discordApiEnabled(lua_State* L, bool w
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::setMultiCaptureGroups(const std::list<std::list<std::string>>& captureList, const std::list<std::list<int>>& posList)
+void TLuaInterpreter::setMultiCaptureGroups(const std::list<std::list<std::string>>& captureList, const std::list<std::list<int>>& posList, QVector<QVector<QPair<QString, QString>>>& nameGroups)
 {
     mMultiCaptureGroupList = captureList;
     mMultiCaptureGroupPosList = posList;
+    mMultiCaptureNameGroups = nameGroups;
 
     /*
      * std::list< std::list<string> >::const_iterator mit = mMultiCaptureGroupList.begin();
@@ -13689,6 +13690,11 @@ void TLuaInterpreter::setCaptureGroups(const std::list<std::string>& captureList
      */
 }
 
+void TLuaInterpreter::setCaptureNameGroups(const NameGroupMatches& nameGroups)
+{
+    mCapturedNameGroups = nameGroups;
+}
+
 // No documentation available in wiki - internal function
 void TLuaInterpreter::clearCaptureGroups()
 {
@@ -13696,6 +13702,8 @@ void TLuaInterpreter::clearCaptureGroups()
     mCaptureGroupPosList.clear();
     mMultiCaptureGroupList.clear();
     mMultiCaptureGroupPosList.clear();
+    mCapturedNameGroups.clear();
+    mMultiCaptureNameGroups.clear();
 
     lua_State* L = pGlobalLua;
     lua_newtable(L);
@@ -14229,6 +14237,11 @@ void TLuaInterpreter::setMatches(lua_State* L)
             lua_pushstring(L, (*it).c_str());
             lua_settable(L, -3);
         }
+        for (auto [name, capture] : mCapturedNameGroups) {
+            lua_pushstring(L, name.toUtf8().constData());
+            lua_pushstring(L, capture.toUtf8().constData());
+            lua_settable(L, -3);
+        }
         lua_setglobal(L, "matches");
     }
 }
@@ -14531,6 +14544,12 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
                 lua_pushnumber(L, i);
                 lua_pushstring(L, (*it).c_str());
                 lua_settable(L, -3); //match in matches
+            }
+            for (auto [name, capture] : mMultiCaptureNameGroups.value(k - 1)) {
+                lua_pushstring(L, name.toUtf8().constData());
+                lua_pushstring(L, capture.toUtf8().constData());
+                lua_settable(L, -3);
+            
             }
             lua_settable(L, -3); //matches in regex
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14549,7 +14549,6 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
                 lua_pushstring(L, name.toUtf8().constData());
                 lua_pushstring(L, capture.toUtf8().constData());
                 lua_settable(L, -3);
-            
             }
             lua_settable(L, -3); //matches in regex
         }

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -55,6 +55,8 @@ extern "C" {
 #include <string>
 #include <memory>
 
+#include "TTrigger.h"
+
 
 class Host;
 class TEvent;
@@ -113,8 +115,8 @@ public:
     void set_lua_string(const QString& varName, const QString& varValue);
     void set_lua_table(const QString& tableName, QStringList& variableList);
     void setCaptureGroups(const std::list<std::string>&, const std::list<int>&);
-    void setMultiCaptureGroups(const std::list<std::list<std::string>>& captureList, const std::list<std::list<int>>& posList);
-
+    void setCaptureNameGroups(const NameGroupMatches&);
+    void setMultiCaptureGroups(const std::list<std::list<std::string>>& captureList, const std::list<std::list<int>>& posList, QVector<NameGroupMatches>& nameMatches);
     void adjustCaptureGroups(int x, int a);
     void clearCaptureGroups();
     bool callEventHandler(const QString& function, const TEvent& pE);
@@ -635,8 +637,9 @@ private:
     std::list<std::string> mCaptureGroupList;
     std::list<int> mCaptureGroupPosList;
     std::list<std::list<std::string>> mMultiCaptureGroupList;
-
     std::list<std::list<int>> mMultiCaptureGroupPosList;
+    QVector<QPair<QString, QString>> mCapturedNameGroups;
+    QVector<QVector<QPair<QString, QString>>> mMultiCaptureNameGroups;
 
     QMap<QNetworkReply*, QString> downloadMap;
 

--- a/src/TMatchState.h
+++ b/src/TMatchState.h
@@ -62,6 +62,7 @@ public:
     int mSpacer;
     std::list<std::list<std::string>> multiCaptureList;
     std::list<std::list<int>> multiCapturePosList;
+    QVector<NameGroupMatches> nameCaptures;
     int mNumberOfConditions;
     int mNextCondition;
     int mLineCount;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -570,9 +570,7 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         mConditionMap[pCondition] = pCondition;
         pCondition->multiCaptureList.push_back(captureList);
         pCondition->multiCapturePosList.push_back(posList);
-        if (nameMatches != nullptr) {
-            pCondition->nameCaptures.push_back(*nameMatches);
-        }
+        pCondition->nameCaptures.push_back(*nameMatches);
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::darkYellow), QColor(Qt::black)) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber
                                                               << "/" << mRegexCodeList.size() << ") regex=" << mRegexCodeList[regexNumber] << "\n"

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -53,6 +53,7 @@ class TMatchState;
 #define REGEX_PROMPT 7
 #define MAX_CAPTURE_GROUPS 33
 
+using NameGroupMatches = QVector<QPair<QString, QString>>;
 
 struct TColorTable
 {
@@ -171,7 +172,7 @@ public:
 private:
     TTrigger() = default;
 
-    void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList);
+    void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
     void filter(std::string&, int&);
 
 

--- a/src/mudlet-lua/lua/DebugTools.lua
+++ b/src/mudlet-lua/lua/DebugTools.lua
@@ -21,7 +21,7 @@ function showMultimatches()
   echo("\n-------------------------------------------------------");
   for k, v in ipairs(multimatches) do
     echo("\nregex " .. k .. " captured: (multimatches[" .. k .. "][1-n])");
-    for k2, v2 in ipairs(v) do
+    for k2, v2 in pairs(v) do
       echo("\n          key=" .. k2 .. " value=" .. v2);
     end
   end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -4,7 +4,8 @@
 
 mudlet = mudlet or {}
 mudlet.supports = {
-  coroutines = true
+  coroutines = true,
+  namedPatterns = true
 }
 
 -- enforce uniform locale so scripts don't get


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

It populates matches with named capture groups:
https://www.regular-expressions.info/named.html

Some skeletal retrieval was there, but never went any further.

I've tested that on regexp trigger and tempRegexTrigger - I guess only those 2 need support for that.
Multimatches also are made to work.

Please take a special look at the retrieval code `TTrigger.ccp:352`

#### Motivation for adding to Mudlet

Multiple triggers matching similar thing can be hell if searched needle is swapping place.
Named groups are very convinent.

#### Other info (issues closed, discussion etc)

Quick test regexp
```lua
if demoRegex then
  killTrigger(demoRegex)
end
demoRegex = tempRegexTrigger("^My name is (?<name>\\w+)\\.$", function() display(matches) cecho("\n<red>".. matches.name) end)
feedTriggers("\nMy name is Dargoth.\n")
echo("\n")
```
