### PR TITLE
Right clicking directly on the room will bring its poup

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3083,7 +3083,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
         connect(mapper, SIGNAL(mapped(QString)), this, SLOT(slot_userAction(QString)));
     }
 
-    toggleSelectionWidget()
+    toggleSelectionWidget();
     update();
 }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2351,7 +2351,7 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
 
 void T2DMap::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if (mDialogLock || (event->buttons() & Qt::RightButton)) {
+    if (mDialogLock || (event->buttons() != Qt::LeftButton)) {
         return;
     }
     int x = event->x();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3083,6 +3083,11 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
         connect(mapper, SIGNAL(mapped(QString)), this, SLOT(slot_userAction(QString)));
     }
 
+    toggleSelectionWidget()
+    update();
+}
+
+void T2DMap::toggleSelectionWidget() {
     // display room selection list widget if more than 1 room has been selected
     // -> user can manually change current selection if rooms are overlapping
     if (mMultiSelectionSet.size() > 1) {
@@ -3126,8 +3131,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
     } else {
         mMultiSelectionListWidget.hide();
     }
-
-    update();
 }
 
 // returns the current mouse position as X, Y coordinates on the map

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3087,7 +3087,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
     update();
 }
 
-void T2DMap::updateSelectionWidget() {
+void T2DMap::updateSelectionWidget()
+{
     // display room selection list widget if more than 1 room has been selected
     // -> user can manually change current selection if rooms are overlapping
     if (mMultiSelectionSet.size() > 1) {
@@ -3105,7 +3106,7 @@ void T2DMap::updateSelectionWidget() {
             int multiSelectionRoomId = itRoom.next();
             _item->setText(0, key_plain.arg(multiSelectionRoomId, mMaxRoomIdDigits));
             _item->setTextAlignment(0, Qt::AlignRight);
-            TRoom* pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
+            TRoom *pR_multiSelection = mpMap->mpRoomDB->getRoom(multiSelectionRoomId);
             if (pR_multiSelection) {
                 QString multiSelectionRoomName = pR_multiSelection->name;
                 if (!multiSelectionRoomName.isEmpty()) {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3083,11 +3083,11 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
         connect(mapper, SIGNAL(mapped(QString)), this, SLOT(slot_userAction(QString)));
     }
 
-    toggleSelectionWidget();
+    updateSelectionWidget();
     update();
 }
 
-void T2DMap::toggleSelectionWidget() {
+void T2DMap::updateSelectionWidget() {
     // display room selection list widget if more than 1 room has been selected
     // -> user can manually change current selection if rooms are overlapping
     if (mMultiSelectionSet.size() > 1) {
@@ -3127,10 +3127,10 @@ void T2DMap::toggleSelectionWidget() {
         mMultiSelectionListWidget.selectAll();
         mMultiSelectionListWidget.blockSignals(false);
         mMultiSelectionListWidget.show();
-        update();
     } else {
         mMultiSelectionListWidget.hide();
     }
+    update();
 }
 
 // returns the current mouse position as X, Y coordinates on the map

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -222,6 +222,7 @@ public slots:
     void slot_newMap();
 
 private:
+    void toggleSelectionWidget();
     void resizeMultiSelectionWidget();
     std::pair<int, int> getMousePosition();
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -222,7 +222,7 @@ public slots:
     void slot_newMap();
 
 private:
-    void toggleSelectionWidget();
+    void updateSelectionWidget();
     void resizeMultiSelectionWidget();
     std::pair<int, int> getMousePosition();
     bool checkButtonIsForGivenDirection(const QPushButton*, const QString&, const int&);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Mapper context menu seems to behave very counter intuitive when clicking on the room.
Right click on the room will select it and bring popup menu right away for this particular room.

It might not be still perfect behavior, but still is better.
E.g. when label selected it will still bring popup for label, but maybe this area can improve later on as well.

Double right click will not act like double left click as well (so far disabled).

#### Motivation for adding to Mudlet

It's definitely not my isolated opinion, since my friend complained to me for it as well. 
I have sometimes trouble remembering to select room first and then right click it.

#### Other info (issues closed, discussion etc)
