### PR TITLE
Remove PTB temporary debug information

### DIFF
--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -66,11 +66,9 @@ function extract_historical_sha1s()
   local history, command
   if github_workspace then
     command = string.format("git log --pretty=%%H -n %d %s", MAX_COMMITS_PER_CHANGELOG, os.getenv("GITHUB_SHA"))
-    print("[temporary debug information: "..command.."]")
     history = string.split(os.capture(command))
   else
     command = "git log --pretty=%H -n "..MAX_COMMITS_PER_CHANGELOG
-    print("[temporary debug information: "..command.."]")
     history = string.split(os.capture(command))
   end
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Remove PTB temporary debug information, now that PTB changelogs are okay again
#### Motivation for adding to Mudlet
So it doesn't show up in PTB changelogs
#### Other info (issues closed, discussion etc)
