### PR TITLE
Simplify unknown text for given encoding message

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -642,17 +642,12 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
 
     if (mpHost->mAllowToSendCommand) {
         std::string outData;
-        auto errorMsgTemplate = "[ WARN ]  - Invalid characters in outgoing data, one or more characters cannot\n"
-            "be encoded into the range that is acceptable for the character\n"
-            "encoding that is currently set {\"%1\"} for the game server.\n"
-            "It may not understand what is sent to it.\n"
-            "Note: this warning will only be issued once, even if this happens again, until\n"
-            "the encoding is changed.";
+        auto errorMsgTemplate = "[ WARN ]  - Tried to send '%1' to the game, but it is unlikely to understand it.";
         if (!mEncoding.isEmpty()) {
             if (outgoingDataEncoder) {
                 if ((!mEncodingWarningIssued) && (!outgoingDataCodec->canEncode(data))) {
                     QString errorMsg = tr(errorMsgTemplate,
-                                          "%1 is the name of the encoding currently set.").arg(QLatin1String(mEncoding));
+                                          "%1 is the command that was sent to the game.").arg(data);
                     postMessage(errorMsg);
                     mEncodingWarningIssued = true;
                 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -672,7 +672,7 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
             for (int i = 0, total = data.size(); i < total; ++i) {
                 if ((!mEncodingWarningIssued) && (data.at(i).row() || data.at(i).cell() > 127)){
                     QString errorMsg = tr(errorMsgTemplate,
-                                          "%1 is the name of the encoding currently set.").arg(data);
+                                          "%1 is the command that was sent to the game.").arg(data);
                     postMessage(errorMsg);
                     mEncodingWarningIssued = true;
                     break;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -672,7 +672,7 @@ bool cTelnet::sendData(QString& data, const bool permitDataSendRequestEvent)
             for (int i = 0, total = data.size(); i < total; ++i) {
                 if ((!mEncodingWarningIssued) && (data.at(i).row() || data.at(i).cell() > 127)){
                     QString errorMsg = tr(errorMsgTemplate,
-                                          "%1 is the name of the encoding currently set.").arg(QStringLiteral("ASCII"));
+                                          "%1 is the name of the encoding currently set.").arg(data);
                     postMessage(errorMsg);
                     mEncodingWarningIssued = true;
                     break;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Simplify unknown text for given encoding message.

Before:
![image](https://user-images.githubusercontent.com/110988/106783888-0b6a5e00-664c-11eb-8581-060035fff196.png)

After:
![image](https://user-images.githubusercontent.com/110988/106784006-29d05980-664c-11eb-82bf-17068bca6cc9.png)

#### Motivation for adding to Mudlet
Less confusion for players
#### Other info (issues closed, discussion etc)
In case the user tries to send data that's not handled by the server codec, throw a small
message just so they know why the game didn't understand it. The warning is only shown once
so not to be annoying. While technically the user could change the encoding to something that works,
most of the time if the server supports something other than ASCII - say utf8 - it would have
preconfigured it using telnet CHARSET anyway, so telling the user to change encodings (something they
have no idea about) isn't helpful.