### PR TITLE
Fix package manager shortcut to always point to package manager. 

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2496,7 +2496,7 @@ void mudlet::slot_update_shortcuts()
         dactionNotepad->setShortcut(QKeySequence());
 
         packagesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
+        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_package_manager);
         dactionPackageManager->setShortcut(QKeySequence());
 
         modulesShortcut = new QShortcut(packagesKeySequence, this);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Fix package manager shortcut to always point to package manager. Right now it would have stopped once the menubar was toggled on/off.
#### Motivation for adding to Mudlet
Bugfix.
#### Other info (issues closed, discussion etc)
