### PR TITLE
Fix problem with black background on mapper (#4701)

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -137,6 +137,8 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     } else {
         qDebug() << "dlgMapper::dlgMapper(...) INFO constructor called, mpHost is null";
     }
+    //stops inheritance of palette from mpConsole->mpMainFrame
+    setPalette(QApplication::palette(new QWidget()));
 }
 
 void dlgMapper::updateAreaComboBox()

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -138,7 +138,7 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
         qDebug() << "dlgMapper::dlgMapper(...) INFO constructor called, mpHost is null";
     }
     //stops inheritance of palette from mpConsole->mpMainFrame
-    setPalette(QApplication::palette(new QWidget()));
+    setPalette(QApplication::palette());
 }
 
 void dlgMapper::updateAreaComboBox()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes the issue with black background on the mapper caused by palette propagation from the main console mpMainFrame
more informations at #4701
#### Motivation for adding to Mudlet
fix #4701 and probably also fixes #3236
#### Other info (issues closed, discussion etc)
