### PR TITLE
Remove response size limit in HTTP calls

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -428,8 +428,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        auto replyText = QString(reply->readAll());
-        event.mArgumentList << replyText;
+        event.mArgumentList << QString(reply->readAll());
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         break;
 
@@ -443,9 +442,8 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        auto replyText = QString(reply->readAll());
-        event.mArgumentList << replyText;
-        event.mArgumentTypeList << ARGUMENT_TYPE_STRING
+        event.mArgumentList << QString(reply->readAll());
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         break;
 
     case QNetworkAccessManager::PutOperation:
@@ -453,8 +451,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        auto replyText = QString(reply->readAll());
-        event.mArgumentList << replyText;
+        event.mArgumentList << QString(reply->readAll());
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         break;
 
@@ -472,8 +469,7 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << reply->url().toString();
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            auto replyText = QString(reply->readAll());
-            event.mArgumentList << replyText;
+            event.mArgumentList << QString(reply->readAll());
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             break;
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -428,12 +428,9 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
-
-            // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
-            event.mArgumentList << replyText;
-            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        }
+        auto replyText = QString(reply->readAll());
+        event.mArgumentList << replyText;
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         break;
 
     case QNetworkAccessManager::CustomOperation:
@@ -446,11 +443,9 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
-            // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
-            event.mArgumentList << replyText;
-            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        }
+        auto replyText = QString(reply->readAll());
+        event.mArgumentList << replyText;
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING
         break;
 
     case QNetworkAccessManager::PutOperation:
@@ -458,12 +453,9 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         event.mArgumentList << reply->url().toString();
         event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
-
-            // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
-            event.mArgumentList << replyText;
-            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-        }
+        auto replyText = QString(reply->readAll());
+        event.mArgumentList << replyText;
+        event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
         break;
 
     case QNetworkAccessManager::GetOperation:
@@ -480,12 +472,9 @@ void TLuaInterpreter::handleHttpOK(QNetworkReply* reply)
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             event.mArgumentList << reply->url().toString();
             event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            if (auto replyText = QString(reply->readAll()); replyText.size() <= 10000) {
-
-                // our linewrapping algorithm doesn't like 150k long lines, so don't show the response if it's too big
-                event.mArgumentList << replyText;
-                event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
-            }
+            auto replyText = QString(reply->readAll());
+            event.mArgumentList << replyText;
+            event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
             break;
         }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

It removes limit that was put on the response size to be even put as argument for event handlers.
Displaying long lines is not an issue anymore and response will now be handled the way it is expected.

#### Motivation for adding to Mudlet

Better user experience of course!

#### Other info (issues closed, discussion etc)
