### PR TITLE
BugFix: correct lua string vs QString replacement argument mixups

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2550,7 +2550,7 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
     }
     QList<int> stubs = pR->exitStubs;
     if (stubs.empty()) {
-        return warnArgumentValue(L, __func__, QStringLiteral("no stubs in this room with id %d").arg(roomId));
+        return warnArgumentValue(L, __func__, QStringLiteral("no stubs in this room with id %1").arg(roomId));
     }
     lua_newtable(L);
     for (int i = 0, total = stubs.size(); i < total; ++i) {
@@ -2578,7 +2578,7 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
     }
     QList<int> stubs = pR->exitStubs;
     if (stubs.empty()) {
-        return warnArgumentValue(L, __func__, QStringLiteral("no stubs in this room with id %d").arg(roomId));
+        return warnArgumentValue(L, __func__, QStringLiteral("no stubs in this room with id %1").arg(roomId));
     }
     lua_newtable(L);
     for (int i = 0, total = stubs.size(); i < total; ++i) {


### PR DESCRIPTION
This was introduced in the recent "Show value warnings in debug" PR #4678.

I believe I have found all of use of `%d` (or `%s`) instead of `%1` or higher numbers in this file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>