### PR TITLE
Add string interpolation via f function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cmake.configureOnOpen": true,
     "cmake.configureSettings": {
         "CMAKE_TOOLCHAIN_FILE": "${workspaceFolder}/3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake"
-      }
+      },
+      "Lua.runtime.version": "Lua 5.1"
 }

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -112,3 +112,49 @@ function string:trim()
     return self
   end
 end
+
+-- following functions fiddled with from https://github.com/hishamhm/f-strings/blob/master/F.lua and https://hisham.hm/2016/01/04/string-interpolation-in-lua/
+-- first bit patches load for lua 5.1.
+local load = load
+
+if _VERSION == "Lua 5.1" then
+  load = function(code, name, _, env)
+    local fn, err = loadstring(code, name)
+    if fn then
+      setfenv(fn, env)
+      return fn
+    end
+    return nil, err
+  end
+end
+
+function f(str)
+  local outer_env = _ENV or getfenv(1)
+  return (str:gsub("%b{}", function(block)
+    local code = block:match("{(.*)}")
+    local exp_env = {}
+    setmetatable(exp_env, {
+      __index = function(_, k)
+        local stack_level = 5
+        while debug.getinfo(stack_level, "") ~= nil do
+          local i = 1
+          repeat
+            local name, value = debug.getlocal(stack_level, i)
+            if name == k then
+              return value
+            end
+            i = i + 1
+          until name == nil
+          stack_level = stack_level + 1
+        end
+        return rawget(outer_env, k)
+      end,
+    })
+    local fn, err = load("return " .. code, "expression `" .. code .. "`", "t", exp_env)
+    if fn then
+      return tostring(fn())
+    else
+      error(err, 0)
+    end
+  end))
+end

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -196,4 +196,54 @@ describe("Tests StringUtils.lua functions", function()
       assert.equals(str, str:trim())
     end)
   end)
+
+  describe("f(str)", function()
+    it("should return a string with no interpolation as itself", function()
+      local str = "This is a test"
+      local expected = str
+      local actual = f(str)
+      assert.equals(expected, actual)
+    end)
+
+    it("should return a string with simple interpolation", function()
+      local str = "This is a {'test'}"
+      local expected = "This is a test"
+      local actual = f(str)
+      assert.equals(expected, actual)
+    end)
+
+    it("should execute simple expressions within the interpolation characters", function()
+      local str = "2 + 2 = {2+2}"
+      local expected = "2 + 2 = 4"
+      local actual = f(str)
+      assert.equals(expected, actual)
+    end)
+
+    it("should be able to interpolate local variables", function()
+      local str = "The secret sauce is {secret}"
+      local secret = "well known"
+      local expected = "The secret sauce is well known"
+      local actual = f(str)
+      assert.equals(expected, actual)
+    end)
+
+    it("should evaluate more complex expressions/functions in interpolation", function()
+      local testFunc = function(msg)
+        return msg:title()
+      end
+      local mesg = "sir"
+      local str = "This is just a test, good {testFunc(mesg)}"
+      local expected = "This is just a test, good Sir"
+      local actual = f(str)
+      assert.equals(expected, actual)
+    end)
+
+    it("should be able to handle two or more interpolations in a single string", function()
+      local str = "This is a {test}. Do make sure to check {2+2} your belongings. {getMudletVersion('string')}"
+      local test = "complete success"
+      local expected = "This is a complete success. Do make sure to check 4 your belongings. " .. getMudletVersion('string')
+      local actual = f(str)
+      assert.equals(expected, actual)
+    end)
+  end)
 end)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Adds global function `f` which allows for string interpolation using `{}` as the delimiters.

I fiddled with the code from [f-strings](https://github.com/hishamhm/f-strings/blob/master/F.lua) until I got it working.

Also adds 6 tests for it.

* `f("2 + 2 = { 2+2 }")` returns `"2 + 2 = 4"`
* sees local variables as well as globals.
* can run functions etc... `f("This profile lives at { getMudletHomeDir() }\n")`

I also set the lua runtime environment to 5.1 for the lua extension.

#### Motivation for adding to Mudlet

* string interpolation is a feature in many modern languages which I've missed greatly in Mudlet
* string.format can be nice, but it quickly gets out of hand if you have more than a few things to replace
* I've already found other attempts at implementing interpolation, both either by presenting something like this (I saw someone on imperian I think it was had edited f-strings as well) and using a common modulo operator hack I've seen a few places on the web when I was researching this prior to implementation. Would be good if we provided an 'official' way to do it.

#### Other info (issues closed, discussion etc)
I tested by copying GUIUtils.lua and the new f function into a script object in the self-test profile and running in Mudlet 4.10.1, since new snapshots will not run on my ubuntu machine currently.


![image](https://user-images.githubusercontent.com/3660/107452727-b92bb000-6b17-11eb-84cf-ddd913c42a91.png)
