### PR TITLE
Only run workflows in the main repo

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-iremapper-source:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -52,7 +52,7 @@ jobs:
 
   update-sparkle-glue-fork:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -93,7 +93,7 @@ jobs:
 
   update-dblsqd-fork:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -134,7 +134,7 @@ jobs:
 
   update-lcf-source-51:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -179,7 +179,7 @@ jobs:
   update-widecharwidth-source:
     runs-on: ubuntu-latest
     # Disabled for the time being due to https://github.com/Mudlet/Mudlet/pull/4299
-    if: github.repository == 'Mudlet/Mudlet' && false
+    if: ${{ github.repository_owner == 'Mudlet' }} && false
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-autocompletion:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/update-geyser-docs.yml
+++ b/.github/workflows/update-geyser-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   update-geyser-docs:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-and-commit-text:
     runs-on: ubuntu-latest
-    if: github.repository == 'Mudlet/Mudlet'
+    if: ${{ github.repository_owner == 'Mudlet' }}
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Only run workflows in the main repo, as originally intended.
#### Motivation for adding to Mudlet
Noticed workflows are for some reason running in my repo as well: https://github.com/vadi2/Mudlet/pulls?q=is%3Apr+is%3Aclosed
#### Other info (issues closed, discussion etc)
