### PR TITLE
Name capture groups - add null check back to prevent crashes

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -570,7 +570,9 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         mConditionMap[pCondition] = pCondition;
         pCondition->multiCaptureList.push_back(captureList);
         pCondition->multiCapturePosList.push_back(posList);
-        pCondition->nameCaptures.push_back(*nameMatches);
+        if (nameMatches != nullptr) {
+            pCondition->nameCaptures.push_back(*nameMatches);
+        }
         if (mudlet::debugMode) {
             TDebug(QColor(Qt::darkYellow), QColor(Qt::black)) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber
                                                               << "/" << mRegexCodeList.size() << ") regex=" << mRegexCodeList[regexNumber] << "\n"


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Add back nullcheck that was not redundant after all.

#### Motivation for adding to Mudlet

Prevent crashes

#### Other info (issues closed, discussion etc)
