### PR TITLE
Fix crash when map info is added, but mapper is not opened yet

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15300,7 +15300,6 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         lua_pop(L, nResult);
         return MapInfoProperties{ isBold, isItalic, text, color };
     });
-    host.mpMap->mpMapper->updateInfoContributors();
 
     lua_pushboolean(L, true);
     return 1;
@@ -15314,7 +15313,6 @@ int TLuaInterpreter::killMapInfo(lua_State* L)
     if (!host.mpMap->mMapInfoContributorManager->removeContributor(name)) {
         return warnArgumentValue(L, __func__, QStringLiteral("map info '%1' does not exist").arg(name));
     }
-    host.mpMap->mpMapper->updateInfoContributors();
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -141,7 +141,10 @@ dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
     }
     //stops inheritance of palette from mpConsole->mpMainFrame
     setPalette(QApplication::palette());
-    updateInfoContributors();
+
+    connect(mpMap->mMapInfoContributorManager, &MapInfoContributorManager::signal_contributorsUpdated, this, &dlgMapper::slot_updateInfoContributors);
+    slot_updateInfoContributors();
+
 }
 
 void dlgMapper::updateAreaComboBox()
@@ -332,7 +335,7 @@ void dlgMapper::slot_switchArea(const int index)
 }
 #endif
 
-void dlgMapper::updateInfoContributors()
+void dlgMapper::slot_updateInfoContributors()
 {
     info_pushButton->menu()->clear();
     auto* clearAction = new QAction(tr("None", "Don't show the map overlay, 'none' meaning no map overlay styled are enabled"), info_pushButton);

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -50,9 +50,7 @@ public:
     void updateAreaComboBox();
     void setDefaultAreaShown(bool);
     bool getDefaultAreaShown() { return mShowDefaultArea; }
-    void resetAreaComboBoxToPlayerRoomArea();    
-
-    void updateInfoContributors();
+    void resetAreaComboBoxToPlayerRoomArea();
 
 public slots:
     void slot_bubbles();
@@ -63,6 +61,7 @@ public slots:
     void slot_togglePanel();
     void slot_roomSize(int d);
     void slot_lineSize(int d);
+    void slot_updateInfoContributors();
 #if (QT_VERSION) >= (QT_VERSION_CHECK(5, 15, 0))
     // Only used in newer Qt versions
     void slot_switchArea(const int);

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -39,12 +39,14 @@ void MapInfoContributorManager::registerContributor(const QString& name, MapInfo
     }
     ordering.append(name);
     contributors.insert(name, callback);
+    emit signal_contributorsUpdated();
 }
 
 bool MapInfoContributorManager::removeContributor(const QString& name)
 {
     mpHost->mMapInfoContributors.remove(name);
     ordering.removeOne(name);
+    emit signal_contributorsUpdated();
     return contributors.remove(name) > 0;
 }
 
@@ -54,9 +56,7 @@ bool MapInfoContributorManager::enableContributor(const QString &name) {
     }
     mpHost->mMapInfoContributors.insert(name);
     mpHost->mpMap->update();
-    if (mpHost->mpMap->mpMapper != nullptr) {
-        mpHost->mpMap->mpMapper->updateInfoContributors();
-    }
+    emit signal_contributorsUpdated();
     return true;
 }
 
@@ -66,9 +66,7 @@ bool MapInfoContributorManager::disableContributor(const QString &name) {
     }
     mpHost->mMapInfoContributors.remove(name);
     mpHost->mpMap->update();
-    if (mpHost->mpMap->mpMapper != nullptr) {
-        mpHost->mpMap->mpMapper->updateInfoContributors();
-    }
+    emit signal_contributorsUpdated();
     return true;
 }
 

--- a/src/mapInfoContributorManager.h
+++ b/src/mapInfoContributorManager.h
@@ -41,9 +41,9 @@ struct MapInfoProperties
 
 using MapInfoCallback = std::function<MapInfoProperties(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor)>;
 
-class MapInfoContributorManager : QObject
+class MapInfoContributorManager : public QObject
 {
-    Q_DECLARE_TR_FUNCTIONS(MapInfoContributorManager)
+    Q_OBJECT
 
 public:
     MapInfoContributorManager(QObject* parent, Host* ph);
@@ -56,6 +56,9 @@ public:
     QList<QString> &getContributorKeys();
     MapInfoProperties fullInfo(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor);
     MapInfoProperties shortInfo(int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor);
+
+signals:
+    void signal_contributorsUpdated();
 
 private:
     QList<QString> ordering;


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions

Instead of multiple ifs with nullchecks switched to signal-slot

#### Motivation for adding to Mudlet

Prevent crash

#### Other info (issues closed, discussion etc)
closes #4785