### PR TITLE
Allow profile tab bars to be moved around

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -334,8 +334,6 @@ void dlgMapper::slot_switchArea(const int index)
 
 void dlgMapper::updateInfoContributors()
 {
-    return;
-
     info_pushButton->menu()->clear();
     auto* clearAction = new QAction(tr("None", "Don't show the map overlay, 'none' meaning no map overlay styled are enabled"), info_pushButton);
     info_pushButton->menu()->addAction(clearAction);

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -334,6 +334,8 @@ void dlgMapper::slot_switchArea(const int index)
 
 void dlgMapper::updateInfoContributors()
 {
+    return;
+
     info_pushButton->menu()->clear();
     auto* clearAction = new QAction(tr("None", "Don't show the map overlay, 'none' meaning no map overlay styled are enabled"), info_pushButton);
     info_pushButton->menu()->addAction(clearAction);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -292,10 +292,7 @@ mudlet::mudlet()
     mpTabBar->setTabsClosable(true);
     mpTabBar->setAutoHide(true);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_close_profile_requested);
-    // TODO: Do not enable this option currently - although the user can drag
-    // the tabs the underlying main TConsoles do not move and then it means that
-    // the wrong title can be shown over the wrong window.
-    mpTabBar->setMovable(false);
+    mpTabBar->setMovable(true);
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tab_changed);
     auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Allow profile tab bars to be moved around

![Peek 2021-02-12 20-20](https://user-images.githubusercontent.com/110988/107812385-e2467d80-6d6f-11eb-81cd-91f8fd1d06a0.gif)


#### Motivation for adding to Mudlet
For player convenience
#### Other info (issues closed, discussion etc)
The comment that was added was incorrect - the underlying console does move around OK.