### PR TITLE
Clarify internal message about movable tabs

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -293,8 +293,7 @@ mudlet::mudlet()
     mpTabBar->setAutoHide(true);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_close_profile_requested);
     // TODO: Do not enable this option currently - although the user can drag
-    // the tabs the underlying main TConsoles do not move and then it means that
-    // the wrong title can be shown over the wrong window.
+    // the tabs the underlying main TConsoles do not move with multiview enabled
     mpTabBar->setMovable(false);
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tab_changed);
     auto layoutTopLevel = new QVBoxLayout(frame);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -293,7 +293,7 @@ mudlet::mudlet()
     mpTabBar->setAutoHide(true);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_close_profile_requested);
     // TODO: Do not enable this option currently - although the user can drag
-    // the tabs the underlying main TConsoles do not move with multiview enabled
+    // the tabs, the underlying main TConsoles do not move with multiview enabled
     mpTabBar->setMovable(false);
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tab_changed);
     auto layoutTopLevel = new QVBoxLayout(frame);


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Clarify internal message about movable tabs - they can't be enabled right now because it doesn't work with multiview.
#### Motivation for adding to Mudlet
Less developer confusion.
#### Other info (issues closed, discussion etc)
Despite being verbose in nature, the warning failed in its mission to warn and resulted in https://github.com/Mudlet/Mudlet/pull/4790.