### PR TITLE
Restore compatibility with macOS 10.14

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -108,8 +108,8 @@ jobs:
         echo "LUA_PATH=$LUA_PATH" >> $GITHUB_ENV
         echo "LUA_CPATH=$LUA_CPATH" >> $GITHUB_ENV
 
-        # Build Mudlet for macOS 10.14 at minimum (latest currently supported by Apple)
-        echo "DEVELOPER_DIR=/Applications/Xcode_11.3.1.app/Contents/Developer" >> $GITHUB_ENV
+        # Use latest available XCode
+        echo "DEVELOPER_DIR=/Applications/Xcode_12.4.app/Contents/Developer" >> $GITHUB_ENV
 
     - name: (Linux) Install non-vcpkg dependencies
       if: runner.os == 'Linux'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -108,6 +108,9 @@ jobs:
         echo "LUA_PATH=$LUA_PATH" >> $GITHUB_ENV
         echo "LUA_CPATH=$LUA_CPATH" >> $GITHUB_ENV
 
+        # Build Mudlet for macOS 10.14 at minimum (latest currently supported by Apple)
+        echo "DEVELOPER_DIR=/Applications/Xcode_11.3.1.app/Contents/Developer" >> $GITHUB_ENV
+
     - name: (Linux) Install non-vcpkg dependencies
       if: runner.os == 'Linux'
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,7 @@
 cmake_minimum_required(VERSION 3.3)
 
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13") # Qt 5.11.2 with which we build on OS
-                                           # X supports 10.11 and up, but some
-                                           # tools are not provided as bottles
-                                           # for that anymore.
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE)
 endif()
 
 project(mudlet)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@
 cmake_minimum_required(VERSION 3.3)
 
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "")
 endif()
 
 project(mudlet)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@
 cmake_minimum_required(VERSION 3.3)
 
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING)
 endif()
 
 project(mudlet)


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Mudlet 4.10 works on macOS 10.13, but that is no longer supported by Apple since December 2010. Current PTBs, after migration to Github Actions, work on 10.15 only.
#### Motivation for adding to Mudlet
More macOS players are able to run Mudlet.
#### Other info (issues closed, discussion etc)
Set XCode to 11.3 which is what we used in Travis to see if that fixes it.