### PR TITLE
Infrastructure: downgrade to GCC 7 from 9

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -115,7 +115,7 @@ jobs:
         # If not available, use other methods
         sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev -y
 
-        # switch to GCC that supports C++17 while retraining support for older OS's
+        # switch to GCC that supports C++17 while retaining support for older OS's
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
         sudo update-alternatives --set gcc /usr/bin/gcc-7

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -115,11 +115,11 @@ jobs:
         # If not available, use other methods
         sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev -y
 
-        # multiple versions of GCC available in Actions - update to latest
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-        sudo update-alternatives --set gcc /usr/bin/gcc-9
-        sudo update-alternatives --set g++ /usr/bin/g++-9
+        # switch to GCC that supports C++17 while retraining support for older OS's
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
+        sudo update-alternatives --set gcc /usr/bin/gcc-7
+        sudo update-alternatives --set g++ /usr/bin/g++-7
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Downgrade to GCC 7 from 9.
#### Motivation for adding to Mudlet
That's what we used in Travis and that's what we need to support older OS's.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/4766