### PR TITLE
Infrastructure: install our own Boost

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -82,9 +82,9 @@ jobs:
     - name: Install Boost
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
-        echo "curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}"
         curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
-        7z e ${{env.BOOST_ROOT}}/download.7z -aoa -o${{env.BOOST_ROOT}}
+        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y
+        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar -y
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
         echo "curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}"
-        curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
+        curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         ls ${{env.BOOST_ROOT}}
         7z e ${{env.BOOST_ROOT}}/download.7z -o${{env.BOOST_ROOT}}
       shell: bash

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -66,7 +66,7 @@ jobs:
         cached: ${{steps.cache-qt.outputs.cache-hit}}
 
     - name: Restore Boost cache
-      uses: actions/cache@v22
+      uses: actions/cache@v2
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -83,9 +83,10 @@ jobs:
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
         curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.tar.bz2 ${{env.BOOST_URL}}
-        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y
-        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar -y
-        cp -r boost_*/* .
+        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y -bd
+        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar -y -bd
+        echo "extracted ok!"
+        cd ${{env.BOOST_ROOT}} && cp -r boost_*/* .
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -46,7 +46,7 @@ jobs:
             deploy: 'deploy'
 
     env:
-      BOOST_ROOT: ${{runner.workspace}}/Boost
+      BOOST_ROOT: ${{github.workspace}}/3rdparty/Boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
     steps:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -81,6 +81,10 @@ jobs:
 
     - name: Install Boost
       run: |
+        if [ "$OS" == "Windows_NT" ]; then
+          # fix up paths to be forward slashes consistently
+          BOOST_ROOT=$(echo $BOOST_ROOT | sed 's/\\/\//g')
+        fi
         mkdir -p ${{env.BOOST_ROOT}}
         curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.tar.bz2 ${{env.BOOST_URL}}
         7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y -bd

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -81,6 +81,7 @@ jobs:
 
     - name: Install Boost
       run: |
+        mkdir -p ${{env.BOOST_ROOT}}
         curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         7z e ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_ROOT}}
         ls ${{env.BOOST_ROOT}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -70,11 +70,11 @@ jobs:
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
-        key: boost-removeme
+        key: boost-removeme2
 
     - name: Install Boost
       run: |
-        curl -x -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
+        curl --parallel -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         7z e ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_ROOT}}
         ls ${{env.BOOST_ROOT}}
       shell: bash

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -46,7 +46,7 @@ jobs:
             deploy: 'deploy'
 
     env:
-      BOOST_ROOT: ${{github.workspace}}/3rdparty/Boost
+      BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.7z/download
 
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -74,8 +74,9 @@ jobs:
 
     - name: Install Boost
       run: |
-        $env:PATH="C:\msys64\usr\bin;${env:PATH}"
-        wget --quiet -O - ${{env.BOOST_URL}} | tar -xj
+        # $env:PATH="C:\msys64\usr\bin;${env:PATH}"
+        wget -O - ${{env.BOOST_URL}} | tar -xj
+        ls ${{env.BOOST_URL}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -70,7 +70,7 @@ jobs:
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
-        key: boost
+        key: boost-removeme
 
     - name: Install Boost
       run: |

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Restore Qt cache
-      uses: actions/cache@v2.1.4
+      uses: pat-s/always-upload-cache@v2.1.3
       id: cache-qt
       with:
         path: ${{runner.workspace}}/Qt/${{matrix.qt}}
@@ -66,14 +66,16 @@ jobs:
         cached: ${{steps.cache-qt.outputs.cache-hit}}
 
     - name: Restore Boost cache
-      uses: actions/cache@v2.1.4
+      uses: pat-s/always-upload-cache@v2.1.3
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
         key: boost
 
     - name: Install Boost
-      run: wget --quiet -O - ${{env.BOOST_URL}} | tar -xj
+      run: |
+        $env:PATH="C:\msys64\usr\bin;${env:PATH}"
+        wget --quiet -O - ${{env.BOOST_URL}} | tar -xj
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 
@@ -231,7 +233,7 @@ jobs:
       run: ctest --output-on-failure
 
     - name: (Linux/macOS) restore Luarocks for packaging
-      uses: actions/cache@v2.1.4
+      uses: pat-s/always-upload-cache@v2.1.3
       with:
         path: $HOME/.luarocks
         key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{hashFiles('.github/workflows/build-mudlet.yml')}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
 
     - name: Restore Qt cache
-      uses: pat-s/always-upload-cache@v2.1.3
+      uses: actions/cache@v2
       id: cache-qt
       with:
         path: ${{runner.workspace}}/Qt/${{matrix.qt}}
@@ -242,7 +242,7 @@ jobs:
       run: ctest --output-on-failure
 
     - name: (Linux/macOS) restore Luarocks for packaging
-      uses: pat-s/always-upload-cache@v2.1.3
+      uses: actions/cache@v2
       with:
         path: $HOME/.luarocks
         key: ccache-${{matrix.os}}-${{matrix.compiler}}-${{hashFiles('.github/workflows/build-mudlet.yml')}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -47,7 +47,7 @@ jobs:
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
-      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.7z/download
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 
     steps:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -47,7 +47,7 @@ jobs:
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/Boost
-      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.7z/download
 
     steps:
     - name: Restore Qt cache
@@ -74,9 +74,9 @@ jobs:
 
     - name: Install Boost
       run: |
-        # $env:PATH="C:\msys64\usr\bin;${env:PATH}"
-        wget -O - ${{env.BOOST_URL}} | tar -xj
-        ls ${{env.BOOST_URL}}
+        curl -x -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
+        7z e ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_ROOT}}
+        ls ${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -66,11 +66,11 @@ jobs:
         cached: ${{steps.cache-qt.outputs.cache-hit}}
 
     - name: Restore Boost cache
-      uses: pat-s/always-upload-cache@v2.1.3
+      uses: actions/cache@v22
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
-        key: boost-removeme2
+        key: boost-removeme3
 
     - name: Install Boost
       run: |

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -84,8 +84,7 @@ jobs:
         mkdir -p ${{env.BOOST_ROOT}}
         echo "curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}"
         curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
-        ls ${{env.BOOST_ROOT}}
-        7z e ${{env.BOOST_ROOT}}/download.7z -aoa${{env.BOOST_ROOT}}
+        7z e ${{env.BOOST_ROOT}}/download.7z -aoa -o${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -48,7 +48,7 @@ jobs:
     env:
       BOOST_ROOT: ${{runner.workspace}}/Boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
-    
+
     steps:
     - name: Restore Qt cache
       uses: actions/cache@v2.1.4

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Install Boost
       run: |
-        curl --parallel -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
+        curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         7z e ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_ROOT}}
         ls ${{env.BOOST_ROOT}}
       shell: bash

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -77,9 +77,10 @@ jobs:
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
-        key: boost-removeme4
+        key: boost
 
     - name: Install Boost
+      if: steps.cache-boost.outputs.cache-hit != 'true'
       run: |
         if [ "$OS" == "Windows_NT" ]; then
           # fix up paths to be forward slashes consistently
@@ -92,7 +93,6 @@ jobs:
         cd $BOOST_ROOT && mv -r boost_*/* .
         rm download.tar.bz2 download.tar
       shell: bash
-      if: steps.cache-boost.outputs.cache-hit != 'true'
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -83,11 +83,15 @@ jobs:
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
         echo "curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}"
-        ls ${{env.BOOST_ROOT}}
         curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
+        ls ${{env.BOOST_ROOT}}
         7z e ${{env.BOOST_ROOT}}/download.7z -o${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: error()
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,6 +85,7 @@ jobs:
         curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y
         7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar -y
+        cp -r boost_*/* .
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -62,7 +62,7 @@ jobs:
       id: cache-qt
       with:
         path: ${{runner.workspace}}/Qt/${{matrix.qt}}
-        key: ${{matrix.os}}-qt-${{matrix.qt}}-deletmee
+        key: ${{matrix.os}}-qt-${{matrix.qt}}
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -89,8 +89,8 @@ jobs:
         curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
         7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
         7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
-        echo "extracted ok!"
-        cd $BOOST_ROOT && cp -r boost_*/* .
+        cd $BOOST_ROOT && mv -r boost_*/* .
+        rm download.tar.bz2 download.tar
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,12 +85,12 @@ jobs:
           # fix up paths to be forward slashes consistently
           BOOST_ROOT=$(echo $BOOST_ROOT | sed 's/\\/\//g')
         fi
-        mkdir -p ${{env.BOOST_ROOT}}
-        curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.tar.bz2 ${{env.BOOST_URL}}
-        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y -bd
-        7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar -y -bd
+        mkdir -p $BOOST_ROOT
+        curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
+        7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
+        7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
         echo "extracted ok!"
-        cd ${{env.BOOST_ROOT}} && cp -r boost_*/* .
+        cd $BOOST_ROOT && cp -r boost_*/* .
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
 
     - name: Restore Qt cache
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       id: cache-qt
       with:
         path: ${{runner.workspace}}/Qt/${{matrix.qt}}
@@ -73,7 +73,7 @@ jobs:
         cached: ${{steps.cache-qt.outputs.cache-hit}}
 
     - name: Restore Boost cache
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -49,7 +49,14 @@ jobs:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/Boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.7z/download
 
+
     steps:
+    - name: Checkout Mudlet source code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
     - name: Restore Qt cache
       uses: pat-s/always-upload-cache@v2.1.3
       id: cache-qt
@@ -79,12 +86,6 @@ jobs:
         ls ${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
-
-    - name: Checkout Mudlet source code
-      uses: actions/checkout@v2
-      with:
-        submodules: true
-        fetch-depth: 0
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -82,9 +82,10 @@ jobs:
     - name: Install Boost
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
+        echo "curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}"
+        ls ${{env.BOOST_ROOT}}
         curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         7z e ${{env.BOOST_ROOT}}/download.7z -o${{env.BOOST_ROOT}}
-        ls ${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
         curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
-        7z e ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_ROOT}}
+        7z e ${{env.BOOST_ROOT}}/download.7z -o${{env.BOOST_ROOT}}
         ls ${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Install Boost
       run: |
         mkdir -p ${{env.BOOST_ROOT}}
-        curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
+        curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.tar.bz2 ${{env.BOOST_URL}}
         7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar.bz2 -y
         7z -o${{env.BOOST_ROOT}} x ${{env.BOOST_ROOT}}/download.tar -y
         cp -r boost_*/* .

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -90,7 +90,7 @@ jobs:
         curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
         7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
         7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
-        cd $BOOST_ROOT && mv -r boost_*/* .
+        cd $BOOST_ROOT && mv -f boost_*/* .
         rm download.tar.bz2 download.tar
       shell: bash
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -90,8 +90,8 @@ jobs:
         curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
         7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
         7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
-        cd $BOOST_ROOT && mv -f boost_*/* .
-        rm download.tar.bz2 download.tar
+        cd $BOOST_ROOT && cp -r boost_*/* .
+        rm -rf boost_*/* download.tar.bz2 download.tar
       shell: bash
 
     - name: Setup tmate session

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -62,7 +62,7 @@ jobs:
       id: cache-qt
       with:
         path: ${{runner.workspace}}/Qt/${{matrix.qt}}
-        key: ${{matrix.os}}-qt-${{matrix.qt}}
+        key: ${{matrix.os}}-qt-${{matrix.qt}}-deletmee
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -85,7 +85,7 @@ jobs:
         echo "curl -o ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}"
         curl --progress-bar --location --output ${{env.BOOST_ROOT}}/download.7z ${{env.BOOST_URL}}
         ls ${{env.BOOST_ROOT}}
-        7z e ${{env.BOOST_ROOT}}/download.7z -o${{env.BOOST_ROOT}}
+        7z e ${{env.BOOST_ROOT}}/download.7z -aoa${{env.BOOST_ROOT}}
       shell: bash
       if: steps.cache-boost.outputs.cache-hit != 'true'
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
-      if: error()
+      if: ${{ failure() }}
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -77,7 +77,7 @@ jobs:
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
-        key: boost-removeme3
+        key: boost-removeme4
 
     - name: Install Boost
       run: |

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -45,6 +45,10 @@ jobs:
             qt: '5.14.1'
             deploy: 'deploy'
 
+    env:
+      BOOST_ROOT: ${{runner.workspace}}/Boost
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
+    
     steps:
     - name: Restore Qt cache
       uses: actions/cache@v2.1.4
@@ -60,6 +64,18 @@ jobs:
         dir: ${{runner.workspace}}
         arch: win64_mingw73 # this key is relevant only for windows
         cached: ${{steps.cache-qt.outputs.cache-hit}}
+
+    - name: Restore Boost cache
+      uses: actions/cache@v2.1.4
+      id: cache-boost
+      with:
+        path: ${{env.BOOST_ROOT}}
+        key: boost
+
+    - name: Install Boost
+      run: wget --quiet -O - ${{env.BOOST_URL}} | tar -xj
+      shell: bash
+      if: steps.cache-boost.outputs.cache-hit != 'true'
 
     - name: Checkout Mudlet source code
       uses: actions/checkout@v2
@@ -142,9 +158,6 @@ jobs:
       if: runner.os == 'Windows'
       shell: powershell
       run: |
-        # Use pre-installed Boost
-        echo "BOOST_ROOT=$env:BOOST_ROOT_1_72_0" >> $env:GITHUB_ENV
-
         # Install dependencies not available on machine
         $env:WORKING_BASE_DIR = "${{runner.workspace}}\src"
         $env:MINGW_BASE_DIR = "${{runner.workspace}}\mingw73_64"

--- a/3rdparty/our-vcpkg-dependencies/vcpkg-x64-linux-dependencies
+++ b/3rdparty/our-vcpkg-dependencies/vcpkg-x64-linux-dependencies
@@ -5,5 +5,4 @@ hunspell
 pugixml
 --overlay-ports=../our-vcpkg-dependencies/lua
 lua[core]
-boost-graph
 sqlite3

--- a/3rdparty/our-vcpkg-dependencies/vcpkg-x64-osx-dependencies
+++ b/3rdparty/our-vcpkg-dependencies/vcpkg-x64-osx-dependencies
@@ -5,5 +5,4 @@ hunspell
 pugixml
 --overlay-ports=../our-vcpkg-dependencies/lua
 lua[core]
-boost-graph
 sqlite3


### PR DESCRIPTION
<!-- Keep the title short & concise so your mom can understand it -->
#### Brief overview of PR changes/additions
Install our own Boost. Since we use only boost-graph, we don't need to compile boost either.
#### Motivation for adding to Mudlet
Pre-installed Boost from Github images is going away: https://github.com/actions/virtual-environments/issues/2667, and it wasn't installed on all platforms to begin with.
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/4506.

It'll also speed up linux/macOS first-time, uncached builds because compiling Boost took 15-20min.