### PR TITLE
Infrastructure: improve resiliency ptb changelogs

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -157,9 +157,10 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
     $Script:DownloadedFeed = [System.IO.Path]::GetTempFileName()
     Invoke-WebRequest "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86" -OutFile $Script:DownloadedFeed
     Write-Output "=== Generating a changelog ==="
-    pushd "$Env:APPVEYOR_BUILD_FOLDER\CI\"
+    Push-Location "$Env:APPVEYOR_BUILD_FOLDER\CI\"
     $Script:Changelog = lua "$Env:APPVEYOR_BUILD_FOLDER\CI\generate-ptb-changelog.lua" --releasefile $Script:DownloadedFeed
-    popd
+    Pop-Location
+    Write-Output $Script:Changelog
     Write-Output "=== Creating release in Dblsqd ==="
     dblsqd release -a mudlet -c public-test-build -m $Script:Changelog "${Env:VERSION}${Env:MUDLET_VERSION_BUILD}".ToLower()
 

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -133,8 +133,15 @@ if [ "${DEPLOY}" = "deploy" ]; then
     dblsqd login -e "https://api.dblsqd.com/v1/jsonrpc" -u "${DBLSQD_USER}" -p "${DBLSQD_PASS}"
 
     if [ "${public_test_build}" == "true" ]; then
+      echo "=== Downloading release feed ==="
+      downloadedfeed=$(mktemp)
+      wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/mac/x86_64" --output-document="$downloadedfeed"
+      echo "=== Generating a changelog ==="
+      cd "${SOURCE_DIR}" || exit
+      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --releasefile "${downloadedfeed}")
+
       echo "=== Creating release in Dblsqd ==="
-      dblsqd release -a mudlet -c public-test-build -m "(test release message here)" "${VERSION}${MUDLET_VERSION_BUILD}" || true
+      dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true
 
       # release registration and uploading will be manual for the time being
     else


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix changelogs were showing up like this:

![image](https://user-images.githubusercontent.com/110988/107880320-49824000-6ede-11eb-9ba5-df62e4081853.png)


#### Motivation for adding to Mudlet
Reliable changelogs
#### Other info (issues closed, discussion etc)
In Travis, macOS builds always took way longer than Linux builds to make - so only the Linux builds generated changelogs. In Github, macOS build times are much less and are now on par to Linux - so if a macOS finished the build first, there'd be no changelog.

Also updated Windows builds to print changelog to the build log, just in case.