### PR TITLE
Show a placeholder in the input first launch

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -451,8 +451,10 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         thankForUsingPTB();
     }
 
-    if (mudlet::self()->firstLaunch()) {
-        mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
+    if (mudlet::self()->firstLaunch) {
+        QTimer::singleShot(0, this, [this]() {
+            mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
+        });
     }
 
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -451,6 +451,10 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         thankForUsingPTB();
     }
 
+    if (mudlet::self()->firstLaunch()) {
+        mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
+    }
+
     connect(&mTelnet, &cTelnet::signal_disconnected, this, [this](){ purgeTimer.start(1min); });
     connect(&mTelnet, &cTelnet::signal_connected, this, [this](){ purgeTimer.stop(); });
     connect(&purgeTimer, &QTimer::timeout, this, &Host::slot_purgeTemps);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -319,6 +319,8 @@ mudlet::mudlet()
         mAutolog = false;
     }
 
+    firstLaunch = !QFile::exists(mudlet::getMudletPath(mudlet::profilesPath));
+
     mpButtonConnect = new QToolButton(this);
     mpButtonConnect->setText(tr("Connect"));
     mpButtonConnect->setObjectName(QStringLiteral("connect"));
@@ -1012,12 +1014,6 @@ void mudlet::migrateDebugConsole(Host* currentHost)
 
     mpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
     mpDebugArea->close();
-}
-
-// returns true if this is the first launch of Mudlet on this machine
-bool mudlet::firstLaunch()
-{
-    return !QFile::exists(mudlet::getMudletPath(mudlet::profilesPath));
 }
 
 // As we are currently only using files from a resource file we only need to

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -266,7 +266,7 @@ public:
     // to tell other profiles to reload the updated
     // maps (via signal_profileMapReloadRequested(...))
     void requestProfilesToReloadMaps(QList<QString>);
-
+    const bool firstLaunch = false;
     void showChangelogIfUpdated();
 
     bool showMapAuditErrors() const { return mshowMapAuditErrors; }
@@ -532,7 +532,6 @@ private:
     void loadTranslators(const QString &languageCode);
     void loadMaps();
     void migrateDebugConsole(Host* currentHost);
-    static bool firstLaunch();
     QString autodetectPreferredLanguage();
     void installModulesList(Host*, QStringList);
     void setupTrayIcon();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -266,7 +266,7 @@ public:
     // to tell other profiles to reload the updated
     // maps (via signal_profileMapReloadRequested(...))
     void requestProfilesToReloadMaps(QList<QString>);
-    const bool firstLaunch = false;
+    bool firstLaunch = false;
     void showChangelogIfUpdated();
 
     bool showMapAuditErrors() const { return mshowMapAuditErrors; }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Show a placeholder in the input first launch. First launch only - any subsequent launches won't show it. 

![image](https://user-images.githubusercontent.com/110988/107886121-1f407a80-6efe-11eb-993c-ff752e6302e8.png)

#### Motivation for adding to Mudlet
Better first-time player experience.
#### Other info (issues closed, discussion etc)
It only gets us halfway there - because of the amount of text, the input line all the way at the bottom wasn't all that noticeable for someone looking at the middle of the screen.