### PR TITLE
fix selection only copying one letter when double/triple click

### DIFF
--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -143,6 +143,7 @@ private:
     void updateTextCursor(const QMouseEvent* event, int lineIndex, int tCharIndex, bool isOutOfbounds);
     bool establishSelectedText();
     void expandSelectionToWords();
+    void expandSelectionToLine(int);
 
     int mFontHeight;
     int mFontWidth;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
fixes copying only one letter if a word by doubleclick or a whole line by triple click is selected

#### Motivation for adding to Mudlet
fix #4769

#### Other info (issues closed, discussion etc)
