### PR TITLE
Add section for release notes blurb to the pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,9 @@
 #### Motivation for adding to Mudlet
 
 #### Other info (issues closed, discussion etc)
+
+#### Release post highlight
+<!--
+Use this space if you wish to write a short statement or example for inclusion
+in the release post for the next release. 
+-->


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adjusts the PR template to include a section for providing a release post entry/example

#### Motivation for adding to Mudlet

Help make release days easier by hopefully being able to pull up the PRs closed for this release and copy release posts entries from the PRs themselves, rather than having to write it all the day or week before.

#### Other info (issues closed, discussion etc)
