### PR TITLE
repair setPopup api

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5336,7 +5336,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
         // removes value, but keeps key for next iteration
         lua_pop(L, 1);
     }
-    if (!lua_istable(L, s++)) {
+    if (!lua_istable(L, ++s)) {
         lua_pushfstring(L, "setPopup: bad argument #%d type (hint list as table expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5353,7 +5353,7 @@ int TLuaInterpreter::setPopup(lua_State* L)
 
     Host& host = getHostFromLua(L);
     if (_commandList.size() != _hintList.size()) {
-        lua_pushstring(L, "Error: command list size and hint list size do not match cannot create popup");
+        lua_pushstring(L, "setPopup: commands and hints list aren't the same size");
         return lua_error(L);
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5318,17 +5318,12 @@ int TLuaInterpreter::setPopup(lua_State* L)
     int n = lua_gettop(L);
 
     // console name is an optional first argument
-    if (n > 4) {
+    if (n > 2) {
         windowName = WINDOW_NAME(L, s++);
     }
-    if (!lua_isstring(L, s)) {
-        lua_pushstring(L, "setPopup: wrong argument type");
-        return lua_error(L);
-    }
-    QString txt = lua_tostring(L, s++);
 
     if (!lua_istable(L, s)) {
-        lua_pushstring(L, "setPopup: wrong argument type");
+        lua_pushfstring(L, "setPopup: bad argument #%d type (command list as table expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
     lua_pushnil(L);
@@ -5341,8 +5336,8 @@ int TLuaInterpreter::setPopup(lua_State* L)
         // removes value, but keeps key for next iteration
         lua_pop(L, 1);
     }
-    if (!lua_istable(L, ++s)) {
-        lua_pushstring(L, "setPopup: wrong argument type");
+    if (!lua_istable(L, s++)) {
+        lua_pushfstring(L, "setPopup: bad argument #%d type (hint list as table expected, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);
     }
     lua_pushnil(L);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes setPopup so it doesn't ignore the windowname (first argument) anymore and it will be really a optional argument.
#### Motivation for adding to Mudlet
fix #4641
#### Other info (issues closed, discussion etc)
There was a discussion on #4641 that 4 arguments were needed but testing in Mudlet 4.10.1 and in the latest PTB
```lua 
echo("Popup")
selectString("Popup", 1)
setPopup("main","notNeeded",{[[send("bye")]], [[echo("hi!")]]}, {"send 'bye' to the MUD", "click to echo 'hi!'"})
``` 
results to 
![image](https://user-images.githubusercontent.com/60551052/108370767-4ac4ad00-71fd-11eb-80a8-f9c8ef65c370.png)
So I don't think the 4th argument was ever needed. I don't think this will affect backwards compatibility.
The only difference is that windowname is working now so the example.
```lua
-- example of selecting text in a miniconsole and turning it into a Popup:
HelloWorld = Geyser.MiniConsole:new({
  name="HelloWorld",
  x="70%", y="50%",
  width="30%", height="50%",
})
HelloWorld:echo("hi")
selectString("HelloWorld", "hi", 1)
setPopup("HelloWorld", {[[send("bye")]], [[echo("hi!")]]}, {"send 'bye' to the MUD", "click to echo 'hi!'"})
```
Will now work as expected (in comparison to Mudlet 4.10.1 or the latest PTB)

Also
```lua
echo("Popup")
moveCursorEnd()
selectString("Popup", 1)
setPopup("main",{[[send("bye")]], [[echo("hi!")]]}, {"send 'bye' to the MUD", "click to echo 'hi!'"})
```
Will work as before.
And
```lua
echo("Popup")
moveCursorEnd()
selectString("Popup", 1)
setPopup({[[send("bye")]], [[echo("hi!")]]}, {"send 'bye' to the MUD", "click to echo 'hi!'"})
```
 Will now work as the first argument will be optional (as suggested in wiki and as comment in TLuaInterpreter code)

