### PR TITLE
BugFix: prevent crashes when clicking on empty maps

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3553,7 +3553,7 @@ void Host::createMapper(bool loadDefaultMap)
     pMap->mpMapper->setStyleSheet(mProfileStyleSheet);
     mpDockableMapWidget->setWidget(pMap->mpMapper);
 
-    if (loadDefaultMap && pMap->mpRoomDB->getRoomIDList().isEmpty()) {
+    if (loadDefaultMap && pMap->mpRoomDB->isEmpty()) {
         qDebug() << "Host::create_mapper() - restore map case 3.";
         pMap->pushErrorMessagesToFile(tr("Pre-Map loading(3) report"), true);
         QDateTime now(QDateTime::currentDateTime());

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2790,7 +2790,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 popup->popup(mapToGlobal(event->pos()));
                 return;
             }
-            // Else there is a map - though it mnight not have ANY rooms!
+            // Else there is a map - though it might not have ANY rooms!
 
             if (mMultiSelectionSet.isEmpty() && !mMapViewOnly) {
                 mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1251,7 +1251,9 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size()); 
+        auto message = mpMap->mpRoomDB
+                ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
+                : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;
@@ -2293,6 +2295,10 @@ void T2DMap::mouseDoubleClickEvent(QMouseEvent* event)
     if (mDialogLock || (event->buttons() != Qt::LeftButton)) {
         return;
     }
+    if (!mpMap||!mpMap->mpRoomDB) {
+        // No map loaded!
+        return;
+    }
     int x = event->x();
     int y = event->y();
     mPHighlight = QPoint(x, y);
@@ -2480,11 +2486,10 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             // But NOT if got one or more rooms already selected!
             TArea* pA = mpMap->mpRoomDB->getArea(mAreaID);
             if (pA) {
-                TArea* pArea = pA;
                 float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
                 float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
                 QPointF pc = QPointF(mx, my);
-                QSetIterator<int> itRoom = pArea->rooms;
+                QSetIterator<int> itRoom = pA->rooms;
                 while (itRoom.hasNext()) {
                     int currentRoomId = itRoom.next();
                     TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
@@ -2572,12 +2577,10 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             // Not in a context menu, so start selection mode - including drag to select if not in viewOnly mode
             mMultiSelection = !mMapViewOnly;
             mMultiRect = QRect(event->pos(), event->pos());
-            int _roomID = mRoomID;
-            if (!mpMap->mpRoomDB->getRoom(_roomID)) {
+            if (!mpMap->mpRoomDB->getRoom(mRoomID)) {
                 return;
             }
-            int _areaID = mAreaID;
-            TArea* pArea = mpMap->mpRoomDB->getArea(_areaID);
+            TArea* pArea = mpMap->mpRoomDB->getArea(mAreaID);
             if (!pArea) {
                 return;
             }
@@ -2586,8 +2589,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             if (!event->modifiers().testFlag(Qt::ControlModifier)) {
                 if (!mMapViewOnly) {
-                  // If control key NOT down then clear selection, and put up helpful text
-                  mHelpMsg = tr("Drag to select multiple rooms or labels, release to finish...", "2D Mapper big, bottom of screen help message");
+                    // If control key NOT down then clear selection, and put up helpful text
+                    mHelpMsg = tr("Drag to select multiple rooms or labels, release to finish...", "2D Mapper big, bottom of screen help message");
                 }
                 mMultiSelectionSet.clear();
             }
@@ -2680,7 +2683,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
     }
 
-
     if (event->buttons() & Qt::RightButton) {
         auto popup = new QMenu(this);
         popup->setToolTipsVisible(true);
@@ -2723,38 +2725,37 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             }
         }
 
-        auto playerRoom = mpMap->mpRoomDB->getRoom(mpMap->mRoomIdHash.value(mpMap->mProfileName));
         auto pArea = mpMap->mpRoomDB->getArea(mAreaID);
-
         if (!mLabelHighlighted && mCustomLineSelectedRoom == 0) {
-
             mMultiRect = QRect(event->pos(), event->pos());
             float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
             float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
 
-            QSetIterator<int> itRoom(pArea->getAreaRooms());
-            while (itRoom.hasNext()) { // Scan to find rooms in selection
-                int currentAreaRoom = itRoom.next();
-                TRoom *room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-                if (!room) {
-                    continue;
-                }
-                int rx = room->x * mRoomWidth + fx;
-                int ry = room->y * -1 * mRoomHeight + fy;
-                int rz = room->z;
-
-                int mx = event->pos().x();
-                int my = event->pos().y();
-                int mz = mOz;
-                if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
-                    if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
-                        mMultiSelectionSet.remove(currentAreaRoom);
-                    } else {
-                        mMultiSelectionSet.insert(currentAreaRoom);
+            if (pArea) {
+                QSetIterator<int> itRoom(pArea->getAreaRooms());
+                while (itRoom.hasNext()) { // Scan to find rooms in selection
+                    int currentAreaRoom = itRoom.next();
+                    TRoom *room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+                    if (!room) {
+                        continue;
                     }
+                    int rx = room->x * mRoomWidth + fx;
+                    int ry = room->y * -1 * mRoomHeight + fy;
+                    int rz = room->z;
 
-                    if (!mMultiSelectionSet.empty()) {
-                        mMultiSelection = false;
+                    int mx = event->pos().x();
+                    int my = event->pos().y();
+                    int mz = mOz;
+                    if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
+                        if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
+                            mMultiSelectionSet.remove(currentAreaRoom);
+                        } else {
+                            mMultiSelectionSet.insert(currentAreaRoom);
+                        }
+
+                        if (!mMultiSelectionSet.empty()) {
+                            mMultiSelection = false;
+                        }
                     }
                 }
             }
@@ -2773,7 +2774,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     getCenterSelection();
             }
 
-            if (!playerRoom || !pArea) {
+            if (!mpMap||!mpMap->mpRoomDB) {
+                // No map loaded
                 auto createMap = new QAction(tr("Create new map", "2D Mapper context menu (no map found) item"), this);
                 connect(createMap, &QAction::triggered, this, &T2DMap::slot_newMap);
 
@@ -2788,6 +2790,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 popup->popup(mapToGlobal(event->pos()));
                 return;
             }
+            // Else there is a map - though it mnight not have ANY rooms!
 
             if (mMultiSelectionSet.isEmpty() && !mMapViewOnly) {
                 mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -791,7 +791,8 @@ void TConsole::closeEvent(QCloseEvent* event)
         mpHost->modulesToWrite.clear();
         mpHost->saveProfile();
 
-        if (mpHost->mpMap->mpRoomDB->size() > 0) {
+        if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
+            // There is a map loaded - but it *could* have no rooms at all!
             QDir dir_map;
             QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
             QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString("yyyy-MM-dd#HH-mm-ss"));
@@ -829,7 +830,8 @@ void TConsole::closeEvent(QCloseEvent* event)
             if (!std::get<0>(result)) {
                 QMessageBox::critical(this, tr("Couldn't save profile"), tr("Sorry, couldn't save your profile - got the following error: %1").arg(std::get<2>(result)));
                 goto ASK;
-            } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB->size() > 0) {
+            } else if (mpHost->mpMap && mpHost->mpMap->mpRoomDB) {
+                // There is a map loaded - but it *could* have no rooms at all!
                 QDir dir_map;
                 QString directory_map = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
                 QString filename_map = mudlet::getMudletPath(mudlet::profileDateTimeStampedMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd#HH-mm-ss")));

--- a/src/TRoomDB.h
+++ b/src/TRoomDB.h
@@ -51,7 +51,8 @@ public:
     TArea* getArea(int id);
     TArea* getRawArea(int, bool*);
     bool addRoom(int id);
-    int size() { return rooms.size(); }
+    int size() const { return rooms.size(); }
+    bool isEmpty() const { return rooms.isEmpty(); }
     bool removeRoom(int);
     void removeRoom(QSet<int>&);
     bool removeArea(int id);

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -380,8 +380,10 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            auto message = mpMap->mpRoomDB->size() == 0 ? tr("You do not have a map yet - load one, or start mapping from scratch to begin.") : tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size()); 
-            painter.drawText(width() / 3, height() / 2, message);
+            auto message = mpMap->mpRoomDB
+                    ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
+                    : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+            painter.drawText(0, 0, (width() -1), (height() -1), Qt::AlignCenter | Qt::TextWordWrap, message);
             painter.end();
 
             glLoadIdentity();
@@ -2153,6 +2155,9 @@ void GLWidget::resizeGL(int w, int h)
 void GLWidget::mousePressEvent(QMouseEvent* event)
 {
     mudlet::self()->activateProfile(mpHost);
+    if (!mpMap||!mpMap->mpRoomDB) {
+        return;
+    }
     if (event->buttons() & Qt::LeftButton) {
         int x = event->x();
         int y = height() - event->y(); // the opengl origin is at bottom left
@@ -2223,6 +2228,9 @@ void GLWidget::mousePressEvent(QMouseEvent* event)
 
 void GLWidget::mouseMoveEvent(QMouseEvent* event)
 {
+    if (!mpMap||!mpMap->mpRoomDB) {
+        return;
+    }
     if (mPanMode) {
         int x = event->x();
         int y = height() - event->y(); // the opengl origin is at bottom left


### PR DESCRIPTION
It prevents several mouse events for the mappers (both 2 and 3D) from doing much if the map is non-existent! This should close Issue #4821.

It also:
* adds a `(bool) TRoomDB::isEmpty()` function to provide a consistent indication that there is no rooms in the current map. (This saves having to count all the rooms in the map {to get the `size()`} and checking the value is not zero - technically it ought to be a tiny bit faster!)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Solves a recently introduced bug that would be visible in some PTBs that caused Mudlet to crash if a map was clicked on with the mouse.