### PR TITLE
Improve clarity in timing code

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -67,6 +67,7 @@
 #include "post_guard.h"
 
 #include <limits>
+using namespace std::chrono_literals;
 
 const QMap<Qt::MouseButton, QString> TLuaInterpreter::mMouseButtons = {
         {Qt::NoButton, QStringLiteral("NoButton")},           {Qt::LeftButton, QStringLiteral("LeftButton")},       {Qt::RightButton, QStringLiteral("RightButton")},
@@ -187,7 +188,7 @@ TLuaInterpreter::TLuaInterpreter(Host* pH, const QString& hostName, int id) : mp
 
     initLuaGlobals();
 
-    purgeTimer.start(2000);
+    purgeTimer.start(2min);
 }
 
 TLuaInterpreter::~TLuaInterpreter()

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -188,7 +188,7 @@ TLuaInterpreter::TLuaInterpreter(Host* pH, const QString& hostName, int id) : mp
 
     initLuaGlobals();
 
-    purgeTimer.start(2min);
+    purgeTimer.start(2s);
 }
 
 TLuaInterpreter::~TLuaInterpreter()

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -53,6 +53,8 @@
 #include <QSslError>
 #include "post_guard.h"
 
+using namespace std::chrono_literals;
+
 // Uncomment this to get debugging messages about WILL/WONT/DO/DONT commands for
 // suboptions - change the value to 2 to get a bit more detail about the sizes
 // of the messages
@@ -481,8 +483,8 @@ void cTelnet::handle_socket_signal_connected()
     QString nothing = "";
     mpHost->mLuaInterpreter.call(func, nothing);
     mConnectionTimer.start();
-    mTimerLogin->start(2000);
-    mTimerPass->start(3000);
+    mTimerLogin->start(2s);
+    mTimerPass->start(3s);
 
     emit signal_connected(mpHost);
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -36,6 +36,8 @@
 #include <QProgressDialog>
 #include "post_guard.h"
 
+using namespace std::chrono_literals;
+
 dlgMapper::dlgMapper( QWidget * parent, Host * pH, TMap * pM )
 : QWidget( parent )
 , mpMap( pM )
@@ -255,7 +257,7 @@ void dlgMapper::show2dView()
         d2buttons->setVisible(false);
     } else {
         // workaround for buttons reloading oddly
-        QTimer::singleShot(100, [this]() {
+        QTimer::singleShot(100ms, [this]() {
             d3buttons->setVisible(false);
             d2buttons->setVisible(true);
         });

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2966,7 +2966,7 @@ void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
     connect(getReply, qOverload<QNetworkReply::NetworkError>(&QNetworkReply::error), this, [=](QNetworkReply::NetworkError) {
 #endif
         theme_download_label->setText(tr("Could not update themes: %1").arg(getReply->errorString()));
-        QTimer::singleShot(5000, theme_download_label, [label = theme_download_label] {
+        QTimer::singleShot(5s, theme_download_label, [label = theme_download_label] {
             label->hide();
             label->setText(tr("Updating themes from colorsublime.github.io..."));
         });

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2037,7 +2037,7 @@ void dlgProfilePreferences::loadMap()
             label_mapFileActionResult->setText(tr("Could not load map from %1.").arg(fileName));
         }
     }
-    QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+    QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
 
     // Restore setting immediately before we used it
     mudlet::self()->setShowMapAuditErrors(showAuditErrors);
@@ -2077,7 +2077,7 @@ void dlgProfilePreferences::saveMap()
     }
     mudlet::self()->setShowMapAuditErrors(showAuditErrors);
 
-    QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+    QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
 }
 
 QString dlgProfilePreferences::mapSaveLoadDirectory(Host* pHost) {
@@ -2242,7 +2242,7 @@ void dlgProfilePreferences::copyMap()
 
     if (!pHost->mpConsole->saveMap(QString())) {
         label_mapFileActionResult->setText(tr("Could not backup the map - saving it failed."));
-        QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+        QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
         return;
     }
 
@@ -2267,7 +2267,7 @@ void dlgProfilePreferences::copyMap()
 
     if (thisProfileLatestMapFile.fileName().isEmpty()) {
         label_mapFileActionResult->setText(tr("Could not copy the map - failed to work out which map file we just saved the map as!"));
-        QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+        QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
         return;
     }
 
@@ -2285,7 +2285,7 @@ void dlgProfilePreferences::copyMap()
 
         if (!thisProfileLatestMapFile.copy(mudlet::getMudletPath(mudlet::profileMapPathFileName, otherHostName, thisProfileLatestMapPathFileName))) {
             label_mapFileActionResult->setText(tr("Could not copy the map to %1 - unable to copy the new map file over.").arg(otherHostName));
-            QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+            QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
             continue; // Try again with next profile
         } else {
             label_mapFileActionResult->setText(tr("Map copied successfully to other profile %1.").arg(otherHostName));
@@ -2301,7 +2301,7 @@ void dlgProfilePreferences::copyMap()
     // QStringList in many ways, the SLOT/SIGNAL system treats them as different
     // - I thinK - so use QList<QString> thoughout the SIGNAL/SLOT links Slysven!
     label_mapFileActionResult->setText(tr("Map copied, now signalling other profiles to reload it."));
-    QTimer::singleShot(10 * 1000, this, &dlgProfilePreferences::hideActionLabel);
+    QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
 
     // CHECK: Race condition? We might be changing this while other profile
     // are accessing it...

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -76,6 +76,8 @@
 #include <zip.h>
 #include "post_guard.h"
 
+using namespace std::chrono_literals;
+
 bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::Close) {
@@ -2852,7 +2854,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
 
 void mudlet::processEventLoopHack()
 {
-    QTimer::singleShot(1, this, &mudlet::processEventLoopHack_timerRun);
+    QTimer::singleShot(1ms, this, &mudlet::processEventLoopHack_timerRun);
 }
 
 void mudlet::processEventLoopHack_timerRun()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Improve clarity in timing code - instead of bizarre `10 * 1000` math, say it plainly how long the timer is for.
#### Motivation for adding to Mudlet
More readable code, it's 2021 after all :)
#### Other info (issues closed, discussion etc)

#### Release post highlight
Not a highlight but a changelog item:

* improved readability of internal timing code
