### PR TITLE
Infrastructure: update build action used for dependencies

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -100,7 +100,7 @@ jobs:
 
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
-      uses: lukka/run-vcpkg@v6
+      uses: lukka/run-vcpkg@v7
       env:
         vcpkgResponseFile: ${{github.workspace}}/3rdparty/our-vcpkg-dependencies/vcpkg-${{matrix.triplet}}-dependencies
       with:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update to run-vcpkg@v7, which is more resilient in handling Github infrastructure updates. It now clears the cache properly when github updates the image.
#### Motivation for adding to Mudlet
More resilient builds and less transient errors.
#### Other info (issues closed, discussion etc)

#### Release post highlight
Not a highlight but a changelog item:
* improved resiliency of macOS CI builds
