### PR TITLE
repair LabelCallback and CmdLineAction error handling

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4039,7 +4039,7 @@ int TLuaInterpreter::setLabelCallback(lua_State* L, const QString& funcName)
         return warnArgumentValue(L, __func__, QStringLiteral("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
 
-    if (lua_result) {
+    if (!lua_result) {
         return warnArgumentValue(L, __func__, QStringLiteral("label name '%1' not found").arg(labelName));
     }
     lua_pushboolean(L, true);

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2285,13 +2285,13 @@ end
 -- This wrapper gives callback functions the possibility to be used like
 -- setCallBackFunction (name,function as string,args)
 -- it is used by setLabelCallBack functions and setCmdLineAction
-local function setActionCallback(callbackFunc, name, func, ...)
+local function setActionCallback(callbackFunc, funcName, name, func, ...)
   local nr = arg.n + 1
   arg.n = arg.n + 1
   if type(func) == "string" then
     func = loadstring("return "..func.."(...)")
   end
-  assert(type(func) == 'function', '<setActionCallback: bad argument #2 type (function expected, got '..type(func)..'!)>')
+  assert(type(func) == 'function', string.format('<%s: bad argument #2 type (function expected, got %s!)>', funcName, type(func)))
   if nr > 1 then
     return callbackFunc(name,
     function(event)
@@ -2302,47 +2302,15 @@ local function setActionCallback(callbackFunc, name, func, ...)
       func(unpack_w_nil(arg))
     end )
   end
-  callbackFunc(name, func)
+  return callbackFunc(name, func)
 end
 
-local setLC = setLC or setLabelClickCallback
-function setLabelClickCallback (...)
-  setActionCallback(setLC, ...)
-end
+local callBackFunc ={"setLabelClickCallback", "setLabelReleaseCallback", "setLabelMoveCallback", "setLabelWheelCallback", "setLabelOnEnter", "setLabelOnLeave", "setCmdLineAction"}
 
-local setLDC = setLDC or setLabelDoubleClickCallback
-function setLabelDoubleClickCallback (...)
-  setActionCallback(setLDC, ...)
-end
-
-local setLRC = setLRC or setLabelReleaseCallback
-function setLabelReleaseCallback(...)
-  setActionCallback(setLRC, ...)
-end
-
-local setLMC = setLMC or setLabelMoveCallback
-function setLabelMoveCallback(...)
-  setActionCallback(setLMC, ...)
-end
-
-local setLWC = setLWC or setLabelWheelCallback
-function setLabelWheelCallback(...)
-  setActionCallback(setLWC, ...)
-end
-
-local setOnE = setOnE or setLabelOnEnter
-function setLabelOnEnter(...)
-  setActionCallback(setOnE, ...)
-end
-
-local setOnL = setOnL or setLabelOnLeave
-function setLabelOnLeave(...)
-  setActionCallback(setOnL,...)
-end
-
-local setCmdLA = setCmdLA or setCmdLineAction
-function setCmdLineAction(...)
-  setActionCallback(setCmdLA,...)
+for i = 1, #callBackFunc do
+  local funcName = callBackFunc[i]
+  local callBackFunction = _G[funcName]
+  _G[funcName] = function(...) return setActionCallback(callBackFunction, funcName, ...) end
 end
 
 function resetUserWindowTitle(windowname)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Messages if the label is not found work again
#### Motivation for adding to Mudlet
This was broken probably by something I added a while ago.
Fixing this issue.
#### Other info (issues closed, discussion etc)
testing
```lua setLabelClickCallback("nonExistentLabel","testfunction")``` 
in Mudlet 4.10.1 doesn't show any message
in this PR it will return
```
nil
"label name 'nonExistentLabel' not found"
``` 