### PR TITLE
Improve Linux theme packaging

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -290,23 +290,23 @@ jobs:
         DBLSQD_PASS: ${{secrets.DBLSQD_PASS}}
         DEPLOY_KEY_PASS: ${{secrets.DEPLOY_KEY_PASS}}
 
-
-    # - name: Setup tmate session for debugging
-    #   if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.deploy == 'deploy'
-    #   uses: mxschmitt/action-tmate@v3
-    #   env:
-    #     BUILD_FOLDER: ${{runner.workspace}}/b/ninja
-    #     RUNNER_OS: ${{runner.os}}
-    #     DEPLOY: ${{matrix.deploy}}
-    #     DBLSQD_USER: ${{secrets.DBLSQD_USER}}
-    #     DBLSQD_PASS: ${{secrets.DBLSQD_PASS}}
-    #     DEPLOY_KEY_PASS: ${{secrets.DEPLOY_KEY_PASS}}
-
-
     - name: (Linux/macOS) package Mudlet
       if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.deploy == 'deploy'
       run: |
         ${{github.workspace}}/CI/travis.after_success.sh
+      env:
+        BUILD_FOLDER: ${{runner.workspace}}/b/ninja
+        RUNNER_OS: ${{runner.os}}
+        DEPLOY: ${{matrix.deploy}}
+        DBLSQD_USER: ${{secrets.DBLSQD_USER}}
+        DBLSQD_PASS: ${{secrets.DBLSQD_PASS}}
+        DEPLOY_KEY_PASS: ${{secrets.DEPLOY_KEY_PASS}}
+
+
+    - name: Setup tmate session for debugging
+      if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.deploy == 'deploy'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
       env:
         BUILD_FOLDER: ${{runner.workspace}}/b/ninja
         RUNNER_OS: ${{runner.os}}

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -40,7 +40,7 @@ if { [ "${DEPLOY}" = "deploy" ]; } ||
   COMMIT_DATE=$(git show -s --format="%cs" | tr -d '-')
   YESTERDAY_DATE=$(date -d "yesterday" '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone https://github.com/Mudlet/installers.git -b improve-linux-packaging "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/generic-linux"
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Improve Linux theme packaging
#### Motivation for adding to Mudlet
More appealing Mudlet on Linux OS's
#### Other info (issues closed, discussion etc)
Found new best practice on https://github.com/probonopd/linuxdeployqt#adding-icon-and-icon-theme-support detailing how to improve this.

Qt style is not the same as a Qt platform plugin.

Relevant variables/switches:
```
-platformtheme or QT_QPA_PLATFORMTHEME
-style or QT_STYLE_OVERRIDE
```
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
WIP.