### PR TITLE
MXP playing MSP Handle No Attribute Names

### DIFF
--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -94,7 +94,7 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
     return MXP_TAG_HANDLED;
 }
 
-QString extractFileName(MxpStartTag* tag)
+QString TMxpMusicTagHandler::extractFileName(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_FNAME)) {
         return tag->getAttributeValue(ATTR_FNAME);
@@ -105,7 +105,7 @@ QString extractFileName(MxpStartTag* tag)
     return QString();
 }
 
-QString extractVolume(MxpStartTag* tag)
+QString TMxpMusicTagHandler::extractVolume(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_V)) {
         return tag->getAttributeValue(ATTR_V);
@@ -116,7 +116,7 @@ QString extractVolume(MxpStartTag* tag)
     return QString();
 }
 
-QString extractLoops(MxpStartTag* tag)
+QString TMxpMusicTagHandler::extractLoops(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_L)) {
         return tag->getAttributeValue(ATTR_L);
@@ -127,7 +127,7 @@ QString extractLoops(MxpStartTag* tag)
     return QString();
 }
 
-QString extractMusicContinue(MxpStartTag* tag)
+QString TMxpMusicTagHandler::extractMusicContinue(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_C)) {
         return tag->getAttributeValue(ATTR_C);
@@ -138,7 +138,7 @@ QString extractMusicContinue(MxpStartTag* tag)
     return QString();
 }
 
-QString extractType(MxpStartTag* tag)
+QString TMxpMusicTagHandler::extractType(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_T)) {
         return tag->getAttributeValue(ATTR_T);
@@ -149,7 +149,7 @@ QString extractType(MxpStartTag* tag)
     return QString();
 }
 
-QString extractUrl(MxpStartTag* tag)
+QString TMxpMusicTagHandler::extractUrl(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_U)) {
         return tag->getAttributeValue(ATTR_U);

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -96,8 +96,8 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 
 QString TMxpMusicTagHandler::extractFileName(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_FNAME)) {
-        return tag->getAttributeValue(ATTR_FNAME);
+    if (tag->hasAttribute(QStringLiteral("fname"))) {
+        return tag->getAttributeValue(QStringLiteral("fname"));
     } else if (tag->getAttributesCount() > 0) {
         return tag->getAttrName(0);
     }
@@ -107,8 +107,8 @@ QString TMxpMusicTagHandler::extractFileName(MxpStartTag* tag)
 
 QString TMxpMusicTagHandler::extractVolume(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_V)) {
-        return tag->getAttributeValue(ATTR_V);
+    if (tag->hasAttribute(QStringLiteral("v"))) {
+        return tag->getAttributeValue(QStringLiteral("v"));
     } else if (tag->getAttributesCount() > 1) {
         return tag->getAttrName(1);
     }
@@ -118,8 +118,8 @@ QString TMxpMusicTagHandler::extractVolume(MxpStartTag* tag)
 
 QString TMxpMusicTagHandler::extractLoops(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_L)) {
-        return tag->getAttributeValue(ATTR_L);
+    if (tag->hasAttribute(QStringLiteral("l"))) {
+        return tag->getAttributeValue(QStringLiteral("l"));
     } else if (tag->getAttributesCount() > 2) {
         return tag->getAttrName(2);
     }
@@ -129,8 +129,8 @@ QString TMxpMusicTagHandler::extractLoops(MxpStartTag* tag)
 
 QString TMxpMusicTagHandler::extractMusicContinue(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_C)) {
-        return tag->getAttributeValue(ATTR_C);
+    if (tag->hasAttribute(QStringLiteral("c"))) {
+        return tag->getAttributeValue(QStringLiteral("c"));
     } else if (tag->getAttributesCount() > 3) {
         return tag->getAttrName(3);
     }
@@ -140,8 +140,8 @@ QString TMxpMusicTagHandler::extractMusicContinue(MxpStartTag* tag)
 
 QString TMxpMusicTagHandler::extractType(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_T)) {
-        return tag->getAttributeValue(ATTR_T);
+    if (tag->hasAttribute(QStringLiteral("t"))) {
+        return tag->getAttributeValue(QStringLiteral("t"));
     } else if (tag->getAttributesCount() > 4) {
         return tag->getAttrName(4);
     }
@@ -151,8 +151,8 @@ QString TMxpMusicTagHandler::extractType(MxpStartTag* tag)
 
 QString TMxpMusicTagHandler::extractUrl(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_U)) {
-        return tag->getAttributeValue(ATTR_U);
+    if (tag->hasAttribute(QStringLiteral("u"))) {
+        return tag->getAttributeValue(QStringLiteral("u"));
     } else if (tag->getAttributesCount() > 5) {
         return tag->getAttrName(5);
     }

--- a/src/TMxpMusicTagHandler.h
+++ b/src/TMxpMusicTagHandler.h
@@ -28,6 +28,21 @@ class TMxpMusicTagHandler : public TMxpSingleTagHandler
 public:
     TMxpMusicTagHandler() : TMxpSingleTagHandler("MUSIC") {}
 
+    static QString extractFileName(MxpStartTag* tag);
+    static QString extractVolume(MxpStartTag* tag);
+    static QString extractLoops(MxpStartTag* tag);
+    static QString extractMusicContinue(MxpStartTag* tag);
+    static QString extractType(MxpStartTag* tag);
+    static QString extractUrl(MxpStartTag* tag);
+
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
+
+private:
+    inline static const QString ATTR_FNAME = QStringLiteral("fname");
+    inline static const QString ATTR_V = QStringLiteral("v");
+    inline static const QString ATTR_L = QStringLiteral("l");
+    inline static const QString ATTR_C = QStringLiteral("c");
+    inline static const QString ATTR_T = QStringLiteral("t");
+    inline static const QString ATTR_U = QStringLiteral("u");
 };
 #endif //MUDLET_TMXPMUSICTAGHANDLER_H

--- a/src/TMxpMusicTagHandler.h
+++ b/src/TMxpMusicTagHandler.h
@@ -36,13 +36,5 @@ public:
     static QString extractUrl(MxpStartTag* tag);
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
-
-private:
-    inline static const QString ATTR_FNAME = QStringLiteral("fname");
-    inline static const QString ATTR_V = QStringLiteral("v");
-    inline static const QString ATTR_L = QStringLiteral("l");
-    inline static const QString ATTR_C = QStringLiteral("c");
-    inline static const QString ATTR_T = QStringLiteral("t");
-    inline static const QString ATTR_U = QStringLiteral("u");
 };
 #endif //MUDLET_TMXPMUSICTAGHANDLER_H

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -91,12 +91,6 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
         } else {
             client.playMedia(mediaData);
         }
-
-        if (mediaData.getMediaFileName() == "Off" && mediaData.getMediaUrl().isEmpty()) {
-            client.stopMedia(mediaData);
-        } else {
-            client.playMedia(mediaData);
-        }
     }
 
     return MXP_TAG_HANDLED;
@@ -104,8 +98,8 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 
 QString TMxpSoundTagHandler::extractFileName(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_FNAME)) {
-        return tag->getAttributeValue(ATTR_FNAME);
+    if (tag->hasAttribute(QStringLiteral("fname"))) {
+        return tag->getAttributeValue(QStringLiteral("fname"));
     } else if (tag->getAttributesCount() > 0) {
         return tag->getAttrName(0);
     }
@@ -115,8 +109,8 @@ QString TMxpSoundTagHandler::extractFileName(MxpStartTag* tag)
 
 QString TMxpSoundTagHandler::extractVolume(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_V)) {
-        return tag->getAttributeValue(ATTR_V);
+    if (tag->hasAttribute(QStringLiteral("v"))) {
+        return tag->getAttributeValue(QStringLiteral("v"));
     } else if (tag->getAttributesCount() > 1) {
         return tag->getAttrName(1);
     }
@@ -126,8 +120,8 @@ QString TMxpSoundTagHandler::extractVolume(MxpStartTag* tag)
 
 QString TMxpSoundTagHandler::extractLoops(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_L)) {
-        return tag->getAttributeValue(ATTR_L);
+    if (tag->hasAttribute(QStringLiteral("l"))) {
+        return tag->getAttributeValue(QStringLiteral("l"));
     } else if (tag->getAttributesCount() > 2) {
         return tag->getAttrName(2);
     }
@@ -137,8 +131,8 @@ QString TMxpSoundTagHandler::extractLoops(MxpStartTag* tag)
 
 QString TMxpSoundTagHandler::extractPriority(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_P)) {
-        return tag->getAttributeValue(ATTR_P);
+    if (tag->hasAttribute(QStringLiteral("p"))) {
+        return tag->getAttributeValue(QStringLiteral("p"));
     } else if (tag->getAttributesCount() > 3) {
         return tag->getAttrName(3);
     }
@@ -148,8 +142,8 @@ QString TMxpSoundTagHandler::extractPriority(MxpStartTag* tag)
 
 QString TMxpSoundTagHandler::extractType(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_T)) {
-        return tag->getAttributeValue(ATTR_T);
+    if (tag->hasAttribute(QStringLiteral("t"))) {
+        return tag->getAttributeValue(QStringLiteral("t"));
     } else if (tag->getAttributesCount() > 4) {
         return tag->getAttrName(4);
     }
@@ -159,8 +153,8 @@ QString TMxpSoundTagHandler::extractType(MxpStartTag* tag)
 
 QString TMxpSoundTagHandler::extractUrl(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(ATTR_U)) {
-        return tag->getAttributeValue(ATTR_U);
+    if (tag->hasAttribute(QStringLiteral("u"))) {
+        return tag->getAttributeValue(QStringLiteral("u"));
     } else if (tag->getAttributesCount() > 5) {
         return tag->getAttrName(5);
     }

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -25,14 +25,22 @@
 TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag)
 {
     Q_UNUSED(ctx)
-    TMediaData mediaData {};
 
-    mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);
-    mediaData.setMediaType(TMediaData::MediaTypeSound);
-    mediaData.setMediaFileName(tag->getAttributeValue("FName"));
+    QString fileName = extractFileName(tag);
 
-    if (tag->hasAttribute("V")) {
-        QString volume = tag->getAttributeValue("V");
+    if (!fileName.isEmpty()) {
+        QString volume = extractVolume(tag);
+        QString loops = extractLoops(tag);
+        QString priority = extractPriority(tag);
+        QString type = extractType(tag);
+        QString url = extractUrl(tag);
+
+        TMediaData mediaData {};
+
+        mediaData.setMediaProtocol(TMediaData::MediaProtocolMSP);
+        mediaData.setMediaType(TMediaData::MediaTypeSound);
+
+        mediaData.setMediaFileName(fileName);
 
         if (!volume.isEmpty()) {
             mediaData.setMediaVolume(volume.toInt());
@@ -44,11 +52,9 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
             } else if (mediaData.getMediaVolume() < TMediaData::MediaVolumeMin) {
                 mediaData.setMediaVolume(TMediaData::MediaVolumeMin);
             }
+        } else {
+            mediaData.setMediaVolume(TMediaData::MediaVolumeMax); // MSP the Max is the Default
         }
-    }
-
-    if (tag->hasAttribute("L")) {
-        QString loops = tag->getAttributeValue("L");
 
         if (!loops.isEmpty()) {
             mediaData.setMediaLoops(loops.toInt());
@@ -56,11 +62,9 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
             if (mediaData.getMediaLoops() < TMediaData::MediaLoopsRepeat || mediaData.getMediaLoops() == 0) {
                 mediaData.setMediaLoops(TMediaData::MediaLoopsDefault);
             }
+        } else {
+            mediaData.setMediaLoops(TMediaData::MediaLoopsDefault);
         }
-    }
-
-    if (tag->hasAttribute("P")) {
-        QString priority = tag->getAttributeValue("P");
 
         if (!priority.isEmpty()) {
             mediaData.setMediaPriority(priority.toInt());
@@ -70,22 +74,22 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
             } else if (mediaData.getMediaPriority() < TMediaData::MediaPriorityMin) {
                 mediaData.setMediaPriority(TMediaData::MediaPriorityMin);
             }
+        } else {
+            mediaData.setMediaPriority(TMediaData::MediaPriorityDefault);
         }
-    }
-
-    if (tag->hasAttribute("T")) {
-        QString type = tag->getAttributeValue("T");
 
         if (!type.isEmpty()) {
             mediaData.setMediaTag(type.toLower());
         }
-    }
-
-    if (tag->hasAttribute("U")) {
-        QString url = tag->getAttributeValue("U");
 
         if (!url.isEmpty()) {
             mediaData.setMediaUrl(url);
+        }
+
+        if (mediaData.getMediaFileName() == "Off" && mediaData.getMediaUrl().isEmpty()) {
+            client.stopMedia(mediaData);
+        } else {
+            client.playMedia(mediaData);
         }
     }
 
@@ -96,4 +100,71 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
     }
 
     return MXP_TAG_HANDLED;
+}
+
+
+QString extractFileName(MxpStartTag* tag)
+{
+    if (tag->hasAttribute(ATTR_FNAME)) {
+        return tag->getAttributeValue(ATTR_FNAME);
+    } else if (tag->getAttributesCount() > 0) {
+        return tag->getAttrName(0);
+    }
+
+    return QString();
+}
+
+QString extractVolume(MxpStartTag* tag)
+{
+    if (tag->hasAttribute(ATTR_V)) {
+        return tag->getAttributeValue(ATTR_V);
+    } else if (tag->getAttributesCount() > 1) {
+        return tag->getAttrName(1);
+    }
+
+    return QString();
+}
+
+QString extractLoops(MxpStartTag* tag)
+{
+    if (tag->hasAttribute(ATTR_L)) {
+        return tag->getAttributeValue(ATTR_L);
+    } else if (tag->getAttributesCount() > 2) {
+        return tag->getAttrName(2);
+    }
+
+    return QString();
+}
+
+QString extractPriority(MxpStartTag* tag)
+{
+    if (tag->hasAttribute(ATTR_P)) {
+        return tag->getAttributeValue(ATTR_P);
+    } else if (tag->getAttributesCount() > 3) {
+        return tag->getAttrName(3);
+    }
+
+    return QString();
+}
+
+QString extractType(MxpStartTag* tag)
+{
+    if (tag->hasAttribute(ATTR_T)) {
+        return tag->getAttributeValue(ATTR_T);
+    } else if (tag->getAttributesCount() > 4) {
+        return tag->getAttrName(4);
+    }
+
+    return QString();
+}
+
+QString extractUrl(MxpStartTag* tag)
+{
+    if (tag->hasAttribute(ATTR_U)) {
+        return tag->getAttributeValue(ATTR_U);
+    } else if (tag->getAttributesCount() > 5) {
+        return tag->getAttrName(5);
+    }
+
+    return QString();
 }

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -102,7 +102,7 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
     return MXP_TAG_HANDLED;
 }
 
-QString extractFileName(MxpStartTag* tag)
+QString TMxpSoundTagHandler::extractFileName(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_FNAME)) {
         return tag->getAttributeValue(ATTR_FNAME);
@@ -113,7 +113,7 @@ QString extractFileName(MxpStartTag* tag)
     return QString();
 }
 
-QString extractVolume(MxpStartTag* tag)
+QString TMxpSoundTagHandler::extractVolume(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_V)) {
         return tag->getAttributeValue(ATTR_V);
@@ -124,7 +124,7 @@ QString extractVolume(MxpStartTag* tag)
     return QString();
 }
 
-QString extractLoops(MxpStartTag* tag)
+QString TMxpSoundTagHandler::extractLoops(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_L)) {
         return tag->getAttributeValue(ATTR_L);
@@ -135,7 +135,7 @@ QString extractLoops(MxpStartTag* tag)
     return QString();
 }
 
-QString extractPriority(MxpStartTag* tag)
+QString TMxpSoundTagHandler::extractPriority(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_P)) {
         return tag->getAttributeValue(ATTR_P);
@@ -146,7 +146,7 @@ QString extractPriority(MxpStartTag* tag)
     return QString();
 }
 
-QString extractType(MxpStartTag* tag)
+QString TMxpSoundTagHandler::extractType(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_T)) {
         return tag->getAttributeValue(ATTR_T);
@@ -157,7 +157,7 @@ QString extractType(MxpStartTag* tag)
     return QString();
 }
 
-QString extractUrl(MxpStartTag* tag)
+QString TMxpSoundTagHandler::extractUrl(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_U)) {
         return tag->getAttributeValue(ATTR_U);

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -91,12 +91,12 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
         } else {
             client.playMedia(mediaData);
         }
-    }
 
-    if (mediaData.getMediaFileName() == "Off" && mediaData.getMediaUrl().isEmpty()) {
-        client.stopMedia(mediaData);
-    } else {
-        client.playMedia(mediaData);
+        if (mediaData.getMediaFileName() == "Off" && mediaData.getMediaUrl().isEmpty()) {
+            client.stopMedia(mediaData);
+        } else {
+            client.playMedia(mediaData);
+        }
     }
 
     return MXP_TAG_HANDLED;

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -102,7 +102,6 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
     return MXP_TAG_HANDLED;
 }
 
-
 QString extractFileName(MxpStartTag* tag)
 {
     if (tag->hasAttribute(ATTR_FNAME)) {

--- a/src/TMxpSoundTagHandler.h
+++ b/src/TMxpSoundTagHandler.h
@@ -36,13 +36,5 @@ public:
     static QString extractUrl(MxpStartTag* tag);
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
-
-private:
-    inline static const QString ATTR_FNAME = QStringLiteral("fname");
-    inline static const QString ATTR_V = QStringLiteral("v");
-    inline static const QString ATTR_L = QStringLiteral("l");
-    inline static const QString ATTR_P = QStringLiteral("p");
-    inline static const QString ATTR_T = QStringLiteral("t");
-    inline static const QString ATTR_U = QStringLiteral("u");
 };
 #endif //MUDLET_TMXPSOUNDTAGHANDLER_H

--- a/src/TMxpSoundTagHandler.h
+++ b/src/TMxpSoundTagHandler.h
@@ -28,6 +28,21 @@ class TMxpSoundTagHandler : public TMxpSingleTagHandler
 public:
     TMxpSoundTagHandler() : TMxpSingleTagHandler("SOUND") {}
 
+    static QString extractFileName(MxpStartTag* tag);
+    static QString extractVolume(MxpStartTag* tag);
+    static QString extractLoops(MxpStartTag* tag);
+    static QString extractPriority(MxpStartTag* tag);
+    static QString extractType(MxpStartTag* tag);
+    static QString extractUrl(MxpStartTag* tag);
+
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
+
+private:
+    inline static const QString ATTR_FNAME = QStringLiteral("fname");
+    inline static const QString ATTR_V = QStringLiteral("v");
+    inline static const QString ATTR_L = QStringLiteral("l");
+    inline static const QString ATTR_P = QStringLiteral("p");
+    inline static const QString ATTR_T = QStringLiteral("t");
+    inline static const QString ATTR_U = QStringLiteral("u");
 };
 #endif //MUDLET_TMXPSOUNDTAGHANDLER_H


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix crash with MXP playing MSP which happened to a player in Discworld.

The Sound and Music MXP tags were not originally designed to handle a part of the MXP specification where attribute names are left out of the syntax. For example, `<music FName="Off">` worked great sending the Fname attribute name, but `<music "Off">` or `<music Off>` did not work. There was a pattern to follow inside TMxpSendTagHandler.cpp to cure the gap and solve the issue.

#### Motivation for adding to Mudlet
Mudlet should not crash.

#### Other info (issues closed, discussion etc)
Replicate by logging into a game with MXP and running this:
```
lua feedTriggers("�[4z<music Off>�[4z</music>You skilfully play an upbeat version of Three Blind Mice on your wooden r")
```
#### Release post highlight
Bug fix, improved adherence to MXP (Mud eXtension Protocol) playing MSP (Mud Sound Protocol) by processing values that do not pass attribute names which cures a crash condition.
