### PR TITLE
Add Clessidra to known games using Discord Rich Presence

### DIFF
--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -53,10 +53,12 @@ Discord::Discord(QObject* parent)
               {"luminari", {"luminarimud.com"}},
               {"achaea", {"achaea.com", "iron-ach.ironrealms.com"}},
               {"aetolia", {"aetolia.com", "iron-aet.ironrealms.com"}},
-              {"imperian", {"imperian.com", " iron-imp.ironrealms.com"}},
+              {"imperian", {"imperian.com", "iron-imp.ironrealms.com"}},
               {"lusternia", {"lusternia.com", "iron-lus.ironrealms.com"}},
               {"starmourn", {"starmourn.com"}},
-              {"stickmud", {"stickmud.com"}}}
+              {"stickmud", {"stickmud.com"}},
+              {"clessidra", {"clessidra.it", "mud.clessidra.it"}},
+            }
 {
 #if defined(Q_OS_WIN64)
     // Only defined on 64 bit Windows

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -57,7 +57,7 @@ Discord::Discord(QObject* parent)
               {"lusternia", {"lusternia.com", "iron-lus.ironrealms.com"}},
               {"starmourn", {"starmourn.com"}},
               {"stickmud", {"stickmud.com"}},
-              {"clessidra", {"clessidra.it", "mud.clessidra.it"}},
+              {"clessidra", {"clessidra.it", "mud.clessidra.it"}}
             }
 {
 #if defined(Q_OS_WIN64)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add Clessidra to known games using Discord Rich Presence
#### Motivation for adding to Mudlet
So players can enable the checkbox right away, without having to login first
#### Other info (issues closed, discussion etc)
https://github.com/Mudlet/Mudlet/issues/3320#issuecomment-782887069
#### Release post highlight
* Clessidra now has Discord checkbox enabled by default as it supports reporting the game via Mudlet (?)