### PR TITLE
Fix text value in showNotification() not being set correctly

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15290,7 +15290,7 @@ int TLuaInterpreter::showNotification(lua_State* L)
     QString title = getVerifiedString(L, __func__, 1, "title");
     QString text = title;
     if (n >= 2) {
-        QString text = getVerifiedString(L, __func__, 2, "message");
+        text = getVerifiedString(L, __func__, 2, "message");
     }
     int notificationExpirationTime = 1;
     if (n >= 3) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix text value in showNotification() not being set correctly
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Found by running clang-tidy+clazy using Qt Creator
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
