### PR TITLE
fix setBackgroundColor first argument to be optional again

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3758,7 +3758,7 @@ int TLuaInterpreter::setBackgroundColor(lua_State* L)
         return number >= 0 && number <= 255;
     };
 
-    if (lua_isstring(L, s)) {
+    if (lua_type(L, s) == LUA_TSTRING) {
         windowName = WINDOW_NAME(L, s++);
         r = getVerifiedInt(L, __func__, s, "red value 0-255");
         if (!validRange(r)) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see title
#### Motivation for adding to Mudlet
the first argument wasn't optional as it was in Mudlet 4.10.1
#### Other info (issues closed, discussion etc)
example ```lua setBackgroundColor(0,0,255)``` doesn't work in latest development build but still works in Mudlet 4.10.1
