### PR TITLE
Add automation to auto-link Linux and macOS PTB to updater

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 2 * * *'
 
 jobs:
   compile-mudlet:

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -62,5 +62,12 @@ jobs:
 
     - name: Link updater with Linux/macOS downloads
       run: |
-        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}"
-        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}"
+        set -e
+        EXIT_CODE_LINUX=0
+        EXIT_CODE_MACOS=0
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
+
+        if [ EXIT_CODE_LINUX != 0 ]; && EXIT_CODE_MACOS != 0]; then
+          exit 1
+        fi

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -73,7 +73,8 @@ jobs:
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
         echo "Linking ${bold}macOS PTB${normal}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
-
+        EXIT_CODE_LINUX=0
+        EXIT_CODE_MACOS=0
         if [ "${EXIT_CODE_LINUX}" != 0 ] && [ "${EXIT_CODE_MACOS}" != 0 ]; then
           exit 1
         fi

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -2,8 +2,9 @@ name: Link Linux/macOS PTBs to the updater (dblsqd)
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
 
 jobs:
   link-ptbs:
@@ -20,7 +21,8 @@ jobs:
 
     - name: Retrieve latest PTB version
       run: |
-        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64 | jq --raw-output ".releases[0].version")
+        # Get the latest Windows version, because that one runs first and will be registered in dblsqd. Linux/macOS won't exist yet
+        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86 | jq --raw-output ".releases[0].version")
         export PTB_COMMIT=$(lua -e "print(os.getenv('PTB_VERSION'):match('.+\-(.+)$'))")
 
         echo "Latest PTB version is: $PTB_VERSION"

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -63,11 +63,16 @@ jobs:
     - name: Link updater with Linux/macOS downloads
       run: |
         set -e
+        bold=$(tput bold)
+        normal=$(tput sgr0)
         EXIT_CODE_LINUX=0
         EXIT_CODE_MACOS=0
+
+        echo "Linking ${bold}Linux PTB${normal}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
+        echo "Linking ${bold}macOS PTB${normal}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
 
-        if [ EXIT_CODE_LINUX != 0 ]; && EXIT_CODE_MACOS != 0]; then
+        if [ EXIT_CODE_LINUX != 0 && EXIT_CODE_MACOS != 0]; then
           exit 1
         fi

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -21,8 +21,8 @@ jobs:
 
     - name: Retrieve latest PTB version
       run: |
-        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64 | jq ".releases[0].version")
-        export PTB_COMMIT=$(lua -e "print(os.getenv('PTB_VERSION'):match('.+\-(.+)\"$'))")
+        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64 | jq --raw-output ".releases[0].version")
+        export PTB_COMMIT=$(lua -e "print(os.getenv('PTB_VERSION'):match('.+\-(.+)$'))")
 
         echo "Latest PTB version is: $PTB_VERSION"
         echo "Latest PTB commit is: $PTB_COMMIT"

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -58,4 +58,4 @@ jobs:
         } >> "$GITHUB_ENV"
 
     - name: Install dblsqd client
-      run: npm install -g dblsqd-cli
+      run: sudo npm install -g dblsqd-cli

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -1,0 +1,61 @@
+name: Link Linux/macOS PTBs to the updater (dblsqd)
+
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  link-ptbs:
+    runs-on: ubuntu-20.04
+    if: ${{ github.repository_owner == 'Mudlet' }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: leafo/gh-actions-lua@v8
+      with:
+        luaVersion: "5.1.5"
+    - uses: actions/setup-node@v2.1.4
+    - uses: leafo/gh-actions-luarocks@v4
+
+    - name: install Lua dependencies
+      run: |
+        luarocks install http
+        luarocks install lunajson
+
+    - name: Retrieve latest PTB version
+      run: |
+        export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64 | jq ".releases[0].version")
+        export PTB_COMMIT=$(lua -e "print(os.getenv('PTB_VERSION'):match('.+\-(.+)\"$'))")
+
+        echo "Latest PTB version is: $PTB_VERSION"
+        echo "Latest PTB commit is: $PTB_COMMIT"
+
+        {
+          echo "PTB_VERSION=$PTB_VERSION"
+          echo "PTB_COMMIT=$PTB_COMMIT"
+        } >> "$GITHUB_ENV"
+
+    - name: Retrieve binaries available on make.mudlet.org
+      run: |
+        LATEST_FEED=$(tempfile) || exit 1
+        curl --silent --output $LATEST_FEED "https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT"
+
+        # if [ "$(cat $LATEST_FEED | jq \".status\")" != "ok"]; then
+        #   echo "Downloaded feed from https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT wasn't OK"
+        # fi
+
+        export LINUX_PTB_URL=$(cat $LATEST_FEED | jq ".data[] | select(.platform == \"linux\") | .url")
+        export MACOS_PTB_URL=$(cat $LATEST_FEED | jq ".data[] | select(.platform == \"macos\") | .url")
+
+        echo "Linux PTB link: $LINUX_PTB_URL"
+        echo "macOS PTB link: $MACOS_PTB_URL"
+
+        {
+          echo "LINUX_PTB_URL=$LINUX_PTB_URL"
+          echo "MACOS_PTB_URL=$MACOS_PTB_URL"
+        } >> "$GITHUB_ENV"
+
+    - name: Install dblsqd client
+      run: npm install -g dblsqd-cli

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -63,6 +63,7 @@ jobs:
     - name: Link updater with Linux/macOS downloads
       run: |
         set -e
+        export TERM=xterm
         bold=$(tput bold)
         normal=$(tput sgr0)
         EXIT_CODE_LINUX=0

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
-  link-ptbs:
+  work:
     runs-on: ubuntu-20.04
     if: ${{ github.repository_owner == 'Mudlet' }}
 
@@ -41,8 +41,8 @@ jobs:
         #   echo "Downloaded feed from https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT wasn't OK"
         # fi
 
-        export LINUX_PTB_URL=$(cat $LATEST_FEED | jq ".data[] | select(.platform == \"linux\") | .url")
-        export MACOS_PTB_URL=$(cat $LATEST_FEED | jq ".data[] | select(.platform == \"macos\") | .url")
+        export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"linux\") | .url")
+        export MACOS_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"macos\") | .url")
 
         echo "Linux PTB link: $LINUX_PTB_URL"
         echo "macOS PTB link: $MACOS_PTB_URL"

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
-  work:
+  link-ptbs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository_owner == 'Mudlet' }}
 
@@ -37,9 +37,10 @@ jobs:
         LATEST_FEED=$(tempfile) || exit 1
         curl --silent --output $LATEST_FEED "https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT"
 
-        # if [ "$(cat $LATEST_FEED | jq \".status\")" != "ok"]; then
-        #   echo "Downloaded feed from https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT wasn't OK"
-        # fi
+        if [ "$(cat "$LATEST_FEED" | jq --raw-output '.status')" != "ok" ]; then
+          echo "Downloaded feed from https://make.mudlet.org/snapshots/json.php?commitid=$PTB_COMMIT wasn't OK, feed is:"
+          cat "${LATEST_FEED}" | jq
+        fi
 
         export LINUX_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"linux\") | .url")
         export MACOS_PTB_URL=$(cat $LATEST_FEED | jq --raw-output ".data[] | select(.platform == \"macos\") | .url")
@@ -73,8 +74,7 @@ jobs:
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
         echo "Linking ${bold}macOS PTB${normal}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
-        EXIT_CODE_LINUX=0
-        EXIT_CODE_MACOS=0
+
         if [ "${EXIT_CODE_LINUX}" != 0 ] && [ "${EXIT_CODE_MACOS}" != 0 ]; then
           exit 1
         fi

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -2,7 +2,6 @@ name: Link Linux/macOS PTBs to the updater (dblsqd)
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: '0 3 * * *'
 

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -71,9 +71,9 @@ jobs:
         EXIT_CODE_LINUX=0
         EXIT_CODE_MACOS=0
 
-        echo "Linking ${bold}Linux PTB${normal}..."
+        echo "Linking ${bold}Linux PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
-        echo "Linking ${bold}macOS PTB${normal}..."
+        echo "Linking ${bold}macOS PTB${normal} ${PTB_VERSION}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
 
         if [ "${EXIT_CODE_LINUX}" != 0 ] && [ "${EXIT_CODE_MACOS}" != 0 ]; then

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -74,6 +74,7 @@ jobs:
         echo "Linking ${bold}macOS PTB${normal}..."
         dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
 
-        if [ EXIT_CODE_LINUX != 0 && EXIT_CODE_MACOS != 0]; then
+        if [ "${EXIT_CODE_LINUX}" != 0 ] && [ "${EXIT_CODE_MACOS}" != 0 ]; then
           exit 1
         fi
+

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -19,11 +19,6 @@ jobs:
     - uses: actions/setup-node@v2.1.4
     - uses: leafo/gh-actions-luarocks@v4
 
-    - name: install Lua dependencies
-      run: |
-        luarocks install http
-        luarocks install lunajson
-
     - name: Retrieve latest PTB version
       run: |
         export PTB_VERSION=$(curl --silent https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64 | jq ".releases[0].version")
@@ -57,5 +52,15 @@ jobs:
           echo "MACOS_PTB_URL=$MACOS_PTB_URL"
         } >> "$GITHUB_ENV"
 
-    - name: Install dblsqd client
-      run: sudo npm install -g dblsqd-cli
+    - name: Setup dblsqd client
+      run: |
+        sudo npm install -g dblsqd-cli
+        dblsqd login -e "https://api.dblsqd.com/v1/jsonrpc" -u "${DBLSQD_USER}" -p "${DBLSQD_PASS}"
+      env:
+        DBLSQD_USER: ${{secrets.DBLSQD_USER}}
+        DBLSQD_PASS: ${{secrets.DBLSQD_PASS}}
+
+    - name: Link updater with Linux/macOS downloads
+      run: |
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}"
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}"

--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -2,7 +2,6 @@ name: Link Linux/macOS PTBs to the updater (dblsqd)
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: '0 2 * * *'
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add automation to auto-link Linux and macOS PTB to updater.
#### Motivation for adding to Mudlet
Daily Linux and macOS PTB's are available once again, without manual effort.
#### Other info (issues closed, discussion etc)
It'll run automatically [1h later](https://github.com/Mudlet/Mudlet/blob/development/.github/workflows/build-mudlet.yml#L8) than PTBs are build (which take ~20min) and can also be triggered manually.

Successful run: https://github.com/Mudlet/Mudlet/runs/1959162047?check_suite_focus=true

Fix https://github.com/Mudlet/Mudlet/issues/4843
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
