### PR TITLE
Fix blurry Mudlet in macOS

### DIFF
--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -16,7 +16,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone https://github.com/Mudlet/installers.git -b macos-fix-hidpi "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix blurry Mudlet in macOS, which broke when we switched from qmake to cmake.
#### Motivation for adding to Mudlet
Good quality Mudlet again :+1: 
#### Other info (issues closed, discussion etc)
See https://github.com/Mudlet/installers/pull/99 for actual fix.

Fixes https://github.com/Mudlet/Mudlet/issues/4847.
#### Release post highlight
None, this is an inter-release issue that won't make it into an official release.