### PR TITLE
AdjustableContainerRepositionFinish event, change in AdjustableContainerReposition event

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -121,6 +121,7 @@ function Adjustable.Container:onClick(label, event)
 end
 
 -- internal function to handle the onRelease event of main Adjustable.Container Label
+--- raises an event "AdjustableContainerRepositionFinish", passed values (name, width, height, x, y)
 -- @param label the main Adjustable.Container Label
 -- @param event the onRelease event and its informations
 function Adjustable.Container:onRelease (label, event)
@@ -128,6 +129,14 @@ function Adjustable.Container:onRelease (label, event)
         if label.cursorShape == "ClosedHand" then
             label:setCursor("OpenHand")
         end
+        raiseEvent(
+          "AdjustableContainerRepositionFinish",
+          self.name,
+          self.get_width(),
+          self.get_height(),
+          self.get_x(),
+          self.get_y()
+        )
         adjustInfo = {}
     end
 end
@@ -826,12 +835,21 @@ function Adjustable.Container:load(slot, dir)
     return true
 end
 
---- overridden reposition function to raise an event of the Adjustable.Container changing position/size
--- event name: "AdjustableContainerReposition" passed values (name, width, height, x, y)
--- it also calls the shrink_title function
+--- overridden reposition function to raise an "AdjustableContainerReposition" event and call the shrink_title function
+--- Event: "AdjustableContainerReposition" passed values (name, width, height, x, y, isMouseAction)
+--- (the isMouseAction property is true if the reposition is an effect of user dragging/resizing the window,
+--- and false if the reposition event comes as effect of external action, such as resigin of main window)
 function Adjustable.Container:reposition()
     Geyser.Container.reposition(self)
-    raiseEvent("AdjustableContainerReposition", self.name, self.get_width(), self.get_height(), self.get_x(), self.get_y())
+    raiseEvent(
+      "AdjustableContainerReposition",
+      self.name,
+      self.get_width(),
+      self.get_height(),
+      self.get_x(),
+      self.get_y(),
+      adjustInfo.name == self.adjLabel.name and (adjustInfo.move or adjustInfo.right or adjustInfo.left or adjustInfo.top or adjustInfo.bottom)
+    )
     if self.titleText and not(self.locked) then
         shrink_title(self)
     end

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -838,7 +838,7 @@ end
 --- overridden reposition function to raise an "AdjustableContainerReposition" event and call the shrink_title function
 --- Event: "AdjustableContainerReposition" passed values (name, width, height, x, y, isMouseAction)
 --- (the isMouseAction property is true if the reposition is an effect of user dragging/resizing the window,
---- and false if the reposition event comes as effect of external action, such as resigin of main window)
+--- and false if the reposition event comes as effect of external action, such as resizing of main window)
 function Adjustable.Container:reposition()
     Geyser.Container.reposition(self)
     raiseEvent(


### PR DESCRIPTION
#### Brief overview of PR changes/additions

- New event, that is being fired when user releases mouse button after dragging/resizing the AdjustableContainer: `AdjustableContainerRepositionFinish (name, width, height, x, y)`

- New property in `AdjustableContainerReposition` event,
```
old: (name, width, height, x, y)
new: (name, width, height, x, y, isMouseAction)
```

The `isMouseAction` property is true if the reposition is an effect of user dragging/resizing the window, and false if the reposition event comes as effect of external action, such as resizing of main window.

#### Motivation for adding to Mudlet

It is nearly impossible to fire an action that causes containers reposition, from inside the reposition event. This is required if you want to have containers on the screen to auto-adjust its positions after one of the containers is dragged/resized.
This either ends in endless loop, or has to be done using timers, which give sketchy UX.

With this change, It is possible to recognize that the user finished his interaction with the Adjustable Containers, so it is possible to reposition other containers.

Things like this are possible after this change: https://drive.google.com/file/d/1rlMb4HzXOBazcvqycCbcLkrw3TWXA7ik/view?usp=sharing

