### PR TITLE
fix backwards capability of some stylesheets + cecho background color handling

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -896,7 +896,6 @@ void TConsole::changeColors()
         mLowerPane->setFont(mDisplayFont);
         if (!mBgImageMode) {
             auto styleSheet = QStringLiteral("QWidget#MainDisplay{background-color: rgba(%1);}").arg(getColorCode(mBgColor));
-            qDebug() << getColorCode(mBgColor);
             mpMainDisplay->setStyleSheet(styleSheet);
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -151,7 +151,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     QSizePolicy sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
-    mpMainFrame->setObjectName("MainFrame");
+    mpMainFrame->setObjectName(QStringLiteral("MainFrame"));
 
     auto centralLayout = new QVBoxLayout;
     setLayout(centralLayout);
@@ -221,7 +221,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
     mpMainDisplay->setContentsMargins(0, 0, 0, 0);
     auto layout = new QVBoxLayout;
-    mpMainDisplay->setObjectName("MainDisplay");
+    mpMainDisplay->setObjectName(QStringLiteral("MainDisplay"));
     mpMainDisplay->setLayout(layout);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
@@ -243,7 +243,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     }
 
     layer = new QWidget(mpMainDisplay);
-    layer->setObjectName("layer");
+    layer->setObjectName(QStringLiteral("layer"));
     layer->setStyleSheet("QWidget#layer{background-color: rgba(0,0,0,0)}");
     layer->setContentsMargins(0, 0, 0, 0);
     layer->setSizePolicy(sizePolicy);
@@ -522,7 +522,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mUpperPane->setFocusPolicy(Qt::ClickFocus);
     mLowerPane->setFocusPolicy(Qt::ClickFocus);
 
-    buttonLayerSpacer->setAutoFillBackground(true);
     mpButtonMainLayer->setAutoFillBackground(true);
     mpButtonMainLayer->setPalette(commandLinePalette);
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -541,12 +541,9 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         setAcceptDrops(true);
         setMouseTracking(true);
     }
-
+    mpMainFrame->setStyleSheet(QStringLiteral("QWidget#MainFrame{ background-color: rgba(0,0,0,255) }"));
     if (mType & MainConsole) {
-        mpMainFrame->setStyleSheet(QStringLiteral("QWidget#MainFrame{ background-color: rgba(0,0,0,255) }"));
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());
-    } else {
-        mpMainFrame->setStyleSheet(QStringLiteral("QWidget#MainFrame{ background-color: rgba(0,0,0,0) }"));
     }
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -934,6 +934,8 @@ void TConsole::changeColors()
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
         }
+        mBgColor = mpHost->mBgColor;
+        mFgColor = mpHost->mFgColor;
         mCommandFgColor = mpHost->mCommandFgColor;
         mCommandBgColor = mpHost->mCommandBgColor;
         if (mpCommandLine) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -81,7 +81,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mpMainFrame(new QWidget(mpBaseHFrame))
 , mpRightToolBar(new QWidget(mpBaseHFrame))
 , mpMainDisplay(new QWidget(mpMainFrame))
-, mpBackground(new QLabel(mpMainFrame))
+, mpBackground(new QWidget(mpMainFrame))
 , mpMapper(nullptr)
 , mpScrollBar(new QScrollBar)
 , mpHScrollBar(new QScrollBar(Qt::Horizontal))
@@ -153,16 +153,9 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     QSizePolicy sizePolicy4(QSizePolicy::Fixed, QSizePolicy::Expanding);
     QSizePolicy sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-    //QVBoxLayout * layoutFrame = new QVBoxLayout( mainFrame );
-    // This seems to be used to set some aspects of the borders - but only the
-    // QPalette::Window is likely to have any effect:
-    QPalette framePalette;
-    framePalette.setColor(QPalette::Text, QColor(Qt::black));
-    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
-    framePalette.setColor(QPalette::Window, QColor(0, 0, 0, 255));
-    mpMainFrame->setPalette(framePalette);
-    mpMainFrame->setAutoFillBackground(true);
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
+    mpMainFrame->setObjectName("MainFrame");
+
     auto centralLayout = new QVBoxLayout;
     setLayout(centralLayout);
     auto baseVFrameLayout = new QVBoxLayout;
@@ -235,7 +228,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpBackground->setContentsMargins(0, 0, 0, 0);
     auto layout = new QVBoxLayout;
     mpMainDisplay->setLayout(layout);
-    mpBackground->setLayout(layout);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
@@ -259,6 +251,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layer->setContentsMargins(0, 0, 0, 0);
     layer->setSizePolicy(sizePolicy);
     layer->setFocusPolicy(Qt::NoFocus);
+    mpBackground->lower();
 
     auto vLayoutLayer = new QVBoxLayout;
     auto layoutLayer = new QHBoxLayout;
@@ -397,10 +390,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpLineEdit_networkLatency->setMinimumSize(120, 30);
     mpLineEdit_networkLatency->setAutoFillBackground(true);
     mpLineEdit_networkLatency->setContentsMargins(0, 0, 0, 0);
-    QPalette basePalette;
-    basePalette.setColor(QPalette::Text, QColor(Qt::black));
-    basePalette.setColor(QPalette::Base, QColor(Qt::white));
-    mpLineEdit_networkLatency->setPalette(basePalette);
     mpLineEdit_networkLatency->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
     QFont latencyFont = QFont("Bitstream Vera Sans Mono", 10, QFont::Normal);
@@ -485,7 +474,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layoutLayer2->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(layer);
     mpLineEdit_networkLatency->setFrame(false);
-    layerCommandLine->setPalette(basePalette);
     layerCommandLine->setAutoFillBackground(true);
 
     centralLayout->addWidget(layerCommandLine);
@@ -566,7 +554,10 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     }
 
     if (mType & MainConsole) {
+        mpMainFrame->setStyleSheet(QStringLiteral("QWidget#MainFrame{ background-color: rgba(0,0,0,255) }"));
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());
+    } else {
+        mpMainFrame->setStyleSheet(QStringLiteral("QWidget#MainFrame{ background-color: rgba(0,0,0,0) }"));
     }
 }
 
@@ -920,7 +911,7 @@ void TConsole::changeColors()
         mUpperPane->setFont(mDisplayFont);
         mLowerPane->setFont(mDisplayFont);
         if (!mBgImageMode) {
-            auto styleSheet = QStringLiteral("QLabel {background-color: rgba(%1);}").arg(getColorCode(mBgColor));
+            auto styleSheet = QStringLiteral("QWidget {background-color: rgba(%1);}").arg(getColorCode(mBgColor));
             mpBackground->setStyleSheet(styleSheet);
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
@@ -951,7 +942,7 @@ void TConsole::changeColors()
         mUpperPane->setFont(mpHost->getDisplayFont());
         mLowerPane->setFont(mpHost->getDisplayFont());
         if (!mBgImageMode) {
-            auto styleSheet = QStringLiteral("QLabel {background-color: rgba(%1);}").arg(getColorCode(mpHost->mBgColor));
+            auto styleSheet = QStringLiteral("QWidget {background-color: rgba(%1);}").arg(getColorCode(mpHost->mBgColor));
             mpBackground->setStyleSheet(styleSheet);
         } else {
             setConsoleBackgroundImage(mBgImagePath, mBgImageMode);
@@ -1402,15 +1393,15 @@ bool TConsole::setConsoleBackgroundImage(const QString& imgPath, int mode)
     }
 
     if (mode == 1) {
-        styleSheet = QStringLiteral("QLabel {background-color: rgba(%1); border-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
+        styleSheet = QStringLiteral("QWidget {background-color: rgba(%1); border-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
     } else if (mode == 2) {
-        styleSheet = QStringLiteral("QLabel {background-color: rgba(%1); background-image: url(%2); background-repeat: no-repeat; background-position: center; background-origin: margin;}")
+        styleSheet = QStringLiteral("QWidget {background-color: rgba(%1); background-image: url(%2); background-repeat: no-repeat; background-position: center; background-origin: margin;}")
                              .arg(getColorCode(bgColor))
                              .arg(imgPath);
     } else if (mode == 3) {
-        styleSheet = QStringLiteral("QLabel {background-color: rgba(%1); background-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
+        styleSheet = QStringLiteral("QWidget {background-color: rgba(%1); background-image: url(%2);}").arg(getColorCode(bgColor)).arg(imgPath);
     } else if (mode == 4) {
-        styleSheet = QStringLiteral("QLabel {background-color: rgba(%1); %2}").arg(getColorCode(bgColor)).arg(imgPath);
+        styleSheet = QStringLiteral("QWidget {background-color: rgba(%1); %2}").arg(getColorCode(bgColor)).arg(imgPath);
     } else {
         return false;
     }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -231,7 +231,7 @@ public:
     QWidget* mpMainFrame;
     QWidget* mpRightToolBar;
     QWidget* mpMainDisplay;
-    QLabel* mpBackground;
+    QWidget* mpBackground;
 
     dlgMapper* mpMapper;
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -231,7 +231,6 @@ public:
     QWidget* mpMainFrame;
     QWidget* mpRightToolBar;
     QWidget* mpMainDisplay;
-    QWidget* mpBackground;
 
     dlgMapper* mpMapper;
 
@@ -243,7 +242,6 @@ public:
     bool mRecordReplay;
     QFile mReplayFile;
     QDataStream mReplayStream;
-    TChar mStandardFormat;
 
     QColor mSystemMessageBgColor;
     QColor mSystemMessageFgColor;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7109,11 +7109,8 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
     int luaGreen = getVerifiedInt(L, __func__, 2, "green");
     int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
     Host& host = getHostFromLua(L);
-    QPalette framePalette;
-    framePalette.setColor(QPalette::Text, QColor(Qt::black));
-    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
-    framePalette.setColor(QPalette::Window, QColor(luaRed, luaGreen, luaBlue, 255));
-    host.mpConsole->mpMainFrame->setPalette(framePalette);
+    auto styleSheet = QStringLiteral("QWidget#MainFrame{ background-color: rgba(%1,%2,%3,255) }").arg(luaRed).arg(luaGreen).arg(luaBlue);
+    host.mpConsole->mpMainFrame->setStyleSheet(styleSheet);
     return 0;
 }
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -773,8 +773,8 @@ bool TMainConsole::lowerWindow(const QString& name)
 
     if (pC) {
         pC->lower();
-        mpBackground->lower();
         mpMainDisplay->lower();
+        mpBackground->lower();
         return true;
     }
     if (pL) {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -774,24 +774,20 @@ bool TMainConsole::lowerWindow(const QString& name)
     if (pC) {
         pC->lower();
         mpMainDisplay->lower();
-        mpBackground->lower();
         return true;
     }
     if (pL) {
         pL->lower();
-        mpBackground->lower();
         mpMainDisplay->lower();
         return true;
     }
     if (pM && !name.compare(QLatin1String("mapper"), Qt::CaseInsensitive)) {
         pM->lower();
-        mpBackground->lower();
         mpMainDisplay->lower();
         return true;
     }
     if (pN) {
         pN->lower();
-        mpBackground->lower();
         mpMainDisplay->lower();
         return true;
     }
@@ -1064,7 +1060,6 @@ bool TMainConsole::setTextFormat(const QString& name, const QColor& fgColor, con
 {
     if (name.isEmpty() || name.compare(QStringLiteral("main"), Qt::CaseSensitive) == 0) {
         mFormatCurrent.setTextFormat(fgColor, bgColor, flags);
-        mSystemMessageBgColor = bgColor;
         return true;
     }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This fixes some issues with older AppStyleSheets which seemed to overwrite the console background.
Examples were found at: https://discord.com/channels/283581582550237184/707692991602491563/786461986560802826
and
https://discord.com/channels/283581582550237184/283582068334526464/813135699922124830

#### Motivation for adding to Mudlet
fix above mentioned issue
fix #3905 
fix #3391
probably fixes #1099

#### Other info (issues closed, discussion etc)
mpBackground was not needed anymore and was deleted.
Some palettes were also deleted/restructured.
Some changes of #4650 were reverted as they weren't needed anymore

I'm aware that this PR is not that scoped and fixes several issues at once but they were unfortunately connected.

~Still have to test a bit but will probably mark it as ready soon.~

#### Release post highlight
restore some backward compatibility with older app style-sheets
issue with cecho/hecho/decho not keeping the original background colour is fixed
setBorderColor keeps the colour now if another app stylesheet is set
changing colour of the commandline now also propagates to the search and connection bar during runtime of Mudlet (before it only happened on a restart)
