### PR TITLE
getPackages and getModules by Lua api

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10381,18 +10381,13 @@ int TLuaInterpreter::getPackages(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto packages = host.mInstalledPackages;
-    if (packages.isEmpty()) {
-        lua_pushnil(L);
-        return 1;
-    }
     lua_newtable(L);
     for (int i = 0; i < packages.size(); i++) {
         lua_pushnumber(L, i + 1);
         lua_pushstring(L, packages.at(i).toUtf8().constData());
         lua_settable(L, -3);
     }
-    lua_pushboolean(L, true);
-    return 2;
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModules
@@ -10400,10 +10395,6 @@ int TLuaInterpreter::getModules(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto modules = host.mInstalledModules;
-    if (modules.isEmpty()) {
-        lua_pushnil(L);
-        return 1;
-    }
     int counter = 1;
     QMap<QString, QStringList>::const_iterator iter = modules.constBegin();
     lua_newtable(L);
@@ -10414,8 +10405,7 @@ int TLuaInterpreter::getModules(lua_State* L)
         counter++;
         ++iter;
     }
-    lua_pushboolean(L, true);
-    return 2;
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDefaultAreaVisible

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10395,14 +10395,13 @@ int TLuaInterpreter::getModules(lua_State* L)
 {
     Host& host = getHostFromLua(L);
     auto modules = host.mInstalledModules;
-    int counter = 1;
+    int counter = 0;
     QMap<QString, QStringList>::const_iterator iter = modules.constBegin();
     lua_newtable(L);
     while (iter != modules.constEnd()) {
-        lua_pushnumber(L, counter);
+        lua_pushnumber(L, ++counter);
         lua_pushstring(L, iter.key().toUtf8().constData());
         lua_settable(L, -3);
-        counter++;
         ++iter;
     }
     return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10375,6 +10375,49 @@ int TLuaInterpreter::getModuleSync(lua_State* L)
     }
 }
 
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getPackages
+int TLuaInterpreter::getPackages(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    auto packages = host.mInstalledPackages;
+    if (packages.isEmpty()) {
+        lua_pushnil(L);
+        return 1;
+    }
+    lua_newtable(L);
+    for (int i = 0; i < packages.size(); i++) {
+        lua_pushnumber(L, i + 1);
+        lua_pushstring(L, packages.at(i).toUtf8().constData());
+        lua_settable(L, -3);
+    }
+    lua_pushboolean(L, true);
+    return 2;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getModules
+int TLuaInterpreter::getModules(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    auto modules = host.mInstalledModules;
+    if (modules.isEmpty()) {
+        lua_pushnil(L);
+        return 1;
+    }
+    int counter = 1;
+    QMap<QString, QStringList>::const_iterator iter = modules.constBegin();
+    lua_newtable(L);
+    while (iter != modules.constEnd()) {
+        lua_pushnumber(L, counter);
+        lua_pushstring(L, iter.key().toUtf8().constData());
+        lua_settable(L, -3);
+        counter++;
+        ++iter;
+    }
+    lua_pushboolean(L, true);
+    return 2;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setDefaultAreaVisible
 int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 {
@@ -13560,6 +13603,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "enableModuleSync", TLuaInterpreter::enableModuleSync);
     lua_register(pGlobalLua, "disableModuleSync", TLuaInterpreter::disableModuleSync);
     lua_register(pGlobalLua, "getModuleSync", TLuaInterpreter::getModuleSync);
+    lua_register(pGlobalLua, "getPackages", TLuaInterpreter::getPackages);
+    lua_register(pGlobalLua, "getModules", TLuaInterpreter::getModules);
     lua_register(pGlobalLua, "createMapImageLabel", TLuaInterpreter::createMapImageLabel);
     lua_register(pGlobalLua, "setMapZoom", TLuaInterpreter::setMapZoom);
     lua_register(pGlobalLua, "uninstallPackage", TLuaInterpreter::uninstallPackage);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -176,6 +176,8 @@ public:
     static int enableModuleSync(lua_State* L);
     static int disableModuleSync(lua_State* L);
     static int getModuleSync(lua_State* L);
+    static int getPackages(lua_State* L);
+    static int getModules(lua_State* L);
     static int lockExit(lua_State*);
     static int lockSpecialExit(lua_State*);
     static int hasExitLock(lua_State*);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
adds functions getPackages() and getModules() in lua api to return a table of installed packages/modules

#### Motivation for adding to Mudlet
fix #4869

#### Other info (issues closed, discussion etc)
When no packages/module is given this just returns nil but I'm not sure if I should change it to return an error message like "no packages/modules installed" and nil or something else (I welcome suggestions)

#### Release post highlight
It is now possible to get a list of installed packages or modules.
