### PR TITLE
BugFix: remove 3 compilation warnings

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -343,6 +343,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mDiscordAccessFlags(DiscordLuaAccessEnabled | DiscordSetSubMask)
 , mLineSize(10.0)
 , mRoomSize(0.5)
+, mMapInfoContributors(QSet<QString>{"Short"})
 , mBubbleMode(false)
 , mShowRoomID(false)
 , mShowPanel(true)
@@ -394,7 +395,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mPlayerRoomInnerDiameterPercentage(70)
 , mDebugShowAllProblemCodepoints(false)
 , mCompactInputLine(false)
-, mMapInfoContributors(QSet<QString>{"Short"})
 {
     // mLogStatus = mudlet::self()->mAutolog;
     mLuaInterface.reset(new LuaInterface(this));

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15381,6 +15381,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
 
     auto& host = getHostFromLua(L);
     host.mpMap->mMapInfoContributorManager->registerContributor(name, [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
+        Q_UNUSED(infoColor);
         lua_rawgeti(L, LUA_REGISTRYINDEX, callback);
         if (roomID > 0) {
             lua_pushinteger(L, roomID);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1382,7 +1382,7 @@ void mudlet::slot_module_clicked(QTableWidgetItem* pItem)
     QTableWidgetItem* entry = moduleTable->item(i, 0);
     QTableWidgetItem* checkStatus = moduleTable->item(i, 2);
     QTableWidgetItem* itemPriority = moduleTable->item(i, 1);
-    QTableWidgetItem* itemPath = moduleTable->item(i, 3);
+    //  Not used programatically now: QTableWidgetItem* itemPath = moduleTable->item(i, 3);
     if (!entry || !checkStatus || !itemPriority || !mpModuleTableHost->mInstalledModules.contains(entry->text())) {
         moduleHelpButton->setDisabled(true);
         if (checkStatus) {


### PR DESCRIPTION
* An out of order member in `Host` constructor initialisation list
* An unused argument to lambda function in:
  `TLuaInterpreter::registerMapInfo(...)`
* A, now unused, variable in `mudlet::slot_module_clicked(...)`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>