### PR TITLE
Removes deprecated, unused code and fixes tests in TMxpParserTest

### DIFF
--- a/src/TMxpElementDefinitionHandler.cpp
+++ b/src/TMxpElementDefinitionHandler.cpp
@@ -65,8 +65,7 @@ TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& c
     el.empty = tag->hasAttribute("EMPTY");
 
     if (!el.definition.isEmpty()) {
-        TMxpTagParser parser;
-        el.parsedDefinition = parser.parseToMxpNodeList(el.definition);
+        el.parsedDefinition = TMxpTagParser::parseToMxpNodeList(el.definition);
     }
 
     ctx.getElementRegistry().registerElement(el);

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -195,10 +195,6 @@ bool TMxpNodeBuilder::acceptSequence(char ch, std::string& buffer)
         }
     }
 
-    if (mIsQuotedSequence && !mSequenceHasSpaces && !mReadingAttrValue && ch == '=') {
-        return true;
-    }
-
     if (!mIsInsideSequence) {
         mIsInsideSequence = true;
     }

--- a/src/TMxpTagParser.cpp
+++ b/src/TMxpTagParser.cpp
@@ -26,31 +26,16 @@
 #include <QDebug>
 #include "post_guard.h"
 
-static QStringView stripTagAndTrim(const QString& tagText)
-{
-    return TStringUtils::strip(QStringView(tagText).trimmed(), '<', '>').trimmed();
-}
-
-static bool isEndTag(const QString& tagText)
-{
-    return stripTagAndTrim(tagText).startsWith('/');
-}
-
-static bool isTag(const QString& tagString)
-{
-    return TStringUtils::isBetween(QStringView(tagString).trimmed(), '<', '>');
-}
-
-QList<QSharedPointer<MxpNode>> TMxpTagParser::parseToMxpNodeList(const QString& tagText, bool ignoreText) const
+QList<QSharedPointer<MxpNode>> TMxpTagParser::parseToMxpNodeList(const QString& tagText, bool ignoreText)
 {
     TMxpNodeBuilder nodeBuilder(ignoreText);
     std::string tagStdStr = tagText.toStdString();
 
     QList<QSharedPointer<MxpNode>> result;
-    for (int i = 0; i < tagText.length(); ++i) {
-        if (nodeBuilder.accept(tagStdStr[i])) {
+    for (auto itr = tagStdStr.begin(); itr != tagStdStr.end(); itr++) {
+        if (nodeBuilder.accept(*itr)) {
             result.append(QSharedPointer<MxpNode>(nodeBuilder.buildNode()));
-            --i;
+            --itr;
         }
     }
 
@@ -59,123 +44,4 @@ QList<QSharedPointer<MxpNode>> TMxpTagParser::parseToMxpNodeList(const QString& 
     }
 
     return result;
-}
-
-MxpTag* TMxpTagParser::parseTag(const QString& tagText) const
-{
-    return isEndTag(tagText) ? static_cast<MxpTag*>(parseEndTag(tagText)) : static_cast<MxpTag*>(parseStartTag(tagText));
-}
-
-MxpEndTag* TMxpTagParser::parseEndTag(const QString& tagText) const
-{
-    QStringView tagContent = stripTagAndTrim(tagText).mid(1);
-    const QStringList& parts = parseToList(tagContent);
-
-    if (parts.size() > 1) {
-        qWarning().noquote().nospace() << "TMxpTagParser::parseEndTag(\"" << tagText << "\") WARNING - this end tag has attributes.";
-    }
-
-    return new MxpEndTag(parts.first());
-}
-
-MxpStartTag* TMxpTagParser::parseStartTag(const QString& tagText) const
-{
-    QStringView tagContent = TStringUtils::strip(tagText, '<', '>');
-
-    const QStringList& parts = parseToList(tagContent);
-
-    const QString& name = parts.first();
-
-    bool isClosed = parts.back() == "/";
-    int attrsEndIndex = isClosed ? parts.size() - 1 : parts.size();
-
-    QList<MxpTagAttribute> attrs;
-    for (int i = 1; i < attrsEndIndex; ++i) {
-        attrs.append(parseAttribute(parts.at(i)));
-    }
-
-    return new MxpStartTag(name, attrs, isClosed);
-}
-
-MxpTagAttribute TMxpTagParser::parseAttribute(const QString& attr) const
-{
-    if (isTag(attr)) {
-        return MxpTagAttribute(attr, QString());
-    }
-
-    int sepIdx = attr.indexOf('=');
-    if (sepIdx == -1) {
-        return MxpTagAttribute(attr, QString());
-    }
-
-    const QString& name = attr.left(sepIdx);
-    const QString& value = TStringUtils::unquote(QStringView(attr).mid(sepIdx + 1)).toString();
-
-    return MxpTagAttribute(name, value);
-}
-
-QStringList TMxpTagParser::parseToList(const QString& tagText)
-{
-    return parseToList(QStringView(tagText));
-}
-
-QStringList TMxpTagParser::parseToList(const QStringView tagText)
-{
-    QStringList result;
-
-    int start = 0;
-
-    while (start < tagText.length()) {
-        if (TStringUtils::isQuote(tagText.at(start))) {
-            auto end = readTextBlock(tagText, start + 1, tagText.length(), tagText.at(start));
-            if (start != end) {
-                result.append(tagText.mid(start + 1, end - start - 1).toString());
-            }
-
-            start = end + 1;
-            continue;
-        }
-
-        if (!tagText.at(start).isSpace()) {
-            auto end = readTextBlock(tagText, start, tagText.length(), ' ');
-            if (start != end) {
-                result.append(tagText.mid(start, end - start).toString());
-            }
-
-            start = end;
-            continue;
-        }
-
-        ++start;
-    }
-
-    return result;
-}
-
-int TMxpTagParser::readTextBlock(QStringView str, const int start, const int end, const QChar terminatingChar)
-{
-    bool inQuote = false;
-    QChar curQuote = QChar::Null;
-
-    int pos = start;
-    while (pos < end) {
-        if (!inQuote && str.at(pos) == terminatingChar) {
-            break;
-        }
-
-        if (TStringUtils::isQuote(str.at(pos))) {
-            if (!inQuote) {
-                inQuote = true;
-                curQuote = str.at(pos);
-            } else {
-                if (str.at(pos) == curQuote) {
-                    inQuote = false;
-                }
-            }
-        }
-
-        ++pos;
-    }
-
-    return pos;
 }

--- a/src/TMxpTagParser.h
+++ b/src/TMxpTagParser.h
@@ -25,26 +25,15 @@
 #include "MxpTag.h"
 
 #include "pre_guard.h"
-#include <QString>
 #include <QList>
 #include <QSharedPointer>
+#include <QString>
 #include "post_guard.h"
 
 class TMxpTagParser
 {
-    static int readTextBlock(QStringView str, const int start, const int end, const QChar terminatingChar);
-
 public:
-    static QStringList parseToList(const QStringView tagText);
-    static QStringList parseToList(const QString& tagText);
-
-    QList<QSharedPointer<MxpNode>> parseToMxpNodeList(const QString& tagText, bool ignoreText = false) const;
-
-    MxpTag* parseTag(const QString& tagText) const;
-    MxpStartTag* parseStartTag(const QString& tagText) const;
-    MxpEndTag* parseEndTag(const QString& tagText) const;
-
-    MxpTagAttribute parseAttribute(const QString& attr) const;
+    static QList<QSharedPointer<MxpNode>> parseToMxpNodeList(const QString& tagText, bool ignoreText = false);
 };
 
 #endif //MUDLET_TMXPTAGPARSER_H

--- a/src/TMxpTagProcessor.cpp
+++ b/src/TMxpTagProcessor.cpp
@@ -39,14 +39,6 @@
 #include "TMxpVarTagHandler.h"
 #include "TMxpVersionTagHandler.h"
 
-TMxpTagHandlerResult TMxpTagProcessor::process(TMxpContext& ctx, TMxpClient& client, const std::string& currentToken)
-{
-    TMxpTagParser parser;
-    QScopedPointer<MxpTag> tag(parser.parseTag(currentToken.c_str()));
-
-    return handleTag(ctx, client, tag.get());
-}
-
 TMxpTagHandlerResult TMxpTagProcessor::handleTag(TMxpContext& ctx, TMxpClient& client, MxpTag* tag)
 {
     if (!client.tagReceived(tag)) {

--- a/src/TMxpTagProcessor.h
+++ b/src/TMxpTagProcessor.h
@@ -49,7 +49,6 @@ class TMxpTagProcessor : public TMxpContext
 
 public:
     TMxpTagProcessor();
-    TMxpTagHandlerResult process(TMxpContext& ctx, TMxpClient& client, const std::string& currentToken);
 
     TMxpTagHandlerResult handleTag(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override;
     void handleContent(char ch) override;

--- a/test/TMxpTagParserTest.cpp
+++ b/test/TMxpTagParserTest.cpp
@@ -1,3 +1,4 @@
+
 #include "TMxpTagParser.h"
 #include <MxpTag.h>
 #include <QtTest/QtTest>
@@ -9,16 +10,20 @@ private:
 private slots:
 
     void initTestCase()
-    {}
+    {
+    }
+
+    QSharedPointer<MxpNode> parseNode(const QString& tagText) const
+    {
+        auto nodes = TMxpTagParser::parseToMxpNodeList(tagText);
+        return nodes.size() > 0 ? nodes.first() : nullptr;
+    }
 
     void testMateriaMagicaScriptedActionEndTag()
     {
-        TMxpTagParser parser;
-        auto list = parser.parseToMxpNodeList("<play hangman/scripted_action>");
-
-        QCOMPARE(list.size(), 1);
-        QVERIFY(list[0]->isEndTag());
-        QCOMPARE(list[0]->asEndTag()->getName(), "scripted_action");
+        auto node = parseNode("<play hangman/scripted_action>");
+        QVERIFY(node->isEndTag());
+        QCOMPARE(node->asEndTag()->getName(), "scripted_action");
     }
 
     void testMateriaMagicaScriptedActionTag()
@@ -26,17 +31,21 @@ private slots:
         TMxpTagParser parser;
         QString tagText = R"(<scripted_action desc="hangman start">play hangman<play hangman/scripted_action>)";
 
-        auto list = parser.parseToMxpNodeList(tagText, true);
-        QCOMPARE(list.size(), 2);
+        auto list = parser.parseToMxpNodeList(tagText, false);
+        QCOMPARE(list.size(), 3);
 
         QVERIFY(list[0]->isStartTag());
         QCOMPARE(list[0]->asStartTag()->getName(), "scripted_action");
 
-        QVERIFY(list[1]->isEndTag());
-        QCOMPARE(list[1]->asEndTag()->getName(), "scripted_action");
+        QVERIFY(!list[1]->isTag());
+        QCOMPARE(list[1]->asText()->getContent(), "play hangman");
+
+        QVERIFY(list[2]->isEndTag());
+        QCOMPARE(list[2]->asEndTag()->getName(), "scripted_action");
     }
 
-    void testSimpleEndTag() {
+    void testSimpleEndTag()
+    {
         TMxpTagParser parser;
         QString tagText = R"(<tag_name desc="blabla">tag content</tag_name>)";
 
@@ -51,7 +60,8 @@ private slots:
         QCOMPARE(list[1]->asEndTag()->getName(), "tag_name");
     }
 
-    void testSimpleTagQuotedSlash() {
+    void testSimpleTagQuotedSlash()
+    {
         TMxpTagParser parser;
         QString tagText = R"(<tag_name desc="a/b">)";
 
@@ -65,24 +75,24 @@ private slots:
 
     void testParseUrl()
     {
-        TMxpTagParser parser;
-        QList<QSharedPointer<MxpNode>> list = parser.parseToMxpNodeList("<A HREF=\"https://www.google.com/search?q=mudlet\">", true);
+        QString tagText = R"(<A HREF="https://www.google.com/search?q=mudlet">)";
+        auto node = parseNode(tagText);
+        QVERIFY(node);
 
-        QCOMPARE(list.size(), 1);
-        QVERIFY(list[0]->isStartTag());
-        QCOMPARE(list[0]->asStartTag()->getName(), "A");
-        QCOMPARE(list[0]->asStartTag()->getAttributeValue("HREF"), "https://www.google.com/search?q=mudlet");
+        QVERIFY(node->isStartTag());
+        QCOMPARE(node->asStartTag()->getName(), "A");
+        QCOMPARE(node->asStartTag()->getAttributeValue("HREF"), "https://www.google.com/search?q=mudlet");
     }
 
     void testParseWithEqualSymbol()
     {
-        TMxpTagParser parser;
-        QList<QSharedPointer<MxpNode>> list = parser.parseToMxpNodeList("<SEND HREF=\"1+1=2\">", true);
+        QString tagText = R"(<SEND HREF="1+1=2">)";
+        auto node = parseNode(tagText);
 
-        QCOMPARE(list.size(), 1);
-        QVERIFY(list[0]->isStartTag());
-        QCOMPARE(list[0]->asStartTag()->getName(), "SEND");
-        QCOMPARE(list[0]->asStartTag()->getAttributeValue("HREF"), "1+1=2");
+        QVERIFY(node);
+        QVERIFY(node->isStartTag());
+        QCOMPARE(node->asStartTag()->getName(), "SEND");
+        QCOMPARE(node->asStartTag()->getAttributeValue("HREF"), "1+1=2");
     }
 
     void testParseWithQuotes()
@@ -168,113 +178,95 @@ private slots:
         QString tagLine =
                 "<!EL get \"<send href='examine &#34;&name;&#34;|get &#34;&name;&#34;' hint='Right mouse click to act on this item|Get &desc;|Examine &desc;|Look in &desc;' expire=get>\" ATT='name desc'>";
         TMxpTagParser parser;
+        auto list = parser.parseToMxpNodeList(tagLine);
 
-        MxpStartTag tag = *parser.parseStartTag(tagLine);
+        QCOMPARE(list.size(), 1);
+        QVERIFY(list[0]->isStartTag());
 
-        QCOMPARE(tag.getName(), "!EL");
-        QCOMPARE(tag.getAttributesCount(), 3);
+        MxpStartTag* tag = list[0]->asStartTag();
 
-        QCOMPARE(tag.getAttribute(0).getName(), "get");
-        QCOMPARE(tag.getAttribute(0).getValue(), "");
+        QCOMPARE(tag->getName(), "!EL");
+        QCOMPARE(tag->getAttributesCount(), 3);
 
-        QCOMPARE(tag.getAttribute(1).getName(),
+        QCOMPARE(tag->getAttribute(0).getName(), "get");
+        QCOMPARE(tag->getAttribute(0).getValue(), "");
+
+        QCOMPARE(tag->getAttribute(1).getName(),
                  "<send href='examine &#34;&name;&#34;|get &#34;&name;&#34;' hint='Right mouse click to act on this item|Get &desc;|Examine &desc;|Look in &desc;' expire=get>");
-        QCOMPARE(tag.getAttributeValue("ATT"), "name desc");
+        QCOMPARE(tag->getAttributeValue("ATT"), "name desc");
 
-        MxpStartTag sendTag = *parser.parseStartTag(tag.getAttribute(1).getName());
-        QCOMPARE(sendTag.getName(), "send");
+        auto sendTagNodeList = parser.parseToMxpNodeList(tag->getAttribute(1).getName());
+        MxpStartTag* sendTag = sendTagNodeList[0]->asStartTag();
+        QCOMPARE(sendTag->getName(), "send");
     }
 
     void testMxpTagParser()
     {
         TMxpTagParser parser;
-        MxpStartTag tag = *parser.parseStartTag("<!EL RExit FLAG=RoomExit>");
 
-        QCOMPARE(tag.getName(), "!EL");
+        auto list = parser.parseToMxpNodeList("<!EL RExit FLAG=RoomExit>");
+        QCOMPARE(list.size(), 1);
+        QVERIFY(list[0]->isStartTag());
 
-        QVERIFY(tag.hasAttribute("RExit"));
-        QCOMPARE(tag.getAttributeValue("RExit"), "");
-        QCOMPARE(tag.getAttribute(0).getName(), "RExit");
-        QCOMPARE(tag.getAttribute(0).getValue(), "");
+        MxpStartTag* tag = list[0]->asStartTag();
 
-        QVERIFY(tag.hasAttribute("FLAG"));
-        QCOMPARE(tag.getAttributeValue("FLAG"), "RoomExit");
-    }
+        QCOMPARE(tag->getName(), "!EL");
 
-    void testComplexElementDefinitionToList()
-    {
-        QString tagLine =
-                "!EL get \"<send href='examine &#34;&name;&#34;|get &#34;&name;&#34;' hint='Right mouse click to act on this item|Get &desc;|Examine &desc;|Look in &desc;' expire=get>\" ATT='name desc'";
+        QVERIFY(tag->hasAttribute("RExit"));
+        QCOMPARE(tag->getAttributeValue("RExit"), "");
+        QCOMPARE(tag->getAttribute(0).getName(), "RExit");
+        QCOMPARE(tag->getAttribute(0).getValue(), "");
 
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list.size(), 4);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "get");
-        QCOMPARE(list[2],
-                 "<send href='examine &#34;&name;&#34;|get &#34;&name;&#34;' hint='Right mouse click to act on this item|Get &desc;|Examine &desc;|Look in &desc;' expire=get>");
-        QCOMPARE(list[3], "ATT='name desc'");
+        QVERIFY(tag->hasAttribute("FLAG"));
+        QCOMPARE(tag->getAttributeValue("FLAG"), "RoomExit");
     }
 
     void testAttrDefinition()
     {
         QString tagLine = R"(<!ATTLIST boldtext 'color=red background=white flags'>)";
-        TMxpTagParser::parseToList(tagLine);
+        TMxpTagParser parser;
+        auto list = parser.parseToMxpNodeList(tagLine);
+
+        QCOMPARE(list.size(), 1);
+        QVERIFY(list[0]->isStartTag());
+
+        MxpStartTag* tag = list[0]->asStartTag();
+        QCOMPARE(tag->getName(), "!ATTLIST");
+        QCOMPARE(tag->getAttribute(0).getName(), "boldtext");
+        QCOMPARE(tag->getAttribute(1).getName(), "color=red background=white flags");
     }
 
-    void testSimpleElementDefition()
+    void testSimpleElementDefinition()
     {
-        TMxpTagParser parser;
+        QString tagLine = "<!EL RExit FLAG=RoomExit>";
+        auto node = parseNode(tagLine);
 
-        QString tagLine = "!EL RExit FLAG=RoomExit";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list.size(), 3);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "RExit");
-        QCOMPARE(list[2], "FLAG=RoomExit");
+        QVERIFY(node->isStartTag());
+        QCOMPARE(node->asStartTag()->getName(), "!EL");
+        QVERIFY(node->asStartTag()->hasAttribute("RExit"));
+        QCOMPARE(node->asStartTag()->getAttributeValue("FLAG"), "RoomExit");
     }
 
-    void testSimpleQuotedElementDefition()
+    void testElementDefinitionWithExtraSpaces()
     {
-        TMxpTagParser parser;
+        QString tagLine = "<!EL RExit   FLAG=RoomExit>";
+        auto node = parseNode(tagLine);
 
-        QString tagLine = "!EL RExit 'FLAG=RoomExit'";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "RExit");
-        QCOMPARE(list[2], "FLAG=RoomExit");
+        QVERIFY(node->isStartTag());
+        QCOMPARE(node->asStartTag()->getName(), "!EL");
+        QVERIFY(node->asStartTag()->hasAttribute("RExit"));
+        QCOMPARE(node->asStartTag()->getAttributeValue("FLAG"), "RoomExit");
     }
 
-    void testElementDefitionWithExtraSpaces()
+    void testElementDefinitionQuotedAttributeSpaces()
     {
-        TMxpTagParser parser;
+        QString tagLine = "<!EL sHp FLAG='Set Hp'>";
+        auto node = parseNode(tagLine);
 
-        QString tagLine = "!EL RExit   FLAG=RoomExit";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "RExit");
-        QCOMPARE(list[2], "FLAG=RoomExit");
-    }
-
-    void testDoubleQuotedElementDefition()
-    {
-        TMxpTagParser parser;
-
-        QString tagLine = R"(!EL RExit "FLAG=RoomExit")";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "RExit");
-        QCOMPARE(list[2], "FLAG=RoomExit");
-    }
-
-    void testElementDefitionQuotedAttributeSpaces()
-    {
-        TMxpTagParser parser;
-
-        QString tagLine = "!EL sHp FLAG='Set Hp'";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "sHp");
-        QCOMPARE(list[2], "FLAG='Set Hp'");
+        QVERIFY(node->isStartTag());
+        QCOMPARE(node->asStartTag()->getName(), "!EL");
+        QVERIFY(node->asStartTag()->hasAttribute("sHp"));
+        QCOMPARE(node->asStartTag()->getAttributeValue("FLAG"), "Set Hp");
     }
 
     void testAccessAttrCaseInsensitive()
@@ -282,74 +274,100 @@ private slots:
         TMxpTagParser parser;
         QString tagLine = "<!EL sHp FLAG='Set Hp'>";
 
-        MxpStartTag tag = *parser.parseStartTag(tagLine);
+        auto node = parseNode(tagLine);
 
-        QVERIFY(tag.hasAttribute("sHp"));
-        QVERIFY(tag.hasAttribute("shp"));
-        QVERIFY(tag.hasAttribute("shP"));
+        QVERIFY(node->isStartTag());
+        MxpStartTag* tag = node->asStartTag();
+
+        QVERIFY(tag->hasAttribute("sHp"));
+        QVERIFY(tag->hasAttribute("shp"));
+        QVERIFY(tag->hasAttribute("shP"));
+        QCOMPARE(tag->getAttributeValue("flag"), "Set Hp");
     }
 
-    void testElementDefitionQuotesInQuotes()
+    void testElementDefinitionQuotesInQuotes()
+    {
+        QString tagLine = "<!EL x FLAG='Quote \" ex'>";
+        auto node = parseNode(tagLine);
+
+        QVERIFY(node->isStartTag());
+        QCOMPARE(node->asStartTag()->getName(), "!EL");
+        QVERIFY(node->asStartTag()->hasAttribute("x"));
+        QCOMPARE(node->asStartTag()->getAttributeValue("FLAG"), "Quote \" ex");
+    }
+
+    void testCompleteElement()
     {
         TMxpTagParser parser;
 
-        QString tagLine = "!EL x FLAG='Quote \" ex'";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-        QCOMPARE(list[0], "!EL");
-        QCOMPARE(list[1], "x");
-        QCOMPARE(list[2], "FLAG='Quote \" ex'");
-    }
+        QString tagLine = R"(<FRAME Name="Map" Left="-20c" Top="0" Width="20c" Height="20c">)";
+        auto node = parseNode(tagLine);
 
-    void testElementComplet1()
-    {
-        TMxpTagParser parser;
+        QVERIFY(node->isStartTag());
+        MxpStartTag* tag = node->asStartTag();
 
-        QString tagLine = R"(FRAME Name="Map" Left="-20c" Top="0" Width="20c" Height="20c")";
-        QStringList list = TMxpTagParser::parseToList(tagLine);
-
-        QCOMPARE(list[0], "FRAME");
-        QCOMPARE(list[1], "Name=\"Map\"");
-        QCOMPARE(list[2], "Left=\"-20c\"");
-        QCOMPARE(list[3], "Top=\"0\"");
-        QCOMPARE(list[4], "Width=\"20c\"");
-        QCOMPARE(list[5], "Height=\"20c\"");
+        QCOMPARE(tag->getName(), "FRAME");
+        QCOMPARE(tag->getAttributeValue("Name"), "Map");
+        QCOMPARE(tag->getAttributeValue("Left"), "-20c");
+        QCOMPARE(tag->getAttributeValue("Top"), "0");
+        QCOMPARE(tag->getAttributeValue("Width"), "20c");
+        QCOMPARE(tag->getAttributeValue("Height"), "20c");
     }
 
     void testEndTag()
     {
-        TMxpTagParser parser;
+        auto node = parseNode("</V>");
+        QVERIFY(node->isEndTag());
 
-        MxpEndTag* endTag = parser.parseEndTag("</V>");
+        MxpEndTag* endTag = node->asEndTag();
         QCOMPARE(endTag->getName(), "V");
-        QVERIFY(endTag->isEndTag());
         QCOMPARE(endTag->asStartTag(), nullptr);
     }
 
     void testParseEndTag()
     {
-        TMxpTagParser parser;
+        auto node = parseNode("</V>");
+        QVERIFY(node);
+        QVERIFY(node->isEndTag());
 
-        MxpTag* tag = parser.parseTag("</V>");
+        MxpEndTag* tag = node->asEndTag();
+
         QCOMPARE(tag->getName(), "V");
-        QVERIFY(tag->isEndTag());
-        QVERIFY(tag->asEndTag());
         QVERIFY(!tag->asStartTag());
     }
 
     void testStartTagClosed()
     {
-        TMxpTagParser parser;
-        MxpTag* tag = parser.parseTag("<RNum 212 />");
+        auto node = parseNode("<RNum 212 />");
 
-        QVERIFY(tag->isStartTag());
-        QVERIFY(tag->asStartTag()->isEmpty());
+        QVERIFY(node);
+        QVERIFY(node->isStartTag());
+
+        MxpStartTag* tag = node->asStartTag();
+
+        QVERIFY(tag->isEmpty());
         QCOMPARE(tag->getName(), "RNum");
-        QCOMPARE(tag->asStartTag()->getAttribute(0).getName(), "212");
-        QCOMPARE(tag->asStartTag()->getAttributesCount(), 1);
+        QCOMPARE(tag->getAttribute(0).getName(), "212");
+        QCOMPARE(tag->getAttributesCount(), 1);
     }
 
-    void cleanupTestCase()
-    {}
+    void testQuotedAttrValue()
+    {
+        auto node = parseNode("<color fore='red' back=\"blue\">");
+
+        QVERIFY(node);
+        QVERIFY(node->isStartTag());
+
+        MxpStartTag* tag = node->asStartTag();
+
+        QVERIFY(tag->isStartTag());
+        QCOMPARE(tag->getName(), "color");
+        QCOMPARE(tag->asStartTag()->getAttributesCount(), 2);
+        QCOMPARE(tag->asStartTag()->getAttribute("fore").getValue(), "red");
+        QCOMPARE(tag->asStartTag()->getAttribute("back").getValue(), "blue");
+    }
+
+    void cleanupTestCase() {}
 };
 
 #include "TMxpTagParserTest.moc"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
- TMxpParserTest was testing functions that are never called and not testing the actual running code for some cases
- This commit changes the TMxpTagParser interface, unused functions and updates TMxpParserTest to test the actual code

#### Motivation for adding to Mudlet
While working on #4717 I noticed the tests were not calling the actual running code, but old functions that weren't used anymore

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
