### PR TITLE
Fix clang-tidy review to run against forks as well

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,6 +1,6 @@
 name: 🔍 Check improvements with Mudlet's C++ style guide
 
-on: [pull_request]
+on: pull_request_target
 
 jobs:
   compile-mudlet:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -28,6 +28,8 @@ jobs:
         fetch-depth: 0
         # https://github.com/ZedThree/clang-tidy-review/issues/10
         ref: ${{ github.event.pull_request.head.sha }}
+        # https://github.community/t/github-actions-are-severely-limited-on-prs/18179/17?u=vadi2
+        repository: ${{github.event.pull_request.head.repo.full_name}}
 
     - name: Restore Qt cache
       uses: actions/cache@v2.1.4

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6210,10 +6210,10 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
     int expiryCount = -1;
     if (lua_isnumber(L, ++s)) {
         expiryCount = lua_tonumber(L, s);
-        if (expiryCount < 1)
+        if (expiryCount < 1) {
             return warnArgumentValue(L, __func__, QStringLiteral(
                 "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
-        
+        }
     } else if (!lua_isnoneornil(L, ++s)) {
         lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d value (trigger expiration count must be a number, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6210,10 +6210,10 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
     int expiryCount = -1;
     if (lua_isnumber(L, ++s)) {
         expiryCount = lua_tonumber(L, s);
-        if (expiryCount < 1) {
+        if (expiryCount < 1)
             return warnArgumentValue(L, __func__, QStringLiteral(
                 "trigger expiration count must be nil or greater than zero, got %1").arg(expiryCount));
-        }
+        
     } else if (!lua_isnoneornil(L, ++s)) {
         lua_pushfstring(L, "tempAnsiColorTrigger: bad argument #%d value (trigger expiration count must be a number, got %s!)", s, luaL_typename(L, s));
         return lua_error(L);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The default event - `pull_request` - had read-only permissions when running from forks - and thus it couldn't make any reviews!

Using a new event Github added, `pull_request_target`, will fix the problem - hopefully. It's not 100% clear, but we can't know until we merge it.
#### Motivation for adding to Mudlet
So the comment bot actually works for forks, which is the vast majority of where Mudlet's PRs come from.
#### Other info (issues closed, discussion etc)
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

What's confusing is:

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. 

So the workflow is trusted - OK. But then it means it's not running against modified code either? Let's see.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
