### PR TITLE
BugFix: do not squash dockable mapper when visibility is toggled

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3156,7 +3156,7 @@ std::pair<bool, QString> Host::openMapWidget(const QString& area, int x, int y, 
     auto pM = mpDockableMapWidget;
     auto pMapper = mpMap.data()->mpMapper;
     if (!pM && !pMapper) {
-        toggleVisibilityOfOrCreateMapper(true);
+        showHideOrCreateMapper(true);
         pM = mpDockableMapWidget;
     }
     if (!pM) {
@@ -3529,11 +3529,11 @@ bool Host::resetBackgroundImage(const QString &name)
     return false;
 }
 
-// Needed to extract into a separate method from slot_mapper() so that we can
-// use it WITHOUT loading a file - at least for the TConsole::importMap(...)
-// case that may need to create a map widget before it loads/imports a
-// non-default (last saved map in profile's map directory.
-void Host::toggleVisibilityOfOrCreateMapper(const bool loadDefaultMap)
+// Needed to extract into a separate method from mudlet::slot_mapper() so that
+// we can use it WITHOUT loading a file - at least for the
+// TConsole::importMap(...) case that may need to create a map widget before it
+// loads/imports a non-default (last saved map in profile's map directory).
+void Host::showHideOrCreateMapper(const bool loadDefaultMap)
 {
     auto pMap = mpMap.data();
     if (pMap->mpMapper) {
@@ -3548,7 +3548,7 @@ void Host::toggleMapperVisibility()
 {
     auto pMap = mpMap.data();
     bool visStatus = mpMap->mpMapper->isVisible();
-    if (pMap->mpMapper->parentWidget()->inherits("QDockWidget")) {
+    if (pMap->mpMapper->isFloatAndDockable()) {
         // If we are using a floating/dockable widget we must show/hide that
         // only and not the mapper widget (otherwise it messes up {shrinks
         // to a minimal size} the mapper inside the container QDockWidget). This

--- a/src/Host.h
+++ b/src/Host.h
@@ -370,7 +370,7 @@ public:
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
     bool setBackgroundImage(const QString& name, QString& path, int mode);
     bool resetBackgroundImage(const QString& name);
-    void createMapper(bool loadDefaultMap);
+    void toggleVisibilityOfOrCreateMapper(const bool loadDefaultMap);
     bool setProfileStyleSheet(const QString& styleSheet);
     void check_for_mappingscript();
 
@@ -633,6 +633,8 @@ private:
     void removeAllNonPersistentStopWatches();
     void updateConsolesFont();
     void thankForUsingPTB();
+    void toggleMapperVisibility();
+    void createMapper(const bool);
 
     QFont mDisplayFont;
     QStringList mModulesToSync;

--- a/src/Host.h
+++ b/src/Host.h
@@ -370,7 +370,7 @@ public:
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
     bool setBackgroundImage(const QString& name, QString& path, int mode);
     bool resetBackgroundImage(const QString& name);
-    void toggleVisibilityOfOrCreateMapper(const bool loadDefaultMap);
+    void showHideOrCreateMapper(const bool loadDefaultMap);
     bool setProfileStyleSheet(const QString& styleSheet);
     void check_for_mappingscript();
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -609,7 +609,7 @@ std::pair<bool, QString> TMainConsole::setLabelCustomCursor(const QString& name,
 }
 
 // Called from TLuaInterpreter::createMapper(...) to create a map in a TConsole,
-// Host::toggleVisibilityOfOrCreateMapper(...) {formerly also called
+// Host::showHideOrCreateMapper(...) {formerly also called
 // createMapper(...)} is used in other cases to make a map in a QDockWidget:
 std::pair<bool, QString> TMainConsole::createMapper(const QString& windowname, int x, int y, int width, int height)
 {
@@ -1185,7 +1185,7 @@ bool TMainConsole::loadMap(const QString& location)
         // No map or map currently loaded - so try and created mapper
         // but don't load a map here by default, we do that below and it may not
         // be the default map anyhow
-        pHost->toggleVisibilityOfOrCreateMapper(false);
+        pHost->showHideOrCreateMapper(false);
     }
 
     if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
@@ -1246,7 +1246,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
 
     if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
         // No map or mapper currently loaded/present - so try and create mapper
-        pHost->toggleVisibilityOfOrCreateMapper(false);
+        pHost->showHideOrCreateMapper(false);
     }
 
     if (!pHost->mpMap || !pHost->mpMap->mpMapper) {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -608,6 +608,9 @@ std::pair<bool, QString> TMainConsole::setLabelCustomCursor(const QString& name,
     return {false, QStringLiteral("label name '%1' not found").arg(name)};
 }
 
+// Called from TLuaInterpreter::createMapper(...) to create a map in a TConsole,
+// Host::toggleVisibilityOfOrCreateMapper(...) {formerly also called
+// createMapper(...)} is used in other cases to make a map in a QDockWidget:
 std::pair<bool, QString> TMainConsole::createMapper(const QString& windowname, int x, int y, int width, int height)
 {
     auto pW = mDockWidgetMap.value(windowname);
@@ -1182,7 +1185,7 @@ bool TMainConsole::loadMap(const QString& location)
         // No map or map currently loaded - so try and created mapper
         // but don't load a map here by default, we do that below and it may not
         // be the default map anyhow
-        pHost->createMapper(false);
+        pHost->toggleVisibilityOfOrCreateMapper(false);
     }
 
     if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
@@ -1243,7 +1246,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
 
     if (!pHost->mpMap || !pHost->mpMap->mpMapper) {
         // No map or mapper currently loaded/present - so try and create mapper
-        pHost->createMapper(false);
+        pHost->toggleVisibilityOfOrCreateMapper(false);
     }
 
     if (!pHost->mpMap || !pHost->mpMap->mpMapper) {

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -367,3 +367,13 @@ void dlgMapper::slot_updateInfoContributors()
         pushButton_info->menu()->addAction(action);
     }
 }
+
+// Is the mapper contained inside a floating/dockable QDockWidget?
+bool dlgMapper::isFloatAndDockable() const
+{
+    // The class name should be a const char* - no QString wrapper is needed:
+    if (parentWidget() && parentWidget()->inherits("QDockWidget")) {
+        return true;
+    }
+    return false;
+}

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -51,6 +51,7 @@ public:
     void setDefaultAreaShown(bool);
     bool getDefaultAreaShown() { return mShowDefaultArea; }
     void resetAreaComboBoxToPlayerRoomArea();
+    bool isFloatAndDockable() const;
 
 public slots:
     void slot_toggleRoundRooms(const bool);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1988,7 +1988,7 @@ void dlgProfilePreferences::downloadMap()
     }
     if (!pHost->mpMap->mpMapper) {
         // CHECK: What happens if we are NOT the current profile anymore?
-        pHost->toggleVisibilityOfOrCreateMapper(false);
+        pHost->showHideOrCreateMapper(false);
     }
 
     pHost->mpMap->downloadMap();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1988,7 +1988,7 @@ void dlgProfilePreferences::downloadMap()
     }
     if (!pHost->mpMap->mpMapper) {
         // CHECK: What happens if we are NOT the current profile anymore?
-        pHost->createMapper(false);
+        pHost->toggleVisibilityOfOrCreateMapper(false);
     }
 
     pHost->mpMap->downloadMap();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2582,7 +2582,7 @@ void mudlet::slot_mapper()
     if (!pHost) {
         return;
     }
-    pHost->createMapper(true);
+    pHost->toggleVisibilityOfOrCreateMapper(true);
 }
 
 void mudlet::slot_open_mappingscripts_page()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2582,7 +2582,7 @@ void mudlet::slot_mapper()
     if (!pHost) {
         return;
     }
-    pHost->toggleVisibilityOfOrCreateMapper(true);
+    pHost->showHideOrCreateMapper(true);
 }
 
 void mudlet::slot_open_mappingscripts_page()


### PR DESCRIPTION
The existing code was showing and hiding both the `dlgMapper` and, when it is contained within a floating/dockable QDockWidget, that container widget. This has the unfortunate side effect of causing that type of mapper to shrink to a minimal size when shown a second time.

It was confusing that the code to show and hide the mapper was actually contained within a method called `createMapper` - so that has been renamed to `toggleVisibilityOfOrCreateMapper` and the functionality - clearly dividable into two parts - has been refactored into two new methods that does one part; coincidentally one of them can now be called `createMapper`!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fixed a bug when using a floating/dockable mapper which would squash the map down to a minimal, (unusable without manual resizing) size if it was shown, hidden and then shown again.