### PR TITLE
Reformat module and package manager code out of mudlet.cpp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,8 +57,10 @@ set(mudlet_SRCS
     dlgIRC.cpp
     dlgKeysMainArea.cpp
     dlgMapper.cpp
+    dlgModuleManager.cpp
     dlgNotepad.cpp
     dlgPackageExporter.cpp
+    dlgPackageManager.cpp
     dlgProfilePreferences.cpp
     dlgRoomExits.cpp
     dlgRoomSymbol.cpp
@@ -160,8 +162,10 @@ set(mudlet_UIS
     ui/irc.ui
     ui/keybindings_main_area.ui
     ui/main_window.ui
+    ui/module_manager.ui
     ui/mapper.ui
     ui/notes_editor.ui
+    ui/package_manager.ui
     ui/profile_preferences.ui
     ui/room_exits.ui
     ui/room_symbol.ui
@@ -190,8 +194,10 @@ set(mudlet_HDRS
     dlgIRC.h
     dlgKeysMainArea.h
     dlgMapper.h
+    dlgModuleManager.h
     dlgNotepad.h
     dlgPackageExporter.h
+    dlgPackageManager.h
     dlgProfilePreferences.h
     dlgRoomExits.h
     dlgRoomSymbol.h

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -41,6 +41,7 @@
 #include "VarUnit.h"
 #include "XMLimport.h"
 #include "dlgMapper.h"
+#include "dlgModuleManager.h"
 #include "dlgNotepad.h"
 #include "dlgProfilePreferences.h"
 #include "dlgIRC.h"
@@ -197,6 +198,8 @@ QString stopWatch::getElapsedDayTimeString() const
 Host::Host(int port, const QString& hostname, const QString& login, const QString& pass, int id)
 : mTelnet(this, hostname)
 , mpConsole(nullptr)
+, mpPackageManager(nullptr)
+, mpModuleManager(nullptr)
 , mLuaInterpreter(this, hostname, id)
 , commandLineMinimumHeight(30)
 , mAlertOnNewData(true)

--- a/src/Host.h
+++ b/src/Host.h
@@ -64,6 +64,8 @@ class TMainConsole;
 class dlgNotepad;
 class TMap;
 class dlgIRC;
+class dlgPackageManager;
+class dlgModuleManager;
 class dlgProfilePreferences;
 
 class stopWatch {
@@ -380,6 +382,8 @@ public:
 
     cTelnet mTelnet;
     QPointer<TMainConsole> mpConsole;
+    dlgPackageManager* mpPackageManager;
+    dlgModuleManager* mpModuleManager;
     TLuaInterpreter mLuaInterpreter;
 
     int commandLineMinimumHeight;

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -1,4 +1,6 @@
 /***************************************************************************
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *   Copyright (C) 2011 by Chris Mitchell                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -41,6 +41,7 @@ dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
     connect(mModuleHelpButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_help_module);
     connect(mModuleTable, &QTableWidget::itemClicked, this, &dlgModuleManager::slot_module_clicked);
     connect(mModuleTable, &QTableWidget::itemChanged, this, &dlgModuleManager::slot_module_changed);
+    connect(mpHost->mpConsole, &QWidget::destroyed, this, &dlgModuleManager::close);
     setWindowTitle(tr("Module Manager - %1").arg(mpHost->getName()));
     setAttribute(Qt::WA_DeleteOnClose);
 }

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include "dlgModuleManager.h"
+#include "ui_module_manager.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+
+dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
+: QDialog(parent)
+, ui(new Ui::module_manager)
+, mpHost(pHost)
+{
+    ui->setupUi(this);
+
+
+    mModuleTable = ui->moduleTable;
+    mModuleUninstallButton = ui->uninstallButton;
+    mModuleInstallButton = ui->installButton;
+    mModuleHelpButton = ui->helpButton;
+
+    layoutModules();
+    connect(mModuleUninstallButton, &QAbstractButton::clicked, this, &mudlet::slot_uninstall_module);
+    connect(mModuleInstallButton, &QAbstractButton::clicked, this, &mudlet::slot_install_module);
+    connect(mModuleHelpButton, &QAbstractButton::clicked, this, &mudlet::slot_help_module);
+    connect(mModuleTable, &QTableWidget::itemClicked, this, &mudlet::slot_module_clicked);
+    connect(mModuleTable, &QTableWidget::itemChanged, this, &mudlet::slot_module_changed);
+    connect(this, &QObject::destroyed, this, &mudlet::slot_module_manager_destroyed);
+    setWindowTitle(tr("Module Manager - %1").arg(mpHost->getName()));
+    setAttribute(Qt::WA_DeleteOnClose);
+}
+
+dlgModuleManager::~dlgModuleManager()
+{
+    delete ui;
+}

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -18,6 +18,7 @@
 
 #include "dlgModuleManager.h"
 #include "ui_module_manager.h"
+#include "mudlet.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -29,25 +30,231 @@ dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
 , mpHost(pHost)
 {
     ui->setupUi(this);
-
-
     mModuleTable = ui->moduleTable;
     mModuleUninstallButton = ui->uninstallButton;
     mModuleInstallButton = ui->installButton;
     mModuleHelpButton = ui->helpButton;
 
     layoutModules();
-    connect(mModuleUninstallButton, &QAbstractButton::clicked, this, &mudlet::slot_uninstall_module);
-    connect(mModuleInstallButton, &QAbstractButton::clicked, this, &mudlet::slot_install_module);
-    connect(mModuleHelpButton, &QAbstractButton::clicked, this, &mudlet::slot_help_module);
-    connect(mModuleTable, &QTableWidget::itemClicked, this, &mudlet::slot_module_clicked);
-    connect(mModuleTable, &QTableWidget::itemChanged, this, &mudlet::slot_module_changed);
-    connect(this, &QObject::destroyed, this, &mudlet::slot_module_manager_destroyed);
+    connect(mModuleUninstallButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_uninstall_module);
+    connect(mModuleInstallButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_install_module);
+    connect(mModuleHelpButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_help_module);
+    connect(mModuleTable, &QTableWidget::itemClicked, this, &dlgModuleManager::slot_module_clicked);
+    connect(mModuleTable, &QTableWidget::itemChanged, this, &dlgModuleManager::slot_module_changed);
     setWindowTitle(tr("Module Manager - %1").arg(mpHost->getName()));
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
 dlgModuleManager::~dlgModuleManager()
 {
+    mpHost->mpModuleManager = nullptr;
     delete ui;
+}
+
+void dlgModuleManager::layoutModules()
+{
+    if (!mpHost) {
+        return;
+    }
+
+    QMapIterator<QString, QStringList> it(mpHost->mInstalledModules);
+    QStringList sl;
+    sl << tr("Module Name") << tr("Priority") << tr("Sync") << tr("Module Location");
+    mModuleTable->setHorizontalHeaderLabels(sl);
+    mModuleTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    mModuleTable->verticalHeader()->hide();
+    mModuleTable->setShowGrid(true);
+    //clear everything
+    for (int i = 0; i <= mModuleTable->rowCount(); i++) {
+        mModuleTable->removeRow(i);
+    }
+    //order modules by priority and then alphabetically
+    QMap<int, QStringList> mOrder;
+    while (it.hasNext()) {
+        it.next();
+        int priority = mpHost->mModulePriorities[it.key()];
+        if (mOrder.contains(priority)) {
+            mOrder[priority].append(it.key());
+        } else {
+            mOrder[priority] = QStringList(it.key());
+        }
+    }
+    QMapIterator<int, QStringList> it2(mOrder);
+    while (it2.hasNext()) {
+        it2.next();
+        QStringList pModules = it2.value();
+        pModules.sort();
+        for (int i = 0; i < pModules.size(); i++) {
+            int row = mModuleTable->rowCount();
+            mModuleTable->insertRow(row);
+            auto masterModule = new QTableWidgetItem();
+            auto itemEntry = new QTableWidgetItem();
+            auto itemLocation = new QTableWidgetItem();
+            auto itemPriority = new QTableWidgetItem();
+            QStringList moduleInfo = mpHost->mInstalledModules[pModules[i]];
+            QFileInfo moduleFile = moduleInfo[0];
+            QStringList accepted_suffix;
+            accepted_suffix << "xml" << "trigger";
+            if (accepted_suffix.contains(moduleFile.suffix().trimmed(), Qt::CaseInsensitive)) {
+                masterModule->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+                masterModule->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                                 .arg(tr("Checking this box will cause the module to be saved and <i>resynchronised</i> across all "
+                                                         "sessions that share it when the <i>Save Profile</i> button is clicked in the Editor or if it "
+                                                         "is saved at the end of the session.")));
+            } else {
+                masterModule->setFlags(Qt::NoItemFlags);
+                masterModule->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
+                                                 .arg(tr("<b>Note:</b> <i>.zip</i> and <i>.mpackage</i> modules are currently unable to be synced<br> "
+                                                         "only <i>.xml</i> packages are able to be synchronized across profiles at the moment. ")));
+            }
+
+
+            if (moduleInfo.at(1).toInt()) {
+                masterModule->setCheckState(Qt::Checked);
+            } else {
+                masterModule->setCheckState(Qt::Unchecked);
+            }
+            masterModule->setText(QString());
+
+            // Although there is now no text used here this may help to make the
+            // checkbox more central in the column
+            masterModule->setTextAlignment(Qt::AlignCenter);
+
+            QString moduleName = pModules[i];
+            itemEntry->setText(moduleName);
+            itemEntry->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+            itemLocation->setText(moduleInfo[0]);
+            itemLocation->setToolTip(moduleInfo[0]);                          // show the full path in a tooltip, in case it doesn't fit in the table
+            itemLocation->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled); // disallow editing of module path, because that is not saved
+            itemPriority->setData(Qt::EditRole, mpHost->mModulePriorities[moduleName]);
+            mModuleTable->setItem(row, 0, itemEntry);
+            mModuleTable->setItem(row, 1, itemPriority);
+            mModuleTable->setItem(row, 2, masterModule);
+            mModuleTable->setItem(row, 3, itemLocation);
+        }
+    }
+    mModuleTable->resizeColumnsToContents();
+}
+
+void dlgModuleManager::slot_install_module()
+{
+    if (!mpHost) {
+        return;
+    }
+
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Load Mudlet Module"), QDir::currentPath());
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    QFile file(fileName);
+    if (!file.open(QFile::ReadOnly | QFile::Text)) {
+        QMessageBox::warning(this, tr("Load Mudlet Module:"), tr("Cannot read file %1:\n%2.").arg(fileName, file.errorString()));
+        return;
+    }
+
+    mpHost->installPackage(fileName, 1);
+    for (int i = mModuleTable->rowCount() - 1; i >= 0; --i) {
+        mModuleTable->removeRow(i);
+    }
+
+    layoutModules();
+}
+
+void dlgModuleManager::slot_uninstall_module()
+{
+    if (!mpHost) {
+        return;
+    }
+
+    int cRow = mModuleTable->currentRow();
+    QTableWidgetItem* pI = mModuleTable->item(cRow, 0);
+    if (pI) {
+        mpHost->uninstallPackage(pI->text(), 1);
+    }
+    for (int i = mModuleTable->rowCount() - 1; i >= 0; --i) {
+        mModuleTable->removeRow(i);
+    }
+    layoutModules();
+}
+
+void dlgModuleManager::slot_module_clicked(QTableWidgetItem* pItem)
+{
+    if (!mpHost) {
+        return;
+    }
+
+    int i = pItem->row();
+
+    QTableWidgetItem* entry = mModuleTable->item(i, 0);
+    QTableWidgetItem* checkStatus = mModuleTable->item(i, 2);
+    QTableWidgetItem* itemPriority = mModuleTable->item(i, 1);
+    //  Not used programatically now: QTableWidgetItem* itemPath = moduleTable->item(i, 3);
+    if (!entry || !checkStatus || !itemPriority || !mpHost->mInstalledModules.contains(entry->text())) {
+        mModuleHelpButton->setDisabled(true);
+        if (checkStatus) {
+            checkStatus->setCheckState(Qt::Unchecked);
+            checkStatus->setFlags(Qt::NoItemFlags);
+        }
+        return;
+    }
+
+    if (mpHost->moduleHelp.contains(entry->text())) {
+        mModuleHelpButton->setDisabled((!mpHost->moduleHelp.value(entry->text()).contains(QStringLiteral("helpURL"))
+                                       || mpHost->moduleHelp.value(entry->text()).value(QStringLiteral("helpURL")).isEmpty()));
+    } else {
+        mModuleHelpButton->setDisabled(true);
+    }
+}
+
+void dlgModuleManager::slot_module_changed(QTableWidgetItem* pItem)
+{
+    if (!mpHost) {
+        return;
+    }
+
+    int i = pItem->row();
+
+    QStringList moduleStringList;
+    QTableWidgetItem* entry = mModuleTable->item(i, 0);
+    QTableWidgetItem* checkStatus = mModuleTable->item(i, 2);
+    QTableWidgetItem* itemPriority = mModuleTable->item(i, 1);
+    if (!entry || !checkStatus || !itemPriority || !mpHost->mInstalledModules.contains(entry->text())) {
+        return;
+    }
+    moduleStringList = mpHost->mInstalledModules.value(entry->text());
+    if (checkStatus->checkState() == Qt::Checked) {
+        moduleStringList[1] = QLatin1String("1");
+    } else {
+        moduleStringList[1] = QLatin1String("0");
+    }
+    mpHost->mInstalledModules[entry->text()] = moduleStringList;
+    mpHost->mModulePriorities[entry->text()] = itemPriority->text().toInt();
+}
+
+void dlgModuleManager::slot_help_module()
+{
+    if (!mpHost) {
+        return;
+    }
+    int cRow = mModuleTable->currentRow();
+    QTableWidgetItem* pI = mModuleTable->item(cRow, 0);
+    if (!pI) {
+        return;
+    }
+    if (mpHost->moduleHelp.value(pI->text()).contains(QLatin1String("helpURL")) && !mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")).isEmpty()) {
+        if (!mudlet::self()->openWebPage(mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")))) {
+            //failed first open, try for a module related path
+            QTableWidgetItem* item = mModuleTable->item(cRow, 3);
+            QString itemPath = item->text();
+            QStringList path = itemPath.split(QDir::separator());
+            path.pop_back();
+            path.append(QDir::separator());
+            path.append(mpHost->moduleHelp.value(pI->text()).value(QLatin1String("helpURL")));
+            QString path2 = path.join(QString());
+            if (!mudlet::self()->openWebPage(path2)) {
+                mModuleHelpButton->setDisabled(true);
+            }
+        }
+    }
 }

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -1,0 +1,55 @@
+#ifndef MUDLET_DLGMODULEMANAGER_H
+#define MUDLET_DLGMODULEMANAGER_H
+
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include "Host.h"
+
+#include "pre_guard.h"
+#include "QTableWidget"
+#include <QDialog>
+#include "post_guard.h"
+
+class Host;
+namespace Ui {
+class module_manager;
+}
+
+class dlgModuleManager : public QDialog
+{
+    Q_OBJECT
+
+public:
+    Q_DISABLE_COPY(dlgModuleManager)
+    explicit dlgModuleManager(QWidget* parent, Host*);
+    ~dlgModuleManager();
+
+private slots:
+
+
+private:
+    Ui::module_manager* ui;
+    Host* mpHost;
+    QTableWidget* mModuleTable;
+    QPushButton* mModuleUninstallButton;
+    QPushButton* mModuleInstallButton;
+    QPushButton* mModuleHelpButton;
+};
+
+#endif

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -2,6 +2,8 @@
 #define MUDLET_DLGMODULEMANAGER_H
 
 /***************************************************************************
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -3,6 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *   Copyright (C) 2011 by Chris Mitchell                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -39,14 +39,19 @@ public:
     Q_DISABLE_COPY(dlgModuleManager)
     explicit dlgModuleManager(QWidget* parent, Host*);
     ~dlgModuleManager();
+     void layoutModules();
+     QTableWidget* mModuleTable;
 
 private slots:
-
+    void slot_install_module();
+    void slot_uninstall_module();
+    void slot_help_module();
+    void slot_module_clicked(QTableWidgetItem*);
+    void slot_module_changed(QTableWidgetItem*);
 
 private:
     Ui::module_manager* ui;
     Host* mpHost;
-    QTableWidget* mModuleTable;
     QPushButton* mModuleUninstallButton;
     QPushButton* mModuleInstallButton;
     QPushButton* mModuleHelpButton;

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *   Copyright (C) 2011 by Heiko Koehn - KoehnHeiko@googlemail.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -35,12 +35,13 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     mPackageList->addItems(mpHost->mInstalledPackages);
     connect(mUninstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_uninstall_package);
     connect(mInstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_install_package);
-    setWindowTitle(tr("Package Manager"));
+    setWindowTitle(tr("Package Manager - %1").arg(mpHost->getName()));
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
 dlgPackageManager::~dlgPackageManager()
 {
+    mpHost->mpPackageManager = nullptr;
     delete ui;
 }
 

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -35,6 +35,7 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     mPackageList->addItems(mpHost->mInstalledPackages);
     connect(mUninstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_uninstall_package);
     connect(mInstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_install_package);
+    connect(mpHost->mpConsole, &QWidget::destroyed, this, &dlgPackageManager::close);
     setWindowTitle(tr("Package Manager - %1").arg(mpHost->getName()));
     setAttribute(Qt::WA_DeleteOnClose);
 }

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -1,4 +1,6 @@
 /***************************************************************************
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -1,0 +1,75 @@
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include "dlgPackageManager.h"
+#include "ui_package_manager.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+
+dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
+: QDialog(parent)
+, ui(new Ui::package_manager)
+, mpHost(pHost)
+{
+    ui->setupUi(this);
+    mPackageList = ui->packageList;
+    mUninstallButton = ui->uninstallButton;
+    mInstallButton = ui->installButton;
+    mPackageList->addItems(mpHost->mInstalledPackages);
+    connect(mUninstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_uninstall_package);
+    connect(mInstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_install_package);
+    setWindowTitle(tr("Package Manager"));
+    setAttribute(Qt::WA_DeleteOnClose);
+}
+
+dlgPackageManager::~dlgPackageManager()
+{
+    delete ui;
+}
+
+void dlgPackageManager::slot_install_package()
+{
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    QFile file(fileName);
+    if (!file.open(QFile::ReadOnly | QFile::Text)) {
+        QMessageBox::warning(this, tr("Import Mudlet Package:"), tr("Cannot read file %1:\n%2.").arg(fileName, file.errorString()));
+        return;
+    }
+
+    mpHost->installPackage(fileName, 0);
+    mPackageList->clear();
+    mPackageList->addItems(mpHost->mInstalledPackages);
+}
+
+void dlgPackageManager::slot_uninstall_package()
+{
+    auto selectedPackages = mPackageList->selectedItems();
+    if (!selectedPackages.empty()) {
+        for (auto package : selectedPackages) {
+            mpHost->uninstallPackage(package->text(), 0);
+        }
+    }
+    mPackageList->clear();
+    mPackageList->addItems(mpHost->mInstalledPackages);
+}

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -2,6 +2,8 @@
 #define MUDLET_DLGPACKAGEMANAGER_H
 
 /***************************************************************************
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -1,0 +1,54 @@
+#ifndef MUDLET_DLGPACKAGEMANAGER_H
+#define MUDLET_DLGPACKAGEMANAGER_H
+
+/***************************************************************************
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+
+#include "Host.h"
+
+#include "pre_guard.h"
+#include <QDialog>
+#include "post_guard.h"
+
+class Host;
+namespace Ui {
+class package_manager;
+}
+
+class dlgPackageManager : public QDialog
+{
+    Q_OBJECT
+
+public:
+    Q_DISABLE_COPY(dlgPackageManager)
+    explicit dlgPackageManager(QWidget* parent, Host*);
+    ~dlgPackageManager();
+
+private slots:
+    void slot_install_package();
+    void slot_uninstall_package();
+
+private:
+    Ui::package_manager* ui;
+    Host* mpHost;
+    QListWidget* mPackageList;
+    QPushButton* mUninstallButton;
+    QPushButton* mInstallButton;
+};
+
+#endif

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -3,6 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *   Copyright (C) 2011 by Heiko Koehn - KoehnHeiko@googlemail.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -247,7 +247,6 @@ public:
     void replayOver();
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
-    bool moduleTableVisible();
     void doAutoLogin(const QString&);
     void stopSounds();
     void playSound(const QString &s, int);
@@ -315,7 +314,6 @@ public:
     QSet<QString> getWordSet();
     void scanForMudletTranslations(const QString&);
     void scanForQtTranslations(const QString&);
-    void layoutModules();
     void startAutoLogin(const QString&);
     int64_t getPhysicalMemoryTotal();
     const QMap<QByteArray, QString>& getEncodingNamesMap() const { return mEncodingNameMap; }
@@ -357,7 +355,6 @@ public:
     static QVariantHash mLuaFunctionNames;
     bool mHasSavedLayout;
     QPointer<dlgAboutDialog> mpAboutDlg;
-    QPointer<QDialog> mpModuleDlg;
     QPointer<dlgConnectionProfiles> mConnectionDialog;
     // More modern Desktop styles no longer include icons on the buttons in
     // QDialogButtonBox buttons - but some users are using Desktops (KDE4?) that
@@ -383,7 +380,6 @@ public:
     // are considered/used/stored
     QTextOption::Flags mEditorTextOptions;
 
-    QPointer<QTableWidget> moduleTable;
     QSystemTrayIcon mTrayIcon;
 
 #if defined(INCLUDE_UPDATER)
@@ -434,8 +430,6 @@ public slots:
     void slot_show_help_dialog_forum();
     void slot_show_help_dialog_irc();
     void slot_open_mappingscripts_page();
-    void slot_module_clicked(QTableWidgetItem*);
-    void slot_module_changed(QTableWidgetItem*);
     void slot_multi_view(const bool);
     void slot_toggle_multi_view();
     void slot_connection_dlg_finished(const QString& profile, bool connectOnLoad);
@@ -449,10 +443,7 @@ public slots:
     void slot_discord();
     void slot_package_manager();
     void slot_package_exporter();
-    void slot_uninstall_module();
-    void slot_install_module();
     void slot_module_manager();
-    void slot_help_module();
 #if defined(INCLUDE_UPDATER)
     void slot_check_manual_update();
 #endif
@@ -505,7 +496,6 @@ private slots:
     void slot_gamepadDisconnected(int deviceId);
     void slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis axis, double value);
 #endif
-    void slot_module_manager_destroyed();
 #if defined(INCLUDE_UPDATER)
     void slot_update_installed();
     void slot_updateAvailable(const int);
@@ -604,11 +594,6 @@ private:
     QPointer<QAction> mpActionTimers;
     QPointer<QAction> mpActionTriggers;
     QPointer<QAction> mpActionVariables;
-
-    QPointer<Host> mpModuleTableHost;
-    QPointer<QPushButton> moduleUninstallButton;
-    QPointer<QPushButton> moduleInstallButton;
-    QPointer<QPushButton> moduleHelpButton;
 
     HostManager mHostManager;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -358,7 +358,6 @@ public:
     bool mHasSavedLayout;
     QPointer<dlgAboutDialog> mpAboutDlg;
     QPointer<QDialog> mpModuleDlg;
-    QPointer<QDialog> mpPackageManagerDlg;
     QPointer<dlgConnectionProfiles> mConnectionDialog;
     // More modern Desktop styles no longer include icons on the buttons in
     // QDialogButtonBox buttons - but some users are using Desktops (KDE4?) that
@@ -448,8 +447,6 @@ public slots:
     void slot_close_profile_requested(int);
     void slot_irc();
     void slot_discord();
-    void slot_uninstall_package();
-    void slot_install_package();
     void slot_package_manager();
     void slot_package_exporter();
     void slot_uninstall_module();
@@ -607,10 +604,6 @@ private:
     QPointer<QAction> mpActionTimers;
     QPointer<QAction> mpActionTriggers;
     QPointer<QAction> mpActionVariables;
-
-    QPointer<QListWidget> packageList;
-    QPointer<QPushButton> uninstallButton;
-    QPointer<QPushButton> installButton;
 
     QPointer<Host> mpModuleTableHost;
     QPointer<QPushButton> moduleUninstallButton;

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -512,9 +512,11 @@ SOURCES += \
     dlgConnectionProfiles.cpp \
     dlgIRC.cpp \
     dlgKeysMainArea.cpp \
+    dlgModuleManager.cpp \
     dlgMapper.cpp \
     dlgNotepad.cpp \
     dlgPackageExporter.cpp \
+    dlgPackageManager.cpp \
     dlgProfilePreferences.cpp \
     dlgRoomExits.cpp \
     dlgRoomSymbol.cpp \
@@ -619,8 +621,10 @@ HEADERS += \
     dlgIRC.h \
     dlgKeysMainArea.h \
     dlgMapper.h \
+    dlgModuleManager.h \
     dlgNotepad.h \
     dlgPackageExporter.h \
+    dlgPackageManager.h \
     dlgProfilePreferences.h \
     dlgRoomExits.h \
     dlgRoomSymbol.h \
@@ -734,8 +738,10 @@ FORMS += \
     ui/irc.ui \
     ui/keybindings_main_area.ui \
     ui/main_window.ui \
+    ui/module_manager.ui \
     ui/mapper.ui \
     ui/notes_editor.ui \
+    ui/package_manager.ui \
     ui/profile_preferences.ui \
     ui/room_exits.ui \
     ui/room_symbol.ui \


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Creates the classes dlgPackageManager and dlgModuleManager and their own files.
Get's the code for them out of mudlet.cpp

#### Motivation for adding to Mudlet
This will make it a lot easier for reformatting or adding features to the package/module manager.

for example to get the infos, which will be put in for packages, visible in a gui (if I will finish #4885 and if it will get in) 

#### Other info (issues closed, discussion etc)
installModule/uninstallModule/enableModuleSync/disableModuleSync in TLuaInterpreter had also to be adjusted
and installModule/uninstallModule now returns true/false on success. I don't think this will break backwards compatibility as installModule before didn't return anything on success/failure and uninstallModule returned the name of the module on failure and a function (itself) on success.
