### PR TITLE
bring focus back to main command line if label/miniconsole in floating UserWindow have been clicked 

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -107,7 +107,7 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
-    auto labelParent = dynamic_cast<TConsole*>(parent());
+    auto labelParent = qobject_cast<TConsole*>(parent());
     if (labelParent && labelParent->mpDockWidget && labelParent->mpDockWidget->isFloating()) {
         mpHost->mpConsole->activateWindow();
         mpHost->mpConsole->setFocus();

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -23,6 +23,8 @@
 
 
 #include "TLabel.h"
+#include "TConsole.h"
+#include "TDockWidget.h"
 #include "mudlet.h"
 
 #include "pre_guard.h"
@@ -105,6 +107,12 @@ void TLabel::mouseDoubleClickEvent(QMouseEvent* event)
 
 void TLabel::mouseReleaseEvent(QMouseEvent* event)
 {
+    auto labelParent = dynamic_cast<TConsole*>(parent());
+    if (labelParent && labelParent->mpDockWidget && labelParent->mpDockWidget->isFloating()) {
+        mpHost->mpConsole->activateWindow();
+        mpHost->mpConsole->setFocus();
+    }
+
     if (mpHost && mReleaseFunction) {
         mpHost->getLuaInterpreter()->callLabelCallbackEvent(mReleaseFunction, event);
         event->accept();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1724,6 +1724,11 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
 
     if (mpConsole->getType() == TConsole::SubConsole) {
         qApp->sendEvent(mpConsole->parentWidget(), &newEvent);
+        auto subConsoleParent = dynamic_cast<TConsole*>(mpConsole->parent());
+        if (subConsoleParent && subConsoleParent->mpDockWidget && subConsoleParent->mpDockWidget->isFloating()) {
+            mpHost->mpConsole->activateWindow();
+            mpHost->mpConsole->setFocus();
+        }
     }
 
     if (mpConsole->getType() == TConsole::MainConsole || mpConsole->getType() == TConsole::UserWindow) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1724,7 +1724,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
 
     if (mpConsole->getType() == TConsole::SubConsole) {
         qApp->sendEvent(mpConsole->parentWidget(), &newEvent);
-        auto subConsoleParent = dynamic_cast<TConsole*>(mpConsole->parent());
+        auto subConsoleParent = qobject_cast<TConsole*>(mpConsole->parent());
         if (subConsoleParent && subConsoleParent->mpDockWidget && subConsoleParent->mpDockWidget->isFloating()) {
             mpHost->mpConsole->activateWindow();
             mpHost->mpConsole->setFocus();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Uses the same method as plain UserWindows already use to bring back the focus to the main command line
if a Label or a Mini(Sub)Console in a (floating) UserWindow have been clicked.
#### Motivation for adding to Mudlet
fix #4891 

#### Other info (issues closed, discussion etc)

#### Release post highlight
Issue with main command line losing focus if elements in a floating UserWindow have been clicked is fixed.
