### PR TITLE
Bug fix make drag and drop trigger chains work again

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -232,7 +232,7 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
         QModelIndex child = parent.model()->index(start, 0, parent);
         int parentPosition = parent.row();
         int childPosition = child.row();
-        if (! mChildID) {
+        if (!mChildID) {
             if (!parent.model()) {
                 QTreeWidget::rowsInserted(parent, start, end);
                 return;

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -190,6 +190,8 @@ void TTreeWidget::mousePressEvent(QMouseEvent* event)
 
 void TTreeWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end)
 {
+    // We only move one element (though it may have its own children) at a time
+    // so end is always the same as start (?)
     Q_UNUSED(end)
 
     if (parent.isValid()) {
@@ -198,17 +200,20 @@ void TTreeWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int
         mOldParentID = 0;
     }
 
-    if (mOldParentID == 0) {
+    if (!mOldParentID) {
         mOldParentID = parent.sibling(start, 0).data(Qt::UserRole).toInt();
     }
 
     if (parent.isValid()) {
         QModelIndex child = parent.model()->index(start, 0, parent);
         mChildID = child.data(Qt::UserRole).toInt();
-        if (mChildID == 0) {
+        if (!mChildID) {
             if (parent.isValid()) {
+                // This if seems redundant - as it has already been done once
+                // and "parent" hasn't changed - so it will always be true:
                 child = parent.model()->index(start, 0, QModelIndex());
             }
+
             if (child.isValid()) {
                 mChildID = child.data(Qt::UserRole).toInt();
             } else {
@@ -227,30 +232,28 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
         QModelIndex child = parent.model()->index(start, 0, parent);
         int parentPosition = parent.row();
         int childPosition = child.row();
-        if (mChildID == 0) {
+        if (! mChildID) {
             if (!parent.model()) {
-                goto END;
+                QTreeWidget::rowsInserted(parent, start, end);
+                return;
             }
             if (!mpHost) {
-                goto END;
+                QTreeWidget::rowsInserted(parent, start, end);
+                return;
             }
             mChildID = parent.model()->index(start, 0).data(Qt::UserRole).toInt();
         }
+
         int newParentID = parent.data(Qt::UserRole).toInt();
         if (mIsTriggerTree) {
             mpHost->getTriggerUnit()->reParentTrigger(mChildID, mOldParentID, newParentID, parentPosition, childPosition);
-        }
-        if (mIsAliasTree) {
+        } else if (mIsAliasTree) {
             mpHost->getAliasUnit()->reParentAlias(mChildID, mOldParentID, newParentID, parentPosition, childPosition);
-        }
-        if (mIsKeyTree) {
+        } else if (mIsKeyTree) {
             mpHost->getKeyUnit()->reParentKey(mChildID, mOldParentID, newParentID, parentPosition, childPosition);
-        }
-
-        if (mIsTimerTree) {
+        } else if (mIsTimerTree) {
             mpHost->getTimerUnit()->reParentTimer(mChildID, mOldParentID, newParentID, parentPosition, childPosition);
             TTimer* pTChild = mpHost->getTimerUnit()->getTimer(mChildID);
-            //TTimer * pTnewParent = mpHost->getTimerUnit()->getTimer( newParentID );
             if (pTChild) {
                 QIcon icon;
                 if (pTChild->isOffsetTimer()) {
@@ -268,12 +271,15 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
                 }
                 QTreeWidgetItem* pParent = itemFromIndex(parent);
                 if (!pParent) {
-                    goto END;
+                    QTreeWidget::rowsInserted(parent, start, end);
+                    return;
                 }
+
                 for (int i = 0; i < pParent->childCount(); i++) {
                     QTreeWidgetItem* pItem = pParent->child(i);
                     if (!pItem) {
-                        goto END;
+                        QTreeWidget::rowsInserted(parent, start, end);
+                        return;
                     }
                     int id = pItem->data(0, Qt::UserRole).toInt();
                     if (id == mChildID) {
@@ -281,20 +287,23 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
                     }
                 }
             }
-        }
-        if (mIsScriptTree) {
+        } else if (mIsScriptTree) {
             mpHost->getScriptUnit()->reParentScript(mChildID, mOldParentID, newParentID, parentPosition, childPosition);
-        }
-        if (mIsActionTree) {
+        } else if (mIsActionTree) {
             mpHost->getActionUnit()->reParentAction(mChildID, mOldParentID, newParentID, parentPosition, childPosition);
             mpHost->getActionUnit()->updateToolbar();
+        } else {
+            qWarning().nospace().noquote() << "TTreeWidget::rowsInserted(...) WARNING - a TTreeWidget item which has not been classified as a mudlet type detected.";
+            // Consider marking this:
+            // Q_UNREACHABLE();
         }
 
+        // CHECK: These things are NOT hit if we have "return"-ed early, is this okay?
         mChildID = 0;
         mOldParentID = 0;
         mIsDropAction = false;
     }
-END:
+
     QTreeWidget::rowsInserted(parent, start, end);
 }
 

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -203,7 +203,7 @@ void TTreeWidget::rowsAboutToBeRemoved(const QModelIndex& parent, int start, int
     }
 
     if (parent.isValid()) {
-        QModelIndex child = parent.model()->index(start, 0);
+        QModelIndex child = parent.model()->index(start, 0, parent);
         mChildID = child.data(Qt::UserRole).toInt();
         if (mChildID == 0) {
             if (parent.isValid()) {
@@ -224,7 +224,7 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
     // determine position in parent list
 
     if (mIsDropAction) {
-        QModelIndex child = parent.model()->index(start, 0);
+        QModelIndex child = parent.model()->index(start, 0, parent);
         int parentPosition = parent.row();
         int childPosition = child.row();
         if (mChildID == 0) {

--- a/src/TTreeWidget.h
+++ b/src/TTreeWidget.h
@@ -47,6 +47,8 @@ public:
     void rowsInserted(const QModelIndex& parent, int start, int end) override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+    // TODO: replace these eight methods with a single one to "characterise"
+    // the TTreeWidget instance after creation:
     void setHost(Host* pH);
     void setIsScriptTree();
     void setIsTimerTree();
@@ -63,6 +65,7 @@ private:
     QPointer<Host> mpHost;
     int mOldParentID;
     int mChildID;
+    // TODO: replace these seven booleans with a single enum:
     bool mIsTriggerTree;
     bool mIsAliasTree;
     bool mIsScriptTree;
@@ -70,6 +73,7 @@ private:
     bool mIsKeyTree;
     bool mIsVarTree;
     bool mIsActionTree;
+    // CHECK: Should this actually be a: QPersistentModelIndex ?
     QModelIndex mClickedItem;
 };
 


### PR DESCRIPTION
It seems the replacement for obsolete code I made in #4461 was incomplete
as I had missed off a defaulted but in our case required argument to:
`[pure virtual] (QModelIndex) QAbstractItemModel::index(int, int,
                          const QModelIndex &parent = QModelIndex()) const`
in two places.

Thanks to @Edru2 for pointing this detail out and thus finding the fix!

This will close #4899.

The second commit contains other turd polishing in the same area of the
code base but not essential to the bug fix.

Marking as a **medium** bugfix because although it is not fatal to the
application it still needs to be got into the code ASAP.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
This will fix a bug introduced into the development branch ***after*** the last release so will not necessarily be a *release* post issue - obviously it will however be present in the PTBs.