### PR TITLE
Enhance: display item Id number

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -821,6 +821,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpScrollArea->setMinimumHeight(triggerWidgetItemMinHeight);
 
     showHiddenVars = false;
+    mIdLabelBlankText = tr("ID: ?");
+    mIdLabelText = tr("ID: %1");
     widget_searchTerm->updateGeometry();
 
     if (mAutosaveInterval > 0) {
@@ -2574,6 +2576,7 @@ void dlgTriggerEditor::delete_alias()
     }
     delete pT;
     mpCurrentAliasItem = nullptr;
+    mpAliasMainArea->label_id->setText(mIdLabelBlankText);
 }
 
 void dlgTriggerEditor::delete_action()
@@ -2603,6 +2606,7 @@ void dlgTriggerEditor::delete_action()
     }
     delete pT;
     mpCurrentActionItem = nullptr;
+    mpActionsMainArea->label_id->setText(mIdLabelBlankText);
     mpHost->getActionUnit()->updateToolbar();
 }
 
@@ -2652,6 +2656,7 @@ void dlgTriggerEditor::delete_script()
     }
     delete pT;
     mpCurrentScriptItem = nullptr;
+    mpScriptsMainArea->label_id->setText(mIdLabelBlankText);
 }
 
 void dlgTriggerEditor::delete_key()
@@ -2674,6 +2679,7 @@ void dlgTriggerEditor::delete_key()
     }
     delete pT;
     mpCurrentKeyItem = nullptr;
+    mpKeysMainArea->label_id->setText(mIdLabelBlankText);
 }
 
 void dlgTriggerEditor::delete_trigger()
@@ -2696,6 +2702,7 @@ void dlgTriggerEditor::delete_trigger()
     }
     delete pT;
     mpCurrentTriggerItem = nullptr;
+    mpTriggersMainArea->label_id->setText(mIdLabelBlankText);
 }
 
 void dlgTriggerEditor::delete_timer()
@@ -2718,6 +2725,7 @@ void dlgTriggerEditor::delete_timer()
     }
     delete pT;
     mpCurrentTimerItem = nullptr;
+    mpTimersMainArea->label_id->setText(mIdLabelBlankText);
 }
 
 
@@ -3339,6 +3347,7 @@ void dlgTriggerEditor::addTrigger(bool isFolder)
         pParent->setExpanded(true);
     }
     mpTriggersMainArea->lineEdit_trigger_name->clear();
+    mpTriggersMainArea->label_id->setText(mIdLabelBlankText);
     mpTriggersMainArea->groupBox_perlSlashGOption->setChecked(false);
 
     clearDocument(mpSourceEditorEdbee); // New Trigger
@@ -3435,8 +3444,6 @@ void dlgTriggerEditor::addTimer(bool isFolder)
     if (pParent) {
         pParent->setExpanded(true);
     }
-    //FIXME
-    //mpOptionsAreaTriggers->lineEdit_trigger_name->clear();
     mpTimersMainArea->lineEdit_timer_command->clear();
     clearDocument(mpSourceEditorEdbee); // New Timer
     mpCurrentTimerItem = pNewItem;
@@ -3454,14 +3461,14 @@ void dlgTriggerEditor::addVar(bool isFolder)
         mpSourceEditorEdbee->setEnabled(false);
         mpVarsMainArea->comboBox_variable_value_type->setDisabled(true);
         mpVarsMainArea->comboBox_variable_value_type->setCurrentIndex(4);
-        mpVarsMainArea->lineEdit_var_name->setText(QString());
+        mpVarsMainArea->lineEdit_var_name->clear();
         mpVarsMainArea->lineEdit_var_name->setPlaceholderText(tr("Table name..."));
 
         clearDocument(mpSourceEditorEdbee, QLatin1String("NewTable"));
     } else {
         // in lieu of readonly
         mpSourceEditorEdbee->setEnabled(true);
-        mpVarsMainArea->lineEdit_var_name->setText(QString());
+        mpVarsMainArea->lineEdit_var_name->clear();
         mpVarsMainArea->lineEdit_var_name->setPlaceholderText(tr("Variable name..."));
         mpVarsMainArea->comboBox_variable_value_type->setDisabled(false);
         mpVarsMainArea->comboBox_variable_value_type->setCurrentIndex(0);
@@ -3679,6 +3686,7 @@ void dlgTriggerEditor::addAlias(bool isFolder)
     mpAliasMainArea->lineEdit_alias_name->clear();
     mpAliasMainArea->lineEdit_alias_pattern->clear();
     mpAliasMainArea->lineEdit_alias_command->clear();
+    mpAliasMainArea->label_id->setText(mIdLabelBlankText);
     clearDocument(mpSourceEditorEdbee); // New Alias
 
     mpAliasMainArea->lineEdit_alias_name->setText(name);
@@ -3849,6 +3857,7 @@ void dlgTriggerEditor::addScript(bool isFolder)
         pParent->setExpanded(true);
     }
     mpScriptsMainArea->lineEdit_script_name->clear();
+    mpScriptsMainArea->label_id->setText(mIdLabelBlankText);
     //FIXME mpScriptsMainArea->pattern_textedit->clear();
 
     clearDocument(mpSourceEditorEdbee, script);
@@ -5009,7 +5018,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
     mpTriggersMainArea->show();
     mpSourceEditorArea->show();
     clearEditorNotification();
-    mpTriggersMainArea->lineEdit_trigger_name->setText("");
+    mpTriggersMainArea->lineEdit_trigger_name->clear();
+    mpTriggersMainArea->label_id->setText(mIdLabelBlankText);
     clearDocument(mpSourceEditorEdbee); // Trigger Select
     mpTriggersMainArea->groupBox_multiLineTrigger->setChecked(false);
     mpTriggersMainArea->groupBox_perlSlashGOption->setChecked(false);
@@ -5121,6 +5131,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
         mpScrollArea->ensureWidgetVisible(mTriggerPatternEdit.at(qBound(0, patternList.size(), 49)));
         QString command = pT->getCommand();
         mpTriggersMainArea->lineEdit_trigger_name->setText(pItem->text(0));
+        mpTriggersMainArea->label_id->setText(mIdLabelText.arg(QString::number(pT->getID())));
         mpTriggersMainArea->lineEdit_trigger_command->setText(command);
         mpTriggersMainArea->groupBox_multiLineTrigger->setChecked(pT->isMultiline());
         mpTriggersMainArea->groupBox_perlSlashGOption->setChecked(pT->mPerlSlashGOption);
@@ -5191,6 +5202,7 @@ void dlgTriggerEditor::slot_alias_selected(QTreeWidgetItem* pItem)
     mpAliasMainArea->lineEdit_alias_name->clear();
     mpAliasMainArea->lineEdit_alias_pattern->clear();
     mpAliasMainArea->lineEdit_alias_command->clear();
+    mpAliasMainArea->label_id->setText(mIdLabelBlankText);
     clearDocument(mpSourceEditorEdbee); // Alias Select
 
     mpAliasMainArea->lineEdit_alias_name->setText(pItem->text(0));
@@ -5204,6 +5216,7 @@ void dlgTriggerEditor::slot_alias_selected(QTreeWidgetItem* pItem)
         mpAliasMainArea->lineEdit_alias_pattern->setText(pattern);
         mpAliasMainArea->lineEdit_alias_command->setText(command);
         mpAliasMainArea->lineEdit_alias_name->setText(name);
+        mpAliasMainArea->label_id->setText(mIdLabelText.arg(QString::number(ID)));
 
         clearDocument(mpSourceEditorEdbee, pT->getScript());
 
@@ -5242,6 +5255,7 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem* pItem)
     mpKeysMainArea->lineEdit_key_command->clear();
     mpKeysMainArea->lineEdit_key_binding->clear();
     mpKeysMainArea->lineEdit_key_name->clear();
+    mpKeysMainArea->label_id->setText(mIdLabelBlankText);
     clearDocument(mpSourceEditorEdbee); // Key Select
 
     mpKeysMainArea->lineEdit_key_binding->setText(pItem->text(0));
@@ -5250,9 +5264,9 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem* pItem)
     if (pT) {
         QString command = pT->getCommand();
         QString name = pT->getName();
-        mpKeysMainArea->lineEdit_key_command->clear();
         mpKeysMainArea->lineEdit_key_command->setText(command);
         mpKeysMainArea->lineEdit_key_name->setText(name);
+        mpKeysMainArea->label_id->setText(mIdLabelText.arg(QString::number(pT->getID())));
         QString keyName = mpHost->getKeyUnit()->getKeyName(pT->getKeyCode(), pT->getKeyModifiers());
         mpKeysMainArea->lineEdit_key_binding->setText(keyName);
 
@@ -5586,6 +5600,7 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem* pItem)
 
     mpActionsMainArea->lineEdit_action_icon->clear();
     mpActionsMainArea->lineEdit_action_name->clear();
+    mpActionsMainArea->label_id->setText(mIdLabelBlankText);
     mpActionsMainArea->checkBox_action_button_isPushDown->setChecked(false);
     mpActionsMainArea->lineEdit_action_button_command_down->clear();
     mpActionsMainArea->lineEdit_action_button_command_up->clear();
@@ -5603,6 +5618,7 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem* pItem)
     TAction* pT = mpHost->getActionUnit()->getAction(ID);
     if (pT) {
         mpActionsMainArea->lineEdit_action_name->setText(pT->getName());
+        mpActionsMainArea->label_id->setText(mIdLabelText.arg(QString::number(ID)));
         mpActionsMainArea->checkBox_action_button_isPushDown->setChecked(pT->isPushDownButton());
         mpActionsMainArea->label_action_button_command_up->hide();
         mpActionsMainArea->label_action_button_command_down->hide();
@@ -5734,6 +5750,7 @@ void dlgTriggerEditor::slot_scripts_selected(QTreeWidgetItem* pItem)
     mpScriptsMainArea->lineEdit_script_name->clear();
     mpScriptsMainArea->listWidget_script_registered_event_handlers->clear();
     mpScriptsMainArea->lineEdit_script_name->setText(pItem->text(0));
+    mpScriptsMainArea->label_id->setText(mIdLabelBlankText);
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(ID);
     if (pT) {
@@ -5749,6 +5766,7 @@ void dlgTriggerEditor::slot_scripts_selected(QTreeWidgetItem* pItem)
         clearDocument(mpSourceEditorEdbee, script);
 
         mpScriptsMainArea->lineEdit_script_name->setText(name);
+        mpScriptsMainArea->label_id->setText(mIdLabelText.arg(QString::number(ID)));
         if (!pT->state()) {
             showError(pT->getError());
         }
@@ -5789,6 +5807,7 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
     mpTimersMainArea->timeEdit_timer_seconds->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->timeEdit_timer_msecs->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->lineEdit_timer_name->setText(pItem->text(0));
+    mpTimersMainArea->label_id->setText(mIdLabelBlankText);
 
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
@@ -5803,6 +5822,7 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
         QString name = pT->getName();
         mpTimersMainArea->lineEdit_timer_command->setText(command);
         mpTimersMainArea->lineEdit_timer_name->setText(name);
+        mpTimersMainArea->label_id->setText(mIdLabelText.arg(QString::number(pT->getID())));
         QTime time = pT->getTime();
         mpTimersMainArea->timeEdit_timer_hours->setTime(QTime(time.hour(), 0, 0, 0));
         mpTimersMainArea->timeEdit_timer_minutes->setTime(QTime(0, time.minute(), 0, 0));

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -5,7 +5,7 @@
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2017-2020 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2015-2018, 2020 by Stephen Lyons                        *
+ *   Copyright (C) 2015-2018, 2020-2021 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -517,6 +517,9 @@ private:
     QString msgInfoAddButton;
     QString msgInfoAddVar;
     QString msgInfoAddKey;
+
+    QString mIdLabelBlankText;
+    QString mIdLabelText;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(dlgTriggerEditor::SearchOptions)

--- a/src/ui/actions_main_area.ui
+++ b/src/ui/actions_main_area.ui
@@ -73,6 +73,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label_id">
+        <property name="frameShape">
+         <enum>QFrame::Box</enum>
+        </property>
+        <property name="text">
+         <string>ID: ?</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/ui/aliases_main_area.ui
+++ b/src/ui/aliases_main_area.ui
@@ -58,6 +58,16 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="4">
+    <widget class="QLabel" name="label_id">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>ID: ?</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_alias_pattern">
      <property name="sizePolicy">
@@ -114,7 +124,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
+   <item row="1" column="3" colspan="2">
     <widget class="QComboBox" name="comboBox_alias_regex">
      <property name="enabled">
       <bool>false</bool>
@@ -153,7 +163,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="3">
+   <item row="2" column="1" colspan="4">
     <widget class="QLineEdit" name="lineEdit_alias_command">
      <property name="minimumSize">
       <size>

--- a/src/ui/keybindings_main_area.ui
+++ b/src/ui/keybindings_main_area.ui
@@ -34,6 +34,16 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_id">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>ID: ?</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="label_key_command">
      <property name="text">
@@ -44,7 +54,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="2">
+   <item row="1" column="1" colspan="3">
     <widget class="QLineEdit" name="lineEdit_key_command">
      <property name="toolTip">
       <string>&lt;p&gt;Type in one or more commands you want the key to send directly to the game when pressed. (Optional)&lt;/p&gt;&lt;p&gt;To send more complex commands, that could depend on or need to modifies variables within this profile a Lua script should be entered &lt;i&gt;instead&lt;/i&gt; in the editor area below.  Anything entered here is, literally, just sent to the game server.&lt;/p&gt;&lt;p&gt;It is permissable to use both this &lt;i&gt;and&lt;/i&gt; a Lua script - this will be sent &lt;b&gt;before&lt;/b&gt; the script is run.&lt;/p&gt;</string>
@@ -71,7 +81,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="2" colspan="2">
     <widget class="QPushButton" name="pushButton_key_grabKey">
      <property name="text">
       <string>Grab New Key</string>

--- a/src/ui/scripts_main_area.ui
+++ b/src/ui/scripts_main_area.ui
@@ -34,6 +34,16 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_id">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>ID: ?</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0" alignment="Qt::AlignRight">
     <widget class="QLabel" name="label_script_registered_event_handlers">
      <property name="text">
@@ -63,7 +73,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="1" column="2" colspan="2">
     <widget class="QToolButton" name="toolButton_script_remove_event_handler">
      <property name="minimumSize">
       <size>
@@ -108,7 +118,7 @@
    <item row="2" column="1">
     <widget class="QLineEdit" name="lineEdit_script_event_handler_entry"/>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="2" colspan="2">
     <widget class="QToolButton" name="toolButton_script_add_event_handler">
      <property name="minimumSize">
       <size>

--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -40,6 +40,16 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="9">
+    <widget class="QLabel" name="label_id">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>ID: ?</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="label_timer_command">
      <property name="sizePolicy">
@@ -68,7 +78,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1" colspan="8">
+   <item row="1" column="1" colspan="9">
     <widget class="QLineEdit" name="lineEdit_timer_command">
      <property name="toolTip">
       <string>&lt;p&gt;Type in one or more commands you want the timer to send directly to the game when the time has elapsed. (Optional)&lt;/p&gt;&lt;p&gt;To send more complex commands, that could depend on or need to modifies variables within this profile a Lua script should be entered &lt;i&gt;instead&lt;/i&gt; in the editor area below.  Anything entered here is, literally, just sent to the game server.&lt;/p&gt;&lt;p&gt;It is permissable to use both this &lt;i&gt;and&lt;/i&gt; a Lua script - this will be sent &lt;b&gt;before&lt;/b&gt; the script is run.&lt;/p&gt;</string>
@@ -123,7 +133,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="7" alignment="Qt::AlignBottom">
+   <item row="2" column="7" colspan="2" alignment="Qt::AlignBottom">
     <widget class="QLabel" name="label_timer_millis">
      <property name="font">
       <font>
@@ -414,7 +424,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="8">
+   <item row="3" column="8" colspan="2">
     <spacer name="horizontalSpacer_timeWidgets">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -128,6 +128,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label_id">
+        <property name="frameShape">
+         <enum>QFrame::Box</enum>
+        </property>
+        <property name="text">
+         <string>ID: ?</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Shows the ID number (for permanent items) in the editor view for all (but
variables) item types.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
indicates the ID number for all (but variables) in the editor.