### PR TITLE
Syncronize list of clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
+# PLACEMARKER: list of clang-tidy checks
 Checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg'
 # Use .clang-format for formatting
 FormatStyle: file

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -109,7 +109,8 @@ jobs:
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory
-        clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion'
+        # PLACEMARKER: list of clang-tidy checks
+        clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg'
         # the action doesn't see system-level libraries, need to replicate them here
         apt_packages: 'pkg-config,libzip-dev,libglu1-mesa-dev,libpulse-dev'
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Syncronize list of clang-tidy checks
#### Motivation for adding to Mudlet
So the analysis bot actually uses the checks relevant to us. I put them in the file, but forgot to also update the bot's list
#### Other info (issues closed, discussion etc)
It's unclear if the bot can use the same file or not: https://github.com/ZedThree/clang-tidy-review/issues/9
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
