### PR TITLE
Automatically set the key name, just like aliases

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4794,7 +4794,7 @@ void dlgTriggerEditor::saveKey()
     }
 
     QString name = mpKeysMainArea->lineEdit_key_name->text();
-    if (name.isEmpty()) {
+    if (name.isEmpty() || name == tr("New key")) {
         name = mpKeysMainArea->lineEdit_key_binding->text();
     }
     QString command = mpKeysMainArea->lineEdit_key_command->text();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Automatically set the key name if one wasn't provided, just like aliases:

![Peek 2021-03-07 10-25](https://user-images.githubusercontent.com/110988/110235380-fffea100-7f2f-11eb-9922-86918d704113.gif)

#### Motivation for adding to Mudlet
A nice QoL improvement as suggested by https://discord.com/channels/283581582550237184/283582068334526464/817723067396390914
#### Other info (issues closed, discussion etc)

#### Release post highlight
Changelog:
* new keybindings will now have the name automatically set if none was given, just like aliases. No more hordes of "New key".