### PR TITLE
Use a normal cursor in view mode & a closed cursor on drag

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -163,7 +163,6 @@ T2DMap::T2DMap(QWidget* parent)
     mMultiSelectionListWidget.move(0, 0);
     mMultiSelectionListWidget.hide();
     connect(&mMultiSelectionListWidget, &QTreeWidget::itemSelectionChanged, this, &T2DMap::slot_roomSelectionChanged);
-    setCursor(Qt::OpenHandCursor);
 }
 
 void T2DMap::init()
@@ -2399,11 +2398,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* e)
     //move map with left mouse button + ALT (->
     if (mpMap->mLeftDown) {
         mpMap->mLeftDown = false;
-        if (mMapViewOnly) {
-            setCursor(Qt::OpenHandCursor);
-        } else {
-            unsetCursor();
-        }
+        unsetCursor();
     }
 
     if (e->button() & Qt::LeftButton) {
@@ -3422,11 +3417,6 @@ void T2DMap::slot_toggleMapViewOnly()
         // In the init() case this is a no-op, otherwise it ensures the profile
         // state matches the local copy (so it gets saved with the profile):
         mpHost->mMapViewOnly = mMapViewOnly;
-        if (mMapViewOnly) {
-            setCursor(Qt::OpenHandCursor);
-        } else {
-            unsetCursor();
-        }
         TEvent mapModeEvent{};
         mapModeEvent.mArgumentList.append(QLatin1String("mapModeChangeEvent"));
         mapModeEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
How users are used to seeing the cursors - normal cursor when not dragging, closed hand when dragging:

https://user-images.githubusercontent.com/110988/110286386-216d9480-7fe5-11eb-87d2-b83a007590f6.mp4

Fix Mudlet to be the same intuitive behaviour:

https://user-images.githubusercontent.com/110988/110286417-2e8a8380-7fe5-11eb-80a8-f03315e1c8d5.mp4


#### Motivation for adding to Mudlet
Intuitive map scrolling

#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/4867

Behavior before was:

https://user-images.githubusercontent.com/110988/110286435-3813eb80-7fe5-11eb-8ce5-75b97865f467.mp4

This does make it not so obvious if you're in viewing or editing mode - but let's see from user feedback if that is a real problem before stressing a lot over it.

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
