### PR TITLE
Rename tray icon function to Quit Mudlet

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4324,7 +4324,7 @@ void mudlet::setupTrayIcon()
        mTrayIcon.hide();
     });
     menu->addAction(hideTrayAction);
-    auto exitAction = new QAction(tr("Exit"), this);
+    auto exitAction = new QAction(tr("Quit Mudlet"), this);
     connect(exitAction, &QAction::triggered, this, &mudlet::close);
     menu->addAction(exitAction);
     mTrayIcon.setContextMenu(menu);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Change text shown in Mudlet tray icon from "Exit" to "Quit Mudlet"

#### Motivation for adding to Mudlet
Players were surprised to see "Exit" tray icon function will close Mudlet with no coming back.

#### Other info (issues closed, discussion etc)
Part of #4918 
Actually choosing between *Exit*, *Close* and *Quit* is no easy platform-independent decision at all:
See for comparison: [https://ux.stackexchange.com/a/50896](https://ux.stackexchange.com/a/50896)
In any case, "Quit" should make it obvious, Mudlet will not continue afterwards in the background maybe.

#### Release post highlight
Maybe pull this in before 4.11 release? Then no highlight necessary