### PR TITLE
clear console selection if cmd line changes selection

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -70,7 +70,8 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
     setCenterOnScroll(false);
     setWordWrapMode(QTextOption::WrapAnywhere);
     setContentsMargins(0, 0, 0, 0);
-
+    // clear console selection if selection in command line changes
+    connect(this, &QPlainTextEdit::copyAvailable, [this](bool yes){mpConsole->clearSelection(yes);});
     // We do NOT want the standard context menu to happen as we generate it
     // ourself:
     setContextMenuPolicy(Qt::PreventContextMenu);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -674,7 +674,7 @@ void TConsole::refresh()
     QApplication::sendEvent(this, &event);
 }
 
-void TConsole::clearSelection(bool yes)
+void TConsole::clearSelection(bool yes) const
 {
     if (yes) {
         mLowerPane->unHighlight();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -674,6 +674,18 @@ void TConsole::refresh()
     QApplication::sendEvent(this, &event);
 }
 
+void TConsole::clearSelection(bool yes)
+{
+    if (yes) {
+        mLowerPane->unHighlight();
+        mUpperPane->unHighlight();
+        mLowerPane->mSelectedRegion = QRegion(0, 0, 0, 0);
+        mUpperPane->mSelectedRegion = QRegion(0, 0, 0, 0);
+        mUpperPane->forceUpdate();
+        mLowerPane->forceUpdate();
+    }
+}
+
 
 void TConsole::closeEvent(QCloseEvent* event)
 {

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -106,6 +106,7 @@ public:
     int getLineNumber();
     int getLineCount();
     bool deleteLine(int);
+    void clearSelection(bool);
 
     int getColumnNumber();
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -106,7 +106,7 @@ public:
     int getLineNumber();
     int getLineCount();
     bool deleteLine(int);
-    void clearSelection(bool);
+    void clearSelection(bool) const;
 
     int getColumnNumber();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Selection in main console gets cleared if something in command line is selected which is intuitive behaviour and prevents
accidental copying of wrong characters/text

#### Motivation for adding to Mudlet
part of #3922 is fixed
fix #4690

#### Other info (issues closed, discussion etc)

#### Release post highlight
copy/paste from command line works now as expected even if something in the main console was selected.
