### PR TITLE
default black background colour for labels

### DIFF
--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -512,6 +512,7 @@ TLabel* TMainConsole::createLabel(const QString& windowname, const QString& name
         pL->setContentsMargins(0, 0, 0, 0);
         pL->move(x, y);
         pL->show();
+        mpHost->setBackgroundColor(name, 0, 0, 0, 255);
         return pL;
     } else {
         return nullptr;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Labels have black background colour as default again.
#### Motivation for adding to Mudlet
fix #4926 
#### Other info (issues closed, discussion etc)
This issue was caused by getting rid of the palettes for mpMainFrame


