### PR TITLE
Align createLabel() with Geyser:Label default background color

### DIFF
--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -512,7 +512,7 @@ TLabel* TMainConsole::createLabel(const QString& windowname, const QString& name
         pL->setContentsMargins(0, 0, 0, 0);
         pL->move(x, y);
         pL->show();
-        mpHost->setBackgroundColor(name, 201, 209, 217, 255);
+        mpHost->setBackgroundColor(name, 32, 32, 32, 255);
         return pL;
     } else {
         return nullptr;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -512,7 +512,7 @@ TLabel* TMainConsole::createLabel(const QString& windowname, const QString& name
         pL->setContentsMargins(0, 0, 0, 0);
         pL->move(x, y);
         pL->show();
-        mpHost->setBackgroundColor(name, 0, 0, 0, 255);
+        mpHost->setBackgroundColor(name, 201, 209, 217, 255);
         return pL;
     } else {
         return nullptr;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Black on black is impossible to see - so use another color and align it with Geyser:Label

#### Motivation for adding to Mudlet
So newbies making their first labels have a better experience, and this'll help experienced devs as well
#### Other info (issues closed, discussion etc)
Not for the upcoming 4.11 release, too late now, but 4.12 yes.

Test with:
```lua
local width, height = getMainWindowSize()
createLabel("messageBox",(width/2)-300,(height/2)-100,250,150,1)
```

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
