### PR TITLE
Add file watches apis and event

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -588,7 +588,7 @@ void TLuaInterpreter::slot_pathChanged(const QString& path)
     }
 
     TEvent event {};
-    event.mArgumentList << QLatin1String("pathChanged");
+    event.mArgumentList << QLatin1String("sysPathChanged");
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
     event.mArgumentList << path;
     event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
@@ -13752,8 +13752,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "enableMapInfo", TLuaInterpreter::enableMapInfo);
     lua_register(pGlobalLua, "disableMapInfo", TLuaInterpreter::disableMapInfo);
     lua_register(pGlobalLua, "getProfileTabNumber", TLuaInterpreter::getProfileTabNumber);
-    lua_register(pGlobalLua, "addFileWatchPath", TLuaInterpreter::addFileWatchPath);
-    lua_register(pGlobalLua, "removeFileWatchPath", TLuaInterpreter::removeFileWatchPath);
+    lua_register(pGlobalLua, "addFileWatch", TLuaInterpreter::addFileWatch);
+    lua_register(pGlobalLua, "removeFileWatch", TLuaInterpreter::removeFileWatch);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     QStringList additionalLuaPaths;
@@ -15511,8 +15511,8 @@ int TLuaInterpreter::disableMapInfo(lua_State* L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addFileWatchPath
-int TLuaInterpreter::addFileWatchPath(lua_State * L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addFileWatch
+int TLuaInterpreter::addFileWatch(lua_State * L)
 {
     auto path = getVerifiedString(L, __func__, 1, "path");
     auto& host = getHostFromLua(L);
@@ -15526,8 +15526,8 @@ int TLuaInterpreter::addFileWatchPath(lua_State * L)
     return 1;
 }
 
-// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeFileWatchPath
-int TLuaInterpreter::removeFileWatchPath(lua_State * L)
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#removeFileWatch
+int TLuaInterpreter::removeFileWatch(lua_State * L)
 {
     auto path = getVerifiedString(L, __func__, 1, "path");
     auto& host = getHostFromLua(L);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -30,6 +30,7 @@
 
 #include "pre_guard.h"
 #include <QEvent>
+#include <QFileSystemWatcher>
 #include <QNetworkAccessManager>
 #include <QNetworkCookieJar>
 #include <QNetworkCookie>
@@ -599,6 +600,8 @@ public:
     static int enableMapInfo(lua_State*);
     static int disableMapInfo(lua_State*);
     static int getProfileTabNumber(lua_State*);
+    static int addFileWatchPath(lua_State*);
+    static int removeFileWatchPath(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 
@@ -608,6 +611,7 @@ public:
 
 public slots:
     void slot_httpRequestFinished(QNetworkReply*);
+    void slot_pathChanged(const QString& path);
     void slotPurge();
     void slotDeleteSender(int, QProcess::ExitStatus);
 
@@ -649,6 +653,7 @@ private:
 
 
     QNetworkAccessManager* mpFileDownloader;
+    QFileSystemWatcher* mpFileSystemWatcher;
     std::list<std::string> mCaptureGroupList;
     std::list<int> mCaptureGroupPosList;
     std::list<std::list<std::string>> mMultiCaptureGroupList;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -600,8 +600,8 @@ public:
     static int enableMapInfo(lua_State*);
     static int disableMapInfo(lua_State*);
     static int getProfileTabNumber(lua_State*);
-    static int addFileWatchPath(lua_State*);
-    static int removeFileWatchPath(lua_State*);
+    static int addFileWatch(lua_State*);
+    static int removeFileWatch(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adds API to add and remove paths from file watches.
Adds event for changes in observed paths.

Usage example:

```lua
addFileWatchPath(getMudletHomeDir() .. "/data.txt")
removeFileWatchPath(getMudletHomeDir() .. "/data.txt")

registerAnonymousEventHandler("pathChanged", function(event, path)
    echo(f("{path} changed"))
end)
```

#### Motivation for adding to Mudlet

Sometimes we provide some data in files... externally edited, downloaded etc. It would be nice to add ways for scripts to react on such edits, file creations, files deletions...

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
