### PR TITLE
Update getConnectionInfo() to mention if you're connected

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13017,10 +13017,11 @@ int TLuaInterpreter::getConnectionInfo(lua_State *L)
 {
     Host& host = getHostFromLua(L);
 
-    auto [hostName, hostPort] = host.mTelnet.getConnectionInfo();
+    auto [hostName, hostPort, connected] = host.mTelnet.getConnectionInfo();
     lua_pushstring(L, hostName.toUtf8().constData());
     lua_pushnumber(L, hostPort);
-    return 2;
+    lua_pushboolean(L, connected);
+    return 3;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Networking_Functions#unzipAsync

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -929,12 +929,15 @@ QString cTelnet::decodeOption(const unsigned char ch) const
     }
 }
 
-std::pair<QString, int> cTelnet::getConnectionInfo() const
+std::tuple<QString, int, bool> cTelnet::getConnectionInfo() const
 {
+    // intentionally simplify connection state to a boolean
+    const bool connected = socket.state() == QAbstractSocket::ConnectedState;
+
     if (hostName.isEmpty() && hostPort == 0) {
-        return {mpHost->getUrl(), mpHost->getPort()};
+        return {mpHost->getUrl(), mpHost->getPort(), connected};
     } else {
-        return {hostName, hostPort};
+        return {hostName, hostPort, connected};
     }
 }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -186,7 +186,7 @@ public:
     void requestDiscordInfo();
     QString decodeOption(const unsigned char) const;
     QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
-    std::pair<QString, int> getConnectionInfo() const;
+    std::tuple<QString, int, bool> getConnectionInfo() const;
 
 
     QMap<int, bool> supportedTelnetOptions;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update getConnectionInfo() to mention if you're connected.
#### Motivation for adding to Mudlet
Listening to the feedback from the players - they needed a `connected()`-like function.
#### Other info (issues closed, discussion etc)
Qt can describe the connection state with much more verbosity, but that isn't needed in our context and would complicate things for our players.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
