### PR TITLE
fix labels losing colour if stylesheet without colour informations is set on label

### DIFF
--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -199,6 +199,7 @@ public:
     QWidget* layerCommandLine;
     QHBoxLayout* layoutLayer2;
     QWidget* layerEdit;
+    QColor mBorderColor;
     QColor mBgColor;
     int mButtonState;
     QColor mCommandBgColor;
@@ -283,6 +284,7 @@ protected:
     void dropEvent(QDropEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
     void mousePressEvent(QMouseEvent*) override;
+    bool eventFilter(QObject*, QEvent*) override;
 
 
 private:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7110,8 +7110,8 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
     int luaGreen = getVerifiedInt(L, __func__, 2, "green");
     int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
     Host& host = getHostFromLua(L);
-    auto styleSheet = QStringLiteral("QWidget#MainFrame{ background-color: rgba(%1,%2,%3,255) }").arg(luaRed).arg(luaGreen).arg(luaBlue);
-    host.mpConsole->mpMainFrame->setStyleSheet(styleSheet);
+    host.mpConsole->mBorderColor.setRgb(luaRed, luaGreen, luaBlue);
+    host.mpConsole->mpMainFrame->update();
     return 0;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see title
#### Motivation for adding to Mudlet
Hotfix for Mudlet 4.11

#### Other info (issues closed, discussion etc)
Issue was caused when a label with a colour set got another stylesheet (without colour information)
minimal example:
```
createLabel("testLabel",0,0,300,300,1)
setBackgroundColor("testLabel",255,0,0)
echo("testLabel","Test")
setLabelStyleSheet("testLabel","padding: 20px;")
```

it seems that even if a stylesheet is only set on a parent with an identifier it still somehow influences children below (imho shouldn't be the case, probably a qt bug)
To avoid palette and or stylesheet propagation I'm using another method to fill the border colours, similar to how it is done in ttextedit.
#### Release post highlight
fix broken gui
