### PR TITLE
Inverted check for special exit lock when looking for useable exits for pathfinding

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -913,7 +913,7 @@ bool TMap::findPath(int from, int to)
         // No available normal exits from this room so check the special ones
         QStringList specialExitCommands = pFrom->getSpecialExits().keys();
         while (!specialExitCommands.isEmpty()) {
-            if (pFrom->hasSpecialExitLock(specialExitCommands.at(0))) {
+            if (!pFrom->hasSpecialExitLock(specialExitCommands.at(0))) {
                 hasUsableExit = true;
                 break;
             }


### PR DESCRIPTION
Simple change to invert special exits lock check when looking for useable exit at start of findPath.

Fix for https://github.com/Mudlet/Mudlet/issues/4946