### PR TITLE
Revert mpMainFrame palettes (Hotfix)

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -65,6 +65,12 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
     mRegularPalette.setColor(QPalette::Base, mpHost->mCommandLineBgColor);
 
     setPalette(mRegularPalette);
+    //style subCommandLines by stylesheet
+    if (mType != MainCommandLine) {
+        QColor c = mpHost->mCommandLineBgColor;
+        QString styleSheet{QStringLiteral("QPlainTextEdit{background-color: rgb(%1, %2, %3);}").arg(c.red()).arg(c.green()).arg(c.blue())};
+        setStyleSheet(styleSheet);
+    }
 
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setCenterOnScroll(false);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -59,7 +59,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , buffer(pH)
 , emergencyStop(new QToolButton)
 , layerCommandLine(nullptr)
-, mBorderColor(Qt::black)
 , mBgColor(Qt::black)
 , mCommandBgColor(Qt::black)
 , mCommandFgColor(QColor(213, 195, 0))
@@ -139,7 +138,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
             Q_ASSERT_X(false, "TConsole::TConsole(...)", "invalid TConsole type detected");
         }
     }
-    mpMainFrame->installEventFilter(this);
     setContentsMargins(0, 0, 0, 0);
     mFormatSystemMessage.setBackground(mBgColor);
     mFormatSystemMessage.setForeground(Qt::red);
@@ -542,8 +540,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         setAcceptDrops(true);
         setMouseTracking(true);
     }
-<<<<<<< Updated upstream
-=======
 
     QPalette framePalette;
     framePalette.setColor(QPalette::Text, QColor(Qt::black));
@@ -552,7 +548,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     mpMainFrame->setPalette(framePalette);
     mpMainFrame->setAutoFillBackground(true);
 
->>>>>>> Stashed changes
     if (mType & MainConsole) {
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());
     }
@@ -578,24 +573,6 @@ void TConsole::resizeConsole()
     QApplication::sendEvent(this, &event);
 }
 
-// mpMainFrame uses this to paint it's colour to avoid stylesheet and or palette propagation to it's children
-bool TConsole::eventFilter(QObject* object, QEvent* event)
-{
-    Q_UNUSED(object);
-    if (event->type() == QEvent::Paint) {
-        QPaintEvent* paintEvent = static_cast<QPaintEvent*>(event);
-        const QRect& rect = paintEvent->rect();
-        QPainter painter(mpMainFrame);
-        if (!painter.isActive()) {
-            return false;
-        }
-        QPixmap pixmap(rect.width(), rect.height());
-        pixmap.fill(mBorderColor);
-        painter.drawPixmap(0, 0, pixmap);
-        return true;
-    }
-    return false;
-}
 
 void TConsole::resizeEvent(QResizeEvent* event)
 {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -542,6 +542,17 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         setAcceptDrops(true);
         setMouseTracking(true);
     }
+<<<<<<< Updated upstream
+=======
+
+    QPalette framePalette;
+    framePalette.setColor(QPalette::Text, QColor(Qt::black));
+    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
+    framePalette.setColor(QPalette::Window, QColor(0, 0, 0, 255));
+    mpMainFrame->setPalette(framePalette);
+    mpMainFrame->setAutoFillBackground(true);
+
+>>>>>>> Stashed changes
     if (mType & MainConsole) {
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());
     }

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -199,7 +199,6 @@ public:
     QWidget* layerCommandLine;
     QHBoxLayout* layoutLayer2;
     QWidget* layerEdit;
-    QColor mBorderColor;
     QColor mBgColor;
     int mButtonState;
     QColor mCommandBgColor;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -284,7 +284,6 @@ protected:
     void dropEvent(QDropEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
     void mousePressEvent(QMouseEvent*) override;
-    bool eventFilter(QObject*, QEvent*) override;
 
 
 private:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7110,8 +7110,16 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
     int luaGreen = getVerifiedInt(L, __func__, 2, "green");
     int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
     Host& host = getHostFromLua(L);
+<<<<<<< Updated upstream
     host.mpConsole->mBorderColor.setRgb(luaRed, luaGreen, luaBlue);
     host.mpConsole->mpMainFrame->update();
+=======
+    QPalette framePalette;
+    framePalette.setColor(QPalette::Text, QColor(Qt::black));
+    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
+    framePalette.setColor(QPalette::Window, QColor(luaRed, luaGreen, luaBlue, 255));
+    host.mpConsole->mpMainFrame->setPalette(framePalette);
+>>>>>>> Stashed changes
     return 0;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7110,16 +7110,11 @@ int TLuaInterpreter::setBorderColor(lua_State* L)
     int luaGreen = getVerifiedInt(L, __func__, 2, "green");
     int luaBlue = getVerifiedInt(L, __func__, 3, "blue");
     Host& host = getHostFromLua(L);
-<<<<<<< Updated upstream
-    host.mpConsole->mBorderColor.setRgb(luaRed, luaGreen, luaBlue);
-    host.mpConsole->mpMainFrame->update();
-=======
     QPalette framePalette;
     framePalette.setColor(QPalette::Text, QColor(Qt::black));
     framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
     framePalette.setColor(QPalette::Window, QColor(luaRed, luaGreen, luaBlue, 255));
     host.mpConsole->mpMainFrame->setPalette(framePalette);
->>>>>>> Stashed changes
     return 0;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Revert mpMainFrame to use palettes instead of stylesheets.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Even though it could bring back some issues with some app stylesheets it seems to solve other issues.
