### PR TITLE
Add StickMUD to IRE Mapper script includes

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2009,7 +2009,7 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
                 {QStringLiteral(":/CF-loader.xml"), {QStringLiteral("carrionfields.net")}},
                 {QStringLiteral(":/run-tests.xml"), {QStringLiteral("mudlet.org")}},
                 {QStringLiteral(":/mudlet-mapper.xml"),
-                 {QStringLiteral("aetolia.com"), QStringLiteral("achaea.com"), QStringLiteral("lusternia.com"), QStringLiteral("imperian.com"), QStringLiteral("starmourn.com")}},
+                 {QStringLiteral("aetolia.com"), QStringLiteral("achaea.com"), QStringLiteral("lusternia.com"), QStringLiteral("imperian.com"), QStringLiteral("starmourn.com"), QStringLiteral("stickmud.com")}},
         };
 
         QHashIterator<QString, QStringList> i(defaultScripts);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
StickMUD is a default game on Mudlet and supports the IRE Mapper.  This change will help it receive the IRE Mapper by default and not the Generic Mapper to simplify the newbie experience.

#### Motivation for adding to Mudlet
Proper loading of mapping scripts.

#### Other info (issues closed, discussion etc)

#### Release post highlight
Auto load the IRE Mapper for StickMUD.
