### PR TITLE
BugFix: prevent initial split view in TConsoles

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -480,8 +480,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     splitter->setSizes(sizeList);
 
     mUpperPane->show();
-    // There is never a need to have the lower pane showing from this
-    // constructor as the associated TBuffer must always be empty at this point:
     mLowerPane->hide();
 
     connect(mpScrollBar, &QAbstractSlider::valueChanged, mUpperPane, &TTextEdit::slot_scrollBarMoved);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2021 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *
@@ -480,10 +480,9 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     splitter->setSizes(sizeList);
 
     mUpperPane->show();
-    mLowerPane->show();
-    mLowerPane->updateScreenView();
-    // timer needed as updateScreenView doesn't seem to finish in time
-    QTimer::singleShot(0, [this]() { mLowerPane->hide(); });
+    // There is never a need to have the lower pane showing from this
+    // constructor as the associated TBuffer must always be empty at this point:
+    mLowerPane->hide();
 
     connect(mpScrollBar, &QAbstractSlider::valueChanged, mUpperPane, &TTextEdit::slot_scrollBarMoved);
     connect(mpHScrollBar, &QAbstractSlider::valueChanged, mUpperPane, &TTextEdit::slot_hScrollBarMoved);


### PR DESCRIPTION
This was because the `(TTextEdit) TConsole::mLowerPane` was being shown and then hidden by a one shot "run when idle" timer when there is no need to AFAICT.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Remove irritating temporary split of consoles when they are created.