### PR TITLE
BugFix: properly dispose of editor when profile closed when multiplaying

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1284,7 +1284,9 @@ void mudlet::slot_close_profile_requested(int tab)
     }
 
     pH->stopAllTriggers();
+    pH->mpEditorDialog->setAttribute(Qt::WA_DeleteOnClose);
     pH->mpEditorDialog->close();
+    pH->mpEditorDialog = nullptr;
 
     for (auto consoleName : hostConsoleMap.keys()) {
         if (dockWindowMap.contains(consoleName)) {


### PR DESCRIPTION
I found whilst running Mudlet in GammaRay and opening/closing profiles that the `dlgTriggerEditor` instance used for each active profile's editor was not being destroyed when that profile was closed from the close button on it's tab in the tab bar...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Clean up memory leakage caused by not getting rid of redundant (though it is not visible) editor after a profile is closed whilst multi-playing.