### PR TITLE
Revert: don't copy timestamps in normal copy, even when they're on

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -855,7 +855,7 @@ void TTextEdit::highlightSelection()
     QClipboard* clipboard = QApplication::clipboard();
     if (clipboard->supportsSelection()) {
         // X11 has a second clipboard that's updated on any selection
-        clipboard->setText(getSelectedText(QChar::LineFeed, mShowTimeStamps), QClipboard::Selection);
+        clipboard->setText(getSelectedText(), QClipboard::Selection);
     }
 }
 
@@ -1399,7 +1399,7 @@ void TTextEdit::slot_copySelectionToClipboard()
         return;
     }
 
-    QString selectedText = getSelectedText(QChar::LineFeed, mShowTimeStamps);
+    QString selectedText = getSelectedText();
     QClipboard* clipboard = QApplication::clipboard();
     clipboard->setText(selectedText);
 }
@@ -1643,12 +1643,12 @@ void TTextEdit::searchSelectionOnline()
     QDesktopServices::openUrl(QUrl(url));
 }
 
-QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTimestamps)
+QString TTextEdit::getSelectedText(const QChar& newlineChar)
 {
     // mPA QPoint where selection started
     // mPB QPoint where selection ended
     // try to prevent crash if buffer is batch deleted
-    if (mPA.y() > mpBuffer->lineBuffer.size() - 1 || mPB.y() > mpBuffer->lineBuffer.size() - 1) {
+    if (mPA.y() > mpBuffer->lineBuffer.size() - 1 || mPB.y() > mpBuffer->lineBuffer.size() - 1){
         mPA.ry() -= mpBuffer->mBatchDeleteSize;
         mPB.ry() -= mpBuffer->mBatchDeleteSize;
     }
@@ -1658,13 +1658,6 @@ QString TTextEdit::getSelectedText(const QChar& newlineChar, const bool showTime
     int startPos = std::max(0, mPA.x());
     int endPos = std::min(mPB.x(), (mpBuffer->lineBuffer.at(endLine).size() - 1));
     QStringList textLines = mpBuffer->lineBuffer.mid(startLine, endLine - startLine + 1);
-    if (showTimestamps) {
-        QStringList timestamps = mpBuffer->timeBuffer.mid(startLine, endLine - startLine + 1);
-        QStringList result;
-        std::transform(textLines.cbegin(), textLines.cend(), timestamps.cbegin(), std::back_inserter(result),
-                               [](const QString& text, const QString& timestamp) { return timestamp + text; });
-        textLines = result;
-    }
 
     if (mPA.y() == mPB.y()) {
         // Is a single line, so trim characters off the beginning and end

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -132,7 +132,7 @@ private slots:
 
 private:
     void initDefaultSettings();
-    QString getSelectedText(const QChar& newlineChar = QChar::LineFeed, const bool showTimestamps = false);
+    QString getSelectedText(const QChar& newlineChar = QChar::LineFeed);
     static QString htmlCenter(const QString&);
     static QString convertWhitespaceToVisual(const QChar& first, const QChar& second = QChar::Null);
     static QString byteToLuaCodeOrChar(const char*);


### PR DESCRIPTION
This reverts commit 127bc02f210172abca8094021b3a0e757cdf4b38.

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Revert "Show timestamps in normal copy as well (#4684)".
#### Motivation for adding to Mudlet
A few people play with timestamps permanently on but don't actually want them copied. Need a better solution for this -> only copy if the mouse cursor was clicked on in the timestamps field.
#### Other info (issues closed, discussion etc)
Revert https://github.com/Mudlet/Mudlet/pull/4684
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
