### PR TITLE
BugFix: restore selection highlight when Cntr or TimeStamp click done

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1171,6 +1171,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
 
         if (mCtrlSelecting) {
             expandSelectionToLine(y);
+            highlightSelection();
             event->accept();
             return;
         }


### PR DESCRIPTION
This will close #4961.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Fixes a bug so that clicking on a timestamp or control-clicking a line in a console will now correctly highlight the whole line to show that it is selected.