### PR TITLE
order of setting the mpMainFrame palette seems to cause transparent miniconsoles to be white

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -151,6 +151,13 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     QSizePolicy sizePolicy5(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     mpMainFrame->setContentsMargins(0, 0, 0, 0);
+
+    QPalette framePalette;
+    framePalette.setColor(QPalette::Text, QColor(Qt::black));
+    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
+    framePalette.setColor(QPalette::Window, QColor(0, 0, 0, 255));
+    mpMainFrame->setPalette(framePalette);
+    mpMainFrame->setAutoFillBackground(true);
     mpMainFrame->setObjectName(QStringLiteral("MainFrame"));
 
     auto centralLayout = new QVBoxLayout;
@@ -541,11 +548,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         setMouseTracking(true);
     }
 
-    QPalette framePalette;
-    framePalette.setColor(QPalette::Text, QColor(Qt::black));
-    framePalette.setColor(QPalette::Highlight, QColor(55, 55, 255));
-    framePalette.setColor(QPalette::Window, QColor(0, 0, 0, 255));
-    mpMainFrame->setPalette(framePalette);
     mpMainFrame->setAutoFillBackground(true);
 
     if (mType & MainConsole) {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -548,7 +548,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         setMouseTracking(true);
     }
 
-    mpMainFrame->setAutoFillBackground(true);
 
     if (mType & MainConsole) {
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This put the setting of the mpMainFrame palette to where it was before the latest changes.
The order seemed to matter transparent miniconsoles seemed to be white in some special situations:
using a dark stylesheet like Darktheme for example
#### Motivation for adding to Mudlet
fixing that issue 
#### Other info (issues closed, discussion etc)
This should be in the next 4.11.2 hotfix as some player on stickmud seem to have this issue