### PR TITLE
Enhance: allow profiles to be reordered when multi-playing

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2492,8 +2492,8 @@ void Host::setName(const QString& newName)
         currentPlayerRoom = mpMap->mRoomIdHash.take(mHostName);
     }
 
-    // Now we have the exclusive lock on this class's protected members
     mHostName = newName;
+    mpConsole->setProperty(TMainConsole::scmProperty_HostName, newName);
 
     mTelnet.mProfileName = newName;
     if (mpMap) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2021 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *                                                                         *

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2493,7 +2493,7 @@ void Host::setName(const QString& newName)
     }
 
     mHostName = newName;
-    mpConsole->setProperty(TMainConsole::scmProperty_HostName, newName);
+    mpConsole->setProperty("HostName", newName);
 
     mTelnet.mProfileName = newName;
     if (mpMap) {

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2021 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -48,6 +48,9 @@
 #include <QPainter>
 #include "post_guard.h"
 
+
+const char* TMainConsole::scmProperty_HostName = "HostName";
+
 TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 : TConsole(pH, TConsole::MainConsole, parent)
 , mClipboard(pH)
@@ -74,6 +77,13 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
     // absence of files for the first run in a new profile or from an older
     // Mudlet version:
     setProfileSpellDictionary();
+
+    // Ensure the QWidget has the profile name embedded into it - since
+    // TMainConsole is derived from TConsole which is derived from QWidget which
+    // is derived from QObject then adding something to the
+    // (QList<QByteArray>) QObject::dynamicPropertyNames should be visible from
+    // the QWidget:
+    setProperty(TMainConsole::scmProperty_HostName, pH->getName());
 }
 
 TMainConsole::~TMainConsole()

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -49,8 +49,6 @@
 #include "post_guard.h"
 
 
-const char* TMainConsole::scmProperty_HostName = "HostName";
-
 TMainConsole::TMainConsole(Host* pH, QWidget* parent)
 : TConsole(pH, TConsole::MainConsole, parent)
 , mClipboard(pH)
@@ -79,7 +77,7 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
     setProfileSpellDictionary();
 
     // Ensure the QWidget has the profile name embedded into it
-    setProperty(TMainConsole::scmProperty_HostName, pH->getName());
+    setProperty("HostName", pH->getName());
 }
 
 TMainConsole::~TMainConsole()

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -78,11 +78,7 @@ TMainConsole::TMainConsole(Host* pH, QWidget* parent)
     // Mudlet version:
     setProfileSpellDictionary();
 
-    // Ensure the QWidget has the profile name embedded into it - since
-    // TMainConsole is derived from TConsole which is derived from QWidget which
-    // is derived from QObject then adding something to the
-    // (QList<QByteArray>) QObject::dynamicPropertyNames should be visible from
-    // the QWidget:
+    // Ensure the QWidget has the profile name embedded into it
     setProperty(TMainConsole::scmProperty_HostName, pH->getName());
 }
 

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -103,7 +103,6 @@ public:
     bool loadMap(const QString&);
     bool importMap(const QString&, QString* errMsg = Q_NULLPTR);
 
-    static const char* scmProperty_HostName;
 
     QMap<QString, TConsole*> mSubConsoleMap;
     QMap<QString, TDockWidget*> mDockWidgetMap;

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2020 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2016, 2018-2021 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *                                                                         *

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -103,6 +103,8 @@ public:
     bool loadMap(const QString&);
     bool importMap(const QString&, QString* errMsg = Q_NULLPTR);
 
+    static const char* scmProperty_HostName;
+
     QMap<QString, TConsole*> mSubConsoleMap;
     QMap<QString, TDockWidget*> mDockWidgetMap;
     QMap<QString, TCommandLine*> mSubCommandLineMap;

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2018, 2020-2021 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -181,4 +182,14 @@ void TTabBar::removeTab(const QString& name)
         setTabUnderline(index, false);
         QTabBar::removeTab(index);
     }
+}
+
+QStringList TTabBar::tabNames() const
+{
+    QStringList results;
+    for (int i = 0, total = count(); i < total; ++i) {
+        results << tabData(i).toString();
+    }
+
+    return results;
 }

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -2,7 +2,8 @@
 #define TTABBAR_H
 
 /***************************************************************************
- *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2018, 2020-2021 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -88,6 +89,7 @@ public:
     int tabIndex(const QString&) const;
     void removeTab(const QString&);
     void removeTab(int);
+    QStringList tabNames() const;
 
 private:
     // This instance of TStyle needs a pointer to a QTabBar on instantiation:

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4347,7 +4347,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
     // gone through them all it will mean that they are in the same order as the
     // tabs:
     for (int index = 0; index < itemsCount; ++index) {
-        auto wantedTabName = tabNamesInOrder.at(index);
+        const auto& wantedTabName = tabNamesInOrder.at(index);
         auto pLayoutItem = layoutItemMap.value(wantedTabName);
         // This will remove the item from whereever it is in the layout:
         mpHBoxLayout_profileContainer->removeItem(pLayoutItem);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4338,7 +4338,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
         auto pLayoutItem = mpHBoxLayout_profileContainer->itemAt(profileIndex);
         auto pWidget = pLayoutItem->widget();
         if (pWidget) {
-            auto name = pWidget->property(TMainConsole::scmProperty_HostName).toString();
+            auto name = pWidget->property("HostName").toString();
             layoutItemMap.insert(name, pLayoutItem);
         }
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1704,12 +1704,6 @@ Host* mudlet::getActiveHost()
     }
 }
 
-void mudlet::addSubWindow(TConsole* pConsole)
-{
-    mainPane->layout()->addWidget(pConsole);
-    pConsole->show(); //NOTE: this is important for Apple OSX otherwise the console isnt displayed
-}
-
 void mudlet::closeEvent(QCloseEvent* event)
 {
     for (auto pHost : mHostManager) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -180,7 +180,7 @@ mudlet::mudlet()
 , mCopyAsImageTimeout{3}
 , mUsingMudletDictionaries(false)
 , mpDlgProfilePreferences(nullptr)
-, mainPane(nullptr)
+, mpWidget_profileContainer(nullptr)
 , mIsGoingDown(false)
 , mMenuBarVisibility(visibleAlways)
 , mToolbarVisibility(visibleAlways)
@@ -297,25 +297,23 @@ mudlet::mudlet()
     mpTabBar->setTabsClosable(true);
     mpTabBar->setAutoHide(true);
     connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_close_profile_requested);
-    // TODO: Do not enable this option currently - although the user can drag
-    // the tabs, the underlying main TConsoles do not move with multiview enabled
-    mpTabBar->setMovable(false);
+    mpTabBar->setMovable(true);
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tab_changed);
+    connect(mpTabBar, &QTabBar::tabMoved, this, &mudlet::slot_tabMoved);
     auto layoutTopLevel = new QVBoxLayout(frame);
     layoutTopLevel->setContentsMargins(0, 0, 0, 0);
     layoutTopLevel->addWidget(mpTabBar);
-    mainPane = new QWidget(frame);
+    mpWidget_profileContainer = new QWidget(frame);
     QPalette mainPalette;
-    mainPane->setPalette(mainPalette);
-    mainPane->setAutoFillBackground(true);
-    mainPane->setFocusPolicy(Qt::NoFocus);
-    layoutTopLevel->addWidget(mainPane);
-    auto layout = new QHBoxLayout(mainPane);
-    layout->setContentsMargins(0, 0, 0, 0);
+    mpWidget_profileContainer->setPalette(mainPalette);
+    mpWidget_profileContainer->setContentsMargins(0, 0, 0, 0);
+    mpWidget_profileContainer->setSizePolicy(sizePolicy);
+    mpWidget_profileContainer->setFocusPolicy(Qt::NoFocus);
+    mpWidget_profileContainer->setAutoFillBackground(true);
+    layoutTopLevel->addWidget(mpWidget_profileContainer);
+    mpHBoxLayout_profileContainer = new QHBoxLayout(mpWidget_profileContainer);
+    mpHBoxLayout_profileContainer->setContentsMargins(0, 0, 0, 0);
 
-    mainPane->setContentsMargins(0, 0, 0, 0);
-    mainPane->setSizePolicy(sizePolicy);
-    mainPane->setFocusPolicy(Qt::NoFocus);
 
     QFile file_autolog(getMudletPath(mainDataItemPath, QStringLiteral("autolog")));
     if (file_autolog.exists()) {
@@ -510,7 +508,6 @@ mudlet::mudlet()
 
     disableToolbarButtons();
 
-    QFont mainFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
     if (mEnableFullScreenMode) {
         showFullScreen();
         QAction* actionFullScreeniew = new QAction(QIcon(QStringLiteral(":/icons/dialog-cancel.png")), tr("Toggle Full Screen View"), this);
@@ -526,11 +523,12 @@ mudlet::mudlet()
     // the related profile - make the font size a little larger that the 6 it
     // once was so that it is a bit more obvious when it changes:
     QFont mdiFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
-    setFont(mainFont);
-    mainPane->setFont(mainFont);
     mpTabBar->setFont(mdiFont);
 
-    mainPane->show();
+    QFont mainFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
+    setFont(mainFont);
+    mpWidget_profileContainer->setFont(mainFont);
+    mpWidget_profileContainer->show();
 
     connect(mpActionConnect.data(), &QAction::triggered, this, &mudlet::slot_show_connection_dialog);
     connect(mpActionHelp.data(), &QAction::triggered, this, &mudlet::show_help_dialog);
@@ -1452,7 +1450,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     //update the main window title when we spawn a new tab
     setWindowTitle(pH->getName() + " - " + version);
 
-    mainPane->layout()->addWidget(pConsole);
+    mpHBoxLayout_profileContainer->addWidget(pConsole);
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->mpConsole->hide();
     }
@@ -4330,4 +4328,36 @@ void mudlet::setupTrayIcon()
     connect(exitAction, &QAction::triggered, this, &mudlet::close);
     menu->addAction(exitAction);
     mTrayIcon.setContextMenu(menu);
+}
+
+void mudlet::slot_tabMoved(const int oldPos, const int newPos)
+{
+    Q_UNUSED(newPos)
+    Q_UNUSED(oldPos)
+    const QStringList& tabNamesInOrder = mpTabBar->tabNames();
+    int itemsCount = mpHBoxLayout_profileContainer->count();
+    Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "missmatch in count of tabs and TMainConsoles");
+    QMap<QString, QLayoutItem*> layoutItemMap;
+    // Gather the QLayoutItem pointers for each TMainConsole and store them
+    // against their profile name:
+    for (int profileIndex = 0, total = mpHBoxLayout_profileContainer->count(); profileIndex < total; ++profileIndex) {
+        auto pLayoutItem = mpHBoxLayout_profileContainer->itemAt(profileIndex);
+        auto pWidget = pLayoutItem->widget();
+        if (pWidget) {
+            auto name = pWidget->property(TMainConsole::scmProperty_HostName).toString();
+            layoutItemMap.insert(name, pLayoutItem);
+        }
+    }
+    // Now go through all the names, pull the associated QLayoutItem from the
+    // layout and then re-add each of them at the end in turn - once we have
+    // gone through them all it will mean that they are in the same order as the
+    // tabs:
+    for (int index = 0; index < itemsCount; ++index) {
+        auto wantedTabName = tabNamesInOrder.at(index);
+        auto pLayoutItem = layoutItemMap.value(wantedTabName);
+        // This will remove the item from whereever it is in the layout:
+        mpHBoxLayout_profileContainer->removeItem(pLayoutItem);
+        // This will readd the item to the end of the layout:
+        mpHBoxLayout_profileContainer->addItem(pLayoutItem);
+    }
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -509,6 +509,7 @@ private slots:
     void slot_compact_input_line(const bool);
     void slot_password_migrated_to_secure(QKeychain::Job *job);
     void slot_password_migrated_to_profile(QKeychain::Job *job);
+    void slot_tabMoved(const int oldPos, const int newPos);
 
 
 private:
@@ -527,7 +528,8 @@ private:
     void installModulesList(Host*, QStringList);
     void setupTrayIcon();
 
-    QWidget* mainPane;
+    QWidget* mpWidget_profileContainer;
+    QHBoxLayout* mpHBoxLayout_profileContainer;
 
     static QPointer<mudlet> _self;
     QMap<Host*, QToolBar*> mUserToolbarMap;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -206,7 +206,6 @@ public:
     static void start();
     HostManager& getHostManager() { return mHostManager; }
     void attachDebugArea(const QString& hostname);
-    void addSubWindow(TConsole* p);
     void addConsoleForNewHost(Host* pH);
     void disableToolbarButtons();
     void enableToolbarButtons();


### PR DESCRIPTION
This implements a requested feature to allow the tabs on the tab bar to be reordered and the profiles displayed underneath when multi-playing to follow suite. This not being done previously was why I had to lock the tab bar because at that time the tabs could move but the profiles did not!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

~~Tabs and their associated profiles' Main Consoles can now be rearranged when multi-playing.~~
Profiles can now be rearranged when multi-playing.