### PR TITLE
Skip unknown MSP elements

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2188,7 +2188,8 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
                 } else if (mspVAR == "U") {
                     mediaData.setMediaUrl(mspVAL);
                 } else {
-                    return; // Invalid MSP.
+                    qDebug() << "MSP: tag" << mspVAR << "isn't one we understand";
+                    continue; // robustness principle: ignore anything we don't understand
                 }
             }
         }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Apply the [Robustness principle](https://en.wikipedia.org/wiki/Robustness_principle) to MSP: if we get an unknown element, ignore it.
#### Motivation for adding to Mudlet
So Alter Aeon's non-standard tags work better.
#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582068334526464/821450256628842547
#### Release post highlight

* unknown MSP elements will be simply skipped, instead of ignoring the whole sound command