### PR TITLE
Trim default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,4 @@
 2. 
 3. 
 
-#### Error output / Expected result of feature
-
-
 #### Extra information, such as Mudlet version, operating system and ideas for how to solve / implement:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Trim default issue template - remove the `#### Error output / Expected result of feature`.
#### Motivation for adding to Mudlet
Make it a tiny easier for people to log things directly in Github. The section was not often used and felt more like a burden than help.
#### Other info (issues closed, discussion etc)

#### Release post highlight
Infrastructure: simplified issue/feature request template.
