### PR TITLE
Don't deselect text if typing in command line

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -77,7 +77,7 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
     setWordWrapMode(QTextOption::WrapAnywhere);
     setContentsMargins(0, 0, 0, 0);
     // clear console selection if selection in command line changes
-    connect(this, &QPlainTextEdit::copyAvailable, [this](bool yes){mpConsole->clearSelection(yes);});
+    connect(this, &QPlainTextEdit::copyAvailable, this, &TCommandLine::slot_clearSelection);
     // We do NOT want the standard context menu to happen as we generate it
     // ourself:
     setContextMenuPolicy(Qt::PreventContextMenu);
@@ -1044,6 +1044,13 @@ void TCommandLine::historyMove(MoveDirection direction)
     }
 }
 
+void TCommandLine::slot_clearSelection(bool yes)
+{
+    if (yes && !mSpellChecking) {
+        mpConsole->clearSelection();
+    }
+}
+
 void TCommandLine::slot_removeWord()
 {
     if (mSpellCheckedWord.isEmpty()) {
@@ -1078,6 +1085,7 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     }
 
     QTextCharFormat f;
+    mSpellChecking = true;
     c.select(QTextCursor::WordUnderCursor);
     QByteArray encodedText = mpHost->mpConsole->getHunspellCodec_system()->fromUnicode(c.selectedText());
     if (!Hunspell_spell(systemDictionaryHandle, encodedText.constData())) {
@@ -1107,6 +1115,7 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     }
     c.setCharFormat(f);
     setTextCursor(c);
+    mSpellChecking = false;
 }
 
 bool TCommandLine::handleCtrlTabChange(QKeyEvent* ke, int tabNumber)

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -94,7 +94,6 @@ private:
     bool keybindingMatched(QKeyEvent*);
     void spellCheckWord(QTextCursor& c);
     bool handleCtrlTabChange(QKeyEvent* key, int tabNumber);
-    bool mSpellChecking = false;
 
     QPointer<Host> mpHost;
     CommandLineType mType;
@@ -112,6 +111,7 @@ private:
     QString mTabCompletionOld;
     QPoint mPopupPosition;
     QString mSpellCheckedWord;
+    bool mSpellChecking = false;
     int mSystemDictionarySuggestionsCount;
     int mUserDictionarySuggestionsCount;
     char** mpSystemSuggestionsList;

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -79,6 +79,7 @@ public slots:
     void slot_popupMenu();
     void slot_addWord();
     void slot_removeWord();
+    void slot_clearSelection(bool yes);
 
 private:
     bool event(QEvent*) override;
@@ -93,6 +94,7 @@ private:
     bool keybindingMatched(QKeyEvent*);
     void spellCheckWord(QTextCursor& c);
     bool handleCtrlTabChange(QKeyEvent* key, int tabNumber);
+    bool mSpellChecking = false;
 
     QPointer<Host> mpHost;
     CommandLineType mType;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -680,16 +680,14 @@ void TConsole::refresh()
     QApplication::sendEvent(this, &event);
 }
 
-void TConsole::clearSelection(bool yes) const
+void TConsole::clearSelection() const
 {
-    if (yes) {
         mLowerPane->unHighlight();
         mUpperPane->unHighlight();
         mLowerPane->mSelectedRegion = QRegion(0, 0, 0, 0);
         mUpperPane->mSelectedRegion = QRegion(0, 0, 0, 0);
         mUpperPane->forceUpdate();
         mLowerPane->forceUpdate();
-    }
 }
 
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -682,12 +682,12 @@ void TConsole::refresh()
 
 void TConsole::clearSelection() const
 {
-        mLowerPane->unHighlight();
-        mUpperPane->unHighlight();
-        mLowerPane->mSelectedRegion = QRegion(0, 0, 0, 0);
-        mUpperPane->mSelectedRegion = QRegion(0, 0, 0, 0);
-        mUpperPane->forceUpdate();
-        mLowerPane->forceUpdate();
+    mLowerPane->unHighlight();
+    mUpperPane->unHighlight();
+    mLowerPane->mSelectedRegion = QRegion(0, 0, 0, 0);
+    mUpperPane->mSelectedRegion = QRegion(0, 0, 0, 0);
+    mUpperPane->forceUpdate();
+    mLowerPane->forceUpdate();
 }
 
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -106,7 +106,7 @@ public:
     int getLineNumber();
     int getLineCount();
     bool deleteLine(int);
-    void clearSelection(bool) const;
+    void clearSelection() const;
 
     int getColumnNumber();
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Selected text in the console window won't be deselected just by typing in the command line if the spellchecker is on anymore.

#### Motivation for adding to Mudlet
fix #4985 
#### Other info (issues closed, discussion etc)
This was caused by the spellchecker (silently) selecting the text in the command line which then deselected the main 
console text.

#### Release post highlight
Text won't get deselected by typing in the command line anymore.
