### PR TITLE
fix broken perm functions

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11501,7 +11501,7 @@ std::pair<bool, QString> TLuaInterpreter::validLuaCode(const QString &code)
             e += "No error message available from Lua";
         }
     }
-    lua_pop(L, topElementIndex);
+    lua_pop(L, 1);
     return {!error, e};
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see title
#### Motivation for adding to Mudlet
fix #5003
#### Other info (issues closed, discussion etc)
```cpp
lua_pop(L, topElementIndex); 
```
was deleting the whole stack but the stack was still needed after code validation
#### Release post highlight
perm functions and set script work again
