### PR TITLE
prevent run code twice if script in group (on resetProfile) and prevent setScript code running twice

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -14221,7 +14221,6 @@ std::pair<int, QString> TLuaInterpreter::setScriptCode(QString& name, const QStr
         pS->setScript(oldCode);
         return {-1, QStringLiteral("unable to compile \"%1\" at position \"%2\", reason: %3").arg(luaCode).arg(++pos).arg(errMsg)};
     }
-    pS->setScript(luaCode);
     int id = pS->getID();
     mpHost->mpEditorDialog->writeScript(id);
     return {id, QString()};

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -85,6 +85,9 @@ void TScript::setEventHandlerList(QStringList handlerList)
 
 void TScript::compileAll()
 {
+    if (mpHost->mResetProfile) {
+        mNeedsToBeCompiled = true;
+    }
     compile();
     for (auto script : *mpMyChildrenList) {
         script->compileAll();
@@ -101,7 +104,7 @@ void TScript::callEventHandler(const TEvent& pE)
 
 void TScript::compile()
 {
-    if (mNeedsToBeCompiled || mpHost->mResetProfile) {
+    if (mNeedsToBeCompiled) {
         if (!compileScript()) {
             if (mudlet::debugMode) {
                 TDebug(QColor(Qt::white), QColor(Qt::red)) << "ERROR: Lua compile error. compiling script of script:" << mName << "\n" >> 0;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see title
#### Motivation for adding to Mudlet
fix  #5005
#### Other info (issues closed, discussion etc)
setScript cannot be tested as long as #5004 isn't in
but I tested it (with that fix in code) and it seems to work

#### Release post highlight
code won't run twice when using setScript anymore.
code won't run twice (or more often) when in a group when using resetProfile() anymore
