### PR TITLE
prevent multiple resize event if size didn't change

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -584,7 +584,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int y = event->size().height();
 
     // don't call event in lua if size didn't change
-    bool preventLuaEvent = (x == mpMainFrame->width() && y == mpMainFrame->height());
+    bool preventLuaEvent = (x == oldSize.width() && y == oldSize.height());
 
     if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
@@ -607,6 +607,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
 
     QWidget::resizeEvent(event);
+    oldSize = size();
 
     if (preventLuaEvent) {
         return;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -583,6 +583,9 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int x = event->size().width();
     int y = event->size().height();
 
+    // don't call event in lua if size didn't change
+    bool preventLuaEvent = (x == mpMainFrame->width() && y == mpMainFrame->height());
+
     if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
@@ -604,6 +607,10 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
 
     QWidget::resizeEvent(event);
+
+    if (preventLuaEvent) {
+        return;
+    }
 
     if (mType & (MainConsole|Buffer)) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -584,7 +584,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int y = event->size().height();
 
     // don't call event in lua if size didn't change
-    bool preventLuaEvent = (x == oldSize.width() && y == oldSize.height());
+    bool preventLuaEvent = (event->size() == mOldSize);
 
     if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
@@ -607,7 +607,7 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
 
     QWidget::resizeEvent(event);
-    oldSize = size();
+    mOldSize = size();
 
     if (preventLuaEvent) {
         return;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -287,6 +287,7 @@ protected:
 
 private:
     ConsoleType mType;
+    QSize oldSize;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -287,7 +287,7 @@ protected:
 
 private:
     ConsoleType mType;
-    QSize oldSize;
+    QSize mOldSize;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
see title
#### Motivation for adding to Mudlet
fix #5002
#### Other info (issues closed, discussion etc)
This definitely needs testing as it is possible that some GUI build on the expected behaviour.
#### Release post highlight
sysWindowResizeEvent won't be called if size didn't really change anymore