### PR TITLE
avoid crash caused by mssp eventhandler

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1477,6 +1477,7 @@ void Host::unregisterEventHandler(const QString& name, TScript* pScript)
     }
 }
 
+// If a handler matches the event, the Lua stack will be cleared after this function
 void Host::raiseEvent(const TEvent& pE)
 {
     if (pE.mArgumentList.isEmpty()) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11988,7 +11988,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
         Host& host = getHostFromLua(L);
 
         for (int i = 1; i < packageList.size(); i++) {
-            //clear the stack to avoid it getting to big
+            // clear the stack to avoid it getting to big
             lua_settop(L, 0);
 
             QStringList payloadList = packageList[i].split(MSSP_VAL);
@@ -12021,7 +12021,6 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
                 QString msg = QStringLiteral("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
                 host.mpConsole->printSystemMessage(msg);
             }
-            //this potentially clears the stack if an eventhandler is set
             host.raiseEvent(event);
         }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11986,9 +11986,11 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
 
     if (packageList.size() > 0) {
         Host& host = getHostFromLua(L);
-        lua_getglobal(L, "mssp");
 
         for (int i = 1; i < packageList.size(); i++) {
+            //clear the stack to avoid it getting to big
+            lua_settop(L, 0);
+
             QStringList payloadList = packageList[i].split(MSSP_VAL);
 
             if (payloadList.size() != 2) {
@@ -11998,6 +12000,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             QString msspVAR = payloadList[0];
             QString msspVAL = payloadList[1];
 
+            lua_getglobal(L, "mssp");
             lua_pushstring(L, msspVAR.toUtf8().constData());
             lua_pushlstring(L, msspVAL.toUtf8().constData(), msspVAL.toUtf8().length());
 
@@ -12009,7 +12012,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             token.append(".");
             token.append(msspVAR);
 
-            TEvent event {};
+            TEvent event{};
             event.mArgumentList.append(token);
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             event.mArgumentList.append(token);
@@ -12018,8 +12021,8 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
                 QString msg = QStringLiteral("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
                 host.mpConsole->printSystemMessage(msg);
             }
+            //this potentially clears the stack if an eventhandler is set
             host.raiseEvent(event);
-            lua_settop (L, 1);
         }
 
         lua_pop(L, lua_gettop(L));


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Avoids crash caused if an eventhandler on mssp is set.
#### Motivation for adding to Mudlet
fix #4970
#### Other info (issues closed, discussion etc)
https://github.com/Mudlet/Mudlet/issues/4970#issuecomment-803947347
#### Release post highlight

