### PR TITLE
Fix crash with getMapLabels() when used on invalid area

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8073,7 +8073,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
     Host& host = getHostFromLua(L);
     lua_newtable(L);
     auto pA = host.mpMap->mpRoomDB->getArea(area);
-    if (!pA->mMapLabels.isEmpty()) {
+    if (pA && !pA->mMapLabels.isEmpty()) {
         QMapIterator<int, TMapLabel> it(pA->mMapLabels);
         while (it.hasNext()) {
             it.next();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix `getMapLabels(134235314)` (invalid area) crashing Mudlet.
#### Motivation for adding to Mudlet
Losing people's map work is a serious issue, should not happen.
#### Other info (issues closed, discussion etc)

#### Release post highlight
Fixed: getMapLabels() crashing when used on an invalid area.