### PR TITLE
BugFix: repair borked searchAreaUserData in with both key and value case

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4912,7 +4912,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-        QList<int> areaIds{areaIdsSet.begin(), areaIdsSet.begin()};
+        QList<int> areaIds{areaIdsSet.begin(), areaIdsSet.end()};
 #else
         QList<int> areaIds{areaIdsSet.toList()};
 #endif


### PR DESCRIPTION
This was introduced by my PR #3705 on 2020/05/01.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Fixed a bug in recent versions where `searchAreaUserData(...)` would fail to give any area ids (as output) when *both* a key **and** a value for that key were provided.