### PR TITLE
Load latest map correctly if it turns out to be a JSON one

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1401,6 +1401,10 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             return false;
         }
 
+        if (file.fileName().endsWith(QStringLiteral(".json"), Qt::CaseInsensitive)) {
+            return readJsonMapFile(file.fileName()).first;
+        }
+
         QDataStream ifs(&file);
         // Is the RUN-TIME version of the Qt libraries equal to or more than
         // Qt 5.13.0? Then force things to use the backwards compatible format


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
If the latest map was a JSON one, 4.11 would error - this fixes it:


https://user-images.githubusercontent.com/110988/112174315-9b616880-8bf6-11eb-96c9-e806a769e550.mp4


([streamable link](https://streamable.com/olo9go))

#### Motivation for adding to Mudlet
Better user experience.
#### Other info (issues closed, discussion etc)
Originally noted in https://github.com/Mudlet/Mudlet/pull/5016#issuecomment-804605480.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
