### PR TITLE
Fix nonsense message for when there's no rooms in the map

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1248,9 +1248,8 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = mpMap->mpRoomDB
-                ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
-                : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+        auto message = (mpMap->mpRoomDB && mpMap->mpRoomDB->size() > 0) ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
+                                                                        : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1251,7 +1251,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
 
         QString message;
         if (mpMap->mpRoomDB) {
-            if (mpMap->mpRoomDB->isEmpty() {
+            if (mpMap->mpRoomDB->isEmpty()) {
                 message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
             } else {
                 message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1248,8 +1248,16 @@ void T2DMap::paintEvent(QPaintEvent* e)
         auto font(painter.font());
         font.setPointSize(10);
         painter.setFont(font);
-        auto message = (mpMap->mpRoomDB && mpMap->mpRoomDB->size() > 0) ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
-                                                                        : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+
+        QString message;
+        if (mpMap->mpRoomDB && mpMap->mpRoomDB->isEmpty()) {
+            message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
+        } else if (mpMap->mpRoomDB && !mpMap->mpRoomDB->isEmpty()) {
+            message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+        } else {
+            message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+        }
+
         painter.drawText(0, 0, widgetWidth, widgetHeight, Qt::AlignCenter | Qt::TextWordWrap, message);
         painter.restore();
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1250,10 +1250,12 @@ void T2DMap::paintEvent(QPaintEvent* e)
         painter.setFont(font);
 
         QString message;
-        if (mpMap->mpRoomDB && mpMap->mpRoomDB->isEmpty()) {
-            message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
-        } else if (mpMap->mpRoomDB && !mpMap->mpRoomDB->isEmpty()) {
-            message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+        if (mpMap->mpRoomDB) {
+            if (mpMap->mpRoomDB->isEmpty() {
+                message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
+            } else {
+                message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+            }
         } else {
             message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
         }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -281,9 +281,15 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            auto message = (mpMap->mpRoomDB && mpMap->mpRoomDB->size() > 0)
-                                   ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
-                                   : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+
+            QString message;
+            if (mpMap->mpRoomDB && mpMap->mpRoomDB->isEmpty()) {
+                message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
+            } else if (mpMap->mpRoomDB && !mpMap->mpRoomDB->isEmpty()) {
+                message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+            } else {
+                message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+            }
             painter.drawText(0, 0, (width() -1), (height() -1), Qt::AlignCenter | Qt::TextWordWrap, message);
             painter.end();
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -281,9 +281,9 @@ void GLWidget::paintGL()
 #endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
-            auto message = mpMap->mpRoomDB
-                    ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
-                    : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
+            auto message = (mpMap->mpRoomDB && mpMap->mpRoomDB->size() > 0)
+                                   ? tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size())
+                                   : tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
             painter.drawText(0, 0, (width() -1), (height() -1), Qt::AlignCenter | Qt::TextWordWrap, message);
             painter.end();
 

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -283,10 +283,12 @@ void GLWidget::paintGL()
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
 
             QString message;
-            if (mpMap->mpRoomDB && mpMap->mpRoomDB->isEmpty()) {
-                message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
-            } else if (mpMap->mpRoomDB && !mpMap->mpRoomDB->isEmpty()) {
-                message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+            if (mpMap->mpRoomDB) {
+                if (mpMap->mpRoomDB->isEmpty() {
+                    message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
+                } else {
+                    message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());
+                }
             } else {
                 message = tr("You do not have a map yet - load one, or start mapping from scratch to begin.");
             }

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -284,7 +284,7 @@ void GLWidget::paintGL()
 
             QString message;
             if (mpMap->mpRoomDB) {
-                if (mpMap->mpRoomDB->isEmpty() {
+                if (mpMap->mpRoomDB->isEmpty()) {
                     message = tr("No rooms in the map - load another one, or start mapping from scratch to begin.");
                 } else {
                     message = tr("You have a map loaded (%n room(s)), but Mudlet does not know where you are at the moment.", "", mpMap->mpRoomDB->size());


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This message arguably makes little sense:

![image](https://user-images.githubusercontent.com/110988/112179609-1fb5ea80-8bfb-11eb-83fe-4de0688b8e79.png)

Now:

![image](https://user-images.githubusercontent.com/110988/112180789-26912d00-8bfc-11eb-8405-dff1b5174dd8.png)


#### Motivation for adding to Mudlet
More professional presentation.
#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
