### PR TITLE
Add icon size recommendation for package exporter

### DIFF
--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -158,6 +158,9 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="toolTip">
+              <string>512x512 recommended</string>
+             </property>
              <property name="text">
               <string>Add icon</string>
              </property>
@@ -176,6 +179,9 @@
                <width>48</width>
                <height>48</height>
               </size>
+             </property>
+             <property name="toolTip">
+              <string>512x512 recommended</string>
              </property>
              <property name="text">
               <string/>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add 512x512 recommendation for icons in package exporter:

![image](https://user-images.githubusercontent.com/110988/112444521-6a944700-8d4e-11eb-8db7-e8c8c1acf277.png)

#### Motivation for adding to Mudlet
So people use high-quality icons that show up in the [package website](http://172.105.1.54:8080/).
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/4996, close https://github.com/Mudlet/Mudlet/issues/4995.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
