### PR TITLE
Only check C++ changes if C++ files were actually updated

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -1,6 +1,10 @@
 name: 🔍 Check improvements with Mudlet's C++ style guide
 
-on: pull_request_target
+on:
+  pull_request_target:
+    paths:
+    - '**.cpp'
+    - '**.h'
 
 jobs:
   compile-mudlet:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Only check C++ changes if C++ files were actually updated
#### Motivation for adding to Mudlet
Doesn't make sense to check... and if this filter works well, I'll add a filter to check that all Lua files are compile-able, which will prevent https://github.com/Mudlet/Mudlet/pull/5040 from happening in the future.
#### Other info (issues closed, discussion etc)
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
