### PR TITLE
Fix Mudlet crash if profile folder didn't match with profile name

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -931,7 +931,7 @@ void XMLimport::readHostPackage(Host* pHost)
             break;
         } else if (isStartElement()) {
             if (name() == "name") {
-                pHost->mHostName = readElementText();
+                // name is intentionally ignored as it is already populated from the profile folder
             } else if (name() == "mInstalledModules") {
                 QMap<QString, QStringList> entry;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix Mudlet crash if profile folder didn't match with profile name
#### Motivation for adding to Mudlet
Mudlet should never crash.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5048.

It could also occur if a profile copy was interrupted.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
