### PR TITLE
BugFix: improve parsing areas in XML map files

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -421,10 +421,12 @@ void XMLimport::readAreas()
 
 void XMLimport::readArea()
 {
-    int id = attributes().value(QStringLiteral("id")).toString().toInt();
-    QString name = attributes().value(QStringLiteral("name")).toString();
+    if (attributes().hasAttribute(QStringLiteral("id"))) {
+        int id = attributes().value(QStringLiteral("id")).toString().toInt();
+        QString name = attributes().value(QStringLiteral("name")).toString();
 
-    mpHost->mpMap->mpRoomDB->addArea(id, name);
+        mpHost->mpMap->mpRoomDB->addArea(id, name);
+    }
 }
 
 void XMLimport::readRooms(QMultiHash<int, int>& areaRoomsHash)


### PR DESCRIPTION
The exact mechanism leading to the issue seems a little odd as it hasn't manifested before. However this should close #5029 by preventing an area being created unless a valid "id" attribute has been read from the \<area> element - which can't happen for a bogus one.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Fixed bogus areas being created when reading XML map files.