### PR TITLE
BugFix: improve handling of non-map and too new files in profile's map dir

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15453,6 +15453,14 @@ int TLuaInterpreter::loadJsonMap(lua_State* L)
         return warnArgumentValue(L, __func__, message);
     }
 
+    // Must run the audit() process now - as it is no longer done within
+    // TMap::readJsonMapFile(...) as that can now be used elsewhere:
+    pHost->mpMap->audit();
+    pHost->mpMap->mpMapper->mp2dMap->init();
+    pHost->mpMap->mpMapper->updateAreaComboBox();
+    pHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
+    pHost->mpMap->mpMapper->show();
+
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -647,6 +647,7 @@ std::pair<bool, QString> TMainConsole::createMapper(const QString& windowname, i
             mpMapper->mp2dMap->init();
             mpMapper->updateAreaComboBox();
             mpMapper->resetAreaComboBoxToPlayerRoomArea();
+            mpMapper->show();
         }
 
         mpHost->mpMap->pushErrorMessagesToFile(tr("Loading map(2) at %1 report").arg(now.toString(Qt::ISODate)), true);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2935,7 +2935,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     QJsonDocument doc(QJsonDocument::fromJson(mapData, &jsonErr));
     if (jsonErr.error != QJsonParseError::NoError) {
         return {false, (translatableTexts
-                    ? tr("could not parse file, reason: \"%2\" at offset %3")
+                    ? tr("could not parse file, reason: \"%1\" at offset %2")
                       .arg(jsonErr.errorString(), QString::number(jsonErr.offset))
                     : QStringLiteral("could not parse file \"%1\", reason: \"%2\" at offset %3")
                       .arg(source, jsonErr.errorString(), QString::number(jsonErr.offset)))};

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1411,8 +1411,7 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
                                  .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
-        QString infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file;\n"
-                             "continuing to find the next newest file that could be a Mudlet map file...");
+        QString infoMsg = tr("[ INFO ]  - Ignoring this unlikely map file.");
         appendErrorMsgWithNoLf(infoMsg);
         postMessage(infoMsg);
         ifs.setDevice(nullptr);
@@ -1427,8 +1426,7 @@ bool TMap::validatePotentialMapFile(QFile& file, QDataStream& ifs)
                                  .arg(file.fileName());
         appendErrorMsgWithNoLf(errMsg);
         postMessage(errMsg);
-        QString infoMsg = tr("[ INFO ]  - You will need to upgrade your Mudlet to read it;\n"
-                             "continuing to find the next newest map file saved in an older format...");
+        QString infoMsg = tr("[ INFO ]  - You will need to upgrade your Mudlet to read it.");
         appendErrorMsgWithNoLf(infoMsg);
         postMessage(infoMsg);
         ifs.setDevice(nullptr);
@@ -1483,303 +1481,298 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
     bool canRestore = true;
     QDataStream ifs;
+    QFile file;
     if (!entries.empty() || !location.isEmpty()) {
         // We get to here if there is one or more entries OR location is
         // supplied - if the latter then there is only one file to consider but
         // if the former we may have to check more than one to find a valid
         // map file:
-        QFile file;
+        bool foundValidFile = false;
         if (location.isEmpty()) {
             // Look through the entries:
             QStringListIterator itFileName(entries);
-            bool foundValidFile = false;
-            while (itFileName.hasNext()) {
-                auto fileName = QStringLiteral("%1/%2").arg(folder, itFileName.next());
-                if (!fileName.endsWith(QStringLiteral(".json"), Qt::CaseInsensitive)) {
-                    file.setFileName(fileName);
-                    if (validatePotentialMapFile(file, ifs)) {
-                        foundValidFile = true;
-                        break;
-                    }
-
-                } else {
-                    if (auto [isOk, message] = readJsonMapFile(fileName, true, false); !isOk) {
-                        // Failed to read the JSON file
-                        QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
-                                            "%1; the file is:\n"
-                                            "\"%2\".").arg(message, fileName);
-                        appendErrorMsgWithNoLf(errMsg);
-                        postMessage(errMsg);
-                        QString infoMsg = tr("[ INFO ]  - Ignoring this map file;\n"
-                                             "continuing to find the next newest file that could be a Mudlet map file...");
-                        appendErrorMsgWithNoLf(infoMsg);
-                        postMessage(infoMsg);
-
-                    } else {
-                        // immediately leave on success:
-                        return true;
-                    }
+            auto fileName = QStringLiteral("%1/%2").arg(folder, itFileName.next());
+            if (!fileName.endsWith(QStringLiteral(".json"), Qt::CaseInsensitive)) {
+                file.setFileName(fileName);
+                if (validatePotentialMapFile(file, ifs)) {
+                    foundValidFile = true;
                 }
 
-                // Allow for somethings to be updated - especially on Windows?
-                qApp->processEvents();
+            } else {
+                if (auto [isOk, message] = readJsonMapFile(fileName, true, false); !isOk) {
+                   // Failed to read the JSON file
+                   QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
+                                       "%1; the file is:\n"
+                                       "\"%2\".").arg(message, fileName);
+                   appendErrorMsgWithNoLf(errMsg);
+                   postMessage(errMsg);
+                   QString infoMsg = tr("[ INFO ]  - Ignoring this map file.");
+                   appendErrorMsgWithNoLf(infoMsg);
+                   postMessage(infoMsg);
+               } else {
+                   // immediately leave on success:
+                   return true;
+               }
+           }
+
+           // Allow for somethings to be updated - especially on Windows?
+           qApp->processEvents();
+        }
+        if (!foundValidFile) {
+            canRestore = false;
+        }
+    } else {
+        file.setFileName(location);
+        canRestore = validatePotentialMapFile(file, ifs);
+    }
+
+    if (canRestore) {
+        // As all but the room reading have version checks the fact that sub-4
+        // files will still be parsed despite canRestore being false is probably OK
+        if (mVersion >= 4) {
+            ifs >> mEnvColors;
+            mpRoomDB->restoreAreaMap(ifs);
+        }
+        if (mVersion >= 5) {
+            ifs >> mCustomEnvColors;
+        }
+        if (mVersion >= 7) {
+            ifs >> mpRoomDB->hashToRoomID;
+            QMap<QString, int>::const_iterator i;
+            for (i = mpRoomDB->hashToRoomID.constBegin(); i != mpRoomDB->hashToRoomID.constEnd(); ++i) {
+                mpRoomDB->roomIDToHash.insert(i.value(), i.key());
             }
-            if (!foundValidFile) {
-                canRestore = false;
-            }
-        } else {
-            file.setFileName(location);
-            canRestore = validatePotentialMapFile(file, ifs);
         }
 
-        if (canRestore) {
-            // As all but the room reading have version checks the fact that sub-4
-            // files will still be parsed despite canRestore being false is probably OK
-            if (mVersion >= 4) {
-                ifs >> mEnvColors;
-                mpRoomDB->restoreAreaMap(ifs);
-            }
-            if (mVersion >= 5) {
-                ifs >> mCustomEnvColors;
-            }
-            if (mVersion >= 7) {
-                ifs >> mpRoomDB->hashToRoomID;
-                QMap<QString, int>::const_iterator i;
-                for (i = mpRoomDB->hashToRoomID.constBegin(); i != mpRoomDB->hashToRoomID.constEnd(); ++i) {
-                    mpRoomDB->roomIDToHash.insert(i.value(), i.key());
+        if (mVersion >= 17) {
+            ifs >> mUserData;
+            if (mVersion >= 19) {
+                // Read the data from the file directly in version 19 or later
+                ifs >> mMapSymbolFont;
+                if ((mVersion < 21) && mMapSymbolFont.toString().split(QLatin1String(",")).size() > 15) {
+                    // We need to clean up the effects of using QFont(string)
+                    // for a format 17 or 18 below - as this fix went in before
+                    // 21 was used it only has to be used for map formats 19 and
+                    // 20:
+                    mMapSymbolFont.fromString(mMapSymbolFont.toString().split(QLatin1String(",")).mid(0, 10).join(QLatin1String(",")));
+                }
+                ifs >> mMapSymbolFontFudgeFactor;
+                ifs >> mIsOnlyMapSymbolFontToBeUsed;
+            } else {
+                // Fallback to reading the data from the map user data - and
+                // remove it from the data the user will see:
+                // BUGFIX: Using QFont::toString() and then using that to
+                // construct a font again afterwards via a QFont(string) was
+                // incorrect as it seemed to cause the last to duplicated the
+                // last nine elements each time. The details of the ::toString()
+                // ::fromString() methods are not currently documented so the
+                // only details are documented in the source:
+                // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.cpp?h=5.15#n2070
+                // and:
+                // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.cpp?h=5.15#n2128
+                // this suggests that only one or ten elements are accepted so
+                // we CAN fix past mistakes by only considering the first ten
+                // elements:
+                QStringList fontStrings{mUserData.take(QStringLiteral("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
+                QString fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
+                QString fontFudgeFactorString = mUserData.take(QStringLiteral("system.fallback_mapSymbolFontFudgeFactor"));
+                QString onlyUseSymbolFontString = mUserData.take(QStringLiteral("system.fallback_onlyUseMapSymbolFont"));
+                if (!fontString.isEmpty()) {
+                    mMapSymbolFont.fromString(fontString);
+                }
+                if (!fontFudgeFactorString.isEmpty()) {
+                    mMapSymbolFontFudgeFactor = fontFudgeFactorString.toDouble();
+                }
+                if (!onlyUseSymbolFontString.isEmpty()) {
+                    mIsOnlyMapSymbolFontToBeUsed = (onlyUseSymbolFontString != QLatin1String("false"));
                 }
             }
+        }
 
-            if (mVersion >= 17) {
-                ifs >> mUserData;
-                if (mVersion >= 19) {
-                    // Read the data from the file directly in version 19 or later
-                    ifs >> mMapSymbolFont;
-                    if ((mVersion < 21) && mMapSymbolFont.toString().split(QLatin1String(",")).size() > 15) {
-                        // We need to clean up the effects of using QFont(string)
-                        // for a format 17 or 18 below - as this fix went in before
-                        // 21 was used it only has to be used for map formats 19 and
-                        // 20:
-                        mMapSymbolFont.fromString(mMapSymbolFont.toString().split(QLatin1String(",")).mid(0, 10).join(QLatin1String(",")));
-                    }
-                    ifs >> mMapSymbolFontFudgeFactor;
-                    ifs >> mIsOnlyMapSymbolFontToBeUsed;
+        mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>((mIsOnlyMapSymbolFontToBeUsed ? QFont::NoFontMerging : 0)
+                                                                          |QFont::PreferOutline | QFont::PreferAntialias | QFont::PreferQuality
+                                                                          |QFont::PreferNoShaping
+                                                                          ));
+        if (mVersion >= 14) {
+            int areaSize = 0;
+            ifs >> areaSize;
+            // restore area table
+            for (int i = 0; i < areaSize; i++) {
+                auto pA = new TArea(this, mpRoomDB);
+                int areaID = 0;
+                ifs >> areaID;
+                if (mVersion >= 18) {
+                    // In version 18 changed from QList<int> to QSet<int> as the later is
+                    // faster in many of the cases where we use it.
+                    ifs >> pA->rooms;
                 } else {
-                    // Fallback to reading the data from the map user data - and
-                    // remove it from the data the user will see:
-                    // BUGFIX: Using QFont::toString() and then using that to
-                    // construct a font again afterwards via a QFont(string) was
-                    // incorrect as it seemed to cause the last to duplicated the
-                    // last nine elements each time. The details of the ::toString()
-                    // ::fromString() methods are not currently documented so the
-                    // only details are documented in the source:
-                    // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.cpp?h=5.15#n2070
-                    // and:
-                    // https://code.qt.io/cgit/qt/qtbase.git/tree/src/gui/text/qfont.cpp?h=5.15#n2128
-                    // this suggests that only one or ten elements are accepted so
-                    // we CAN fix past mistakes by only considering the first ten
-                    // elements:
-                    QStringList fontStrings{mUserData.take(QStringLiteral("system.fallback_mapSymbolFont")).split(QLatin1Char(','))};
-                    QString fontString{fontStrings.mid(0, 10).join(QLatin1Char(','))};
-                    QString fontFudgeFactorString = mUserData.take(QStringLiteral("system.fallback_mapSymbolFontFudgeFactor"));
-                    QString onlyUseSymbolFontString = mUserData.take(QStringLiteral("system.fallback_onlyUseMapSymbolFont"));
-                    if (!fontString.isEmpty()) {
-                        mMapSymbolFont.fromString(fontString);
-                    }
-                    if (!fontFudgeFactorString.isEmpty()) {
-                        mMapSymbolFontFudgeFactor = fontFudgeFactorString.toDouble();
-                    }
-                    if (!onlyUseSymbolFontString.isEmpty()) {
-                        mIsOnlyMapSymbolFontToBeUsed = (onlyUseSymbolFontString != QLatin1String("false"));
-                    }
-                }
-            }
-
-            mMapSymbolFont.setStyleStrategy(static_cast<QFont::StyleStrategy>((mIsOnlyMapSymbolFontToBeUsed ? QFont::NoFontMerging : 0)
-                                                                              |QFont::PreferOutline | QFont::PreferAntialias | QFont::PreferQuality
-                                                                              |QFont::PreferNoShaping
-                                                                              ));
-            if (mVersion >= 14) {
-                int areaSize = 0;
-                ifs >> areaSize;
-                // restore area table
-                for (int i = 0; i < areaSize; i++) {
-                    auto pA = new TArea(this, mpRoomDB);
-                    int areaID = 0;
-                    ifs >> areaID;
-                    if (mVersion >= 18) {
-                        // In version 18 changed from QList<int> to QSet<int> as the later is
-                        // faster in many of the cases where we use it.
-                        ifs >> pA->rooms;
-                    } else {
-                        QList<int> oldRoomsList;
-                        ifs >> oldRoomsList;
+                    QList<int> oldRoomsList;
+                    ifs >> oldRoomsList;
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-                        pA->rooms = QSet<int>{oldRoomsList.begin(), oldRoomsList.end()};
+                    pA->rooms = QSet<int>{oldRoomsList.begin(), oldRoomsList.end()};
 #else
-                        pA->rooms = oldRoomsList.toSet();
+                    pA->rooms = oldRoomsList.toSet();
 #endif
-                    }
-                    // Can be useful when analysing suspect map files!
-                    //                qDebug() << "TMap::restore(...)" << "Area:" << areaID;
-                    //                qDebug() << "Rooms:" << pA->rooms;
-                    ifs >> pA->zLevels;
-                    ifs >> pA->mAreaExits;
-                    ifs >> pA->gridMode;
-                    ifs >> pA->max_x;
-                    ifs >> pA->max_y;
-                    ifs >> pA->max_z;
-                    ifs >> pA->min_x;
-                    ifs >> pA->min_y;
-                    ifs >> pA->min_z;
-                    ifs >> pA->span;
-                    if (mVersion >= 17) {
-                        ifs >> pA->xmaxForZ;
-                        ifs >> pA->ymaxForZ;
-                        ifs >> pA->xminForZ;
-                        ifs >> pA->yminForZ;
-                    } else {
-                        QMap<int, int> dummyMinMaxForZ;
-                        ifs >> pA->xmaxForZ;
-                        ifs >> pA->ymaxForZ;
-                        ifs >> dummyMinMaxForZ;
-                        ifs >> pA->xminForZ;
-                        ifs >> pA->yminForZ;
-                        ifs >> dummyMinMaxForZ;
-                    }
-                    ifs >> pA->pos;
-                    ifs >> pA->isZone;
-                    ifs >> pA->zoneAreaRef;
-                    if (mVersion >= 17) {
-                        ifs >> pA->mUserData;
-                    }
-                    if (mVersion >= 21) {
-                        int mapLabelsCount = -1;
-                        ifs >> mapLabelsCount;
-                        for (int i = 0; i < mapLabelsCount; ++i) {
-                            int labelId = -1;
-                            ifs >> labelId;
-                            TMapLabel label;
-                            ifs >> label.size;
-                            ifs >> label.text;
-                            ifs >> label.fgColor;
-                            ifs >> label.bgColor;
-                            ifs >> label.pix;
-                            ifs >> label.noScaling;
-                            ifs >> label.showOnTop;
-                            pA->mMapLabels.insert(labelId, label);
-                        }
-                    }
-                    mpRoomDB->restoreSingleArea(areaID, pA);
                 }
-            }
-
-            if (!mpRoomDB->getAreaMap().keys().contains(-1)) {
-                auto pDefaultA = new TArea(this, mpRoomDB);
-                mpRoomDB->restoreSingleArea(-1, pDefaultA);
-                QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
-                                                     "area) not found, adding reserved -1 id.");
-                appendErrorMsgWithNoLf(defaultAreaInsertionMsg, false);
-                if (mudlet::self()->showMapAuditErrors()) {
-                    postMessage(defaultAreaInsertionMsg);
+                // Can be useful when analysing suspect map files!
+                //                qDebug() << "TMap::restore(...)" << "Area:" << areaID;
+                //                qDebug() << "Rooms:" << pA->rooms;
+                ifs >> pA->zLevels;
+                ifs >> pA->mAreaExits;
+                ifs >> pA->gridMode;
+                ifs >> pA->max_x;
+                ifs >> pA->max_y;
+                ifs >> pA->max_z;
+                ifs >> pA->min_x;
+                ifs >> pA->min_y;
+                ifs >> pA->min_z;
+                ifs >> pA->span;
+                if (mVersion >= 17) {
+                    ifs >> pA->xmaxForZ;
+                    ifs >> pA->ymaxForZ;
+                    ifs >> pA->xminForZ;
+                    ifs >> pA->yminForZ;
+                } else {
+                    QMap<int, int> dummyMinMaxForZ;
+                    ifs >> pA->xmaxForZ;
+                    ifs >> pA->ymaxForZ;
+                    ifs >> dummyMinMaxForZ;
+                    ifs >> pA->xminForZ;
+                    ifs >> pA->yminForZ;
+                    ifs >> dummyMinMaxForZ;
                 }
-            }
-
-            if (mVersion >= 18) {
-                // In version 18 we changed to store the "userRoom" for each profile
-                // so that when copied/shared between profiles they do not interfere
-                // with each other's saved value
-                ifs >> mRoomIdHash;
-            } else if (mVersion >= 12) {
-                int oldRoomId = 0;
-                ifs >> oldRoomId;
-                mRoomIdHash[mProfileName] = oldRoomId;
-            }
-
-            if (mVersion >= 11 && mVersion <= 20) {
-                // After version 20 the map labels have been moved to each area
-                int areasWithLabelsTotal = 0;
-                ifs >> areasWithLabelsTotal;
-                int areasWithLabelsCounter = 0;
-                while (!ifs.atEnd() && areasWithLabelsCounter < areasWithLabelsTotal) {
-                    int areaID = -1;
-                    int areaLabelsTotal = 0;
-                    ifs >> areaLabelsTotal;
-                    // Only used to identify the area for this batch of labels:
-                    ifs >> areaID;
-                    int areaLabelCounter = 0;
-                    auto pA = mpRoomDB->getArea(areaID);
-                    while (!ifs.atEnd() && areaLabelCounter < areaLabelsTotal) {
-                        int labelID = 0;
-                        ifs >> labelID;
+                ifs >> pA->pos;
+                ifs >> pA->isZone;
+                ifs >> pA->zoneAreaRef;
+                if (mVersion >= 17) {
+                    ifs >> pA->mUserData;
+                }
+                if (mVersion >= 21) {
+                    int mapLabelsCount = -1;
+                    ifs >> mapLabelsCount;
+                    for (int i = 0; i < mapLabelsCount; ++i) {
+                        int labelId = -1;
+                        ifs >> labelId;
                         TMapLabel label;
-                        if (mVersion >= 12) {
-                            // From version 12 labels could be placed on any level,
-                            // so they have a z coordinate:
-                            ifs >> label.pos;
-                        } else {
-                            QPointF labelPos2D;
-                            ifs >> labelPos2D;
-                            label.pos = QVector3D(labelPos2D);
-                        }
-                        // There was an unused QPointF in versions prior to 21
-                        QPointF dummyPointF;
-                        ifs >> dummyPointF;
                         ifs >> label.size;
                         ifs >> label.text;
                         ifs >> label.fgColor;
                         ifs >> label.bgColor;
                         ifs >> label.pix;
-                        if (mVersion >= 15) {
-                            ifs >> label.noScaling;
-                            ifs >> label.showOnTop;
-                        }
-                        if (pA) {
-                            pA->mMapLabels.insert(labelID, label);
-                        }
-                        ++areaLabelCounter;
-                        // Else: we dump labels for areas not in map - this should
-                        // not be happening nowadays but did in the past - see
-                        // PR #4369
+                        ifs >> label.noScaling;
+                        ifs >> label.showOnTop;
+                        pA->mMapLabels.insert(labelId, label);
                     }
-                    ++areasWithLabelsCounter;
                 }
+                mpRoomDB->restoreSingleArea(areaID, pA);
             }
+        }
 
-            while (!ifs.atEnd()) {
-                int i = 0;
-                ifs >> i;
-                auto pT = new TRoom(mpRoomDB);
-                pT->restore(ifs, i, mVersion);
-                mpRoomDB->restoreSingleRoom(i, pT);
+        if (!mpRoomDB->getAreaMap().keys().contains(-1)) {
+            auto pDefaultA = new TArea(this, mpRoomDB);
+            mpRoomDB->restoreSingleArea(-1, pDefaultA);
+            QString defaultAreaInsertionMsg = tr("[ INFO ]  - Default (reset) area (for rooms that have not been assigned to an\n"
+                                                 "area) not found, adding reserved -1 id.");
+            appendErrorMsgWithNoLf(defaultAreaInsertionMsg, false);
+            if (mudlet::self()->showMapAuditErrors()) {
+                postMessage(defaultAreaInsertionMsg);
             }
+        }
 
-            mCustomEnvColors[257] = mpHost->mRed_2;
-            mCustomEnvColors[258] = mpHost->mGreen_2;
-            mCustomEnvColors[259] = mpHost->mYellow_2;
-            mCustomEnvColors[260] = mpHost->mBlue_2;
-            mCustomEnvColors[261] = mpHost->mMagenta_2;
-            mCustomEnvColors[262] = mpHost->mCyan_2;
-            mCustomEnvColors[263] = mpHost->mWhite_2;
-            mCustomEnvColors[264] = mpHost->mBlack_2;
-            mCustomEnvColors[265] = mpHost->mLightRed_2;
-            mCustomEnvColors[266] = mpHost->mLightGreen_2;
-            mCustomEnvColors[267] = mpHost->mLightYellow_2;
-            mCustomEnvColors[268] = mpHost->mLightBlue_2;
-            mCustomEnvColors[269] = mpHost->mLightMagenta_2;
-            mCustomEnvColors[270] = mpHost->mLightCyan_2;
-            mCustomEnvColors[271] = mpHost->mLightWhite_2;
-            mCustomEnvColors[272] = mpHost->mLightBlack_2;
+        if (mVersion >= 18) {
+            // In version 18 we changed to store the "userRoom" for each profile
+            // so that when copied/shared between profiles they do not interfere
+            // with each other's saved value
+            ifs >> mRoomIdHash;
+        } else if (mVersion >= 12) {
+            int oldRoomId = 0;
+            ifs >> oldRoomId;
+            mRoomIdHash[mProfileName] = oldRoomId;
+        }
 
-            QString okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
-                               "consistency details..." )
-                                    .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
-
-            postMessage(okMsg);
-            appendErrorMsgWithNoLf(okMsg);
-            if (canRestore) {
-                return true;
+        if (mVersion >= 11 && mVersion <= 20) {
+            // After version 20 the map labels have been moved to each area
+            int areasWithLabelsTotal = 0;
+            ifs >> areasWithLabelsTotal;
+            int areasWithLabelsCounter = 0;
+            while (!ifs.atEnd() && areasWithLabelsCounter < areasWithLabelsTotal) {
+                int areaID = -1;
+                int areaLabelsTotal = 0;
+                ifs >> areaLabelsTotal;
+                // Only used to identify the area for this batch of labels:
+                ifs >> areaID;
+                int areaLabelCounter = 0;
+                auto pA = mpRoomDB->getArea(areaID);
+                while (!ifs.atEnd() && areaLabelCounter < areaLabelsTotal) {
+                    int labelID = 0;
+                    ifs >> labelID;
+                    TMapLabel label;
+                    if (mVersion >= 12) {
+                        // From version 12 labels could be placed on any level,
+                        // so they have a z coordinate:
+                        ifs >> label.pos;
+                    } else {
+                        QPointF labelPos2D;
+                        ifs >> labelPos2D;
+                        label.pos = QVector3D(labelPos2D);
+                    }
+                    // There was an unused QPointF in versions prior to 21
+                    QPointF dummyPointF;
+                    ifs >> dummyPointF;
+                    ifs >> label.size;
+                    ifs >> label.text;
+                    ifs >> label.fgColor;
+                    ifs >> label.bgColor;
+                    ifs >> label.pix;
+                    if (mVersion >= 15) {
+                        ifs >> label.noScaling;
+                        ifs >> label.showOnTop;
+                    }
+                    if (pA) {
+                        pA->mMapLabels.insert(labelID, label);
+                    }
+                    ++areaLabelCounter;
+                    // Else: we dump labels for areas not in map - this should
+                    // not be happening nowadays but did in the past - see
+                    // PR #4369
+                }
+                ++areasWithLabelsCounter;
             }
+        }
+
+        while (!ifs.atEnd()) {
+            int i = 0;
+            ifs >> i;
+            auto pT = new TRoom(mpRoomDB);
+            pT->restore(ifs, i, mVersion);
+            mpRoomDB->restoreSingleRoom(i, pT);
+        }
+
+        mCustomEnvColors[257] = mpHost->mRed_2;
+        mCustomEnvColors[258] = mpHost->mGreen_2;
+        mCustomEnvColors[259] = mpHost->mYellow_2;
+        mCustomEnvColors[260] = mpHost->mBlue_2;
+        mCustomEnvColors[261] = mpHost->mMagenta_2;
+        mCustomEnvColors[262] = mpHost->mCyan_2;
+        mCustomEnvColors[263] = mpHost->mWhite_2;
+        mCustomEnvColors[264] = mpHost->mBlack_2;
+        mCustomEnvColors[265] = mpHost->mLightRed_2;
+        mCustomEnvColors[266] = mpHost->mLightGreen_2;
+        mCustomEnvColors[267] = mpHost->mLightYellow_2;
+        mCustomEnvColors[268] = mpHost->mLightBlue_2;
+        mCustomEnvColors[269] = mpHost->mLightMagenta_2;
+        mCustomEnvColors[270] = mpHost->mLightCyan_2;
+        mCustomEnvColors[271] = mpHost->mLightWhite_2;
+        mCustomEnvColors[272] = mpHost->mLightBlack_2;
+
+        QString okMsg = tr("[ INFO ]  - Successfully read the map file (%1s), checking some\n"
+                           "consistency details..." )
+                                .arg(_time.nsecsElapsed() * 1.0e-9, 0, 'f', 2);
+
+        postMessage(okMsg);
+        appendErrorMsgWithNoLf(okMsg);
+        if (canRestore) {
+            return true;
         }
     }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3125,14 +3125,6 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     // This is it - the point at which the new map gets activated:
     TRoomDB* pOldRoomDB = mpRoomDB;
     mpRoomDB = pNewRoomDB;
-    audit();
-    if (mpMapper) {
-        mpMapper->mp2dMap->init();
-        mpMapper->updateAreaComboBox();
-        mpMapper->resetAreaComboBoxToPlayerRoomArea();
-        mpMapper->show();
-        update();
-    }
     delete pOldRoomDB;
     mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose, true);
     mpProgressDialog->close();

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1575,12 +1575,12 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                                                                               |QFont::PreferNoShaping
                                                                               ));
             if (mVersion >= 14) {
-                int areaSize;
+                int areaSize = 0;
                 ifs >> areaSize;
                 // restore area table
                 for (int i = 0; i < areaSize; i++) {
                     auto pA = new TArea(this, mpRoomDB);
-                    int areaID;
+                    int areaID = 0;
                     ifs >> areaID;
                     if (mVersion >= 18) {
                         // In version 18 changed from QList<int> to QSet<int> as the later is
@@ -1666,7 +1666,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 // with each other's saved value
                 ifs >> mRoomIdHash;
             } else if (mVersion >= 12) {
-                int oldRoomId;
+                int oldRoomId = 0;
                 ifs >> oldRoomId;
                 mRoomIdHash[mProfileName] = oldRoomId;
             }
@@ -1685,7 +1685,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                     int areaLabelCounter = 0;
                     auto pA = mpRoomDB->getArea(areaID);
                     while (!ifs.atEnd() && areaLabelCounter < areaLabelsTotal) {
-                        int labelID;
+                        int labelID = 0;
                         ifs >> labelID;
                         TMapLabel label;
                         if (mVersion >= 12) {
@@ -1722,7 +1722,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
             }
 
             while (!ifs.atEnd()) {
-                int i;
+                int i = 0;
                 ifs >> i;
                 auto pT = new TRoom(mpRoomDB);
                 pT->restore(ifs, i, mVersion);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1499,7 +1499,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 }
 
             } else {
-                if (auto [isOk, message] = readJsonMapFile(fileName, true, false); !isOk) {
+                if (auto [isOk, message] = readJsonMapFile(fileName, true); !isOk) {
                    // Failed to read the JSON file
                    QString errMsg = tr("[ ALERT ] - Failed to load a Mudlet JSON Map file, reason:\n"
                                        "%1; the file is:\n"

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -268,6 +268,7 @@ private:
     const QString createFileHeaderLine(QString, QChar);
     void writeJsonUserData(QJsonObject&) const;
     void readJsonUserData(const QJsonObject&);
+    bool validatePotentialMapFile(QFile&, QDataStream&);
 
     QStringList mStoredMessages;
 
@@ -281,7 +282,7 @@ private:
     QList<QString> mMapAuditErrors;
 
     // Are things so bad the user needs to check the log (ignored if messages ARE already sent to screen)
-    bool mIsFileViewingRecommended = false;;
+    bool mIsFileViewingRecommended = false;
 
     // Moved and revised from dlgMapper:
     QNetworkAccessManager* mpNetworkAccessManager = nullptr;

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -144,7 +144,7 @@ public:
     void setRoomNamesShown(bool shown);
 
     std::pair<bool, QString> writeJsonMapFile(const QString&);
-    std::pair<bool, QString> readJsonMapFile(const QString&);
+    std::pair<bool, QString> readJsonMapFile(const QString&, const bool translatableTexts = false);
     int getCurrentProgressRoomCount() const { return mProgressDialogRoomsCount; }
     bool incrementJsonProgressDialog(const bool isExportNotImport, const bool isRoomNotLabel, const int increment = 1);
     QString getDefaultAreaName() const { return mDefaultAreaName; }

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -144,7 +144,7 @@ public:
     void setRoomNamesShown(bool shown);
 
     std::pair<bool, QString> writeJsonMapFile(const QString&);
-    std::pair<bool, QString> readJsonMapFile(const QString&, const bool translatableTexts = false);
+    std::pair<bool, QString> readJsonMapFile(const QString&, const bool translatableTexts = false, const bool allowUserCancellation = true);
     int getCurrentProgressRoomCount() const { return mProgressDialogRoomsCount; }
     bool incrementJsonProgressDialog(const bool isExportNotImport, const bool isRoomNotLabel, const int increment = 1);
     QString getDefaultAreaName() const { return mDefaultAreaName; }

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2021 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -23,6 +23,7 @@
 #include "XMLimport.h"
 
 
+#include "dlgMapper.h"
 #include "LuaInterface.h"
 #include "TConsole.h"
 #include "TMap.h"
@@ -174,6 +175,10 @@ bool XMLimport::importPackage(QFile* pfile, QString packName, int moduleFlag, QS
             } else if (name() == "map") {
                 readMap();
                 mpHost->mpMap->audit();
+                mpHost->mpMap->mpMapper->mp2dMap->init();
+                mpHost->mpMap->mpMapper->updateAreaComboBox();
+                mpHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
+                mpHost->mpMap->mpMapper->show();
             } else {
                 qDebug().nospace() << "XMLimport::importPackage(...) ERROR: "
                                       "unrecognised element with name: "


### PR DESCRIPTION
This is an **alternative** to #5022 - and *one* of them will be needed so that #5016 is safe - though, TBH I do not think that the latter should be dumping JSON format files into a folder which we had previously reserved for binary map save files!

This will also close #4275 by checking for the map version number (the first four bytes of the file) being between 1 and 127 and rejecting it if that test is not met.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Mudlet will behave better if non-map files get placed into the location where a profile saves its map files.