### PR TITLE
BugFix: prevent crash on profile loading

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2549,7 +2549,6 @@ void Host::setName(const QString& newName)
     }
 
     mHostName = newName;
-    mpConsole->setProperty("HostName", newName);
 
     mTelnet.mProfileName = newName;
     if (mpMap) {
@@ -2560,6 +2559,8 @@ void Host::setName(const QString& newName)
     }
 
     if (mpConsole) {
+        // If skipped they will be taken care of in the TMainConsole constructor:
+        mpConsole->setProperty("HostName", newName);
         mpConsole->setProfileName(newName);
     }
     mTimerUnit.changeHostName(newName);


### PR DESCRIPTION
Not entirely sure of the mechanism that introduced this issue. However it seems that my #4976 was too optimistic about when:
`(void) Host::setName(const QString&)` was to be used and did not guard sufficiently against a `Host` instance not having it's `TMainConsole` instantiated yet.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>