### PR TITLE
BugFix: S. Exits not staying locked when loaded from current file formats

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -729,7 +729,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             if (cmd.startsWith(QLatin1String("1"))) {
                 // Is locked:
                 mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());
-                mSpecialExitLocks.insert(cmd);
+                mSpecialExitLocks.insert(cmd.mid(1));
             } else if (Q_LIKELY(cmd.startsWith(QLatin1String("0")))) {
                 // Is not locked:
                 mSpecialExits.insert(cmd.mid(1), itOldSpecialExit.key());


### PR DESCRIPTION
A coding error meant the current file formats that retained the previous storage of the special exit lock status as a `1` or `0` prefix on the name/command for the special exit was not being corrected inserted into the recently added separate container to store the lock status of special exits - this meant they were effectively lost.

This will close #4999.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Fix for recent bug where Special exits lost their lock status when saved and then loaded from a (binary) map file.