### PR TITLE
Fix profile loading

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -931,7 +931,7 @@ void XMLimport::readHostPackage(Host* pHost)
             break;
         } else if (isStartElement()) {
             if (name() == "name") {
-                // name is intentionally ignored as it is already populated from the profile folder
+                pHost->mHostName = readElementText();
             } else if (name() == "mInstalledModules") {
                 QMap<QString, QStringList> entry;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This reverts commit 368f6c72a5feabe5c3192b9248d05ecb20eeca37. Despite my testing, somehow now in `development` it breaks profile loading completely so you just get a blank.
#### Motivation for adding to Mudlet
Fix it so profiles can actually be loaded again.
#### Other info (issues closed, discussion etc)
This reverts https://github.com/Mudlet/Mudlet/pull/5049.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
