### PR TITLE
Fix macOS / Ubuntu CMake builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -229,7 +229,6 @@ jobs:
         useVcpkgToolchainFile: true
         buildDirectory: '${{runner.workspace}}/b/ninja'
         cmakeAppendedArgs: >-
-          --target test
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{env.MINGW_BASE_DIR}}
           -DVCPKG_APPLOCAL_DEPS=OFF

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -232,6 +232,7 @@ jobs:
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{env.MINGW_BASE_DIR}}
           -DVCPKG_APPLOCAL_DEPS=OFF
+        buildWithCMakeArgs: --target test
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -232,7 +232,6 @@ jobs:
           -G Ninja
           -DCMAKE_PREFIX_PATH=${{env.MINGW_BASE_DIR}}
           -DVCPKG_APPLOCAL_DEPS=OFF
-        buildWithCMakeArgs: --target test
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
CMake compiles broke when Github upgraded to CMake to latest 3.20 - and it looks like CMake breaks on unrecognized flags now. Turns out we were using `--target` flag wrong all along, passing it to the configure step instead of the build step.
#### Motivation for adding to Mudlet
Fix macOS CMake builds.
#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
