### PR TITLE
Revert "Prevent multiple resize event if size didn't change (#5009)"

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -584,9 +584,6 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int x = event->size().width();
     int y = event->size().height();
 
-    // don't call event in lua if size didn't change
-    bool preventLuaEvent = (event->size() == mOldSize);
-
     if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);
@@ -608,11 +605,6 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
 
     QWidget::resizeEvent(event);
-    mOldSize = size();
-
-    if (preventLuaEvent) {
-        return;
-    }
 
     if (mType & (MainConsole|Buffer)) {
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -287,7 +287,6 @@ protected:
 
 private:
     ConsoleType mType;
-    QSize mOldSize;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TConsole::ConsoleType)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet
Githzerai
 — 
Today at 18:34
I think it was the one with the ResizeEvent. Profile starts, command line is at default height. As soon as something is entered into cmd line, input area aadjusts the height to one set in Preferences or a script, Mudlet attempts to resize the min console and elements, Geyser stuff gets borked up. Once settings/scripts leave input value at defult, everything works normally. :thinking:
Githzerai
 — 
Today at 18:45
right, as soon as the Command Line Minimum Height is set above the default vaulue, bottom end of main console gets borked up, exact area that is taken by cmd line height increase, cause it resized, main console did not
#### Other info (issues closed, discussion etc)
This reverts commit 6ad8b96757f6848f4f0e4d84ecae12bb829405a5.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
