### PR TITLE
Repair getMapMenus()

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1555,27 +1555,25 @@ int TLuaInterpreter::removeMapMenu(lua_State* L)
 int TLuaInterpreter::getMapMenus(lua_State* L)
 {
     Host& host = getHostFromLua(L);
-    if (host.mpMap) {
-        if (host.mpMap->mpMapper) {
-            if (host.mpMap->mpMapper->mp2dMap) {
-                lua_newtable(L);
-                QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserMenus);
-                while (it.hasNext()) {
-                    it.next();
-                    QString parent, display;
-                    QStringList menuInfo = it.value();
-                    parent = menuInfo[0];
-                    display = menuInfo[1];
-                    lua_pushstring(L, it.key().toUtf8().constData());
-                    lua_pushstring(L, parent.toUtf8().constData());
-                    lua_pushstring(L, display.toUtf8().constData());
-                    lua_settable(L, -3);
-                }
-            }
-            return 1;
-        }
+    if (!(host.mpMap && host.mpMap->mpMapper && host.mpMap->mpMapper->mp2dMap)) {
+        return warnArgumentValue(L, __func__, "you haven't opened a map yet");
     }
-    return 0;
+
+    lua_newtable(L);
+    QMapIterator<QString, QStringList> it(host.mpMap->mpMapper->mp2dMap->mUserMenus);
+    while (it.hasNext()) {
+        it.next();
+        QString parent, display;
+        QStringList menuInfo = it.value();
+        parent = menuInfo[0];
+        display = menuInfo[1];
+        qDebug() << it.key() << parent << display;
+        lua_pushstring(L, display.toUtf8().constData());
+        lua_pushstring(L, parent.isEmpty() ? "top-level" :parent.toUtf8().constData());
+        lua_settable(L, -3);
+    }
+
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#addMapEvent


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Repair getMapMenus() to work. The function did not work prior to this and was undocumented, so I restructured it to return output as `map menu - parent item`. If it's at the top-level, it'll say `top-level`.
#### Motivation for adding to Mudlet
Proper, working function.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/4138.

![image](https://user-images.githubusercontent.com/110988/114188119-16da4e00-9949-11eb-8cf5-ecadb7fe5c4e.png)

#### Release post highlight
* fix: repaired getMapMenus().
