### PR TITLE
Coverity: fix issue registered as CID1503730

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3080,10 +3080,11 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
         TArea* pArea = new TArea(this, pNewRoomDB);
         auto [id, name] = pArea->readJsonArea(mapObj.value(QLatin1String("areas")).toArray(), i);
         ++mProgressDialogAreasCount;
-        if (incrementJsonProgressDialog(false, true, 0)) {
-            if (allowUserCancellation) {
-                abort = true;
-            }
+        if (incrementJsonProgressDialog(false, true, 0) && allowUserCancellation) {
+            abort = true;
+            // Since we are break-ing and not going to store the TArea we just
+            // instantiated with new we need to clean it up:
+            delete pArea;
             break;
         }
         // This will populate the TRoomDB::areas and TRoomDB::areaNameMap:


### PR DESCRIPTION
When aborting during parsing of an area in the JSON map file reader we did not take care to clean up the `TArea` that was being read when the abort was requested.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>