### PR TITLE
Coverity: fix issue registered as CID 1503729

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -8112,7 +8112,7 @@ int TLuaInterpreter::getMapLabels(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getMapLabel
 int TLuaInterpreter::getMapLabel(lua_State* L)
 {
-    int area = getVerifiedInt(L, __func__, 1, "areaID");
+    int areaId = getVerifiedInt(L, __func__, 1, "areaID");
 
     if (!lua_isstring(L, 2) && !lua_isnumber(L, 2)) {
         lua_pushfstring(L, "getMapLabel: bad argument #2 type (labelID as number or labelText as string expected, got %s!)", luaL_typename(L, 2));
@@ -8131,7 +8131,10 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
     }
 
     Host& host = getHostFromLua(L);
-    auto pA = host.mpMap->mpRoomDB->getArea(area);
+    auto pA = host.mpMap->mpRoomDB->getArea(areaId);
+    if (!pA) {
+        return warnArgumentValue(L, __func__, QStringLiteral("areaID %1 does not exist").arg(areaId));
+    }
     if (pA->mMapLabels.isEmpty()) {
         // Return an empty table:
         lua_newtable(L);
@@ -8141,7 +8144,7 @@ int TLuaInterpreter::getMapLabel(lua_State* L)
     if (labelId >= 0) {
         if (!pA->mMapLabels.contains(labelId)) {
             return warnArgumentValue(L, __func__, QStringLiteral("labelID %1 does not exist in area with areaID %2")
-                .arg(QString::number(labelId), QString::number(area)));
+                .arg(QString::number(labelId), QString::number(areaId)));
         }
         lua_newtable(L);
         auto label = pA->mMapLabels.value(labelId);


### PR DESCRIPTION
It seems like there was no check for a valid TArea pointer in `TLuaInterpreter::getMapLabel(...)` - in fact it also means that there was no error being handled for a positive but missing area's Id number. This would result in a nullptr being dereferenced which is a significant (seg. faulting, i.e. fatal to the application) issue!

Looking more closely I can see that in (my) PR #4604 a couple of months back I put a `QMap` container into every area so that all of them may contain map labels, whereas the prior code held all the QMaps in another centralised QMap and the prior code checked for a container for an area when a label was sought - my revised design was what introduced this regression.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

Fatal regression in `getMapLabel(...)` fixed.