### PR TITLE
Use unique ptr which won't leak memory on us (alternative CID1503730)

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3077,7 +3077,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     TRoomDB* pNewRoomDB = new TRoomDB(this);
     bool abort = false;
     for (int i = 0, total = mapObj.value(QLatin1String("areas")).toArray().count(); i < total; ++i) {
-        TArea* pArea = new TArea(this, pNewRoomDB);
+        std::unique_ptr<TArea> pArea = std::make_unique<TArea>(this, pNewRoomDB);
         auto [id, name] = pArea->readJsonArea(mapObj.value(QLatin1String("areas")).toArray(), i);
         ++mProgressDialogAreasCount;
         if (incrementJsonProgressDialog(false, true, 0)) {
@@ -3087,7 +3087,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
             break;
         }
         // This will populate the TRoomDB::areas and TRoomDB::areaNameMap:
-        pNewRoomDB->addArea(pArea, id, name);
+        pNewRoomDB->addArea(pArea.release(), id, name);
     }
     if (abort) {
         mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose, true);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use unique ptr which modern C++ and has more obvious semantics, won't leak memory on us if we forget it.
#### Motivation for adding to Mudlet
Plug a memory leak if the JSON map import was cancelled.
#### Other info (issues closed, discussion etc)
Fix CID1503730.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
