### PR TITLE
selectCaptureGroup will work with named capture groups

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1300,38 +1300,60 @@ int TLuaInterpreter::spawn(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCaptureGroup
 int TLuaInterpreter::selectCaptureGroup(lua_State* L)
 {
-    int captureGroup = getVerifiedInt(L, __func__, 1, "capture group");
-    Host& host = getHostFromLua(L);
-    if (captureGroup < 1) {
-        lua_pushnumber(L, -1);
-        return 1;
+    if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
+        lua_pushfstring(L, "selectCaptureGroup: bad argument #1 type (capture group as number or capture group name as string expected, got %s!)",
+                        luaL_typename(L, 1));
+        return lua_error(L);
     }
-    // We want capture groups to start with 1 instead of 0 so predecrement
-    // luaNumOfMatch :
-    if (--captureGroup < static_cast<int>(host.getLuaInterpreter()->mCaptureGroupList.size())) {
-        TLuaInterpreter* pL = host.getLuaInterpreter();
-        auto iti = pL->mCaptureGroupPosList.begin();
-        auto its = pL->mCaptureGroupList.begin();
-        int begin = *iti;
-        std::string& s = *its;
 
-        for (int i = 0; iti != pL->mCaptureGroupPosList.end(); ++iti, ++i) {
+    Host &host = getHostFromLua(L);
+    TLuaInterpreter *pL = host.getLuaInterpreter();
+    int begin = 0;
+    int length = 0;
+
+    if (lua_isnumber(L, 1)) {
+        auto captureGroup = lua_tonumber(L, 1);
+        if (captureGroup < 1) {
+            lua_pushnumber(L, -1);
+            return 1;
+        }
+        // We want capture groups to start with 1 instead of 0 so predecrement
+        // luaNumOfMatch :
+        if (--captureGroup < static_cast<int>(host.getLuaInterpreter()->mCaptureGroupList.size())) {
+            auto iti = pL->mCaptureGroupPosList.begin();
+            auto its = pL->mCaptureGroupList.begin();
             begin = *iti;
-            if (i >= captureGroup) {
-                break;
-            }
-        }
-        for (int i = 0; its != pL->mCaptureGroupList.end(); ++its, ++i) {
-            s = *its;
-            if (i >= captureGroup) {
-                break;
-            }
-        }
+            std::string &s = *its;
 
-        int length = QString::fromStdString(s).size();
-        if (mudlet::debugMode) {
-            TDebug(Qt::white, Qt::red) << "selectCaptureGroup(" << begin << ", " << length << ")\n" >> &host;
+            for (int i = 0; iti != pL->mCaptureGroupPosList.end(); ++iti, ++i) {
+                begin = *iti;
+                if (i >= captureGroup) {
+                    break;
+                }
+            }
+            for (int i = 0; its != pL->mCaptureGroupList.end(); ++its, ++i) {
+                s = *its;
+                if (i >= captureGroup) {
+                    break;
+                }
+            }
+
+            length = QString::fromStdString(s).size();
+            if (mudlet::debugMode) {
+                TDebug(Qt::white, Qt::red) << "selectCaptureGroup(" << begin << ", " << length << ")\n" >> &host;
+            }
         }
+    } else if (lua_isstring(L, 1)) {
+        auto name = lua_tostring(L, 1);
+        for (const auto key : pL->mCapturedNameGroupsPosList.keys()) {
+            qDebug() << key;
+        }
+        if (pL->mCapturedNameGroupsPosList.contains(name)) {
+            begin = pL->mCapturedNameGroupsPosList.value(name).first;
+            length = pL->mCapturedNameGroupsPosList.value(name).second;
+        }
+    }
+    if (length > 0) {
         int pos = host.mpConsole->selectSection(begin, length);
         lua_pushnumber(L, pos);
     } else {
@@ -11632,9 +11654,10 @@ void TLuaInterpreter::setCaptureGroups(const std::list<std::string>& captureList
      */
 }
 
-void TLuaInterpreter::setCaptureNameGroups(const NameGroupMatches& nameGroups)
+void TLuaInterpreter::setCaptureNameGroups(const NameGroupMatches& nameGroups, const QMap<QString, QPair<int, int>>& namePositions)
 {
     mCapturedNameGroups = nameGroups;
+    mCapturedNameGroupsPosList = namePositions;
 }
 
 // No documentation available in wiki - internal function
@@ -11645,6 +11668,7 @@ void TLuaInterpreter::clearCaptureGroups()
     mMultiCaptureGroupList.clear();
     mMultiCaptureGroupPosList.clear();
     mCapturedNameGroups.clear();
+    mCapturedNameGroupsPosList.clear();
     mMultiCaptureNameGroups.clear();
 
     lua_State* L = pGlobalLua;
@@ -11664,6 +11688,12 @@ void TLuaInterpreter::adjustCaptureGroups(int x, int a)
         if (it >= x) {
             it += a;
         }
+    }
+
+    QMap<QString, QPair<int,int>>::iterator i;
+    for (i = mCapturedNameGroupsPosList.begin(); i != mCapturedNameGroupsPosList.end(); ++i) {
+        i.value().first += a;
+        i.value().second += a;
     }
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11652,7 +11652,7 @@ void TLuaInterpreter::setCaptureGroups(const std::list<std::string>& captureList
      */
 }
 
-void TLuaInterpreter::setCaptureNameGroups(const NameGroupMatches& nameGroups, const QMap<QString, QPair<int, int>>& namePositions)
+void TLuaInterpreter::setCaptureNameGroups(const NameGroupMatches& nameGroups, const NamedMatchesRanges& namePositions)
 {
     mCapturedNameGroups = nameGroups;
     mCapturedNameGroupsPosList = namePositions;
@@ -11688,8 +11688,8 @@ void TLuaInterpreter::adjustCaptureGroups(int x, int a)
         }
     }
 
-    QMap<QString, QPair<int,int>>::iterator i;
-    for (i = mCapturedNameGroupsPosList.begin(); i != mCapturedNameGroupsPosList.end(); ++i) {
+    NamedMatchesRanges::iterator i;
+    for (i = mCapturedNameGroupsPosList.begin(); i != mCapturedNameGroupsPosList.cend(); ++i) {
         i.value().first += a;
         i.value().second += a;
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1298,10 +1298,11 @@ int TLuaInterpreter::spawn(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCaptureGroup
-int TLuaInterpreter::selectCaptureGroup(lua_State* L)
+int TLuaInterpreter::selectCaptureGroup(lua_State *L)
 {
     if (!(lua_isnumber(L, 1) || lua_isstring(L, 1))) {
-        lua_pushfstring(L, "selectCaptureGroup: bad argument #1 type (capture group as number or capture group name as string expected, got %s!)",
+        lua_pushfstring(L,
+                        "selectCaptureGroup: bad argument #1 type (capture group as number or capture group name as string expected, got %s!)",
                         luaL_typename(L, 1));
         return lua_error(L);
     }
@@ -1345,9 +1346,6 @@ int TLuaInterpreter::selectCaptureGroup(lua_State* L)
         }
     } else if (lua_isstring(L, 1)) {
         auto name = lua_tostring(L, 1);
-        for (const auto key : pL->mCapturedNameGroupsPosList.keys()) {
-            qDebug() << key;
-        }
         if (pL->mCapturedNameGroupsPosList.contains(name)) {
             begin = pL->mCapturedNameGroupsPosList.value(name).first;
             length = pL->mCapturedNameGroupsPosList.value(name).second;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -71,6 +71,8 @@ class TTrigger;
 #define PROMPT 3
 #define RAWDATA 4
 
+using NamedMatchesRanges = QMap<QString, QPair<int, int>>;
+
 
 class TLuaInterpreter : public QThread
 {
@@ -115,7 +117,7 @@ public:
     void set_lua_string(const QString& varName, const QString& varValue);
     void set_lua_table(const QString& tableName, QStringList& variableList);
     void setCaptureGroups(const std::list<std::string>&, const std::list<int>&);
-    void setCaptureNameGroups(const NameGroupMatches&, const QMap<QString, QPair<int, int>>&);
+    void setCaptureNameGroups(const NameGroupMatches&, const NamedMatchesRanges&);
     void setMultiCaptureGroups(const std::list<std::list<std::string>>& captureList, const std::list<std::list<int>>& posList, QVector<NameGroupMatches>& nameMatches);
     void adjustCaptureGroups(int x, int a);
     void clearCaptureGroups();

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -115,7 +115,7 @@ public:
     void set_lua_string(const QString& varName, const QString& varValue);
     void set_lua_table(const QString& tableName, QStringList& variableList);
     void setCaptureGroups(const std::list<std::string>&, const std::list<int>&);
-    void setCaptureNameGroups(const NameGroupMatches&);
+    void setCaptureNameGroups(const NameGroupMatches&, const QMap<QString, QPair<int, int>>&);
     void setMultiCaptureGroups(const std::list<std::list<std::string>>& captureList, const std::list<std::list<int>>& posList, QVector<NameGroupMatches>& nameMatches);
     void adjustCaptureGroups(int x, int a);
     void clearCaptureGroups();
@@ -662,6 +662,7 @@ private:
     std::list<std::list<std::string>> mMultiCaptureGroupList;
     std::list<std::list<int>> mMultiCaptureGroupPosList;
     QVector<QPair<QString, QString>> mCapturedNameGroups;
+    QMap<QString, QPair<int, int>> mCapturedNameGroupsPosList;
     QVector<QVector<QPair<QString, QString>>> mMultiCaptureNameGroups;
 
     QMap<QNetworkReply*, QString> downloadMap;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -356,6 +356,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         char* tabptr = reinterpret_cast<char*>(name_table);
         for (i = 0; i < namecount; i++) {
             int n = (tabptr[0] << 8) | tabptr[1];
+            // Trim doesn't remove null character at the end of name that sometimes shows up
             auto name = QString::fromUtf8(tabptr + 2, name_entry_size - 3).trimmed().remove(QStringLiteral("\u0000"));
             char* substring_start = subject + ovector[2*n];
             int substring_length = ovector[2*n+1] - ovector[2*n];

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -356,7 +356,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         char* tabptr = reinterpret_cast<char*>(name_table);
         for (i = 0; i < namecount; i++) {
             int n = (tabptr[0] << 8) | tabptr[1];
-            auto name = QString::fromUtf8( tabptr + 2, name_entry_size - 3).trimmed().remove(QStringLiteral("\u0000"));
+            auto name = QString::fromUtf8(tabptr + 2, name_entry_size - 3).trimmed().remove(QStringLiteral("\u0000"));
             char* substring_start = subject + ovector[2*n];
             int substring_length = ovector[2*n+1] - ovector[2*n];
             int utf16_pos = toMatch.indexOf(QString(substring_start));

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -357,7 +357,6 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         for (i = 0; i < namecount; i++) {
             int n = (tabptr[0] << 8) | tabptr[1];
             auto name = QString::fromUtf8( tabptr + 2, name_entry_size - 3).trimmed().remove(QStringLiteral("\u0000"));
-            qDebug() << name;
             char* substring_start = subject + ovector[2*n];
             int substring_length = ovector[2*n+1] - ovector[2*n];
             int utf16_pos = toMatch.indexOf(QString(substring_start));

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -357,7 +357,7 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMEENTRYSIZE, &name_entry_size);
         for (i = 0; i < namecount; i++) {
             int n = (tabptr[0] << 8) | tabptr[1];
-            auto name = QString::fromUtf8(tabptr + 2).trimmed();
+            auto name = QString::fromUtf8(&tabptr[2]).trimmed();
             auto* substring_start = subject + ovector[2*n];
             auto substring_length = ovector[2*n+1] - ovector[2*n];
             auto utf16_pos = toMatch.indexOf(QString(substring_start));

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -344,9 +344,9 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         }
     }
 
-    int namecount;
-    int name_entry_size;
-    char* tabptr;
+    int namecount; //NOLINT(cppcoreguidelines-init-variables)
+    int name_entry_size; //NOLINT(cppcoreguidelines-init-variables)
+    char* tabptr; //NOLINT(cppcoreguidelines-init-variables)
 
     pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMECOUNT, &namecount);
 
@@ -357,9 +357,9 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         pcre_fullinfo(re.data(), nullptr, PCRE_INFO_NAMEENTRYSIZE, &name_entry_size);
         for (i = 0; i < namecount; i++) {
             int n = (tabptr[0] << 8) | tabptr[1];
-            auto name = QString::fromUtf8(&tabptr[2]).trimmed();
-            auto* substring_start = subject + ovector[2*n];
-            auto substring_length = ovector[2*n+1] - ovector[2*n];
+            auto name = QString::fromUtf8(&tabptr[2]).trimmed(); //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
+            auto* substring_start = subject + ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-bounds-constant-array-index)
+            auto substring_length = ovector[2*n+1] - ovector[2*n]; //NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
             auto utf16_pos = toMatch.indexOf(QString(substring_start));
             auto capture = QString::fromUtf8(substring_start, substring_length);
             nameGroups << qMakePair(name, capture);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Make it possible to use `selectCaptureGroup` with name parameter

#### Motivation for adding to Mudlet

Consistency.

#### Other info (issues closed, discussion etc)

closes #5107

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
