### PR TITLE
Coverity: fix issue registered as CID 1503731

### DIFF
--- a/src/dlgRoomSymbol.cpp
+++ b/src/dlgRoomSymbol.cpp
@@ -54,10 +54,12 @@ void dlgRoomSymbol::init(QHash<QString, int>& pSymbols, QSet<TRoom*>& pRooms)
     initInstructionLabel();
     if (!pRooms.isEmpty()) {
         auto pRoom = *(pRooms.begin());
-        firstRoomId = pRoom->getId();
-        selectedColor = pRoom->mSymbolColor;
-        previewColor = pRoom->mSymbolColor;
-        roomColor = mpHost->mpMap->getColor(firstRoomId);
+        if (pRoom) {
+            auto firstRoomId = pRoom->getId();
+            selectedColor = pRoom->mSymbolColor;
+            previewColor = pRoom->mSymbolColor;
+            roomColor = mpHost->mpMap->getColor(firstRoomId);
+        }
     }
     updatePreview();
 }

--- a/src/dlgRoomSymbol.h
+++ b/src/dlgRoomSymbol.h
@@ -51,7 +51,6 @@ private:
     Host* mpHost;
     QSet<TRoom*> mpRooms;
     QHash<QString, int> mpSymbols;
-    int firstRoomId;
     QColor selectedColor = nullptr;
     QColor previewColor = nullptr;
     QColor roomColor;


### PR DESCRIPTION
A class member was local to a single method but it was not being initialised. Made it back into a local.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>