### PR TITLE
Coverity: fix issue registered as CID 1503740

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4247,7 +4247,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     //FIXME:
     if (mLabelHighlighted) {
         auto pA = mpMap->mpRoomDB->getArea(mAreaID);
-        if (!pA->mMapLabels.isEmpty()) {
+        if (pA && !pA->mMapLabels.isEmpty()) {
             bool needUpdate = false;
             QMapIterator<int, TMapLabel> itMapLabel(pA->mMapLabels);
             while (itMapLabel.hasNext()) {


### PR DESCRIPTION
As it happens I do not think that execution *could* reach the point where the change is made with `pA` not being valid - but I guess it is better to be safe than to dereference a null pointer...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>