### PR TITLE
Coverity: fix issue registered as CID 1503736

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -79,7 +79,6 @@ const QString& key_icon_dialog_cancel = QStringLiteral(":/icons/dialog-cancel.pn
 
 T2DMap::T2DMap(QWidget* parent)
 : QWidget(parent)
-, mpMap()
 , xyzoom(20)
 , mRX()
 , mRY()
@@ -173,8 +172,8 @@ void T2DMap::init()
 
     isCenterViewCall = false;
 
-    eSize = mpMap->mpHost->mLineSize;
-    rSize = mpMap->mpHost->mRoomSize;
+    eSize = mpHost->mLineSize;
+    rSize = mpHost->mRoomSize;
     mMapperUseAntiAlias = mpHost->mMapperUseAntiAlias;
     if (mMapViewOnly != mpHost->mMapViewOnly) {
         // If it was initialised in one state but the stored setting is the
@@ -2297,11 +2296,11 @@ int T2DMap::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
 
 void T2DMap::mouseDoubleClickEvent(QMouseEvent* event)
 {
-    if (mDialogLock || (event->buttons() != Qt::LeftButton)) {
-        return;
-    }
     if (!mpMap||!mpMap->mpRoomDB) {
         // No map loaded!
+        return;
+    }
+    if (mDialogLock || (event->buttons() != Qt::LeftButton)) {
         return;
     }
     int x = event->x();
@@ -2400,6 +2399,10 @@ void T2DMap::createLabel(QRectF labelRectangle)
 
 void T2DMap::mouseReleaseEvent(QMouseEvent* e)
 {
+    if (!mpMap) {
+        return;
+    }
+
     if (mMoveLabel) {
         mMoveLabel = false;
     }
@@ -2455,6 +2458,9 @@ bool T2DMap::event(QEvent* event)
 
 void T2DMap::mousePressEvent(QMouseEvent* event)
 {
+    if (!mpMap) {
+        return;
+    }
     mudlet::self()->activateProfile(mpHost);
     mNewMoveAction = true;
     if (event->buttons() & Qt::LeftButton) {
@@ -2775,7 +2781,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     getCenterSelection();
             }
 
-            if (!mpMap||!mpMap->mpRoomDB) {
+            if (!mpMap->mpRoomDB) {
                 // No map loaded
                 auto createMap = new QAction(tr("Create new map", "2D Mapper context menu (no map found) item"), this);
                 connect(createMap, &QAction::triggered, this, &T2DMap::slot_newMap);
@@ -3100,27 +3106,25 @@ void T2DMap::slot_createRoom()
         return;
     }
 
-    auto roomID = mpHost->mpMap->createNewRoomID();
-    if (!mpHost->mpMap->addRoom(roomID)) {
+    auto roomID = mpMap->createNewRoomID();
+    if (!mpMap->addRoom(roomID)) {
         return;
     }
 
-    mpHost->mpMap->setRoomArea(roomID, mAreaID, false);
+    mpMap->setRoomArea(roomID, mAreaID, false);
 
     auto mousePosition = getMousePosition();
-    mpHost->mpMap->setRoomCoordinates(roomID, mousePosition.first, mousePosition.second, mOz);
+    mpMap->setRoomCoordinates(roomID, mousePosition.first, mousePosition.second, mOz);
 
-    mpHost->mpMap->mMapGraphNeedsUpdate = true;
+    mpMap->mMapGraphNeedsUpdate = true;
 #if defined(INCLUDE_3DMAPPER)
-    if (mpHost->mpMap->mpM) {
-        mpHost->mpMap->mpM->update();
+    if (mpMap->mpM) {
+        mpMap->mpM->update();
     }
 #endif
-    if (mpHost->mpMap->mpMapper->mp2dMap) {
-        mpHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = true;
-        mpHost->mpMap->mpMapper->mp2dMap->update();
-        mpHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = false;
-    }
+    isCenterViewCall = true;
+    update();
+    isCenterViewCall = false;
 }
 
 // Used both by "Properties..." context menu item for existing lines AND
@@ -4094,31 +4098,29 @@ void T2DMap::slot_newMap()
         return;
     }
 
-    auto roomID = mpHost->mpMap->createNewRoomID();
+    auto roomID = mpMap->createNewRoomID();
 
-    if (!mpHost->mpMap->addRoom(roomID)) {
+    if (!mpMap->addRoom(roomID)) {
         return;
     }
 
-    mpHost->mpMap->setRoomArea(roomID, -1, false);
-    mpHost->mpMap->setRoomCoordinates(roomID, 0, 0, 0);
-    mpHost->mpMap->mMapGraphNeedsUpdate = true;
+    mpMap->setRoomArea(roomID, -1, false);
+    mpMap->setRoomCoordinates(roomID, 0, 0, 0);
+    mpMap->mMapGraphNeedsUpdate = true;
 
-    mpHost->mpMap->mRoomIdHash[mpMap->mProfileName] = roomID;
-    mpHost->mpMap->mNewMove = true;
+    mpMap->mRoomIdHash[mpMap->mProfileName] = roomID;
+    mpMap->mNewMove = true;
 
 #if defined(INCLUDE_3DMAPPER)
-    if (mpHost->mpMap->mpM) {
-        mpHost->mpMap->mpM->update();
+    if (mpMap->mpM) {
+        mpMap->mpM->update();
     }
 #endif
 
-    if (mpHost->mpMap->mpMapper->mp2dMap) {
-        mpHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = true;
-        mpHost->mpMap->mpMapper->mp2dMap->update();
-        mpHost->mpMap->mpMapper->mp2dMap->isCenterViewCall = false;
-        mpHost->mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
-    }
+    isCenterViewCall = true;
+    update();
+    isCenterViewCall = false;
+    mpMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
 }
 
 void T2DMap::slot_setArea()

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -88,7 +88,7 @@ public:
 #endif
 
 
-    TMap* mpMap;
+    TMap* mpMap = nullptr;
     QPointer<Host> mpHost;
     qreal xyzoom;
     int mRX;


### PR DESCRIPTION
The original moan was about a check for the `(TMap*) T2DMap::mpMap` member being a nullptr when it had already been dereferenced several (many) times before in the same method: `(void) T2DMap::mouseDoubleClickEvent(QMouseEvent*)` to correct this I moved the test to the top of method - and I spotted that some of the related methods had a similar check and others did not. So I put a similar check in all of them.

Then studying the code more closely I spotted that the class had both a `(QPointer<Host>) T2DMap::mpHost` and a `(TMap*) T2DMap::mpMap` yet in quite a few places was using the pointed to class instances own pointer to the other class instance. This looks to be doing unnecessary indirection so I have changed them to use this own class's member values as the pointers instead. Indeed in a further case involving I think some update code copy-pasted from elsewhere I found some indirection that would in fact resolve to point to the class `T2Map` instance directly!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>