### PR TITLE
Coverity: fix issue registered as CID 1414989 (x10 ?)

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -293,9 +293,10 @@ void dlgRoomExits::save()
 
     QString exitKey = QStringLiteral("nw");
     int dirCode = DIR_NORTHWEST;
+    auto pExit = originalExits.value(dirCode);
     if (nw->isEnabled() && !nw->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != nullptr) {
         // There IS a valid exit on the dialogue in this direction
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != nw->text().toInt()) {
+        if (pExit && pExit->destination != nw->text().toInt()) {
             pR->setExit(nw->text().toInt(), dirCode); // Destination is different - so store it
         }
         if (pR->hasExitStub(dirCode)) { // And ensure that stub exit is cleared if set
@@ -307,7 +308,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else { // No valid exit on the dialogue
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode); // Destination has been deleted so ensure the value for no exit is stored
         }
         if (stub_nw->isChecked() != pR->hasExitStub(dirCode)) {
@@ -323,8 +324,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("n");
     dirCode = DIR_NORTH;
+    pExit = originalExits.value(dirCode);
     if (n->isEnabled() && !n->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != n->text().toInt()) {
+        if (pExit && pExit->destination != n->text().toInt()) {
             pR->setExit(n->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -336,7 +338,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_n->isChecked() != pR->hasExitStub(dirCode)) {
@@ -351,8 +353,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("ne");
     dirCode = DIR_NORTHEAST;
+    pExit = originalExits.value(dirCode);
     if (ne->isEnabled() && !ne->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != ne->text().toInt()) {
+        if (pExit && pExit->destination != ne->text().toInt()) {
             pR->setExit(ne->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -364,7 +367,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_ne->isChecked() != pR->hasExitStub(dirCode)) {
@@ -379,8 +382,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("up");
     dirCode = DIR_UP;
+    pExit = originalExits.value(dirCode);
     if (up->isEnabled() && !up->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != up->text().toInt()) {
+        if (pExit && pExit->destination != up->text().toInt()) {
             pR->setExit(up->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -392,7 +396,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_up->isChecked() != pR->hasExitStub(dirCode)) {
@@ -407,8 +411,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("w");
     dirCode = DIR_WEST;
+    pExit = originalExits.value(dirCode);
     if (w->isEnabled() && !w->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != w->text().toInt()) {
+        if (pExit && pExit->destination != w->text().toInt()) {
             pR->setExit(w->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -420,7 +425,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_w->isChecked() != pR->hasExitStub(dirCode)) {
@@ -435,8 +440,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("e");
     dirCode = DIR_EAST;
+    pExit = originalExits.value(dirCode);
     if (e->isEnabled() && !e->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != e->text().toInt()) {
+        if (pExit && pExit->destination != e->text().toInt()) {
             pR->setExit(e->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -448,7 +454,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_e->isChecked() != pR->hasExitStub(dirCode)) {
@@ -463,8 +469,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("down");
     dirCode = DIR_DOWN;
+    pExit = originalExits.value(dirCode);
     if (down->isEnabled() && !down->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != down->text().toInt()) {
+        if (pExit && pExit->destination != down->text().toInt()) {
             pR->setExit(down->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -476,7 +483,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_down->isChecked() != pR->hasExitStub(dirCode)) {
@@ -491,8 +498,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("sw");
     dirCode = DIR_SOUTHWEST;
+    pExit = originalExits.value(dirCode);
     if (sw->isEnabled() && !sw->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != sw->text().toInt()) {
+        if (pExit && pExit->destination != sw->text().toInt()) {
             pR->setExit(sw->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -504,7 +512,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_sw->isChecked() != pR->hasExitStub(dirCode)) {
@@ -519,8 +527,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("s");
     dirCode = DIR_SOUTH;
+    pExit = originalExits.value(dirCode);
     if (s->isEnabled() && !s->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != s->text().toInt()) {
+        if (pExit && pExit->destination != s->text().toInt()) {
             pR->setExit(s->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -532,7 +541,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_s->isChecked() != pR->hasExitStub(dirCode)) {
@@ -547,8 +556,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("se");
     dirCode = DIR_SOUTHEAST;
+    pExit = originalExits.value(dirCode);
     if (se->isEnabled() && !se->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != se->text().toInt()) {
+        if (pExit && pExit->destination != se->text().toInt()) {
             pR->setExit(se->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -560,7 +570,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_se->isChecked() != pR->hasExitStub(dirCode)) {
@@ -575,8 +585,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("in");
     dirCode = DIR_IN;
+    pExit = originalExits.value(dirCode);
     if (in->isEnabled() && !in->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != in->text().toInt()) {
+        if (pExit && pExit->destination != in->text().toInt()) {
             pR->setExit(in->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -588,7 +599,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_in->isChecked() != pR->hasExitStub(dirCode)) {
@@ -603,8 +614,9 @@ void dlgRoomExits::save()
 
     exitKey = QStringLiteral("out");
     dirCode = DIR_OUT;
+    pExit = originalExits.value(dirCode);
     if (out->isEnabled() && !out->text().isEmpty() && mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != nullptr) {
-        if (originalExits.contains(dirCode) && originalExits.value(dirCode)->destination != out->text().toInt()) {
+        if (pExit && pExit->destination != out->text().toInt()) {
             pR->setExit(out->text().toInt(), dirCode);
         }
         if (pR->hasExitStub(dirCode)) {
@@ -616,8 +628,7 @@ void dlgRoomExits::save()
             pR->setExitWeight(exitKey, 0);
         }
     } else {
-        auto exit = originalExits.value(dirCode);
-        if (exit && exit->destination > 0) {
+        if (pExit && pExit->destination > 0) {
             pR->setExit(-1, dirCode);
         }
         if (stub_out->isChecked() != pR->hasExitStub(dirCode)) {


### PR DESCRIPTION
Technically we are storing a pointer in a `QMap`/`QHash` type container so as well as checking that there is an entry for the particular key we also should check that the stored key is non-null before we use it in further checks.

Whilst we could do this by converting the existing:
`if (originalExits.contains(dirCode)
     && originalExits.value(dirCode)->destination > 0) {`
to be:
`if (originalExits.contains(dirCode)
     && originalExits.value(dirCode)
     && originalExits.value(dirCode)->destination > 0) {`
we can just as well rely on the `QMap/QHash::value()` method to return a default constructed (i.e. `nullptr`) if the key provided is not found:
`if (originalExits.value(dirCode)
     && originalExits.value(dirCode)->destination > 0) {`

Further inspection shows that a more compact modification for the LAST exit being considered in that chunk of code (the one not in the instances picked up by Coverity) has already been done so it can be applied to these as well (with a renaming of the local variable from `exit` to `pExit`)!
`auto pExit = originalExits.value(dirCode);
 if (pExit && pExit->destination > 0) {`

It also seems that the same issue is also present in 12 cases in a higher `if` that contains each of the 11 (or 12) pieces of code in this issue.

This commit should silence this warning in this file but I think it also appears in other parts of our code (we store a pointer in a container and check for the presence of the pointer but not that it is not a null one before trying to dereference it)...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>