### PR TITLE
Don't set the tabs / main buttons font to a monospace one

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -517,16 +517,8 @@ mudlet::mudlet()
         mpMainToolBar->widgetForAction(actionFullScreeniew)->setObjectName(actionFullScreeniew->objectName());
         connect(actionFullScreeniew, &QAction::triggered, this, &mudlet::toggleFullScreenView);
     }
-    // This is the only place the tabBar font is set and it influences the
-    // height of the tabs used - since we now want to adjust the appearance of
-    // the tab if it is not the active one and new data has arrived to show in
-    // the related profile - make the font size a little larger that the 6 it
-    // once was so that it is a bit more obvious when it changes:
-    QFont mdiFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
-    mpTabBar->setFont(mdiFont);
 
     QFont mainFont = QFont(QStringLiteral("Bitstream Vera Sans Mono"), 8, QFont::Normal);
-    setFont(mainFont);
     mpWidget_profileContainer->setFont(mainFont);
     mpWidget_profileContainer->show();
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't set the tabs / main buttons font to a monospace one.

Linux:

![image](https://user-images.githubusercontent.com/110988/114528983-ce24dc80-9c49-11eb-90bd-d02db690201c.png)

Windows:

![image](https://user-images.githubusercontent.com/110988/114529331-2360ee00-9c4a-11eb-9e99-6f664a8fe3e8.png)


#### Motivation for adding to Mudlet
Qt 5.14 has a bug with it - and it looks better without monospace.
#### Other info (issues closed, discussion etc)

#### Release post highlight
Improved: buttons in the main toolbar are no longer monospaced.
