### PR TITLE
Only build for Coverity in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,6 @@ env:
 git:
   submodules: false # We selectively pull in the wanted submodules ourselves now
 jobs:
-  include:
-  - os: osx
-    osx_image: xcode11.3
-    compiler: clang
-    env:
-    - Q_OR_C_MAKE=qmake
-      DEPLOY=deploy
-
   - os: linux
     compiler: gcc
     env:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Only build for Coverity in Travis - remove the costly macOS build as we don't need it.
#### Motivation for adding to Mudlet
Travis re-enabled our builds, but we no longer need it for much except Coverity scanning. Let's reduce our usage of Travis - especially with the expensive macOS minutes - to make Coverity scanning work for as long as we can.
#### Other info (issues closed, discussion etc)
Coverity uploads still need to be ported to Github, see https://github.com/Mudlet/Mudlet/issues/4887
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
