### PR TITLE
More resilient libhunspell detection for qmake

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -284,7 +284,7 @@ unix:!macx {
         LIBS +=  \
             -L"$${MINGW_BASE_DIR_TEST}\\bin" \
             -llua51 \
-            -llibhunspell-1.6
+            -lhunspell-1.6
 
         INCLUDEPATH += \
              "C:\\Libraries\\boost_1_71_0" \


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
More resilient libhunspell detection for qmake - `-llibhunspell-1.6` works for all Qt versions except 5.14.2 where they broke it and fixed it in 5.15.2. Perhaps if we just use `-lhunspell-1.6`, it'll work in all Qt versions without exception.
#### Motivation for adding to Mudlet
Easier Qt version switching.