### PR TITLE
Fix error shown for map load on new profiles

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1480,15 +1480,13 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
     }
 
     bool canRestore = true;
-    bool noMapFile = false;
     if (entries.empty() && location.isEmpty()) {
-        noMapFile = true;
         canRestore = false;
     }
 
     QDataStream ifs;
     QFile file;
-    if (!entries.empty() || !location.isEmpty()) {
+    if (canRestore && (!entries.empty() || !location.isEmpty())) {
         // We get to here if there is one or more entries OR location is
         // supplied - if the latter then there is only one file to consider but
         // if the former we may have to check more than one to find a valid
@@ -1527,7 +1525,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         if (!foundValidFile) {
             canRestore = false;
         }
-    } else if (!noMapFile) {
+    } else if (canRestore && !location.isEmpty()) {
         file.setFileName(location);
         canRestore = validatePotentialMapFile(file, ifs);
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1479,11 +1479,13 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         entries = dir.entryList(filters, QDir::Files, QDir::Time);
     }
 
+    bool canRestore = true;
+    bool noMapFile = false;
     if (entries.empty() && location.isEmpty()) {
-        return false;
+        noMapFile = true;
+        canRestore = false;
     }
 
-    bool canRestore = true;
     QDataStream ifs;
     QFile file;
     if (!entries.empty() || !location.isEmpty()) {
@@ -1525,7 +1527,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         if (!foundValidFile) {
             canRestore = false;
         }
-    } else {
+    } else if (!noMapFile) {
         file.setFileName(location);
         canRestore = validatePotentialMapFile(file, ifs);
     }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1479,6 +1479,10 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
         entries = dir.entryList(filters, QDir::Files, QDir::Time);
     }
 
+    if (entries.empty() && location.isEmpty()) {
+        return false;
+    }
+
     bool canRestore = true;
     QDataStream ifs;
     QFile file;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix logic error in map loading - there are no maps in the `map` folder and we tried to load the default one, there would be an error.

![image](https://user-images.githubusercontent.com/110988/115057786-c16fe500-9ee4-11eb-9529-e87dadd0a713.png)

#### Motivation for adding to Mudlet
No regressions should make it into the official release.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5113 which was only ever present in PTBs. 
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
