### PR TITLE
Fix image updates not taking effect

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -55,7 +55,6 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
 {
     ui->setupUi(this);
     ui->splitter_metadataAssets->hide();
-    //    ui->splitter_metadata->setSizes({})
     ui->Icon->hide();
 
     mpExportSelection = ui->treeWidget_exportSelection;
@@ -499,19 +498,19 @@ void dlgPackageExporter::slot_export_package()
 
     if (!imageList.isEmpty()) {
         //Create description image dir
-        QString descriptionImageDirName = QStringLiteral("%1.mudlet/description_images/").arg(tempPath);
-        QDir descriptionImageDir = QDir(descriptionImageDirName);
+        QString descriptionImagesDirName = QStringLiteral("%1.mudlet/description_images/").arg(tempPath);
+        QDir descriptionImageDir = QDir(descriptionImagesDirName);
         if (!descriptionImageDir.exists()) {
-            descriptionImageDir.mkpath(descriptionImageDirName);
+            descriptionImageDir.mkpath(descriptionImagesDirName);
         }
         for (int i = imageList.size() - 1; i >= 0; i--) {
             QFileInfo imageFile(imageList.at(i));
             if (imageFile.exists()) {
-                QString imageDir = descriptionImageDirName;
+                QString imageDir = descriptionImagesDirName;
                 imageDir.append(imageFile.fileName());
                 QFile::copy(imageFile.absoluteFilePath(), imageDir);
             }
-            //replace $Imageindex with $packagePath in description file
+            //replace temporary path with the path that is now inside the package
             plainDescription.replace(QStringLiteral("$%1").arg(imageFile.fileName()), QStringLiteral("$packagePath/.mudlet/description_images/%1").arg(imageFile.fileName()));
         }
     }
@@ -797,7 +796,7 @@ std::pair<bool, QString> dlgPackageExporter::copyAssetsToTmp(const QStringList& 
             QFile::remove(filePath);
             QFile::copy(asset.absoluteFilePath(), filePath);
         } else if (asset.isDir()) {
-            copy_directory(asset.absoluteFilePath(), filePath, true);
+            copy_directory(asset.absoluteFilePath(), filePath, false);
         }
     }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix image updates not taking effect. The issue was that the new description images are copied first, and then old description images are overwritten on top of them - fix that by not overwriting what's already there.
#### Motivation for adding to Mudlet
Fix bug in new package exporter.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5150.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
