### PR TITLE
Add clang-tidy, clazy, valgrind to docker dev image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,10 +56,13 @@ COPY --chown=mudlet:mudlet src src
 
 USER mudlet
 
-ARG BUILD_CORES=4
-RUN mkdir build && cd build && cmake .. && cmake --build . --parallel ${BUILD_CORES}
-RUN mkdir /home/mudlet/settings
+RUN mkdir build
+VOLUME /home/mudlet/build
 
+ARG BUILD_CORES=4
+RUN cd build && cmake .. && cmake --build . --parallel ${BUILD_CORES}
+
+RUN mkdir /home/mudlet/settings
 VOLUME /home/mudlet/settings
 
 CMD ["build/src/mudlet"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,11 +56,9 @@ COPY --chown=mudlet:mudlet src src
 
 USER mudlet
 
-RUN mkdir build
-VOLUME /home/mudlet/build
-
 ARG BUILD_CORES=4
-RUN cd build && cmake .. && cmake --build . --parallel ${BUILD_CORES}
+RUN mkdir build && cd build && cmake .. && cmake --build . --parallel ${BUILD_CORES}
+VOLUME /home/mudlet/build
 
 RUN mkdir /home/mudlet/settings
 VOLUME /home/mudlet/settings

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
     ccache \
+    clang-tidy \
+    clazy \
     cmake \
     gdb \
     git \
@@ -33,6 +35,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     qttools5-dev \
     qt5keychain-dev \
     qtcreator \
+    valgrind \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -43,7 +46,7 @@ RUN luarocks install lcf && \
 RUN useradd -ms /bin/bash mudlet
 WORKDIR /home/mudlet
 
-COPY --chown=mudlet:mudlet CMakeLists.txt CPPLINT.cfg mudlet.desktop mudlet.png mudlet.svg ./
+COPY --chown=mudlet:mudlet .clang-tidy CMakeLists.txt CPPLINT.cfg mudlet.desktop mudlet.png mudlet.svg ./
 COPY --chown=mudlet:mudlet 3rdparty 3rdparty
 COPY --chown=mudlet:mudlet templates templates
 COPY --chown=mudlet:mudlet translations translations

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     <<: *base-settings
     volumes:
       - settings:/home/mudlet/settings
-      - build:/home/mudlet/build
       - ../CMakeLists.txt:/home/mudlet/CMakeLists.txt
       - ../src:/home/mudlet/src
       - ../translations:/home/mudlet/translations
@@ -17,5 +16,4 @@ services:
     command: qtcreator CMakeLists.txt -settingspath /home/mudlet/settings/
 
 volumes:
-  build:
   settings:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds some of the CI tooling to the dockerfile so they can be ran. A bit of a problem wrt imports, so still requires manually running the checks outside of qtcreator at the moment

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

#### Release post highlight

