### PR TITLE
Allow variable creation without initial selection

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7072,9 +7072,7 @@ void dlgTriggerEditor::slot_add_new()
         addKey(false); //add normal alias
         break;
     case EditorViewType::cmVarsView:
-        if (mpCurrentVarItem) {
-            addVar(false); //add normal action
-        }
+        addVar(false); //add variable
         break;
     default:
         qDebug() << "ERROR: dlgTriggerEditor::slot_save_edit() undefined view";
@@ -7103,9 +7101,7 @@ void dlgTriggerEditor::slot_add_new_folder()
         addKey(true); //add alias group
         break;
     case EditorViewType::cmVarsView:
-        if (mpCurrentVarItem) {
-            addVar(true);
-        }
+        addVar(true); // add lua table
         break;
     default:
         qDebug() << "ERROR: dlgTriggerEditor::slot_save_edit() undefined view";

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3469,18 +3469,22 @@ void dlgTriggerEditor::addVar(bool isFolder)
         mpVarsMainArea->comboBox_variable_value_type->setCurrentIndex(0);
     }
 
-    QStringList nameL;
-    nameL << QString();
-    QTreeWidgetItem* cItem = treeWidget_variables->currentItem();
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
-    TVar* cVar = vu->getWVar(cItem);
+
+    QStringList nameL;
+    nameL << QString(isFolder ? "New table name" : "New variable name");
+
     QTreeWidgetItem* pParent;
     QTreeWidgetItem* pNewItem;
-    if (cVar && cVar->getValueType() == LUA_TTABLE) {
-        pParent = cItem;
-    } else {
-        pParent = cItem->parent();
+    QTreeWidgetItem* cItem = treeWidget_variables->currentItem();
+    TVar* cVar = vu->getWVar(cItem);
+    if (cItem) {
+        if (cVar && cVar->getValueType() == LUA_TTABLE) {
+            pParent = cItem;
+        } else {
+            pParent = cItem->parent();
+        }
     }
 
     auto newVar = new TVar();
@@ -3507,13 +3511,11 @@ void dlgTriggerEditor::addVar(bool isFolder)
     }
     vu->addTempVar(pNewItem, newVar);
     pNewItem->setFlags(pNewItem->flags() & ~(Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled));
-// The following test is pointless - we will already have seg. faulted if pNewItem is a nullptr...!
-//    if (pNewItem) {
-        mpCurrentVarItem = pNewItem;
-        treeWidget_variables->setCurrentItem(pNewItem);
-        showInfo(msgInfoAddVar);
-        slot_var_selected(treeWidget_variables->currentItem());
-//    }
+
+    mpCurrentVarItem = pNewItem;
+    treeWidget_variables->setCurrentItem(pNewItem);
+    showInfo(msgInfoAddVar);
+    slot_var_selected(treeWidget_variables->currentItem());
 }
 
 void dlgTriggerEditor::addKey(bool isFolder)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -3473,13 +3473,13 @@ void dlgTriggerEditor::addVar(bool isFolder)
     VarUnit* vu = lI->getVarUnit();
 
     QStringList nameL;
-    nameL << QString(isFolder ? "New table name" : "New variable name");
+    nameL << QString(isFolder ? tr("New table name") : tr("New variable name"));
 
     QTreeWidgetItem* pParent;
     QTreeWidgetItem* pNewItem;
     QTreeWidgetItem* cItem = treeWidget_variables->currentItem();
-    TVar* cVar = vu->getWVar(cItem);
     if (cItem) {
+        TVar* cVar = vu->getWVar(cItem);
         if (cVar && cVar->getValueType() == LUA_TTABLE) {
             pParent = cItem;
         } else {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Fixes #831 and some/perhaps all of #2640

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

#### Release post highlight
1) The variables interface will no longer require you to select an existing variable to add the first items.
2) Variables will have some default text in the tree view, so multiple add items don't result in blanks
