### PR TITLE
Fix assets to expand fully as well in package exporter

### DIFF
--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -313,6 +313,12 @@
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <item>
             <widget class="QLabel" name="label_assets">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="text">
               <string>Include assets (images, sounds, fonts)</string>
              </property>
@@ -320,12 +326,6 @@
            </item>
            <item>
             <widget class="QListWidget" name="listWidget_addedFiles">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
              <property name="acceptDrops">
               <bool>true</bool>
              </property>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
I previously made it so the description area could be resized to be bigger - and now I've improved the assets area to be expandable to max as well if needed.


https://user-images.githubusercontent.com/110988/115190576-876f3080-a0e8-11eb-9663-6412e07d2f73.mp4



([alternative link](https://streamable.com/sbgt9d))

#### Motivation for adding to Mudlet
Better package exporter experience.