### PR TITLE
Update generic_mapper.xml find_me() to prevent low-id rooms from wrongly matching 

### DIFF
--- a/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
+++ b/src/mudlet-lua/lua/generic-mapper/generic_mapper.xml
@@ -2432,7 +2432,7 @@ function map.find_me(name, exits, dir, manual)
     if table.size(match_IDs) == 0 then
         match_IDs = rooms
     end
-    if table.contains(match_IDs,map.currentRoom) then
+    if table.index_of(match_IDs,map.currentRoom) then
         match_IDs = {map.currentRoom}
     end
     if not table.is_empty(match_IDs) and not find_portal then


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
changes find_me's table.contains to table.index_of to prevent erroneous matches when in rooms with its id matching-or-less than number of valid room names

#### Motivation for adding to Mudlet
table.contains, for a table of { 123, 456, 789 }, will also match ids 1, 2, 3 since they are the keys of those values. This is bad behavior in the mapper since it sees if the table contains the current room - which may possibly be 1 2 or 3.

#### Other info (issues closed, discussion etc)
https://discord.com/channels/283581582550237184/283582068334526464/832755701192720414
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
