### PR TITLE
Remove unused description images from packages

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -607,7 +607,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
 }
 
 // purge images from tmp which are no longer used by the description
-void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QString& plainDescription) const
+void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QString& plainDescription)
 {
     static QRegularExpression imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\")");
     QStringList imagesInUse;

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -488,27 +488,27 @@ void dlgPackageExporter::slot_export_package()
     displayResultMessage(tr("Exporting package..."), true);
     qApp->processEvents();
 
-    //copy description image files
-    QStringList imageList;
+    //copy the newly-added description image files
+    QStringList newImageList;
     //don't change the original plain description here as it may still be needed, for example if creating another package
     QString plainDescription = mPlainDescription;
     for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
         QString fname = mDescriptionImages.at(i);
         QFileInfo info(fname);
         if (plainDescription.contains(QStringLiteral("$%1").arg(info.fileName()))) {
-            imageList.append(fname);
+            newImageList.append(fname);
         }
     }
 
-    if (!imageList.isEmpty()) {
+    if (!newImageList.isEmpty()) {
         //Create description image dir
         QString descriptionImagesDirName = QStringLiteral("%1.mudlet/description_images/").arg(tempPath);
         QDir descriptionImageDir = QDir(descriptionImagesDirName);
         if (!descriptionImageDir.exists()) {
             descriptionImageDir.mkpath(descriptionImagesDirName);
         }
-        for (int i = imageList.size() - 1; i >= 0; i--) {
-            QFileInfo imageFile(imageList.at(i));
+        for (int i = newImageList.size() - 1; i >= 0; i--) {
+            QFileInfo imageFile(newImageList.at(i));
             if (imageFile.exists()) {
                 QString imageDir = descriptionImagesDirName;
                 imageDir.append(imageFile.fileName());
@@ -821,11 +821,6 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
     zip* archive = zip_open(packagePathFileName.toUtf8().constData(), ZIP_CREATE | ZIP_TRUNCATE, &ze);
 
     if (!archive) {
-        // Failed to open/create archive file
-        // We now use the better zipError handling system (not requiring a
-        // previously defined finite-sized char type buffer {which obviously
-        // could have string buffer overflow issues} which is available in
-        // post 0.10 versions of libzip):
         zip_error_t zipError;
         zip_error_init_with_code(&zipError, ze);
         QString errMsg = tr("Failed to open package file. Error is: \"%1\".",
@@ -851,44 +846,39 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
 */
     qt_ntfs_permission_lookup++;
 #endif // defined(Q_OS_WIN32)
-    QDirIterator itDir(stagingDirName, QDir::NoDotAndDotDot | QDir::AllDirs | QDir::Files, QDirIterator::Subdirectories);
+    QDirIterator stagingFile(stagingDirName, QDir::NoDotAndDotDot | QDir::AllDirs | QDir::Files, QDirIterator::Subdirectories);
     // relative names to use in archive:
     QStringList directoryEntries;
     // Key is relative name to use in archive
     // Value is fullName in file-system:
     QMap<QString, QString> fileEntries;
-    while (itDir.hasNext() && isOk) {
-        QString itEntry = itDir.next();
+    while (stagingFile.hasNext() && isOk) {
+        QString itEntry = stagingFile.next();
         Q_UNUSED(itEntry);
-        //              Comment out the preceding line if the following is uncommented!
-        //              qDebug() << " parsing entry:" << itEntry << " fileName() is:" << itDir.fileName() << " filePath() is:" << itDir.filePath();
-        // QString::compare(...) returns 0 (false) if the two arguments
-        // MATCH and non-0 (true) otherwise and De Morgans' Laws means
-        // that the if branch should be taken if the fileName IS a Dot
-        // OR IS a DotDot file...!
-        if (!(itDir.fileName().compare(QStringLiteral(".")) && itDir.fileName().compare(QStringLiteral("..")))) {
+        // Dot and DotDot entries are no use to us so skip them
+        if (!(stagingFile.fileName().compare(QStringLiteral(".")) && stagingFile.fileName().compare(QStringLiteral("..")))) {
             // Dot and DotDot entries are no use to us so skip them
             continue;
         }
 
-        QFileInfo entryInfo(itDir.fileInfo());
-        if (!entryInfo.isReadable()) {
-            qWarning() << "dlgPackageExporter::slot_export_package() skipping file: " << itDir.fileName() << "it is NOT readable!";
+        QFileInfo stagingFileInfo(stagingFile.fileInfo());
+        if (!stagingFileInfo.isReadable()) {
+            qWarning() << "dlgPackageExporter::slot_export_package() skipping file: " << stagingFile.fileName() << "it is NOT readable!";
             continue;
         }
 
-        if (entryInfo.isSymLink()) {
-            qWarning() << "dlgPackageExporter::slot_export_package() skipping file: " << itDir.fileName() << "it is a Symlink - avoided to prevent file-system loops!";
+        if (stagingFileInfo.isSymLink()) {
+            qWarning() << "dlgPackageExporter::slot_export_package() skipping file: " << stagingFile.fileName() << "it is a Symlink - avoided to prevent file-system loops!";
             continue;
         }
 
-        QString nameInArchive = itDir.filePath();
+        QString nameInArchive = stagingFile.filePath();
         nameInArchive.remove(QStringLiteral("%1/").arg(stagingDirName));
 
-        if (entryInfo.isDir()) {
+        if (stagingFileInfo.isDir()) {
             directoryEntries.append(nameInArchive);
-        } else if (entryInfo.isFile()) {
-            fileEntries.insert(nameInArchive, itDir.filePath());
+        } else if (stagingFileInfo.isFile()) {
+            fileEntries.insert(nameInArchive, stagingFile.filePath());
         }
     }
 

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -488,36 +488,7 @@ void dlgPackageExporter::slot_export_package()
     displayResultMessage(tr("Exporting package..."), true);
     qApp->processEvents();
 
-    //copy the newly-added description image files
-    QStringList newImageList;
-    //don't change the original plain description here as it may still be needed, for example if creating another package
-    QString plainDescription = mPlainDescription;
-    for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
-        QString fname = mDescriptionImages.at(i);
-        QFileInfo info(fname);
-        if (plainDescription.contains(QStringLiteral("$%1").arg(info.fileName()))) {
-            newImageList.append(fname);
-        }
-    }
-
-    if (!newImageList.isEmpty()) {
-        //Create description image dir
-        QString descriptionImagesDirName = QStringLiteral("%1.mudlet/description_images/").arg(tempPath);
-        QDir descriptionImageDir = QDir(descriptionImagesDirName);
-        if (!descriptionImageDir.exists()) {
-            descriptionImageDir.mkpath(descriptionImagesDirName);
-        }
-        for (int i = newImageList.size() - 1; i >= 0; i--) {
-            QFileInfo imageFile(newImageList.at(i));
-            if (imageFile.exists()) {
-                QString imageDir = descriptionImagesDirName;
-                imageDir.append(imageFile.fileName());
-                QFile::copy(imageFile.absoluteFilePath(), imageDir);
-            }
-            //replace temporary path with the path that is now inside the package
-            plainDescription.replace(QStringLiteral("$%1").arg(imageFile.fileName()), QStringLiteral("$packagePath/.mudlet/description_images/%1").arg(imageFile.fileName()));
-        }
-    }
+    auto plainDescription = copyNewImagesToTmp(tempPath);
 
     QStringList assetPaths;
     for (int i = 0; i < ui->listWidget_addedFiles->count(); ++i) {
@@ -530,7 +501,6 @@ void dlgPackageExporter::slot_export_package()
     QFileInfo iconFile = copyIconToTmp(tempPath);
 
     mXmlPathFileName = QStringLiteral("%1/%2.xml").arg(stagingDirName, mPackageName);
-
     writeConfigFile(stagingDirName, iconFile, plainDescription);
 
     QFile checkWriteability(mXmlPathFileName);
@@ -563,6 +533,7 @@ void dlgPackageExporter::slot_export_package()
         // this will freeze the main thread, so it's not the perfect way - ideally
         // only start this after assets copy + xml writing is complete
         assetsFuture.waitForFinished();
+        cleanupUnusedImages(tempPath, plainDescription);
         if (auto [success, message] = assetsFuture.result(); !success) {
             displayResultMessage(message);
             isOk = false;
@@ -597,6 +568,64 @@ void dlgPackageExporter::slot_export_package()
         mCancelButton->setVisible(false);
         mCloseButton->setVisible(true);
         QApplication::restoreOverrideCursor();
+    }
+}
+
+//copy the newly-added description image files
+QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
+{
+    QStringList newImagesList;
+    //don't change the original plain description here as it may still be needed, for example if creating another package
+    QString plainDescription = mPlainDescription;
+    for (int i = mDescriptionImages.size() - 1; i >= 0; i--) {
+        QString fname = mDescriptionImages.at(i);
+        QFileInfo info(fname);
+        if (plainDescription.contains(QStringLiteral("$%1").arg(info.fileName()))) {
+            newImagesList.append(fname);
+        }
+    }
+
+    if (!newImagesList.isEmpty()) {
+        //Create description image dir
+        QString descriptionImagesDirName = QStringLiteral("%1.mudlet/description_images/").arg(tempPath);
+        QDir descriptionImageDir = QDir(descriptionImagesDirName);
+        if (!descriptionImageDir.exists()) {
+            descriptionImageDir.mkpath(descriptionImagesDirName);
+        }
+        for (int i = newImagesList.size() - 1; i >= 0; i--) {
+            QFileInfo imageFile(newImagesList.at(i));
+            if (imageFile.exists()) {
+                QString imageDir = descriptionImagesDirName;
+                imageDir.append(imageFile.fileName());
+                QFile::copy(imageFile.absoluteFilePath(), imageDir);
+            }
+            //replace temporary path with the path that is now inside the package
+            plainDescription.replace(QStringLiteral("$%1").arg(imageFile.fileName()), QStringLiteral("$packagePath/.mudlet/description_images/%1").arg(imageFile.fileName()));
+        }
+    }
+    return plainDescription;
+}
+
+// purge images from tmp which are no longer used by the description
+void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QString& plainDescription) const
+{
+    static QRegularExpression imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\")");
+    QStringList imagesInUse;
+    QRegularExpressionMatchIterator i = imagesInUsePattern.globalMatch(plainDescription);
+    while (i.hasNext()) {
+        auto match = i.next();
+        imagesInUse << match.captured(1).remove(QChar('\"'));
+    }
+
+    // iterate through all images in folder, if our list doesn't contain it - remove
+    QDirIterator allImagesCopied(QStringLiteral("%1.mudlet/description_images").arg(tempPath), QDir::Files);
+    while (allImagesCopied.hasNext()) {
+        QFileInfo copiedImage(allImagesCopied.next());
+        if (!imagesInUse.contains(copiedImage.fileName())) {
+            if (!QFile(copiedImage.absoluteFilePath()).remove()) {
+                qDebug() << "couldn't remove unused image" << copiedImage.fileName();
+            }
+        }
     }
 }
 

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -131,6 +131,8 @@ private:
                          QList<QTreeWidgetItem*>& actionList,
                          QList<QTreeWidgetItem*>& scriptList,
                          QList<QTreeWidgetItem*>& keyList);
+    QString copyNewImagesToTmp(const QString& tempPath) const;
+    void cleanupUnusedImages(const QString& tempPath, const QString& plainDescription) const;
 
     Ui::dlgPackageExporter* ui;
     QPointer<Host> mpHost;

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -132,7 +132,7 @@ private:
                          QList<QTreeWidgetItem*>& scriptList,
                          QList<QTreeWidgetItem*>& keyList);
     QString copyNewImagesToTmp(const QString& tempPath) const;
-    void cleanupUnusedImages(const QString& tempPath, const QString& plainDescription) const;
+    static void cleanupUnusedImages(const QString& tempPath, const QString& plainDescription);
 
     Ui::dlgPackageExporter* ui;
     QPointer<Host> mpHost;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When an image was part of a package description, removed from the description and the package re-exported, the image didn't actually get removed from being included in the package. 


https://user-images.githubusercontent.com/110988/116779554-357ac300-aa77-11eb-92f4-4de315161613.mp4



([alternative link](https://streamable.com/506xho))
#### Motivation for adding to Mudlet
So there's no rubbish generated in `.mudlet/description_images` and not to bloat them up in size.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5195
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
