### PR TITLE
Fix loadMap() to work again

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -1517,6 +1517,11 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
 
            // Allow for somethings to be updated - especially on Windows?
            qApp->processEvents();
+        } else {
+            file.setFileName(location);
+            if (validatePotentialMapFile(file, ifs)) {
+                foundValidFile = true;
+            }
         }
         if (!foundValidFile) {
             canRestore = false;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix loadMap() to work again - new code wasn't handling the part where a location _was_ supplied.
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
The recent change here added 2 bugs, which is far too many - this code is a candidate for simplifying. The logic is just too messy to work with and generates bugs.
