### PR TITLE
Run builds on the 'main' branch as well

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -1,7 +1,7 @@
 name: 🔨 Build Mudlet
 on:
   push:
-    branches: [master, development]
+    branches: [main, development]
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix builds to run on the renamed 'main' branch as well.
#### Motivation for adding to Mudlet
So we can know when merges into `main` are OK.
### Other info
Forgot to rename this when changing `master` to be `main`.