### PR TITLE
Add paths-ignore

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - 3rdparty

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -83,6 +83,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
+        config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,7 @@ on:
     branches: [development, main]
   schedule:
     - cron: '0 7 * * 3'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Changes the CodeQL workflow to ignore paths in the 3rdparty folder. This does not affect the analysis directly, but it does allow our lines of code counter to run without memory errors. This is not an ideal situation, we will have to do some more work to determine ways we can avoid counting third party code without explicit paths, but this PR should allow your codeql scanning to start functioning again.

See github/codeql#5873 for the original issue.

And also #5223 for a previous attempt at this change.