### PR TITLE
Enhance: get and set state of push-down-buttons (button love part1) 

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2017, 2021 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -416,7 +416,7 @@ TAction* ActionUnit::getHeadAction(TToolBar* pT)
 void ActionUnit::showToolBar(const QString& name)
 {
     for (auto& easyButtonBar : mEasyButtonBarList) {
-        if (easyButtonBar->mpTAction->mName == name) {
+        if (easyButtonBar->mpTAction->getName() == name) {
             easyButtonBar->mpTAction->setIsActive(true);
             updateToolbar();
         }
@@ -428,7 +428,7 @@ void ActionUnit::showToolBar(const QString& name)
 void ActionUnit::hideToolBar(const QString& name)
 {
     for (auto& easyButtonBar : mEasyButtonBarList) {
-        if (easyButtonBar->mpTAction->mName == name) {
+        if (easyButtonBar->mpTAction->getName() == name) {
             easyButtonBar->mpTAction->setIsActive(false);
             updateToolbar();
         }
@@ -466,7 +466,7 @@ void ActionUnit::constructToolbar(TAction* pA, TToolBar* pTB)
     pTB->setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
     if (pA->mLocation == 4) {
         if (pA->mToolbarLastDockArea == Qt::NoDockWidgetArea) {
-            qWarning() << "ActionUnit::constructToolbar(TAction*, TToolBar*) WARNING - no last dockarea was set for the TAction (\"" << pA->mName << "\"), for this toolbar forcing it to the Left one!";
+            qWarning() << "ActionUnit::constructToolbar(TAction*, TToolBar*) WARNING - no last dockarea was set for the TAction (\"" << pA->getName() << "\"), for this toolbar forcing it to the Left one!";
         }
         mudlet::self()->addDockWidget(((pA->mToolbarLastDockArea != Qt::NoDockWidgetArea) ? pA->mToolbarLastDockArea : Qt::LeftDockWidgetArea), pTB);
         if (pA->mToolbarLastFloatingState) {

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -70,7 +70,6 @@ TAction::TAction(const QString& name, Host* pHost)
 , mPosY(0)
 , mOrientation()
 , mLocation()
-, mName(name)
 , mIsPushDownButton()
 , mNeedsToBeCompiled(true)
 , mButtonRotation()
@@ -86,6 +85,7 @@ TAction::TAction(const QString& name, Host* pHost)
 , mModuleMasterFolder(false)
 , mToolbarLastDockArea(Qt::LeftDockWidgetArea)
 , mToolbarLastFloatingState(true)
+, mName(name)
 , mModuleMember(false)
 , mDataChanged(true)
 {
@@ -269,6 +269,11 @@ void TAction::expandToolbar(TToolBar* pT)
             button->setMenu(newMenu);
         }
 
+        if (action->mpFButton) {
+            action->mpFButton->deleteLater();
+        }
+        action->mpFButton = button;
+
         // Moved to be AFTER the action->mIsFolder test as I think we ought to
         // add the button to the toolbar AFTER any menu (children) items have
         // been put on the button - Slysven
@@ -288,6 +293,10 @@ void TAction::insertActions(TToolBar* pT, QMenu* menu)
     action->mID = mID;
     action->mpHost = mpHost;
     action->setStatusTip(mName);
+    if (mpEButton) {
+        mpEButton->deleteLater();
+    }
+    mpEButton = action;
     menu->addAction(action);
 
     if (isFolder()) {
@@ -355,6 +364,11 @@ void TAction::expandToolbar(TEasyButtonBar* pT)
             button->setMenu(newMenu);
         }
 
+        if (action->mpFButton) {
+            action->mpFButton->deleteLater();
+        }
+        action->mpFButton = button;
+
         // Moved to be AFTER the action->mIsFolder test as I think we ought to
         // add the button to the toolbar AFTER any menu (children) items have
         // been put on the button - Slysven
@@ -383,6 +397,11 @@ void TAction::fillMenu(TEasyButtonBar* pT, QMenu* menu)
         } else {
             newAction->setChecked(false);
         }
+
+        if (action->mpEButton) {
+            action->mpEButton->deleteLater();
+        }
+        action->mpEButton = newAction;
 
         //FIXME: Heiko April 2012 -> expandToolBar()
         if (action->mIsPushDownButton && mpHost->mIsProfileLoadingSequence) {
@@ -420,6 +439,10 @@ void TAction::insertActions(TEasyButtonBar* pT, QMenu* menu)
     action->mID = mID;
     action->mpHost = mpHost;
     action->setStatusTip(mName);
+    if (mpEButton) {
+        mpEButton->deleteLater();
+    }
+    mpEButton = action;
     Q_ASSERT_X(menu, "TAction::insertActions(TEasyButtonBar*, QMenu*)", "method called with a NULL QMenu pointer!");
     menu->addAction(action);
 }

--- a/src/TAction.h
+++ b/src/TAction.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2020 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2017, 2020-2021 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -31,6 +32,7 @@
 #include <QPointer>
 #include "post_guard.h"
 
+class EAction;
 class Host;
 class mudlet;
 class TEasyButtonBar;
@@ -95,6 +97,8 @@ public:
 
     QPointer<TToolBar> mpToolBar;
     QPointer<TEasyButtonBar> mpEasyButtonBar;
+    QPointer<EAction> mpEButton;
+    QPointer<TFlipButton> mpFButton;
     // The following was an int but there was confusion over:
     // EITHER: "1" = released/unclicked/up & "2" = pressed/clicked/down
     // OR:     "1" = pressed/clicked/down  & "0" = released/unclicked/up
@@ -107,10 +111,6 @@ public:
     int mPosY;
     int mOrientation;
     int mLocation;
-    QString mName;
-    QString mCommandButtonUp;
-    QString mCommandButtonDown;
-    QString mScript;
     bool mIsPushDownButton;
 
     bool mNeedsToBeCompiled;
@@ -135,6 +135,10 @@ public:
 private:
     TAction() = default;
 
+    QString mName;
+    QString mCommandButtonUp;
+    QString mCommandButtonDown;
+    QString mScript;
     QString mFuncName;
     bool mModuleMember;
     bool mDataChanged;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15715,10 +15715,11 @@ int TLuaInterpreter::setButtonStateByName(lua_State* L)
 
     if (pItem->mButtonState != checked) {
         pItem->mButtonState = checked;
-        // This should probably be a Q_ASSERT_X(...) but this is a bit more
-        // foregiving:
         if (pItem->mpEButton) {
             pItem->mpEButton->setChecked(checked);
+        }
+        if (pItem->mpFButton) {
+            pItem->mpFButton->setChecked(checked);
         }
         lua_pushboolean(L, true);
         return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5793,16 +5793,16 @@ int TLuaInterpreter::getButtonState(lua_State* L)
     auto argType = lua_type(L, 1);
     TAction* pItem = nullptr;
     if (argType == LUA_TNUMBER) {
-        int id = lua_tonumber(L, 1);
+        int id = qRound(lua_tonumber(L, 1));
         if (id < 0) {
-            return warnArgumentValue(L, __func__, QStringLiteral("item Id (%1) invalid, it must be equal or greater than zero").arg(id).toUtf8().constData());
+            return warnArgumentValue(L, __func__, QStringLiteral("item ID (%1) invalid, it must be equal or greater than zero").arg(id).toUtf8().constData());
         }
         pItem = host.getActionUnit()->getAction(id);
         if (!pItem) {
-            return warnArgumentValue(L, __func__, QStringLiteral("no button item with Id %1 found").arg(id).toUtf8().constData());
+            return warnArgumentValue(L, __func__, QStringLiteral("no button item with ID %1 found").arg(id).toUtf8().constData());
         }
         if (!pItem->isPushDownButton()) {
-            return warnArgumentValue(L, __func__, QStringLiteral("item Id with %1 is not a push-down button").arg(id).toUtf8().constData());
+            return warnArgumentValue(L, __func__, QStringLiteral("item ID with %1 is not a push-down button").arg(id).toUtf8().constData());
         }
     }
 
@@ -5838,16 +5838,16 @@ int TLuaInterpreter::setButtonState(lua_State* L)
     auto argType = lua_type(L, 1);
     TAction* pItem = nullptr;
     if (argType == LUA_TNUMBER) {
-        int id = lua_tonumber(L, 1);
+        int id = qRound(lua_tonumber(L, 1));
         if (id < 0) {
-            return warnArgumentValue(L, __func__, QStringLiteral("item Id (%1) invalid, it must be equal or greater than zero").arg(id).toUtf8().constData());
+            return warnArgumentValue(L, __func__, QStringLiteral("item ID (%1) invalid, it must be equal or greater than zero").arg(id).toUtf8().constData());
         }
         pItem = host.getActionUnit()->getAction(id);
         if (!pItem) {
-            return warnArgumentValue(L, __func__, QStringLiteral("no button item with Id %1 found").arg(id).toUtf8().constData());
+            return warnArgumentValue(L, __func__, QStringLiteral("no button item with ID %1 found").arg(id).toUtf8().constData());
         }
         if (!pItem->isPushDownButton()) {
-            return warnArgumentValue(L, __func__, QStringLiteral("item Id with %1 is not a push-down button").arg(id).toUtf8().constData());
+            return warnArgumentValue(L, __func__, QStringLiteral("item ID with %1 is not a push-down button").arg(id).toUtf8().constData());
         }
     }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -607,6 +607,10 @@ public:
     static int getProfileTabNumber(lua_State*);
     static int addFileWatch(lua_State*);
     static int removeFileWatch(lua_State*);
+    static int getButtonStateById(lua_State*);
+    static int getButtonStateByName(lua_State*);
+    static int setButtonStateById(lua_State*);
+    static int setButtonStateByName(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -406,6 +406,7 @@ public:
     static int selectCurrentLine(lua_State*);
     static int spawn(lua_State*);
     static int getButtonState(lua_State*);
+    static int setButtonState(lua_State*);
     static int showToolBar(lua_State*);
     static int hideToolBar(lua_State*);
     static int loadReplay(lua_State*);
@@ -607,8 +608,6 @@ public:
     static int getProfileTabNumber(lua_State*);
     static int addFileWatch(lua_State*);
     static int removeFileWatch(lua_State*);
-    static int getButtonStateByIdOrName(lua_State*);
-    static int setButtonState(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -60,6 +60,7 @@ extern "C" {
 
 
 class Host;
+class TAction;
 class TEvent;
 class TLuaThread;
 class TMapLabel;
@@ -655,6 +656,8 @@ private:
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State* L);
     static void pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel& label);
+    static int getTActionFromIdOrName(lua_State*, TAction**, const int, const char*);
+
     const int LUA_FUNCTION_MAX_ARGS = 50;
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -607,10 +607,8 @@ public:
     static int getProfileTabNumber(lua_State*);
     static int addFileWatch(lua_State*);
     static int removeFileWatch(lua_State*);
-    static int getButtonStateById(lua_State*);
-    static int getButtonStateByName(lua_State*);
-    static int setButtonStateById(lua_State*);
-    static int setButtonStateByName(lua_State*);
+    static int getButtonStateByIdOrName(lua_State*);
+    static int setButtonState(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -656,7 +656,7 @@ private:
     bool loadLuaModule(QQueue<QString>& resultMsgQueue, const QString& requirement, const QString& failureConsequence = QString(), const QString& description = QString(), const QString& luaModuleId = QString());
     void insertNativeSeparatorsFunction(lua_State* L);
     static void pushMapLabelPropertiesToLua(lua_State* L, const TMapLabel& label);
-    static int getTActionFromIdOrName(lua_State*, TAction**, const int, const char*);
+    static std::pair<int, TAction*> getTActionFromIdOrName(lua_State*, const int, const char*);
 
     const int LUA_FUNCTION_MAX_ARGS = 50;
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Provide a means to get and set the state of push down buttons (the latter without executing the associate command or script). It requires adding members to the `TAction` class to keep track of the `EAction` or `TFlipButton` instance that is the implementation of the button on a `TEasyButton` or `TToolBar` respectively. As it happens this showed that the previous code to regenerate them was creating new buttons each time but was not deleting the existing ones that were getting replaced.

Also:
* made some members of the `TAtion` class (the name, script and both commands) private as otherwise there is no point in the setters and getters also provided!
* simplified the existing `getButtonState()` {that only works within the script for a button) to remove an unneeded intermediate local (`int`) value.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Motivation for adding to Mudlet
It is something has been requested in the past (I think recently on Discord). 

#### Other info (issues closed, discussion etc)
Further improvements to buttons/menus/toolbars are desirable and I can foresee some of them.

#### Release post highlight
Allow Lua scripts to get the state of *click-down* (toggle-able) buttons outside of the script for said button and allow for them to also set that state.