### PR TITLE
Only show relevant actions in mapper's right-click menu

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2914,15 +2914,12 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 popup->addAction(createLabel);
             }
 
-            auto setPlayerLocation = new QAction(tr("Set location", "2D Mapper context menu (room) item"), this);
-            if (selectionSize == 1) { // Only enable if ONE room is highlighted
+            if (selectionSize == 1) {
+                auto setPlayerLocation = new QAction(tr("Set location", "2D Mapper context menu (room) item"), this);
                 setPlayerLocation->setToolTip(tr("Set player current location to here", "2D Mapper context menu (room) item tooltip (enabled state)"));
                 connect(setPlayerLocation, &QAction::triggered, this, &T2DMap::slot_setPlayerLocation);
-            } else {
-                setPlayerLocation->setEnabled(false);
-                setPlayerLocation->setToolTip(tr("Can only set location when exactly one room is selected", "2D Mapper context menu (room) item tooltip (disabled state)"));
+                popup->addAction(setPlayerLocation);
             }
-            popup->addAction(setPlayerLocation);
 
             popup->addSeparator();
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2771,8 +2771,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
             }
 
-
-            switch (mMultiSelectionSet.size()) {
+            int selectionSize = mMultiSelectionSet.size();
+            switch (selectionSize) {
                 case 0:
                     mMultiSelectionHighlightRoomId = 0;
                     break;
@@ -2804,12 +2804,12 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             // Else there is a map - though it might not have ANY rooms!
 
             if (!mMapViewOnly) {
-              if (mMultiSelectionSet.isEmpty()) {
-                  mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
-                  mpCreateRoomAction->setToolTip(tr("Create a new room here"));
-                  connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
-                  popup->addAction(mpCreateRoomAction);
-              }
+                if (selectionSize == 0) {
+                    mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
+                    mpCreateRoomAction->setToolTip(tr("Create a new room here"));
+                    connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
+                    popup->addAction(mpCreateRoomAction);
+                }
 
               auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
               moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
@@ -2890,7 +2890,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             }
 
             auto setPlayerLocation = new QAction(tr("Set location", "2D Mapper context menu (room) item"), this);
-            if (mMultiSelectionSet.size() == 1) { // Only enable if ONE room is highlighted
+            if (selectionSize == 1) { // Only enable if ONE room is highlighted
                 setPlayerLocation->setToolTip(tr("Set player current location to here", "2D Mapper context menu (room) item tooltip (enabled state)"));
                 connect(setPlayerLocation, &QAction::triggered, this, &T2DMap::slot_setPlayerLocation);
             } else {

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2803,14 +2803,14 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             }
             // Else there is a map - though it might not have ANY rooms!
 
-            if (mMultiSelectionSet.isEmpty() && !mMapViewOnly) {
-                mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
-                mpCreateRoomAction->setToolTip(tr("Create a new room here"));
-                connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
-                popup->addAction(mpCreateRoomAction);
-            }
-
             if (!mMapViewOnly) {
+              if (mMultiSelectionSet.isEmpty()) {
+                  mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
+                  mpCreateRoomAction->setToolTip(tr("Create a new room here"));
+                  connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
+                  popup->addAction(mpCreateRoomAction);
+              }
+
               auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
               moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
               connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2811,82 +2811,107 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     popup->addAction(mpCreateRoomAction);
                 }
 
-                auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
-                moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
-                connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
-                popup->addAction(moveRoom);
-
-                auto roomExits = new QAction(tr("Exits", "2D Mapper context menu (room) item"), this);
-                roomExits->setToolTip(tr("Set room exits", "2D Mapper context menu (room) item tooltip"));
-                connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
-                popup->addAction(roomExits);
-
-                auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
-                if (pArea && !pArea->gridMode) {
-                    customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
-                    connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
-                } else {
-                    // Disable custom exit lines in grid mode as they aren't visible anyway
-                    customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
-                    customExitLine->setEnabled(false);
+                if (selectionSize > 0) {
+                    auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
+                    moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
+                    connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
+                    popup->addAction(moveRoom);
                 }
-                popup->addAction(customExitLine);
 
-                auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
-                recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
-                connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
-                popup->addAction(recolorRoom);
+                if (selectionSize > 0) {
+                    auto roomExits = new QAction(tr("Exits", "2D Mapper context menu (room) item"), this);
+                    roomExits->setToolTip(tr("Set room exits", "2D Mapper context menu (room) item tooltip"));
+                    connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
+                    popup->addAction(roomExits);
+                }
 
-                auto roomSymbol = new QAction(tr("Symbol", "2D Mapper context menu (room) item"), this);
-                roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
-                connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
-                popup->addAction(roomSymbol);
+                if (selectionSize == 1) {
+                    auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
+                    if (pArea && !pArea->gridMode) {
+                        customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
+                        connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
+                    } else {
+                        // Disable custom exit lines in grid mode as they aren't visible anyway
+                        customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
+                        customExitLine->setEnabled(false);
+                    }
+                    popup->addAction(customExitLine);
+                }
 
-                auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
-                spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
-                connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
-                popup->addAction(spreadRooms);
+                if (selectionSize > 0) {
+                    auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
+                    recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
+                    connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
+                    popup->addAction(recolorRoom);
+                }
 
-                auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
-                shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
-                connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
-                popup->addAction(shrinkRooms);
+                if (selectionSize > 0) {
+                    auto roomSymbol = new QAction(tr("Symbol", "2D Mapper context menu (room) item"), this);
+                    roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
+                    connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
+                    popup->addAction(roomSymbol);
+                }
 
-                auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
-                lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
-                connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
-                popup->addAction(lockRoom);
+                if (selectionSize > 1) {
+                    auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
+                    spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
+                    connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
+                    popup->addAction(spreadRooms);
+                }
 
-                auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
-                unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
-                connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
-                popup->addAction(unlockRoom);
+                if (selectionSize > 1) {
+                    auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
+                    shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
+                    connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
+                    popup->addAction(shrinkRooms);
+                }
 
-                auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
-                weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
-                connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
-                popup->addAction(weightRoom);
+                if (selectionSize > 0) {
+                    // TODO: Do not show both action simultaneously, if all selected rooms have same status.
 
-                auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
-                deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
-                connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
-                popup->addAction(deleteRoom);
+                    auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
+                    lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
+                    connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
+                    popup->addAction(lockRoom);
 
-                auto moveRoomXY = new QAction(tr("Move to", "2D Mapper context menu (room) item"), this);
-                moveRoomXY->setToolTip(tr("Move selected group to a given position", "2D Mapper context menu (room) item tooltip"));
-                connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
-                popup->addAction(moveRoomXY);
+                    auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
+                    unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
+                    connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
+                    popup->addAction(unlockRoom);
+                }
 
-                auto roomArea = new QAction(tr("Area", "2D Mapper context menu (room) item"), this);
-                roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
-                connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
-                popup->addAction(roomArea);
+                if (selectionSize > 0) {
+                    auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
+                    weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
+                    connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
+                    popup->addAction(weightRoom);
+                }
+
+                if (selectionSize > 0) {
+                    auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
+                    deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
+                    connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
+                    popup->addAction(deleteRoom);
+                }
+
+                if (selectionSize > 0) {
+                    auto moveRoomXY = new QAction(tr("Move to", "2D Mapper context menu (room) item"), this);
+                    moveRoomXY->setToolTip(tr("Move selected group to a given position", "2D Mapper context menu (room) item tooltip"));
+                    connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
+                    popup->addAction(moveRoomXY);
+                }
+
+                if (selectionSize > 0) {
+                    auto roomArea = new QAction(tr("Area", "2D Mapper context menu (room) item"), this);
+                    roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
+                    connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
+                    popup->addAction(roomArea);
+                }
 
                 auto createLabel = new QAction(tr("Create Label", "2D Mapper context menu (room) item"), this);
                 createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));
                 connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
                 popup->addAction(createLabel);
-
             }
 
             auto setPlayerLocation = new QAction(tr("Set location", "2D Mapper context menu (room) item"), this);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2814,50 +2814,62 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
               auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
               moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
               connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
-
-              auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
-              deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
-              connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
-
-              auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
-              recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
-              connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
-
-              auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
-              spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
-              connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
-
-              auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
-              shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
-              connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
-
-              auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
-              lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
-              connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
-
-              auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
-              unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
-              connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
-
-              auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
-              weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
-              connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
+              popup->addAction(moveRoom);
 
               auto roomExits = new QAction(tr("Exits", "2D Mapper context menu (room) item"), this);
               roomExits->setToolTip(tr("Set room exits", "2D Mapper context menu (room) item tooltip"));
               connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
+              popup->addAction(roomExits);
+
+              auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
+              recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
+              connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
+              popup->addAction(recolorRoom);
 
               auto roomSymbol = new QAction(tr("Symbol", "2D Mapper context menu (room) item"), this);
               roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
               connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
+              popup->addAction(roomSymbol);
+
+              auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
+              spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
+              connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
+              popup->addAction(spreadRooms);
+
+              auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
+              shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
+              connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
+              popup->addAction(shrinkRooms);
+
+              auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
+              lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
+              connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
+              popup->addAction(lockRoom);
+
+              auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
+              unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
+              connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
+              popup->addAction(unlockRoom);
+
+              auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
+              weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
+              connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
+              popup->addAction(weightRoom);
+
+              auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
+              deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
+              connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
+              popup->addAction(deleteRoom);
 
               auto moveRoomXY = new QAction(tr("Move to", "2D Mapper context menu (room) item"), this);
               moveRoomXY->setToolTip(tr("Move selected group to a given position", "2D Mapper context menu (room) item tooltip"));
               connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
+              popup->addAction(moveRoomXY);
 
               auto roomArea = new QAction(tr("Area", "2D Mapper context menu (room) item"), this);
               roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
               connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
+              popup->addAction(roomArea);
 
               auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
               if (pArea && !pArea->gridMode) {
@@ -2868,25 +2880,13 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                   customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
                   customExitLine->setEnabled(false);
               }
+              popup->addAction(customExitLine);
 
               auto createLabel = new QAction(tr("Create Label", "2D Mapper context menu (room) item"), this);
               createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));
               connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
-
-              popup->addAction(moveRoom);
-              popup->addAction(roomExits);
-              popup->addAction(customExitLine);
-              popup->addAction(recolorRoom);
-              popup->addAction(roomSymbol);
-              popup->addAction(spreadRooms);
-              popup->addAction(shrinkRooms);
-              popup->addAction(lockRoom);
-              popup->addAction(unlockRoom);
-              popup->addAction(weightRoom);
-              popup->addAction(deleteRoom);
-              popup->addAction(moveRoomXY);
-              popup->addAction(roomArea);
               popup->addAction(createLabel);
+
             }
 
             auto setPlayerLocation = new QAction(tr("Set location", "2D Mapper context menu (room) item"), this);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2821,6 +2821,17 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
               connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
               popup->addAction(roomExits);
 
+              auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
+              if (pArea && !pArea->gridMode) {
+                  customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
+                  connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
+              } else {
+                  // Disable custom exit lines in grid mode as they aren't visible anyway
+                  customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
+                  customExitLine->setEnabled(false);
+              }
+              popup->addAction(customExitLine);
+
               auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
               recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
               connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
@@ -2870,17 +2881,6 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
               roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
               connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
               popup->addAction(roomArea);
-
-              auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
-              if (pArea && !pArea->gridMode) {
-                  customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
-                  connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
-              } else {
-                  // Disable custom exit lines in grid mode as they aren't visible anyway
-                  customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
-                  customExitLine->setEnabled(false);
-              }
-              popup->addAction(customExitLine);
 
               auto createLabel = new QAction(tr("Create Label", "2D Mapper context menu (room) item"), this);
               createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2923,12 +2923,14 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             popup->addSeparator();
 
-            QString viewModeItem = mMapViewOnly
-              ? tr("Switch to editing mode", "2D Mapper context menu (room) item")
-              : tr("Switch to viewing mode", "2D Mapper context menu (room) item");
-            auto setMapViewOnly = new QAction(viewModeItem, this);
-            connect(setMapViewOnly, &QAction::triggered, this, &T2DMap::slot_toggleMapViewOnly);
-            popup->addAction(setMapViewOnly);
+            if (selectionSize == 0) {
+                QString viewModeItem = mMapViewOnly
+                ? tr("Switch to editing mode", "2D Mapper context menu (room) item")
+                : tr("Switch to viewing mode", "2D Mapper context menu (room) item");
+                auto setMapViewOnly = new QAction(viewModeItem, this);
+                connect(setMapViewOnly, &QAction::triggered, this, &T2DMap::slot_toggleMapViewOnly);
+                popup->addAction(setMapViewOnly);
+            }
 
             mPopupMenu = true;
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2811,81 +2811,81 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     popup->addAction(mpCreateRoomAction);
                 }
 
-              auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
-              moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
-              connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
-              popup->addAction(moveRoom);
+                auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
+                moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
+                connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
+                popup->addAction(moveRoom);
 
-              auto roomExits = new QAction(tr("Exits", "2D Mapper context menu (room) item"), this);
-              roomExits->setToolTip(tr("Set room exits", "2D Mapper context menu (room) item tooltip"));
-              connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
-              popup->addAction(roomExits);
+                auto roomExits = new QAction(tr("Exits", "2D Mapper context menu (room) item"), this);
+                roomExits->setToolTip(tr("Set room exits", "2D Mapper context menu (room) item tooltip"));
+                connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
+                popup->addAction(roomExits);
 
-              auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
-              if (pArea && !pArea->gridMode) {
-                  customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
-                  connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
-              } else {
-                  // Disable custom exit lines in grid mode as they aren't visible anyway
-                  customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
-                  customExitLine->setEnabled(false);
-              }
-              popup->addAction(customExitLine);
+                auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
+                if (pArea && !pArea->gridMode) {
+                    customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
+                    connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
+                } else {
+                    // Disable custom exit lines in grid mode as they aren't visible anyway
+                    customExitLine->setToolTip(tr("Custom exit lines are not shown and are not editable in grid mode", "2D Mapper context menu (room) item tooltip (disabled state)"));
+                    customExitLine->setEnabled(false);
+                }
+                popup->addAction(customExitLine);
 
-              auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
-              recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
-              connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
-              popup->addAction(recolorRoom);
+                auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
+                recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
+                connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
+                popup->addAction(recolorRoom);
 
-              auto roomSymbol = new QAction(tr("Symbol", "2D Mapper context menu (room) item"), this);
-              roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
-              connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
-              popup->addAction(roomSymbol);
+                auto roomSymbol = new QAction(tr("Symbol", "2D Mapper context menu (room) item"), this);
+                roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
+                connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
+                popup->addAction(roomSymbol);
 
-              auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
-              spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
-              connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
-              popup->addAction(spreadRooms);
+                auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
+                spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
+                connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
+                popup->addAction(spreadRooms);
 
-              auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
-              shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
-              connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
-              popup->addAction(shrinkRooms);
+                auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
+                shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
+                connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
+                popup->addAction(shrinkRooms);
 
-              auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
-              lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
-              connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
-              popup->addAction(lockRoom);
+                auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
+                lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
+                connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
+                popup->addAction(lockRoom);
 
-              auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
-              unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
-              connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
-              popup->addAction(unlockRoom);
+                auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
+                unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
+                connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
+                popup->addAction(unlockRoom);
 
-              auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
-              weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
-              connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
-              popup->addAction(weightRoom);
+                auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
+                weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
+                connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
+                popup->addAction(weightRoom);
 
-              auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
-              deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
-              connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
-              popup->addAction(deleteRoom);
+                auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
+                deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
+                connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
+                popup->addAction(deleteRoom);
 
-              auto moveRoomXY = new QAction(tr("Move to", "2D Mapper context menu (room) item"), this);
-              moveRoomXY->setToolTip(tr("Move selected group to a given position", "2D Mapper context menu (room) item tooltip"));
-              connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
-              popup->addAction(moveRoomXY);
+                auto moveRoomXY = new QAction(tr("Move to", "2D Mapper context menu (room) item"), this);
+                moveRoomXY->setToolTip(tr("Move selected group to a given position", "2D Mapper context menu (room) item tooltip"));
+                connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
+                popup->addAction(moveRoomXY);
 
-              auto roomArea = new QAction(tr("Area", "2D Mapper context menu (room) item"), this);
-              roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
-              connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
-              popup->addAction(roomArea);
+                auto roomArea = new QAction(tr("Area", "2D Mapper context menu (room) item"), this);
+                roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
+                connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
+                popup->addAction(roomArea);
 
-              auto createLabel = new QAction(tr("Create Label", "2D Mapper context menu (room) item"), this);
-              createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));
-              connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
-              popup->addAction(createLabel);
+                auto createLabel = new QAction(tr("Create Label", "2D Mapper context menu (room) item"), this);
+                createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));
+                connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
+                popup->addAction(createLabel);
 
             }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
For each action, add a check on how many rooms are selected, and hide it where appropiate

#### Motivation for adding to Mudlet
Fix #5220

See discussion there!

#### Other info (issues closed, discussion etc)

1. Viewing mode - no rooms selected
![image](https://user-images.githubusercontent.com/117238/118359270-025e2680-b583-11eb-84bd-a3e1925a6964.png)

1. Viewing mode - one room selected
![image](https://user-images.githubusercontent.com/117238/118359289-0f7b1580-b583-11eb-84b7-3557aff76e4a.png)

1. Viewing mode - more rooms selected
(no menu actions, no menu)

1. Editing mode - no rooms selected
![image](https://user-images.githubusercontent.com/117238/118359322-2e79a780-b583-11eb-8418-27e3a0117753.png)

1. Editing mode - one room selected
![image](https://user-images.githubusercontent.com/117238/118359338-389ba600-b583-11eb-85fa-cb8bb412e9e7.png)

1. Editing mode - more rooms selected
![image](https://user-images.githubusercontent.com/117238/118359256-f83c2800-b582-11eb-82a9-800601b62f42.png)


#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
