### PR TITLE
Fix: newly created profiles will remember their connection info

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -484,7 +484,7 @@ void dlgConnectionProfiles::slot_update_name(const QString& newName)
 
 void dlgConnectionProfiles::slot_save_name()
 {
-        QListWidgetItem* pItem = profiles_tree_widget->currentItem();
+    QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     QString newProfileName = profile_name_entry->text().trimmed();
 
     validateProfile();

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -487,6 +487,7 @@ void dlgConnectionProfiles::slot_save_name()
         QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     QString newProfileName = profile_name_entry->text().trimmed();
 
+    validateProfile();
     if (!validName || newProfileName.isEmpty() || !pItem) {
         return;
     }
@@ -2068,6 +2069,8 @@ bool dlgConnectionProfiles::validateProfile()
             valid = false;
         }
 
+        validName = true;
+
         QString port = port_entry->text().trimmed();
         if (!port.isEmpty() && (port.indexOf(QRegularExpression(QStringLiteral("^\\d+$")), 0) == -1)) {
             QString val = port;
@@ -2095,6 +2098,8 @@ bool dlgConnectionProfiles::validateProfile()
             validPort = false;
             valid = false;
         }
+
+        validPort = true;
 
 #if defined(QT_NO_SSL)
         port_ssl_tsl->setEnabled(false);
@@ -2160,6 +2165,8 @@ bool dlgConnectionProfiles::validateProfile()
                 valid = false;
             }
         }
+
+        validUrl = true;
 
         if (valid) {
             port_entry->setPalette(mOKPalette);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2034,6 +2034,8 @@ bool dlgConnectionProfiles::validateProfile()
 {
     bool valid = true;
 
+    validName = true, validPort = true, validUrl = true;
+
     clearNotificationArea();
 
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
@@ -2069,7 +2071,6 @@ bool dlgConnectionProfiles::validateProfile()
             valid = false;
         }
 
-        validName = true;
 
         QString port = port_entry->text().trimmed();
         if (!port.isEmpty() && (port.indexOf(QRegularExpression(QStringLiteral("^\\d+$")), 0) == -1)) {
@@ -2098,8 +2099,6 @@ bool dlgConnectionProfiles::validateProfile()
             validPort = false;
             valid = false;
         }
-
-        validPort = true;
 
 #if defined(QT_NO_SSL)
         port_ssl_tsl->setEnabled(false);
@@ -2165,8 +2164,6 @@ bool dlgConnectionProfiles::validateProfile()
                 valid = false;
             }
         }
-
-        validUrl = true;
 
         if (valid) {
             port_entry->setPalette(mOKPalette);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -484,7 +484,7 @@ void dlgConnectionProfiles::slot_update_name(const QString& newName)
 
 void dlgConnectionProfiles::slot_save_name()
 {
-    QListWidgetItem* pItem = profiles_tree_widget->currentItem();
+        QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     QString newProfileName = profile_name_entry->text().trimmed();
 
     if (!validName || newProfileName.isEmpty() || !pItem) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -2071,7 +2071,6 @@ bool dlgConnectionProfiles::validateProfile()
             valid = false;
         }
 
-
         QString port = port_entry->text().trimmed();
         if (!port.isEmpty() && (port.indexOf(QRegularExpression(QStringLiteral("^\\d+$")), 0) == -1)) {
             QString val = port;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additionsN
ewly created profiles will now remember their connection info.
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5181, a high priority issue.
#### Release post highlight
