### PR TITLE
BugFix: repair loss of custom profile icons

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1644,7 +1644,7 @@ void dlgConnectionProfiles::generateCustomProfile(const QString& profileName) co
 void dlgConnectionProfiles::slot_profile_menu(QPoint pos)
 {
     QPoint globalPos = profiles_tree_widget->mapToGlobal(pos);
-    auto profileName = profiles_tree_widget->currentItem()->text();
+    auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
     QMenu menu;
     if (hasCustomIcon(profileName)) {
@@ -1658,7 +1658,7 @@ void dlgConnectionProfiles::slot_profile_menu(QPoint pos)
 
 void dlgConnectionProfiles::slot_set_custom_icon()
 {
-    auto profileName = profiles_tree_widget->currentItem()->text();
+    auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
     QString imageLocation = QFileDialog::getOpenFileName(this, tr("Select custom image for profile (should be 120x30)"),
                                                     QStandardPaths::writableLocation(QStandardPaths::HomeLocation),
@@ -1678,7 +1678,7 @@ void dlgConnectionProfiles::slot_set_custom_icon()
 
 void dlgConnectionProfiles::slot_reset_custom_icon()
 {
-    auto profileName = profiles_tree_widget->currentItem()->text();
+    auto profileName = profiles_tree_widget->currentItem()->data(csmNameRole).toString();
 
     bool success = mudlet::self()->resetProfileIcon(profileName).first;
     if (!success) {


### PR DESCRIPTION
This should close #5248 which looks to have been introduced by my #3948 from last July. It failed to accommodate the custom icon code from a couple of years ago done by #2814.

Basically the problem was that I removed storage of the profile name from the "display text" for the `QTreeWidgetItem`s in the profile connection dialogue. It was moved to a UserRole stored in the item's data area so that it was stored but not shown under the item and just showed the icon. However the custom icon code was still looking at the item's `text()` which now, of course, is empty!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fixes inability to set a custom profile icon in the profile connection dialogue.