### PR TITLE
Re-do windeployqt fixes for Qt 5.14.2

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -3,7 +3,16 @@ if ("$Env:APPVEYOR_REPO_NAME" -ne "Mudlet/Mudlet") {
 }
 
 cd "$Env:APPVEYOR_BUILD_FOLDER\src\release"
-windeployqt.exe --release mudlet.exe
+
+$Script:QtVersionRegex = [regex]'\\([\d\.]+)\\mingw'
+$Script:QtVersion = $QtVersionRegex.Match($Env:QT_BASE_DIR).Groups[1].Value
+if ([version]$Script:QtVersion -ge [version]'5.14.0') {
+  windeployqt.exe mudlet.exe
+}
+else {
+  windeployqt.exe --release mudlet.exe
+}
+
 . "$Env:APPVEYOR_BUILD_FOLDER\CI\copy-non-qt-win-dependencies.ps1"
 
 Remove-Item * -include *.cpp, *.o


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Re-do windeployqt fixes for Qt 5.14.2
#### Motivation for adding to Mudlet
So Windows snapshot builds work again.
#### Other info (issues closed, discussion etc)
https://github.com/Mudlet/Mudlet/pull/5258 accidentally undid too much!

Should also beef up the CI pipeline to fail if the Windows build was not created quite right.
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
