### PR TITLE
Fix "southeastst" to "southeast"

### DIFF
--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -110,7 +110,7 @@ QString TRoom::dirCodeToString(const int dirCode) const
     case DIR_EAST:      return QLatin1String("east");
     case DIR_WEST:      return QLatin1String("west");
     case DIR_SOUTH:     return QLatin1String("south");
-    case DIR_SOUTHEAST: return QLatin1String("southeastst");
+    case DIR_SOUTHEAST: return QLatin1String("southeast");
     case DIR_SOUTHWEST: return QLatin1String("southwest");
     case DIR_UP:        return QLatin1String("up");
     case DIR_DOWN:      return QLatin1String("down");
@@ -166,7 +166,7 @@ int TRoom::stringToDirCode(const QString& string) const
     if (string == QLatin1String("northwest")) {
         return DIR_NORTHWEST;
     }
-    if (string == QLatin1String("southeastst")) {
+    if (string == QLatin1String("southeast")) {
         return DIR_SOUTHEAST;
     }
     if (string == QLatin1String("southwest")) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
JSON map export was using "southeastst"

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
FIx #5265
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
