### PR TITLE
Added mouse menu actions to windows.

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -617,6 +617,9 @@ public:
     QList<QString> mDockLayoutChanges;
     QList<TToolBar*> mToolbarLayoutChanges;
 
+    // string list: 0 - event name, 1 - display label
+    QMap<QString, QStringList> mConsoleActions;
+
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous
     // width characters:

--- a/src/Host.h
+++ b/src/Host.h
@@ -617,7 +617,7 @@ public:
     QList<QString> mDockLayoutChanges;
     QList<TToolBar*> mToolbarLayoutChanges;
 
-    // string list: 0 - event name, 1 - display label
+    // string list: 0 - event name, 1 - display label, 2 - tooltip text
     QMap<QString, QStringList> mConsoleActions;
 
 signals:

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15647,7 +15647,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 
     // tooltip text
     if (!lua_isstring(L, 4)) {
-        actionInfo << "";
+        actionInfo << QString();
     } else {
         actionInfo << lua_tostring(L, 4);
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15641,7 +15641,7 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 
     Host& host = getHostFromLua(L);
     host.mConsoleActions.insert(uniqueName, actionInfo);
-    return 0;
+    return 1;
 }
 
 int TLuaInterpreter::removeMouseEvent(lua_State * L)
@@ -15649,7 +15649,7 @@ int TLuaInterpreter::removeMouseEvent(lua_State * L)
     QString displayName = getVerifiedString(L, __func__, 1, "event name");
     Host& host = getHostFromLua(L);
     host.mConsoleActions.remove(displayName);
-    return 0;
+    return 1;
 }
 
 int TLuaInterpreter::getMouseEvents(lua_State * L)

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15641,6 +15641,8 @@ int TLuaInterpreter::addMouseEvent(lua_State * L)
 
     Host& host = getHostFromLua(L);
     host.mConsoleActions.insert(uniqueName, actionInfo);
+
+    lua_pushboolean(L, true);
     return 1;
 }
 
@@ -15649,6 +15651,8 @@ int TLuaInterpreter::removeMouseEvent(lua_State * L)
     QString displayName = getVerifiedString(L, __func__, 1, "event name");
     Host& host = getHostFromLua(L);
     host.mConsoleActions.remove(displayName);
+
+    lua_pushboolean(L, true);
     return 1;
 }
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -607,6 +607,9 @@ public:
     static int getProfileTabNumber(lua_State*);
     static int addFileWatch(lua_State*);
     static int removeFileWatch(lua_State*);
+    static int addMouseEvent(lua_State* L);
+    static int removeMouseEvent(lua_State* L);
+    static int getMouseEvents(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1369,14 +1369,12 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
 
         // Add user actions
         QMapIterator<QString, QStringList> it(mpHost->mConsoleActions);
-        auto mapper = new QSignalMapper(this);
         while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();
             QString actionName = actionInfo[1];
             QAction * action = new QAction(actionInfo[1], this);
             popup->addAction(action);
-            mapper->setMapping(action, it.key());
             connect(action, &QAction::triggered, this, [this, actionName] { slot_mouseAction(actionName); });
         }
         popup->popup(mapToGlobal(event->pos()), action);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2415,7 +2415,7 @@ void TTextEdit::slot_changeDebugShowAllProblemCodepoints(const bool state)
     }
 }
 
-void TTextEdit::slot_mouseAction(QString uniqueName)
+void TTextEdit::slot_mouseAction(const QString &uniqueName)
 {
     TEvent event {};
     QStringList mouseEvent = mpHost->mConsoleActions[uniqueName];

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1369,7 +1369,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
 
         // Add user actions
         QMapIterator<QString, QStringList> it(mpHost->mConsoleActions);
-        QSignalMapper* mapper = new QSignalMapper(this);
+        auto mapper = new QSignalMapper(this);
         while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1372,8 +1372,9 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();
-            QString actionName = actionInfo[1];
-            QAction * action = new QAction(actionInfo[1], this);
+            const QString actionName = actionInfo.at(1);
+            QAction * action = new QAction(actionName, this);
+            action->setToolTip(actionInfo.at(2));
             popup->addAction(action);
             connect(action, &QAction::triggered, this, [this, actionName] { slot_mouseAction(actionName); });
         }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1370,7 +1370,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         // Add user actions
         QMapIterator<QString, QStringList> it(mpHost->mConsoleActions);
         QSignalMapper* mapper = new QSignalMapper(this);
-        while(it.hasNext()) {
+        while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();
             QAction * action = new QAction(actionInfo[1], this);
@@ -2419,12 +2419,12 @@ void TTextEdit::slot_mouseAction(const QString &uniqueName)
 {
     TEvent event {};
     QStringList mouseEvent = mpHost->mConsoleActions[uniqueName];
-    event.mArgumentList.append( mouseEvent[0] );
+    event.mArgumentList.append(mouseEvent[0]);
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( uniqueName );
+    event.mArgumentList.append(uniqueName);
 
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-    event.mArgumentList.append( mpConsole->mConsoleName);
+    event.mArgumentList.append(mpConsole->mConsoleName);
 
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
     event.mArgumentList.append(QString::number(mPA.x()));
@@ -2435,7 +2435,7 @@ void TTextEdit::slot_mouseAction(const QString &uniqueName)
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
     event.mArgumentList.append(QString::number(mPB.y()));
     event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
-    mpHost->raiseEvent( event );
+    mpHost->raiseEvent(event);
 }
 
 // Originally this was going to be part of the destructor - but it was unable

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1372,7 +1372,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();
-            const QString actionName = actionInfo.at(1);
+            const QString &actionName = actionInfo.at(1);
             QAction * action = new QAction(actionName, this);
             action->setToolTip(actionInfo.at(2));
             popup->addAction(action);

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1373,13 +1373,12 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();
+            QString actionName = actionInfo[1];
             QAction * action = new QAction(actionInfo[1], this);
             popup->addAction(action);
             mapper->setMapping(action, it.key());
-            connect(action, SIGNAL(triggered()), mapper, SLOT(map()));
+            connect(action, &QAction::triggered, this, [this, actionName] { slot_mouseAction(actionName); });
         }
-        connect(mapper, SIGNAL(mapped(QString)), this, SLOT(slot_mouseAction(QString)));
-
         popup->popup(mapToGlobal(event->pos()), action);
         event->accept();
         return;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1367,6 +1367,19 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             popup->addAction(actionRestoreMainToolBar);
         }
 
+        // Add user actions
+        QMapIterator<QString, QStringList> it(mpHost->mConsoleActions);
+        QSignalMapper* mapper = new QSignalMapper(this);
+        while(it.hasNext()) {
+            it.next();
+            QStringList actionInfo = it.value();
+            QAction * action = new QAction(actionInfo[1], this);
+            popup->addAction(action);
+            mapper->setMapping(action, it.key());
+            connect(action, SIGNAL(triggered()), mapper, SLOT(map()));
+        }
+        connect(mapper, SIGNAL(mapped(QString)), this, SLOT(slot_mouseAction(QString)));
+
         popup->popup(mapToGlobal(event->pos()), action);
         event->accept();
         return;
@@ -2400,6 +2413,29 @@ void TTextEdit::slot_changeDebugShowAllProblemCodepoints(const bool state)
     if (mShowAllCodepointIssues != state) {
         mShowAllCodepointIssues = state;
     }
+}
+
+void TTextEdit::slot_mouseAction(QString uniqueName)
+{
+    TEvent event {};
+    QStringList mouseEvent = mpHost->mConsoleActions[uniqueName];
+    event.mArgumentList.append( mouseEvent[0] );
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( uniqueName );
+
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append( mpConsole->mConsoleName);
+
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+    event.mArgumentList.append(QString::number(mPA.x()));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append(QString::number(mPA.y()));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append(QString::number(mPB.x()));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    event.mArgumentList.append(QString::number(mPB.y()));
+    event.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+    mpHost->raiseEvent( event );
 }
 
 // Originally this was going to be part of the destructor - but it was unable

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -126,6 +126,7 @@ public slots:
     void slot_analyseSelection();
     void slot_changeIsAmbigousWidthGlyphsToBeWide(bool);
     void slot_changeDebugShowAllProblemCodepoints(const bool);
+    void slot_mouseAction(QString);
 
 private slots:
     void slot_copySelectionToClipboardImage();

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -126,7 +126,7 @@ public slots:
     void slot_analyseSelection();
     void slot_changeIsAmbigousWidthGlyphsToBeWide(bool);
     void slot_changeDebugShowAllProblemCodepoints(const bool);
-    void slot_mouseAction(QString);
+    void slot_mouseAction(const QString&);
 
 private slots:
     void slot_copySelectionToClipboardImage();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added mouse menu actions to windows, similar to ones for the map.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Fixes #4962 
I have the functionality close to map menu logic, as well as keeping changes minimal- no sub-menus and the mouse cursor position is exposed only through the action event.

That does leave space for improvement, specifically those two points, but still satisfies solving the issue, so hopefully this is good enough for a start!
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
