### PR TITLE
Added shortcuts to navigate editor between triggers, aliases, etc.

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8375,49 +8375,39 @@ void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
     /* Deactivate instead with optional "true" - useful to grab for a keybinding */
     /* TODO: Refactor into nice array to iterate */
     QList<QAction*> actionList = toolBar->actions();
+    QString actionText;
     for (auto& action : actionList) {
-        switch (action->text()) {
-            case "Save Item": /* Not sure why, but this seems to work without tr() */
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
-                break;
-            case "Save Profile":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
-                break;
+        actionText = action->text();
+        if (actionText == "Save Item") { /* Not sure why, but this seems to work without tr() */
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
+        } else if (actionText == "Save Profile") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
         }
     }
     actionList = toolBar2->actions();
     for (auto& action : actionList) {
-        switch (action->text()) {
-            case "Triggers":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+1"));
-                break;
-            case "Aliases":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+2"));
-                break;
-            case "Scripts":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+3"));
-                break;
-            case "Timers":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+4"));
-                break;
-            case "Keys":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+5"));
-                break;
-            case "Variables":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+6"));
-                break;
-            case "Buttons":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+7"));
-                break;
-            case "Errors":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+8"));
-                break;
-            case "Statistics":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+9"));
-                break;
-            case "Debug":
-                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+0"));
-                break;
+        actionText = action->text();
+        if (actionText == "Triggers") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+1"));
+        } else if (actionText == "Aliases") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+2"));
+        } else if (actionText == "Scripts") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+3"));
+        } else if (actionText == "Timers") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+4"));
+        } else if (actionText == "Keys") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+5"));
+        } else if (actionText == "Variables") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+6"));
+        } else if (actionText == "Buttons") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+7"));
+        } else if (actionText == "Errors") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+8"));
+        } else if (actionText == "Statistics") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+9"));
+        } else if (actionText == "Debug") {
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+0"));
+        }
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8378,34 +8378,34 @@ void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
     QString actionText;
     for (auto& action : actionList) {
         actionText = action->text();
-        if (actionText == "Save Item") { /* Not sure why, but this seems to work without tr() */
+        if (actionText ==  tr("Save Item")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
-        } else if (actionText == "Save Profile") {
+        } else if (actionText == tr("Save Profile")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
         }
     }
     actionList = toolBar2->actions();
     for (auto& action : actionList) {
         actionText = action->text();
-        if (actionText == "Triggers") {
+        if (actionText == tr("Triggers")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+1"));
-        } else if (actionText == "Aliases") {
+        } else if (actionText == tr("Aliases")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+2"));
-        } else if (actionText == "Scripts") {
+        } else if (actionText == tr("Scripts")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+3"));
-        } else if (actionText == "Timers") {
+        } else if (actionText == tr("Timers")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+4"));
-        } else if (actionText == "Keys") {
+        } else if (actionText == tr("Keys")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+5"));
-        } else if (actionText == "Variables") {
+        } else if (actionText == tr("Variables")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+6"));
-        } else if (actionText == "Buttons") {
+        } else if (actionText == tr("Buttons")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+7"));
-        } else if (actionText == "Errors") {
+        } else if (actionText == tr("Errors")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+8"));
-        } else if (actionText == "Statistics") {
+        } else if (actionText == tr("Statistics")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+9"));
-        } else if (actionText == "Debug") {
+        } else if (actionText == tr("Debug")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+0"));
         }
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8369,11 +8369,10 @@ void dlgTriggerEditor::slot_key_grab()
     QCoreApplication::instance()->installEventFilter(this);
 }
 
+// Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc.
+// Deactivate instead with optional "true" - useful to grab for a keybinding
 void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
 {
-    /* Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc. */
-    /* Deactivate instead with optional "true" - useful to grab for a keybinding */
-    /* TODO: Refactor into nice array to iterate */
     QList<QAction*> actionList = toolBar->actions();
     QString actionText;
     for (auto& action : actionList) {
@@ -8387,6 +8386,7 @@ void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
     actionList = toolBar2->actions();
     for (auto& action : actionList) {
         actionText = action->text();
+        // TODO: Refactor into nice array to iterate
         if (actionText == tr("Triggers")) {
             action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+1"));
         } else if (actionText == tr("Aliases")) {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8409,6 +8409,7 @@ void dlgTriggerEditor::setShortcuts(const bool setNotUnset)
             action->setShortcut((setNotUnset) ? tr("Ctrl+0") : tr(""));
         }
     }
+}
 
 void dlgTriggerEditor::key_grab_callback(const Qt::Key key, const Qt::KeyboardModifiers modifier)
 {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -419,44 +419,53 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QAction* viewTriggerAction = new QAction(QIcon(QStringLiteral(":/icons/tools-wizard.png")), tr("Triggers"), this);
     viewTriggerAction->setStatusTip(tr("Show Triggers"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Triggers"), tr("Ctrl+1"))
     connect(viewTriggerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_triggers);
 
     QAction* viewAliasAction = new QAction(QIcon(QStringLiteral(":/icons/system-users.png")), tr("Aliases"), this);
     viewAliasAction->setStatusTip(tr("Show Aliases"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2"))
     connect(viewAliasAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_aliases);
 
     QAction* viewScriptsAction = new QAction(QIcon(QStringLiteral(":/icons/document-properties.png")), tr("Scripts"), this);
     viewScriptsAction->setStatusTip(tr("Show Scripts"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3"))
     connect(viewScriptsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_scripts);
 
     QAction* showTimersAction = new QAction(QIcon(QStringLiteral(":/icons/chronometer.png")), tr("Timers"), this);
     showTimersAction->setStatusTip(tr("Show Timers"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4"))
     connect(showTimersAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_timers);
 
     QAction* viewKeysAction = new QAction(QIcon(QStringLiteral(":/icons/preferences-desktop-keyboard.png")), tr("Keys"), this);
     viewKeysAction->setStatusTip(tr("Show Keybindings"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5"))
     connect(viewKeysAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_keys);
 
     QAction* viewVarsAction = new QAction(QIcon(QStringLiteral(":/icons/variables.png")), tr("Variables"), this);
     viewVarsAction->setStatusTip(tr("Show Variables"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6"))
     connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_vars);
 
     QAction* viewActionAction = new QAction(QIcon(QStringLiteral(":/icons/bookmarks.png")), tr("Buttons"), this);
     viewActionAction->setStatusTip(tr("Show Buttons"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7"))
     connect(viewActionAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_actions);
 
 
     QAction* viewErrorsAction = new QAction(QIcon(QStringLiteral(":/icons/errors.png")), tr("Errors"), this);
-    viewErrorsAction->setStatusTip(tr("Shows/Hides the errors console in the bottom right of this editor."));
+    viewErrorsAction->setStatusTip(tr("Show/Hide the errors console in the bottom right of this editor."));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8"))
     connect(viewErrorsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewErrorsAction);
 
     QAction* viewStatsAction = new QAction(QIcon(QStringLiteral(":/icons/view-statistics.png")), tr("Statistics"), this);
-    viewStatsAction->setStatusTip(tr("Generates a statistics summary display on the main profile console."));
+    viewStatsAction->setStatusTip(tr("Generate a statistics summary display on the main profile console."));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9"))
     connect(viewStatsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewStatsAction);
 
     QAction* showDebugAreaAction = new QAction(QIcon(QStringLiteral(":/icons/tools-report-bug.png")), tr("Debug"), this);
-    showDebugAreaAction->setToolTip(tr("Activates Debug Messages -> system will be <b><i>slower</i></b>."));
-    showDebugAreaAction->setStatusTip(tr("Shows/Hides the separate Central Debug Console - when being displayed the system will be slower."));
+    showDebugAreaAction->setStatusTip(tr("Show/Hide the separate Central Debug Console - when being displayed the system will be slower."));
+    showDebugAreaAction->setToolTip(tr("Show/Hide Debug Console (Ctrl+0) -> system will be <b><i>slower</i></b>."));
     connect(showDebugAreaAction, &QAction::triggered, this, &dlgTriggerEditor::slot_debug_mode);
 
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8369,7 +8369,6 @@ void dlgTriggerEditor::slot_key_grab()
     QCoreApplication::instance()->installEventFilter(this);
 }
 
-/* private void setShortcuts(const bool unsetInstead = false); */
 void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
 {
     /* Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc. */

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -419,48 +419,48 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QAction* viewTriggerAction = new QAction(QIcon(QStringLiteral(":/icons/tools-wizard.png")), tr("Triggers"), this);
     viewTriggerAction->setStatusTip(tr("Show Triggers"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Triggers"), tr("Ctrl+1"));
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Triggers"), tr("Ctrl+1")));
     connect(viewTriggerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_triggers);
 
     QAction* viewAliasAction = new QAction(QIcon(QStringLiteral(":/icons/system-users.png")), tr("Aliases"), this);
     viewAliasAction->setStatusTip(tr("Show Aliases"));
-    viewAliasAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2"));
+    viewAliasAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2")));
     connect(viewAliasAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_aliases);
 
     QAction* viewScriptsAction = new QAction(QIcon(QStringLiteral(":/icons/document-properties.png")), tr("Scripts"), this);
     viewScriptsAction->setStatusTip(tr("Show Scripts"));
-    viewScriptsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3"));
+    viewScriptsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3")));
     connect(viewScriptsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_scripts);
 
     QAction* showTimersAction = new QAction(QIcon(QStringLiteral(":/icons/chronometer.png")), tr("Timers"), this);
     showTimersAction->setStatusTip(tr("Show Timers"));
-    showTimersAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4"));
+    showTimersAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4")));
     connect(showTimersAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_timers);
 
     QAction* viewKeysAction = new QAction(QIcon(QStringLiteral(":/icons/preferences-desktop-keyboard.png")), tr("Keys"), this);
     viewKeysAction->setStatusTip(tr("Show Keybindings"));
-    viewKeysAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5"));
+    viewKeysAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5")));
     connect(viewKeysAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_keys);
 
     QAction* viewVarsAction = new QAction(QIcon(QStringLiteral(":/icons/variables.png")), tr("Variables"), this);
     viewVarsAction->setStatusTip(tr("Show Variables"));
-    viewVarsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6"));
+    viewVarsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6")));
     connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_vars);
 
     QAction* viewActionAction = new QAction(QIcon(QStringLiteral(":/icons/bookmarks.png")), tr("Buttons"), this);
     viewActionAction->setStatusTip(tr("Show Buttons"));
-    viewActionAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7"));
+    viewActionAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7")));
     connect(viewActionAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_actions);
 
 
     QAction* viewErrorsAction = new QAction(QIcon(QStringLiteral(":/icons/errors.png")), tr("Errors"), this);
     viewErrorsAction->setStatusTip(tr("Show/Hide the errors console in the bottom right of this editor."));
-    viewErrorsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8"));
+    viewErrorsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8")));
     connect(viewErrorsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewErrorsAction);
 
     QAction* viewStatsAction = new QAction(QIcon(QStringLiteral(":/icons/view-statistics.png")), tr("Statistics"), this);
     viewStatsAction->setStatusTip(tr("Generate a statistics summary display on the main profile console."));
-    viewStatsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9"));
+    viewStatsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9")));
     connect(viewStatsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewStatsAction);
 
     QAction* showDebugAreaAction = new QAction(QIcon(QStringLiteral(":/icons/tools-report-bug.png")), tr("Debug"), this);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -475,7 +475,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(addFolderAction, &QAction::triggered, this, &dlgTriggerEditor::slot_add_new_folder);
 
     QAction* saveAction = new QAction(QIcon(QStringLiteral(":/icons/document-save-as.png")), tr("Save Item"), this);
-    saveAction->setShortcut(tr("Ctrl+S"));
     saveAction->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>")
                                    .arg(tr("Saves the selected item. (Ctrl+S)</p>Saving causes any changes to the item to take effect.\nIt will not save to disk, "
                                            "so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)")));
@@ -525,7 +524,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     mProfileSaveAction = new QAction(QIcon(QStringLiteral(":/icons/document-save-all.png")), tr("Save Profile"), this);
     mProfileSaveAction->setEnabled(true);
-    mProfileSaveAction->setShortcut(tr("Ctrl+Shift+S"));
     mProfileSaveAction->setToolTip(
             QStringLiteral("<html><head/><body><p>%1</p></body></html>")
                     .arg(tr(R"(Saves your profile. (Ctrl+Shift+S)<p>Saves your entire profile (triggers, aliases, scripts, timers, buttons and keys, but not the map or script-specific settings) to your computer disk, so in case of a computer or program crash, all changes you have done will be retained.</p><p>It also makes a backup of your profile, you can load an older version of it when connecting.</p><p>Should there be any modules that are marked to be "<i>synced</i>" this will also cause them to be saved and reloaded into other profiles if they too are active.)")));
@@ -614,6 +612,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QMainWindow::addToolBar(Qt::LeftToolBarArea, toolBar2);
     QMainWindow::addToolBar(Qt::TopToolBarArea, toolBar);
+    setShortcuts();
 
     auto config = mpSourceEditorEdbee->config();
     config->beginChanges();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8378,13 +8378,47 @@ void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
     QList<QAction*> actionList = toolBar->actions();
     for (auto& action : actionList) {
         switch (action->text()) {
-          case "Save Item": /* Not sure why, but this seems to work without tr() */
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
-            break;
-          case "Save Profile":
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
-            break;
+            case "Save Item": /* Not sure why, but this seems to work without tr() */
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
+                break;
+            case "Save Profile":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
+                break;
         }
+    }
+    actionList = toolBar2->actions();
+    for (auto& action : actionList) {
+        switch (action->text()) {
+            case "Triggers":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+1"));
+                break;
+            case "Aliases":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+2"));
+                break;
+            case "Scripts":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+3"));
+                break;
+            case "Timers":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+4"));
+                break;
+            case "Keys":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+5"));
+                break;
+            case "Variables":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+6"));
+                break;
+            case "Buttons":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+7"));
+                break;
+            case "Errors":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+8"));
+                break;
+            case "Statistics":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+9"));
+                break;
+            case "Debug":
+                action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+0"));
+                break;
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8357,36 +8357,28 @@ void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
 void dlgTriggerEditor::slot_key_grab()
 {
     mIsGrabKey = true;
-    unsetShortcuts();
+    setShortcuts(true);
     QCoreApplication::instance()->installEventFilter(this);
 }
 
-void dlgTriggerEditor::setShortcuts()
+/* private void setShortcuts(const bool unsetInstead = false); */
+void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
 {
-    /* Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc */
-    /* TODO: Refactor into nice array to iterate in both un- and setShortcuts() */
+    /* Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc. */
+    /* Deactivate instead with optional "true" - useful to grab for a keybinding */
+    /* TODO: Refactor into nice array to iterate */
     QList<QAction*> actionList = toolBar->actions();
+    QString shortcut;
     for (auto& action : actionList) {
-        if (action->text() == "Save Item") {
-            action->setShortcut(tr("Ctrl+S"));
-        } else if (action->text() == "Save Profile") {
-            action->setShortcut(tr("Ctrl+Shift+S"));
+        switch (action->text()) {
+          case "Save Item": /* Not sure why, but this seems to work without tr() */
+            shortcut = (unsetInstead) ? tr("") : tr("Ctrl+S");
+            break;
+          case "Save Profile":
+            shortcut = (unsetInstead) ? tr("") : tr("Ctrl+Shift+S");
+            break;
         }
-    }
-}
-
-void dlgTriggerEditor::unsetShortcuts()
-{
-    /* Temporarily disabling the existing shortcuts for editor menu items like Ctrl+S etc.
-       This will allow binding them for macros until key was input or canceled with Escape */
-    /* TODO: Refactor into nice array to iterate in both un- and setShortcuts() */
-    QList<QAction*> actionList = toolBar->actions();
-    for (auto& action : actionList) {
-        if (action->text() == "Save Item") {
-            action->setShortcut(tr(""));
-        } else if (action->text() == "Save Profile") {
-            action->setShortcut(tr(""));
-        }
+        action->setShortcut(shortcut);
     }
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -419,48 +419,48 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QAction* viewTriggerAction = new QAction(QIcon(QStringLiteral(":/icons/tools-wizard.png")), tr("Triggers"), this);
     viewTriggerAction->setStatusTip(tr("Show Triggers"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Triggers"), tr("Ctrl+1"))
+    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Triggers"), tr("Ctrl+1"));
     connect(viewTriggerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_triggers);
 
     QAction* viewAliasAction = new QAction(QIcon(QStringLiteral(":/icons/system-users.png")), tr("Aliases"), this);
     viewAliasAction->setStatusTip(tr("Show Aliases"));
-    viewAliasAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2"))
+    viewAliasAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2"));
     connect(viewAliasAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_aliases);
 
     QAction* viewScriptsAction = new QAction(QIcon(QStringLiteral(":/icons/document-properties.png")), tr("Scripts"), this);
     viewScriptsAction->setStatusTip(tr("Show Scripts"));
-    viewScriptsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3"))
+    viewScriptsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3"));
     connect(viewScriptsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_scripts);
 
     QAction* showTimersAction = new QAction(QIcon(QStringLiteral(":/icons/chronometer.png")), tr("Timers"), this);
     showTimersAction->setStatusTip(tr("Show Timers"));
-    showTimersAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4"))
+    showTimersAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4"));
     connect(showTimersAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_timers);
 
     QAction* viewKeysAction = new QAction(QIcon(QStringLiteral(":/icons/preferences-desktop-keyboard.png")), tr("Keys"), this);
     viewKeysAction->setStatusTip(tr("Show Keybindings"));
-    viewKeysAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5"))
+    viewKeysAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5"));
     connect(viewKeysAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_keys);
 
     QAction* viewVarsAction = new QAction(QIcon(QStringLiteral(":/icons/variables.png")), tr("Variables"), this);
     viewVarsAction->setStatusTip(tr("Show Variables"));
-    viewVarsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6"))
+    viewVarsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6"));
     connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_vars);
 
     QAction* viewActionAction = new QAction(QIcon(QStringLiteral(":/icons/bookmarks.png")), tr("Buttons"), this);
     viewActionAction->setStatusTip(tr("Show Buttons"));
-    viewActionAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7"))
+    viewActionAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7"));
     connect(viewActionAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_actions);
 
 
     QAction* viewErrorsAction = new QAction(QIcon(QStringLiteral(":/icons/errors.png")), tr("Errors"), this);
     viewErrorsAction->setStatusTip(tr("Show/Hide the errors console in the bottom right of this editor."));
-    viewErrorsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8"))
+    viewErrorsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8"));
     connect(viewErrorsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewErrorsAction);
 
     QAction* viewStatsAction = new QAction(QIcon(QStringLiteral(":/icons/view-statistics.png")), tr("Statistics"), this);
     viewStatsAction->setStatusTip(tr("Generate a statistics summary display on the main profile console."));
-    viewStatsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9"))
+    viewStatsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9"));
     connect(viewStatsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewStatsAction);
 
     QAction* showDebugAreaAction = new QAction(QIcon(QStringLiteral(":/icons/tools-report-bug.png")), tr("Debug"), this);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -424,43 +424,43 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QAction* viewAliasAction = new QAction(QIcon(QStringLiteral(":/icons/system-users.png")), tr("Aliases"), this);
     viewAliasAction->setStatusTip(tr("Show Aliases"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2"))
+    viewAliasAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Aliases"), tr("Ctrl+2"))
     connect(viewAliasAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_aliases);
 
     QAction* viewScriptsAction = new QAction(QIcon(QStringLiteral(":/icons/document-properties.png")), tr("Scripts"), this);
     viewScriptsAction->setStatusTip(tr("Show Scripts"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3"))
+    viewScriptsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Scripts"), tr("Ctrl+3"))
     connect(viewScriptsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_scripts);
 
     QAction* showTimersAction = new QAction(QIcon(QStringLiteral(":/icons/chronometer.png")), tr("Timers"), this);
     showTimersAction->setStatusTip(tr("Show Timers"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4"))
+    showTimersAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Timers"), tr("Ctrl+4"))
     connect(showTimersAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_timers);
 
     QAction* viewKeysAction = new QAction(QIcon(QStringLiteral(":/icons/preferences-desktop-keyboard.png")), tr("Keys"), this);
     viewKeysAction->setStatusTip(tr("Show Keybindings"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5"))
+    viewKeysAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Keybindings"), tr("Ctrl+5"))
     connect(viewKeysAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_keys);
 
     QAction* viewVarsAction = new QAction(QIcon(QStringLiteral(":/icons/variables.png")), tr("Variables"), this);
     viewVarsAction->setStatusTip(tr("Show Variables"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6"))
+    viewVarsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6"))
     connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_vars);
 
     QAction* viewActionAction = new QAction(QIcon(QStringLiteral(":/icons/bookmarks.png")), tr("Buttons"), this);
     viewActionAction->setStatusTip(tr("Show Buttons"));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7"))
+    viewActionAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show Buttons"), tr("Ctrl+7"))
     connect(viewActionAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_actions);
 
 
     QAction* viewErrorsAction = new QAction(QIcon(QStringLiteral(":/icons/errors.png")), tr("Errors"), this);
     viewErrorsAction->setStatusTip(tr("Show/Hide the errors console in the bottom right of this editor."));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8"))
+    viewErrorsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Show/Hide errors console"), tr("Ctrl+8"))
     connect(viewErrorsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewErrorsAction);
 
     QAction* viewStatsAction = new QAction(QIcon(QStringLiteral(":/icons/view-statistics.png")), tr("Statistics"), this);
     viewStatsAction->setStatusTip(tr("Generate a statistics summary display on the main profile console."));
-    viewTriggerAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9"))
+    viewStatsAction->setToolTip(QStringLiteral("%1 (%2)").arg(tr("Generate statistics"), tr("Ctrl+9"))
     connect(viewStatsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewStatsAction);
 
     QAction* showDebugAreaAction = new QAction(QIcon(QStringLiteral(":/icons/tools-report-bug.png")), tr("Debug"), this);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8365,7 +8365,7 @@ void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
 void dlgTriggerEditor::slot_key_grab()
 {
     mIsGrabKey = true;
-    setShortcuts(true);
+    setShortcuts(false);
     QCoreApplication::instance()->installEventFilter(this);
 }
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8313,17 +8313,10 @@ bool dlgTriggerEditor::event(QEvent* event)
     if (mIsGrabKey) {
         if (event->type() == QEvent::KeyPress) {
             auto * ke = static_cast<QKeyEvent*>(event);
-            QList<QAction*> actionList = toolBar->actions();
             switch (ke->key()) {
             case Qt::Key_Escape:
                 mIsGrabKey = false;
-                for (auto& action : actionList) {
-                    if (action->text() == "Save Item") {
-                        action->setShortcut(tr("Ctrl+S"));
-                    } else if (action->text() == "Save Profile") {
-                        action->setShortcut(tr("Ctrl+Shift+S"));
-                    }
-                }
+                setShortcuts();
                 QCoreApplication::instance()->removeEventFilter(this);
                 ke->accept();
                 return true;
@@ -8342,13 +8335,7 @@ bool dlgTriggerEditor::event(QEvent* event)
             default:
                 key_grab_callback(static_cast<Qt::Key>(ke->key()), static_cast<Qt::KeyboardModifiers>(ke->modifiers()));
                 mIsGrabKey = false;
-                for (auto& action : actionList) {
-                    if (action->text() == "Save Item") {
-                        action->setShortcut(tr("Ctrl+S"));
-                    } else if (action->text() == "Save Profile") {
-                        action->setShortcut(tr("Ctrl+Shift+S"));
-                    }
-                }
+                setShortcuts();
                 QCoreApplication::instance()->removeEventFilter(this);
                 ke->accept();
                 return true;
@@ -8370,6 +8357,29 @@ void dlgTriggerEditor::resizeEvent(QResizeEvent* event)
 void dlgTriggerEditor::slot_key_grab()
 {
     mIsGrabKey = true;
+    unsetShortcuts();
+    QCoreApplication::instance()->installEventFilter(this);
+}
+
+void dlgTriggerEditor::setShortcuts()
+{
+    /* Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc */
+    /* TODO: Refactor into nice array to iterate in both un- and setShortcuts() */
+    QList<QAction*> actionList = toolBar->actions();
+    for (auto& action : actionList) {
+        if (action->text() == "Save Item") {
+            action->setShortcut(tr("Ctrl+S"));
+        } else if (action->text() == "Save Profile") {
+            action->setShortcut(tr("Ctrl+Shift+S"));
+        }
+    }
+}
+
+void dlgTriggerEditor::unsetShortcuts()
+{
+    /* Temporarily disabling the existing shortcuts for editor menu items like Ctrl+S etc.
+       This will allow binding them for macros until key was input or canceled with Escape */
+    /* TODO: Refactor into nice array to iterate in both un- and setShortcuts() */
     QList<QAction*> actionList = toolBar->actions();
     for (auto& action : actionList) {
         if (action->text() == "Save Item") {
@@ -8378,7 +8388,6 @@ void dlgTriggerEditor::slot_key_grab()
             action->setShortcut(tr(""));
         }
     }
-    QCoreApplication::instance()->installEventFilter(this);
 }
 
 void dlgTriggerEditor::key_grab_callback(const Qt::Key key, const Qt::KeyboardModifiers modifier)

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8370,46 +8370,45 @@ void dlgTriggerEditor::slot_key_grab()
 }
 
 // Activate shortcuts for editor menu items like Ctrl+S for "Save Item" etc.
-// Deactivate instead with optional "true" - useful to grab for a keybinding
-void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
+// Deactivate instead with optional "false" - to allow these for keybindings
+void dlgTriggerEditor::setShortcuts(const bool setNotUnset)
 {
     QList<QAction*> actionList = toolBar->actions();
     QString actionText;
     for (auto& action : actionList) {
         actionText = action->text();
         if (actionText ==  tr("Save Item")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+S") : tr(""));
         } else if (actionText == tr("Save Profile")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+Shift+S") : tr(""));
         }
     }
     actionList = toolBar2->actions();
     for (auto& action : actionList) {
         actionText = action->text();
-        // TODO: Refactor into nice array to iterate
+        // TODO: Refactor into nice list to iterate
         if (actionText == tr("Triggers")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+1"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+1") : tr(""));
         } else if (actionText == tr("Aliases")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+2"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+2") : tr(""));
         } else if (actionText == tr("Scripts")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+3"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+3") : tr(""));
         } else if (actionText == tr("Timers")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+4"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+4") : tr(""));
         } else if (actionText == tr("Keys")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+5"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+5") : tr(""));
         } else if (actionText == tr("Variables")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+6"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+6") : tr(""));
         } else if (actionText == tr("Buttons")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+7"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+7") : tr(""));
         } else if (actionText == tr("Errors")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+8"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+8") : tr(""));
         } else if (actionText == tr("Statistics")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+9"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+9") : tr(""));
         } else if (actionText == tr("Debug")) {
-            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+0"));
+            action->setShortcut((setNotUnset) ? tr("Ctrl+0") : tr(""));
         }
     }
-}
 
 void dlgTriggerEditor::key_grab_callback(const Qt::Key key, const Qt::KeyboardModifiers modifier)
 {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -421,23 +421,17 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     viewTriggerAction->setStatusTip(tr("Show Triggers"));
     connect(viewTriggerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_triggers);
 
-    QAction* viewActionAction = new QAction(QIcon(QStringLiteral(":/icons/bookmarks.png")), tr("Buttons"), this);
-    viewActionAction->setStatusTip(tr("Show Buttons"));
-    connect(viewActionAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_actions);
-
-
     QAction* viewAliasAction = new QAction(QIcon(QStringLiteral(":/icons/system-users.png")), tr("Aliases"), this);
     viewAliasAction->setStatusTip(tr("Show Aliases"));
     connect(viewAliasAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_aliases);
 
+    QAction* viewScriptsAction = new QAction(QIcon(QStringLiteral(":/icons/document-properties.png")), tr("Scripts"), this);
+    viewScriptsAction->setStatusTip(tr("Show Scripts"));
+    connect(viewScriptsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_scripts);
 
     QAction* showTimersAction = new QAction(QIcon(QStringLiteral(":/icons/chronometer.png")), tr("Timers"), this);
     showTimersAction->setStatusTip(tr("Show Timers"));
     connect(showTimersAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_timers);
-
-    QAction* viewScriptsAction = new QAction(QIcon(QStringLiteral(":/icons/document-properties.png")), tr("Scripts"), this);
-    viewScriptsAction->setStatusTip(tr("Show Scripts"));
-    connect(viewScriptsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_scripts);
 
     QAction* viewKeysAction = new QAction(QIcon(QStringLiteral(":/icons/preferences-desktop-keyboard.png")), tr("Keys"), this);
     viewKeysAction->setStatusTip(tr("Show Keybindings"));
@@ -446,6 +440,25 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     QAction* viewVarsAction = new QAction(QIcon(QStringLiteral(":/icons/variables.png")), tr("Variables"), this);
     viewVarsAction->setStatusTip(tr("Show Variables"));
     connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_vars);
+
+    QAction* viewActionAction = new QAction(QIcon(QStringLiteral(":/icons/bookmarks.png")), tr("Buttons"), this);
+    viewActionAction->setStatusTip(tr("Show Buttons"));
+    connect(viewActionAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_actions);
+
+
+    QAction* viewErrorsAction = new QAction(QIcon(QStringLiteral(":/icons/errors.png")), tr("Errors"), this);
+    viewErrorsAction->setStatusTip(tr("Shows/Hides the errors console in the bottom right of this editor."));
+    connect(viewErrorsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewErrorsAction);
+
+    QAction* viewStatsAction = new QAction(QIcon(QStringLiteral(":/icons/view-statistics.png")), tr("Statistics"), this);
+    viewStatsAction->setStatusTip(tr("Generates a statistics summary display on the main profile console."));
+    connect(viewStatsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewStatsAction);
+
+    QAction* showDebugAreaAction = new QAction(QIcon(QStringLiteral(":/icons/tools-report-bug.png")), tr("Debug"), this);
+    showDebugAreaAction->setToolTip(tr("Activates Debug Messages -> system will be <b><i>slower</i></b>."));
+    showDebugAreaAction->setStatusTip(tr("Shows/Hides the separate Central Debug Console - when being displayed the system will be slower."));
+    connect(showDebugAreaAction, &QAction::triggered, this, &dlgTriggerEditor::slot_debug_mode);
+
 
     QAction* toggleActiveAction = new QAction(QIcon(QStringLiteral(":/icons/document-encrypt.png")), tr("Activate"), this);
     toggleActiveAction->setStatusTip(tr("Toggle Active or Non-Active Mode for Triggers, Scripts etc."));
@@ -534,19 +547,6 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mProfileSaveAsAction = new QAction(QIcon(QStringLiteral(":/icons/utilities-file-archiver.png")), tr("Save Profile As"), this);
     mProfileSaveAsAction->setEnabled(true);
     connect(mProfileSaveAsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_profileSaveAsAction);
-
-    QAction* viewStatsAction = new QAction(QIcon(QStringLiteral(":/icons/view-statistics.png")), tr("Statistics"), this);
-    viewStatsAction->setStatusTip(tr("Generates a statistics summary display on the main profile console."));
-    connect(viewStatsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewStatsAction);
-
-    QAction* viewErrorsAction = new QAction(QIcon(QStringLiteral(":/icons/errors.png")), tr("Errors"), this);
-    viewErrorsAction->setStatusTip(tr("Shows/Hides the errors console in the bottom right of this editor."));
-    connect(viewErrorsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_viewErrorsAction);
-
-    QAction* showDebugAreaAction = new QAction(QIcon(QStringLiteral(":/icons/tools-report-bug.png")), tr("Debug"), this);
-    showDebugAreaAction->setToolTip(tr("Activates Debug Messages -> system will be <b><i>slower</i></b>."));
-    showDebugAreaAction->setStatusTip(tr("Shows/Hides the separate Central Debug Console - when being displayed the system will be slower."));
-    connect(showDebugAreaAction, &QAction::triggered, this, &dlgTriggerEditor::slot_debug_mode);
 
     auto *nextSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Tab), this);
     QObject::connect(nextSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_next_section);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -8368,17 +8368,15 @@ void dlgTriggerEditor::setShortcuts(const bool unsetInstead)
     /* Deactivate instead with optional "true" - useful to grab for a keybinding */
     /* TODO: Refactor into nice array to iterate */
     QList<QAction*> actionList = toolBar->actions();
-    QString shortcut;
     for (auto& action : actionList) {
         switch (action->text()) {
           case "Save Item": /* Not sure why, but this seems to work without tr() */
-            shortcut = (unsetInstead) ? tr("") : tr("Ctrl+S");
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+S"));
             break;
           case "Save Profile":
-            shortcut = (unsetInstead) ? tr("") : tr("Ctrl+Shift+S");
+            action->setShortcut((unsetInstead) ? tr("") : tr("Ctrl+Shift+S"));
             break;
         }
-        action->setShortcut(shortcut);
     }
 }
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -416,7 +416,7 @@ private:
     void autoSave();
     void setupPatternControls(const int type, dlgTriggerPatternEdit* pItem);
     void key_grab_callback(const Qt::Key, const Qt::KeyboardModifiers);
-    void setShortcuts(const bool unsetInstead = false);
+    void setShortcuts(const bool setNotUnset = true);
 
     QToolBar* toolBar;
     QToolBar* toolBar2;

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -416,7 +416,7 @@ private:
     void autoSave();
     void setupPatternControls(const int type, dlgTriggerPatternEdit* pItem);
     void key_grab_callback(const Qt::Key, const Qt::KeyboardModifiers);
-
+    void setShortcuts(const bool unsetInstead = false);
 
     QToolBar* toolBar;
     QToolBar* toolBar2;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Add shortcuts to navigate editor between triggers, aliases, etc.

![64490049-84983280-d259-11e9-83b2-d4163ef98f4c](https://user-images.githubusercontent.com/117238/121613334-87dad680-ca5c-11eb-89fc-688f0965d6fe.png)

#### Motivation for adding to Mudlet
Fix #3055

#### Other info (issues closed, discussion etc)
All editor menu shortcuts (including Ctrl+S and Ctrl+Shift+S added in #350) are now handled in a dedicated function to reduce repetitions. 

#### Release post highlight
Added shortcuts to navigate editor between triggers, aliases, etc.
