### PR TITLE
Update Ubuntu builds to 18.04

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -144,8 +144,6 @@ jobs:
     - name: (Linux) Install non-vcpkg dependencies
       if: runner.os == 'Linux'
       run: |
-        # workaround to install libzip-dev in Github Actions
-        #sudo apt-add-repository "ppa:ondrej/php" -y
         sudo apt-get update
 
         # Install from vcpkg everything we can for cross-platform consistency

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             buildname: 'ubuntu / gcc'
             triplet: x64-linux
             compiler: gcc_64
@@ -145,7 +145,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         # workaround to install libzip-dev in Github Actions
-        sudo apt-add-repository "ppa:ondrej/php" -y
+        #sudo apt-add-repository "ppa:ondrej/php" -y
         sudo apt-get update
 
         # Install from vcpkg everything we can for cross-platform consistency


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This PR updates the Linux build environment used for GitHub actions to Ubuntu 18.04 (Bionic). This is required since 16.04 is EOL and certain packages are not provided anymore. This means, that we might have to drop support for other distributions as well, if they ship an older version of glibc.

#### Motivation for adding to Mudlet
Make CI build again.

#### Other info (issues closed, discussion etc)
Fixes #5273

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
