### PR TITLE
Enhance: improve line-breaking in Command Line

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -74,7 +74,7 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
 
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     setCenterOnScroll(false);
-    setWordWrapMode(QTextOption::WrapAnywhere);
+    setWordWrapMode(QTextOption::WrapAtWordBoundaryOrAnywhere);
     setContentsMargins(0, 0, 0, 0);
     // clear console selection if selection in command line changes
     connect(this, &QPlainTextEdit::copyAvailable, this, &TCommandLine::slot_clearSelection);


### PR DESCRIPTION
This was suggested by the Discord User Kaylee # 0064 in the mudlet-development channel on 2021/06/11T18:56Z. :

> Kaylee — Yesterday at 19:56
> https://github.com/Mudlet/Mudlet/blob/fc0dd65fa8b022681ae073848150bac634d05d3b/src/TCommandLine.cpp#L77
>
> Is there a particular reason this isn't `QTextOption::WrapAtWordBoundaryOrAnywhere`?

> SlySven — Today at 16:29
> :thinking:
> SlySven — Today at 16:34
> Not that I can think of!
>
> The difference between that and the current `QTextOption::WrapAnywhere` is the option you suggest will wrap at a word boundary if possible - I guess the only effect might be that word boundaries for pure text is not necessarily the same when one is entering some lua incantation (or a funky alias) so the splitting might be surprising - OTOH at least trying to keep "words" contiguous on one line (by splitting before a word starts) is going to be easier on the :eyes: than split a word up simple because it straddles the effective margin...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>