### PR TITLE
Testing: revert "Update Ubuntu builds to 18.04 (#5282)"

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # oldest OS supported for maximum compatibility of built AppImage
-          - os: ubuntu-18.04
+          - os: ubuntu-16.04
             buildname: 'ubuntu / gcc'
             triplet: x64-linux
             compiler: gcc_64
@@ -144,6 +144,8 @@ jobs:
     - name: (Linux) Install non-vcpkg dependencies
       if: runner.os == 'Linux'
       run: |
+        # workaround to install libzip-dev in Github Actions
+        sudo apt-add-repository "ppa:ondrej/php" -y
         sudo apt-get update
 
         # Install from vcpkg everything we can for cross-platform consistency


### PR DESCRIPTION
This reverts commit fc0dd65fa8b022681ae073848150bac634d05d3b.

This is intended to check whether it was responsible for the loss of test builds from the "add-deployment-links" bot and probably will not be merged into the development branch because that was addressing another problem in our build infrastructure that probably cannot be avoided.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>