### PR TITLE
Right click action in command line to paste without line breaks

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -832,7 +832,7 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
                 QIcon::fromTheme(QStringLiteral("edit-paste"), QIcon(QStringLiteral(":/icons/edit-paste.png"))),
                 tr("Paste without line breaks"), this);
         pasteOneLine->setEnabled(canPaste());
-        pasteOneLine->setShortcut(QStringLiteral("Ctrl+Shift+B"));
+        pasteOneLine->setShortcut(QStringLiteral("Ctrl+Shift+V"));
         connect(pasteOneLine, &QAction::triggered, [=]() { pasteWithNoLineBreaks(); });
         popup->addAction(pasteOneLine);
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -208,6 +208,14 @@ bool TCommandLine::event(QEvent* event)
             }
             break;
 
+            case Qt::Key_V:
+                if ((ke->modifiers() & (allModifiers & (Qt::AltModifier))) == Qt::NoModifier) {
+                    pasteWithNoLineBreaks();
+                    ke->accept();
+                    return true;
+                }
+                break;
+
         case Qt::Key_unknown:
             qWarning() << "ERROR: key unknown!";
             break;
@@ -820,6 +828,14 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
             // one:
         }
 
+        auto pasteOneLine = new QAction(
+                QIcon::fromTheme(QStringLiteral("edit-paste"), QIcon(QStringLiteral(":/icons/edit-paste.png"))),
+                tr("Paste without line breaks"), this);
+        pasteOneLine->setEnabled(canPaste());
+        pasteOneLine->setShortcut(QStringLiteral("Ctrl+Shift+B"));
+        connect(pasteOneLine, &QAction::triggered, [=]() { pasteWithNoLineBreaks(); });
+        popup->addAction(pasteOneLine);
+
         mPopupPosition = event->pos();
         popup->popup(event->globalPos());
         // The use of accept here prevents this event from reaching any parent
@@ -1209,4 +1225,10 @@ void TCommandLine::removeSuggestion(const QString& suggestion)
 void TCommandLine::clearSuggestions()
 {
     commandLineSuggestions.clear();
+}
+
+void TCommandLine::pasteWithNoLineBreaks()
+{
+    QClipboard *clipboard = QGuiApplication::clipboard();
+    insertPlainText(clipboard->text().remove("\n"));
 }

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -70,6 +70,7 @@ public:
     void addSuggestion(const QString&);
     void removeSuggestion(const QString&);
     void clearSuggestions();
+    void pasteWithNoLineBreaks();
 
     int mActionFunction = 0;
     QPalette mRegularPalette;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

![Screenshot from 2021-06-18 07-35-48](https://user-images.githubusercontent.com/3740628/122519724-13cba000-d013-11eb-9bd9-175bb482fb00.png)

#### Motivation for adding to Mudlet

It tends to happen that ling text/commands pasted from Discord etc. has some line breaks that are no intended.
This is way to remove those line breaks while pasting.

#### Other info (issues closed, discussion etc)
I've assigned it with `Ctrl+Shit+V` shortcut. Whether this one can be used or remove at all is open for discussion.

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
