### PR TITLE
Add go to errors button in console toolbar

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -57,6 +57,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mpHost(pH)
 , buffer(pH)
 , emergencyStop(new QToolButton)
+, goToErrors(new QToolButton)
 , mpBaseVFrame(new QWidget(this))
 , mpTopToolBar(new QWidget(mpBaseVFrame))
 , mpBaseHFrame(new QWidget(mpBaseVFrame))
@@ -391,6 +392,21 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         tr("Emergency Stop. Stops all timers and triggers.")));
     connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stop_all_triggers);
 
+    goToErrors->setMinimumSize(QSize(30, 30));
+    goToErrors->setMaximumSize(QSize(30, 30));
+    goToErrors->setIcon(QIcon(QStringLiteral(":/icons/errors.png")));
+    goToErrors->setSizePolicy(sizePolicy4);
+    goToErrors->setFocusPolicy(Qt::NoFocus);
+    goToErrors->setToolTip(QStringLiteral("<html><head/><body><p>%1</p></body></html>").arg(
+            tr("Go to errors console.")));
+    connect(goToErrors, &QAbstractButton::clicked, [=]() {
+        mpHost->mpEditorDialog->slot_show_current();
+        mpHost->mpEditorDialog->raise();
+        mpHost->mpEditorDialog->showNormal();
+        mpHost->mpEditorDialog->activateWindow();
+        mpHost->mpEditorDialog->mpErrorConsole->setVisible(true);
+    });
+
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));
     mpBufferSearchBox->setMaximumSize(QSize(150, 30));
     mpBufferSearchBox->setSizePolicy(sizePolicy5);
@@ -440,7 +456,8 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layoutButtonLayer->addWidget(replayButton, 0, 8);
     layoutButtonLayer->addWidget(logButton, 0, 9);
     layoutButtonLayer->addWidget(emergencyStop, 0, 10);
-    layoutButtonLayer->addWidget(mpLineEdit_networkLatency, 0, 11);
+    layoutButtonLayer->addWidget(goToErrors, 0, 11);
+    layoutButtonLayer->addWidget(mpLineEdit_networkLatency, 0, 12);
     layoutLayer2->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(layer);
     mpLineEdit_networkLatency->setFrame(false);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -195,6 +195,7 @@ public:
     TTextEdit* mLowerPane = nullptr;
 
     QToolButton* emergencyStop = nullptr;
+    QToolButton* goToErrors = nullptr;
     QWidget* layer = nullptr;
     QWidget* layerCommandLine = nullptr;
     QHBoxLayout* layoutLayer2 = nullptr;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

![image](https://user-images.githubusercontent.com/3740628/122634326-df70e600-d0dd-11eb-9ebe-2de72fdc15c8.png)


#### Motivation for adding to Mudlet

It's cumbersome to tell people how at access error logs. Should be easier... I had little temptation to put button in top toolbar, maybe this would make it even more obvious?

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
