### PR TITLE
Add notarization to macOS builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -115,8 +115,10 @@ jobs:
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
       run: |
+        # add new tap to brew for installing gon
+        brew tap mitchellh/gon
         # these aren't available or don't work well in vcpkg
-        brew install pkg-config libzzip libzip ccache luarocks expect
+        brew install pkg-config libzzip libzip ccache luarocks expect mitchellh/gon/gon
 
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
@@ -292,6 +294,8 @@ jobs:
         DBLSQD_PASS: ${{secrets.DBLSQD_PASS}}
         DEPLOY_KEY_PASS: ${{secrets.DEPLOY_KEY_PASS}}
         MACOS_SIGNING_PASS: ${{secrets.MACOS_SIGNING_PASS}}
+        AC_USERNAME: ${{secrets.APPLE_USERNAME}}
+        AC_PASSWORD: ${{secrets.APPLE_PASSWORD}}
 
     - name: Upload packaged Mudlet
       uses: actions/upload-artifact@v2

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -111,7 +111,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
     if [ ! -z "$MACOS_SIGNING_PASS" ]; then
       if [ "${public_test_build}" == "true" ]; then
-         sign_and_notarize "${HOME}/Desktop/Mudlet PTB.dmg"
+        sign_and_notarize "${HOME}/Desktop/Mudlet PTB.dmg"
       else
         sign_and_notarize "${HOME}/Desktop/Mudlet.dmg"
       fi

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -34,7 +34,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone -b keneanung-sign-with-hardened-runtime https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -2,6 +2,24 @@
 
 set -e
 
+sign_and_notarize () {
+
+  local appBundle="$1"
+  codesign --deep -o runtime -s "$IDENTITY" "${appBundle}"
+  echo "Signed final .dmg"
+
+  cat << EOF > gon.json
+{
+  "notarize": [{
+    "path": "${appBundle}",
+    "bundle_id": "mudlet",
+    "staple": true
+  }]
+}
+EOF
+  gon gon.json
+}
+
 [ -n "$TRAVIS_REPO_SLUG" ] && BUILD_DIR="${TRAVIS_BUILD_DIR}" || BUILD_DIR="${BUILD_FOLDER}"
 [ -n "$TRAVIS_REPO_SLUG" ] && SOURCE_DIR="${TRAVIS_BUILD_DIR}" || SOURCE_DIR="${GITHUB_WORKSPACE}"
 
@@ -48,8 +66,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
     ./make-installer.sh "${appBaseName}.app"
 
     if [ -n "$MACOS_SIGNING_PASS" ]; then
-      codesign --deep -o runtime -s "$IDENTITY" "${HOME}/Desktop/${appBaseName}.dmg"
-      echo "Signed final .dmg"
+      sign_and_notarize "${HOME}/Desktop/${appBaseName}.dmg"
     fi
 
     if [ -n "$TRAVIS_REPO_SLUG" ]; then
@@ -94,11 +111,10 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
     if [ ! -z "$MACOS_SIGNING_PASS" ]; then
       if [ "${public_test_build}" == "true" ]; then
-        codesign --deep -o runtime -s "$IDENTITY" "${HOME}/Desktop/Mudlet PTB.dmg"
+         sign_and_notarize "${HOME}/Desktop/Mudlet PTB.dmg"
       else
-        codesign --deep -o runtime -s "$IDENTITY" "${HOME}/Desktop/Mudlet.dmg"
+        sign_and_notarize "${HOME}/Desktop/Mudlet.dmg"
       fi
-      echo "Signed final .dmg"
     fi
 
     if [ "${public_test_build}" == "true" ]; then

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -16,7 +16,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
   COMMIT_DATE=$(git show -s --pretty="tformat:%cI" | cut -d'T' -f1 | tr -d '-')
   YESTERDAY_DATE=$(date -v-1d '+%F' | tr -d '-')
 
-  git clone https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
+  git clone -b keneanung-sign-with-hardened-runtime https://github.com/Mudlet/installers.git "${BUILD_DIR}/../installers"
 
   cd "${BUILD_DIR}/../installers/osx"
 
@@ -48,7 +48,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
     ./make-installer.sh "${appBaseName}.app"
 
     if [ -n "$MACOS_SIGNING_PASS" ]; then
-      codesign --deep -s "$IDENTITY" "${HOME}/Desktop/${appBaseName}.dmg"
+      codesign --deep -o runtime -s "$IDENTITY" "${HOME}/Desktop/${appBaseName}.dmg"
       echo "Signed final .dmg"
     fi
 
@@ -94,9 +94,9 @@ if [ "${DEPLOY}" = "deploy" ]; then
 
     if [ ! -z "$MACOS_SIGNING_PASS" ]; then
       if [ "${public_test_build}" == "true" ]; then
-        codesign --deep -s "$IDENTITY" "${HOME}/Desktop/Mudlet PTB.dmg"
+        codesign --deep -o runtime -s "$IDENTITY" "${HOME}/Desktop/Mudlet PTB.dmg"
       else
-        codesign --deep -s "$IDENTITY" "${HOME}/Desktop/Mudlet.dmg"
+        codesign --deep -o runtime -s "$IDENTITY" "${HOME}/Desktop/Mudlet.dmg"
       fi
       echo "Signed final .dmg"
     fi


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

This adds notarization to macOS builds to let users download the app without annoying dialogues.

#### Motivation for adding to Mudlet

Let Mudlet look legit on macOS.

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
