### PR TITLE
Enhance: change exit status indication in room exits dialogue

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3905,8 +3905,7 @@ void T2DMap::slot_setExits()
         return;
     }
     if (mpMap->mpRoomDB->getRoom(mMultiSelectionHighlightRoomId)) {
-        auto pD = new dlgRoomExits(mpHost, this);
-        pD->init(mMultiSelectionHighlightRoomId);
+        auto pD = new dlgRoomExits(mpHost, mMultiSelectionHighlightRoomId, this);
         pD->show();
         pD->raise();
     }

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -178,7 +178,7 @@ void RoomIdLineEditDelegate::updateEditorGeometry(QWidget* pEditor, const QStyle
     pEditor->setGeometry(option.rect);
 }
 
-void RoomIdLineEditDelegate::slot_specialRoomExitEdited(const QString& text)
+void RoomIdLineEditDelegate::slot_specialRoomExitEdited(const QString& text) const
 {
     qDebug().nospace().noquote() << "RoomIdLineEditDelegate::slot_specialRoomExitEdited(\"" << text << "\") INFO - called with given text.";
     // We do not set an icon in the status column whilst we are editing the
@@ -362,7 +362,8 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
             //            qDebug() << "Closed PE on item:" << mpEditItem->text(colIndex_command) << "column:" << mEditColumn;
             break;
-        default:; //noop for other column (colIndex_exitStatus & colIndex_lockExit)
+        default:
+            {} //noop for other column (colIndex_exitStatus & colIndex_lockExit)
         }
 
         setIconAndToolTipsOnSpecialExit(mpEditItem, true);
@@ -973,7 +974,7 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     }
 }
 
-void dlgRoomExits::setActionOnExit(QLineEdit* pExitLineEdit, QAction* pWantedAction)
+void dlgRoomExits::setActionOnExit(QLineEdit* pExitLineEdit, QAction* pWantedAction) const
 {
     auto pActions = pExitLineEdit->actions();
     // In fact there should only be one action but this code is flexible enough
@@ -1015,7 +1016,7 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
     return nullptr;
 }
 
-QString dlgRoomExits::generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight) const
+/* static */ QString dlgRoomExits::generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight)
 {
     if (exitRoomName.trimmed().length()) {
         if (outOfAreaExit) {

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -44,9 +44,245 @@
 const QString singleParagraph{QStringLiteral("<p>%1</p>")};
 const QString doubleParagraph{QStringLiteral("<p>%1</p><p>%2</p>")};
 
-dlgRoomExits::dlgRoomExits(Host* pH, QWidget* pW) : QDialog(pW), mpHost(pH), mpEditItem(nullptr), pR(), mRoomID(), mEditColumn()
+// Abstract all the indexes into the special exits treewidget so that we can
+// tweak them and change all of them correctly:
+const int colIndex_exitRoomId = 0;
+const int colIndex_exitStatus = 1;
+const int colIndex_lockExit = 2;
+const int colIndex_exitWeight = 3;
+const int colIndex_doorNone = 4;
+const int colIndex_doorOpen = 5;
+const int colIndex_doorClosed = 6;
+const int colIndex_doorLocked = 7;
+const int colIndex_command = 8;
+
+WeightSpinBoxDelegate::WeightSpinBoxDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+QWidget* WeightSpinBoxDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /* option */, const QModelIndex& /* index */) const
+{
+    auto* pEditor = new QSpinBox(parent);
+    pEditor->setFrame(false);
+    pEditor->setMinimum(0);
+    pEditor->setMaximum(9999);
+
+    return pEditor;
+}
+
+void WeightSpinBoxDelegate::setEditorData(QWidget* pEditor, const QModelIndex& index) const
+{
+    auto value = index.model()->data(index, Qt::EditRole).toInt();
+    auto* pSpinBox = static_cast<QSpinBox*>(pEditor);
+    pSpinBox->setValue(value);
+}
+
+void WeightSpinBoxDelegate::setModelData(QWidget* pEditor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+    auto* pSpinBox = static_cast<QSpinBox*>(pEditor);
+    pSpinBox->interpretText();
+    auto value = pSpinBox->value();
+    model->setData(index, value, Qt::EditRole);
+}
+
+void WeightSpinBoxDelegate::updateEditorGeometry(QWidget* pEditor, const QStyleOptionViewItem& option, const QModelIndex& /* index */) const
+{
+    pEditor->setGeometry(option.rect);
+}
+
+RoomIdLineEditDelegate::RoomIdLineEditDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /* option */, const QModelIndex& index) const
+{
+    // Work our way up through the ancestors to get to the one that is the
+    // dlgRoomExit pointer:
+    auto* pSpecialExits = qobject_cast<ExitsTreeWidget*>(parent->parent());
+    // This should end up pointing to the item that contains the roomIdLineEdit
+    // that is being edited - we need it so as to be able to modify other
+    // elements of the same item. We cannot access them via index.sibling(...)
+    // as that returns const values which cannot thus be modified (and that is
+    // to prevent changes which might modify index itself) - basically be
+    // careful not to modify the roomID element that is contained in what mpItem
+    // points to!
+    if (pSpecialExits) {
+        auto* pGroupBox_specialExits = qobject_cast<QGroupBox*>(pSpecialExits->parent());
+        if (pGroupBox_specialExits) {
+            mpDlgRoomExits = qobject_cast<dlgRoomExits*>(pGroupBox_specialExits->parent());
+        }
+        mpItem = pSpecialExits->topLevelItem(index.row());
+    }
+    mpEditor = new QLineEdit(parent);
+    mpEditor->setFrame(false);
+    if (mpDlgRoomExits) {
+        if (!mpHost) {
+            mpHost = mpDlgRoomExits->getHost();
+        }
+        if (!mAreaID) {
+            mAreaID = mpDlgRoomExits->getAreaID();
+        }
+        if (mpHost) {
+            // Need to set the status icon on the QLineEdit on the opening of
+            // the editor otherwise it will not be shown until the user edits it:
+            auto text = index.model()->data(index, Qt::EditRole).toString();
+            TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
+            if (exitToRoom) {
+                // Valid exit roomID in place:
+                int exitAreaID = exitToRoom->getArea();
+                bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+                QString exitAreaName;
+                const QString roomIdToolTipText{mpDlgRoomExits->generateToolTip(exitToRoom->name, exitAreaName, outOfAreaExit, exitToRoom->getWeight())};
+                mpDlgRoomExits->setActionOnExit(mpEditor, outOfAreaExit ? mpDlgRoomExits->mpAction_otherAreaExit : mpDlgRoomExits->mpAction_inAreaExit);
+                // Set the tooltip for the QLineEdit:
+                mpEditor->setToolTip(roomIdToolTipText);
+                if (mpItem) {
+                    auto commandModelIndex = index.sibling(index.row(), colIndex_command);
+                    if (commandModelIndex.isValid() && commandModelIndex.model()->data(commandModelIndex, Qt::EditRole).toString() == mpDlgRoomExits->mSpecialExitCommandPlaceholder) {
+                        const QString commandToolTipText = singleParagraph.arg(tr("No command or Lua script entered, if left like this, this exit will be deleted when <tt>save</tt> is clicked."));
+                        mpItem->setToolTip(colIndex_exitStatus, commandToolTipText);
+                        mpItem->setToolTip(colIndex_command, commandToolTipText);
+                    } else {
+                        mpItem->setToolTip(colIndex_exitStatus, roomIdToolTipText);
+                        mpItem->setToolTip(colIndex_command, QString());
+                    }
+                }
+            } else if (!text.isEmpty()) {
+                // Something is entered but it does not yield a valid exit roomID:
+                mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
+                mpEditor->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room that this special exit goes to.")));
+            } else {
+                // Nothing is entered:
+                mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_noExit);
+                mpEditor->setToolTip(singleParagraph.arg(tr("Set the number of the room that this special exit goes to.")));
+            }
+        }
+    }
+
+    connect(mpEditor, &QLineEdit::textEdited, this, &RoomIdLineEditDelegate::slot_specialRoomExitEdited);
+    return mpEditor;
+}
+
+void RoomIdLineEditDelegate::setEditorData(QWidget* pEditor, const QModelIndex& index) const
+{
+    auto value = index.model()->data(index, Qt::EditRole).toString();
+    auto* pLineEdit = static_cast<QLineEdit*>(pEditor);
+    pLineEdit->setText(value);
+}
+
+void RoomIdLineEditDelegate::setModelData(QWidget* pEditor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+    auto* pLineEdit = static_cast<QLineEdit*>(pEditor);
+    auto value = pLineEdit->text();
+    model->setData(index, value, Qt::EditRole);
+}
+
+void RoomIdLineEditDelegate::updateEditorGeometry(QWidget* pEditor, const QStyleOptionViewItem& option, const QModelIndex& /* index */) const
+{
+    pEditor->setGeometry(option.rect);
+}
+
+void RoomIdLineEditDelegate::slot_specialRoomExitEdited(const QString& text)
+{
+    qDebug().nospace().noquote() << "RoomIdLineEditDelegate::slot_specialRoomExitEdited(\"" << text << "\") INFO - called with given text.";
+    // We do not set an icon in the status column whilst we are editing the
+    // exit room ID.
+
+    if (!mpHost || !mpItem || !mAreaID) {
+        return;
+    }
+    // The following code is a variation of that of
+    // dlgRoomExits::setIconAndToolTipsOnSpecialExit(...) :
+    TRoom* pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
+    QString roomIdToolTipText;
+    if (pExitToRoom) {
+        // A valid exit roomID number:
+        int exitAreaID = pExitToRoom->getArea();
+        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        QString exitAreaName;
+        if (outOfAreaExit) {
+            exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
+        }
+
+        // This is the toolTip text for the room ID number column (and the
+        // status icon - but only for the latter if there is a valid command as
+        // well):
+        roomIdToolTipText = mpDlgRoomExits->generateToolTip(pExitToRoom->name, exitAreaName, outOfAreaExit, pExitToRoom->getWeight());
+        if (mpItem->text(colIndex_command) == mpDlgRoomExits->mSpecialExitCommandPlaceholder) {
+            const QString commandToolTipText{singleParagraph.arg(tr("No command or Lua script entered, if left like this, this exit will be deleted when <tt>save</tt> is clicked."))};
+            mpItem->setToolTip(colIndex_exitStatus, commandToolTipText);
+            mpItem->setToolTip(colIndex_command, commandToolTipText);
+        } else {
+            mpItem->setToolTip(colIndex_exitStatus, roomIdToolTipText);
+            mpItem->setToolTip(colIndex_command, QString());
+        }
+        mpDlgRoomExits->setActionOnExit(mpEditor, outOfAreaExit ? mpDlgRoomExits->mpAction_otherAreaExit : mpDlgRoomExits->mpAction_inAreaExit);
+    } else if (text.toInt() > 0) {
+        // A number but not valid
+        mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
+        roomIdToolTipText = singleParagraph.arg(tr("Entered number is invalid, set the number of the room that this special exit leads to; "
+                                                   "if left like this, this exit will be deleted when <tt>save</tt> is clicked."));
+        mpItem->setToolTip(colIndex_exitStatus, roomIdToolTipText);
+    } else if (!text.isEmpty()) {
+        // Something else that isn't a positive number
+        mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
+        roomIdToolTipText = singleParagraph.arg(tr("A positive room ID of the room that this special exit leads to is expected here; "
+                                                   "if left like this, this exit will be deleted when <tt>save</tt> is clicked."));
+        mpItem->setToolTip(colIndex_exitStatus, roomIdToolTipText);
+    } else {
+        // Nothing is entered:
+        mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_noExit);
+        roomIdToolTipText = singleParagraph.arg(tr("Set the number of the room that this special exit goes to."));
+        mpItem->setToolTip(colIndex_exitStatus, roomIdToolTipText);
+    }
+    mpEditor->setToolTip(roomIdToolTipText);
+}
+
+dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
+: QDialog(pW)
+, mpHost(pH)
+, mRoomID(roomNumber)
 {
     setupUi(this);
+
+    mIcon_invalidExit.addFile(QStringLiteral(":/icons/dialog-error.png"), QSize(24, 24));
+    mIcon_inAreaExit.addFile(QStringLiteral(":/icons/dialog-ok-apply.png"), QSize(24, 24));
+    mIcon_otherAreaExit.addFile(QStringLiteral(":/icons/dialog-warning.png"), QSize(24, 24));
+
+    mpAction_noExit = new QAction(this);
+    mpAction_noExit->setText(QString());
+
+    mpAction_invalidExit = new QAction(this);
+    mpAction_invalidExit->setText(QString());
+    mpAction_invalidExit->setToolTip(QString());
+    mpAction_invalidExit->setIcon(mIcon_invalidExit);
+
+    mpAction_inAreaExit = new QAction(this);
+    mpAction_inAreaExit->setText(QString());
+    mpAction_inAreaExit->setToolTip(QString());
+    mpAction_inAreaExit->setIcon(mIcon_inAreaExit);
+
+    mpAction_otherAreaExit = new QAction(this);
+    mpAction_otherAreaExit->setText(QString());
+    mpAction_otherAreaExit->setToolTip(QString());
+    mpAction_otherAreaExit->setIcon(mIcon_otherAreaExit);
+
+    mAllExitActionsSet << mpAction_noExit << mpAction_invalidExit << mpAction_inAreaExit << mpAction_otherAreaExit;
+    mSpecialExitRoomIdPlaceholder = tr("(room ID)", "Placeholder, if no room ID is set for an exit, yet. This string is used programmatically in several places but is now defined only once so no need to check for multiple copies of it! 8-)");
+    mSpecialExitCommandPlaceholder = tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is used programmatically in several places but is now defined only once so no need to check for multiple copies of it! 8-)");
+
+    init();
+
+    // Can't really use this now as the delegate for the exit weight is much
+    // larger than the text shown normally when there isn't a "persistant
+    // editor" active:
+    // specialExits->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    specialExits->setItemDelegateForColumn(colIndex_exitRoomId, new RoomIdLineEditDelegate);
+    specialExits->setItemDelegateForColumn(colIndex_exitWeight, new WeightSpinBoxDelegate);
+}
+
+dlgRoomExits::~dlgRoomExits()
+{
+    delete mpAction_otherAreaExit;
+    delete mpAction_inAreaExit;
+    delete mpAction_invalidExit;
+    delete mpAction_noExit;
 }
 
 void dlgRoomExits::slot_endEditSpecialExits()
@@ -57,6 +293,7 @@ void dlgRoomExits::slot_endEditSpecialExits()
     }
     if (mpEditItem != nullptr && mEditColumn >= 0) {
         specialExits->closePersistentEditor(mpEditItem, mEditColumn);
+        setIconAndToolTipsOnSpecialExit(mpEditItem, true);
         mpEditItem = nullptr;
         mEditColumn = -1;
     }
@@ -65,17 +302,6 @@ void dlgRoomExits::slot_endEditSpecialExits()
 
 void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
 {
-    /* column is now
-       0 = exitRoomID
-       1 = no route (locked)
-       2 = exit weight
-       3 = door type: none
-       4 = door type: open
-       5 = door type: closed
-       6 = door type: locked
-       7 = cmd
-     */
-
     if (!button_endEditing->isEnabled()) {
         button_endEditing->setEnabled(true);
     }
@@ -86,124 +312,115 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
     if (mpEditItem != nullptr && (pI != mpEditItem || mEditColumn != column)) {
         // Thing that was clicked on is not the same as last thing that was clicked on
         // ... so clean up the old column
-        TRoom* pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom(mpEditItem->text(0).toInt());
         switch (mEditColumn) {
-        case 0:
-            if (mpEditItem->text(0).toInt() < 1) {
-                mpEditItem->setText(0, tr("(room ID)", "Placeholder, if no room ID is set for an exit, yet. This string is used in 2 places, ensure they match!"));
+        case colIndex_exitRoomId:
+            if (mpEditItem->text(colIndex_exitRoomId).toInt() < 1) {
+                mpEditItem->setText(colIndex_exitRoomId, mSpecialExitRoomIdPlaceholder);
             }
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
+            setIconAndToolTipsOnSpecialExit(mpEditItem, true);
             break;
 
-        case 2:
-            mpEditItem->setText(2, QString::number((mpEditItem->text(2).toInt() < 0) ? (-1 * mpEditItem->text(2).toInt()) : mpEditItem->text(2).toInt())); //Force result to be non-negative integer
+        case colIndex_exitWeight:
+            mpEditItem->setData(colIndex_exitWeight, Qt::EditRole,
+                                abs(mpEditItem->data(colIndex_exitWeight, Qt::EditRole).toInt()));
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
             break;
 
-        case 3: // Enforce exclusive Radio Button type behaviour on the checkboxes in these four columns
-            mpEditItem->setCheckState(3, Qt::Checked);
-            mpEditItem->setCheckState(4, Qt::Unchecked);
-            mpEditItem->setCheckState(5, Qt::Unchecked);
-            mpEditItem->setCheckState(6, Qt::Unchecked);
+        case colIndex_doorNone: // Enforce exclusive Radio Button type behaviour on the checkboxes in these four columns
+            mpEditItem->setCheckState(colIndex_doorNone, Qt::Checked);
+            mpEditItem->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorLocked, Qt::Unchecked);
             break;
 
-        case 4:
-            mpEditItem->setCheckState(3, Qt::Unchecked);
-            mpEditItem->setCheckState(4, Qt::Checked);
-            mpEditItem->setCheckState(5, Qt::Unchecked);
-            mpEditItem->setCheckState(6, Qt::Unchecked);
+        case colIndex_doorOpen:
+            mpEditItem->setCheckState(colIndex_doorNone, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorOpen, Qt::Checked);
+            mpEditItem->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorLocked, Qt::Unchecked);
             break;
 
-        case 5:
-            mpEditItem->setCheckState(3, Qt::Unchecked);
-            mpEditItem->setCheckState(4, Qt::Unchecked);
-            mpEditItem->setCheckState(5, Qt::Checked);
-            mpEditItem->setCheckState(6, Qt::Unchecked);
+        case colIndex_doorClosed:
+            mpEditItem->setCheckState(colIndex_doorNone, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorClosed, Qt::Checked);
+            mpEditItem->setCheckState(colIndex_doorLocked, Qt::Unchecked);
             break;
 
-        case 6:
-            mpEditItem->setCheckState(3, Qt::Unchecked);
-            mpEditItem->setCheckState(4, Qt::Unchecked);
-            mpEditItem->setCheckState(5, Qt::Unchecked);
-            mpEditItem->setCheckState(6, Qt::Checked);
+        case colIndex_doorLocked:
+            mpEditItem->setCheckState(colIndex_doorNone, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+            mpEditItem->setCheckState(colIndex_doorLocked, Qt::Checked);
             break;
 
-        case 7:
-            if (!mpEditItem->text(7).trimmed().length()) {
-                mpEditItem->setText(7, tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is also used programmatically - ensure all five instances are the same"));
+        case colIndex_command:
+            if (!mpEditItem->text(colIndex_command).trimmed().length()) {
+                mpEditItem->setText(colIndex_command, mSpecialExitCommandPlaceholder);
             }
             specialExits->closePersistentEditor(mpEditItem, mEditColumn);
-            //            qDebug()<<"Closed PE on item:"<<mpEditItem->text(7)<<"column:"<<mEditColumn;
+            //            qDebug() << "Closed PE on item:" << mpEditItem->text(colIndex_command) << "column:" << mEditColumn;
             break;
-        default:; //noop for other column (1)
+        default:; //noop for other column (colIndex_exitStatus & colIndex_lockExit)
         }
 
-        if (pExitToRoom) {
-            mpEditItem->setForeground(0, QColor(Qt::blue));
-            if (!pExitToRoom->name.isEmpty()) {
-                mpEditItem->setToolTip(0, doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(pExitToRoom->name),
-                                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                                      .arg(pExitToRoom->getWeight())));
-            } else {
-                mpEditItem->setToolTip(0, doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                                      .arg(pExitToRoom->getWeight())));
-            }
-        } else {
-            mpEditItem->setForeground(0, QColor(Qt::red));
-            mpEditItem->setToolTip(0, singleParagraph.arg(tr("Entered number is invalid, set the number of the room that this special exit leads to, will turn blue for "
-                                                             "a valid number; if left like this, this exit will be deleted when &lt;i&gt;save&lt;/i&gt; is clicked.")));
-        }
+        setIconAndToolTipsOnSpecialExit(mpEditItem, true);
 
-        mpEditItem = nullptr; //This will cause a new PE to be opened, it will also be zeroed on the first time this funciton is called
+        mpEditItem = nullptr; //This will cause a new PE to be opened, it will also be zeroed on the first time this function is called
         mEditColumn = -1;
     }
 
     // Now process the new column that was selected:
     if (mpEditItem == nullptr) {
-        if (column == 0 || column == 2 || column == 7) {
-            //            qDebug()<<"Opened PE on item:"<<pI->text(7)<<"column:"<<column;
+        if (column == colIndex_exitRoomId || column == colIndex_exitWeight || column == colIndex_command) {
+            //            qDebug() << "Opened PE on item:" << pI->text(colIndex_command) << "column:" << column;
             specialExits->openPersistentEditor(pI, column);
             specialExits->editItem(pI, column);
+            if (column == colIndex_exitRoomId) {
+                setIconAndToolTipsOnSpecialExit(pI, false);
+                // Hide the Edit Status icon (as the status will be replicated
+                // and adjusted within the Exit Room ID column's QLineEdit)
+                // whilst the value is being edited:
+                // pI->setIcon(colIndex_exitStatus, QIcon());
+            }
         }
         mpEditItem = pI;
         mEditColumn = column;
     }
 
-    //    qDebug()<<"A Special Exit is been edited, it has the command:" << pI->text(7) <<"and the editing is on column "<<column;
+    //    qDebug() << "A Special Exit is been edited, it has the command:" << pI->text(colIndex_command) << "and the editing is on column " << column;
     switch (column) {
-    case 2:
-        pI->setText(2, QString::number((pI->text(2).toInt() < 0) ? (-1 * pI->text(2).toInt()) : pI->text(2).toInt())); //Force result to be non-negative
+    case colIndex_exitWeight:
+        pI->setData(colIndex_exitWeight, Qt::EditRole, abs(pI->data(colIndex_exitWeight, Qt::EditRole).toInt())); //Force result to be non-negative
         break;
 
-    case 3: // Enforce exclusive Radio Button type behaviour on the checkboxes in these four columns
-        pI->setCheckState(3, Qt::Checked);
-        pI->setCheckState(4, Qt::Unchecked);
-        pI->setCheckState(5, Qt::Unchecked);
-        pI->setCheckState(6, Qt::Unchecked);
+    case colIndex_doorNone: // Enforce exclusive Radio Button type behaviour on the checkboxes in these four columns
+        pI->setCheckState(colIndex_doorNone, Qt::Checked);
+        pI->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorLocked, Qt::Unchecked);
         break;
 
-    case 4:
-        pI->setCheckState(3, Qt::Unchecked);
-        pI->setCheckState(4, Qt::Checked);
-        pI->setCheckState(5, Qt::Unchecked);
-        pI->setCheckState(6, Qt::Unchecked);
+    case colIndex_doorOpen:
+        pI->setCheckState(colIndex_doorNone, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorOpen, Qt::Checked);
+        pI->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorLocked, Qt::Unchecked);
         break;
 
-    case 5:
-        pI->setCheckState(3, Qt::Unchecked);
-        pI->setCheckState(4, Qt::Unchecked);
-        pI->setCheckState(5, Qt::Checked);
-        pI->setCheckState(6, Qt::Unchecked);
+    case colIndex_doorClosed:
+        pI->setCheckState(colIndex_doorNone, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorClosed, Qt::Checked);
+        pI->setCheckState(colIndex_doorLocked, Qt::Unchecked);
         break;
 
-    case 6:
-        pI->setCheckState(3, Qt::Unchecked);
-        pI->setCheckState(4, Qt::Unchecked);
-        pI->setCheckState(5, Qt::Unchecked);
-        pI->setCheckState(6, Qt::Checked);
+    case colIndex_doorLocked:
+        pI->setCheckState(colIndex_doorNone, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+        pI->setCheckState(colIndex_doorLocked, Qt::Checked);
         break;
 
     default:; //noop for other columns?
@@ -213,26 +430,26 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
 void dlgRoomExits::slot_addSpecialExit()
 {
     auto pI = new QTreeWidgetItem(specialExits);
-    pI->setText(0, tr("(room ID)", "Placeholder, if no room ID is set for an exit, yet. This string is used in 2 places, ensure they match!")); //Exit RoomID
-    pI->setForeground(0, QColor(Qt::red));
-    pI->setToolTip(0, singleParagraph.arg(tr("Set the number of the room that this special exit leads to, will turn blue for a valid number; if left like "
-                                             "this, this exit will be deleted when &lt;i&gt;save&lt;/i&gt; is clicked.")));
-    pI->setTextAlignment(0, Qt::AlignRight);
-    pI->setToolTip(1, singleParagraph.arg(tr("Prevent a route being created via this exit, equivalent to an infinite exit weight.")));
-    pI->setCheckState(1, Qt::Unchecked); //Locked
-    pI->setText(2, QStringLiteral("0")); //Exit Weight
-    pI->setTextAlignment(2, Qt::AlignRight);
-    pI->setToolTip(2, singleParagraph.arg(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
-    pI->setCheckState(3, Qt::Checked); //Doortype: none
-    pI->setToolTip(3, singleParagraph.arg(tr("No door symbol is drawn on 2D Map for this exit (only functional choice currently).")));
-    pI->setCheckState(4, Qt::Unchecked); //Doortype: open
-    pI->setToolTip(4, singleParagraph.arg(tr("Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-    pI->setCheckState(5, Qt::Unchecked); //Doortype: closed
-    pI->setToolTip(5, singleParagraph.arg(tr("Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-    pI->setCheckState(6, Qt::Unchecked); //Doortype: locked
-    pI->setToolTip(6, singleParagraph.arg(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-    pI->setText(7, tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is also used programmatically - ensure all five instances are the same")); //Exit command
-    pI->setTextAlignment(7, Qt::AlignLeft);
+    pI->setIcon(colIndex_exitStatus, QIcon());
+    pI->setText(colIndex_exitRoomId, mSpecialExitRoomIdPlaceholder); //Exit RoomID
+    pI->setToolTip(colIndex_exitRoomId, singleParagraph.arg(tr("Set the number of the room that this special exit leads to; if left like "
+                                                               "this, this exit will be deleted when <tt>save</tt> is clicked.")));
+    pI->setTextAlignment(colIndex_exitRoomId, Qt::AlignRight);
+    pI->setToolTip(colIndex_lockExit, singleParagraph.arg(tr("Prevent a route being created via this exit, equivalent to an infinite exit weight.")));
+    pI->setCheckState(colIndex_lockExit, Qt::Unchecked); //Locked
+    pI->setData(colIndex_exitWeight, Qt::EditRole, 0); //Exit Weight
+    // pI->setTextAlignment(colIndex_exitWeight, Qt::AlignRight);
+    pI->setToolTip(colIndex_exitWeight, singleParagraph.arg(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
+    pI->setCheckState(colIndex_doorNone, Qt::Checked); //Doortype: none
+    pI->setToolTip(colIndex_doorNone, singleParagraph.arg(tr("No door symbol is drawn on 2D Map for this exit (only functional choice currently).")));
+    pI->setCheckState(colIndex_doorOpen, Qt::Unchecked); //Doortype: open
+    pI->setToolTip(colIndex_doorOpen, singleParagraph.arg(tr("Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
+    pI->setCheckState(colIndex_doorClosed, Qt::Unchecked); //Doortype: closed
+    pI->setToolTip(colIndex_doorClosed, singleParagraph.arg(tr("Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
+    pI->setCheckState(colIndex_doorLocked, Qt::Unchecked); //Doortype: locked
+    pI->setToolTip(colIndex_doorLocked, singleParagraph.arg(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
+    pI->setText(colIndex_command, mSpecialExitCommandPlaceholder); //Exit command
+    pI->setTextAlignment(colIndex_command, Qt::AlignLeft);
     specialExits->addTopLevelItem(pI);
 }
 
@@ -252,24 +469,24 @@ void dlgRoomExits::save()
 
     for (int i = 0; i < specialExits->topLevelItemCount(); ++i) {
         QTreeWidgetItem* pI = specialExits->topLevelItem(i);
-        int value = pI->text(0).toInt();
-        int weight = pI->text(2).toInt();
+        int value = pI->text(colIndex_exitRoomId).toInt();
+        int weight = pI->data(colIndex_exitWeight, Qt::EditRole).toInt();
         int door = 0;
         bool locked = false;
-        if (pI->checkState(6) == Qt::Checked) {
+        if (pI->checkState(colIndex_doorLocked) == Qt::Checked) {
             door = 3;
-        } else if (pI->checkState(5) == Qt::Checked) {
+        } else if (pI->checkState(colIndex_doorClosed) == Qt::Checked) {
             door = 2;
-        } else if (pI->checkState(4) == Qt::Checked) {
+        } else if (pI->checkState(colIndex_doorOpen) == Qt::Checked) {
             door = 1;
-        } else if (pI->checkState(3) == Qt::Checked) {
+        } else {
             door = 0;
         }
-        QString key = pI->text(7);
-        if (key != tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is also used programmatically - ensure all five instances are the same")
+        QString key = pI->text(colIndex_command);
+        if (key != mSpecialExitCommandPlaceholder
             && value != 0 && mpHost->mpMap->mpRoomDB->getRoom(value) != nullptr) {
             originalExitCmds.remove(key);
-            locked = (pI->checkState(1) != Qt::Unchecked);
+            locked = (pI->checkState(colIndex_lockExit) != Qt::Unchecked);
             pR->setSpecialExit(value, key); // Now can overwrite an existing exit with a different destination
             pR->setSpecialExitLock(key, locked);
             if (pR->hasExitWeight(key) || weight > 0) {
@@ -282,7 +499,7 @@ void dlgRoomExits::save()
     }
 
     // Clean up after any deleted specialExits originally present but not now so
-    for (auto value : originalExitCmds) {
+    for (auto& value : originalExitCmds) {
         pR->customLinesArrow.remove(value);
         pR->customLinesColor.remove(value);
         pR->customLinesStyle.remove(value);
@@ -715,978 +932,415 @@ void dlgRoomExits::save()
     close();
 }
 
+void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit, const bool showIconOnExitStatus)
+{
+    TRoom* pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom(pSpecialExit->text(colIndex_exitRoomId).toInt());
+    if (pExitToRoom) {
+        // A valid exit roomID number:
+        int exitAreaID = pExitToRoom->getArea();
+        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        QString exitAreaName;
+        if (outOfAreaExit) {
+            exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
+        }
+
+        // This is the toolTip text for the room ID number column (and the
+        // status icon - but only for the latter if there is a valid command as
+        // well):
+        const QString roomIdToolTipText{generateToolTip(pExitToRoom->name, exitAreaName, outOfAreaExit, pExitToRoom->getWeight())};
+        if (pSpecialExit->text(colIndex_command) == mSpecialExitCommandPlaceholder) {
+            const QString commandToolTipText{singleParagraph.arg(tr("No command or Lua script entered, if left like this, this exit will be deleted when <tt>save</tt> is clicked."))};
+            pSpecialExit->setIcon(colIndex_exitStatus, showIconOnExitStatus ? mIcon_invalidExit : QIcon());
+            pSpecialExit->setToolTip(colIndex_exitStatus, commandToolTipText);
+            pSpecialExit->setToolTip(colIndex_command, commandToolTipText);
+        } else {
+            pSpecialExit->setIcon(colIndex_exitStatus, showIconOnExitStatus ? (outOfAreaExit ? mIcon_otherAreaExit : mIcon_inAreaExit) : QIcon());
+            pSpecialExit->setToolTip(colIndex_exitStatus, roomIdToolTipText);
+            pSpecialExit->setToolTip(colIndex_command, QString());
+        }
+        pSpecialExit->setToolTip(colIndex_exitRoomId, roomIdToolTipText);
+
+    } else if (pSpecialExit->text(colIndex_exitRoomId).toInt() > 0) {
+        // A number but not valid
+        pSpecialExit->setIcon(colIndex_exitStatus, showIconOnExitStatus ? mIcon_invalidExit : QIcon());
+        pSpecialExit->setToolTip(colIndex_exitRoomId, singleParagraph.arg(tr("Entered number is invalid, set the number of the room that this special exit leads to; "
+                                                                           "if left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
+    } else if (!pSpecialExit->text(colIndex_exitRoomId).isEmpty()) {
+        // Something else that isn't a positive number
+        pSpecialExit->setIcon(colIndex_exitStatus, showIconOnExitStatus ? mIcon_invalidExit : QIcon());
+        pSpecialExit->setToolTip(colIndex_exitRoomId, singleParagraph.arg(tr("A positive room ID of the room that this special exit leads to is expected here; "
+                                                                             "if left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
+    }
+}
+
+void dlgRoomExits::setActionOnExit(QLineEdit* pExitLineEdit, QAction* pWantedAction)
+{
+    auto pActions = pExitLineEdit->actions();
+    // In fact there should only be one action but this code is flexible enough
+    // to deal with there being other unrealated ones also present:
+    bool found = false;
+    for (int index = 0, total = pActions.count(); index < total; ++index) {
+        auto pAction = pActions[index];
+        if (pAction && mAllExitActionsSet.contains(pAction)) {
+            // This is one of the four we are looking for.
+            if (pAction != pWantedAction) {
+                // but it isn't the one we want - so remove it from the QLineEdit
+                pExitLineEdit->removeAction(pAction);
+            } else {
+                // it is already there:
+                found = true;
+            }
+        }
+    }
+    if (!found) {
+        // It wasn't there so add it - so that the position is similar for the
+        // special exit form put it to the right of the QLineEdit text:
+        pExitLineEdit->addAction(pWantedAction, QLineEdit::TrailingPosition);
+    }
+}
+
+// Check for and return the (first one of the) QAction's used for the status
+// icon on the ExitRoomID - this is actually only used for the special exits:
+QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
+{
+    auto pActions = pExitLineEdit->actions();
+    for (int index = 0, total = pActions.count(); index < total; ++index) {
+        auto pAction = pActions[index];
+        if (pAction && mAllExitActionsSet.contains(pAction)) {
+            // This is one of the four we are looking for.
+            return pAction;
+        }
+    }
+    // Handle the not found case:
+    return nullptr;
+}
+
+QString dlgRoomExits::generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight) const
+{
+    if (exitRoomName.trimmed().length()) {
+        if (outOfAreaExit) {
+            return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
+                                           .arg(exitRoomName, exitAreaName),
+                                       tr("<b>Room</b> Weight of destination: %1.",
+                                          // Intentional comment to separate arguments
+                                          "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
+                                           .arg(exitRoomWeight));
+        }
+        return doubleParagraph.arg(tr("Exit to \"%1\".")
+                                       .arg(exitRoomName),
+                                   tr("<b>Room</b> Weight of destination: %1.",
+                                      // Intentional comment to separate arguments
+                                      "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
+                                       .arg(exitRoomWeight));
+    }
+
+    if (outOfAreaExit) {
+        return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.")
+                                       .arg(exitAreaName),
+                                   tr("<b>Room</b> Weight of destination: %1.",
+                                      // Intentional comment to separate arguments
+                                      "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
+                                       .arg(exitRoomWeight));
+    }
+
+    return doubleParagraph.arg(tr("Exit to unnamed room is valid."),
+                               tr("<b>Room</b> Weight of destination: %1.",
+                                  // Intentional comment to separate arguments
+                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
+                                     .arg(exitRoomWeight));
+}
+
+void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pExit, QCheckBox* pNoRoute, QCheckBox* pStub, QSpinBox* pWeight, QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked, const QString& invalidExitToolTipText, const QString& noExitToolTipText)
+{
+    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(roomExitIdText.toInt());
+    if (exitToRoom) {
+        int exitAreaID = exitToRoom->getArea();
+        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        QString exitAreaName;
+        if (outOfAreaExit) {
+            exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
+        }
+        // Valid exit roomID in place
+        pStub->setChecked(false);
+        pStub->setEnabled(false);
+        pNoRoute->setEnabled(true);
+        pWeight->setEnabled(true);
+        pDoorType_none->setEnabled(true);
+        pDoorType_open->setEnabled(true);
+        pDoorType_closed->setEnabled(true);
+        pDoorType_locked->setEnabled(true);
+        setActionOnExit(pExit, outOfAreaExit ? mpAction_otherAreaExit : mpAction_inAreaExit);
+        pExit->setToolTip(generateToolTip(exitToRoom->name, exitAreaName, outOfAreaExit, exitToRoom->getWeight()));
+    } else if (!roomExitIdText.isEmpty()) {
+        // Something is entered but it does not yield a valid exit roomID
+        // Enable stub exit control
+        setActionOnExit(pExit, mpAction_invalidExit);
+        pExit->setToolTip(invalidExitToolTipText);
+        pStub->setEnabled(true);
+        pNoRoute->setEnabled(false);
+        pWeight->setEnabled(false);
+        pDoorType_none->setEnabled(false);
+        pDoorType_open->setEnabled(false);
+        pDoorType_closed->setEnabled(false);
+        pDoorType_locked->setEnabled(false);
+    } else {
+        // Nothing is entered - so we can enable the stub exit control
+        setActionOnExit(pExit, mpAction_noExit);
+        pExit->setToolTip(noExitToolTipText);
+        pStub->setEnabled(true);
+        pNoRoute->setEnabled(false);
+        pWeight->setEnabled(false);
+        pDoorType_none->setEnabled(false);
+        pDoorType_open->setEnabled(false);
+        pDoorType_closed->setEnabled(false);
+        pDoorType_locked->setEnabled(false);
+    }
+}
+
+void dlgRoomExits::normalStubExitChanged(const int state, QLineEdit* pExit, QCheckBox* pNoRoute, QSpinBox* pWeight,
+                                         QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked, const QString& noExitToolTipText)
+{
+    if (state == Qt::Checked) {
+        if (!pExit->text().isEmpty()) {
+            // There might be some text that does not evaluate to a valid Room
+            // Id still in that field - so clear it:
+            pExit->setText(QString());
+            setActionOnExit(pExit, mpAction_noExit);
+            pWeight->setValue(0);        // Can't have a weight for a stub pExit
+            pNoRoute->setChecked(false); // nor a "lock"
+        }
+        pNoRoute->setEnabled(false); // Disable "lock" on this exit
+        pExit->setEnabled(false);         // Prevent entry of an exit roomID
+        pExit->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
+        pDoorType_none->setEnabled(true);
+        pDoorType_open->setEnabled(true);
+        pDoorType_closed->setEnabled(true);
+        pDoorType_locked->setEnabled(true); // Permit a door to be set on a stub exit
+        pWeight->setEnabled(false);         // Prevent a weight to be set/changed on a stub
+    } else {
+        pExit->setEnabled(true);
+        setActionOnExit(pExit, mpAction_noExit);
+        pExit->setToolTip(noExitToolTipText);
+        //  noroute_nw->setEnabled(true); although this branch will enable the exit entry
+        //  there will not be a valid one there yet so don't enable the noroute(lock) control here!
+        pDoorType_none->setEnabled(false);
+        pDoorType_open->setEnabled(false);
+        pDoorType_closed->setEnabled(false);
+        pDoorType_locked->setEnabled(false);
+        pDoorType_none->setChecked(true);
+        //  similarly as there won't be a valid exit or a stub exit at theis point disable/reset the door type controls
+        pWeight->setEnabled(false);
+        pWeight->setValue(0); // Prevent a weight to be set/changed on a also
+    }
+}
+
 // These slots are called as the text for the exitID is edited
 void dlgRoomExits::slot_nw_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        // Valid exit roomID in place
-        nw->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_nw->setChecked(false);
-        stub_nw->setEnabled(false);
-        noroute_nw->setEnabled(true);
-        weight_nw->setEnabled(true);
-        doortype_none_nw->setEnabled(true);
-        doortype_open_nw->setEnabled(true);
-        doortype_closed_nw->setEnabled(true);
-        doortype_locked_nw->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            nw->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        } else {
-            nw->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        }
-    } else if (!text.isEmpty()) {
-        // Something is entered but it does not yield a valid exit roomID
-        // Enable stub exit control
-        nw->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        nw->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room northwest of this one, will turn blue for a valid number.")));
-        stub_nw->setEnabled(true);
-        noroute_nw->setEnabled(false);
-        weight_nw->setEnabled(false);
-        doortype_none_nw->setEnabled(false);
-        doortype_open_nw->setEnabled(false);
-        doortype_closed_nw->setEnabled(false);
-        doortype_locked_nw->setEnabled(false);
-    } else {
-        // Nothing is entered - so we can enable the stub exit control
-        nw->setStyleSheet(QString());
-        nw->setToolTip(singleParagraph.arg(tr("Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.")));
-        stub_nw->setEnabled(true);
-        noroute_nw->setEnabled(false);
-        weight_nw->setEnabled(false);
-        doortype_none_nw->setEnabled(false);
-        doortype_open_nw->setEnabled(false);
-        doortype_closed_nw->setEnabled(false);
-        doortype_locked_nw->setEnabled(false);
-    }
+    normalExitEdited(text, nw, noroute_nw, stub_nw, weight_nw,
+                     doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room northwest of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room northwest of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_n_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        n->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        ;
-        stub_n->setChecked(false);
-        stub_n->setEnabled(false);
-        noroute_n->setEnabled(true);
-        weight_n->setEnabled(true);
-        doortype_none_n->setEnabled(true);
-        doortype_open_n->setEnabled(true);
-        doortype_closed_n->setEnabled(true);
-        doortype_locked_n->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            n->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        } else {
-            n->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        n->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        n->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room north of this one, will turn blue for a valid number.")));
-        stub_n->setEnabled(true);
-        noroute_n->setEnabled(false);
-        weight_n->setEnabled(false);
-        doortype_none_n->setEnabled(false);
-        doortype_open_n->setEnabled(false);
-        doortype_closed_n->setEnabled(false);
-        doortype_locked_n->setEnabled(false);
-    } else {
-        n->setStyleSheet(QString());
-        n->setToolTip(singleParagraph.arg(tr("Set the number of the room north of this one, will be blue for a valid number or red for invalid.")));
-        stub_n->setEnabled(true);
-        noroute_n->setEnabled(false);
-        weight_n->setEnabled(false);
-        doortype_none_n->setEnabled(false);
-        doortype_open_n->setEnabled(false);
-        doortype_closed_n->setEnabled(false);
-        doortype_locked_n->setEnabled(false);
-    }
+    normalExitEdited(text, n, noroute_n, stub_n, weight_n,
+                     doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room north of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room north of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_ne_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        ne->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_ne->setChecked(false);
-        stub_ne->setEnabled(false);
-        noroute_ne->setEnabled(true);
-        weight_ne->setEnabled(true);
-        doortype_none_ne->setEnabled(true);
-        doortype_open_ne->setEnabled(true);
-        doortype_closed_ne->setEnabled(true);
-        doortype_locked_ne->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            ne->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        } else {
-            ne->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        ne->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        ne->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room northeast of this one, will turn blue for a valid number.")));
-        stub_ne->setEnabled(true);
-        noroute_ne->setEnabled(false);
-        weight_ne->setEnabled(false);
-        doortype_none_ne->setEnabled(false);
-        doortype_open_ne->setEnabled(false);
-        doortype_closed_ne->setEnabled(false);
-        doortype_locked_ne->setEnabled(false);
-    } else {
-        ne->setStyleSheet(QString());
-        ne->setToolTip(singleParagraph.arg(tr("Set the number of the room northeast of this one, will be blue for a valid number or red for invalid.")));
-        stub_ne->setEnabled(true);
-        noroute_ne->setEnabled(false);
-        weight_ne->setEnabled(false);
-        doortype_none_ne->setEnabled(false);
-        doortype_open_ne->setEnabled(false);
-        doortype_closed_ne->setEnabled(false);
-        doortype_locked_ne->setEnabled(false);
-    }
+    normalExitEdited(text, ne, noroute_ne, stub_ne, weight_ne,
+                     doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room northeast of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room northeast of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_up_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        up->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_up->setChecked(false);
-        stub_up->setEnabled(false);
-        noroute_up->setEnabled(true);
-        weight_up->setEnabled(true);
-        doortype_none_up->setEnabled(true);
-        doortype_open_up->setEnabled(true);
-        doortype_closed_up->setEnabled(true);
-        doortype_locked_up->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            up->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        } else {
-            up->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        up->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        up->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room up from this one, will turn blue for a valid number.")));
-        stub_up->setEnabled(true);
-        noroute_up->setEnabled(false);
-        weight_up->setEnabled(false);
-        doortype_none_up->setEnabled(false);
-        doortype_open_up->setEnabled(false);
-        doortype_closed_up->setEnabled(false);
-        doortype_locked_up->setEnabled(false);
-    } else {
-        up->setStyleSheet(QString());
-        up->setToolTip(singleParagraph.arg(tr("Set the number of the room up from this one, will be blue for a valid number or red for invalid.")));
-        stub_up->setEnabled(true);
-        noroute_up->setEnabled(false);
-        weight_up->setEnabled(false);
-        doortype_none_up->setEnabled(false);
-        doortype_open_up->setEnabled(false);
-        doortype_closed_up->setEnabled(false);
-        doortype_locked_up->setEnabled(false);
-    }
+    normalExitEdited(text, up, noroute_up, stub_up, weight_up,
+                     doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room up from this one.")),
+                     singleParagraph.arg(tr("Set the number of the room up from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_w_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        w->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_w->setChecked(false);
-        stub_w->setEnabled(false);
-        noroute_w->setEnabled(true);
-        weight_w->setEnabled(true);
-        doortype_none_w->setEnabled(true);
-        doortype_open_w->setEnabled(true);
-        doortype_closed_w->setEnabled(true);
-        doortype_locked_w->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            w->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        } else {
-            w->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        w->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        w->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room west of this one, will turn blue for a valid number.")));
-        stub_w->setEnabled(true);
-        noroute_w->setEnabled(false);
-        weight_w->setEnabled(false);
-        doortype_none_w->setEnabled(false);
-        doortype_open_w->setEnabled(false);
-        doortype_closed_w->setEnabled(false);
-        doortype_locked_w->setEnabled(false);
-    } else {
-        w->setStyleSheet(QString());
-        w->setToolTip(singleParagraph.arg(tr("Set the number of the room west of this one, will be blue for a valid number or red for invalid.")));
-        stub_w->setEnabled(true);
-        noroute_w->setEnabled(false);
-        weight_w->setEnabled(false);
-        doortype_none_w->setEnabled(false);
-        doortype_open_w->setEnabled(false);
-        doortype_closed_w->setEnabled(false);
-        doortype_locked_w->setEnabled(false);
-    }
+    normalExitEdited(text, w, noroute_w, stub_w, weight_w,
+                     doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room west of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room west of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_e_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        e->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_e->setChecked(false);
-        stub_e->setEnabled(false);
-        noroute_e->setEnabled(true);
-        weight_e->setEnabled(true);
-        doortype_none_e->setEnabled(true);
-        doortype_open_e->setEnabled(true);
-        doortype_closed_e->setEnabled(true);
-        doortype_locked_e->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            e->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        } else {
-            e->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        e->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        e->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room east of this one, will turn blue for a valid number.")));
-        stub_e->setEnabled(true);
-        noroute_e->setEnabled(false);
-        weight_e->setEnabled(false);
-        doortype_none_e->setEnabled(false);
-        doortype_open_e->setEnabled(false);
-        doortype_closed_e->setEnabled(false);
-        doortype_locked_e->setEnabled(false);
-    } else {
-        e->setStyleSheet(QString());
-        e->setToolTip(singleParagraph.arg(tr("Set the number of the room east of this one, will be blue for a valid number or red for invalid.")));
-        stub_e->setEnabled(true);
-        noroute_e->setEnabled(false);
-        weight_e->setEnabled(false);
-        doortype_none_e->setEnabled(false);
-        doortype_open_e->setEnabled(false);
-        doortype_closed_e->setEnabled(false);
-        doortype_locked_e->setEnabled(false);
-    }
+    normalExitEdited(text, e, noroute_e, stub_e, weight_e,
+                     doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room east of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room east of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_down_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        down->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_down->setChecked(false);
-        stub_down->setEnabled(false);
-        noroute_down->setEnabled(true);
-        weight_down->setEnabled(true);
-        doortype_none_down->setEnabled(true);
-        doortype_open_down->setEnabled(true);
-        doortype_closed_down->setEnabled(true);
-        doortype_locked_down->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            down->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                                 tr("<b>Room</b> Weight of destination: %1.",
-                                                    "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                         .arg(exitToRoom->getWeight())));
-        } else {
-            down->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                                 tr("<b>Room</b> Weight of destination: %1.",
-                                                    "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                         .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        down->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        down->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room down from this one, will turn blue for a valid number.")));
-        stub_down->setEnabled(true);
-        noroute_down->setEnabled(false);
-        weight_down->setEnabled(false);
-        doortype_none_down->setEnabled(false);
-        doortype_open_down->setEnabled(false);
-        doortype_closed_down->setEnabled(false);
-        doortype_locked_down->setEnabled(false);
-    } else {
-        down->setStyleSheet(QString());
-        down->setToolTip(singleParagraph.arg(tr("Set the number of the room down from this one, will be blue for a valid number or red for invalid.")));
-        stub_down->setEnabled(true);
-        noroute_down->setEnabled(false);
-        weight_down->setEnabled(false);
-        doortype_none_down->setEnabled(false);
-        doortype_open_down->setEnabled(false);
-        doortype_closed_down->setEnabled(false);
-        doortype_locked_down->setEnabled(false);
-    }
+    normalExitEdited(text, down, noroute_down, stub_down, weight_down,
+                     doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room down from this one.")),
+                     singleParagraph.arg(tr("Set the number of the room down from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_sw_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        sw->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_sw->setChecked(false);
-        stub_sw->setEnabled(false);
-        noroute_sw->setEnabled(true);
-        weight_sw->setEnabled(true);
-        doortype_none_sw->setEnabled(true);
-        doortype_open_sw->setEnabled(true);
-        doortype_closed_sw->setEnabled(true);
-        doortype_locked_sw->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            sw->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        } else {
-            sw->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        sw->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        sw->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room southwest of this one, will turn blue for a valid number.")));
-        stub_sw->setEnabled(true);
-        noroute_sw->setEnabled(false);
-        weight_sw->setEnabled(false);
-        doortype_none_sw->setEnabled(false);
-        doortype_open_sw->setEnabled(false);
-        doortype_closed_sw->setEnabled(false);
-        doortype_locked_sw->setEnabled(false);
-    } else {
-        sw->setStyleSheet(QString());
-        sw->setToolTip(singleParagraph.arg(tr("Set the number of the room southwest of this one, will be blue for a valid number or red for invalid.")));
-        stub_sw->setEnabled(true);
-        noroute_sw->setEnabled(false);
-        weight_sw->setEnabled(false);
-        doortype_none_sw->setEnabled(false);
-        doortype_open_sw->setEnabled(false);
-        doortype_closed_sw->setEnabled(false);
-        doortype_locked_sw->setEnabled(false);
-    }
+    normalExitEdited(text, sw, noroute_sw, stub_sw, weight_sw,
+                     doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room southwest of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room southwest of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_s_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        s->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_s->setChecked(false);
-        stub_s->setEnabled(false);
-        noroute_s->setEnabled(true);
-        weight_s->setEnabled(true);
-        doortype_none_s->setEnabled(true);
-        doortype_open_s->setEnabled(true);
-        doortype_closed_s->setEnabled(true);
-        doortype_locked_s->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            s->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        } else {
-            s->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                              tr("<b>Room</b> Weight of destination: %1.",
-                                                 "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                      .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        s->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        s->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room south of this one, will turn blue for a valid number.")));
-        stub_s->setEnabled(true);
-        noroute_s->setEnabled(false);
-        weight_s->setEnabled(false);
-        doortype_none_s->setEnabled(false);
-        doortype_open_s->setEnabled(false);
-        doortype_closed_s->setEnabled(false);
-        doortype_locked_s->setEnabled(false);
-    } else {
-        s->setStyleSheet(QString());
-        s->setToolTip(singleParagraph.arg(tr("Set the number of the room south of this one, will be blue for a valid number or red for invalid.")));
-        stub_s->setEnabled(true);
-        noroute_s->setEnabled(false);
-        weight_s->setEnabled(false);
-        doortype_none_s->setEnabled(false);
-        doortype_open_s->setEnabled(false);
-        doortype_closed_s->setEnabled(false);
-        doortype_locked_s->setEnabled(false);
-    }
+    normalExitEdited(text, s, noroute_s, stub_s, weight_s,
+                     doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room south of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room south of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_se_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        se->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_se->setChecked(false);
-        stub_se->setEnabled(false);
-        noroute_se->setEnabled(true);
-        weight_se->setEnabled(true);
-        doortype_none_se->setEnabled(true);
-        doortype_open_se->setEnabled(true);
-        doortype_closed_se->setEnabled(true);
-        doortype_locked_se->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            se->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        } else {
-            se->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        se->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        se->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room southeast of this one, will turn blue for a valid number.")));
-        stub_se->setEnabled(true);
-        noroute_se->setEnabled(false);
-        weight_se->setEnabled(false);
-        doortype_none_se->setEnabled(false);
-        doortype_open_se->setEnabled(false);
-        doortype_closed_se->setEnabled(false);
-        doortype_locked_se->setEnabled(false);
-    } else {
-        se->setStyleSheet(QString());
-        se->setToolTip(singleParagraph.arg(tr("Set the number of the room southeast of this one, will be blue for a valid number or red for invalid.")));
-        stub_se->setEnabled(true);
-        noroute_se->setEnabled(false);
-        weight_se->setEnabled(false);
-        doortype_none_se->setEnabled(false);
-        doortype_open_se->setEnabled(false);
-        doortype_closed_se->setEnabled(false);
-        doortype_locked_se->setEnabled(false);
-    }
+    normalExitEdited(text, se, noroute_se, stub_se, weight_se,
+                     doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room southeast of this one.")),
+                     singleParagraph.arg(tr("Set the number of the room southeast of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_in_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        in->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_in->setChecked(false);
-        stub_in->setEnabled(false);
-        noroute_in->setEnabled(true);
-        weight_in->setEnabled(true);
-        doortype_none_in->setEnabled(true);
-        doortype_open_in->setEnabled(true);
-        doortype_closed_in->setEnabled(true);
-        doortype_locked_in->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            in->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        } else {
-            in->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                               tr("<b>Room</b> Weight of destination: %1.",
-                                                  "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                       .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        in->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        in->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room in from this one, will turn blue for a valid number.")));
-        stub_in->setEnabled(true);
-        noroute_in->setEnabled(false);
-        weight_in->setEnabled(false);
-        doortype_none_in->setEnabled(false);
-        doortype_open_in->setEnabled(false);
-        doortype_closed_in->setEnabled(false);
-        doortype_locked_in->setEnabled(false);
-    } else {
-        in->setStyleSheet(QString());
-        in->setToolTip(singleParagraph.arg(tr("Set the number of the room in from this one, will be blue for a valid number or red for invalid.")));
-        stub_in->setEnabled(true);
-        noroute_in->setEnabled(false);
-        weight_in->setEnabled(false);
-        doortype_none_in->setEnabled(false);
-        doortype_open_in->setEnabled(false);
-        doortype_closed_in->setEnabled(false);
-        doortype_locked_in->setEnabled(false);
-    }
+    normalExitEdited(text, in, noroute_in, stub_in, weight_in,
+                     doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room in from this one.")),
+                     singleParagraph.arg(tr("Set the number of the room in from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_out_textEdited(const QString& text)
 {
-    TRoom* exitToRoom = mpHost->mpMap->mpRoomDB->getRoom(text.toInt());
-
-    if (exitToRoom) {
-        out->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        stub_out->setChecked(false);
-        stub_out->setEnabled(false);
-        noroute_out->setEnabled(true);
-        weight_out->setEnabled(true);
-        doortype_none_out->setEnabled(true);
-        doortype_open_out->setEnabled(true);
-        doortype_closed_out->setEnabled(true);
-        doortype_locked_out->setEnabled(true);
-        if (exitToRoom->name.trimmed().length()) {
-            out->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(exitToRoom->name),
-                                                tr("<b>Room</b> Weight of destination: %1.",
-                                                   "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                        .arg(exitToRoom->getWeight())));
-        } else {
-            out->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                                tr("<b>Room</b> Weight of destination: %1.",
-                                                   "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                        .arg(exitToRoom->getWeight())));
-        }
-    } else if (text.size() > 0) {
-        out->setStyleSheet(QStringLiteral(".QLineEdit { color:red }"));
-        out->setToolTip(singleParagraph.arg(tr("Entered number is invalid, set the number of the room out from this one, will turn blue for a valid number.")));
-        stub_out->setEnabled(true);
-        noroute_out->setEnabled(false);
-        weight_out->setEnabled(false);
-        doortype_none_out->setEnabled(false);
-        doortype_open_out->setEnabled(false);
-        doortype_closed_out->setEnabled(false);
-        doortype_locked_out->setEnabled(false);
-    } else {
-        out->setStyleSheet(QString());
-        out->setToolTip(singleParagraph.arg(tr("Set the number of the room out from this one, will be blue for a valid number or red for invalid.")));
-        stub_out->setEnabled(true);
-        noroute_out->setEnabled(false);
-        weight_out->setEnabled(false);
-        doortype_none_out->setEnabled(false);
-        doortype_open_out->setEnabled(false);
-        doortype_closed_out->setEnabled(false);
-        doortype_locked_out->setEnabled(false);
-    }
+    normalExitEdited(text, out, noroute_out, stub_out, weight_out,
+                     doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out,
+                     singleParagraph.arg(tr("Entered number is invalid, set the number of the room out from this one.")),
+                     singleParagraph.arg(tr("Set the number of the room out from this one.")));
     slot_checkModified();
 }
 
 // These slots are called as the stub exit checkboxes are clicked
 void dlgRoomExits::slot_stub_nw_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(nw->text().toInt()) != nullptr) {
-            nw->setText(QString());
-            nw->setStyleSheet(QString());
-            weight_nw->setValue(0);        // Can't have a weight for a stub exit
-            noroute_nw->setChecked(false); // nor a "lock"
-        }
-        noroute_nw->setEnabled(false); // Disable "lock" on this exit
-        nw->setEnabled(false);         // Prevent entry of an exit roomID
-        nw->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_nw->setEnabled(true);
-        doortype_open_nw->setEnabled(true);
-        doortype_closed_nw->setEnabled(true);
-        doortype_locked_nw->setEnabled(true); // Permit a door to be set on a stub exit
-        weight_nw->setEnabled(false);         // Prevent a weight to be set/changed on a stub
-    } else {
-        nw->setEnabled(true);
-        nw->setToolTip(singleParagraph.arg(tr("Set the number of the room northwest of this one, will be blue for a valid number or red for invalid.")));
-        //  noroute_nw->setEnabled(true); although this branch will enable the exit entry
-        //  there will not be a valid one there yet so don't enable the noroute(lock) control here!
-        doortype_none_nw->setEnabled(false);
-        doortype_open_nw->setEnabled(false);
-        doortype_closed_nw->setEnabled(false);
-        doortype_locked_nw->setEnabled(false);
-        doortype_none_nw->setChecked(true);
-        //  similarly as there won't be a valid exit or a stub exit at theis point disable/reset the door type controls
-        weight_nw->setEnabled(false);
-        weight_nw->setValue(0); // Prevent a weight to be set/changed on a also
-    }
+    normalStubExitChanged(state, nw, noroute_nw, weight_nw,
+                          doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_n,
+                          singleParagraph.arg(tr("Set the number of the room northwest of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_n_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(n->text().toInt()) != nullptr) {
-            n->setText(QString());
-            n->setStyleSheet(QString());
-            weight_n->setValue(0);
-            noroute_n->setChecked(false);
-        }
-        noroute_n->setEnabled(false);
-        n->setEnabled(false);
-        n->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_n->setEnabled(true);
-        doortype_open_n->setEnabled(true);
-        doortype_closed_n->setEnabled(true);
-        doortype_locked_n->setEnabled(true);
-        weight_n->setEnabled(false);
-    } else {
-        n->setEnabled(true);
-        n->setToolTip(singleParagraph.arg(tr("Set the number of the room north of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_n->setEnabled(false);
-        doortype_open_n->setEnabled(false);
-        doortype_closed_n->setEnabled(false);
-        doortype_locked_n->setEnabled(false);
-        doortype_none_n->setChecked(true);
-        weight_n->setEnabled(false);
-        weight_n->setValue(0);
-    }
+    normalStubExitChanged(state, n, noroute_n, weight_n,
+                          doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n,
+                          singleParagraph.arg(tr("Set the number of the room north of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_ne_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(ne->text().toInt()) != nullptr) {
-            ne->setText(QString());
-            ne->setStyleSheet(QString());
-            weight_ne->setValue(0);
-            noroute_ne->setChecked(false);
-        }
-        noroute_ne->setEnabled(false);
-        ne->setEnabled(false);
-        ne->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_ne->setEnabled(true);
-        doortype_open_ne->setEnabled(true);
-        doortype_closed_ne->setEnabled(true);
-        doortype_locked_ne->setEnabled(true);
-        weight_ne->setEnabled(false);
-    } else {
-        ne->setEnabled(true);
-        ne->setToolTip(singleParagraph.arg(tr("Set the number of the room northeast of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_ne->setEnabled(false);
-        doortype_open_ne->setEnabled(false);
-        doortype_closed_ne->setEnabled(false);
-        doortype_locked_ne->setEnabled(false);
-        doortype_none_ne->setChecked(true);
-        weight_ne->setEnabled(false);
-        weight_ne->setValue(0);
-    }
+    normalStubExitChanged(state, ne, noroute_ne, weight_ne,
+                          doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne,
+                          singleParagraph.arg(tr("Set the number of the room northeast of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_up_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(up->text().toInt()) != nullptr) {
-            up->setText(QString());
-            up->setStyleSheet(QString());
-            weight_up->setValue(0);
-            noroute_up->setChecked(false);
-        }
-        noroute_up->setEnabled(false);
-        up->setEnabled(false);
-        up->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_up->setEnabled(true);
-        doortype_open_up->setEnabled(true);
-        doortype_closed_up->setEnabled(true);
-        doortype_locked_up->setEnabled(true);
-        weight_up->setEnabled(false);
-    } else {
-        up->setEnabled(true);
-        up->setToolTip(singleParagraph.arg(tr("Set the number of the room up from this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_up->setEnabled(false);
-        doortype_open_up->setEnabled(false);
-        doortype_closed_up->setEnabled(false);
-        doortype_locked_up->setEnabled(false);
-        doortype_none_up->setChecked(true);
-        weight_up->setEnabled(false);
-        weight_up->setValue(0);
-    }
+    normalStubExitChanged(state, up, noroute_up, weight_up,
+                          doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up,
+                          singleParagraph.arg(tr("Set the number of the room up from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_w_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(w->text().toInt()) != nullptr) {
-            w->setText(QString());
-            w->setStyleSheet(QString());
-            weight_w->setValue(0);
-            noroute_w->setChecked(false);
-        }
-        noroute_w->setEnabled(false);
-        w->setEnabled(false);
-        w->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_w->setEnabled(true);
-        doortype_open_w->setEnabled(true);
-        doortype_closed_w->setEnabled(true);
-        doortype_locked_w->setEnabled(true);
-        weight_w->setEnabled(false);
-    } else {
-        w->setEnabled(true);
-        w->setToolTip(singleParagraph.arg(tr("Set the number of the room west of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_w->setEnabled(false);
-        doortype_open_w->setEnabled(false);
-        doortype_closed_w->setEnabled(false);
-        doortype_locked_w->setEnabled(false);
-        doortype_none_w->setChecked(true);
-        weight_w->setEnabled(false);
-        weight_w->setValue(0);
-    }
+    normalStubExitChanged(state, w, noroute_w, weight_w,
+                          doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w,
+                          singleParagraph.arg(tr("Set the number of the room west of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_e_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(e->text().toInt()) != nullptr) {
-            e->setText(QString());
-            e->setStyleSheet(QString());
-            weight_e->setValue(0);
-            noroute_e->setChecked(false);
-        }
-        noroute_e->setEnabled(false);
-        e->setEnabled(false);
-        e->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_e->setEnabled(true);
-        doortype_open_e->setEnabled(true);
-        doortype_closed_e->setEnabled(true);
-        doortype_locked_e->setEnabled(true);
-        weight_e->setEnabled(false);
-    } else {
-        e->setEnabled(true);
-        e->setToolTip(singleParagraph.arg(tr("Set the number of the room east of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_e->setEnabled(false);
-        doortype_open_e->setEnabled(false);
-        doortype_closed_e->setEnabled(false);
-        doortype_locked_e->setEnabled(false);
-        doortype_none_e->setChecked(true);
-        weight_e->setEnabled(false);
-        weight_e->setValue(0);
-    }
+    normalStubExitChanged(state, e, noroute_e, weight_e,
+                          doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e,
+                          singleParagraph.arg(tr("Set the number of the room east of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_down_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(down->text().toInt()) != nullptr) {
-            down->setText(QString());
-            down->setStyleSheet(QString());
-            weight_down->setValue(0);
-            noroute_down->setChecked(false);
-        }
-        noroute_down->setEnabled(false);
-        down->setEnabled(false);
-        down->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_down->setEnabled(true);
-        doortype_open_down->setEnabled(true);
-        doortype_closed_down->setEnabled(true);
-        doortype_locked_down->setEnabled(true);
-        weight_down->setEnabled(false);
-    } else {
-        down->setEnabled(true);
-        down->setToolTip(singleParagraph.arg(tr("Set the number of the room down from this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_down->setEnabled(false);
-        doortype_open_down->setEnabled(false);
-        doortype_closed_down->setEnabled(false);
-        doortype_locked_down->setEnabled(false);
-        doortype_none_down->setChecked(true);
-        weight_down->setEnabled(false);
-        weight_down->setValue(0);
-    }
+    normalStubExitChanged(state, down, noroute_down, weight_down,
+                          doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down,
+                          singleParagraph.arg(tr("Set the number of the room down from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_sw_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(sw->text().toInt()) != nullptr) {
-            sw->setText(QString());
-            sw->setStyleSheet(QString());
-            weight_sw->setValue(0);
-            noroute_sw->setChecked(false);
-        }
-        noroute_sw->setEnabled(false);
-        sw->setEnabled(false);
-        sw->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_sw->setEnabled(true);
-        doortype_open_sw->setEnabled(true);
-        doortype_closed_sw->setEnabled(true);
-        doortype_locked_sw->setEnabled(true);
-        weight_sw->setEnabled(false);
-    } else {
-        sw->setEnabled(true);
-        sw->setToolTip(singleParagraph.arg(tr("Set the number of the room southwest of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_sw->setEnabled(false);
-        doortype_open_sw->setEnabled(false);
-        doortype_closed_sw->setEnabled(false);
-        doortype_locked_sw->setEnabled(false);
-        doortype_none_sw->setChecked(true);
-        weight_sw->setEnabled(false);
-        weight_sw->setValue(0);
-    }
+    normalStubExitChanged(state, sw, noroute_sw, weight_sw,
+                          doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw,
+                          singleParagraph.arg(tr("Set the number of the room southwest of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_s_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(s->text().toInt()) != nullptr) {
-            s->setText(QString());
-            s->setStyleSheet(QString());
-            weight_s->setValue(0);
-            noroute_s->setChecked(false);
-        }
-        noroute_s->setEnabled(false);
-        s->setEnabled(false);
-        s->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_s->setEnabled(true);
-        doortype_open_s->setEnabled(true);
-        doortype_closed_s->setEnabled(true);
-        doortype_locked_s->setEnabled(true);
-        weight_s->setEnabled(false);
-    } else {
-        s->setEnabled(true);
-        s->setToolTip(singleParagraph.arg(tr("Set the number of the room south of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_s->setEnabled(false);
-        doortype_open_s->setEnabled(false);
-        doortype_closed_s->setEnabled(false);
-        doortype_locked_s->setEnabled(false);
-        doortype_none_s->setChecked(true);
-        weight_s->setEnabled(false);
-        weight_s->setValue(0);
-    }
+    normalStubExitChanged(state, s, noroute_s, weight_s,
+                          doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s,
+                          singleParagraph.arg(tr("Set the number of the room south of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_se_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(se->text().toInt()) != nullptr) {
-            se->setText(QString());
-            se->setStyleSheet(QString());
-            weight_se->setValue(0);
-            noroute_se->setChecked(false);
-        }
-        noroute_se->setEnabled(false);
-        se->setEnabled(false);
-        se->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_se->setEnabled(true);
-        doortype_open_se->setEnabled(true);
-        doortype_closed_se->setEnabled(true);
-        doortype_locked_se->setEnabled(true);
-        weight_se->setEnabled(false);
-    } else {
-        se->setEnabled(true);
-        se->setToolTip(singleParagraph.arg(tr("Set the number of the room southeast of this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_se->setEnabled(false);
-        doortype_open_se->setEnabled(false);
-        doortype_closed_se->setEnabled(false);
-        doortype_locked_se->setEnabled(false);
-        doortype_none_se->setChecked(true);
-        weight_se->setEnabled(false);
-        weight_se->setValue(0);
-    }
+    normalStubExitChanged(state, se, noroute_se, weight_se,
+                          doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se,
+                          singleParagraph.arg(tr("Set the number of the room southeast of this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_in_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(in->text().toInt()) != nullptr) {
-            in->setText(QString());
-            in->setStyleSheet(QString());
-            weight_in->setValue(0);
-            noroute_in->setChecked(false);
-        }
-        noroute_in->setEnabled(false);
-        in->setEnabled(false);
-        in->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_in->setEnabled(true);
-        doortype_open_in->setEnabled(true);
-        doortype_closed_in->setEnabled(true);
-        doortype_locked_in->setEnabled(true);
-        weight_in->setEnabled(false);
-    } else {
-        in->setEnabled(true);
-        in->setToolTip(singleParagraph.arg(tr("Set the number of the room in from this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_in->setEnabled(false);
-        doortype_open_in->setEnabled(false);
-        doortype_closed_in->setEnabled(false);
-        doortype_locked_in->setEnabled(false);
-        doortype_none_in->setChecked(true);
-        weight_in->setEnabled(false);
-        weight_in->setValue(0);
-    }
+    normalStubExitChanged(state, in, noroute_in, weight_in,
+                          doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in,
+                          singleParagraph.arg(tr("Set the number of the room in from this one.")));
     slot_checkModified();
 }
 
 void dlgRoomExits::slot_stub_out_stateChanged(int state)
 {
-    if (state == Qt::Checked) {
-        if (mpHost->mpMap->mpRoomDB->getRoom(out->text().toInt()) != nullptr) {
-            out->setText(QString());
-            out->setStyleSheet(QString());
-            weight_out->setValue(0);
-            noroute_out->setChecked(false);
-        }
-        noroute_out->setEnabled(false);
-        out->setEnabled(false);
-        out->setToolTip(singleParagraph.arg(tr("Clear the stub exit for this exit to enter an exit roomID.")));
-        doortype_none_out->setEnabled(true);
-        doortype_open_out->setEnabled(true);
-        doortype_closed_out->setEnabled(true);
-        doortype_locked_out->setEnabled(true);
-        weight_out->setEnabled(false);
-    } else {
-        out->setEnabled(true);
-        out->setToolTip(singleParagraph.arg(tr("Set the number of the room out from this one, will be blue for a valid number or red for invalid.")));
-        doortype_none_out->setEnabled(false);
-        doortype_open_out->setEnabled(false);
-        doortype_closed_out->setEnabled(false);
-        doortype_locked_out->setEnabled(false);
-        doortype_none_out->setChecked(true);
-        weight_out->setEnabled(false);
-        weight_out->setValue(0);
-    }
+    normalStubExitChanged(state, out, noroute_out, weight_out,
+                          doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out,
+                          singleParagraph.arg(tr("Set the number of the room out from this one.")));
     slot_checkModified();
 }
 
-void dlgRoomExits::initExit(int roomId,
-                            int direction,
+void dlgRoomExits::initExit(int direction,
                             int exitId,
                             QLineEdit* exitLineEdit,
                             QCheckBox* noRoute,
@@ -1731,10 +1385,10 @@ void dlgRoomExits::initExit(int roomId,
         locked->setChecked(true);
         break;
     default:
-        qWarning() << "dlgRoomExits::initExit(...) in room id(" << roomId << ") unexpected doors[" << doorAndWeightText << "] value:" << pR->getDoor(doorAndWeightText) << "found for room!";
+        qWarning() << "dlgRoomExits::initExit(...) in room id(" << mRoomID << ") unexpected doors[" << doorAndWeightText << "] value:" << pR->getDoor(doorAndWeightText) << "found for room!";
     }
 
-    TRoom* pExitR;
+    TRoom* pExitR = nullptr;
     if (exitId > 0) {
         pExitR = mpHost->mpMap->mpRoomDB->getRoom(exitId);
         if (!pExitR) {
@@ -1747,18 +1401,14 @@ void dlgRoomExits::initExit(int roomId,
     if (exitId > 0 && pExitR) {                         //Does this exit point anywhere
         exitLineEdit->setText(QString::number(exitId)); //Put in the value
         exitLineEdit->setEnabled(true);                 //Enable it for editing
-        exitLineEdit->setStyleSheet(QStringLiteral(".QLineEdit { color:blue }"));
-        if (pExitR->name.trimmed().length()) {
-            exitLineEdit->setToolTip(doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(pExitR->name),
-                                                         tr("<b>Room</b> Weight of destination: %1.",
-                                                            "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                                 .arg(pExitR->getWeight())));
-        } else {
-            exitLineEdit->setToolTip(doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                                         tr("<b>Room</b> Weight of destination: %1.",
-                                                            "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                                 .arg(pExitR->getWeight())));
+        int exitAreaID = pExitR->getArea();
+        bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        QString exitAreaName;
+        if (outOfAreaExit) {
+            exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
         }
+        setActionOnExit(exitLineEdit, outOfAreaExit ? mpAction_otherAreaExit : mpAction_inAreaExit);
+        exitLineEdit->setToolTip(generateToolTip(pExitR->name, exitAreaName, outOfAreaExit, pExitR->getWeight()));
         noRoute->setEnabled(true); //Enable speedwalk lock control
         none->setEnabled(true);    //Enable door type controls...
         open->setEnabled(true);
@@ -1770,7 +1420,7 @@ void dlgRoomExits::initExit(int roomId,
         noRoute->setChecked(pR->hasExitLock(direction)); //Set/reset "locK" control as appropriate
     } else {                                             //No exit is set on initialisation
         exitLineEdit->setText(QString());                //Nothing to put in exitID box
-        exitLineEdit->setStyleSheet(QString());
+        setActionOnExit(exitLineEdit, mpAction_noExit);
         noRoute->setEnabled(false); //Disable lock control, can't lock a non-existant exit..
         noRoute->setChecked(false); //.. and ensure there isn't one
         weight->setEnabled(false);  //Disable exit weight control...
@@ -1786,7 +1436,7 @@ void dlgRoomExits::initExit(int roomId,
             locked->setEnabled(true);
         } else {
             exitLineEdit->setEnabled(true);
-            exitLineEdit->setToolTip(singleParagraph.arg(tr("Set the number of the room %1 of this one, will be blue for a valid number or red for invalid.").arg(exitText)));
+            exitLineEdit->setToolTip(singleParagraph.arg(tr("Set the number of the room %1 of this one.").arg(exitText)));
             stub->setChecked(false);
             none->setEnabled(false); //Disable door type controls, can't lock a non-existant exit..
             open->setEnabled(false); //.. and ensure the "none" one is set if it ever gets enabled
@@ -1798,20 +1448,21 @@ void dlgRoomExits::initExit(int roomId,
     originalExits[direction] = makeExitFromControls(direction);
 }
 
-void dlgRoomExits::init(int id)
+void dlgRoomExits::init()
 {
-    pR = mpHost->mpMap->mpRoomDB->getRoom(id);
+    pR = mpHost->mpMap->mpRoomDB->getRoom(mRoomID);
     if (!pR) {
         return;
     }
 
-    roomID->setText(QString::number(id));
+    mAreaID = pR->getArea();
+    roomID->setText(QString::number(mRoomID));
     roomWeight->setText(QString::number(pR->getWeight()));
     QString titleText;
     if (pR->name.trimmed().length()) {
         titleText = tr(R"(Exits for room: "%1" [*])").arg(pR->name);
     } else {
-        titleText = tr("Exits for room Id: %1 [*]").arg(id);
+        titleText = tr("Exits for room Id: %1 [*]").arg(mRoomID);
     }
 
     this->setWindowTitle(titleText);
@@ -1819,29 +1470,29 @@ void dlgRoomExits::init(int id)
     // Because we are manipulating the settings for the exit we need to know
     // explicitly where the weight comes from, pR->getExitWeight() hides that
     // detail deliberately for normal usage
-    initExit(id, DIR_NORTHWEST, pR->getExit(DIR_NORTHWEST), nw, noroute_nw, stub_nw, doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw, weight_nw);
+    initExit(DIR_NORTHWEST, pR->getExit(DIR_NORTHWEST), nw, noroute_nw, stub_nw, doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw, weight_nw);
 
-    initExit(id, DIR_NORTH, pR->getExit(DIR_NORTH), n, noroute_n, stub_n, doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n, weight_n);
+    initExit(DIR_NORTH, pR->getExit(DIR_NORTH), n, noroute_n, stub_n, doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n, weight_n);
 
-    initExit(id, DIR_NORTHEAST, pR->getExit(DIR_NORTHEAST), ne, noroute_ne, stub_ne, doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne, weight_ne);
+    initExit(DIR_NORTHEAST, pR->getExit(DIR_NORTHEAST), ne, noroute_ne, stub_ne, doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne, weight_ne);
 
-    initExit(id, DIR_UP, pR->getExit(DIR_UP), up, noroute_up, stub_up, doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up, weight_up);
+    initExit(DIR_UP, pR->getExit(DIR_UP), up, noroute_up, stub_up, doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up, weight_up);
 
-    initExit(id, DIR_WEST, pR->getExit(DIR_WEST), w, noroute_w, stub_w, doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w, weight_w);
+    initExit(DIR_WEST, pR->getExit(DIR_WEST), w, noroute_w, stub_w, doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w, weight_w);
 
-    initExit(id, DIR_EAST, pR->getExit(DIR_EAST), e, noroute_e, stub_e, doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e, weight_e);
+    initExit(DIR_EAST, pR->getExit(DIR_EAST), e, noroute_e, stub_e, doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e, weight_e);
 
-    initExit(id, DIR_DOWN, pR->getExit(DIR_DOWN), down, noroute_down, stub_down, doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down, weight_down);
+    initExit(DIR_DOWN, pR->getExit(DIR_DOWN), down, noroute_down, stub_down, doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down, weight_down);
 
-    initExit(id, DIR_SOUTHWEST, pR->getExit(DIR_SOUTHWEST), sw, noroute_sw, stub_sw, doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw, weight_sw);
+    initExit(DIR_SOUTHWEST, pR->getExit(DIR_SOUTHWEST), sw, noroute_sw, stub_sw, doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw, weight_sw);
 
-    initExit(id, DIR_SOUTH, pR->getExit(DIR_SOUTH), s, noroute_s, stub_s, doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s, weight_s);
+    initExit(DIR_SOUTH, pR->getExit(DIR_SOUTH), s, noroute_s, stub_s, doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s, weight_s);
 
-    initExit(id, DIR_SOUTHEAST, pR->getExit(DIR_SOUTHEAST), se, noroute_se, stub_se, doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se, weight_se);
+    initExit(DIR_SOUTHEAST, pR->getExit(DIR_SOUTHEAST), se, noroute_se, stub_se, doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se, weight_se);
 
-    initExit(id, DIR_IN, pR->getExit(DIR_IN), in, noroute_in, stub_in, doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in, weight_in);
+    initExit(DIR_IN, pR->getExit(DIR_IN), in, noroute_in, stub_in, doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in, weight_in);
 
-    initExit(id, DIR_OUT, pR->getExit(DIR_OUT), out, noroute_out, stub_out, doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out, weight_out);
+    initExit(DIR_OUT, pR->getExit(DIR_OUT), out, noroute_out, stub_out, doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out, weight_out);
 
     QMapIterator<QString, int> it(pR->getSpecialExits());
     while (it.hasNext()) {
@@ -1852,98 +1503,76 @@ void dlgRoomExits::init(int id)
         // It should be impossible for this not to be valid:
         Q_ASSERT_X(pSpecialExit, "dlgRoomExits::init(...)", "failed to generate a new TExit");
         auto pI = new QTreeWidgetItem(specialExits);
-        TRoom* pExitToRoom = mpHost->mpMap->mpRoomDB->getRoom(id_to);
-        //0 exit roomID
-        pI->setText(0, QString::number(id_to));
-        pI->setTextAlignment(0, Qt::AlignRight);
-        if (pExitToRoom) {
-            pI->setForeground(0, QColor(Qt::blue));
-            if (!pExitToRoom->name.isEmpty()) {
-                pI->setToolTip(0, doubleParagraph.arg(tr(R"(Exit to "%1".)").arg(pExitToRoom->name),
-                                                      tr("<b>Room</b> Weight of destination: %1.",
-                                                         "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                              .arg(pExitToRoom->getWeight())));
-            } else {
-                pI->setToolTip(0, doubleParagraph.arg(tr("Exit to unnamed room is valid"),
-                                                      tr("<b>Room</b> Weight of destination: %1.",
-                                                         "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
-                                                              .arg(pExitToRoom->getWeight())));
-            }
-        } else {
-            pI->setForeground(0, QColor(Qt::red));
-            pI->setToolTip(0, singleParagraph.arg(tr("Room Id is invalid, set the number of the room that this special exit leads to, will turn blue for a valid number.")));
-        }
+
+        // exit status
+        pI->setTextAlignment(colIndex_exitStatus, Qt::AlignRight);
+        pI->setIcon(colIndex_exitStatus, QIcon());
+
+        // exit roomID
+        pI->setText(colIndex_exitRoomId, QString::number(id_to));
+        pI->setTextAlignment(colIndex_exitRoomId, Qt::AlignRight);
+
         pSpecialExit->destination = id_to;
-        //1 locked (or more properly "No route") - setCheckedState
-        //automagically makes it a CheckBox!!!
+        // locked (or more properly "No route") - setCheckedState
+        // automagically makes it a CheckBox!!!
         if (pR->hasSpecialExitLock(dir)) {
-            pI->setCheckState(1, Qt::Checked);
+            pI->setCheckState(colIndex_lockExit, Qt::Checked);
             pSpecialExit->hasNoRoute = true;
         } else {
-            pI->setCheckState(1, Qt::Unchecked);
+            pI->setCheckState(colIndex_lockExit, Qt::Unchecked);
             pSpecialExit->hasNoRoute = false;
         }
-        pI->setToolTip(1, singleParagraph.arg(tr("Prevent a route being created via this exit, equivalent to an infinite exit weight.")));
+        pI->setToolTip(colIndex_lockExit, singleParagraph.arg(tr("Prevent a route being created via this exit, equivalent to an infinite exit weight.")));
 
-        //2 exit weight - ideally want a spin box - but use a text edit for now
-        if (pR->hasExitWeight(dir)) {
-            pI->setText(2, QString::number(pR->getExitWeight(dir)));
-        } else {
-            pI->setText(2, QString::number(0));
-        }
-        pI->setTextAlignment(2, Qt::AlignRight);
-        pI->setToolTip(2, singleParagraph.arg(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
-        pSpecialExit->weight = pI->text(2).toInt();
+        pI->setData(colIndex_exitWeight, Qt::EditRole, pR->hasExitWeight(dir) ? pR->getExitWeight(dir) : 0);
+        // pI->setTextAlignment(colIndex_exitWeight, Qt::AlignRight);
+        pI->setToolTip(colIndex_exitWeight, singleParagraph.arg(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
+        pSpecialExit->weight = pI->data(colIndex_exitWeight, Qt::EditRole).toInt();
 
-
-        //3-6 hold a buttongroup of 4, ideally QRadioButtons, to select a door type
-        pI->setCheckState(3, Qt::Unchecked);
-        pI->setTextAlignment(3, Qt::AlignCenter);
-        pI->setToolTip(3, singleParagraph.arg(tr("No door symbol is drawn on 2D Map for this exit (only functional choice currently).")));
-        pI->setCheckState(4, Qt::Unchecked);
-        pI->setTextAlignment(4, Qt::AlignCenter);
-        pI->setToolTip(
-                4, singleParagraph.arg(tr("Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-        pI->setCheckState(5, Qt::Unchecked);
-        pI->setTextAlignment(5, Qt::AlignCenter);
-        pI->setToolTip(
-                5,
-                singleParagraph.arg(tr("Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-        pI->setTextAlignment(6, Qt::AlignCenter);
-        pI->setToolTip(
-                6, singleParagraph.arg(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
-        pI->setCheckState(6, Qt::Unchecked);
+        // a buttongroup of 4, ideally QRadioButtons, to select a door type
+        pI->setCheckState(colIndex_doorNone, Qt::Unchecked);
+        pI->setTextAlignment(colIndex_doorNone, Qt::AlignCenter);
+        pI->setToolTip(colIndex_doorNone, singleParagraph.arg(tr("No door symbol is drawn on 2D Map for this exit (only functional choice currently).")));
+        pI->setCheckState(colIndex_doorOpen, Qt::Unchecked);
+        pI->setTextAlignment(colIndex_doorOpen, Qt::AlignCenter);
+        pI->setToolTip(colIndex_doorOpen, singleParagraph.arg(tr("Green (Open) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
+        pI->setCheckState(colIndex_doorClosed, Qt::Unchecked);
+        pI->setTextAlignment(colIndex_doorClosed, Qt::AlignCenter);
+        pI->setToolTip(colIndex_doorClosed, singleParagraph.arg(tr("Orange (Closed) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
+        pI->setTextAlignment(colIndex_doorLocked, Qt::AlignCenter);
+        pI->setToolTip(colIndex_doorLocked, singleParagraph.arg(tr("Red (Locked) door symbol would be drawn on a custom exit line for this exit on 2D Map (but not currently).")));
+        pI->setCheckState(colIndex_doorLocked, Qt::Unchecked);
         {
             int specialDoor = pR->getDoor(dir);
             switch (specialDoor) {
             case 0:
-                pI->setCheckState(3, Qt::Checked);
+                pI->setCheckState(colIndex_doorNone, Qt::Checked);
                 break;
             case 1:
-                pI->setCheckState(4, Qt::Checked);
+                pI->setCheckState(colIndex_doorOpen, Qt::Checked);
                 break;
             case 2:
-                pI->setCheckState(5, Qt::Checked);
+                pI->setCheckState(colIndex_doorClosed, Qt::Checked);
                 break;
             case 3:
-                pI->setCheckState(6, Qt::Checked);
+                pI->setCheckState(colIndex_doorLocked, Qt::Checked);
                 break;
             default:
-                qWarning().nospace().noquote() << "dlgRoomExits::init(" << id << ") WARNING - unexpected (special exit) doors[" << dir << "] value:" << pR->doors[dir] << " found!";
+                qWarning().nospace().noquote() << "dlgRoomExits::init(" << mRoomID << ") WARNING - unexpected (special exit) doors[" << dir << "] value:" << pR->doors[dir] << " found!";
             }
             pSpecialExit->door = specialDoor;
             originalSpecialExits[dir] = pSpecialExit;
         }
 
-        //7 holds the script/name
-        pI->setText(7, dir);
+        // the script/name
+        pI->setText(colIndex_command, dir);
         // Not relevant for special exits but better initialise it
         pSpecialExit->hasStub = false;
 
-
+        setIconAndToolTipsOnSpecialExit(pI, true);
     }
-    mRoomID = id;
-    button_save->setEnabled( false );
+
+    button_save->setEnabled(false);
 // We now do not connect up all these things until AFTER we have initialised
 // things as some controls will issue unwanted signals upon setting values into
 // them as we have above...
@@ -1954,6 +1583,7 @@ void dlgRoomExits::init(int id)
     connect(button_addSpecialExit, &QAbstractButton::clicked,                      this, &dlgRoomExits::slot_addSpecialExit);
     connect(specialExits,          &QTreeWidget::itemClicked,                      this, &dlgRoomExits::slot_editSpecialExit);
     connect(specialExits,          &QTreeWidget::itemClicked,                      this, &dlgRoomExits::slot_checkModified);
+    connect(specialExits,          &QTreeWidget::itemChanged,                      this, &dlgRoomExits::slot_itemChanged);
     connect(button_endEditing,     &QAbstractButton::clicked,                      this, &dlgRoomExits::slot_endEditSpecialExits);
     connect(button_endEditing,     &QAbstractButton::clicked,                      this, &dlgRoomExits::slot_checkModified);
     connect(nw,                    &QLineEdit::textEdited,                         this, &dlgRoomExits::slot_nw_textEdited);
@@ -2143,111 +1773,111 @@ void dlgRoomExits::slot_checkModified()
     // exit doors
     // exit weights
 
-    TExit* originalExit = originalExits.value(DIR_NORTHWEST);
-    TExit* currentExit = makeExitFromControls(DIR_NORTHWEST);
+    TExit* pOriginalExit = originalExits.value(DIR_NORTHWEST);
+    TExit* pCurrentExit = makeExitFromControls(DIR_NORTHWEST);
 
-    if (originalExit && currentExit && *originalExit != *currentExit) {
+    if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
         isModified = true;
     }
-    delete currentExit;
+    delete pCurrentExit;
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_NORTH);
-        currentExit = makeExitFromControls(DIR_NORTH);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_NORTH);
+        pCurrentExit = makeExitFromControls(DIR_NORTH);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_NORTHEAST);
-        currentExit = makeExitFromControls(DIR_NORTHEAST);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_NORTHEAST);
+        pCurrentExit = makeExitFromControls(DIR_NORTHEAST);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_UP);
-        currentExit = makeExitFromControls(DIR_UP);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_UP);
+        pCurrentExit = makeExitFromControls(DIR_UP);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_WEST);
-        currentExit = makeExitFromControls(DIR_WEST);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_WEST);
+        pCurrentExit = makeExitFromControls(DIR_WEST);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_EAST);
-        currentExit = makeExitFromControls(DIR_EAST);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_EAST);
+        pCurrentExit = makeExitFromControls(DIR_EAST);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_DOWN);
-        currentExit = makeExitFromControls(DIR_DOWN);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_DOWN);
+        pCurrentExit = makeExitFromControls(DIR_DOWN);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_SOUTHWEST);
-        currentExit = makeExitFromControls(DIR_SOUTHWEST);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_SOUTHWEST);
+        pCurrentExit = makeExitFromControls(DIR_SOUTHWEST);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_SOUTH);
-        currentExit = makeExitFromControls(DIR_SOUTH);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_SOUTH);
+        pCurrentExit = makeExitFromControls(DIR_SOUTH);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_SOUTHEAST);
-        currentExit = makeExitFromControls(DIR_SOUTHEAST);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_SOUTHEAST);
+        pCurrentExit = makeExitFromControls(DIR_SOUTHEAST);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_IN);
-        currentExit = makeExitFromControls(DIR_IN);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_IN);
+        pCurrentExit = makeExitFromControls(DIR_IN);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     if (!isModified) {
-        originalExit = originalExits.value(DIR_OUT);
-        currentExit = makeExitFromControls(DIR_OUT);
-        if (originalExit && currentExit && *originalExit != *currentExit) {
+        pOriginalExit = originalExits.value(DIR_OUT);
+        pCurrentExit = makeExitFromControls(DIR_OUT);
+        if (pOriginalExit && pCurrentExit && *pOriginalExit != *pCurrentExit) {
             isModified = true;
         }
-        delete currentExit;
+        delete pCurrentExit;
     }
 
     // Detecting actual changes in the special exits is hard because of the
@@ -2261,13 +1891,12 @@ void dlgRoomExits::slot_checkModified()
         for (int i = 0; i < specialExits->topLevelItemCount(); i++) {
             QTreeWidgetItem* pI = specialExits->topLevelItem(i);
             /*            qDebug("dlgRoomExits::slot_checkModified() considering specialExit (item %i, pass 1) to:%i, command:%s",
- *                   i,
- *                   pI->text(0).toInt(),
- *                   qPrintable(pI->text(7)));
- */
-            if (pI->text(7)
-                        == tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is also used programmatically - ensure all five instances are the same")
-                || pI->text(0).toInt() <= 0) {
+             *                   i,
+             *                   pI->text(colIndex_exitRoomId).toInt(),
+             *                   qPrintable(pI->text(colIndex_command)));
+             */
+            if (pI->text(colIndex_command) == mSpecialExitCommandPlaceholder
+                || pI->text(colIndex_exitRoomId).toInt() <= 0) {
                 continue;
             } // Ignore new or to be deleted entries
             currentCount++;
@@ -2284,20 +1913,22 @@ void dlgRoomExits::slot_checkModified()
                 for (int i = 0; i < specialExits->topLevelItemCount(); i++) {
                     QTreeWidgetItem* pI = specialExits->topLevelItem(i);
                     /*                    qDebug("dlgRoomExits::slot_checkModified() considering specialExit (item %i, pass 2) to:%i, command:%s",
- *                           i,
- *                           pI->text(0).toInt(),
- *                           qPrintable(pI->text(7)));
- */
-                    if (pI->text(7) == tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is also used programmatically - ensure all five instances are the same")
-                        || pI->text(0).toInt() <= 0) {
+                     *                           i,
+                     *                           pI->text(colIndex_exitRoomId).toInt(),
+                     *                           qPrintable(pI->text(colIndex_command)));
+                     */
+                    if (pI->text(colIndex_command) == mSpecialExitCommandPlaceholder
+                        || pI->text(colIndex_exitRoomId).toInt() <= 0) {
                         continue; // Ignore new or to be deleted entries
                     }
-                    QString currentCmd = pI->text(7);
+                    QString currentCmd = pI->text(colIndex_command);
                     TExit currentExit;
-                    currentExit.destination = pI->text(0).toInt();
-                    currentExit.hasNoRoute = pI->checkState(1) == Qt::Checked;
-                    currentExit.door = pI->checkState(6) == Qt::Checked ? 3 : pI->checkState(5) == Qt::Checked ? 2 : pI->checkState(4) == Qt::Checked ? 1 : 0;
-                    currentExit.weight = pI->text(2).toInt();
+                    currentExit.destination = pI->text(colIndex_exitRoomId).toInt();
+                    currentExit.hasNoRoute = pI->checkState(colIndex_lockExit) == Qt::Checked;
+                    currentExit.door = pI->checkState(colIndex_doorLocked) == Qt::Checked
+                                               ? 3 : pI->checkState(colIndex_doorClosed) == Qt::Checked
+                                                         ? 2 : pI->checkState(colIndex_doorOpen) == Qt::Checked ? 1 : 0;
+                    currentExit.weight = pI->data(colIndex_exitWeight, Qt::EditRole).toInt();
                     currentExit.hasStub = false;
                     auto exit = foundMap.value(currentCmd);
                     if (exit
@@ -2328,5 +1959,18 @@ void dlgRoomExits::slot_checkModified()
         // do not have a fix version - yet!
         button_save->repaint();
 #endif
+    }
+}
+
+// By changed this means "the currently selected row or column number in the
+// special exits has changed":
+void dlgRoomExits::slot_itemChanged(QTreeWidgetItem* pI, int column)
+{
+    if (column != colIndex_exitRoomId && column != colIndex_command) {
+        return;
+    }
+
+    if (column == colIndex_command) {
+        setIconAndToolTipsOnSpecialExit(pI, true);
     }
 }

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1099,7 +1099,7 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
 }
 
 void dlgRoomExits::normalStubExitChanged(const int state, QLineEdit* pExit, QCheckBox* pNoRoute, QSpinBox* pWeight,
-                                         QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked, const QString& noExitToolTipText)
+                                         QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked, const QString& noExitToolTipText) const
 {
     if (state == Qt::Checked) {
         if (!pExit->text().isEmpty()) {

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1350,23 +1350,23 @@ void dlgRoomExits::initExit(int direction,
                             QRadioButton* open,
                             QRadioButton* closed,
                             QRadioButton* locked,
-                            QSpinBox* weight)
+                            QSpinBox* weight,
+                            const QString& validExitToolTip)
 {
     QString doorAndWeightText; // lowercase, initials for XY-plane, words for others
-    QString exitText;          // lowercase, full words, no space
     switch (direction) {
-        case DIR_NORTHWEST: doorAndWeightText = QStringLiteral("nw");   exitText = tr("northwest"); break;
-        case DIR_NORTH    : doorAndWeightText = QStringLiteral("n");    exitText = tr("north");     break;
-        case DIR_NORTHEAST: doorAndWeightText = QStringLiteral("ne");   exitText = tr("northeast"); break;
-        case DIR_UP       : doorAndWeightText = QStringLiteral("up");   exitText = tr("up");        break;
-        case DIR_WEST     : doorAndWeightText = QStringLiteral("w");    exitText = tr("west");      break;
-        case DIR_EAST     : doorAndWeightText = QStringLiteral("e");    exitText = tr("east");      break;
-        case DIR_DOWN     : doorAndWeightText = QStringLiteral("down"); exitText = tr("down");      break;
-        case DIR_SOUTHWEST: doorAndWeightText = QStringLiteral("sw");   exitText = tr("southwest"); break;
-        case DIR_SOUTH    : doorAndWeightText = QStringLiteral("s");    exitText = tr("south");     break;
-        case DIR_SOUTHEAST: doorAndWeightText = QStringLiteral("se");   exitText = tr("southeast"); break;
-        case DIR_IN       : doorAndWeightText = QStringLiteral("in");   exitText = tr("in");        break;
-        case DIR_OUT      : doorAndWeightText = QStringLiteral("out");  exitText = tr("out");       break;
+        case DIR_NORTHWEST: doorAndWeightText = QStringLiteral("nw");   break;
+        case DIR_NORTH    : doorAndWeightText = QStringLiteral("n");    break;
+        case DIR_NORTHEAST: doorAndWeightText = QStringLiteral("ne");   break;
+        case DIR_UP       : doorAndWeightText = QStringLiteral("up");   break;
+        case DIR_WEST     : doorAndWeightText = QStringLiteral("w");    break;
+        case DIR_EAST     : doorAndWeightText = QStringLiteral("e");    break;
+        case DIR_DOWN     : doorAndWeightText = QStringLiteral("down"); break;
+        case DIR_SOUTHWEST: doorAndWeightText = QStringLiteral("sw");   break;
+        case DIR_SOUTH    : doorAndWeightText = QStringLiteral("s");    break;
+        case DIR_SOUTHEAST: doorAndWeightText = QStringLiteral("se");   break;
+        case DIR_IN       : doorAndWeightText = QStringLiteral("in");   break;
+        case DIR_OUT      : doorAndWeightText = QStringLiteral("out");  break;
         default: Q_UNREACHABLE();
     }
 
@@ -1394,7 +1394,7 @@ void dlgRoomExits::initExit(int direction,
         pExitR = mpHost->mpMap->mpRoomDB->getRoom(exitId);
         if (!pExitR) {
             // Recover from a missing exit room - not doing this was causing seg. faults
-            qWarning() << "dlgRoomExits::initExit(...): Warning: missing exit to" << exitId << "in direction" << exitText << ", resetting exit.";
+            qWarning().nospace().noquote() << "dlgRoomExits::initExit(...): Warning: missing exit to " << exitId << " in direction " << doorAndWeightText << ", resetting exit.";
             exitId = -1;
         }
     }
@@ -1437,7 +1437,7 @@ void dlgRoomExits::initExit(int direction,
             locked->setEnabled(true);
         } else {
             exitLineEdit->setEnabled(true);
-            exitLineEdit->setToolTip(singleParagraph.arg(tr("Set the number of the room %1 of this one.").arg(exitText)));
+            exitLineEdit->setToolTip(validExitToolTip);
             stub->setChecked(false);
             none->setEnabled(false); //Disable door type controls, can't lock a non-existant exit..
             open->setEnabled(false); //.. and ensure the "none" one is set if it ever gets enabled
@@ -1471,29 +1471,29 @@ void dlgRoomExits::init()
     // Because we are manipulating the settings for the exit we need to know
     // explicitly where the weight comes from, pR->getExitWeight() hides that
     // detail deliberately for normal usage
-    initExit(DIR_NORTHWEST, pR->getExit(DIR_NORTHWEST), nw, noroute_nw, stub_nw, doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw, weight_nw);
+    initExit(DIR_NORTHWEST, pR->getExit(DIR_NORTHWEST), nw, noroute_nw, stub_nw, doortype_none_nw, doortype_open_nw, doortype_closed_nw, doortype_locked_nw, weight_nw, singleParagraph.arg(tr("Set the number of the room northwest of this one.")));
 
-    initExit(DIR_NORTH, pR->getExit(DIR_NORTH), n, noroute_n, stub_n, doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n, weight_n);
+    initExit(DIR_NORTH, pR->getExit(DIR_NORTH), n, noroute_n, stub_n, doortype_none_n, doortype_open_n, doortype_closed_n, doortype_locked_n, weight_n, singleParagraph.arg(tr("Set the number of the room north of this one.")));
 
-    initExit(DIR_NORTHEAST, pR->getExit(DIR_NORTHEAST), ne, noroute_ne, stub_ne, doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne, weight_ne);
+    initExit(DIR_NORTHEAST, pR->getExit(DIR_NORTHEAST), ne, noroute_ne, stub_ne, doortype_none_ne, doortype_open_ne, doortype_closed_ne, doortype_locked_ne, weight_ne, singleParagraph.arg(tr("Set the number of the room northeast of this one.")));
 
-    initExit(DIR_UP, pR->getExit(DIR_UP), up, noroute_up, stub_up, doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up, weight_up);
+    initExit(DIR_UP, pR->getExit(DIR_UP), up, noroute_up, stub_up, doortype_none_up, doortype_open_up, doortype_closed_up, doortype_locked_up, weight_up, singleParagraph.arg(tr("Set the number of the room up from this one.")));
 
-    initExit(DIR_WEST, pR->getExit(DIR_WEST), w, noroute_w, stub_w, doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w, weight_w);
+    initExit(DIR_WEST, pR->getExit(DIR_WEST), w, noroute_w, stub_w, doortype_none_w, doortype_open_w, doortype_closed_w, doortype_locked_w, weight_w, singleParagraph.arg(tr("Set the number of the room west of this one.")));
 
-    initExit(DIR_EAST, pR->getExit(DIR_EAST), e, noroute_e, stub_e, doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e, weight_e);
+    initExit(DIR_EAST, pR->getExit(DIR_EAST), e, noroute_e, stub_e, doortype_none_e, doortype_open_e, doortype_closed_e, doortype_locked_e, weight_e, singleParagraph.arg(tr("Set the number of the room east of this one.")));
 
-    initExit(DIR_DOWN, pR->getExit(DIR_DOWN), down, noroute_down, stub_down, doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down, weight_down);
+    initExit(DIR_DOWN, pR->getExit(DIR_DOWN), down, noroute_down, stub_down, doortype_none_down, doortype_open_down, doortype_closed_down, doortype_locked_down, weight_down, singleParagraph.arg(tr("Set the number of the room down from this one.")));
 
-    initExit(DIR_SOUTHWEST, pR->getExit(DIR_SOUTHWEST), sw, noroute_sw, stub_sw, doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw, weight_sw);
+    initExit(DIR_SOUTHWEST, pR->getExit(DIR_SOUTHWEST), sw, noroute_sw, stub_sw, doortype_none_sw, doortype_open_sw, doortype_closed_sw, doortype_locked_sw, weight_sw, singleParagraph.arg(tr("Set the number of the room southwest of this one.")));
 
-    initExit(DIR_SOUTH, pR->getExit(DIR_SOUTH), s, noroute_s, stub_s, doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s, weight_s);
+    initExit(DIR_SOUTH, pR->getExit(DIR_SOUTH), s, noroute_s, stub_s, doortype_none_s, doortype_open_s, doortype_closed_s, doortype_locked_s, weight_s, singleParagraph.arg(tr("Set the number of the room south of this one.")));
 
-    initExit(DIR_SOUTHEAST, pR->getExit(DIR_SOUTHEAST), se, noroute_se, stub_se, doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se, weight_se);
+    initExit(DIR_SOUTHEAST, pR->getExit(DIR_SOUTHEAST), se, noroute_se, stub_se, doortype_none_se, doortype_open_se, doortype_closed_se, doortype_locked_se, weight_se, singleParagraph.arg(tr("Set the number of the room southeast of this one.")));
 
-    initExit(DIR_IN, pR->getExit(DIR_IN), in, noroute_in, stub_in, doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in, weight_in);
+    initExit(DIR_IN, pR->getExit(DIR_IN), in, noroute_in, stub_in, doortype_none_in, doortype_open_in, doortype_closed_in, doortype_locked_in, weight_in, singleParagraph.arg(tr("Set the number of the room in from this one.")));
 
-    initExit(DIR_OUT, pR->getExit(DIR_OUT), out, noroute_out, stub_out, doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out, weight_out);
+    initExit(DIR_OUT, pR->getExit(DIR_OUT), out, noroute_out, stub_out, doortype_none_out, doortype_open_out, doortype_closed_out, doortype_locked_out, weight_out, singleParagraph.arg(tr("Set the number of the room out from this one.")));
 
     QMapIterator<QString, int> it(pR->getSpecialExits());
     while (it.hasNext()) {

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -70,7 +70,7 @@ class WeightSpinBoxDelegate : public QStyledItemDelegate
     Q_OBJECT
 
 public:
-    WeightSpinBoxDelegate(QObject* parent = nullptr);
+    explicit WeightSpinBoxDelegate(QObject* parent = nullptr);
 
     QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
     void setEditorData(QWidget* editor, const QModelIndex& index) const override;
@@ -83,7 +83,7 @@ class RoomIdLineEditDelegate : public QStyledItemDelegate
     Q_OBJECT
 
 public:
-    RoomIdLineEditDelegate(QObject* parent = nullptr);
+    explicit RoomIdLineEditDelegate(QObject* parent = nullptr);
 
     QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
     void setEditorData(QWidget* editor, const QModelIndex& index) const override;
@@ -105,7 +105,7 @@ public:
     mutable int mAreaID = 0;
 
 private slots:
-    void slot_specialRoomExitEdited(const QString&);
+    void slot_specialRoomExitEdited(const QString&) const;
 };
 
 class dlgRoomExits : public QDialog, public Ui::room_exits
@@ -120,9 +120,9 @@ public:
     QSet<QAction*> mAllExitActionsSet;
     QPointer<Host> getHost() const { return mpHost; }
     int getAreaID() const { return mAreaID; }
-    void setActionOnExit(QLineEdit*, QAction*);
+    void setActionOnExit(QLineEdit*, QAction*) const;
     QAction* getActionOnExit(QLineEdit* pExitLineEdit) const;
-    QString generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight) const;
+    static QString generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight);
 
     // These need to be public so they can be accessed from the
     // RoomIdLineEditDelegate:
@@ -182,13 +182,13 @@ private:
     void setIconAndToolTipsOnSpecialExit(QTreeWidgetItem*, const bool);
     void normalExitEdited(const QString& roomExitIdText,
                           QLineEdit* pExit,
-                          QCheckBox* pL, QCheckBox* pS,
+                          QCheckBox* pNoRoute, QCheckBox* pS,
                           QSpinBox* pW,
                           QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked,
                           const QString& invalidExitToolTipText, const QString& noExitToolTipText);
     void normalStubExitChanged(const int state,
                                QLineEdit* pExit,
-                               QCheckBox* pL,
+                               QCheckBox* pNoRoute,
                                QSpinBox* pW,
                                QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked,
                                const QString& noExitToolTipText);

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -177,7 +177,7 @@ private:
     void initExit(int direction, int exitId, QLineEdit* exitLineEdit,
                   QCheckBox* noRoute, QCheckBox* stub,
                   QRadioButton* none, QRadioButton* open, QRadioButton* closed, QRadioButton* locked,
-                  QSpinBox* weight);
+                  QSpinBox* weight, const QString& validExitToolTip);
     TExit* makeExitFromControls(int direction);
     void setIconAndToolTipsOnSpecialExit(QTreeWidgetItem*, const bool);
     void normalExitEdited(const QString& roomExitIdText,

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -191,7 +191,7 @@ private:
                                QCheckBox* pNoRoute,
                                QSpinBox* pW,
                                QRadioButton* pDoorType_none, QRadioButton* pDoorType_open, QRadioButton* pDoorType_closed, QRadioButton* pDoorType_locked,
-                               const QString& noExitToolTipText);
+                               const QString& noExitToolTipText) const;
 
 
     QPointer<Host> mpHost;

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1665,6 +1665,145 @@
         </layout>
        </widget>
       </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QFrame" name="frame_key">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="cursor">
+         <cursorShape>WhatsThisCursor</cursorShape>
+        </property>
+        <layout class="QGridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_key">
+           <property name="text">
+            <string>Key:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="noroute_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="text">
+            <string>No route</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="stub_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Stub Exit</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2" colspan="4">
+          <widget class="QLineEdit" name="key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;p&gt;Set the number of the room that's to the southwest here.&lt;/p&gt;</string>
+           </property>
+           <property name="placeholderText">
+            <string>Exit RoomID number</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QSpinBox" name="weight_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="specialValueText">
+            <string>Exit Weight (0=No override)</string>
+           </property>
+           <property name="maximum">
+            <number>9999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QRadioButton" name="doortype_none_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>No door</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QRadioButton" name="doortype_open_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Open door</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="4">
+          <widget class="QRadioButton" name="doortype_closed_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Closed door</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="5">
+          <widget class="QRadioButton" name="doortype_locked_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Locked door</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item row="3" column="3">
        <widget class="QFrame" name="frame_out">
         <property name="sizePolicy">
@@ -1805,194 +1944,7 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="QFrame" name="frame_key">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="cursor">
-         <cursorShape>WhatsThisCursor</cursorShape>
-        </property>
-        <layout class="QGridLayout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_key">
-           <property name="text">
-            <string>Key:</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="noroute_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="text">
-            <string>No route</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="stub_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Stub Exit</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2" colspan="4">
-          <widget class="QLineEdit" name="key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string>&lt;p&gt;Set the number of the room that's to the southwest here.&lt;/p&gt;</string>
-           </property>
-           <property name="placeholderText">
-            <string>Exit RoomID number</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QSpinBox" name="weight_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="specialValueText">
-            <string>Exit Weight (0=No override)</string>
-           </property>
-           <property name="maximum">
-            <number>9999</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QRadioButton" name="doortype_none_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>No door</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="3">
-          <widget class="QRadioButton" name="doortype_open_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Open door</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="4">
-          <widget class="QRadioButton" name="doortype_closed_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Closed door</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="5">
-          <widget class="QRadioButton" name="doortype_locked_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Locked door</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <spacer name="horizontalSpacer_controlButtons">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="3">
-    <widget class="QPushButton" name="button_save">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>140</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>&lt;p&gt;Use this button to save any changes, will also remove any invalid Special exits.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string>&amp;Save</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="QPushButton" name="button_cancel">
-     <property name="minimumSize">
-      <size>
-       <width>140</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>&lt;p&gt;Use this button to close the dialogue without changing anything.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string>&amp;Cancel</string>
-     </property>
     </widget>
    </item>
    <item row="1" column="0" colspan="5">
@@ -2000,8 +1952,8 @@
      <property name="title">
       <string>Special exits:</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_specialExits">
-      <item row="0" column="0">
+     <layout class="QVBoxLayout" name="vBoxLayout_specialExits">
+      <item>
        <widget class="ExitsTreeWidget" name="specialExits">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
@@ -2046,6 +1998,15 @@ Room ID</string>
          </property>
          <property name="toolTip">
           <string>&lt;p&gt;Set the number of the room that this exit leads to, if set to zero the exit will be removed on saving the exits.&lt;/p&gt;</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Exit
+Status</string>
+         </property>
+         <property name="toolTip">
+          <string>&lt;p&gt;Indicates whether the exit is invalid, leads to another room in this area or leads to a room in another area.&lt;/p&gt;</string>
          </property>
         </column>
         <column>
@@ -2108,7 +2069,7 @@ Locked</string>
 or LUA script</string>
          </property>
          <property name="toolTip">
-          <string>&lt;p&gt;(Lua scripts need to be prefixed with &quot;script:&quot;).&lt;/p&gt;</string>
+          <string>&lt;p&gt;(Lua scripts for some mapper packages {those using the &lt;tt&gt;mudlet-mapper&lt;/tt&gt;, i.e. I.R.E. Muds and StickMUD} need to be prefixed with &quot;script:&quot;).&lt;/p&gt;</string>
          </property>
         </column>
        </widget>
@@ -2148,6 +2109,54 @@ or LUA script</string>
      </property>
      <property name="text">
       <string>&amp;End S. Exits editing</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <spacer name="horizontalSpacer_controlButtons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="3">
+    <widget class="QPushButton" name="button_save">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;p&gt;Use this button to save any changes, will also remove any invalid Special exits.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string>&amp;Save</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QPushButton" name="button_cancel">
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;p&gt;Use this button to close the dialogue without changing anything.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string>&amp;Cancel</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
# NOT TO BE MERGED

### See bottom of this mesage

It has been pointed out that using colours to indicate whether an exit room id number is valid or not in the room exits dialogue is not always helpful when the end-user wants to apply styling to Mudlet - or for those with some visual impairments.  This commit is intended to improve the situation by instead applying an icon to indicate the exit status with one of three icons indicating an invalid exit room id number, a valid number in the same area or a valid number in another area. This is shown as an icon in the `QLineEdit` on the right side (after the number) for *normal* exits and as an icon in a separate column to the right of the field used to enter and display the exit room id for *special* exits. This replaces the previous code that only showed valid or invalid numbers with blue or red text respectively.

As these changes needed some reorganisation of the individual columns used for the special exits in the room exit dialogue I converted all the column numbers into constants that are defined at the top of the `dlgRoomExit.cpp` file - this means it is more easy to readjust them in the future if that should prove necessary (and reduces the chance of missing out or mixing up those index numbers in the event of further editing...!)

During development I discovered how to use custom *item delegates*, e.g. like described in:
https://doc.qt.io/qt-5/model-view-programming.html#a-simple-delegate
for both:
* the special exit weight - during editing the `QLineEdit` that was used for special exit weights is replaced with a `QSpinBox` that acts in the same manner as those for the normal exits.
* the special exit room ID -  during editing a replacement `QLineEdit` is used which gains an icon in the same manner as the ones used for the normal exits. Outside of that editing a separate column holds the same icon except that it also considers the status of the exit command/script so as to show an "invalid" exit if there isn't one. Tooltips for both the exit room ID and status columns are also updated during and after editing of the exit room ID.

Also:
* refactored the initialisation process for the room exits dialogue so that it is no longer necessary to explicitly call an `init(...)` method after instantiating the dialogue - that is now done from the constructor itself - which takes the additional argument (the room that the exits are to be displayed for) that was originally needed from that method.
* reordered the items in the `QGridLayout`s in the `room_exits.ui` form XML file so that they are back in ascending order again.
* refactored out some highly repetitive (one for each normal exit direction) code to some separate methods that take pointers to all the individual widgets involved in that exit:
    * `normalExitEdited(...)`
    * `normalStubExitChanged(...)`
* similarly for special exits:
    * `setIconAndToolTipsOnSpecialExit(QTreeWidgetItem*)`
* also for the tooltips for normal exits - which now also include the area involved for exits that go to other areas:
    * `generateToolTip(...)`
* and to put an icon (as an `QAction` with no action) into the `QLineEdit`s for normal exits:
    * `setActionOnExit(QLineEdit*, QAction*)`
* refactored out some translated `QString`s that are used programmatically for special exits - so that they are only specified in one place - thereby making the code more robust so that each usage can be revised by only editing one string instead of six or seven instances in one case.
* added in a slot method connected to the special exits' `QTreeWidget::itemChanged` signal so that it updates better during editing of special exits (after moving to or from the exit room id or command fields to others within the same special exit instead of only when moving to a *different* special exit completely).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Room exits dialogue enhanced to use icons instead of colours to indicate the status of the value entered. This is extended into the special exits part as well which also now uses spin-box widgets to allow the exit weight to be set by mouse clicks as well as the previous typing in of a numeric value.

### This PR is to be broken up into smaller chunks to make it easier to resolve, so far they are:
- [x] Convert numeric indexes (currently `0` to `7`) used to identify particular columns in the *special* exits `QListWidget` in the dialogue used for room exit manipulation in the 2D Mapper to `const int`s so that reading the code and reordering them can be done consistently and correctly (avoiding weirdness if one or more usages are missed when revising them),
#5505
- [x] Remove need for code using the class to call `dlgRoomExits::init(....)`,
#5498
- [x] Change `QLineEdit`s used for **normal** room exit IDs to show icons instead of having coloured text to indicate validity of exit,
#5513
- [x] Re-reorder some elements in the `./src/us/room_exits.ui` XML form/dialogue design file so that `QGridLayout` components contain items in {a|an} (predictable and an) ordered way,
#5512
- [x] Change widget used for **special** room exit IDs (which are cells in a `QListWidget`) to show icons instead of having coloured text to indicate validity of exit,
#5543
- [x] Change widget used for **special** room exit weights (which are cells in a `QListWidget`) to show a spin box instead of being a pure text entry widget,
#5758