### PR TITLE
BugFix: fix Json Map room symbol loading

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2675,8 +2675,6 @@ void Host::setPlayerRoomStyleDetails(const quint8 styleCode, const quint8 outerD
 
 void Host::getPlayerRoomStyleDetails(quint8& styleCode, quint8& outerDiameter, quint8& innerDiameter, QColor& primaryColor, QColor& secondaryColor)
 {
-    // Now we have the exclusive lock on this class's protected members
-
     styleCode = mPlayerRoomStyle;
     outerDiameter = mPlayerRoomOuterDiameterPercentage;
     innerDiameter = mPlayerRoomInnerDiameterPercentage;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3056,7 +3056,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     if (mapObj.contains(QLatin1String("customEnvColors")) && mapObj.value(QLatin1String("customEnvColors")).isArray()) {
         const QJsonArray customEnvColorArray = mapObj.value(QLatin1String("customEnvColors")).toArray();
         if (!customEnvColorArray.isEmpty()) {
-            for (auto customEnvColorValue : qAsConst(customEnvColorArray)) {
+            for (const auto& customEnvColorValue : qAsConst(customEnvColorArray)) {
                 const QJsonObject customEnvColorObj{customEnvColorValue.toObject()};
                 if (customEnvColorObj.contains(QLatin1String("id"))
                     && ((customEnvColorObj.contains(QLatin1String("color32RGBA")) && customEnvColorObj.value(QLatin1String("color32RGBA")).isArray())
@@ -3132,6 +3132,12 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
     // This is it - the point at which the new map gets activated:
     TRoomDB* pOldRoomDB = mpRoomDB;
     mpRoomDB = pNewRoomDB;
+    // Need to update the master copy of these details in the Host class:
+    mpHost->setPlayerRoomStyleDetails(mPlayerRoomStyle, mPlayerRoomOuterDiameterPercentage, mPlayerRoomInnerDiameterPercentage, mPlayerRoomOuterColor, mPlayerRoomInnerColor);
+    // And redraw the indicator if a 2D map is being shown:
+    if (mpMapper && mpMapper->mp2dMap) {
+        mpMapper->mp2dMap->setPlayerRoomStyle(mPlayerRoomStyle);
+    }
     delete pOldRoomDB;
     mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose, true);
     mpProgressDialog->close();

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1763,8 +1763,8 @@ int TRoom::readJsonRoom(const QJsonArray& array, const int index, const int area
         weight = roomObj.value(QLatin1String("weight")).toInt();
     }
 
-    if (roomObj.contains(QLatin1String("symbol")) && roomObj.value(QLatin1String("symbol")).isString()) {
-        mSymbol = roomObj.value(QLatin1String("symbol")).toString();
+    if (roomObj.contains(QLatin1String("symbol")) && roomObj.value(QLatin1String("symbol")).isObject()) {
+        readJsonSymbol(roomObj);
     }
 
     if (roomObj.contains(QLatin1String("environment")) && roomObj.value(QLatin1String("environment")).isDouble()) {
@@ -2355,5 +2355,13 @@ void TRoom::writeJsonSymbol(QJsonObject& roomObj) const
 
 void TRoom::readJsonSymbol(const QJsonObject& roomObj)
 {
-    Q_UNUSED(roomObj);
+    const QJsonObject symbolObj{roomObj.value(QLatin1String("symbol")).toObject()};
+    if (symbolObj.contains(QLatin1String("text")) && symbolObj.value(QLatin1String("text")).isString()) {
+        mSymbol = symbolObj.value(QLatin1String("text")).toString();
+    }
+
+    QColor color = TMap::readJsonColor(symbolObj);
+    if (color.isValid()) {
+        mSymbolColor = color;
+    }
 }


### PR DESCRIPTION
This should close #5295 by providing the code that is missing from `(void) TRoom::readJsonSymbol(...)` - I think it was omitted because the person who coded the ability to colourise the room symbol text was working on that whilst I was coding the JSON map handling.

It also fixes:
* a Qt advisory (warning) to use a const reference when using a C++ `for` loop to iterate through a QJsonArray of custom environements (colors).
* a failure to update the player room indicator when it is changed by loading a Json Map file.
* a comment in `(void) Host::getPlayerRoomStyleDetails(...)` that is redundant since we remove the mutex for accessors.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Room symbols (and their colouration if they are not colour emojis) will now be loaded from a JSON format map file.