### PR TITLE
BugFix: prevent crashing from double-click on connect button

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -299,7 +299,10 @@ dlgConnectionProfiles::~dlgConnectionProfiles()
 void dlgConnectionProfiles::accept()
 {
     if (validName && validUrl && validPort) {
-        slot_connectToServer();
+        setVisible(false);
+        // This is needed to make the above take effect as fast as possible:
+        qApp->processEvents();
+        loadProfile(true);
         QDialog::accept();
     }
 }
@@ -1901,13 +1904,11 @@ void dlgConnectionProfiles::saveProfileCopy(const QDir& newProfiledir, const pug
 
 void dlgConnectionProfiles::slot_load()
 {
+    setVisible(false);
+    // This is needed to make the above take effect as fast as possible:
+    qApp->processEvents();
     loadProfile(false);
     QDialog::accept();
-}
-
-void dlgConnectionProfiles::slot_connectToServer()
-{
-    loadProfile(true);
 }
 
 void dlgConnectionProfiles::loadProfile(bool alsoConnect)

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -83,7 +83,6 @@ public slots:
     void slot_update_autologin(int state);
     void slot_update_autoreconnect(int state);
     void slot_update_discord_optin(int state);
-    void slot_connectToServer();
     void slot_load();
     void slot_cancel();
     void slot_copy_profile();


### PR DESCRIPTION
This is done by hiding the connect profile dialogue as quickly as possible after the load or connect buttons have been clicked (and before the possibly lengthy profile loading operations commenced). This should close #5303.

Also, it was found that the: `(void) dlgConnectionProfiles::slot_connectToServer()` slot method was redundant and could be removed.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Reduce possibility of crashing Mudlet by double-clicking on "load" or "connect" buttons in profile selection dialogue.