### PR TITLE
Fix for unwanted height change of command line when typing.

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -580,10 +580,11 @@ void TCommandLine::adjustHeight()
     if (lines > 10) {
         lines = 10;
     }
-    int _baseHeight = fontH * lines;
-    int _height = _baseHeight + fontH;
-
-    if (_height < mpHost->commandLineMinimumHeight) {
+    int _height = fontH * lines;
+    if( _height < 31 ) {
+        _height = 31; // Minimum usable height taken from buttonLayer in TConsole.cpp
+    }
+     if (_height < mpHost->commandLineMinimumHeight) {
         _height = mpHost->commandLineMinimumHeight;
     }
     if (_height > height() || _height < height()) {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -581,7 +581,7 @@ void TCommandLine::adjustHeight()
         lines = 10;
     }
     int _height = fontH * lines;
-    if( _height < 31 ) {
+    if(_height < 31) {
         _height = 31; // Minimum usable height taken from buttonLayer in TConsole.cpp
     }
      if (_height < mpHost->commandLineMinimumHeight) {

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -581,7 +581,7 @@ void TCommandLine::adjustHeight()
         lines = 10;
     }
     int _height = fontH * lines;
-    if(_height < 31) {
+    if (_height < 31) {
         _height = 31; // Minimum usable height taken from buttonLayer in TConsole.cpp
     }
      if (_height < mpHost->commandLineMinimumHeight) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update the minimum height calculation in TCommandLine::adjustHeight method. Keeps the minimum size of the command line to be consistent with the icons next to the command line.

#### Motivation for adding to Mudlet
Fixes the behaviour where the command line height grows as soon as you start to typing. The old behaviour was making the minimum command line height twice that of the font height, which for many users is bigger than the icons next to it.

#### Other info (issues closed, discussion etc)

#### Release post highlight
Improved the command line height adjustment when typing