### PR TITLE
Fix incorrect height adjustment of the command line

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -574,15 +574,17 @@ void TCommandLine::adjustHeight()
         return;
     }
     int fontH = QFontMetrics(font()).height();
+    int marginH = lines > 1 ? fontH : 0;
     if (lines < 1) {
         lines = 1;
     }
     if (lines > 10) {
         lines = 10;
     }
-    int _baseHeight = fontH * lines;
-    int _height = _baseHeight + fontH;
-
+    int _height = fontH * lines + marginH;
+    if (_height < 31) {
+        _height = 31; // Minimum usable height taken from buttonLayer in TConsole.cpp
+    }
     if (_height < mpHost->commandLineMinimumHeight) {
         _height = mpHost->commandLineMinimumHeight;
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update the minimum height calculation in TCommandLine::adjustHeight method. Keeps the minimum size of the command line to be consistent with the icons next to the command line.

#### Motivation for adding to Mudlet
Fixes the behaviour where the command line height grows as soon as you start to typing. The old behaviour was making the minimum command line height twice that of the font height, which for many users is bigger than the icons next to it.

#### Other info (issues closed, discussion etc)

#### Release post highlight
Improved the command line height adjustment when typing