### PR TITLE
Implement commands to make command line text selected

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -163,7 +163,7 @@ static const char *bad_cmdline_value = "command line \"%s\" not found";
 
 #define COMMANDLINE(_L, _name)                                                                 \
     ({                                                                                         \
-        const QString name_ = (_name); //NOLINT(performance-unnecessary-copy-initialization)   \
+        const QString name_ = (_name);                                                         \
         auto console_ = getHostFromLua(_L).mpConsole;                                          \
         auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
                                     : console_->mSubCommandLineMap.value(name_);               \

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10336,6 +10336,20 @@ int TLuaInterpreter::appendCmdLine(lua_State* L)
     return 0;
 }
 
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#selectCmdLineText
+int TLuaInterpreter::selectCmdLineText(lua_State* L)
+{
+    int n = lua_gettop(L);
+    QString name = "main";
+    if (n >= 1) {
+        name = CMDLINE_NAME(L, 1);
+    }
+    auto commandline = COMMANDLINE(L, name);
+    commandline->selectAll();
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCmdLine
 int TLuaInterpreter::getCmdLine(lua_State* L)
 {
@@ -13728,6 +13742,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "clearRoomUserDataItem", TLuaInterpreter::clearRoomUserDataItem);
     lua_register(pGlobalLua, "downloadFile", TLuaInterpreter::downloadFile);
     lua_register(pGlobalLua, "appendCmdLine", TLuaInterpreter::appendCmdLine);
+    lua_register(pGlobalLua, "selectCmdLineText", TLuaInterpreter::selectCmdLineText);
     lua_register(pGlobalLua, "getCmdLine", TLuaInterpreter::getCmdLine);
     lua_register(pGlobalLua, "addCmdLineSuggestion", TLuaInterpreter::addCmdLineSuggestion);
     lua_register(pGlobalLua, "removeCmdLineSuggestion", TLuaInterpreter::removeCmdLineSuggestion);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -163,7 +163,7 @@ static const char *bad_cmdline_value = "command line \"%s\" not found";
 
 #define COMMANDLINE(_L, _name)                                                                 \
     ({                                                                                         \
-        const QString name_ = (_name);                                                         \
+        const QString name_ = (_name); //NOLINT(performance-unnecessary-copy-initialization)   \
         auto console_ = getHostFromLua(_L).mpConsole;                                          \
         auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
                                     : console_->mSubCommandLineMap.value(name_);               \

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -239,6 +239,7 @@ public:
     static int getSpecialExitsSwap(lua_State*);
     static int appendCmdLine(lua_State*);
     static int getCmdLine(lua_State* L);
+    static int selectCmdLineText(lua_State* L);
     static int addCmdLineSuggestion(lua_State* L);
     static int removeCmdLineSuggestion(lua_State* L);
     static int clearCmdLineSuggestions(lua_State* L);

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -333,6 +333,7 @@
     "searchAreaUserData": "searchRoom (room number | room name[, case-sensitive [, exact-match]])",
     "searchRoomUserData": "searchRoomUserData(key, value)",
     "selectCaptureGroup": "selectCaptureGroup(groupNumber)",
+    "selectCmdLineText": "selectCmdLineText()",
     "selectCurrentLine": "selectCurrentLine([windowName])",
     "selectSection": "selectSection( [windowName], fromPosition, length )",
     "selectString": "selectString( [windowName], text, number_of_match )",

--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -33,6 +33,12 @@ function Geyser.CommandLine:append(text)
   appendCmdLine(self.name, text)
 end
 
+--- selects the text in the commandline
+function Geyser.CommandLine:selectText()
+  return selectCmdLineText(self.name)
+end
+
+
 --- returns the text in the commandline
 -- see: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCmdLine
 function Geyser.CommandLine:getText()


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Adds commands to make the text in commandline selected.

Implements the command `selectCmdLineText()` together with the Geyser CommandLine variant `Geyser.CommandLine:selectText()`

Examples:
- `selectCmdLineText()` -- selects all text in the main command line
- `selectCmdLineText('extraCmdLine'`) -- selects the text in the command line named extraCmdLine
- `extraCmdLine:selectText()` -- same as above, but using a Geyser.CommandLine stored assigned to extraCmdLine
#### Motivation for adding to Mudlet
Implements requested command from issue #5277 

#### Other info (issues closed, discussion etc)
See  #5277 for more comments.

#### Testing
To test this I created an extra commandline with the following lua script:

> inputContainer = inputContainer or Adjustable.Container:new({
>   x = 0, y = "-4c", 
>   name = "InputContainer", padding = 2, 
>   width = "100%", height = "4c", 
>   autoLoad = false
> })
> 
> extraCmdLine = extraCmdLine or Geyser.CommandLine:new({
>   name = "extraCmdLine", 
>   x = 0, y = 0, width = "100%", height = "100%"
> }, inputContainer)
> 
> inputContainer:attachToBorder("bottom")

After that I called the functions as in the above examples using a temptimer to give enough time to make changes, deselect text etc:
`lua tempTimer(2, function() selectCmdLineText() end)`

#### Release post highlight
Added functions to select all text from the commandline
