### PR TITLE
Improvements to command line font handling

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -58,6 +58,7 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
     setFocusPolicy(Qt::StrongFocus);
 
     setFont(mpHost->getDisplayFont());
+    document()->setDocumentMargin(2);
 
     mRegularPalette.setColor(QPalette::Text, mpHost->mCommandLineFgColor);
     mRegularPalette.setColor(QPalette::Highlight, QColor(0, 0, 192));
@@ -573,18 +574,15 @@ void TCommandLine::adjustHeight()
         }
         return;
     }
-    int fontH = QFontMetrics(font()).height();
-    int marginH = lines > 1 ? fontH : 0;
     if (lines < 1) {
         lines = 1;
     }
     if (lines > 10) {
         lines = 10;
     }
+    int fontH = QFontMetrics(font()).height();
+    int marginH = fontH/4 < 4 ? 4 : fontH/4;
     int _height = fontH * lines + marginH;
-    if (_height < 31) {
-        _height = 31; // Minimum usable height taken from buttonLayer in TConsole.cpp
-    }
     if (_height < mpHost->commandLineMinimumHeight) {
         _height = mpHost->commandLineMinimumHeight;
     }

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -565,6 +565,9 @@ void TCommandLine::hideEvent(QHideEvent* event)
 
 void TCommandLine::adjustHeight()
 {
+    if(!mpConsole->layerCommandLine) {
+        return;
+    }
     int lines = document()->size().height();
     // Workaround for SubCommandLines textCursor not visible in some situations
     // SubCommandLines cannot autoresize

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -586,7 +586,11 @@ void TCommandLine::adjustHeight()
         lines = 10;
     }
     int fontH = QFontMetrics(font()).height();
-    int marginH = fontH/4 < 4 ? 4 : fontH/4;
+    // Adjust height margin based on font size and if it is more than one row
+    int marginH = lines > 1 ? 2+fontH/3 : 5;
+    if (lines > 1 && marginH < 8) {
+        marginH = 8; // needed for very small fonts
+    }
     int _height = fontH * lines + marginH;
     if (_height < mpHost->commandLineMinimumHeight) {
         _height = mpHost->commandLineMinimumHeight;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -565,7 +565,9 @@ void TCommandLine::hideEvent(QHideEvent* event)
 
 void TCommandLine::adjustHeight()
 {
-    if(!mpConsole->layerCommandLine) {
+    // Make sure adjustHeight won't crash if it's used before mpConsole->layerCommandLine has a value
+    if (!mpConsole->layerCommandLine) {
+        qWarning() << "TCommandLine::adjustHeight() ERROR: mpConsole->layerCommandLine is NULL!";
         return;
     }
     int lines = document()->size().height();

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -70,6 +70,7 @@ public:
     void addSuggestion(const QString&);
     void removeSuggestion(const QString&);
     void clearSuggestions();
+    void adjustHeight();
 
     int mActionFunction = 0;
     QPalette mRegularPalette;
@@ -89,7 +90,6 @@ private:
     void handleTabCompletion(bool);
     void historyMove(MoveDirection);
     void enterCommand(QKeyEvent*);
-    void adjustHeight();
     void processNormalKey(QEvent*);
     bool keybindingMatched(QKeyEvent*);
     void spellCheckWord(QTextCursor& c);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -651,6 +651,10 @@ void TConsole::refresh()
 
     mpMainDisplay->resize(x - mMainFrameLeftWidth - mMainFrameRightWidth, y - mMainFrameTopHeight - mMainFrameBottomHeight - mpCommandLine->height());
 
+    if (mType & MainConsole) {
+        mpCommandLine->adjustHeight();
+    }
+
     mpMainDisplay->move(mMainFrameLeftWidth, mMainFrameTopHeight);
     x = width();
     y = height();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -517,6 +517,10 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     if (mType & MainConsole) {
         mpButtonMainLayer->setVisible(!mpHost->getCompactInputLine());
     }
+
+    if (mType & MainConsole) {
+        mpCommandLine->adjustHeight();
+    }
 }
 
 TConsole::~TConsole()

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1632,8 +1632,7 @@ void dlgProfilePreferences::setCommandBgColor()
 void dlgProfilePreferences::setFontSize()
 {
     mFontSize = fontSize->currentIndex() + 1;
-    // delay setting pHost->mDisplayFont until save is clicked by the user.
-    //setDisplayFont();
+    setDisplayFont();
 }
 
 void dlgProfilePreferences::setDisplayFont()

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1632,7 +1632,8 @@ void dlgProfilePreferences::setCommandBgColor()
 void dlgProfilePreferences::setFontSize()
 {
     mFontSize = fontSize->currentIndex() + 1;
-    setDisplayFont();
+    // delay setting pHost->mDisplayFont until save is clicked by the user.
+    //setDisplayFont();
 }
 
 void dlgProfilePreferences::setDisplayFont()


### PR DESCRIPTION
#### Brief overview of PR changes

- Makes the text fit the command line better, 
- Adjusts the command line height at startup, including when using big fonts or having a big minimum size in settings.
- Allow for a thinner input line when using small font sizes.

#### Motivation for adding to Mudlet
Fixes #5340, where big fonts no longer fit the first line, or when a user has a different screen zoom. Also makes the command line height consistent at startup. Before the change it was updated once the users started typing.

#### Other info
TCommandLine::adjustHeight was changed to public so it can be called when font is updated.

#### Release post highlight
Improvements to command line font handling
