### PR TITLE
Update fontsize as soon as it is selected in  preferences

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1632,8 +1632,7 @@ void dlgProfilePreferences::setCommandBgColor()
 void dlgProfilePreferences::setFontSize()
 {
     mFontSize = fontSize->currentIndex() + 1;
-    // delay setting pHost->mDisplayFont until save is clicked by the user.
-    //setDisplayFont();
+    setDisplayFont();
 }
 
 void dlgProfilePreferences::setDisplayFont()


### PR DESCRIPTION
#### Brief overview of PR changes
Changes the way that preferences behaves, so that when you change the font size, you will see the effect in Mudlet immediately without clicking on save.

#### Motivation for adding to Mudlet
Provides a better user experience by making it easier for the user to select a good fontsize.

#### Other info
Split off from PR 5349
Reverts changes to  dlgProfilePreferences::setFontSize() from commit 71ba6a8da12c5c6fcb24a4b5aaab9d72f0c467ad
