### PR TITLE
Make f work with variable named 'str'

### DIFF
--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -128,6 +128,8 @@ if _VERSION == "Lua 5.1" then
   end
 end
 
+-- long and inconvenient variable name is to help avoid collisions
+-- str (what it was before) was causing f("Hello {str}") to return "Hello Hello {str}"
 function f(supersecretstringvariablenocollision)
   local outer_env = _ENV or getfenv(1)
   return (supersecretstringvariablenocollision:gsub("%b{}", function(block)

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -128,9 +128,9 @@ if _VERSION == "Lua 5.1" then
   end
 end
 
-function f(str)
+function f(supersecretstringvariablenocollision)
   local outer_env = _ENV or getfenv(1)
-  return (str:gsub("%b{}", function(block)
+  return (supersecretstringvariablenocollision:gsub("%b{}", function(block)
     local code = block:match("{(.*)}")
     local exp_env = {}
     setmetatable(exp_env, {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

The parameter 'str' is a little too generic and has proven to be a collision risk

#### Motivation for adding to Mudlet

Someone in the Mudlet discord tries to use {str} in a string passed through f and it put the full str passed in in its place.

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
