### PR TITLE
Fix --profile not working for default games

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -42,7 +42,7 @@
 using namespace std::chrono_literals;
 
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
-: QDialog(parent), validName(), validUrl(), validPort(), mProfileList(QStringList()), offline_button(nullptr), connect_button(nullptr), delete_profile_lineedit(nullptr), delete_button(nullptr)
+: QDialog(parent), validName(), validUrl(), validPort(), offline_button(nullptr), connect_button(nullptr), delete_profile_lineedit(nullptr), delete_button(nullptr)
 {
     setupUi(this);
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -42,21 +42,7 @@
 using namespace std::chrono_literals;
 
 dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
-: QDialog(parent)
-, validName()
-, validUrl()
-, validPort()
-, mProfileList(QStringList())
-, offline_button(nullptr)
-, connect_button(nullptr)
-, delete_profile_lineedit(nullptr)
-, delete_button(nullptr)
-, mDefaultGames({"3Kingdoms", "3Scapes", "Aardwolf", "Achaea", "Aetolia",
-                 "Avalon.de", "BatMUD", "Clessidra", "Fierymud", "Imperian", "Luminari",
-                 "Lusternia", "Materia Magica", "Midnight Sun 2", "Realms of Despair",
-                 "Reinos de Leyenda", "StickMUD", "WoTMUD", "ZombieMUD", "Carrion Fields",
-                 "Cleft of Dimensions", "CoreMUD", "God Wars II", "Slothmud",
-                 "Legends of the Jedi"})
+: QDialog(parent), validName(), validUrl(), validPort(), mProfileList(QStringList()), offline_button(nullptr), connect_button(nullptr), delete_profile_lineedit(nullptr), delete_button(nullptr)
 {
     setupUi(this);
 
@@ -1572,6 +1558,8 @@ void dlgConnectionProfiles::fillout_form()
 
 void dlgConnectionProfiles::setProfileIcon() const
 {
+    const auto defaultGames = mudlet::self()->getDefaultGames();
+
     for (int i = 0; i < mProfileList.size(); i++) {
         const QString& profileName = mProfileList.at(i);
         if (profileName.isEmpty()) {
@@ -1585,7 +1573,7 @@ void dlgConnectionProfiles::setProfileIcon() const
             // necessarily case preserving for file names so any tests on them
             // should be case insensitive
             // skip creating icons for default MUDs as they are already created above
-            if (mDefaultGames.contains(profileName, Qt::CaseInsensitive)) {
+            if (defaultGames.contains(profileName, Qt::CaseInsensitive)) {
                 continue;
             }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1558,8 +1558,6 @@ void dlgConnectionProfiles::fillout_form()
 
 void dlgConnectionProfiles::setProfileIcon() const
 {
-    const auto defaultGames = mudlet::self()->getDefaultGames();
-
     for (int i = 0; i < mProfileList.size(); i++) {
         const QString& profileName = mProfileList.at(i);
         if (profileName.isEmpty()) {
@@ -1573,7 +1571,7 @@ void dlgConnectionProfiles::setProfileIcon() const
             // necessarily case preserving for file names so any tests on them
             // should be case insensitive
             // skip creating icons for default MUDs as they are already created above
-            if (defaultGames.contains(profileName, Qt::CaseInsensitive)) {
+            if (mudlet::scmDefaultGames.contains(profileName, Qt::CaseInsensitive)) {
                 continue;
             }
 

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -138,7 +138,6 @@ private:
     QLineEdit* delete_profile_lineedit;
     QPushButton* delete_button;
     QString mDiscordApplicationId;
-    const QStringList mDefaultGames;
     QAction* mpAction_revealPassword;
     // true for the duration of the 'Copy profile' action
     bool mCopyingProfile {};

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2424,6 +2424,8 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 void mudlet::startAutoLogin(const QString& cliProfile)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    hostList += mudlet::self()->getDefaultGames();
+    hostList.removeDuplicates();
     bool openedProfile = false;
 
     for (auto& pHost : hostList) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2424,7 +2424,7 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 void mudlet::startAutoLogin(const QString& cliProfile)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-    hostList += mudlet::self()->getDefaultGames();
+    hostList += mudlet::scmDefaultGames;
     hostList.removeDuplicates();
     bool openedProfile = false;
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -258,7 +258,6 @@ public:
     void stopSounds();
     void playSound(const QString &s, int);
     QStringList getAvailableFonts();
-    const QStringList& getDefaultGames() const { return mDefaultGames; }
     std::pair<bool, QString> setProfileIcon(const QString& profile, const QString& newIconPath);
     std::pair<bool, QString> resetProfileIcon(const QString& profile);
 #if defined(Q_OS_WIN32)
@@ -431,6 +430,32 @@ public:
     // Options dialog when there's no active host
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
 
+    inline static const QStringList scmDefaultGames {
+        "3Scapes",
+        "Aardwolf",
+        "Achaea",
+        "Aetolia",
+        "Avalon.de",
+        "BatMUD",
+        "Clessidra",
+        "Fierymud",
+        "Imperian",
+        "Luminari",
+        "Lusternia",
+        "Materia Magica",
+        "Midnight Sun 2",
+        "Realms of Despair",
+        "Reinos de Leyenda",
+        "StickMUD",
+        "WoTMUD",
+        "ZombieMUD",
+        "Carrion Fields",
+        "Cleft of Dimensions",
+        "CoreMUD",
+        "God Wars II",
+        "Slothmud",
+        "Legends of the Jedi"
+    };
 
 public slots:
     void processEventLoopHack_timerRun();
@@ -652,32 +677,6 @@ private:
 
     // Whether multi-view is in effect:
     bool mMultiView;
-
-    const QStringList mDefaultGames = {"3Kingdoms",
-                                       "3Scapes",
-                                       "Aardwolf",
-                                       "Achaea",
-                                       "Aetolia",
-                                       "Avalon.de",
-                                       "BatMUD",
-                                       "Clessidra",
-                                       "Fierymud",
-                                       "Imperian",
-                                       "Luminari",
-                                       "Lusternia",
-                                       "Materia Magica",
-                                       "Midnight Sun 2",
-                                       "Realms of Despair",
-                                       "Reinos de Leyenda",
-                                       "StickMUD",
-                                       "WoTMUD",
-                                       "ZombieMUD",
-                                       "Carrion Fields",
-                                       "Cleft of Dimensions",
-                                       "CoreMUD",
-                                       "God Wars II",
-                                       "Slothmud",
-                                       "Legends of the Jedi"};
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -258,6 +258,7 @@ public:
     void stopSounds();
     void playSound(const QString &s, int);
     QStringList getAvailableFonts();
+    const QStringList& getDefaultGames() const { return mDefaultGames; }
     std::pair<bool, QString> setProfileIcon(const QString& profile, const QString& newIconPath);
     std::pair<bool, QString> resetProfileIcon(const QString& profile);
 #if defined(Q_OS_WIN32)
@@ -429,6 +430,7 @@ public:
 
     // Options dialog when there's no active host
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
+
 
 public slots:
     void processEventLoopHack_timerRun();
@@ -650,6 +652,32 @@ private:
 
     // Whether multi-view is in effect:
     bool mMultiView;
+
+    const QStringList mDefaultGames = {"3Kingdoms",
+                                       "3Scapes",
+                                       "Aardwolf",
+                                       "Achaea",
+                                       "Aetolia",
+                                       "Avalon.de",
+                                       "BatMUD",
+                                       "Clessidra",
+                                       "Fierymud",
+                                       "Imperian",
+                                       "Luminari",
+                                       "Lusternia",
+                                       "Materia Magica",
+                                       "Midnight Sun 2",
+                                       "Realms of Despair",
+                                       "Reinos de Leyenda",
+                                       "StickMUD",
+                                       "WoTMUD",
+                                       "ZombieMUD",
+                                       "Carrion Fields",
+                                       "Cleft of Dimensions",
+                                       "CoreMUD",
+                                       "God Wars II",
+                                       "Slothmud",
+                                       "Legends of the Jedi"};
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
`--profile` didn't work for a default game that was not launched yet manually - this fixes it.