### PR TITLE
BugFix: pass correct string length to zip_set_archive_comment(...)

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -979,18 +979,18 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
     }
 
     if (isOk) {
-        // THIS is the point that the archive gets created from the
-        // source materials - it may take a short while!
-        // If it fails to write out the new file 'archive' is left
-        // unchanged (and we can still access it to get the error
-        // details):
-        zip_set_archive_comment(archive, packageConfig.toUtf8().constData(), packageConfig.length());
+        zip_set_archive_comment(archive, packageConfig.toUtf8().constData(), packageConfig.toUtf8().length());
 
 #ifdef LIBZIP_SUPPORTS_CANCELLING
         auto cancel_callback = [](zip*, void*) -> int { return !mExportingPackage; };
         zip_register_cancel_callback_with_state(archive, cancel_callback, nullptr, nullptr);
 #endif
 
+        // THIS is the point that the archive gets created from the
+        // source materials - it may take a short while!
+        // If it fails to write out the new file 'archive' is left
+        // unchanged (and we can still access it to get the error
+        // details):
         ze = zip_close(archive);
         if (ze) {
             // libzip's C interface around the error message isn't trivial - so copy it over into Qt land where things are simpler


### PR DESCRIPTION
The previous code was passing the length of a `QString` i.e. UTF-16BE encoded data but the function needs to have the length of the string when it is UTF-8 encoded (in bytes/chars) in a `QByteArray`. Whilst these values will be the same if the string is purely an ASCII character one they will be different as soon as the string contains characters outside of that range of values.

It also repositions an adjacent comment that was in the wrong place because of other additions to the same area of code.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>