### PR TITLE
Refactor: remove unneeded SLOT function

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -98,8 +98,6 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     connect(ui->lineEdit_packageName, &QLineEdit::textChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     connect(this, &dlgPackageExporter::signal_exportLocationChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     slot_updateLocationPlaceholder();
-    connect(ui->lineEdit_packageName, &QLineEdit::textChanged, this, &dlgPackageExporter::slot_enableExportButton);
-    slot_enableExportButton(QString());
     connect(ui->packageList, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgPackageExporter::slot_packageChanged);
     connect(ui->addDependency, &QPushButton::clicked, this, &dlgPackageExporter::slot_addDependency);
     connect(ui->pushButton_addIcon, &QPushButton::clicked, this, &dlgPackageExporter::slot_import_icon);
@@ -315,19 +313,18 @@ void dlgPackageExporter::slot_updateLocationPlaceholder()
         path = tr("Export to %1").arg(QStringLiteral("%1/%2.mpackage").arg(getActualPath(), packageName));
     }
 
+    checkToEnableExportButton();
+
     ui->lineEdit_filePath->setPlaceholderText(path);
 }
 
-void dlgPackageExporter::slot_enableExportButton(const QString& text)
+void dlgPackageExporter::checkToEnableExportButton()
 {
-    Q_UNUSED(text);
-
     if (ui->lineEdit_packageName->text().isEmpty() || mExportingPackage) {
         mExportButton->setEnabled(false);
-        return;
+    } else {
+        mExportButton->setEnabled(true);
     }
-
-    mExportButton->setEnabled(true);
 }
 
 void dlgPackageExporter::slot_import_icon()
@@ -478,7 +475,7 @@ void dlgPackageExporter::slot_export_package()
 
     mExportingPackage = true;
     QApplication::setOverrideCursor(Qt::BusyCursor);
-    slot_enableExportButton({});
+    checkToEnableExportButton();
 
 #if LIBZIP_SUPPORTS_CANCELLING
     mCancelButton->setVisible(true);
@@ -509,7 +506,7 @@ void dlgPackageExporter::slot_export_package()
                              .arg(mXmlPathFileName), false);
         assetsFuture.cancel();
         mExportingPackage = false;
-        slot_enableExportButton({});
+        checkToEnableExportButton();
         QApplication::restoreOverrideCursor();
         return;
     }
@@ -542,7 +539,7 @@ void dlgPackageExporter::slot_export_package()
             auto watcher = new QFutureWatcher<std::pair<bool, QString>>;
             QObject::connect(watcher, &QFutureWatcher<std::pair<bool, QString>>::finished, [=]() {
                 mExportingPackage = false;
-                slot_enableExportButton({});
+                checkToEnableExportButton();
 
                 if (auto [isOk, errorMsg] = future.result(); !isOk) {
                     displayResultMessage(errorMsg);
@@ -564,7 +561,7 @@ void dlgPackageExporter::slot_export_package()
         displayResultMessage(tr("Exporting package..."), true);
     } else {
         mExportingPackage = false;
-        slot_enableExportButton({});
+        checkToEnableExportButton();
         mCancelButton->setVisible(false);
         mCloseButton->setVisible(true);
         QApplication::restoreOverrideCursor();
@@ -1462,7 +1459,7 @@ QString dlgPackageExporter::getActualPath() const
 void dlgPackageExporter::slot_cancelExport()
 {
     mExportingPackage = false;
-    slot_enableExportButton({});
+    checkToEnableExportButton();
 
     mCancelButton->setVisible(false);
     mCloseButton->setVisible(true);

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -96,7 +96,6 @@ private slots:
     void slot_openPackageLocation();
     void slot_packageChanged(int);
     void slot_updateLocationPlaceholder();
-    void slot_enableExportButton(const QString &text);
     void slot_recountItems(QTreeWidgetItem *item);
     void slot_rightClickOnItems(const QPoint &point);
     void slot_cancelExport();
@@ -133,6 +132,7 @@ private:
                          QList<QTreeWidgetItem*>& keyList);
     QString copyNewImagesToTmp(const QString& tempPath) const;
     static void cleanupUnusedImages(const QString& tempPath, const QString& plainDescription);
+    void checkToEnableExportButton();
 
     Ui::dlgPackageExporter* ui;
     QPointer<Host> mpHost;


### PR DESCRIPTION
The same effect can just as easily be done with a normal method - and there is no need for an argument that is no-longer used since the package exporter was redesigned by someone else after my previous work.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>