### PR TITLE
Revise: fixup some package exporter results messages

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -535,7 +535,7 @@ void dlgPackageExporter::slot_export_package()
         assetsFuture.waitForFinished();
         cleanupUnusedImages(tempPath, plainDescription);
         if (auto [success, message] = assetsFuture.result(); !success) {
-            displayResultMessage(message);
+            displayResultMessage(message, false);
             isOk = false;
         } else {
             auto future = QtConcurrent::run(dlgPackageExporter::zipPackage, stagingDirName, mPackagePathFileName, mXmlPathFileName, mPackageName, mPackageConfig);
@@ -545,11 +545,11 @@ void dlgPackageExporter::slot_export_package()
                 slot_enableExportButton({});
 
                 if (auto [isOk, errorMsg] = future.result(); !isOk) {
-                    displayResultMessage(errorMsg);
+                    displayResultMessage(errorMsg, false);
                 } else {
                     displayResultMessage(tr("Package \"%1\" exported to: %2")
-                                                 .arg(mPackageName, QStringLiteral("<a href=\"file:///%1\">%2</a>"))
-                                                 .arg(getActualPath().toHtmlEscaped(), getActualPath().toHtmlEscaped()),
+                                                 .arg(mPackageName, QStringLiteral("<a href=\"file:///%1\">%1</a>")
+                                                                            .arg(getActualPath().toHtmlEscaped())),
                                          true);
                 }
                 mCancelButton->setVisible(false);


### PR DESCRIPTION
Two of them were missing the `(bool) false` flag needed to make them show in red to indicate they are failure messages, and a third was providing a two identical `QString::arg` values (as `QString::arg(xxx, xxx)`) when only one (and the same `%1` parameter) is needed.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>