### PR TITLE
BugFix: use proper C Preprocessor form

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -488,7 +488,7 @@ void dlgPackageExporter::slot_export_package()
     QApplication::setOverrideCursor(Qt::BusyCursor);
     slot_enableExportButton({});
 
-#if LIBZIP_SUPPORTS_CANCELLING
+#if defined(LIBZIP_SUPPORTS_CANCELLING)
     mCancelButton->setVisible(true);
 #endif
 
@@ -994,7 +994,7 @@ dlgPackageExporter::zipPackage(const QString& stagingDirName, const QString& pac
         // details):
         zip_set_archive_comment(archive, packageConfig.toUtf8().constData(), packageConfig.length());
 
-#ifdef LIBZIP_SUPPORTS_CANCELLING
+#if defined(LIBZIP_SUPPORTS_CANCELLING)
         auto cancel_callback = [](zip*, void*) -> int { return !mExportingPackage; };
         zip_register_cancel_callback_with_state(archive, cancel_callback, nullptr, nullptr);
 #endif

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1557,6 +1557,9 @@ unix:!macx {
 
 
 DISTFILES += \
+    ../docker/Dockerfile \
+    ../docker/docker-compose.override.linux.yml \
+    ../docker/docker-compose.yml \
     CF-loader.xml \
     CMakeLists.txt \
     .clang-format \


### PR DESCRIPTION
Using a only potentially defined symbol directly in a preprocessor `#if` lights up as a warning in the QtCreator IDE when the symbol is NOT defined.

It is cleaner to use the `defined(...)` macro(?)...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>