### PR TITLE
Prevent addCustomLine crash when passing empty table of points

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7914,6 +7914,10 @@ int TLuaInterpreter::addCustomLine(lua_State* L)
     }
 
     bool arrow = getVerifiedBool(L, __func__, 6, "end with arrow");
+    if (z.empty()) {
+        lua_pushfstring(L, "addCustomLine: bad argument #2 (points table cannot be empty)");
+        return lua_error(L);
+    }
     int lz = z.at(0);
     QList<QPointF> points;
     // TODO: make provision for 3D custom lines (and store the z coordinates and allow them to vary)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

I've run across into issue when Mudlet was crashing when adding some bulk of custom lines.
Turned out, points table wasn't created correctly and passing empty table completely crashed Mudlet.

#### Motivation for adding to Mudlet

We don't want Mudlet to crash! :)

#### Other info (issues closed, discussion etc)

"Crash code"

```lua
addCustomLine(1, {}, "n", "solid line", {255,0,0}, false)
```

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
