### PR TITLE
Fix loading Mudlet's self-test profile with the --profile argument

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2425,6 +2425,7 @@ void mudlet::startAutoLogin(const QString& cliProfile)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
     hostList += mudlet::scmDefaultGames;
+    hostList << QStringLiteral("Mudlet self-test");
     hostList.removeDuplicates();
     bool openedProfile = false;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix `--profile "Mudlet self-test"` to work - it got missed in 
#### Motivation for adding to Mudlet
So self-tests in CI can be launched
#### Other info (issues closed, discussion etc)
Builds upon https://github.com/Mudlet/Mudlet/pull/5354
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
