### PR TITLE
BugFix: make optional part of package exporter UI expand if there is space

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -94,7 +94,7 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     mXmlPathFileName.clear();
     connect(ui->addFiles, &QAbstractButton::clicked, this, &dlgPackageExporter::slot_addFiles);
     connect(mExportButton, &QAbstractButton::clicked, this, &dlgPackageExporter::slot_export_package);
-    connect(ui->pushBotton_packageLocation, &QPushButton::clicked, this, &dlgPackageExporter::slot_openPackageLocation);
+    connect(ui->pushButton_packageLocation, &QPushButton::clicked, this, &dlgPackageExporter::slot_openPackageLocation);
     connect(ui->lineEdit_packageName, &QLineEdit::textChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     connect(this, &dlgPackageExporter::signal_exportLocationChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     slot_updateLocationPlaceholder();

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -137,7 +137,7 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <layout class="QFormLayout" name="formLayout_metadata">
+          <layout class="QGridLayout" name="gridLayout_metadata">
            <property name="leftMargin">
             <number>0</number>
            </property>

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>566</width>
-    <height>824</height>
+    <height>825</height>
    </rect>
   </property>
   <property name="maximumSize">
@@ -21,32 +21,34 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_packageName">
-     <item>
-      <widget class="QLineEdit" name="lineEdit_packageName">
-       <property name="placeholderText">
-        <string>Package name here</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>or</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="packageList">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="editable">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QWidget" name="widget_newOrExistingPackageName" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_packageName">
+      <item>
+       <widget class="QLineEdit" name="lineEdit_packageName">
+        <property name="placeholderText">
+         <string>Package name here</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_or">
+        <property name="text">
+         <string>or</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="packageList">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="editable">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QSplitter" name="splitter_metadata">
@@ -110,10 +112,16 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
-         <widget class="QWidget" name="layoutWidget">
+         <widget class="QWidget" name="widget_optionalsForm" native="true">
           <layout class="QFormLayout" name="formLayout_metadata">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
            <item row="0" column="0">
-            <widget class="QLabel" name="label_4">
+            <widget class="QLabel" name="label_author">
              <property name="text">
               <string>Author</string>
              </property>
@@ -139,63 +147,74 @@
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_3">
+            <widget class="QLabel" name="label_icon">
              <property name="text">
               <string>Icon</string>
+             </property>
+             <property name="buddy">
+              <cstring>pushButton_addIcon</cstring>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QPushButton" name="pushButton_addIcon">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>Icon size of 512x512 recommended</string>
-               </property>
-               <property name="text">
-                <string>Add icon</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="Icon">
-               <property name="minimumSize">
-                <size>
-                 <width>48</width>
-                 <height>48</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>48</width>
-                 <height>48</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>Icon size of 512x512 recommended</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>512x512 recommended</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <widget class="QWidget" name="widget_icon" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QPushButton" name="pushButton_addIcon">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Icon size of 512x512 recommended</string>
+                </property>
+                <property name="text">
+                 <string>Add icon</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="Icon">
+                <property name="minimumSize">
+                 <size>
+                  <width>48</width>
+                  <height>48</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>48</width>
+                  <height>48</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>Icon size of 512x512 recommended</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>512x512 recommended</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_7">
+            <widget class="QLabel" name="label_shortDescription">
              <property name="text">
               <string>Short description</string>
              </property>
@@ -215,7 +234,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_5">
+            <widget class="QLabel" name="label_detailedDescription">
              <property name="text">
               <string>Description</string>
              </property>
@@ -235,7 +254,7 @@
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_8">
+            <widget class="QLabel" name="label_version">
              <property name="text">
               <string>Version</string>
              </property>
@@ -252,7 +271,7 @@
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_9">
+            <widget class="QLabel" name="label_requiredPackages">
              <property name="toolTip">
               <string>Does this package make use of other packages? List them here as requirements</string>
              </property>
@@ -265,52 +284,66 @@
             </widget>
            </item>
            <item row="5" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_dependencies">
-             <item>
-              <widget class="QComboBox" name="DependencyList">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-             <item alignment="Qt::AlignHCenter">
-              <widget class="QPushButton" name="addDependency">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string notr="true">+</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="comboBox_dependencies">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>Does this package make use of other packages? List them here as requirements. Press 'Delete' to remove a package</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <widget class="QWidget" name="widget_requiredPackages" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_dependencies">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QComboBox" name="DependencyList">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>150</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignHCenter">
+               <widget class="QPushButton" name="addDependency">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string notr="true">+</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="comboBox_dependencies">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="toolTip">
+                 <string>Does this package make use of other packages? List them here as requirements. Press 'Delete' to remove a package</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </widget>
          <widget class="QWidget" name="widget_assets" native="true">
           <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
            <item>
             <widget class="QLabel" name="label_assets">
              <property name="sizePolicy">
@@ -342,50 +375,61 @@
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <item>
-              <spacer name="horizontalSpacer_2">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="addFiles">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="layoutDirection">
-                <enum>Qt::LeftToRight</enum>
-               </property>
-               <property name="text">
-                <string>Select files to include in package</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
+            <widget class="QWidget" name="widget_addFilesButton" native="true">
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QPushButton" name="addFiles">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="text">
+                 <string>Select files to include in package</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -397,8 +441,14 @@
    </item>
    <item>
     <widget class="QWidget" name="widget_exportLocation" native="true">
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="1">
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
        <widget class="QLineEdit" name="lineEdit_filePath">
         <property name="frame">
          <bool>false</bool>
@@ -408,8 +458,8 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="pushBotton_packageLocation">
+      <item>
+       <widget class="QPushButton" name="pushButton_packageLocation">
         <property name="text">
          <string>Select export location</string>
         </property>
@@ -497,12 +547,12 @@
    <slot>showMenu()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>311</x>
-     <y>249</y>
+     <x>330</x>
+     <y>216</y>
     </hint>
     <hint type="destinationlabel">
-     <x>311</x>
-     <y>249</y>
+     <x>330</x>
+     <y>216</y>
     </hint>
    </hints>
   </connection>
@@ -513,8 +563,8 @@
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>282</x>
-     <y>237</y>
+     <x>301</x>
+     <y>216</y>
     </hint>
     <hint type="destinationlabel">
      <x>282</x>

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -66,6 +66,12 @@
        <string>Select what to export</string>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QTreeWidget" name="treeWidget_exportSelection">
          <attribute name="headerVisible">
@@ -135,7 +141,13 @@
            <property name="leftMargin">
             <number>0</number>
            </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
            <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item row="0" column="0">
@@ -180,7 +192,13 @@
               <property name="leftMargin">
                <number>0</number>
               </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
               <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -313,7 +331,13 @@
               <property name="leftMargin">
                <number>0</number>
               </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
               <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -52,6 +52,12 @@
    </item>
    <item>
     <widget class="QSplitter" name="splitter_metadata">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -76,7 +82,7 @@
      </widget>
      <widget class="QFrame" name="frame_metadata">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+       <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
@@ -89,7 +95,7 @@
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QPushButton" name="pushBotton_openInfos">
+        <widget class="QPushButton" name="pushButton_openInfos">
          <property name="focusPolicy">
           <enum>Qt::TabFocus</enum>
          </property>
@@ -109,10 +115,22 @@
        </item>
        <item>
         <widget class="QSplitter" name="splitter_metadataAssets">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
          <widget class="QWidget" name="widget_optionalsForm" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <layout class="QFormLayout" name="formLayout_metadata">
            <property name="leftMargin">
             <number>0</number>
@@ -285,7 +303,13 @@
            </item>
            <item row="5" column="1">
             <widget class="QWidget" name="widget_requiredPackages" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_dependencies">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_dependencies" stretch="1,0,1">
               <property name="leftMargin">
                <number>0</number>
               </property>
@@ -295,16 +319,10 @@
               <item>
                <widget class="QComboBox" name="DependencyList">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
-                </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>150</width>
-                  <height>16777215</height>
-                 </size>
                 </property>
                </widget>
               </item>
@@ -337,6 +355,12 @@
           </layout>
          </widget>
          <widget class="QWidget" name="widget_assets" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <property name="leftMargin">
             <number>0</number>
@@ -503,7 +527,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>pushBotton_openInfos</tabstop>
+  <tabstop>pushButton_openInfos</tabstop>
   <tabstop>lineEdit_filePath</tabstop>
  </tabstops>
  <resources/>
@@ -541,9 +565,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>pushBotton_openInfos</sender>
+   <sender>pushButton_openInfos</sender>
    <signal>toggled(bool)</signal>
-   <receiver>pushBotton_openInfos</receiver>
+   <receiver>pushButton_openInfos</receiver>
    <slot>showMenu()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -557,7 +581,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>pushBotton_openInfos</sender>
+   <sender>pushButton_openInfos</sender>
    <signal>toggled(bool)</signal>
    <receiver>splitter_metadataAssets</receiver>
    <slot>setVisible(bool)</slot>


### PR DESCRIPTION
This will close #5352.

The issue is that several `QLayouts` have been included on their own instead of being assigned to a `QWidget` or other container widget. The fix is to "morph" them into `QWidgets` which makes the later take on that layout. In doing so I realised that where there were nested layouts (one inside the other) there was some duplication of left/right margins so that some of the displayed widgets were not as wide as some others; this was improved by setting some of the left/right margins to zero.

It also corrects the spelling of a `QPushButton` pointer,
from: `pushBotton_packageLocation`
to: `pushButton_packageLocation`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>