### PR TITLE
Upload vcpkg error logs in case of 3rd party dependency failure

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -246,7 +246,7 @@ jobs:
         NINJA_STATUS: '[%f/%t %o/sec] '
 
     - name: Upload GitHub Actions artifact of vcpkg build logs
-      if: error()
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: vcpkg-logs-${{ runner.os }}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -245,6 +245,13 @@ jobs:
       env:
         NINJA_STATUS: '[%f/%t %o/sec] '
 
+    - name: Upload GitHub Actions artifact of vcpkg build logs
+      if: error()
+      uses: actions/upload-artifact@v2
+      with:
+        name: vcpkg-logs-${{ runner.os }}
+        path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
+
     - name: (Linux/macOS) check ccache stats post build
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: ccache --show-stats


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Upload vcpkg error logs in case of 3rd party dependency failure
#### Motivation for adding to Mudlet
Easier github actions debugging for anything vcpkg-based