### PR TITLE
fix: description images are not removed anymore from a newly created package

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -633,7 +633,7 @@ QString dlgPackageExporter::copyNewImagesToTmp(const QString& tempPath) const
 // purge images from tmp which are no longer used by the description
 void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QString& plainDescription)
 {
-    static QRegularExpression imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\")");
+    static QRegularExpression imagesInUsePattern(R"(\$packagePath\/\.mudlet\/description_images\/(.+?)\.)");
     QStringList imagesInUse;
     QRegularExpressionMatchIterator i = imagesInUsePattern.globalMatch(plainDescription);
     while (i.hasNext()) {
@@ -645,7 +645,7 @@ void dlgPackageExporter::cleanupUnusedImages(const QString& tempPath, const QStr
     QDirIterator allImagesCopied(QStringLiteral("%1.mudlet/description_images").arg(tempPath), QDir::Files);
     while (allImagesCopied.hasNext()) {
         QFileInfo copiedImage(allImagesCopied.next());
-        if (!imagesInUse.contains(copiedImage.fileName())) {
+        if (!imagesInUse.contains(copiedImage.baseName())) {
             if (!QFile(copiedImage.absoluteFilePath()).remove()) {
                 qDebug() << "couldn't remove unused image" << copiedImage.fileName();
             }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
changes in #5191 caused an issue which lead to every description image being remove
when a package was created

#### Motivation for adding to Mudlet
only not needed images should be deleted

#### Other info (issues closed, discussion etc)
was not noticed earlier as it was only introduced by the last commit (merging development in #5191)

