### PR TITLE
Add pause, stop, and resume functions to complement speedwalk()

### DIFF
--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -440,7 +440,14 @@ end
 
 --- Resumes a paused speedwalk
 function resumeSpeedwalk()
-  if speedwalkTimerID then return end
+  if speedwalkTimerID then
+    debugc("resumeSpeedwalk(): attempted to resume an already running speedwalk")
+    return
+  end
+  if not speedwalkList or table.is_empty(speedwalkList) then
+    debugc("resumeSpeedwalk(): attempted to resume a speedwalk but no active speedwalk found")
+    return
+  end
   speedwalktimer(speedwalkList, speedwalkDelay, speedwalkShow)
 end
 

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -413,12 +413,36 @@ function table.unpickle( t, tables, tcopy, pickled )
 end
 
 
+
+--- local functions used for pausing/resuming a speedwalk
 local speedwalkTimerID
+local speedwalkDelay
+local speedwalkList
+local speedwalkShow
+
+--- Stops a speedwalk and clears the walklist
 function stopSpeedwalk()
+  pauseSpeedwalk()
+  speedwalkList = {}
+end
+
+
+
+--- pauses a running speedwalk, but leaves the walklist intact in case you want to resume
+function pauseSpeedwalk()
   if speedwalkTimerID then
     killTimer(speedwalkTimerID)
+    speedwalkTimerID = false
   end
 end
+
+
+
+--- Resumes a paused speedwalk
+function resumeSpeedWalk()
+  speedwalktimer(speedwalkList, speedwalkDelay, speedwalkShow)
+end
+
 
 --- <b><u>TODO</u></b> speedwalktimer()
 function speedwalktimer(walklist, walkdelay, show)
@@ -438,6 +462,8 @@ function speedwalk(dirString, backwards, delay, show)
   local dirString = dirString:lower()
   local walkdelay = delay
   if show ~= false then show = true end
+  speedwalkShow = show
+  speedwalkDelay = delay
   local walklist = {}
   local long_dir = {north = 'n', south = 's', east = 'e', west = 'w', up = 'u', down = 'd'}
   for k,v in pairs(long_dir) do
@@ -479,6 +505,7 @@ function speedwalk(dirString, backwards, delay, show)
     end
   end
   if walkdelay then
+    speedwalkList = walklist
     speedwalktimer(walklist, walkdelay, show)
   end
 end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -439,7 +439,7 @@ end
 
 
 --- Resumes a paused speedwalk
-function resumeSpeedWalk()
+function resumeSpeedwalk()
   if speedwalkTimerID then return end
   speedwalktimer(speedwalkList, speedwalkDelay, speedwalkShow)
 end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -422,8 +422,12 @@ local speedwalkShow
 
 --- Stops a speedwalk and clears the walklist
 function stopSpeedwalk()
-  pauseSpeedwalk()
-  speedwalkList = {}
+  local active = pauseSpeedwalk()
+  if active then 
+    speedwalkList = {}
+    return true
+  end
+  return nil, "stopSpeedwalk(): no active speedwalk found"
 end
 
 
@@ -433,7 +437,9 @@ function pauseSpeedwalk()
   if speedwalkTimerID then
     killTimer(speedwalkTimerID)
     speedwalkTimerID = false
+    return true
   end
+  return nil, "pauseSpeedwalk(): no active speedwalk found"
 end
 
 
@@ -441,14 +447,13 @@ end
 --- Resumes a paused speedwalk
 function resumeSpeedwalk()
   if speedwalkTimerID then
-    debugc("resumeSpeedwalk(): attempted to resume an already running speedwalk")
-    return
+    return nil, "resumeSpeedwalk(): attempted to resume an already running speedwalk"
   end
   if not speedwalkList or table.is_empty(speedwalkList) then
-    debugc("resumeSpeedwalk(): attempted to resume a speedwalk but no active speedwalk found")
-    return
+    return nil, "resumeSpeedwalk(): attempted to resume a speedwalk but no active speedwalk found"
   end
   speedwalktimer(speedwalkList, speedwalkDelay, speedwalkShow)
+  return true
 end
 
 

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -413,13 +413,19 @@ function table.unpickle( t, tables, tcopy, pickled )
 end
 
 
+local speedwalkTimerID
+function stopSpeedwalk()
+  if speedwalkTimerID then
+    killTimer(speedwalkTimerID)
+  end
+end
 
 --- <b><u>TODO</u></b> speedwalktimer()
 function speedwalktimer(walklist, walkdelay, show)
   send(walklist[1], show)
   table.remove(walklist, 1)
   if #walklist > 0 then
-    tempTimer(walkdelay, function()
+    speedwalkTimerID = tempTimer(walkdelay, function()
       speedwalktimer(walklist, walkdelay, show)
     end)
   end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -440,6 +440,7 @@ end
 
 --- Resumes a paused speedwalk
 function resumeSpeedWalk()
+  if speedwalkTimerID then return end
   speedwalktimer(speedwalkList, speedwalkDelay, speedwalkShow)
 end
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adds the following functions:

* stopSpeedwalk()
  * Stops the running speedwalk and clears the walklist
* pauseSpeedwalk()
  * Pauses the running speedwalk, but leaves the walklist intact so you can
* resumeSpeedwalk()
  * resumes a paused speedwalk

#### Motivation for adding to Mudlet

Resolves https://github.com/Mudlet/Mudlet/issues/5369

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
