### PR TITLE
Fix missing include

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -27,6 +27,7 @@
 #include "Host.h"
 #include "HostManager.h"
 #include "LuaInterface.h"
+#include <optional>
 #include "XMLimport.h"
 #include "mudlet.h"
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -27,7 +27,6 @@
 #include "Host.h"
 #include "HostManager.h"
 #include "LuaInterface.h"
-#include <optional>
 #include "XMLimport.h"
 #include "mudlet.h"
 

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -25,6 +25,7 @@
 
 #include "pre_guard.h"
 #include "ui_connection_profiles.h"
+#include <optional>
 #include <QTimer>
 #include <QKeyEvent>
 #include <pugixml.hpp>


### PR DESCRIPTION
Just a small fix to enable compiling again.
Not sure if adding the include to both places was necessary, but can't hurt.

Please merge, thank you.