### PR TITLE
Remove `experimental` label from the package exporter

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -453,7 +453,7 @@ mudlet::mudlet()
     mpActionModuleManager->setIcon(QIcon(QStringLiteral(":/icons/module-manager.png")));
     mpActionModuleManager->setObjectName(QStringLiteral("module_manager"));
 
-    mpActionPackageExporter = new QAction(tr("Package Exporter (experimental)"), this);
+    mpActionPackageExporter = new QAction(tr("Package Exporter"), this);
     mpActionPackageExporter->setIcon(QIcon(QStringLiteral(":/icons/package-exporter.png")));
     mpActionPackageExporter->setObjectName(QStringLiteral("package_exporter"));
 

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Package Exporter (experimental)</string>
+   <string>Package Exporter</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -279,7 +279,7 @@
   </action>
   <action name="dactionPackageExporter">
    <property name="text">
-    <string>Package exporter (experimental)</string>
+    <string>Package exporter</string>
    </property>
    <property name="toolTip">
     <string>&lt;p&gt;Gather and bundle up collections of Mudlet Lua items and other reasources into a module.&lt;/p&gt;</string>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove `experimental` label from the package exporter
#### Motivation for adding to Mudlet
It's been hammered out pretty well over the last couple of months and the known issues have been solved
#### Other info (issues closed, discussion etc)
Package manager isn't quite there yet - I feel like we can do a better job on the design