### PR TITLE
Fix `--profile` to load connection info for first-time profiles (2/2)

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -878,83 +878,9 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
     QString host_url = readProfileData(profile_name, QStringLiteral("url"));
     if (host_url.isEmpty()) {
         // Host to connect to, see below for port
-        if (profile_name == QStringLiteral("Avalon.de")) {
-            host_url = QStringLiteral("avalon.mud.de");
-        }
-        if (profile_name == QStringLiteral("God Wars II")) {
-            host_url = QStringLiteral("godwars2.org");
-        }
-        if (profile_name == QStringLiteral("Materia Magica")) {
-            host_url = QStringLiteral("materiamagica.com");
-        }
-        if (profile_name == QStringLiteral("BatMUD")) {
-            host_url = QStringLiteral("batmud.bat.org");
-        }
-        if (profile_name == QStringLiteral("Aardwolf")) {
-            host_url = QStringLiteral("aardmud.org");
-        }
-        if (profile_name == QStringLiteral("Achaea")) {
-            host_url = QStringLiteral("achaea.com");
-        }
-        if (profile_name == QStringLiteral("Aetolia")) {
-            host_url = QStringLiteral("aetolia.com");
-        }
-        if (profile_name == QStringLiteral("Lusternia")) {
-            host_url = QStringLiteral("lusternia.com");
-        }
-        if (profile_name == QStringLiteral("Imperian")) {
-            host_url = QStringLiteral("imperian.com");
-        }
-        if (profile_name == QStringLiteral("Realms of Despair")) {
-            host_url = QStringLiteral("realmsofdespair.com");
-        }
-        if (profile_name == QStringLiteral("ZombieMUD")) {
-            host_url = QStringLiteral("zombiemud.org");
-        }
-        if (profile_name == QStringLiteral("Carrion Fields")) {
-            host_url = QStringLiteral("carrionfields.net");
-        }
-        if (profile_name == QStringLiteral("Cleft of Dimensions")) {
-            host_url = QStringLiteral("cleftofdimensions.net");
-        }
-        if (profile_name == QStringLiteral("3Scapes")) {
-            host_url = QStringLiteral("3k.org");
-        }
-        if (profile_name == QStringLiteral("3Kingdoms")) {
-            host_url = QStringLiteral("3k.org");
-        }
-        if (profile_name == QStringLiteral("Slothmud")) {
-            host_url = QStringLiteral("slothmud.org");
-        }
-        if (profile_name == QStringLiteral("WoTMUD")) {
-            host_url = QStringLiteral("game.wotmud.org");
-        }
-        if (profile_name == QStringLiteral("Midnight Sun 2")) {
-            host_url = QStringLiteral("midnightsun2.org");
-        }
-        if (profile_name == QStringLiteral("Luminari")) {
-            host_url = QStringLiteral("luminarimud.com");
-        }
-        if (profile_name == QStringLiteral("StickMUD")) {
-            host_url = QStringLiteral("stickmud.com");
-        }
-        if (profile_name == QStringLiteral("Clessidra")) {
-            host_url = QStringLiteral("mud.clessidra.it");
-        }
-        if (profile_name == QStringLiteral("Reinos de Leyenda")) {
-            host_url = QStringLiteral("reinosdeleyenda.es");
-        }
-        if (profile_name == QStringLiteral("Fierymud")) {
-            host_url = QStringLiteral("fierymud.org");
-        }
-        if (profile_name == QStringLiteral("Mudlet self-test")) {
-            host_url = QStringLiteral("mudlet.org");
-        }
-        if (profile_name == QStringLiteral("CoreMUD")) {
-            host_url = QStringLiteral("coremud.org");
-        }
-        if (profile_name == QStringLiteral("Legends of the Jedi")) {
-            host_url = QStringLiteral("legendsofthejedi.com");
+        const auto it = mudlet::scmDefaultGames.constFind(profile_name);
+        if (it != mudlet::scmDefaultGames.cend()) {
+            host_url = it->hostUrl;
         }
     }
     host_name_entry->setText(host_url);
@@ -968,125 +894,10 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
     }
 
     if (host_port.isEmpty()) {
-        if (profile_name == QStringLiteral("Avalon.de")) {
-            //host_url = QStringLiteral("avalon.mud.de");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("God Wars II")) {
-            //host_url = QStringLiteral("godwars2.org");
-            host_port = QStringLiteral("3000");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Materia Magica")) {
-            //host_url = QStringLiteral("materiamagica.com");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("BatMUD")) {
-            //host_url = QStringLiteral("batmud.bat.org");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Aardwolf")) {
-            //host_url = QStringLiteral("aardmud.org");
-            host_port = QStringLiteral("4000");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Achaea")) {
-            //host_url = QStringLiteral("achaea.com");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Aetolia")) {
-            //host_url = QStringLiteral("aetolia.com");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Lusternia")) {
-            //host_url = QStringLiteral("lusternia.com");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Imperian")) {
-            //host_url = QStringLiteral("imperian.com");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Realms of Despair")) {
-            //host_url = QStringLiteral("realmsofdespair.com");
-            host_port = QStringLiteral("4000");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("ZombieMUD")) {
-            //host_url = QStringLiteral("zombiemud.org");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Carrion Fields")) {
-            host_port = QStringLiteral("4449");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Cleft of Dimensions")) {
-            host_port = QStringLiteral("4354");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("3Scapes")) {
-            //host_url = QStringLiteral("3k.org");
-            host_port = QStringLiteral("3200");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("3Kingdoms")) {
-            //host_url = QStringLiteral("3k.org");
-            host_port = QStringLiteral("3000");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Slothmud")) {
-            //host_url = QStringLiteral("slothmud.org");
-            host_port = QStringLiteral("6101");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("WoTMUD")) {
-            //host_url = QStringLiteral("game.wotmud.org");
-            host_port = QStringLiteral("2224");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Midnight Sun 2")) {
-            //host_url = QStringLiteral("midnightsun2.org");
-            host_port = QStringLiteral("3000");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Luminari")) {
-            //host_url = QStringLiteral("luminarimud.com");
-            host_port = QStringLiteral("4100");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("StickMUD")) {
-            host_port = QStringLiteral("7680");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Clessidra")) {
-            host_port = QStringLiteral("4000");
-        }
-        if (profile_name == QStringLiteral("Reinos de Leyenda")) {
-            //host_url = QStringLiteral("reinosdeleyenda.es");
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Fierymud")) {
-            host_port = QStringLiteral("4000");
-        }
-        if (profile_name == QStringLiteral("CoreMUD")) {
-            host_port = QStringLiteral("4000");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Legends of the Jedi")) {
-            host_port = QStringLiteral("5656");
-            port_ssl_tsl->setChecked(false);
-        }
-        if (profile_name == QStringLiteral("Mudlet self-test")) {
-            host_port = QStringLiteral("23");
-            port_ssl_tsl->setChecked(false);
+        const auto it = mudlet::scmDefaultGames.constFind(profile_name);
+        if (it != mudlet::scmDefaultGames.cend()) {
+            host_port = QString::number(it->port);
+            port_ssl_tsl->setChecked(it->tlsEnabled);
         }
     }
 
@@ -1142,83 +953,9 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
 
     val = readProfileData(profile_name, QStringLiteral("website"));
     if (val.isEmpty()) {
-        if (profile_name == QStringLiteral("Avalon.de")) {
-            val = QStringLiteral("<center><a href='http://avalon.mud.de'>http://avalon.mud.de</a></center>");
-        }
-        if (profile_name == QStringLiteral("God Wars II")) {
-            val = QStringLiteral("<center><a href='http://www.godwars2.org'>http://www.godwars2.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("Materia Magica")) {
-            val = QStringLiteral("<center><a href='http://www.materiamagica.com'>http://www.materiamagica.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("BatMUD")) {
-            val = QStringLiteral("<center><a href='http://www.bat.org'>http://www.bat.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("Aardwolf")) {
-            val = QStringLiteral("<center><a href='http://www.aardwolf.com/'>http://www.aardwolf.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("Achaea")) {
-            val = QStringLiteral("<center><a href='http://www.achaea.com/'>http://www.achaea.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("Realms of Despair")) {
-            val = QStringLiteral("<center><a href='http://www.realmsofdespair.com/'>http://www.realmsofdespair.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("ZombieMUD")) {
-            val = QStringLiteral("<center><a href='http://www.zombiemud.org/'>http://www.zombiemud.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("Carrion Fields")) {
-            val = QStringLiteral("<center><a href='http://www.carrionfields.net'>www.carrionfields.net</a></center>");
-        }
-        if (profile_name == QStringLiteral("Cleft of Dimensions")) {
-            val = QStringLiteral("<center><a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a></center>");
-        }
-        if (profile_name == QStringLiteral("Aetolia")) {
-            val = QStringLiteral("<center><a href='http://www.aetolia.com/'>http://www.aetolia.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("Lusternia")) {
-            val = QStringLiteral("<center><a href='http://www.lusternia.com/'>http://www.lusternia.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("Imperian")) {
-            val = QStringLiteral("<center><a href='http://www.imperian.com/'>http://www.imperian.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("3Scapes")) {
-            val = QStringLiteral("<center><a href='http://www.3scapes.org/'>http://www.3scapes.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("3Kingdoms")) {
-            val = QStringLiteral("<center><a href='http://www.3k.org/'>http://www.3k.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("Slothmud")) {
-            val = QStringLiteral("<center><a href='http://www.slothmud.org/'>http://www.slothmud.org/</a></center>");
-        }
-        if (profile_name == QStringLiteral("WoTMUD")) {
-            val = QStringLiteral("<center><a href='http://www.wotmud.org/'>Main website</a></center>\n"
-                                 "<center><a href='http://www.wotmod.org/'>Forums</a></center>");
-        }
-        if (profile_name == QStringLiteral("Midnight Sun 2")) {
-            val = QStringLiteral("<center><a href='http://midnightsun2.org/'>http://midnightsun2.org/</a></center>");
-        }
-        if (profile_name == QStringLiteral("Luminari")) {
-            val = QStringLiteral("<center><a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a></center>");
-        }
-        if (profile_name == QStringLiteral("StickMUD")) {
-            val = QStringLiteral("<center><a href='http://www.stickmud.com/'>stickmud.com</a></center>");
-        }
-        if (profile_name == QStringLiteral("Clessidra")) {
-            val = QStringLiteral("<center><a href='http://www.clessidra.it/'>http://www.clessidra.it</a></center>");
-        }
-        if (profile_name == QStringLiteral("Fierymud")) {
-            val = QStringLiteral("<center><a href='https://www.fierymud.org/'>https://www.fierymud.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("Reinos de Leyenda")) {
-            val = QStringLiteral("<center><a href='https://www.reinosdeleyenda.es/'>Main website</a></center>\n"
-                                 "<center><a href='https://www.reinosdeleyenda.es/foro/'>Forums</a></center>\n"
-                                 "<center><a href='https://wiki.reinosdeleyenda.es/'>Wiki</a></center>\n");
-        }
-        if (profile_name == QStringLiteral("CoreMUD")) {
-            val = QStringLiteral("<center><a href='https://coremud.org/'>coremud.org</a></center>");
-        }
-        if (profile_name == QStringLiteral("Legends of the Jedi")) {
-            val = QStringLiteral("<center><a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a></center>");
+        const auto it = mudlet::scmDefaultGames.constFind(profile_name);
+        if (it != mudlet::scmDefaultGames.cend()) {
+            val = it->websiteInfo;
         }
     }
     website_entry->setText(val);
@@ -1362,166 +1099,22 @@ void dlgConnectionProfiles::fillout_form()
     }
 
     profiles_tree_widget->setIconSize(QSize(120, 30));
-    QString mudServer, description;
+    QString description;
     QListWidgetItem* pItem;
 
     auto& settings = *mudlet::self()->mpSettings;
     auto deletedDefaultMuds = settings.value(QStringLiteral("deletedDefaultMuds"), QStringList()).toStringList();
+    const auto defaultGames = mudlet::scmDefaultGames.keys();
 
-    mudServer = QStringLiteral("Avalon.de");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("avalon.mud.de"), 0, mudServer), QStringLiteral(":/icons/avalon.png"));
+    for (auto& game : defaultGames) {
+        if (!deletedDefaultMuds.contains(game)) {
+            pItem = new QListWidgetItem();
+            setupMudProfile(pItem, game, getDescription(mudlet::scmDefaultGames[game].hostUrl, mudlet::scmDefaultGames[game].port, game), mudlet::scmDefaultGames[game].icon);
+        }
     }
-
-    mudServer = QStringLiteral("Achaea");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("achaea.com"), 0, mudServer), QStringLiteral(":/icons/achaea_120_30.png"));
-    }
-
-    mudServer = QStringLiteral("3Kingdoms");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("3k.org"), 3000, mudServer), QStringLiteral(":/icons/3klogo.png"));
-    }
-
-    mudServer = QStringLiteral("3Scapes");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("3k.org"), 3200, mudServer), QStringLiteral(":/icons/3slogo.png"));
-    }
-
-    mudServer = QStringLiteral("Lusternia");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("lusternia.com"), 0, mudServer), QStringLiteral(":/icons/lusternia_120_30.png"));
-    }
-
-    mudServer = QStringLiteral("BatMUD");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("batmud.bat.org"), 0, mudServer), QStringLiteral(":/icons/batmud_mud.png"));
-    }
-
-    mudServer = QStringLiteral("God Wars II");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("godwars2.org"), 0, mudServer), QStringLiteral(":/icons/gw2.png"));
-    }
-
-    mudServer = QStringLiteral("Slothmud");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("slothmud.org"), 0, mudServer), QStringLiteral(":/icons/Slothmud.png"));
-    }
-
-    mudServer = QStringLiteral("Aardwolf");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("aardmud.org"), 0, mudServer), QStringLiteral(":/icons/aardwolf_mud.png"));
-    }
-
-    mudServer = QStringLiteral("Materia Magica");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("materiamagica.com"), 0, mudServer), QStringLiteral(":/materiaMagicaIcon"));
-    }
-
-    mudServer = QStringLiteral("Realms of Despair");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("realmsofdespair.com"), 0, mudServer), QStringLiteral(":/icons/120x30RoDLogo.png"));
-    }
-
-    mudServer = QStringLiteral("ZombieMUD");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("zombiemud.org"), 0, mudServer), QStringLiteral(":/icons/zombiemud.png"));
-    }
-
-    mudServer = QStringLiteral("Aetolia");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("aetolia.com"), 0, mudServer), QStringLiteral(":/icons/aetolia_120_30.png"));
-    }
-
-    mudServer = QStringLiteral("Imperian");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("imperian.com"), 0, mudServer), QStringLiteral(":/icons/imperian_120_30.png"));
-    }
-
-    mudServer = QStringLiteral("WoTMUD");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("game.wotmud.org"), 0, mudServer), QStringLiteral(":/icons/wotmudicon.png"));
-    }
-
-    mudServer = QStringLiteral("Midnight Sun 2");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("midnightsun2.org"), 0, mudServer), QStringLiteral(":/icons/midnightsun2.png"));
-    }
-
-    mudServer = QStringLiteral("Luminari");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("luminari_icon.com"), 0, mudServer), QStringLiteral(":/icons/luminari_icon.png"));
-    }
-
-    mudServer = QStringLiteral("StickMUD");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("stickmud.com"), 0, mudServer), QStringLiteral(":/icons/stickmud_icon.jpg"));
-    }
-
-    mudServer = QStringLiteral("Clessidra");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("clessidra.it"), 0, mudServer), QStringLiteral(":/icons/clessidra.jpg"));
-    }
-
-    mudServer = QStringLiteral("Reinos de Leyenda");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("reinosdeleyenda.es"), 0, mudServer), QStringLiteral(":/icons/reinosdeleyenda_mud.png"));
-    }
-
-
-    mudServer = QStringLiteral("Fierymud");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("fierymud.org"), 0, mudServer), QStringLiteral(":/icons/fiery_mud.png"));
-    }
-
-    mudServer = QStringLiteral("Carrion Fields");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("carrionfields.net"), 0, mudServer), QStringLiteral(":/icons/carrionfields.png"));
-    }
-
-    mudServer = QStringLiteral("Cleft of Dimensions");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("cleftofdimensions.net"), 0, mudServer), QStringLiteral(":/icons/cleftofdimensions.png"));
-    }
-
-    mudServer = QStringLiteral("CoreMUD");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("coremud.org"), 0, mudServer), QStringLiteral(":/icons/coremud_icon.jpg"));
-    }
-
-    mudServer = QStringLiteral("Legends of the Jedi");
-    if (!deletedDefaultMuds.contains(mudServer)) {
-        pItem = new QListWidgetItem();
-        setupMudProfile(pItem, mudServer, getDescription(QStringLiteral("legendsofthejedi.com"), 0, mudServer), QStringLiteral(":/icons/legendsofthejedi_120x30.png"));
-    }
-
 
 #if defined(QT_DEBUG)
-    mudServer = QStringLiteral("Mudlet self-test");
+    QString mudServer = QStringLiteral("Mudlet self-test");
     if (!deletedDefaultMuds.contains(mudServer) && !mProfileList.contains(mudServer)) {
         mProfileList.append(mudServer);
         pItem = new QListWidgetItem();
@@ -1585,6 +1178,8 @@ void dlgConnectionProfiles::fillout_form()
 
 void dlgConnectionProfiles::setProfileIcon() const
 {
+    const QStringList defaultGames = mudlet::scmDefaultGames.keys();
+
     for (int i = 0; i < mProfileList.size(); i++) {
         const QString& profileName = mProfileList.at(i);
         if (profileName.isEmpty()) {
@@ -1598,7 +1193,7 @@ void dlgConnectionProfiles::setProfileIcon() const
             // necessarily case preserving for file names so any tests on them
             // should be case insensitive
             // skip creating icons for default MUDs as they are already created above
-            if (mudlet::scmDefaultGames.contains(profileName, Qt::CaseInsensitive)) {
+            if (defaultGames.contains(profileName, Qt::CaseInsensitive)) {
                 continue;
             }
 
@@ -2350,6 +1945,10 @@ void dlgConnectionProfiles::setupMudProfile(QListWidgetItem* pItem, const QStrin
     profiles_tree_widget->addItem(pItem);
     if (!hasCustomIcon(mudServer)) {
         QPixmap p(iconFileName);
+        if (p.isNull()) {
+            qWarning() << mudServer << "doesn't have a valid icon";
+            return;
+        }
         if (p.width() != 120) {
             pItem->setIcon(p.scaled(QSize(120, 30), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
         } else {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2424,7 +2424,7 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 void mudlet::startAutoLogin(const QString& cliProfile)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
-    hostList += mudlet::scmDefaultGames;
+    hostList += mudlet::scmDefaultGames.keys();
     hostList << QStringLiteral("Mudlet self-test");
     hostList.removeDuplicates();
     bool openedProfile = false;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2554,7 +2554,17 @@ void mudlet::doAutoLogin(const QString& profile_name)
     QDir dir(folder);
     dir.setSorting(QDir::Time);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
-    if (!entries.isEmpty()) {
+    bool preInstallPackages = false;
+    if (entries.isEmpty()) {
+        preInstallPackages = true;
+
+        const auto it = mudlet::scmDefaultGames.constFind(profile_name);
+        if (it != mudlet::scmDefaultGames.cend()) {
+            pHost->setUrl(it->hostUrl);
+            pHost->setPort(it->port);
+            pHost->mSslTsl = it->tlsEnabled;
+        }
+    } else {
         QFile file(QStringLiteral("%1/%2").arg(folder, entries.at(0)));
         file.open(QFile::ReadOnly | QFile::Text);
         XMLimport importer(pHost);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -430,32 +430,61 @@ public:
     // Options dialog when there's no active host
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
 
-    inline static const QStringList scmDefaultGames {
-        "3Scapes",
-        "Aardwolf",
-        "Achaea",
-        "Aetolia",
-        "Avalon.de",
-        "BatMUD",
-        "Clessidra",
-        "Fierymud",
-        "Imperian",
-        "Luminari",
-        "Lusternia",
-        "Materia Magica",
-        "Midnight Sun 2",
-        "Realms of Despair",
-        "Reinos de Leyenda",
-        "StickMUD",
-        "WoTMUD",
-        "ZombieMUD",
-        "Carrion Fields",
-        "Cleft of Dimensions",
-        "CoreMUD",
-        "God Wars II",
-        "Slothmud",
-        "Legends of the Jedi"
+    struct GameDetails {
+        QString hostUrl;
+        int port;
+        bool tlsEnabled;
+        QString websiteInfo;
+        QString icon;
     };
+
+    // clang-format off
+    inline static const QHash<QString, GameDetails> scmDefaultGames = {
+        {"3Scapes", {
+            "3k.org",   // address to connect to
+            3200,       // port to connect on
+            false,      // secure connection possible?
+            // game's website
+            "<center><a href='http://www.3scapes.org/'>http://www.3scapes.org</a></center>",
+            // path to the profile icon
+            ":/icons/3slogo.png"
+        }},
+        {"Avalon.de", {"avalon.mud.de", 23, false,
+                        "<center><a href='http://avalon.mud.de'>http://avalon.mud.de</a></center>",
+                        ":/icons/avalon.png"}},
+        {"God Wars II", {"godwars2.org", 3000, false,
+                        "<center><a href='http://www.godwars2.org'>http://www.godwars2.org</a></center>",
+                        ":/icons/gw2.png"}},
+        {"Materia Magica", {"materiamagica.com", 23, false,
+                        "<center><a href='http://www.materiamagica.com'>http://www.materiamagica.com</a></center>",
+                        ":/materiaMagicaIcon"}},
+        {"BatMUD", {"batmud.bat.org", 23, false, "<center><a href='http://www.bat.org'>http://www.bat.org</a></center>", ":/icons/batmud_mud.png"}},
+        {"Aardwolf", {"aardmud.org", 4000, false, "<center><a href='http://www.aardwolf.com/'>http://www.aardwolf.com</a></center>", ":/icons/aardwolf_mud.png"}},
+        {"Achaea", {"achaea.com", 23, false, "<center><a href='http://www.achaea.com/'>http://www.achaea.com</a></center>", ":/icons/achaea_120_30.png"}},
+        {"Aetolia", {"aetolia.com", 23, false, "<center><a href='http://www.aetolia.com/'>http://www.aetolia.com</a></center>", ":/icons/aetolia_120_30.png"}},
+        {"Lusternia", {"lusternia.com", 23, false, "<center><a href='http://www.lusternia.com/'>http://www.lusternia.com</a></center>", ":/icons/lusternia_120_30.png"}},
+        {"Imperian", {"imperian.com", 23, false, "<center><a href='http://www.imperian.com/'>http://www.imperian.com</a></center>", ":/icons/imperian_120_30.png"}},
+        {"Realms of Despair", {"realmsofdespair.com", 4000, false, "<center><a href='http://www.realmsofdespair.com/'>http://www.realmsofdespair.com</a></center>", ":/icons/120x30RoDLogo.png"}},
+        {"ZombieMUD", {"zombiemud.org", 23, false, "<center><a href='http://www.zombiemud.org/'>http://www.zombiemud.org</a></center>", ":/icons/zombiemud.png"}},
+        {"Carrion Fields", {"carrionfields.net", 4449, false, "<center><a href='http://www.carrionfields.net'>www.carrionfields.net</a></center>", ":/icons/carrionfields.png"}},
+        {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<center><a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a></center>",":/icons/cleftofdimensions.png"}},
+        {"3Kingdoms", {"3k.org", 3200, false, "<center><a href='http://www.3k.org/'>http://www.3k.org</a></center>", ":/icons/3klogo.png"}},
+        {"Slothmud", {"slothmud.org", 6101, false, "<center><a href='http://www.slothmud.org/'>http://www.slothmud.org/</a></center>", ":/icons/Slothmud.png"}},
+        {"WoTMUD", {"game.wotmud.org", 2224, false, "<center><a href='http://www.wotmud.org/'>Main website</a></center>\n"
+                                 "<center><a href='http://www.wotmod.org/'>Forums</a></center>",":/icons/wotmudicon.png"}},
+        {"Midnight Sun 2", {"midnightsun2.org", 3000, false, "<center><a href='http://midnightsun2.org/'>http://midnightsun2.org/</a></center>", ":/icons/midnightsun2.png"}},
+        {"Luminari", {"luminarimud.com", 4100, false, "<center><a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a></center>", ":/icons/luminari_icon.png"}},
+        {"StickMUD", {"stickmud.com", 7680, false, "<center><a href='http://www.stickmud.com/'>stickmud.com</a></center>", ":/icons/stickmud_icon.jpg"}},
+        {"Clessidra", {"mud.clessidra.it", 4000, false, "<center><a href='http://www.clessidra.it/'>http://www.clessidra.it</a></center>", ":/icons/clessidra.jpg"}},
+        {"Reinos de Leyenda", {"reinosdeleyenda.es", 23, false, "<center><a href='https://www.reinosdeleyenda.es/'>Main website</a></center>\n"
+                                 "<center><a href='https://www.reinosdeleyenda.es/foro/'>Forums</a></center>\n"
+                                 "<center><a href='https://wiki.reinosdeleyenda.es/'>Wiki</a></center>\n", ":/icons/reinosdeleyenda_mud.png"}},
+        {"Fierymud", {"fierymud.org", 4000, false, "<center><a href='https://www.fierymud.org/'>https://www.fierymud.org</a></center>", ":/icons/fiery_mud.png"}},
+        // {"Mudlet self-test", {"mudlet.org", 23, false,}},
+        {"CoreMUD", {"coremud.org", 4000, false, "<center><a href='https://coremud.org/'>coremud.org</a></center>", ":/icons/coremud_icon.jpg"}},
+        {"Legends of the Jedi", {"legendsofthejedi.com", 5656, false, "<center><a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a></center>", ":/icons/legendsofthejedi_120x30.png"}},
+    };
+    // clang-format on
 
 public slots:
     void processEventLoopHack_timerRun();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -467,11 +467,11 @@ public:
         {"Realms of Despair", {"realmsofdespair.com", 4000, false, "<center><a href='http://www.realmsofdespair.com/'>http://www.realmsofdespair.com</a></center>", ":/icons/120x30RoDLogo.png"}},
         {"ZombieMUD", {"zombiemud.org", 23, false, "<center><a href='http://www.zombiemud.org/'>http://www.zombiemud.org</a></center>", ":/icons/zombiemud.png"}},
         {"Carrion Fields", {"carrionfields.net", 4449, false, "<center><a href='http://www.carrionfields.net'>www.carrionfields.net</a></center>", ":/icons/carrionfields.png"}},
-        {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<center><a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a></center>",":/icons/cleftofdimensions.png"}},
+        {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<center><a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a></center>", ":/icons/cleftofdimensions.png"}},
         {"3Kingdoms", {"3k.org", 3200, false, "<center><a href='http://www.3k.org/'>http://www.3k.org</a></center>", ":/icons/3klogo.png"}},
         {"Slothmud", {"slothmud.org", 6101, false, "<center><a href='http://www.slothmud.org/'>http://www.slothmud.org/</a></center>", ":/icons/Slothmud.png"}},
         {"WoTMUD", {"game.wotmud.org", 2224, false, "<center><a href='http://www.wotmud.org/'>Main website</a></center>\n"
-                                 "<center><a href='http://www.wotmod.org/'>Forums</a></center>",":/icons/wotmudicon.png"}},
+                                 "<center><a href='http://www.wotmod.org/'>Forums</a></center>", ":/icons/wotmudicon.png"}},
         {"Midnight Sun 2", {"midnightsun2.org", 3000, false, "<center><a href='http://midnightsun2.org/'>http://midnightsun2.org/</a></center>", ":/icons/midnightsun2.png"}},
         {"Luminari", {"luminarimud.com", 4100, false, "<center><a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a></center>", ":/icons/luminari_icon.png"}},
         {"StickMUD", {"stickmud.com", 7680, false, "<center><a href='http://www.stickmud.com/'>stickmud.com</a></center>", ":/icons/stickmud_icon.jpg"}},


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix `--profile` to load connection info for first-time profiles
#### Motivation for adding to Mudlet
So tests running in a clean CI environment can be loaded into the `Mudlet self-test` profile
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5368

This also exposes the `Mudlet self-test` profile publicly - something we can decide on if it's worth to do. I think it can't hurt.