### PR TITLE
Improve error messages for secure password storage

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1768,7 +1768,7 @@ void dlgConnectionProfiles::slot_reset_custom_icon()
 void dlgConnectionProfiles::slot_password_saved(QKeychain::Job* job)
 {
     if (job->error()) {
-        qWarning() << "dlgConnectionProfiles::slot_password_saved ERROR: couldn't save password for" << job->property("profile") << "; error was:" << job->errorString();
+        qWarning() << "dlgConnectionProfiles::slot_password_saved ERROR: couldn't save password for" << job->property("profile").toString() << "; error was:" << job->errorString();
     }
 
     job->deleteLater();
@@ -1777,7 +1777,7 @@ void dlgConnectionProfiles::slot_password_saved(QKeychain::Job* job)
 void dlgConnectionProfiles::slot_password_deleted(QKeychain::Job* job)
 {
     if (job->error()) {
-        qWarning() << "dlgConnectionProfiles::slot_password_deleted ERROR: couldn't delete password for" << job->property("profile") << "; error was:" << job->errorString();
+        qWarning() << "dlgConnectionProfiles::slot_password_deleted ERROR: couldn't delete password for" << job->property("profile").toString() << "; error was:" << job->errorString();
     }
 
     job->deleteLater();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The message before was this:

```
dlgConnectionProfiles::slot_password_saved ERROR: couldn't save password for QVariant(QString, "HeadlessRaspberry") ; error was: "Unknown error"
```

This removes that `QVariant` bit so just the profile name is shown.
#### Motivation for adding to Mudlet
Less nonsense in the error message
#### Other info (issues closed, discussion etc)
I know @SlySven will be keen on making it even prettier... but this works for me :)