### PR TITLE
Fix 160 typos in C++ code

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2514,7 +2514,7 @@ void Host::setUserDictionaryOptions(const bool _useDictionary, const bool useSha
     }
 
     if (dictionaryChanged) {
-        // This will propogate the changes in the two flags to the main
+        // This will propagate the changes in the two flags to the main
         // TConsole's copies of them - although setProfileSpellDictionary() is
         // also called in the main TConsole constructor:
         mpConsole->setProfileSpellDictionary();
@@ -2863,7 +2863,7 @@ std::pair<bool, QString> Host::createMiniConsole(const QString& windowname, cons
             return {true, QString()};
         }
     } else if (pC) {
-        // CHECK: The absence of an explict return statement in this block means that
+        // CHECK: The absence of an explicit return statement in this block means that
         // reusing an existing mini console causes the lua function to seem to
         // fail - is this as per Wiki?
         // This part was causing problems with UserWindows
@@ -3712,7 +3712,7 @@ bool Host::commitLayoutUpdates(bool flush)
         for (auto pToolBar : mToolbarLayoutChanges) {
             // Under some circumstances there is NOT a
             // pToolBar->property("layoutChanged") and examining that
-            // non-existant variant to see if it was true or false causes seg. faults!
+            // non-existent variant to see if it was true or false causes seg. faults!
             if (Q_UNLIKELY(!pToolBar->property("layoutChanged").isValid())) {
                 qWarning().nospace().noquote() << "host::commitLayoutUpdates() WARNING - was about to check for \"layoutChanged\" meta-property on a toolbar without that property!";
             } else if (pToolBar->property("layoutChanged").toBool()) {

--- a/src/Host.h
+++ b/src/Host.h
@@ -734,7 +734,7 @@ private:
     bool mEnableUserDictionary;
     bool mUseSharedDictionary;
 
-    // These hold values that are needed in the TMap clas which are saved with
+    // These hold values that are needed in the TMap class which are saved with
     // the profile - but which cannot be kept there as that class is not
     // necessarily instantiated when the profile is read.
     // Base color(s) for the player room in the mappers:

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -5078,8 +5078,8 @@ void T2DMap::resizeMultiSelectionWidget()
     if (mMultiSelectionListWidget.topLevelItemCount() > 0) {
         QTreeWidgetItem* rowItem = mMultiSelectionListWidget.topLevelItem(1);
         // The following factors are tweaks to ensure that the widget shows all
-        // the rows, as the header seems bigger than the value returned, statistics
-        // used to enable values to be change by debugger at runtime!
+        // the rows, as the header seems bigger than the value returned, static values
+        // used to enable values to be changed by debugger at runtime!
         static float headerFactor = 1.2;
         static float rowFactor = 1.0;
         _newHeight = headerFactor * mMultiSelectionListWidget.header()->height();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -729,7 +729,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QFont& mapN
         QPointF roomCenter = QPointF(rx, ry);
         if (!isRoomSelected) {
             // CHECK: The use of a gradient fill to a white center on round
-            // rooms might look nice in some sitations but not in all:
+            // rooms might look nice in some situations but not in all:
             QRadialGradient gradient(roomCenter, roomRadius);
             gradient.setColorAt(0.85, roomColor);
             gradient.setColorAt(0, Qt::white);
@@ -746,7 +746,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QFont& mapN
         mPick = false;
         if (mStartSpeedWalk) {
             mStartSpeedWalk = false;
-            // This draws a red circle around the room that was choosen as
+            // This draws a red circle around the room that was chosen as
             // the target for the speedwalk, but it is only shown for one
             // paintEvent call and it is not obvious that it is useful, note
             // that this is the code for a room being clicked on that is
@@ -1140,7 +1140,7 @@ inline void T2DMap::drawRoom(QPainter& painter, QFont& roomVNumFont, QFont& mapN
                 // clang-format on
                 mStartSpeedWalk = false;
                 // This draws a red circle around the out of area exit that
-                // was choosen as the target for the speedwalk, but it is
+                // was chosen as the target for the speedwalk, but it is
                 // only shown for one paintEvent call and it is not obvious
                 // that it is useful, note that there is similar code for a
                 // room being clicked on that is WITHIN the area, that is
@@ -2990,7 +2990,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     }
 
                     auto lineProperties = new QAction(tr("Properties", "2D Mapper context menu (custom line editing) item name (but not used as display text as that is set separately)"), this);
-                    // Changed seperately, because the constructor silently copies the text elsewhere
+                    // Changed separately, because the constructor silently copies the text elsewhere
                     // (tooltip and/or object name IIRC) whereas the ellipsis is meant only for display
                     lineProperties->setText(
                             tr("properties...", "2D Mapper context menu (custom line editing) item display text (has to be entered separately as the ... would get stripped off otherwise"));
@@ -5078,7 +5078,7 @@ void T2DMap::resizeMultiSelectionWidget()
     if (mMultiSelectionListWidget.topLevelItemCount() > 0) {
         QTreeWidgetItem* rowItem = mMultiSelectionListWidget.topLevelItem(1);
         // The following factors are tweaks to ensure that the widget shows all
-        // the rows, as the header seems bigger than the value returned, statics
+        // the rows, as the header seems bigger than the value returned, statistics
         // used to enable values to be change by debugger at runtime!
         static float headerFactor = 1.2;
         static float rowFactor = 1.0;

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -108,7 +108,7 @@ public:
     bool mRoomBeingMoved;
     // These are the on-screen width and height pixel numbers of the area for a
     // room symbol, (for the non-grid map mode case what gets filled in is
-    // multipled by rsize which is 1.0 to exactly fill space between adjacent
+    // multiplied by rsize which is 1.0 to exactly fill space between adjacent
     // coordinates):
     float mRoomWidth;
     float mRoomHeight;

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -174,7 +174,7 @@ bool TAlias::match(const QString& toMatch)
             tabptr += name_entry_size;
         }
     }
-    //TODO: add named groups seperately later as Lua::namedGroups
+    //TODO: add named groups separately later as Lua::namedGroups
     for (;;) {
         int options = 0;
         int start_offset = ovector[1];

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -486,7 +486,7 @@ void TArea::removeRoom(int room, bool isToDeferAreaRelatedRecalculations)
     QElapsedTimer timer;
     timer.start();
 
-    // Will use to flag whether some things have to be recalcuated.
+    // Will use to flag whether some things have to be recalculated.
     bool isOnExtreme = false;
     if (rooms.contains(room) && !isToDeferAreaRelatedRecalculations) {
         // just a check, if the area DOESN'T have the room then it is not wise
@@ -924,7 +924,7 @@ QList<QByteArray> TArea::convertImageToBase64Data(const QPixmap& pixmap) const
     QBuffer imageInputBuffer;
 
     imageInputBuffer.open(QIODevice::WriteOnly);
-    // Go for maximum compresssion - for the smallest amount of data, the second
+    // Go for maximum compression - for the smallest amount of data, the second
     // argument is a const char[] so does not require a QString wrapper:
     pixmap.save(&imageInputBuffer, "PNG", 0);
     QBuffer imageOutputBuffer;

--- a/src/TArea.h
+++ b/src/TArea.h
@@ -124,8 +124,4 @@ private:
     // Made private as we may change implementation detail
 };
 
-// - gezeichnet werden erstmal die areas
-//   unter berücksichtigung der an die area angrenzenden edges
-// - der span der area ist unterschiedlich
-
 #endif // MUDLET_TAREA_H

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -592,7 +592,7 @@ void TBuffer::translateToPlainText(std::string& incoming, const bool isFromServe
                     /*
                      * Also seen in output from mud.durismud.com see 'C' case above:
                      * Is ED 'Erase Display' command and has three variants:
-                     * * 0 (or ommitted): clear from cursor to end of screen
+                     * * 0 (or omitted): clear from cursor to end of screen
                      *   - which is a NOP for us!
                      * * 1: clear from cursor to beginning of screen
                      *   - which is a NWIH for us!
@@ -1007,9 +1007,9 @@ void TBuffer::decodeSGR38(const QStringList& parameters, bool isColonSeparated)
 
 #if defined(DEBUG_SGR_PROCESSING)
         if (isColonSeparated) {
-            qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unexpect SGR code: SGR...;38:" << parameters.at(1) << ":...;...m ignoring sequence!";
+            qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unexpected SGR code: SGR...;38:" << parameters.at(1) << ":...;...m ignoring sequence!";
         } else {
-            qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unexpect SGR code: SGR...;38;" << parameters.at(1) << ";...m ignoring sequence!";
+            qDebug().noquote().nospace() << "TBuffer::decodeSGR38(...) WARNING - unexpected SGR code: SGR...;38;" << parameters.at(1) << ";...m ignoring sequence!";
         }
 #endif
 
@@ -1171,9 +1171,9 @@ void TBuffer::decodeSGR48(const QStringList& parameters, bool isColonSeparated)
 
 #if defined(DEBUG_SGR_PROCESSING)
         if (isColonSeparated) {
-            qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unexpect SGR code: SGR...;48:" << parameters.at(1) << ":...;...m ignoring sequence!";
+            qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unexpected SGR code: SGR...;48:" << parameters.at(1) << ":...;...m ignoring sequence!";
         } else {
-            qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unexpect SGR code: SGR...;48;" << parameters.at(1) << ";...m ignoring sequence!";
+            qDebug().noquote().nospace() << "TBuffer::decodeSGR48(...) WARNING - unexpected SGR code: SGR...;48;" << parameters.at(1) << ";...m ignoring sequence!";
         }
 #endif
     }
@@ -1485,14 +1485,14 @@ void TBuffer::decodeSGR(const QString& sequence)
                 case 3:
                     // There is a proposal by the "VTE" terminal
                     // emulator to use a (sub)parameter entry to
-                    // destinguish between italics and slanted text by
+                    // distinguish between italics and slanted text by
                     // using ESC[...;3:1;...m and ESC[...;3:2;...m
                     // respectively - that is handled above in the colon
                     // sub-string separated part:
                     mItalics = true;
                     break;
                 case 4:
-                    // There is a implimention by some terminal
+                    // There is a implementation by some terminal
                     // emulators ("Kitty" and "VTE") to use a
                     // (sub)parameter entry of 3 for a wavy underline
                     // {presumably 2 would be a double underline and 1
@@ -2317,7 +2317,7 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
 
 // This is very poorly designed as P2 is used to determine the last character to
 // copy BUT no consideration is given to P2.y() != p1.y() i.e. a copy of more
-// than a single line - and it copys a single QChar at a time....
+// than a single line - and it copies a single QChar at a time....
 TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
 {
     TBuffer slice(mpHost);
@@ -3256,7 +3256,7 @@ bool TBuffer::processUtf8Sequence(const std::string& bufferData, const bool isFr
             // locally generated material from Lua feedTriggers(...)
             if (isFromServer) {
 #if defined(DEBUG_UTF8_PROCESSING)
-                qDebug() << "TBuffer::processUtf8Sequence(...) Insufficent bytes in buffer to complate UTF-8 sequence, need:" << utf8SequenceLength
+                qDebug() << "TBuffer::processUtf8Sequence(...) Insufficient bytes in buffer to complete UTF-8 sequence, need:" << utf8SequenceLength
                          << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
 #endif
                 mIncompleteSequenceBytes = bufferData.substr(pos);
@@ -3453,7 +3453,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
 // mapping, instead we use one TChar per QChar - and that has to be
 // tweaked for non-BMP characters that use TWO QChars per codepoint.
 // GB2312 is the predecessor to both and - according to Wikipedia (EN) covers
-// over 99% of the characters of contempory usage.
+// over 99% of the characters of contemporary usage.
 // GBK is a sub-set of GB18030 so can be processed in the same method
 // Assume we are at the first byte of a single (ASCII), pair (GBK/GB18030)
 // or four byte (GB18030) sequence
@@ -3624,8 +3624,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             // Not enough bytes to process yet - so store what we have and return
             if (isFromServer) {
 #if defined(DEBUG_GB_PROCESSING)
-                qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficent bytes in buffer to "
-                                      "complate GB2312/GBK sequence, need at least: "
+                qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficient bytes in buffer to "
+                                      "complete GB2312/GBK sequence, need at least: "
                                    << gbSequenceLength << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
 #endif
                 mIncompleteSequenceBytes = bufferData.substr(pos);
@@ -3656,8 +3656,8 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
                     // Not enough bytes to process yet - so store what we have and return
                     if (isFromServer) {
 #if defined(DEBUG_GB_PROCESSING)
-                        qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficent bytes in buffer to "
-                                              "complate GB18030 sequence, need at least: "
+                        qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficient bytes in buffer to "
+                                              "complete GB18030 sequence, need at least: "
                                            << gbSequenceLength << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
 #endif
                         mIncompleteSequenceBytes = bufferData.substr(pos);
@@ -3809,7 +3809,7 @@ bool TBuffer::processGBSequence(const std::string& bufferData, const bool isFrom
             // we only have one - so store what we have and return
             if (isFromServer) {
 #if defined(DEBUG_GB_PROCESSING)
-                qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficent bytes in buffer to complate GB18030 sequence, need at least:"
+                qDebug().nospace() << "TBuffer::processGBSequence(...) Insufficient bytes in buffer to complete GB18030 sequence, need at least:"
                                    << gbSequenceLength << " but we currently only have: " << bufferData.substr(pos).length()
                                    << " bytes (which we will store for next call to this method)...";
 #endif
@@ -3917,7 +3917,7 @@ bool TBuffer::processBig5Sequence(const std::string& bufferData, const bool isFr
             // Not enough bytes to process yet - so store what we have and return
             if (isFromServer) {
 #if defined(DEBUG_BIG5_PROCESSING)
-                qDebug().nospace() << "TBuffer::processBig5Sequence(...) Insufficent bytes in buffer to "
+                qDebug().nospace() << "TBuffer::processBig5Sequence(...) Insufficient bytes in buffer to "
                                       "complete Big5 sequence, need at least: "
                                    << big5SequenceLength << " but we currently only have: " << bufferData.substr(pos).length() << " bytes (which we will store for next call to this method)...";
 #endif

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -205,7 +205,7 @@ public:
 
     int mCursorY;
 
-    // State of MXP systen:
+    // State of MXP system:
     bool mEchoingText;
 
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -120,7 +120,7 @@ bool TCommandLine::event(QEvent* event)
         auto* ke = dynamic_cast<QKeyEvent*>(event);
         if (!ke) {
             // Something is wrong -
-            qCritical().noquote() << "TCommandLine::event(QEvent*) CRITICAL - a QEvent that is supposed to be a QKeyEvent is not dynmically castable to the latter - so the processing of this event "
+            qCritical().noquote() << "TCommandLine::event(QEvent*) CRITICAL - a QEvent that is supposed to be a QKeyEvent is not dynamically castable to the latter - so the processing of this event "
                                      "has been aborted - please report this to Mudlet Makers.";
             // Indicate that we don't want to touch this event with a barge-pole!
             return false;
@@ -147,7 +147,7 @@ bool TCommandLine::event(QEvent* event)
 
             if (keybindingMatched(ke)) {
                 // Process as a possible key binding if there are ANY modifiers
-                // other than just a <SHIFT> one; may actaully be configured as
+                // other than just a <SHIFT> one; may actually be configured as
                 // a non-breaking space when used with a modifier!
                 return true;
             }
@@ -1167,7 +1167,7 @@ void TCommandLine::recheckWholeLine()
     QTextCursor c = textCursor();
     // Move Cursor AND selection anchor to start:
     c.movePosition(QTextCursor::Start);
-    // In case the first character is something other than the begining of a
+    // In case the first character is something other than the beginning of a
     // word
     c.movePosition(QTextCursor::NextWord);
     c.movePosition(QTextCursor::PreviousWord);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -85,7 +85,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         mWrapAt = 50;
     } else {
         if (mType & (ErrorConsole|SubConsole|UserWindow)) {
-            // Orginally this was for TConsole instances with a parent pointer
+            // Originally this was for TConsole instances with a parent pointer
             // This branch for: UserWindows, SubConsole, ErrorConsole
             // mIsSubConsole was true for these
             mMainFrameTopHeight = 0;
@@ -93,7 +93,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
             mMainFrameLeftWidth = 0;
             mMainFrameRightWidth = 0;
         } else if (mType & (MainConsole|Buffer)) {
-            // Orginally this was for TConsole instances without a parent pointer
+            // Originally this was for TConsole instances without a parent pointer
             // This branch for: Buffers, MainConsole
             // mIsSubConsole was false for these
             mMainFrameTopHeight = mpHost->mBorderTopHeight;
@@ -1546,7 +1546,7 @@ bool TConsole::selectSection(int from, int to)
 }
 
 // returns whenever the selection is valid, the selection text,
-// start position, and the length of the seletion
+// start position, and the length of the selection
 std::tuple<bool, QString, int, int> TConsole::getSelection()
 {
     if (mUserCursor.y() >= static_cast<int>(buffer.buffer.size())) {

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -195,7 +195,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
     hostName.detach();
     QPair<QString, QString> newIdentifier;
     if (TDebug::smAvailableIdentifiers.isEmpty()) {
-        // Run out of identifers - use fall-back one:
+        // Run out of identifiers - use fall-back one:
         newIdentifier = qMakePair(hostName, csmTagOverflow);
         TDebug::smIdentifierMap.insert(pHost, newIdentifier);
     } else {

--- a/src/TEntityResolver.cpp
+++ b/src/TEntityResolver.cpp
@@ -137,7 +137,7 @@ const QHash<QString, QString> TEntityResolver::scmStandardEntites = {
         {QStringLiteral("&iexcl;"), QStringLiteral("¡")},
         {QStringLiteral("&cent;"), QStringLiteral("¢")},
         {QStringLiteral("&pound;"), QStringLiteral("£")},
-        {QStringLiteral("&curren;"), QStringLiteral("¤")},
+        {QStringLiteral("&current;"), QStringLiteral("¤")},
         {QStringLiteral("&yen;"), QStringLiteral("¥")},
         {QStringLiteral("&brvbar;"), QStringLiteral("¦")},
         {QStringLiteral("&sect;"), QStringLiteral("§")},

--- a/src/TEntityResolver.cpp
+++ b/src/TEntityResolver.cpp
@@ -137,7 +137,7 @@ const QHash<QString, QString> TEntityResolver::scmStandardEntites = {
         {QStringLiteral("&iexcl;"), QStringLiteral("¡")},
         {QStringLiteral("&cent;"), QStringLiteral("¢")},
         {QStringLiteral("&pound;"), QStringLiteral("£")},
-        {QStringLiteral("&current;"), QStringLiteral("¤")},
+        {QStringLiteral("&curren;"), QStringLiteral("¤")},
         {QStringLiteral("&yen;"), QStringLiteral("¥")},
         {QStringLiteral("&brvbar;"), QStringLiteral("¦")},
         {QStringLiteral("&sect;"), QStringLiteral("§")},

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -86,7 +86,7 @@ void TLabel::mousePressEvent(QMouseEvent* event)
 
     if (mpHost && mClickFunction) {
         mpHost->getLuaInterpreter()->callLabelCallbackEvent(mClickFunction, event);
-        // The use of accept() here prevents the propogation of the event to
+        // The use of accept() here prevents the propagation of the event to
         // any parent, e.g. the containing TConsole
         event->accept();
         mudlet::self()->activateProfile(mpHost);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10673,7 +10673,7 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 
     bool isToShowDefaultArea = getVerifiedBool(L, __func__, 1, "isToShowDefaultArea");
     if (host.mpMap->mpMapper) {
-        // If we are re-enabled the display of the default area
+        // If we are re-enabling the display of the default area
         // AND the mapper was showing the default area
         // the area widget will NOT be showing the correct area name afterwards
         bool isAreaWidgetInNeedOfResetting = false;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5032,7 +5032,7 @@ int TLuaInterpreter::getAreaRooms(lua_State* L)
     while (itAreaRoom.hasNext()) {
         lua_pushnumber(L, ++i);
         // We should have started at 1 but past code had incorrectly started
-        // with a zero index and we must maintain compatibilty with code written
+        // with a zero index and we must maintain compatibility with code written
         // for that
         lua_pushnumber(L, itAreaRoom.next());
         lua_settable(L, -3);
@@ -5074,7 +5074,7 @@ int TLuaInterpreter::getAreaExits(lua_State* L)
 
     lua_newtable(L);
     if (n < 2 || (n > 1 && !isFullDataRequired)) {
-        // Replicate original implimentation
+        // Replicate original implementation
         QList<int> areaExits = pA->getAreaExitRoomIds();
         if (areaExits.size() > 1) {
             std::sort(areaExits.begin(), areaExits.end());
@@ -5143,7 +5143,7 @@ int TLuaInterpreter::gotoRoom(lua_State* L)
     }
 
     if (!host.mpMap->gotoRoom(targetRoomId)) {
-        int totalWeight = host.assemblePath(); // Needed if unsucessful to clear lua speedwalk tables
+        int totalWeight = host.assemblePath(); // Needed if unsuccessful to clear lua speedwalk tables
         Q_UNUSED(totalWeight);
         return warnArgumentValue(L, __func__, QStringLiteral("no path found from current room to room with id %1").arg(targetRoomId), true);
     }
@@ -5168,7 +5168,7 @@ int TLuaInterpreter::getPath(lua_State* L)
     }
 
     bool ret = host.mpMap->gotoRoom(originRoomId, targetRoomId);
-    int totalWeight = host.assemblePath(); // Needed even if unsucessful, to clear lua tables then
+    int totalWeight = host.assemblePath(); // Needed even if unsuccessful, to clear lua tables then
     if (ret) {
         lua_pushboolean(L, true);
         lua_pushnumber(L, totalWeight);
@@ -5786,11 +5786,11 @@ int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
     }
     // We have already validated output to contain a 2 byte payload so we
     // should not need to worry about the "encoding" in this use of
-    // socketOutRaw(...) - with the exception of handling any occurance of
+    // socketOutRaw(...) - with the exception of handling any occurrence of
     // 0xFF as either of the bytes to send - however Aardwolf does not use
     // *THAT* value so, though it is probably okay to not worry about the
     // need to "escape" it to get it through the telnet protocol unscathed
-    // it is trival to fix:
+    // it is trivial to fix:
     output = mudlet::replaceString(output, "\xff", "\xff\xff");
     host.mTelnet.socketOutRaw(output);
     lua_pushboolean(L, true);
@@ -5799,7 +5799,7 @@ int TLuaInterpreter::sendTelnetChannel102(lua_State* L)
 
 // Internal helper function for two following functions:
 // returns 0 and a pointer to the TAction with the ID or
-//   the first one found with the name as the index item on sucess.
+//   the first one found with the name as the index item on success.
 // returns a non-zero number and a nullptr on failure (the first is the number
 //   of items on the stack for the caller to return to ITS caller).
 // does NOT return (normally) if the index item on the stack is not a number or
@@ -6294,7 +6294,7 @@ int TLuaInterpreter::tempAnsiColorTrigger(lua_State* L)
         int value = lua_tointeger(L, s);
         if (value == TTrigger::scmIgnored && lua_gettop(L) < 2) {
             return warnArgumentValue(L, __func__, QStringLiteral(
-                "invalid ANSI color number %1, it cannot be used (to ignore the foreground color) if the background color is ommitted")
+                "invalid ANSI color number %1, it cannot be used (to ignore the foreground color) if the background color is omitted")
                 .arg(value));
         }
         // At present we limit the range to (Trigger::scmIgnored),
@@ -7298,7 +7298,7 @@ int TLuaInterpreter::setAreaName(lua_State* L)
         }
         // Strangely, previous code allowed this command to create a NEW area's name
         // with this ID, but without a TArea instance to accompany it (the latter was/is
-        // instantiated as needed when a room is moved to the relevent area...) and we
+        // instantiated as needed when a room is moved to the relevant area...) and we
         // need to continue to allow this - Slysven
         //        else if (!host.mpMap->mpRoomDB->getAreaIDList().contains(id)) {
         //            return warnArgumentValue(L, __func__, QStringLiteral(
@@ -8120,7 +8120,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
     int roomID = getVerifiedInt(L, __func__, 1, "room id");
     Host& host = getHostFromLua(L);
     TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
-    if (!pR) { //if the room doesnt exist return nil
+    if (!pR) { //if the room doesn't exist return nil
         return warnArgumentValue(L, __func__, QStringLiteral("room %1 doesn't exist").arg(roomID));
     }
     lua_newtable(L); //return table customLines[]
@@ -8435,8 +8435,8 @@ int TLuaInterpreter::clearRoomUserDataItem(lua_State* L)
     }
     // Turns out that an empty key IS possible, but if this changes this should be uncommented
     //        if (key.isEmpty()) {
-    //            // If the user accidently supplied an white-space only or empty key
-    //            // string we don't do anything, but we, sucessfully, fail to do it... 8-)
+    //            // If the user accidentally supplied an white-space only or empty key
+    //            // string we don't do anything, but we, successfully, fail to do it... 8-)
     //            lua_pushboolean( L, false );
     //        }
     /*      else */ if (pR->userData.contains(key)) {
@@ -8988,7 +8988,7 @@ int TLuaInterpreter::setRoomArea(lua_State* L)
     // appear in the TRoomDB::areaNamesMap...
     bool result = host.mpMap->setRoomArea(id, areaId, false);
     if (result) {
-        // As a sucessfull result WILL change the area a room is in then the map
+        // As a successful result WILL change the area a room is in then the map
         // should be updated.  The GUI code that modifies room(s) areas already
         // includes such a call to update the mapper.
         if (host.mpMap->mpMapper) {
@@ -9018,7 +9018,7 @@ int TLuaInterpreter::resetRoomArea(lua_State* L)
     }
     bool result = host.mpMap->setRoomArea(id, -1, false);
     if (result) {
-        // As a sucessfull result WILL change the area a room is in then the map
+        // As a successful result WILL change the area a room is in then the map
         // should be updated.  The GUI code that modifies room(s) areas already
         // includes such a call to update the mapper.
         if (host.mpMap->mpMapper) {
@@ -10673,7 +10673,7 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 
     bool isToShowDefaultArea = getVerifiedBool(L, __func__, 1, "isToShowDefaultArea");
     if (host.mpMap->mpMapper) {
-        // If we are reenabled the display of the default area
+        // If we are re-enabled the display of the default area
         // AND the mapper was showing the default area
         // the area widget will NOT be showing the correct area name afterwards
         bool isAreaWidgetInNeedOfResetting = false;
@@ -10697,7 +10697,7 @@ int TLuaInterpreter::setDefaultAreaVisible(lua_State* L)
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#registerAnonymousEventHandler
 // The function below is mostly unused now as it is overwritten in lua.
-// The overwriting function poses as a transperant proxy and internally uses
+// The overwriting function poses as a transparent proxy and internally uses
 // this function to get called events.
 int TLuaInterpreter::registerAnonymousEventHandler(lua_State* L)
 {
@@ -13457,7 +13457,7 @@ static lua_State* newstate()
 // No documentation available in wiki - internal function
 static void storeHostInLua(lua_State* L, Host* h);
 
-// No documentation available in wiki - internal helper funtion
+// No documentation available in wiki - internal helper function
 // On success will swap out any messages in the queue and replace them
 // with its success message, on failure will just append...
 bool TLuaInterpreter::loadLuaModule(QQueue<QString>& resultMsgsQueue, const QString& requirement, const QString& failureConsequence, const QString& description, const QString& luaModuleId)
@@ -14032,9 +14032,9 @@ void TLuaInterpreter::initLuaGlobals()
      *     QString if needed for a placeholder for following arguments)
      * 4 - string describing the module (optional, for alternatives may be
      *     different and reflect the luarock name for the particular
-     *     alternative, when ommitted or a null/empty QString the second
+     *     alternative, when omitted or a null/empty QString the second
      *     argument is used instead)
-     * 5 - string used in Lua as the identifier for the loaded module/libary,
+     * 5 - string used in Lua as the identifier for the loaded module/library,
      *     passed as X in the lua 'X = require("name")' (optional, in which
      *     case nothing is put before the "require" in that usage and the module
      *     assumes whatever Lua name it offers).
@@ -14598,7 +14598,7 @@ std::pair<int, QString> TLuaInterpreter::startPermKey(QString& name, QString& pa
     TKey* pT;
 
     if (parent.isEmpty()) {
-        pT = new TKey("a", mpHost); // The use of "a" seems a bit arbitary...!
+        pT = new TKey("a", mpHost); // The use of "a" seems a bit arbitrary...!
     } else {
         TKey* pP = mpHost->getKeyUnit()->findFirstKey(parent);
         if (!pP) {
@@ -15247,7 +15247,7 @@ void TLuaInterpreter::updateAnsi16ColorsInTable()
     // Okay so now we point ourselves at the wanted table:
     lua_setfield(L, LUA_GLOBALSINDEX, "color_table");
 
-    // Now we can add/update the items we need to, though it is a bit repetative:
+    // Now we can add/update the items we need to, though it is a bit repetitive:
     QColor color = mpHost->mBlack;
     insertColorTableEntry(L, color, QStringLiteral("ansi_000"));
     insertColorTableEntry(L, color, QStringLiteral("ansi_black"));
@@ -15406,7 +15406,7 @@ void TLuaInterpreter::updateExtendedAnsiColorsInTable()
 
 // Internal function - Creates a table for useful information from the http
 // response. It creates an empty table, calls upon other functions to
-// add things to it, and then returns a key to where it is in the lua registery.
+// add things to it, and then returns a key to where it is in the lua registry.
 int TLuaInterpreter::createHttpResponseTable(QNetworkReply* reply)
 {
     lua_State* L = pGlobalLua;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -141,7 +141,7 @@ std::pair<bool, QString> TMainConsole::setCmdLineStyleSheet(const QString& name,
 
 void TMainConsole::toggleLogging(bool isMessageEnabled)
 {
-    // CHECKME: This path seems suspicious, it is shared amoungst ALL profiles
+    // CHECKME: This path seems suspicious, it is shared amongst ALL profiles
     // but the action is "Per Profile"...!
     QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, QStringLiteral("autolog")));
     QDateTime logDateTime = QDateTime::currentDateTime();
@@ -1280,7 +1280,7 @@ bool TMainConsole::importMap(const QString& location, QString* errMsg)
             filePathNameString = QDir::cleanPath(mudlet::getMudletPath(mudlet::profileDataItemPath, mProfileName, fileInfo.filePath()));
         } else {
             if (fileInfo.exists()) {
-                filePathNameString = fileInfo.canonicalFilePath(); // Cannot use cannonical path if file doesn't exist!
+                filePathNameString = fileInfo.canonicalFilePath(); // Cannot use canonical path if file doesn't exist!
             } else {
                 filePathNameString = fileInfo.absoluteFilePath();
             }

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -598,7 +598,7 @@ void TMap::initGraph()
     unsigned int roomCount = 0;
     unsigned int edgeCount = 0;
     QSet<unsigned int> unUsableRoomSet;
-    // Keep track of the unusuable rather than the useable ones because that is
+    // Keep track of the unusable rather than the usable ones because that is
     // hopefully a MUCH smaller set in normal situations!
     QHashIterator<int, TRoom*> itRoom = mpRoomDB->getRoomMap();
     while (itRoom.hasNext()) {
@@ -822,7 +822,7 @@ void TMap::initGraph()
             }
         } // End of while(itSpecialExit.hasNext())
 
-        // Now we have eliminated possibe duplicate and useless edges we can create and
+        // Now we have eliminated possible duplicate and useless edges we can create and
         // insert the remainder into the BGL graph:
         QHashIterator<unsigned int, route> itRoute = bestRoutes;
         while (itRoute.hasNext()) {
@@ -841,7 +841,7 @@ void TMap::initGraph()
 
     mMapGraphNeedsUpdate = false;
     qDebug() << "TMap::initGraph() INFO: built graph with:" << locations.size() << "(" << roomCount << ") locations(roomCount), and discarded" << unUsableRoomSet.count()
-             << "other NOT useable rooms and found:" << edgeCount << "distinct, usable edges in:" << _time.nsecsElapsed() * 1.0e-6 << "ms.";
+             << "other NOT usable rooms and found:" << edgeCount << "distinct, usable edges in:" << _time.nsecsElapsed() * 1.0e-6 << "ms.";
 }
 
 bool TMap::findPath(int from, int to)
@@ -860,7 +860,7 @@ bool TMap::findPath(int from, int to)
     // passed, the data is empty - and valid for THAT case!
 
     if (from == to) {
-        return true; // Take a short-cut for trival "already there" case!
+        return true; // Take a short-cut for trivial "already there" case!
     }
 
     TRoom* pFrom = mpRoomDB->getRoom(from);
@@ -2876,7 +2876,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
         // "colorRGBA"
         writeJsonColor(customEnvColorObj, itCustomEnvColor.value());
         customEnvColorObj.insert(QLatin1String("id"), QJsonValue{itCustomEnvColor.key()});
-        // Covert the customEnvColorObj into a QJsonValue:
+        // Convert the customEnvColorObj into a QJsonValue:
         const QJsonValue customEnvColorValue{customEnvColorObj};
         // Now append this object onto the array:
         customEnvColorArray.append(customEnvColorValue);

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -850,7 +850,7 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
                         customLinesColor.insert(itCustomLineColor.key().toLower(), QColor(itCustomLineColor.value().at(0), itCustomLineColor.value().at(1), itCustomLineColor.value().at(2)));
                     }
                     // Otherwise we will fixup both empty
-                    // itCustomLineColor.value() entites AND altogether missing
+                    // itCustomLineColor.value() entities AND altogether missing
                     // ones outside of the while() {...}:
                 } else {
                     if (itCustomLineColor.value().count() > 2) {
@@ -2106,7 +2106,7 @@ void TRoom::writeJsonCustomExitLine(QJsonObject& exitObj, const QString& directi
         const QPointF point{points.at(i)};
         customLinePointCoordinateArray.append(static_cast<double>(point.x()));
         customLinePointCoordinateArray.append(static_cast<double>(point.y()));
-        // We might wish to consider storing a z in the future to accomodate 3D
+        // We might wish to consider storing a z in the future to accommodate 3D
         // custom lines...!
         const QJsonValue customLinePointCoordinatesValue{customLinePointCoordinateArray};
         customLinePointsArray.append(customLinePointCoordinatesValue);
@@ -2157,7 +2157,7 @@ void TRoom::readJsonCustomExitLine(const QJsonObject& exitObj, const QString& di
             QPointF point{customLinePointCoordinateArray.at(0).toDouble(), customLinePointCoordinateArray.at(1).toDouble()};
 
             // We might wish to consider if there is a z in the future to
-            // accomodate 3D custom lines...!
+            // accommodate 3D custom lines...!
             points.append(point);
         }
     }

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -141,7 +141,7 @@ void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
         QString values;
         // to update this we need to iterate the entire entranceMap and remove invalid
         // connections. I'm not sure if this is efficient for every update, and given
-        // that we check for rooms existance when the map is used, we'll deal with
+        // that we check for rooms existence when the map is used, we'll deal with
         // possible spurious exits for now.
         // entranceMap.remove(id); // <== not what is wanted
         // We need to remove all values == id NOT keys == id, so try and do that
@@ -177,7 +177,7 @@ void TRoomDB::updateEntranceMap(TRoom* pR, bool isMapLoading)
 // this is call by TRoom destructor only
 bool TRoomDB::__removeRoom(int id)
 {
-    static QMultiHash<int, int> _entranceMap; // Make it persistant - for multiple room deletions
+    static QMultiHash<int, int> _entranceMap; // Make it persistent - for multiple room deletions
     static bool isBulkDelete = false;
     // Gets set / reset by mpTempRoomDeletionSet being non-null, used to setup
     // _entranceMap the first time around for multi-room deletions
@@ -309,7 +309,7 @@ void TRoomDB::removeRoom(QSet<int>& ids)
     mpTempRoomDeletionSet = &ids; // Will activate "bulk room deletion" code
                                   // When used by TLuaInterpreter::deleteArea()
                                   // via removeArea(int) the list of rooms to
-                                  // delete - as suppplied by the reference
+                                  // delete - as supplied by the reference
                                   // type argument IS NOT CONSTANT - it is
                                   // ALTERED by TArea::removeRoom( int room )
                                   // for each room that is removed
@@ -654,7 +654,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
     }
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    // Check for existance of all areas needed by rooms
+    // Check for existence of all areas needed by rooms
     QList<int> areaIdsFromRoomsList{areaRoomMultiHash.uniqueKeys()};
     QSet<int> areaIdSet{areaIdsFromRoomsList.begin(), areaIdsFromRoomsList.end()};
 
@@ -666,7 +666,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         areaIdSet.unite(areaIdsFromAreaNamesSet);
     }
 #else
-    // Check for existance of all areas needed by rooms
+    // Check for existence of all areas needed by rooms
     QSet<int> areaIdSet = areaRoomMultiHash.keys().toSet();
 
     // START OF TASK 3
@@ -934,7 +934,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Exit stubs:
             int _listCount = pR->exitStubs.count();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            // These next few constuction of a QSet from a QList or vice versa
+            // These next few construction of a QSet from a QList or vice versa
             // are probably safe as both iterators refer to the SAME instance
             // that is persistent:
             QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
@@ -1267,7 +1267,7 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
             // A single unnamed area found
             alertText = tr("[ ALERT ] - An empty area name was detected in the Map file!");
             // Use OK for this one because it is the last part and indicates the
-            // sucessful end of something, whereas INFO is an intermediate step
+            // successful end of something, whereas INFO is an intermediate step
             informativeText = tr("[  OK  ]  - Due to some situations not being checked in the past, Mudlet had\n"
                                  "allowed the map to have an area with no name. This can make some\n"
                                  "things confusing and is now disallowed.\n"
@@ -1315,7 +1315,7 @@ void TRoomDB::setAreaRooms(const int areaId, const QSet<int>& roomIds)
 {
     TArea* pA = areas.value(areaId);
     if (!pA) {
-        qWarning() << "TRoomDB::setAreaRooms(" << areaId << ", ... ) ERROR - Non-existant area Id given...!";
+        qWarning() << "TRoomDB::setAreaRooms(" << areaId << ", ... ) ERROR - Non-existent area Id given...!";
         return;
     }
 

--- a/src/TTextCodec.cpp
+++ b/src/TTextCodec.cpp
@@ -324,7 +324,7 @@ QString TTextCodec_869::convertToUnicode(const char *in, int length, ConverterSt
 // * consider the second of the three int state_data[3] array and if castable to
 //   a (bool) false, i.e. zero we should remove a BOM if the IgnoreHeader flag
 //   is not set and it is present at the start of the data. If there is no state
-//   we should remove such a BOM at the begining of "in" for all calls.
+//   we should remove such a BOM at the beginning of "in" for all calls.
 // * if ConvertInvalidToNull is set we are to convert invalid individual QChars
 //   to nulls or if NOT set do what other encoders do and insert a '?' as we
 //   should if there is no state
@@ -340,7 +340,7 @@ QByteArray TTextCodec_437::convertFromUnicode(const QChar *in, int length, Conve
     QByteArray result;
 
     if (!length) {
-        // Avoid extra tests elsewere on an empty Unicode string
+        // Avoid extra tests elsewhere on an empty Unicode string
         return {};
     }
 
@@ -361,7 +361,7 @@ QByteArray TTextCodec_437::convertFromUnicode(const QChar *in, int length, Conve
     } else {
         if (in[i] == QChar::ByteOrderMark) {
             ++i;
-            // Redundent but keeps things simpler if debugging.
+            // Redundant but keeps things simpler if debugging.
             --remainingChars;
         }
     }
@@ -444,7 +444,7 @@ QByteArray TTextCodec_667::convertFromUnicode(const QChar *in, int length, Conve
     QByteArray result;
 
     if (!length) {
-        // Avoid extra tests elsewere on an empty Unicode string
+        // Avoid extra tests elsewhere on an empty Unicode string
         return {};
     }
 
@@ -465,7 +465,7 @@ QByteArray TTextCodec_667::convertFromUnicode(const QChar *in, int length, Conve
     } else {
         if (in[i] == QChar::ByteOrderMark) {
             ++i;
-            // Redundent but keeps things simpler if debugging.
+            // Redundant but keeps things simpler if debugging.
             --remainingChars;
         }
     }
@@ -548,7 +548,7 @@ QByteArray TTextCodec_737::convertFromUnicode(const QChar *in, int length, Conve
     QByteArray result;
 
     if (!length) {
-        // Avoid extra tests elsewere on an empty Unicode string
+        // Avoid extra tests elsewhere on an empty Unicode string
         return {};
     }
 
@@ -569,7 +569,7 @@ QByteArray TTextCodec_737::convertFromUnicode(const QChar *in, int length, Conve
     } else {
         if (in[i] == QChar::ByteOrderMark) {
             ++i;
-            // Redundent but keeps things simpler if debugging.
+            // Redundant but keeps things simpler if debugging.
             --remainingChars;
         }
     }
@@ -652,7 +652,7 @@ QByteArray TTextCodec_869::convertFromUnicode(const QChar *in, int length, Conve
     QByteArray result;
 
     if (!length) {
-        // Avoid extra tests elsewere on an empty Unicode string
+        // Avoid extra tests elsewhere on an empty Unicode string
         return {};
     }
 
@@ -673,7 +673,7 @@ QByteArray TTextCodec_869::convertFromUnicode(const QChar *in, int length, Conve
     } else {
         if (in[i] == QChar::ByteOrderMark) {
             ++i;
-            // Redundent but keeps things simpler if debugging.
+            // Redundant but keeps things simpler if debugging.
             --remainingChars;
         }
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1341,7 +1341,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             // the hovered() signal can be *problematic* - as hitting a
             // breakpoint - or getting an OS signal (like a Segment Violation)
             // can hang not only Mudlet but also Qt Creator and possibly even
-            // your Desktop - though for *nix users swithing to a console and
+            // your Desktop - though for *nix users switching to a console and
             // killing the gdb debugger instance run by Qt Creator will restore
             // normality.
             connect(mpContextMenuAnalyser, &QAction::hovered, this, &TTextEdit::slot_analyseSelection);
@@ -1789,7 +1789,7 @@ void TTextEdit::wheelEvent(QWheelEvent* e)
     // Convert to degrees:
     delta /= 8.0;
     // Allow the control key to introduce a speed up - but also allow it to be
-    // overriden by a shift key to slow the scroll down to one line/character
+    // overridden by a shift key to slow the scroll down to one line/character
     // per click:
     delta.rx() *= (e->modifiers() & Qt::ShiftModifier ? 1.0 : (e->modifiers() & Qt::ControlModifier ? xSpeedUp : 3.0));
     delta.ry() *= (e->modifiers() & Qt::ShiftModifier ? 1.0 : (e->modifiers() & Qt::ControlModifier ? ySpeedUp : 3.0));
@@ -1920,7 +1920,7 @@ inline QString TTextEdit::convertWhitespaceToVisual(const QChar& first, const QC
         quint16 value = first.unicode();
         switch (value) {
         case 0x003c:                    return htmlCenter(QStringLiteral("&lt;")); break; // As '<' gets interpreted as an opening HTML tag we have to handle it specially
-        case 0x003e:                    return htmlCenter(QStringLiteral("&gt;")); break; // '>' does not seem to get interpreted as a closing HTML tag but for symetry it is probably best to also handle it in the same way
+        case 0x003e:                    return htmlCenter(QStringLiteral("&gt;")); break; // '>' does not seem to get interpreted as a closing HTML tag but for symmetry it is probably best to also handle it in the same way
         case QChar::Tabulation:         return htmlCenter(tr("{tab}", "Unicode U+0009 codepoint.")); break;
         case QChar::LineFeed:           return htmlCenter(tr("{line-feed}", "Unicode U+000A codepoint. Not likely to be seen as it gets filtered out.")); break;
         case QChar::CarriageReturn:     return htmlCenter(tr("{carriage-return}", "Unicode U+000D codepoint. Not likely to be seen as it gets filtered out.")); break;

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -195,7 +195,7 @@ private:
     // making this a const value for the moment:
     const int mTimeStampWidth;
     bool mShowAllCodepointIssues;
-    // Marked mutable so that it is permissable to change this in class methods
+    // Marked mutable so that it is permissible to change this in class methods
     // that are otherwise const!
     mutable QHash<uint, std::tuple<uint, std::string>> mProblemCodepoints;
     // We scroll on the basis that one vertical mouse wheel click is one line

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -1067,7 +1067,7 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
                 if (matchStatePair.second->isComplete()) {
                     mKeepFiring = mStayOpen;
                     if (mudlet::debugMode) {
-                        TDebug(Qt::yellow, Qt::darkMagenta) << "multiline trigger name=" << mName << " *FIRES* all conditons are fullfilled. Executing script.\n" >> mpHost;
+                        TDebug(Qt::yellow, Qt::darkMagenta) << "multiline trigger name=" << mName << " *FIRES* all conditions are fulfilled. Executing script.\n" >> mpHost;
                     }
                     removeList.push_back(matchStatePair.first);
                     conditionMet = true;
@@ -1106,7 +1106,7 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
                 if (mConditionMap.find(matchState) != mConditionMap.end()) {
                     delete mConditionMap[matchState];
                     if (mudlet::debugMode) {
-                        TDebug(Qt::darkBlue, Qt::black) << "removing condition from conditon table.\n" >> mpHost;
+                        TDebug(Qt::darkBlue, Qt::black) << "removing condition from condition table.\n" >> mpHost;
                     }
                     mConditionMap.erase(matchState);
                 }
@@ -1116,7 +1116,7 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
 
         // definition trigger chain: a folder is part of a trigger chain if it has a regex defined
         // a trigger chain only lets data pass if the condition matches or in case of multiline all
-        // all conditions are fullfilled
+        // all conditions are fulfilled
         //
         // a folder can also be a simple structural element in which case all data passes through
         // if at least one regex is defined a folder is considered a trigger chain otherwise a structural element
@@ -1173,7 +1173,7 @@ bool TTrigger::match(char* subject, const QString& toMatch, int line, int posOff
 // colors for foreground and background (proper ANSI indexes) and what they look
 // like give the current Host settings (the first 16 ANSI ones and the default
 // fore and background colors can be changed by the user and since OSC P/R
-// support has been implimented - by the MUD Server!)
+// support has been implemented - by the MUD Server!)
 TColorTable* TTrigger::createColorPattern(int ansiFg, int ansiBg)
 {
     /*

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -332,11 +332,11 @@ bool XMLexport::saveXmlFile(QFile& file)
 {
     std::stringstream saveStringStream(std::ios::out);
     // Remember, the mExportDoc is the data in the form of a pugi::xml_document
-    // instance - the save method needs a stream that impliments the
+    // instance - the save method needs a stream that implements the
     // std::ostream interface into which it can push the data:
     mExportDoc.save(saveStringStream);
     // We need to do our own replacement of ASCII control characters that are
-    // not valid in XML verison 1.0 and that means we cannot use the pugixml
+    // not valid in XML version 1.0 and that means we cannot use the pugixml
     // file methods as it does that in a different way which is not helpful
     // as we do not use that library for READING the XML files - so convert
     // the data to a std::string :

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -892,11 +892,11 @@ void XMLimport::readHostPackage(Host* pHost)
     if (qFuzzyCompare(1.0 + pHost->mRoomSize, 1.0)) {
         // The value is a float/double and the prior code using "== 0" is a BAD
         // THING to do with non-integer number types!
-        pHost->mRoomSize = 0.5; // Same value as is in Host class initalizer list
+        pHost->mRoomSize = 0.5; // Same value as is in Host class initializer list
     }
     pHost->mLineSize = attributes().value(QStringLiteral("mLineSize")).toString().toDouble();
     if (qFuzzyCompare(1.0 + pHost->mLineSize, 1.0)) {
-        pHost->mLineSize = 10.0; // Same value as is in Host class initalizer list
+        pHost->mLineSize = 10.0; // Same value as is in Host class initializer list
     }
     pHost->mBubbleMode = attributes().value(QStringLiteral("mBubbleMode")) == YES;
     pHost->mMapViewOnly = attributes().value(QStringLiteral("mMapViewOnly")) == YES;
@@ -1197,7 +1197,7 @@ int XMLimport::readTriggerGroup(TTrigger* pParent)
                 readIntegerList(pT->mRegexCodePropertyList, pT->getName());
                 if (Q_UNLIKELY(pT->mRegexCodeList.count() != pT->mRegexCodePropertyList.count())) {
                     qWarning().nospace() << "XMLimport::readTriggerGroup(...) ERROR: "
-                                            "mis-match in regexCode details for Trigger: "
+                                            "mismatch in regexCode details for Trigger: "
                                          << pT->getName() << " there were " << pT->mRegexCodeList.count() << " 'regexCodeList' sub-elements and " << pT->mRegexCodePropertyList.count()
                                          << " 'regexCodePropertyList' sub-elements so "
                                             "something is broken!";
@@ -1792,7 +1792,7 @@ void XMLimport::remapColorsToAnsiNumber(QStringList & patternList, const QList<i
             }
 
         } else {
-            // Must advance the pattern interator if it isn't a colour pattern
+            // Must advance the pattern iterator if it isn't a colour pattern
             itPattern.next();
         }
     }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3013,7 +3013,7 @@ void cTelnet::setKeepAlive(int socketHandle)
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPIDLE, &timeout, sizeof(timeout));
 #endif
 
-    // Interval between keep-alive, in seconds:
+    // Interval between keep-alives, in seconds:
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval));
     // Number of failed keep alives before forcing a close:
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -338,7 +338,7 @@ QPair<bool, QString> cTelnet::setEncoding(const QByteArray& newEncoding, const b
     } else if (!(mAcceptableEncodings.contains(newEncoding) || mAcceptableEncodings.contains("M_" + newEncoding))) {
         // Not in list (even with a "M_" prefix that indicates the relevant
         // QTextCodec is actually one of our own TTextCodecs) - so reject it
-        // Since we want to hide the implimentation detail that some of the
+        // Since we want to hide the implementation detail that some of the
         // encoding names could have a "M_"  prefix we will need to preprocess
         // the list of encodings.
         // Since the mAcceptableEncodings list is unchanging once it has been
@@ -725,7 +725,7 @@ bool cTelnet::socketOutRaw(std::string& data)
         if (chunkWritten < 0) {
             // -1 is the sentinel (error) value but any other negative value
             // would not make sense and it would break the cast to the
-            // (unsigned) std::size_t type in the next code fragement!
+            // (unsigned) std::size_t type in the next code fragment!
             return false;
         }
 
@@ -1188,7 +1188,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
             triedToEnable[idxOption] = false;
         } else {
             if (!hisOptionState[idxOption]) {
-                //only if this is not set; if it's set, something's wrong wth the server
+                //only if this is not set; if it's set, something's wrong with the server
                 //(according to telnet specification, option announcement may not be
                 //unless explicitly requested)
 
@@ -1834,7 +1834,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
     } //end switch 1
 
     // raise sysTelnetEvent for all unhandled protocols
-    // EXCEPT TN_GA / TN_EOR, which come at the end of every transmission, for performance reaons
+    // EXCEPT TN_GA / TN_EOR, which come at the end of every transmission, for performance reasons
     if (command[1] != TN_GA && command[1] != TN_EOR) {
         auto type = static_cast<unsigned char>(command[1]);
         auto telnetOption = static_cast<unsigned char>(command[2]);
@@ -2305,7 +2305,7 @@ void cTelnet::atcpComposerSave(QString txt)
 // following prefix.
 // Prefixes are made uppercase.
 // Will store messages if the TConsole on which they are to be placed is not yet
-// in existance as happens during startup, then pumps them out in order of
+// in existence as happens during startup, then pumps them out in order of
 // arrival once a message arrives when the TConsole DOES exist.
 void cTelnet::postMessage(QString msg)
 {
@@ -3013,7 +3013,7 @@ void cTelnet::setKeepAlive(int socketHandle)
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPIDLE, &timeout, sizeof(timeout));
 #endif
 
-    // Interval between keep-alives, in seconds:
+    // Interval between keep-alive, in seconds:
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval));
     // Number of failed keep alives before forcing a close:
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
@@ -3041,7 +3041,7 @@ QByteArray cTelnet::decodeBytes(const char* bytes)
 // encoding and cooks any 0xff bytes by doubling them to get them through Telnet
 // protocol handling in the Server - this is needed, at least, for the following
 //  characters in the following encodings which WILL become the 0xff value:
-// 'ÿ' {U+00FF Latin small letter y with diaresis} ==> ISO 8859-1/9/14/15/16
+// 'ÿ' {U+00FF Latin small letter y with diaeresis} ==> ISO 8859-1/9/14/15/16
 // '˙' {U+02D9 Dot above}                          ==> ISO 8859-2/3/4
 // 'џ' {U+045F Cyrillic small letter dzhe}         ==> ISO 8859-5
 // 'ĸ' {U+0138 Latin small letter kra}             ==> ISO 8859-10

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -486,7 +486,7 @@ QString Discord::deduceGameName(const QString& address)
         fragments.removeLast();
         otherName = fragments.join(QLatin1String("."));
         if (otherName.startsWith(QLatin1String("game."))) {
-            // WoTMUD type case - so take remaing term in the middle of original
+            // WoTMUD type case - so take remaining term in the middle of original
             otherName = otherName.split(QChar('.')).last();
             break;
         } else if (otherName.startsWith(QLatin1String("www."))) {

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -891,7 +891,7 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 
     QString Sparkle3rdPartyHeader(tr("<h4>bspatch.c and bsdiff.c, from bsdiff 4.3 <a href=\"http://www.daemonology.net/bsdiff/\">http://www.daemonology.net/bsdiff</a>:</h4>"
                                      "<h3>Copyright © 2003-2005 Colin Percival.</h3>"
-                                     "<h4>says.c and says.c, from says-lite (2010/08/07) <a href=\"https://sites.google.com/site/yuta256/says\">https://sites.google.com/site/yuta256/says</a>:</h4>"
+                                     "<h4>sais.c and sais.c, from sais-lite (2010/08/07) <a href=\"https://sites.google.com/site/yuta256/sais\">https://sites.google.com/site/yuta256/sais</a>:</h4>"
                                      "<h3>Copyright © 2008-2010 Yuta Mori.</h3>"
                                      "<h4>SUDSAVerifier.m:</h4>"
                                      "<h3>Copyright © 2011 Mark Hamlin.<br>"

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -115,7 +115,7 @@ dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
      * the most efficient way of putting together a set of large QStrings
      * some of which will shortly be made translable, it is intended to make
      * it easier to add and remove sections according to the build settings
-     * and for boiler-plate licences to be reused mulitple times if necessary.
+     * and for boiler-plate licences to be reused multiple times if necessary.
      */
 
     // A uniform header for all tabs:
@@ -294,7 +294,7 @@ void dlgAboutDialog::setLicenseTab(const QString& htmlHead) const
     QString headerText(tr("<p>Mudlet was originally written by Heiko Köhn, KoehnHeiko@googlemail.com.</p>\n"
                           "<p>Mudlet is released under the GPL license version 2, which is reproduced below:</p>",
                           "For non-english language versions please append a translation of the following "
-                          "to explain why the GPL is NOT reproduced in the relevent language: 'but only "
+                          "to explain why the GPL is NOT reproduced in the relevant language: 'but only "
                           "the English form is considered the official version of the license, so the "
                           "following is reproduced in that language:' to replace 'which is reproduced below:'..."));
 
@@ -891,7 +891,7 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
 
     QString Sparkle3rdPartyHeader(tr("<h4>bspatch.c and bsdiff.c, from bsdiff 4.3 <a href=\"http://www.daemonology.net/bsdiff/\">http://www.daemonology.net/bsdiff</a>:</h4>"
                                      "<h3>Copyright © 2003-2005 Colin Percival.</h3>"
-                                     "<h4>sais.c and sais.c, from sais-lite (2010/08/07) <a href=\"https://sites.google.com/site/yuta256/sais\">https://sites.google.com/site/yuta256/sais</a>:</h4>"
+                                     "<h4>says.c and says.c, from says-lite (2010/08/07) <a href=\"https://sites.google.com/site/yuta256/says\">https://sites.google.com/site/yuta256/says</a>:</h4>"
                                      "<h3>Copyright © 2008-2010 Yuta Mori.</h3>"
                                      "<h4>SUDSAVerifier.m:</h4>"
                                      "<h3>Copyright © 2011 Mark Hamlin.<br>"

--- a/src/dlgColorTrigger.cpp
+++ b/src/dlgColorTrigger.cpp
@@ -369,7 +369,7 @@ void dlgColorTrigger::slot_moreColorsClicked()
     // Used to pull the button down if this slot is called from the constructor:
     buttonBox->button(QDialogButtonBox::Apply)->setChecked(true);
 
-    // Impliment a one-shot action by disabling it once it is pressed:
+    // Implement a one-shot action by disabling it once it is pressed:
     buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 
     buttonBox->button(QDialogButtonBox::Apply)->setToolTip(tr("All color options are showing."));

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -399,7 +399,7 @@ void dlgConnectionProfiles::slot_update_autoreconnect(int state)
 }
 
 // This gets called when the QCheckBox that it is connect-ed to gets its
-// checked state set programatically AS WELL as when the user clicks on it:
+// checked state set programmatically AS WELL as when the user clicks on it:
 void dlgConnectionProfiles::slot_update_discord_optin(int state)
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
@@ -728,7 +728,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
     } else if (hostUrl == QLatin1String("carrionfields.net")) {
         return QLatin1String("Carrion Fields is a unique blend of high-caliber roleplay and complex, hardcore player-versus-player combat that has been running continuously, and 100% free, for over "
                              "25 years.\n\nChoose from among 21 races, 17 highly customizable classes, and several cabals and religions to suit your playstyle and the story you want to tell. Our "
-                             "massive, original world is full of secrets and envied limited objects that take skill to acquire and great care to keep.\n\nWe like to think of ourselves as the Dark "
+                             "massive, original world is full of secrets and envied limited objects that take skill to acquire and great care to keep.\n\new like to think of ourselves as the Dark "
                              "Souls of MUDs, with a community that is supportive of new players - unforgiving though our world may be. Join us for a real challenge and real rewards: "
                              "adrenalin-pumping battles, memorable quests run by our volunteer immortal staff, and stories that will stick with you for a lifetime.");
     } else if (hostUrl == QLatin1String("cleftofdimensions.net")) {

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -728,7 +728,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
     } else if (hostUrl == QLatin1String("carrionfields.net")) {
         return QLatin1String("Carrion Fields is a unique blend of high-caliber roleplay and complex, hardcore player-versus-player combat that has been running continuously, and 100% free, for over "
                              "25 years.\n\nChoose from among 21 races, 17 highly customizable classes, and several cabals and religions to suit your playstyle and the story you want to tell. Our "
-                             "massive, original world is full of secrets and envied limited objects that take skill to acquire and great care to keep.\n\new like to think of ourselves as the Dark "
+                             "massive, original world is full of secrets and envied limited objects that take skill to acquire and great care to keep.\n\nWe like to think of ourselves as the Dark "
                              "Souls of MUDs, with a community that is supportive of new players - unforgiving though our world may be. Join us for a real challenge and real rewards: "
                              "adrenalin-pumping battles, memorable quests run by our volunteer immortal staff, and stories that will stick with you for a lifetime.");
     } else if (hostUrl == QLatin1String("cleftofdimensions.net")) {

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -193,7 +193,7 @@ void dlgModuleManager::slot_module_clicked(QTableWidgetItem* pItem)
     QTableWidgetItem* entry = mModuleTable->item(i, 0);
     QTableWidgetItem* checkStatus = mModuleTable->item(i, 2);
     QTableWidgetItem* itemPriority = mModuleTable->item(i, 1);
-    //  Not used programatically now: QTableWidgetItem* itemPath = moduleTable->item(i, 3);
+    //  Not used programmatically now: QTableWidgetItem* itemPath = moduleTable->item(i, 3);
     if (!entry || !checkStatus || !itemPriority || !mpHost->mInstalledModules.contains(entry->text())) {
         mModuleHelpButton->setDisabled(true);
         if (checkStatus) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -183,7 +183,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     tabWidget->setCurrentIndex(0);
 
     // To be moved to a slot that is used on GUI language change when that gets
-    // implimented:
+    // implemented:
 
     // Set the tooltip on the containing widget so both the label and the
     // control have the same tool-tip:
@@ -240,7 +240,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
                                              "<li><b>Checked</b> '<i>on</i>' = Allow menus to be drawn with icons.</li>"
                                              "<li><b>Partly checked</b> <i>(Default) 'auto'</i> = Use the setting that the system provides.</li></ul></p>"
                                              "<p><i>This setting is only processed when individual menus are created and changes may not "
-                                             "propogate everywhere until Mudlet is restarted.</i></p>"));
+                                             "propagate everywhere until Mudlet is restarted.</i></p>"));
 
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
@@ -406,7 +406,7 @@ void dlgProfilePreferences::disableHostDetails()
 
     // on tab_mapper:
     // most of groupBox_mapFiles is disabled but there is ONE checkBox that
-    // is accessable because it is application wide - so disable EVERYTHING
+    // is accessible because it is application wide - so disable EVERYTHING
     // else that is not already disabled:
     label_saveMap->setEnabled(false);
     pushButton_saveMap->setEnabled(false);
@@ -485,7 +485,7 @@ void dlgProfilePreferences::enableHostDetails()
 
     // on tab_mapper:
     // most of groupBox_mapFiles is disabled but there is ONE checkBox that
-    // is accessable because it is application wide - so disable EVERYTHING
+    // is accessible because it is application wide - so disable EVERYTHING
     // else that is not already disabled:
     label_saveMap->setEnabled(true);
     pushButton_saveMap->setEnabled(true);
@@ -614,7 +614,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             }
         }
 
-        // Reenable sorting now we have populated the widget:
+        // Re-enable sorting now we have populated the widget:
         dictList->setSortingEnabled(true);
         // Actually do the sort:
         dictList->sortItems();
@@ -804,7 +804,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     hidePasswordMigrationLabel();
 
-    //doubleclick ignore
+    //double-click ignore
     QString ignore;
     QSetIterator<QChar> it(pHost->mDoubleClickIgnore);
     while (it.hasNext()) {
@@ -2299,7 +2299,7 @@ void dlgProfilePreferences::copyMap()
     mudlet::self()->requestProfilesToReloadMaps(toProfilesRoomIdMap.keys());
     // GOTCHA: keys() is a QList<QString>, however, though it IS equivalent to a
     // QStringList in many ways, the SLOT/SIGNAL system treats them as different
-    // - I thinK - so use QList<QString> thoughout the SIGNAL/SLOT links Slysven!
+    // - I thinK - so use QList<QString> throughout the SIGNAL/SLOT links Slysven!
     label_mapFileActionResult->setText(tr("Map copied, now signalling other profiles to reload it."));
     QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
 
@@ -2331,7 +2331,7 @@ void dlgProfilePreferences::slot_setLogDir()
      * QFileDialog constructors."
      *
      * That warning suggests *bad things* would happen if the "Save" button or
-     * the widget title bar close button was pressed on the Profile Preferrences
+     * the widget title bar close button was pressed on the Profile Preferences
      * dialog while the directory selector is open...!
      */
     // Seems to return "." when Cancel is hit:
@@ -3507,7 +3507,7 @@ void dlgProfilePreferences::slot_setMapSymbolFont(const QFont & font)
 
 // These next two prevent BOTH controls being set to never to prevent the lose
 // of access to the setting/controls completely - once there is a profile loaded
-// access to the settings/controls can be overriden by a context menu action on
+// access to the settings/controls can be overridden by a context menu action on
 // any TConsole instance:
 void dlgProfilePreferences::slot_changeShowMenuBar(int newIndex)
 {
@@ -3601,7 +3601,7 @@ void dlgProfilePreferences::setButtonColor(QPushButton* button, const QColor& co
                                       .scaled(iconBackground.width(), iconBackground.height(), Qt::KeepAspectRatioByExpanding));
             painter.fillRect(0, 0, iconBackground.width(), iconBackground.height(), disabledColor);
             painter.end();
-            // Because the button is disabled we have to explictly force our
+            // Because the button is disabled we have to explicitly force our
             // icon to be used for that state otherwise the built-in icon engine
             // will assume our image is for the normal state and grey it out
             // completely by automagic means instead of making use of the
@@ -3755,7 +3755,7 @@ void dlgProfilePreferences::slot_guiLanguageChanged(const QString& language)
 
     // Now change the displayed texts that are translated - importantly this
     // is done so that the message that says "restart Mudlet to finish changing
-    // the language" is shown in the newly selected langauge - on the basis that
+    // the language" is shown in the newly selected language - on the basis that
     // it is the one the user understands rather than the currently used one.
     retranslateUi(this);
 

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -23,7 +23,7 @@
 /*
  * Eventually these should be defined for whole application to force explicit
  * definition of all strings as:
- * EITHER: QStringLiteral("<string>") for internal non-user visable use not
+ * EITHER: QStringLiteral("<string>") for internal non-user visible use not
  * subject to translation
  * OR: tr("<string>") for GUI or other user visible strings that need to be
  * handled by the translation system {or qApp->translate("<classname>",
@@ -157,7 +157,7 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
                                                              "a valid number; if left like this, this exit will be deleted when &lt;i&gt;save&lt;/i&gt; is clicked.")));
         }
 
-        mpEditItem = nullptr; //This will cause a new PE to be opened, it will also be zeroed on the first time this funciton is called
+        mpEditItem = nullptr; //This will cause a new PE to be opened, it will also be zeroed on the first time this function is called
         mEditColumn = -1;
     }
 
@@ -303,7 +303,7 @@ void dlgRoomExits::save()
         if (pR->hasExitStub(dirCode)) { // And ensure that stub exit is cleared if set
             pR->setExitStub(dirCode, false);
         }
-        if (weight_nw->value()) { // And store any weighing specifed
+        if (weight_nw->value()) { // And store any weighing specified
             pR->setExitWeight(exitKey, weight_nw->value());
         } else {
             pR->setExitWeight(exitKey, 0);
@@ -657,7 +657,7 @@ void dlgRoomExits::save()
 
     // return value from checkedId() is -1 for no radio button in group checked,
     //   and then more negative values starting from -2 for each button that was
-    //   created without an explict Id, any attempt to set a different Id using
+    //   created without an explicit Id, any attempt to set a different Id using
     //   setId() seems to fail for me :(
     if (doortype_nw->checkedId() < -1) {
         pR->setDoor(QStringLiteral("nw"), -2 - doortype_nw->checkedId());
@@ -1337,7 +1337,7 @@ void dlgRoomExits::slot_stub_nw_stateChanged(int state)
         doortype_closed_nw->setEnabled(false);
         doortype_locked_nw->setEnabled(false);
         doortype_none_nw->setChecked(true);
-        //  similarly as there won't be a valid exit or a stub exit at theis point disable/reset the door type controls
+        //  similarly as there won't be a valid exit or a stub exit at this point disable/reset the door type controls
         weight_nw->setEnabled(false);
         weight_nw->setValue(0); // Prevent a weight to be set/changed on a also
     }
@@ -1771,7 +1771,7 @@ void dlgRoomExits::initExit(int roomId,
     } else {                                             //No exit is set on initialisation
         exitLineEdit->setText(QString());                //Nothing to put in exitID box
         exitLineEdit->setStyleSheet(QString());
-        noRoute->setEnabled(false); //Disable lock control, can't lock a non-existant exit..
+        noRoute->setEnabled(false); //Disable lock control, can't lock a non-existent exit..
         noRoute->setChecked(false); //.. and ensure there isn't one
         weight->setEnabled(false);  //Disable exit weight control...
         weight->setValue(0);        //And reset to default value (which will now cause the room's one to be used
@@ -1788,7 +1788,7 @@ void dlgRoomExits::initExit(int roomId,
             exitLineEdit->setEnabled(true);
             exitLineEdit->setToolTip(singleParagraph.arg(tr("Set the number of the room %1 of this one, will be blue for a valid number or red for invalid.").arg(exitText)));
             stub->setChecked(false);
-            none->setEnabled(false); //Disable door type controls, can't lock a non-existant exit..
+            none->setEnabled(false); //Disable door type controls, can't lock a non-existent exit..
             open->setEnabled(false); //.. and ensure the "none" one is set if it ever gets enabled
             closed->setEnabled(false);
             locked->setEnabled(false);

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -579,7 +579,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar->addAction(saveAction);
     toolBar->setWindowTitle(tr("Editor Toolbar - %1 - Actions",
                                // Intentional comment to separate arguments
-                               "This is the toolbar that is initally placed at the top of the editor.")
+                               "This is the toolbar that is initially placed at the top of the editor.")
                             .arg(hostName));
 
     toolBar->addSeparator();
@@ -615,7 +615,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     toolBar2->setMovable(true);
     toolBar2->setWindowTitle(tr("Editor Toolbar - %1 - Items",
                                 // Intentional comment to separate arguments
-                                "This is the toolbar that is initally placed at the left side of the editor.")
+                                "This is the toolbar that is initially placed at the left side of the editor.")
                              .arg(hostName));
     toolBar2->setOrientation(Qt::Vertical);
 
@@ -5045,7 +5045,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
 
         for (int i = 0; i < patternList.size(); i++) {
             if (i >= 50) {
-                break; //pattern liste ist momentan auf 50 begrenzt
+                break; // pattern list is limited to 50 at the moment
             }
             if (i >= pT->mColorPatternList.size()) {
                 break;
@@ -5314,7 +5314,7 @@ void dlgTriggerEditor::recursiveSearchVariables(TVar* var, QList<TVar*>& list, b
 
 void dlgTriggerEditor::slot_var_changed(QTreeWidgetItem* pItem)
 {
-    // This handles a small case where the radio buttom is clicked while the item is currently selected
+    // This handles a small case where the radio button is clicked while the item is currently selected
     // which causes the variable to not save. In places where we populate the TreeWidgetItem, we have
     // to guard it with mChangingVar or else this will be called with every change such as the variable
     // name, etc.
@@ -8935,7 +8935,7 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
                 if (QColor::isValidColor(match.captured(1))) {
                     return QColor(match.captured(1));
                 } else {
-                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invaid string \"" <<  match.captured(1) << "\" found as name of foreground color!";
+                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid string \"" <<  match.captured(1) << "\" found as name of foreground color!";
                     return QColor();
                 }
             } else {
@@ -8969,7 +8969,7 @@ QColor dlgTriggerEditor::parseButtonStyleSheetColors(const QString& styleSheetTe
                 if (QColor::isValidColor(match.captured(1))) {
                     return QColor(match.captured(1));
                 } else {
-                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invaid string \"" <<  match.captured(1) << "\" found as name of background color!";
+                    qDebug().noquote().nospace() << "dlgTriggerEditor::parseButtonStyleSheetColors(\"" << styleSheetText << "\", " << isToGetForeground << ") ERROR - Invalid string \"" <<  match.captured(1) << "\" found as name of background color!";
                     return QColor();
                 }
             } else {

--- a/src/dlgVarsMainArea.cpp
+++ b/src/dlgVarsMainArea.cpp
@@ -35,7 +35,7 @@ dlgVarsMainArea::dlgVarsMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    // Modify the normal QComboBoxes with customised data models that impliment
+    // Modify the normal QComboBoxes with customised data models that implement
     // https://stackoverflow.com/a/21376774/4805858 so that individual entries
     // can be "disabled":
     // Key type widget:

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -700,7 +700,7 @@ void mudlet::loadMaps()
     // QMap<T1, T2>::value(const T1&) where the parameter has been previously
     // been converted to all-lower case:
     // From https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes:
-    // More useful is the cross-referenced (Country <-> Languges):
+    // More useful is the cross-referenced (Country <-> Languages):
     // https://www.unicode.org/cldr/charts/latest/supplemental/language_territory_information.html
     // Initially populated from the dictionaries provided within the Debian
     // GNU/Linux distribution:
@@ -941,8 +941,8 @@ void mudlet::loadMaps()
                                   {QStringLiteral("ve"), tr("Venda")},
                                   {QStringLiteral("vi"), tr("Vietnamese")},
                                   {QStringLiteral("vi_vn"), tr("Vietnamese (Vietnam)")},
-                                  {QStringLiteral("vi_daucu"), tr("Vietnamese (DauCu varient - old-style diacritics)")},
-                                  {QStringLiteral("vi_daumoi"), tr("Vietnamese (DauMoi varient - new-style diacritics)")},
+                                  {QStringLiteral("vi_daucu"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
+                                  {QStringLiteral("vi_daumoi"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
                                   {QStringLiteral("wa"), tr("Walloon")},
                                   {QStringLiteral("xh"), tr("Xhosa")},
                                   {QStringLiteral("yi"), tr("Yiddish")},
@@ -1062,7 +1062,7 @@ void mudlet::scanForMudletTranslations(const QString& path)
                     percentageTranslated = 0;
                 }
             }
-            // PLACEMARKER: Start of locale codes to native language decoding - insert an entry here for any futher Mudlet supported languages
+            // PLACEMARKER: Start of locale codes to native language decoding - insert an entry here for any further Mudlet supported languages
             translation currentTranslation(percentageTranslated);
             if (!languageCode.compare(QLatin1String("en_US"), Qt::CaseInsensitive)) {
                 currentTranslation.mNativeName = QStringLiteral("English (American)");
@@ -1103,7 +1103,7 @@ void mudlet::scanForMudletTranslations(const QString& path)
             mTranslationsMap.insert(languageCode, currentTranslation);
         } else {
             // This is very unlikely to be reached as it means that a file that
-            // matched the naming to be a Mudlet translation file was not infact
+            // matched the naming to be a Mudlet translation file was not in fact
             // one...
             qDebug().noquote().nospace() << "    no Mudlet translation found for locale code: \"" << languageCode << "\".";
         }
@@ -1135,7 +1135,7 @@ void mudlet::scanForQtTranslations(const QString& path)
              * IS detected.
              *
              * So although we can note the load of a given pathFileName is
-             * sucessful it might not be exactly what it seems to be!
+             * successful it might not be exactly what it seems to be!
              */
             translation current = itTranslation.value();
             current.mQtTranslationFileName = translationFileName;
@@ -2773,7 +2773,7 @@ void mudlet::toggleFullScreenView()
 bool mudlet::replayStart()
 {
     // Do not proceed if there is a problem with the main toolbar (it isn't there)
-    // OR if there is already a replay toolbar in existance (a replay is already
+    // OR if there is already a replay toolbar in existence (a replay is already
     // in progress)...
     if (!mpMainToolBar || mpToolBarReplay) {
         return false;
@@ -3535,13 +3535,13 @@ void mudlet::showChangelogIfUpdated()
 bool mudlet::loadReplay(Host* pHost, const QString& replayFileName, QString* pErrMsg)
 {
     // Do not proceed if there is a problem with the main toolbar (it isn't there)
-    // OR if there is already a replay toolbar in existance (a replay is already
+    // OR if there is already a replay toolbar in existence (a replay is already
     // in progress)...
     if (!mpMainToolBar || mpToolBarReplay) {
         // This was in (bool) ctelnet::loadReplay(const QString&, QString*)
         // but is needed here to prevent getting into there otherwise a lua call
         // to start a replay would mess up (QFile) ctelnet::replayFile for a
-        // replay already in progess in the SAME profile.  Technically there
+        // replay already in progress in the SAME profile.  Technically there
         // could be a very small chance of a race condition if a lua call of
         // loadReplay happens at the same time as a file was selected for a
         // replay after the toolbar/menu command to do a reaply for the same
@@ -3898,7 +3898,7 @@ bool mudlet::scanDictionaryFile(QFile& dict, int& oldWC, QHash<QString, unsigned
 bool mudlet::overwriteDictionaryFile(QFile& dict, const QStringList& wl)
 {
     // (Re)Open the file to write out the cleaned/new contents
-    // QFile::WriteOnly automatically implies QFile::Truncate in the abscence of
+    // QFile::WriteOnly automatically implies QFile::Truncate in the absence of
     // certain other flags:
     if (!dict.open(QFile::WriteOnly|QFile::Text)) {
         qWarning().nospace().noquote() << "mudlet::overwriteDictionaryFile(...) ERROR - failed to open dictionary file (for writing): \"" << dict.fileName() << "\" reason: " << dict.errorString();
@@ -4072,7 +4072,7 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
     // to confuse our add/remove code.  We just need the SET line to force the
     // Hunspell API to be UTF-8 and the TRY line to allow for searching for
     // completions. Anyhow we now need to keep the copy of the word list ourself
-    // to allow for persistant editing of it as it is not possible to obtain it
+    // to allow for persistent editing of it as it is not possible to obtain it
     // from the Hunspell library:
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
@@ -4370,7 +4370,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
     Q_UNUSED(oldPos)
     const QStringList& tabNamesInOrder = mpTabBar->tabNames();
     int itemsCount = mpHBoxLayout_profileContainer->count();
-    Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "missmatch in count of tabs and TMainConsoles");
+    Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "mismatch in count of tabs and TMainConsoles");
     QMap<QString, QLayoutItem*> layoutItemMap;
     // Gather the QLayoutItem pointers for each TMainConsole and store them
     // against their profile name:
@@ -4389,9 +4389,9 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
     for (int index = 0; index < itemsCount; ++index) {
         const auto& wantedTabName = tabNamesInOrder.at(index);
         auto pLayoutItem = layoutItemMap.value(wantedTabName);
-        // This will remove the item from whereever it is in the layout:
+        // This will remove the item from wherever it is in the layout:
         mpHBoxLayout_profileContainer->removeItem(pLayoutItem);
-        // This will readd the item to the end of the layout:
+        // This will re-add the item to the end of the layout:
         mpHBoxLayout_profileContainer->addItem(pLayoutItem);
     }
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -399,7 +399,7 @@ public:
 #endif
 
 
-    // Currently tracks the "mudlet_option_use_smallscreen" file's existance but
+    // Currently tracks the "mudlet_option_use_smallscreen" file's existence but
     // may eventually migrate solely to the "EnableFullScreenMode" in the main
     // QSetting file - it is only stored as a file now to maintain backwards
     // compatibility...
@@ -644,7 +644,7 @@ private:
     // on the mpToolBarReplay:
     QString mTimeFormat;
 
-    // Has default form of "en_US" but can be just an ISO langauge code e.g. "fr" for french,
+    // Has default form of "en_US" but can be just an ISO language code e.g. "fr" for french,
     // without a country designation. Replaces xx in "mudlet_xx.qm" to provide the translation
     // file for GUI translation
     QString mInterfaceLanguage {};
@@ -653,7 +653,7 @@ private:
     QLocale mUserLocale {};
 
     // The next pair retains the path argument supplied to the corresponding
-    // scanForXxxTranslations(...) method so it is available to the subsquent
+    // scanForXxxTranslations(...) method so it is available to the subsequent
     // loadTranslators(...) call
     QString mQtTranslationsPathName;
     QString mMudletTranslationsPathName;
@@ -694,7 +694,7 @@ protected:
 
 
 // A convenience class to keep all the details for the translators for a
-// specific locale code (langauge only "xx" or language/country "xx_YY")
+// specific locale code (language only "xx" or language/country "xx_YY")
 // in one unified structure.
 class translation
 {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix typos in C++ code
#### Motivation for adding to Mudlet
More professionalism
#### Other info (issues closed, discussion etc)
This is thanks to https://github.com/Mudlet/Mudlet/pull/5386.

Removed the last bit of remaining German commentary as well.