### PR TITLE
Fix new typos

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -140,7 +140,7 @@ void dlgPackageExporter::appendToDetails(const QString& what, const QString& val
         // Insert a leading linefeed at the start as some zip utilities prefix
         // the first line with, say something like "Comment: " which does not
         // look so good when immediately followed by "Package name:". For
-        // Similiar layout reasons, indent all the comment entries by, say,
+        // similar layout reasons, indent all the comment entries by, say,
         // four spaces in the next chunk of code.
         mPackageComment.append(QChar::LineFeed);
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4428,7 +4428,7 @@ void mudlet::refreshTabBar()
 }
 
 //NOLINT(readability-convert-member-functions-to-static)
-// doesn't make sense to make it static since it modfies a class variable
+// doesn't make sense to make it static since it modifies a class variable
 void mudlet::setupPreInstallPackages(const QString& gameUrl)
 {
     const QHash<QString, QStringList> defaultScripts = {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix new typos that got introduced when merging new code
#### Motivation for adding to Mudlet
More professional
#### Other info (issues closed, discussion etc)
Codespell right now will points out typos, but it won't block builds - it'll still give a green tick even if there's typos. Let's turn it on so it shows a red `X` when there's a problem, thoughts about that?