### PR TITLE
Show a workflow error if typos in code are detected

### DIFF
--- a/.github/workflows/codespell-analysis.yml
+++ b/.github/workflows/codespell-analysis.yml
@@ -22,4 +22,3 @@ jobs:
           skip: ./.git,./3rdparty,./translations,./src/fonts,./src/mudlet-lua/lua/utf8_filenames.lua,./squish-tests,*.aff,*.dic,*.ts
           ignore_words_file: ./.github/codespell-wordlist.txt
           builtin: 'clear,code,rare,informal,names'
-          only_warn: 1


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Show a workflow error if typos in code are detected. Previously, it would point out the typos but still always give green.
#### Motivation for adding to Mudlet
Better enforcement of quality spelling.
#### Other info (issues closed, discussion etc)
It still won't prevent us from merging if we have typos, it is not yet a `required` check - but it's a gentle step up in tightening the quality.