### PR TITLE
Enhance: provide ID numbers in editor

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -176,6 +176,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p>This will create a string called 'foo' with 'bar' as its value.</p>"
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Contents'>more information</a>.</p>");
 
+    QString mUnknownIdText = tr("<p>ID: <b>?</b></p>");
+    QString mIdText = tr("<p>ID: <b>%1</b></p>");
+
     setUnifiedTitleAndToolBarOnMac(true); //MAC OSX: make window moveable
     const QString hostName{mpHost->getName()};
     setWindowTitle(tr("%1 - Editor").arg(hostName));
@@ -5032,6 +5035,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(QString());
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, QVariant());
     mpTriggersMainArea->spinBox_lineMargin->setValue(1);
+    mpTriggersMainArea->label_id->setText(mIdText.arg(ID));
 
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(ID);
@@ -5172,6 +5176,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
             showError(pT->getError());
         }
 
+        mpTriggersMainArea->label_id->setText(mIdText.arg(ID));
+
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
@@ -5204,6 +5210,7 @@ void dlgTriggerEditor::slot_alias_selected(QTreeWidgetItem* pItem)
     mpAliasMainArea->lineEdit_alias_pattern->clear();
     mpAliasMainArea->lineEdit_alias_command->clear();
     clearDocument(mpSourceEditorEdbee); // Alias Select
+    mpAliasMainArea->label_id->setText(mUnknownIdText);
 
     mpAliasMainArea->lineEdit_alias_name->setText(pItem->text(0));
     int ID = pItem->data(0, Qt::UserRole).toInt();
@@ -5222,6 +5229,8 @@ void dlgTriggerEditor::slot_alias_selected(QTreeWidgetItem* pItem)
         if (!pT->state()) {
             showError(pT->getError());
         }
+
+        mpAliasMainArea->label_id->setText(mIdText.arg(ID));
 
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
@@ -5255,6 +5264,7 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem* pItem)
     mpKeysMainArea->lineEdit_key_binding->clear();
     mpKeysMainArea->lineEdit_key_name->clear();
     clearDocument(mpSourceEditorEdbee); // Key Select
+    mpKeysMainArea->label_id->setText(mUnknownIdText);
 
     mpKeysMainArea->lineEdit_key_binding->setText(pItem->text(0));
     int ID = pItem->data(0, Qt::UserRole).toInt();
@@ -5273,6 +5283,9 @@ void dlgTriggerEditor::slot_key_selected(QTreeWidgetItem* pItem)
         if (!pT->state()) {
             showError(pT->getError());
         }
+
+        mpKeysMainArea->label_id->setText(mIdText.arg(ID));
+
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
@@ -5607,6 +5620,7 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem* pItem)
     mpActionsMainArea->comboBox_action_bar_orientation->setCurrentIndex(0);
     mpActionsMainArea->comboBox_action_button_rotation->setCurrentIndex(0);
     mpActionsMainArea->spinBox_action_bar_columns->setValue(1);
+    mpActionsMainArea->label_id->setText(mUnknownIdText);
 
     mpCurrentActionItem = pItem; //remember what has been clicked to save it
     // ID will be 0 for the root of the treewidget and it is not appropriate
@@ -5688,6 +5702,9 @@ void dlgTriggerEditor::slot_action_selected(QTreeWidgetItem* pItem)
         if (!pT->state()) {
             showError(pT->getError());
         }
+
+        mpActionsMainArea->label_id->setText(mIdText.arg(ID));
+
     } else {
         // On root of treewidget_actions: - show help message instead
         mpActionsMainArea->hide();
@@ -5746,6 +5763,8 @@ void dlgTriggerEditor::slot_scripts_selected(QTreeWidgetItem* pItem)
     mpScriptsMainArea->lineEdit_script_name->clear();
     mpScriptsMainArea->listWidget_script_registered_event_handlers->clear();
     mpScriptsMainArea->lineEdit_script_name->setText(pItem->text(0));
+    mpScriptsMainArea->label_id->setText(mUnknownIdText);
+
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TScript* pT = mpHost->getScriptUnit()->getScript(ID);
     if (pT) {
@@ -5765,6 +5784,7 @@ void dlgTriggerEditor::slot_scripts_selected(QTreeWidgetItem* pItem)
             showError(pT->getError());
         }
 
+        mpScriptsMainArea->label_id->setText(mIdText.arg(ID));
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
@@ -5801,6 +5821,7 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
     mpTimersMainArea->timeEdit_timer_seconds->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->timeEdit_timer_msecs->setTime(QTime(0, 0, 0, 0));
     mpTimersMainArea->lineEdit_timer_name->setText(pItem->text(0));
+    mpTimersMainArea->label_id->setText(mUnknownIdText);
 
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
@@ -5826,6 +5847,9 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
         if (!pT->state()) {
             showError(pT->getError());
         }
+
+        mpTimersMainArea->label_id->setText(mIdText.arg(ID));
+
     } else {
         // No details to show - as will be the case if the top item (ID = 0) is
         // selected - so show the help message:
@@ -6732,7 +6756,7 @@ void dlgTriggerEditor::focusInEvent(QFocusEvent* pE)
 
 void dlgTriggerEditor::focusOutEvent(QFocusEvent* pE)
 {
-    Q_UNUSED(pE);
+    Q_UNUSED(pE)
 
     saveOpenChanges();
 }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -176,8 +176,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                        "<p>This will create a string called 'foo' with 'bar' as its value.</p>"
                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Contents'>more information</a>.</p>");
 
-    QString mUnknownIdText = tr("<p>ID: <b>?</b></p>");
-    QString mIdText = tr("<p>ID: <b>%1</b></p>");
+    mUnknownIdText = tr("<p>ID: <b>?</b></p>");
+    mIdText = tr("<p>ID: <b>%1</b></p>");
 
     setUnifiedTitleAndToolBarOnMac(true); //MAC OSX: make window moveable
     const QString hostName{mpHost->getName()};
@@ -2570,6 +2570,7 @@ void dlgTriggerEditor::recursiveSearchKeys(TKey* pTriggerParent, const QString& 
 
 void dlgTriggerEditor::delete_alias()
 {
+    mpAliasMainArea->label_id->setText(mUnknownIdText);
     QTreeWidgetItem* pItem = treeWidget_aliases->currentItem();
     if (!pItem) {
         return;
@@ -2591,6 +2592,7 @@ void dlgTriggerEditor::delete_alias()
 
 void dlgTriggerEditor::delete_action()
 {
+    mpActionsMainArea->label_id->setText(mUnknownIdText);
     QTreeWidgetItem* pItem = treeWidget_actions->currentItem();
     if (!pItem) {
         return;
@@ -2648,6 +2650,7 @@ void dlgTriggerEditor::delete_variable()
 
 void dlgTriggerEditor::delete_script()
 {
+    mpScriptsMainArea->label_id->setText(mUnknownIdText);
     QTreeWidgetItem* pItem = treeWidget_scripts->currentItem();
     if (!pItem) {
         return;
@@ -2669,6 +2672,7 @@ void dlgTriggerEditor::delete_script()
 
 void dlgTriggerEditor::delete_key()
 {
+    mpKeysMainArea->label_id->setText(mUnknownIdText);
     QTreeWidgetItem* pItem = treeWidget_keys->currentItem();
     if (!pItem) {
         return;
@@ -2691,6 +2695,7 @@ void dlgTriggerEditor::delete_key()
 
 void dlgTriggerEditor::delete_trigger()
 {
+    mpTriggersMainArea->label_id->setText(mUnknownIdText);
     QTreeWidgetItem* pItem = treeWidget_triggers->currentItem();
     if (!pItem) {
         return;
@@ -2713,6 +2718,7 @@ void dlgTriggerEditor::delete_trigger()
 
 void dlgTriggerEditor::delete_timer()
 {
+    mpTimersMainArea->label_id->setText(mUnknownIdText);
     QTreeWidgetItem* pItem = treeWidget_timers->currentItem();
     if (!pItem) {
         return;
@@ -5035,7 +5041,7 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(QString());
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, QVariant());
     mpTriggersMainArea->spinBox_lineMargin->setValue(1);
-    mpTriggersMainArea->label_id->setText(mIdText.arg(ID));
+    mpTriggersMainArea->label_id->setText(mUnknownIdText);
 
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TTrigger* pT = mpHost->getTriggerUnit()->getTrigger(ID);

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -517,6 +517,9 @@ private:
     QString msgInfoAddButton;
     QString msgInfoAddVar;
     QString msgInfoAddKey;
+
+    QString mUnknownIdText;
+    QString mIdText;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(dlgTriggerEditor::SearchOptions)

--- a/src/ui/actions_main_area.ui
+++ b/src/ui/actions_main_area.ui
@@ -73,6 +73,19 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label_id">
+        <property name="text">
+         <string>&lt;p&gt;ID: &lt;b&gt;?&lt;/b&gt;&lt;/p&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/ui/aliases_main_area.ui
+++ b/src/ui/aliases_main_area.ui
@@ -39,7 +39,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="3">
+   <item row="0" column="1" colspan="2">
     <widget class="QLineEdit" name="lineEdit_alias_name">
      <property name="minimumSize">
       <size>
@@ -55,6 +55,19 @@
      </property>
      <property name="toolTip">
       <string>choose a unique name for your alias; it will show in the tree and is needed for scripting.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="QLabel" name="label_id">
+     <property name="text">
+      <string>&lt;p&gt;ID: &lt;b&gt;?&lt;/b&gt;&lt;/p&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>

--- a/src/ui/keybindings_main_area.ui
+++ b/src/ui/keybindings_main_area.ui
@@ -27,10 +27,23 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
+   <item row="0" column="1">
     <widget class="QLineEdit" name="lineEdit_key_name">
      <property name="toolTip">
       <string>&lt;p&gt;Choose a good, ideally unique, name for your key or key group. This will be displayed in the key tree.&lt;/p&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="label_id">
+     <property name="text">
+      <string>&lt;p&gt;ID: &lt;b&gt;?&lt;/b&gt;&lt;/p&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>

--- a/src/ui/scripts_main_area.ui
+++ b/src/ui/scripts_main_area.ui
@@ -27,10 +27,23 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
+   <item row="0" column="1">
     <widget class="QLineEdit" name="lineEdit_script_name">
      <property name="toolTip">
       <string>&lt;p&gt;Choose a good, (ideally, though it need not be, unique) name for your script or script group. This will be displayed in the script tree.&lt;/p&gt;&lt;p&gt;If a function within the script is to be used to handle events entered in the list below &lt;b&gt;&lt;u&gt;it must have the same name as is entered here.&lt;/u&gt;&lt;/b&gt;&lt;/p&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="label_id">
+     <property name="text">
+      <string>&lt;p&gt;ID: &lt;b&gt;?&lt;/b&gt;&lt;/p&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>

--- a/src/ui/timers_main_area.ui
+++ b/src/ui/timers_main_area.ui
@@ -33,10 +33,23 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="8">
+   <item row="0" column="1" colspan="7">
     <widget class="QLineEdit" name="lineEdit_timer_name">
      <property name="toolTip">
       <string>&lt;p&gt;Choose a good, (ideally, though it need not be, unique) name for your timer, offset-timer or timer group. This will be displayed in the timer tree.&lt;/p&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="8">
+    <widget class="QLabel" name="label_id">
+     <property name="text">
+      <string>&lt;p&gt;ID: &lt;b&gt;?&lt;/b&gt;&lt;/p&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>

--- a/src/ui/triggers_main_area.ui
+++ b/src/ui/triggers_main_area.ui
@@ -128,6 +128,19 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QLabel" name="label_id">
+        <property name="text">
+         <string>&lt;p&gt;ID: &lt;b&gt;?&lt;/b&gt;&lt;/p&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::TextSelectableByMouse</set>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This is to help when debugging as it aides identifying which Mudlet item is being referred to when an ID number is seen in the Lua API. Or if there are duplicate items with the same name (but which will have different ID numbers).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Mudlet Editor will give the ID number of the current item being edited.