### PR TITLE
Fix autowrap when changing fontsize in Geyser MiniConsoles

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -217,8 +217,10 @@ function Geyser.MiniConsole:setFontSize(size)
   if size then
     self.parent.setFontSize(self, size)
   end
-
   setMiniConsoleFontSize(self.name, size)
+  if self.autoWrap then
+    self:resetAutoWrap()
+  end
 end
 
 --- Appends copied selection to this miniconsole.


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Right now, Geyser.MiniConsoles do not reset their autowrap when font size is changed, but font size is part of what determines the wrap width for autowrapping. This fixes that.

#### Motivation for adding to Mudlet

Fix a bug

#### Other info (issues closed, discussion etc)

Came up in discord

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
