### PR TITLE
Allow optional fontName, text and background transparency in `createMapLabel()`

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7667,6 +7667,7 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     float zoom = 30.0;
     bool showOnTop = true;
     bool noScaling = true;
+    QString fontName;
 
     int args = lua_gettop(L);
     int area = getVerifiedInt(L, __func__, 1, "areaID");
@@ -7690,9 +7691,12 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
             }
         }
     }
+    if (args > 15) {
+        fontName = getVerifiedString(L, __func__, 16, "fontName", true);
+    }
 
     Host& host = getHostFromLua(L);
-    lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb), QColor(bgr, bgg, bgb), showOnTop, noScaling, zoom, fontSize));
+    lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb), QColor(bgr, bgg, bgb), showOnTop, noScaling, zoom, fontSize, fontName));
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7668,6 +7668,8 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     bool showOnTop = true;
     bool noScaling = true;
     QString fontName;
+    int foregroundTransparency = 255;
+    int backgroundTransparency = 50;
 
     int args = lua_gettop(L);
     int area = getVerifiedInt(L, __func__, 1, "areaID");
@@ -7694,9 +7696,15 @@ int TLuaInterpreter::createMapLabel(lua_State* L)
     if (args > 15) {
         fontName = getVerifiedString(L, __func__, 16, "fontName", true);
     }
+    if (args > 16) {
+        foregroundTransparency = getVerifiedInt(L, __func__, 17, "foregroundTransparency", true);
+    }
+    if (args > 17) {
+        backgroundTransparency = getVerifiedInt(L, __func__, 18, "backgroundTransparency", true);
+    }
 
     Host& host = getHostFromLua(L);
-    lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb), QColor(bgr, bgg, bgb), showOnTop, noScaling, zoom, fontSize, fontName));
+    lua_pushinteger(L, host.mpMap->createMapLabel(area, text, posx, posy, posz, QColor(fgr, fgg, fgb, foregroundTransparency), QColor(bgr, bgg, bgb, backgroundTransparency), showOnTop, noScaling, zoom, fontSize, fontName));
     return 1;
 }
 

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2053,6 +2053,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     return true;
 }
 
+//NOLINT(readability-make-member-function-const)
 int TMap::createMapLabel(int area, const QString& text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop, bool noScaling, qreal zoom, int fontSize, std::optional<QString> fontName)
 {
     auto pA = mpRoomDB->getArea(area);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2053,7 +2053,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     return true;
 }
 
-int TMap::createMapLabel(int area, QString text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop, bool noScaling, qreal zoom, int fontSize, std::optional<QString> fontName)
+int TMap::createMapLabel(int area, const QString& text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop, bool noScaling, qreal zoom, int fontSize, std::optional<QString> fontName)
 {
     auto pA = mpRoomDB->getArea(area);
     if (!pA) {

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -463,7 +463,7 @@ void TMap::audit()
                         // Note that two of the last three arguments here
                         // (false, 40.0) are not the defaults (true, 30.0) used
                         // now:
-                        int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50);
+                        int newID = createMapLabel(areaID, l.text, l.pos.x(), l.pos.y(), l.pos.z(), l.fgColor, l.bgColor, true, false, 40.0, 50, std::nullopt);
                         if (newID > -1) {
                             if (mudlet::self()->showMapAuditErrors()) {
                                 QString msg = tr("[ INFO ] - CONVERTING: old style label, areaID:%1 labelID:%2.").arg(areaID).arg(i);
@@ -2053,7 +2053,7 @@ bool TMap::retrieveMapFileStats(QString profile, QString* latestFileName = nullp
     return true;
 }
 
-int TMap::createMapLabel(int area, QString text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop, bool noScaling, qreal zoom, int fontSize)
+int TMap::createMapLabel(int area, QString text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop, bool noScaling, qreal zoom, int fontSize, std::optional<QString> fontName)
 {
     auto pA = mpRoomDB->getArea(area);
     if (!pA) {
@@ -2082,7 +2082,10 @@ int TMap::createMapLabel(int area, QString text, float x, float y, float z, QCol
     QPen lpen;
     lpen.setColor(label.fgColor);
     QFont font;
-    font.setPointSize(fontSize); //good: font size = 50, zoom = 30.0
+    font.setPointSize(fontSize);
+    if (fontName.has_value()) {
+        font.setFamily(fontName.value());
+    }
     lp.setRenderHint(QPainter::TextAntialiasing, true);
     lp.setPen(lpen);
     lp.setFont(font);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2067,7 +2067,6 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     TMapLabel label;
     label.text = text;
     label.bgColor = bg;
-    label.bgColor.setAlpha(50);
     label.fgColor = fg;
     label.size = QSizeF(100, 100);
     label.pos = QVector3D(x, y, z);

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2081,11 +2081,7 @@ int TMap::createMapLabel(int area, const QString& text, float x, float y, float 
     lp.fillRect(lr, label.bgColor);
     QPen lpen;
     lpen.setColor(label.fgColor);
-    QFont font;
-    font.setPointSize(fontSize);
-    if (fontName.has_value()) {
-        font.setFamily(fontName.value());
-    }
+    QFont font(fontName.has_value() ? fontName.value() : QString(), fontSize);
     lp.setRenderHint(QPainter::TextAntialiasing, true);
     lp.setPen(lpen);
     lp.setFont(font);

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -77,7 +77,7 @@ public:
     void mapClear();
     int createMapImageLabel(int area, QString filePath, float x, float y, float z, float width, float height, float zoom, bool showOnTop);
     int createMapLabel(int area,
-                       QString text,
+                       const QString& text,
                        float x,
                        float y,
                        float z,

--- a/src/TMap.h
+++ b/src/TMap.h
@@ -42,9 +42,10 @@
 #include <QPointer>
 #include <QSizeF>
 #include <QVector3D>
+#include <stdlib.h>
+#include <optional>
 #include "post_guard.h"
 
-#include <stdlib.h>
 
 class dlgMapper;
 class Host;
@@ -75,7 +76,18 @@ public:
     ~TMap();
     void mapClear();
     int createMapImageLabel(int area, QString filePath, float x, float y, float z, float width, float height, float zoom, bool showOnTop);
-    int createMapLabel(int area, QString text, float x, float y, float z, QColor fg, QColor bg, bool showOnTop = true, bool noScaling = true, qreal zoom = 30.0, int fontSize = 50);
+    int createMapLabel(int area,
+                       QString text,
+                       float x,
+                       float y,
+                       float z,
+                       QColor fg,
+                       QColor bg,
+                       bool showOnTop = true,
+                       bool noScaling = true,
+                       qreal zoom = 30.0,
+                       int fontSize = 50,
+                       std::optional<QString> fontName = std::nullopt);
     void deleteMapLabel(int area, int labelID);
     bool addRoom(int id = 0);
     bool setRoomArea(int id, int area, bool isToDeferAreaRelatedRecalculations = false);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allow people to choose the font, text, and background transparency used when working with `createMapLabel()`

`createMapLabel(getRoomArea(getPlayerRoom()), "my map label", -1,-6,1, 255,0,0, 23,0,0, 0,20, true, true, "Ubuntu", 255, 0)`
#### Motivation for adding to Mudlet
Make the function more enticing for people to use.
#### Other info (issues closed, discussion etc)
Used `std::optional` instead of relying in on an empty QString - it's more clear then what you're trying to say as opposed to relying on a convention.