### PR TITLE
Add closestColor function for finding the best match out of color_table

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2370,7 +2370,7 @@ function closestColor(r,g,b)
     local nr = tonumber(r)
     local ng = tonumber(g)
     local nb = tonumber(b)
-    if not nr or not ng or not nb then
+    if not nr or not ng or not nb or (nr < 0 or nr > 255) or (ng < 0 or ng > 255) or (nb < 0 or nb > 255) then
       return nil, f"Could not parse {r},{g},{b} into a set of RGB coordinates to look for.\n"
     end
     rgb = {nr,ng,nb}

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2334,3 +2334,45 @@ end
 function resetMapWindowTitle()
   return setMapWindowTitle("")
 end
+
+--- This function takes in a color and returns the closest color from color_table. The following all return "ansi_001"
+--- closest_color({127,0,0})
+--- closest_color(127,0,0)
+--- closest_color("#7f0000")
+--- closest_color("|c7f0000")
+--- closest_color("<127,0,0>")
+function closest_color(r,g,b)
+  local rtype = type(r)
+  local rgb
+  if rtype == "table" then
+    rgb = r
+  elseif rtype == "string" and not tonumber(r) then
+    if color_table[r] then
+      return r
+    end
+    rgb = {Geyser.Color.parse(r)}
+    if rgb[1] == nil then
+      return nil, f"Could not parse {r} into a set of RGB coordinates to look for.\n"
+    end
+  elseif rtype == "number" or tonumber(r) then
+    local nr = tonumber(r)
+    local ng = tonumber(g)
+    local nb = tonumber(b)
+    if not nr or not ng or not nb then
+      return nil, f"Could not parse {r},{g},{b} into a set of RGB coordinates to look for.\n"
+    end
+    rgb = {nr,ng,nb}
+  else
+    return nil, f"Could not parse your parameters into RGB coordinates."
+  end
+  local least_distance = math.huge
+  local cname = ""
+  for name, color in pairs(color_table) do
+    local color_distance = math.sqrt((color[1] - rgb[1]) ^ 2 + (color[2] - rgb[2]) ^ 2 + (color[3] - rgb[3]) ^ 2)
+    if color_distance < least_distance then
+      least_distance = color_distance
+      cname = name
+    end
+  end
+  return cname
+end

--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2336,16 +2336,28 @@ function resetMapWindowTitle()
 end
 
 --- This function takes in a color and returns the closest color from color_table. The following all return "ansi_001"
---- closest_color({127,0,0})
---- closest_color(127,0,0)
---- closest_color("#7f0000")
---- closest_color("|c7f0000")
---- closest_color("<127,0,0>")
-function closest_color(r,g,b)
+--- closestColor({127,0,0})
+--- closestColor(127,0,0)
+--- closestColor("#7f0000")
+--- closestColor("|c7f0000")
+--- closestColor("<127,0,0>")
+function closestColor(r,g,b)
   local rtype = type(r)
   local rgb
   if rtype == "table" then
-    rgb = r
+    rgb = {}
+    local tmp = r
+    local err = f"Could not parse {table.concat(tmp, ',')} into RGB coordinates to look for.\n"
+    if #tmp ~= 3 then
+      return nil, err
+    end
+    for index,coord in ipairs(tmp) do
+      local num = tonumber(coord)
+      if not num or num < 0 or num > 255 then
+        return nil, err
+      end
+      rgb[index] = num
+    end
   elseif rtype == "string" and not tonumber(r) then
     if color_table[r] then
       return r
@@ -2363,7 +2375,7 @@ function closest_color(r,g,b)
     end
     rgb = {nr,ng,nb}
   else
-    return nil, f"Could not parse your parameters into RGB coordinates."
+    return nil, f"Could not parse your parameters into RGB coordinates.\n"
   end
   local least_distance = math.huge
   local cname = ""

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -183,6 +183,79 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
 
   end)
 
+  describe("Tests the functionality of closestColor", function()
+    it("Should handle a table of {R,G,B} components: closestColor({R,G,B})", function()
+      local expected = "ansi_001"
+      local actual = closestColor({127,0,0})
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle separate R,G,B parameters: closestColor(R,G,B)", function()
+      local expected = "ansi_001"
+      local actual = closestColor(127,0,0)
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle a decho color string: closestColor('<R,G,B>')", function()
+      local expected = "ansi_001"
+      local actual = closestColor({127,0,0})
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle an hecho # color string: closestColor('#RRGGBB')", function()
+      local expected = "ansi_001"
+      local actual = closestColor("#7f0000")
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle an hecho |c color string: closestColor('|cRRGGBB')", function()
+      local expected = "ansi_001"
+      local actual = closestColor("|c7f0000")
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle return the parameter if it's an entry in color_table: closestColor('purple')", function()
+      local expected = "purple"
+      local actual = closestColor("purple")
+      assert.equals(expected, actual)
+    end)
+
+    it("Should return nil + error if handed garbage: closestColor('asdf')", function()
+      local expectedErr = "Could not parse asdf into a set of RGB coordinates to look for.\n"
+      local actual, actualErr = closestColor("asdf")
+      assert.is_nil(actual)
+      assert.equals(expectedErr, actualErr)
+    end)
+
+    it("Should return nil + error if handed garbage: closestColor({'tea', 1, 1})", function()
+      local expectedErr = "Could not parse tea,1,1 into RGB coordinates to look for.\n"
+      local actual, actualErr = closestColor({'tea', 1, 1})
+      assert.is_nil(actual)
+      assert.equals(expectedErr, actualErr)
+    end)
+
+    it("Should return nil + error if handed garbage: closestColor({1, 1})", function()
+      local expectedErr = "Could not parse 1,1 into RGB coordinates to look for.\n"
+      local actual, actualErr = closestColor({1, 1})
+      assert.is_nil(actual)
+      assert.equals(expectedErr, actualErr)
+    end)
+
+    it("Should return nil + error if handed garbage: closestColor({500, 0, 1})", function()
+      local expectedErr = "Could not parse 500,0,1 into RGB coordinates to look for.\n"
+      local actual, actualErr = closestColor({500, 0, 1})
+      assert.is_nil(actual)
+      assert.equals(expectedErr, actualErr)
+    end)
+
+    it("Should return nil + error if handed garbage: closestColor(true)", function()
+      local expectedErr = "Could not parse your parameters into RGB coordinates.\n"
+      local actual, actualErr = closestColor({500, 0, 1})
+      assert.is_nil(actual)
+      assert.equals(expectedErr, actualErr)
+    end)
+  end)
+
   describe("Tests the functionality of _Echoes.Process()", function()
     it("Should parse hex patterns correctly", function()
       assert.are.same(

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -250,7 +250,7 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
 
     it("Should return nil + error if handed garbage: closestColor(true)", function()
       local expectedErr = "Could not parse your parameters into RGB coordinates.\n"
-      local actual, actualErr = closestColor({500, 0, 1})
+      local actual, actualErr = closestColor(true)
       assert.is_nil(actual)
       assert.equals(expectedErr, actualErr)
     end)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adds closestColor, which can be used to get the nearest matching color name from color_table to a set of color coordinates.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
The following will all work, and all return ansi_001 which is 128,0,0

```
 closestColor({127,0,0})
 closestColor(127,0,0)
 closestColor("#7f0000")
 closestColor("|c7f0000")
 closestColor("<127,0,0>")
```

#### Release post highlight
