### PR TITLE
Enhance: allow wait for more network packets to be adjusted

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -152,7 +152,7 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
     // initialize telnet session
     reset();
 
-    mpPostingTimer->setInterval(300); //FIXME
+    mpPostingTimer->setInterval(mTimeOut);
     connect(mpPostingTimer, &QTimer::timeout, this, &cTelnet::slot_timerPosting);
 
     mTimerLogin = new QTimer(this);
@@ -2427,6 +2427,9 @@ void cTelnet::postMessage(QString msg)
 void cTelnet::gotPrompt(std::string& mud_data)
 {
     mpPostingTimer->stop();
+    if (mpPostingTimer->interval() != mTimeOut) {
+        mpPostingTimer->setInterval(mTimeOut);
+    }
     mMudData += mud_data;
 
     if (mUSE_IRE_DRIVER_BUGFIX && mGA_Driver) {
@@ -2476,6 +2479,9 @@ void cTelnet::gotRest(std::string& mud_data)
         if (i != std::string::npos) {
             mMudData += mud_data.substr(0, i + 1);
             postData();
+            if (!mIsTimerPosting && (mpPostingTimer->interval() != mTimeOut)) {
+                mpPostingTimer->setInterval(mTimeOut);
+            }
             mpPostingTimer->start();
             mIsTimerPosting = true;
             if (i + 1 < mud_data.size()) {
@@ -2486,6 +2492,9 @@ void cTelnet::gotRest(std::string& mud_data)
         } else {
             mMudData += mud_data;
             if (!mIsTimerPosting) {
+                if (mpPostingTimer->interval() != mTimeOut) {
+                    mpPostingTimer->setInterval(mTimeOut);
+                }
                 mpPostingTimer->start();
                 mIsTimerPosting = true;
             }
@@ -3059,5 +3068,12 @@ std::string cTelnet::encodeAndCookBytes(const std::string& data)
         // std::string::c_str() converts the std::string into a char array WITH
         // a garenteed terminating null byte.
         return mudlet::replaceString(data, "\xff", "\xff\xff");
+    }
+}
+
+void cTelnet::setPostingTimeout(const int timeout)
+{
+    if (mTimeOut != timeout) {
+        mTimeOut = timeout;
     }
 }

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -187,6 +187,8 @@ public:
     QString decodeOption(const unsigned char) const;
     QAbstractSocket::SocketState getConnectionState() const { return socket.state(); }
     std::tuple<QString, int, bool> getConnectionInfo() const;
+    void setPostingTimeout(const int);
+    int getPostingTimeout() const { return mTimeOut; }
 
 
     QMap<int, bool> supportedTelnetOptions;
@@ -281,6 +283,11 @@ private:
     QString termType;
     QByteArray mEncoding;
     QTimer* mpPostingTimer;
+    // We do not directly adjust the interval for the above because doing so
+    // while it is active changes the timerId which might have unforseen
+    // effects - so instead we change the following and the revised value is
+    // then used the next time the timer is stopped and then started:
+    int mTimeOut = 300;
     bool mUSE_IRE_DRIVER_BUGFIX;
 
     QNetworkReply* mpPackageDownloadReply = nullptr;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1002,6 +1002,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     checkBox_expectCSpaceIdInColonLessMColorCode->setChecked(pHost->getHaveColorSpaceId());
     checkBox_allowServerToRedefineColors->setChecked(pHost->getMayRedefineColors());
+    spinBox_networkPacketTimeout->setValue(pHost->mTelnet.getPostingTimeout());
 
     // Enable the controls that would be disabled if there wasn't a Host instance
     // on tab_general:
@@ -1083,6 +1084,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(pushButton_resetLogDir, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetLogDir);
     connect(comboBox_logFileNameFormat, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_logFileNameFormatChange);
     connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
+    connect(spinBox_networkPacketTimeout, qOverload<int>(&QSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
 
     //Security tab
 
@@ -3908,4 +3910,14 @@ void dlgProfilePreferences::setPlayerRoomColor(QPushButton* b, QColor& c)
         // visible and adjusts the saturation of a disabled button:
         setButtonColor(b, color);
     }
+}
+
+void dlgProfilePreferences::slot_setPostingTimeout(const int timeout)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+
+    pHost->mTelnet.setPostingTimeout(timeout);
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -157,6 +157,7 @@ private slots:
     void slot_setPlayerRoomSecondaryColor();
     void slot_setPlayerRoomOuterDiameter(const int);
     void slot_setPlayerRoomInnerDiameter(const int);
+    void slot_setPostingTimeout(const int);
 
 private:
     void setColors();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>501</height>
+    <width>718</width>
+    <height>661</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -720,16 +720,6 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="mNoAntiAlias">
-            <property name="toolTip">
-             <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
-            </property>
-            <property name="text">
-             <string>Enable anti-aliasing</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="0" colspan="4">
            <widget class="QLabel" name="label_variableWidthFontWarning">
             <property name="font">
@@ -740,6 +730,16 @@
             <property name="text">
              <string comment="Note that this text is split into two lines so that the message is not too wide in English, please do the same for other locales where the text is the same or longer">This font is not monospace, which may not be ideal for playing some text games:
 you can use it but there could be issues with aligning columns of text</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="mNoAntiAlias">
+            <property name="toolTip">
+             <string>Use anti aliasing on fonts. Smoothes fonts if you have a high screen resolution and you can use larger fonts. Note that on low resolutions and small font sizes, the font gets blurry. </string>
+            </property>
+            <property name="text">
+             <string>Enable anti-aliasing</string>
             </property>
            </widget>
           </item>
@@ -2004,6 +2004,19 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="checkbox_mMapperShowRoomBorders">
+            <property name="toolTip">
+             <string>&lt;p&gt;This enables borders around room. Color can be set in Mapper colors tab&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Show room borders</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_mapSymbolsFont">
             <property name="text">
@@ -2151,19 +2164,6 @@ you can use it but there could be issues with aligning columns of text</string>
               </widget>
              </item>
             </layout>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkbox_mMapperShowRoomBorders">
-            <property name="toolTip">
-             <string>&lt;p&gt;This enables borders around room. Color can be set in Mapper colors tab&lt;/p&gt;</string>
-            </property>
-            <property name="text">
-             <string>Show room borders</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
            </widget>
           </item>
          </layout>
@@ -2908,6 +2908,36 @@ you can use it but there could be issues with aligning columns of text</string>
             </layout>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="checkBox_self_signed">
+            <property name="toolTip">
+             <string extracomment="Accept secure certificates from the game even if they have expired. This presents a security risk"/>
+            </property>
+            <property name="text">
+             <string>Accept self-signed certificates</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBox_expired">
+            <property name="toolTip">
+             <string extracomment="Accept secure certificates from the game even if they have expired. This presents a security risk"/>
+            </property>
+            <property name="text">
+             <string>Accept expired certificates</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBox_ignore_all">
+            <property name="toolTip">
+             <string extracomment="Ignore all SSL/TLS errors - this negates the point of a secure connection, use carefully"/>
+            </property>
+            <property name="text">
+             <string>Accept all certificate errors       (unsecure)</string>
+            </property>
+           </widget>
+          </item>
           <item row="3" column="0" colspan="2">
            <widget class="QFrame" name="notificationArea">
             <property name="sizePolicy">
@@ -3109,36 +3139,6 @@ you can use it but there could be issues with aligning columns of text</string>
               </widget>
              </item>
             </layout>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBox_self_signed">
-            <property name="toolTip">
-             <string extracomment="Accept secure certificates from the game even if they have expired. This presents a security risk"/>
-            </property>
-            <property name="text">
-             <string>Accept self-signed certificates</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBox_expired">
-            <property name="toolTip">
-             <string extracomment="Accept secure certificates from the game even if they have expired. This presents a security risk"/>
-            </property>
-            <property name="text">
-             <string>Accept expired certificates</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBox_ignore_all">
-            <property name="toolTip">
-             <string extracomment="Ignore all SSL/TLS errors - this negates the point of a secure connection, use carefully"/>
-            </property>
-            <property name="text">
-             <string>Accept all certificate errors       (unsecure)</string>
-            </property>
            </widget>
           </item>
          </layout>
@@ -3381,6 +3381,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Store character login passwords in:</string>
             </property>
+            <property name="buddy">
+             <cstring>comboBox_store_passwords_in</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -3479,11 +3482,44 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="5" column="0">
            <widget class="QCheckBox" name="checkBox_debugShowAllCodepointProblems">
+            <property name="toolTip">
+             <string>&lt;p&gt;If checked this will cause all problem Unicode codepoints to be reported in the debug output as they occur; if cleared then each different one will only be reported once and summarized in as a table when the console in which they occurred is finally destroyed (when the profile is closed).&lt;/p&gt;</string>
+            </property>
             <property name="text">
              <string>Report all Codepoint problems immediately</string>
             </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_networkPackerTimeout">
+            <property name="text">
+             <string>Network packet timeout:</string>
+            </property>
+            <property name="buddy">
+             <cstring>spinBox_networkPacketTimeout</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QSpinBox" name="spinBox_networkPacketTimeout">
             <property name="toolTip">
-             <string>&lt;p&gt;If checked this will cause all problem Unicode codepoints to be reported in the debug output as they occur; if cleared then each different one will only be reported once and summarized in as a table when the console in which they occurred is finally destroyed (when the profile is closed).&lt;/p&gt;</string>
+             <string>&lt;p&gt;On Game Servers which do not use GA &lt;i&gt;go-ahead&lt;/i&gt; signalling this sets how long Mudlet will wait for further network packets before assuming that there is not any more to arrive. The default is 300 milli-seconds. Larger values will help to prevent &lt;i&gt;packet fragmentation&lt;/i&gt; but can make Mudlet seem less responsive to incoming Game text; smaller values may make Mudlet seem to handle such text faster but runs the risk of breaking what is supposed to be a single piece of text or out-of-band game data into multiple chunks. This can break triggers or OOB features.&lt;/p&gt;
+&lt;p&gt;&lt;i&gt;Adjustment of this control is &lt;b&gt;NOT&lt;/b&gt; recommended unless needed and tested for particular network conditions and MUD Game servers.&lt;/i&gt;&lt;/p&gt;</string>
+            </property>
+            <property name="suffix">
+             <string> milli-seconds</string>
+            </property>
+            <property name="minimum">
+             <number>10</number>
+            </property>
+            <property name="maximum">
+             <number>500</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
+            </property>
+            <property name="value">
+             <number>300</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This might be useful for tweaking for MUDs that do not use Go Aheads for
end-users with a good network connection.

This commit does not currently save the (per profile) setting but if it
proves useful it might need that as well.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>