### PR TITLE
Always parse GMCP as utf8

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1933,14 +1933,8 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
 
 void cTelnet::setGMCPVariables(const QByteArray& msg)
 {
-    QString transcodedMsg;
-    if (mpOutOfBandDataIncomingCodec) {
-        // Message is encoded
-        transcodedMsg = mpOutOfBandDataIncomingCodec->toUnicode(msg);
-    } else {
-        // Message is in ASCII (though this can handle Utf-8):
-        transcodedMsg = msg;
-    }
+    // JSON is always utf8
+    QString transcodedMsg{std::move(msg)};
 
     QString packageMessage;
     QString data;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1933,7 +1933,7 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
 
 void cTelnet::setGMCPVariables(const QByteArray& msg)
 {
-    // JSON is always utf8
+    // JSON (and thus the GMCP data) is always utf8
     QString transcodedMsg(msg);
 
     QString packageMessage;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1934,7 +1934,7 @@ void cTelnet::setATCPVariables(const QByteArray& msg)
 void cTelnet::setGMCPVariables(const QByteArray& msg)
 {
     // JSON is always utf8
-    QString transcodedMsg{std::move(msg)};
+    QString transcodedMsg(msg);
 
     QString packageMessage;
     QString data;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Always parse GMCP as utf8
#### Motivation for adding to Mudlet
So games using non-utf8 encoding can still send utf8 data via GMCP.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5421