### PR TITLE
Fixed map pan to better follow mouse cursor

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4233,10 +4233,10 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
         int x = event->x();
         int y = event->y();
         mShiftMode = true;
-        mOx = mOx + (mpMap->m2DPanXStart - float(x)) / mRoomWidth;
-        mOy = mOy + (mpMap->m2DPanYStart - float(y)) / mRoomHeight;
-        mpMap->m2DPanYStart = float(y);
-        mpMap->m2DPanXStart = float(x);
+        mOx = mOx + (mpMap->m2DPanXStart - static_cast<float>(x)) / mRoomWidth;
+        mOy = mOy + (mpMap->m2DPanYStart - static_cast<float>(y)) / mRoomHeight;
+        mpMap->m2DPanYStart = static_cast<float>(y);
+        mpMap->m2DPanXStart = static_cast<float>(x);
         update();
         return;
     }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2414,6 +2414,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* e)
     //move map with left mouse button + ALT (->
     if (mpMap->mLeftDown) {
         mpMap->mLeftDown = false;
+        mpMap->m2DPanMode = false;
         unsetCursor();
     }
 
@@ -4230,21 +4231,13 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
     }
     if (mpMap->m2DPanMode) {
         int x = event->x();
-        int y = height() - event->y();
-        if ((mpMap->m2DPanXStart - x) > 1) {
-            slot_shiftRight();
-            mpMap->m2DPanXStart = x;
-        } else if ((mpMap->m2DPanXStart - x) < -1) {
-            slot_shiftLeft();
-            mpMap->m2DPanXStart = x;
-        }
-        if ((mpMap->m2DPanYStart - y) > 1) {
-            slot_shiftDown();
-            mpMap->m2DPanYStart = y;
-        } else if ((mpMap->m2DPanYStart - y) < -1) {
-            slot_shiftUp();
-            mpMap->m2DPanYStart = y;
-        }
+        int y = event->y();
+        mShiftMode = true;
+        mOx = mOx + (mpMap->m2DPanXStart - x) / mRoomWidth;
+        mOy = mOy + (mpMap->m2DPanYStart - y) / mRoomHeight;
+        mpMap->m2DPanYStart = y;
+        mpMap->m2DPanXStart = x;
+        update();
         return;
     }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4233,10 +4233,10 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
         int x = event->x();
         int y = event->y();
         mShiftMode = true;
-        mOx = mOx + (mpMap->m2DPanXStart - x) / mRoomWidth;
-        mOy = mOy + (mpMap->m2DPanYStart - y) / mRoomHeight;
-        mpMap->m2DPanYStart = y;
-        mpMap->m2DPanXStart = x;
+        mOx = mOx + (mpMap->m2DPanXStart - float(x)) / mRoomWidth;
+        mOy = mOy + (mpMap->m2DPanYStart - float(y)) / mRoomHeight;
+        mpMap->m2DPanYStart = float(y);
+        mpMap->m2DPanXStart = float(x);
         update();
         return;
     }


### PR DESCRIPTION
I've been asked to take a look on this half year ago, but I kind of stopped playing mud for a while, and went to some other stuff. But, slowly but surely, I fixed that thing that bugged me for a long time.

You can now move the map like a Google map, it just sticks to the cursor and moves smoothly, no matter what zoom level you are using.

The below recording shows how it works. In reality it looks much smoother, but GIF compression reduced the framerate to 10 fps:
![mudlet_map_pan](https://user-images.githubusercontent.com/5413271/132913551-92c46113-0400-4b1e-b526-93b5f2524762.gif)

Did some basic testing, and looks like I didn't break anything, but please test it too.