### PR TITLE
Revert "BugFix: Repairs shortcuts to work 100% of the time"

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -618,42 +618,6 @@ mudlet::mudlet()
     disconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_D);
     reconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_R);
 #endif
-
-    triggersShortcut = new QShortcut(triggersKeySequence, this);
-    connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_editor_dialog);
-    showMapShortcut = new QShortcut(showMapKeySequence, this);
-    connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
-    inputLineShortcut = new QShortcut(inputLineKeySequence, this);
-    connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_compact_input_line);
-    optionsShortcut = new QShortcut(optionsKeySequence, this);
-    connect(optionsShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
-    notepadShortcut = new QShortcut(notepadKeySequence, this);
-    connect(notepadShortcut.data(), &QShortcut::activated, this, &mudlet::slot_notes);
-    packagesShortcut = new QShortcut(packagesKeySequence, this);
-    connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
-    modulesShortcut = new QShortcut(packagesKeySequence, this);
-    connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
-    multiViewShortcut = new QShortcut(multiViewKeySequence, this);
-    connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_multi_view);
-    connectShortcut = new QShortcut(connectKeySequence, this);
-    connect(connectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_connection_dialog);
-    disconnectShortcut = new QShortcut(disconnectKeySequence, this);
-    connect(disconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
-    reconnectShortcut = new QShortcut(reconnectKeySequence, this);
-    connect(reconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
-
-    dactionScriptEditor->setShortcut(triggersKeySequence);
-    dactionShowMap->setShortcut(showMapKeySequence);
-    dactionInputLine->setShortcut(inputLineKeySequence);
-    dactionOptions->setShortcut(optionsKeySequence);
-    dactionNotepad->setShortcut(notepadKeySequence);
-    dactionPackageManager->setShortcut(packagesKeySequence);
-    dactionModuleManager->setShortcut(modulesKeySequence);
-    dactionMultiView->setShortcut(multiViewKeySequence);
-    dactionConnect->setShortcut(connectKeySequence);
-    dactionDisconnect->setShortcut(disconnectKeySequence);
-    dactionReconnect->setShortcut(reconnectKeySequence);
-
     connect(this, &mudlet::signal_menuBarVisibilityChanged, this, &mudlet::slot_update_shortcuts);
 
     mpSettings = getQSettings();
@@ -1729,7 +1693,6 @@ void mudlet::commitLayoutUpdates(bool flush)
 void mudlet::showEvent(QShowEvent* event)
 {
     mWindowMinimized = false;
-    slot_update_shortcuts();
     QMainWindow::showEvent(event);
 }
 
@@ -2217,30 +2180,83 @@ void mudlet::show_options_dialog(const QString& tab)
 
 void mudlet::slot_update_shortcuts()
 {
-    if (MenuBar->isVisible()) {
-        triggersShortcut->setEnabled(false);
-        showMapShortcut->setEnabled(false);
-        inputLineShortcut->setEnabled(false);
-        optionsShortcut->setEnabled(false);
-        notepadShortcut->setEnabled(false);
-        packagesShortcut->setEnabled(false);
-        modulesShortcut->setEnabled(false);
-        multiViewShortcut->setEnabled(false);
-        connectShortcut->setEnabled(false);
-        disconnectShortcut->setEnabled(false);
-        reconnectShortcut->setEnabled(false);
+    if (mpMainToolBar->isVisible()) {
+        triggersShortcut = new QShortcut(triggersKeySequence, this);
+        connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::show_editor_dialog);
+        dactionScriptEditor->setShortcut(QKeySequence());
+
+        showMapShortcut = new QShortcut(showMapKeySequence, this);
+        connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
+        dactionShowMap->setShortcut(QKeySequence());
+
+        inputLineShortcut = new QShortcut(inputLineKeySequence, this);
+        connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_compact_input_line);
+        dactionInputLine->setShortcut(QKeySequence());
+
+        optionsShortcut = new QShortcut(optionsKeySequence, this);
+        connect(optionsShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_options_dialog);
+        dactionOptions->setShortcut(QKeySequence());
+
+        notepadShortcut = new QShortcut(notepadKeySequence, this);
+        connect(notepadShortcut.data(), &QShortcut::activated, this, &mudlet::slot_notes);
+        dactionNotepad->setShortcut(QKeySequence());
+
+        packagesShortcut = new QShortcut(packagesKeySequence, this);
+        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_package_manager);
+        dactionPackageManager->setShortcut(QKeySequence());
+
+        modulesShortcut = new QShortcut(packagesKeySequence, this);
+        connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
+        dactionModuleManager->setShortcut(QKeySequence());
+
+        multiViewShortcut = new QShortcut(multiViewKeySequence, this);
+        connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_multi_view);
+        dactionMultiView->setShortcut(QKeySequence());
+
+        connectShortcut = new QShortcut(connectKeySequence, this);
+        connect(connectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_show_connection_dialog);
+        dactionConnect->setShortcut(QKeySequence());
+
+        disconnectShortcut = new QShortcut(disconnectKeySequence, this);
+        connect(disconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
+        dactionDisconnect->setShortcut(QKeySequence());
+
+        reconnectShortcut = new QShortcut(reconnectKeySequence, this);
+        connect(reconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
+        dactionReconnect->setShortcut(QKeySequence());
     } else {
-        triggersShortcut->setEnabled(true);
-        showMapShortcut->setEnabled(true);
-        inputLineShortcut->setEnabled(true);
-        optionsShortcut->setEnabled(true);
-        notepadShortcut->setEnabled(true);
-        packagesShortcut->setEnabled(true);
-        modulesShortcut->setEnabled(true);
-        multiViewShortcut->setEnabled(true);
-        connectShortcut->setEnabled(true);
-        disconnectShortcut->setEnabled(true);
-        reconnectShortcut->setEnabled(true);
+        triggersShortcut.clear();
+        dactionScriptEditor->setShortcut(triggersKeySequence);
+
+        showMapShortcut.clear();
+        dactionShowMap->setShortcut(showMapKeySequence);
+
+        inputLineShortcut.clear();
+        dactionInputLine->setShortcut(inputLineKeySequence);
+
+        optionsShortcut.clear();
+        dactionOptions->setShortcut(optionsKeySequence);
+
+        notepadShortcut.clear();
+        dactionNotepad->setShortcut(notepadKeySequence);
+
+        packagesShortcut.clear();
+        dactionPackageManager->setShortcut(packagesKeySequence);
+
+        modulesShortcut.clear();
+        dactionModuleManager->setShortcut(modulesKeySequence);
+
+        multiViewShortcut.clear();
+        dactionMultiView->setShortcut(multiViewKeySequence);
+
+        connectShortcut.clear();
+        dactionConnect->setShortcut(connectKeySequence);
+
+        disconnectShortcut.clear();
+        dactionDisconnect->setShortcut(disconnectKeySequence);
+
+        reconnectShortcut.clear();
+        dactionReconnect->setShortcut(reconnectKeySequence);
     }
 }
 


### PR DESCRIPTION
Reverts Mudlet/Mudlet#3994.

It causes a regression:

> think I found a bit of a regression after all.  Shortcuts do not seem to be working like they used to in 4.12. I press  Alt + R and get this

![image](https://user-images.githubusercontent.com/110988/132973353-f973fb81-c9a1-43f3-af63-0f79e6ecea0a.png)
