### PR TITLE
Add automated clang-format

### DIFF
--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -1,10 +1,7 @@
 name: "Auto-format C++ code"
 
 on:
-  pull_request_target:
-    paths:
-    - '**.cpp'
-    - '**.h'
+  push:
 
 jobs:
   clang-format:

--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -2,6 +2,7 @@ name: "Auto-format C++ code"
 
 on:
   pull_request_target:
+    types: [opened, edited, synchronize, reopened]
     paths:
     - '**.cpp'
     - '**.h'

--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -15,7 +15,7 @@ jobs:
           # that's what will get formatted (i.e. the most recent commit)
           fetch-depth: 2
       # format the latest commit
-      - uses: purduesigbots/clang-format-action@1
+      - uses: purduesigbots/clang-format-action@master
         # use one of clang-format's supported styles or leave this out to use the style in your .clang-format file
         with:
           style: file

--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -1,0 +1,31 @@
+name: "Auto-format C++ code"
+
+on:
+  pull_request_target:
+    paths:
+    - '**.cpp'
+    - '**.h'
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # check out HEAD on the branch
+          ref: ${{ github.head_ref }}
+          # make sure the parent commit is grabbed as well, because
+          # that's what will get formatted (i.e. the most recent commit)
+          fetch-depth: 2
+      # format the latest commit
+      - uses: purduesigbots/clang-format-action@1
+        # use one of clang-format's supported styles or leave this out to use the style in your .clang-format file
+        with:
+          style: file
+      # commit the changes (if there are any)
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_message: 🎨 apply clang-format changes
+          branch: ${{ github.head_ref }}
+

--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -15,7 +15,7 @@ jobs:
           # that's what will get formatted (i.e. the most recent commit)
           fetch-depth: 2
       # format the latest commit
-      - uses: purduesigbots/clang-format-action@master
+      - uses: purduesigbots/clang-format-action@1.0.2
         # use one of clang-format's supported styles or leave this out to use the style in your .clang-format file
         with:
           style: file

--- a/.github/workflows/clang-formatter.yml
+++ b/.github/workflows/clang-formatter.yml
@@ -2,7 +2,6 @@ name: "Auto-format C++ code"
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
     paths:
     - '**.cpp'
     - '**.h'

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -139,7 +139,7 @@ public:
 
     QPair<int, QString> startTempTimer(double timeout, const QString& function, const bool repeating = false);
     int startTempAlias(const QString&, const QString&);
-    int startTempKey(int&, int&, const QString&);
+    int startTempKey(  int&, int&, const QString&);
     int startTempTrigger(const QString& regex, const QString& function, int expiryCount = -1);
     int startTempBeginOfLineTrigger(const QString&, const QString&, int expiryCount = -1);
     int startTempExactMatchTrigger(const QString&, const QString&, int expiryCount = -1);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add automated clang-format
#### Motivation for adding to Mudlet
So new contributors don't have to go through the hoops of configuring clant-format on their machine
#### Other info (issues closed, discussion etc)
Should only format the parts of the codebase changed by the PR, not the entire codebase itself which would be a problem