### PR TITLE
Use consistent (alphabetical) order for listing games

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1108,7 +1108,6 @@ void dlgConnectionProfiles::fillout_form()
     auto iterator = mudlet::scmDefaultGames.constBegin();
     while (iterator != mudlet::scmDefaultGames.constEnd()) {
         const auto& game = iterator.key();
-        qDebug() << "processing" << game;
         if (!deletedDefaultMuds.contains(game)) {
             pItem = new QListWidgetItem();
             setupMudProfile(pItem, game, getDescription(mudlet::scmDefaultGames[game].hostUrl, mudlet::scmDefaultGames[game].port, game), mudlet::scmDefaultGames[game].icon);

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1104,14 +1104,18 @@ void dlgConnectionProfiles::fillout_form()
 
     auto& settings = *mudlet::self()->mpSettings;
     auto deletedDefaultMuds = settings.value(QStringLiteral("deletedDefaultMuds"), QStringList()).toStringList();
-    const auto defaultGames = mudlet::scmDefaultGames.keys();
 
-    for (auto& game : defaultGames) {
+    auto iterator = mudlet::scmDefaultGames.constBegin();
+    while (iterator != mudlet::scmDefaultGames.constEnd()) {
+        const auto& game = iterator.key();
+        qDebug() << "processing" << game;
         if (!deletedDefaultMuds.contains(game)) {
             pItem = new QListWidgetItem();
             setupMudProfile(pItem, game, getDescription(mudlet::scmDefaultGames[game].hostUrl, mudlet::scmDefaultGames[game].port, game), mudlet::scmDefaultGames[game].icon);
         }
+        ++iterator;
     }
+
 
 #if defined(QT_DEBUG)
     QString mudServer = QStringLiteral("Mudlet self-test");

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -439,7 +439,7 @@ public:
     };
 
     // clang-format off
-    inline static const QHash<QString, GameDetails> scmDefaultGames = {
+    inline static const QMap<QString, GameDetails> scmDefaultGames = {
         {"3Scapes", {
             "3k.org",   // address to connect to
             3200,       // port to connect on


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use consistent (alphabetical) order for listing games
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/5420
#### Other info (issues closed, discussion etc)
Originally intended to revert to the previous behaviour - where the order was fixed in code - but C++ isn't cooperating here for some reason and coming out alphabetical.

Ideally we'll have `telnet://` links support for games to open up Mudlet directly. Last body of work is [available here](https://github.com/Mudlet/Mudlet/pull/3131).
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
