### PR TITLE
BugFix: repair "prevent all controls from being hidden" feature

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1927,9 +1927,8 @@ void mudlet::setMenuBarVisibility(const controlsVisibility state)
 // This only adjusts the visibility as appropriate
 void mudlet::adjustMenuBarVisibility()
 {
-    // Are there any profiles loaded?
-    if ((mHostManager.getHostCount() && mMenuBarVisibility & visibleAlways)
-            || (mMenuBarVisibility & visibleMaskNormally)) {
+    const int hostCount = mHostManager.getHostCount();
+    if ((hostCount < 1 && (mMenuBarVisibility & visibleAlways)) || (hostCount >= 1 && (mMenuBarVisibility & visibleMaskNormally))) {
         menuBar()->show();
     } else {
         menuBar()->hide();
@@ -1952,8 +1951,8 @@ void mudlet::slot_handleToolbarVisibilityChanged(bool isVisible)
 {
     if (!isVisible && mMenuBarVisibility == visibleNever) {
         // Only need to worry about it DIS-appearing if the menu bar is not showing
-        int hostCount = mHostManager.getHostCount();
-        if ((hostCount < 2 && (mToolbarVisibility & visibleAlways)) || (hostCount >= 2 && (mToolbarVisibility & visibleMaskNormally))) {
+        const int hostCount = mHostManager.getHostCount();
+        if ((hostCount < 1 && (mToolbarVisibility & visibleAlways)) || (hostCount >= 1 && (mToolbarVisibility & visibleMaskNormally))) {
             mpMainToolBar->show();
         }
     }
@@ -1961,9 +1960,8 @@ void mudlet::slot_handleToolbarVisibilityChanged(bool isVisible)
 
 void mudlet::adjustToolBarVisibility()
 {
-    // Are there any profiles loaded?
-    if ((mHostManager.getHostCount() && mToolbarVisibility & visibleAlways)
-            || (mToolbarVisibility & visibleMaskNormally)) {
+    const int hostCount = mHostManager.getHostCount();
+    if ((hostCount < 1 && (mToolbarVisibility & visibleAlways)) || (hostCount >= 1 && (mToolbarVisibility & visibleMaskNormally))) {
         mpMainToolBar->show();
     } else {
         mpMainToolBar->hide();


### PR DESCRIPTION
It seems, *I think* that the removal of the "default host" profile (in #2950) broke the logic that detected that any "real" profiles were loaded and prevented both the main menu bar and the main toolbar from being hidden when no such profiles were active. As it is now it is not possible to hide both the main menu and the main toolbar AFTER a profile is loaded - even though we provide the settings that are suppose to allow that.

The original `enum` used to encode the wanted settings for the visibility of those two items used a cunning combination of bit patterns (and some application of DeMorgan's laws) to work out what the visibility settings are and what state the application is in (number of profiles active) so as to show or hide the main menu and main toolbars. Unfortunately I've lost track of how I put it together when the single "default host" profile was included in the count so had to rewrite the logic tests without changing the `enum` values.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
You can now hide both the Main Menu and Toolbar (after a profile is loaded) again.