### PR TITLE
Adjust height of command box when cycle through history

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1046,7 +1046,6 @@ void TCommandLine::historyMove(MoveDirection direction)
         } else {
             moveCursor(QTextCursor::End);
         }
-        adjustHeight();
     } else {
         mAutoCompletionCount += shift;
         handleAutoCompletion();

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1051,6 +1051,7 @@ void TCommandLine::historyMove(MoveDirection direction)
         mAutoCompletionCount += shift;
         handleAutoCompletion();
     }
+    adjustHeight();
 }
 
 void TCommandLine::slot_clearSelection(bool yes)

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -285,6 +285,7 @@ bool TCommandLine::event(QEvent* event)
             if ((ke->modifiers() & allModifiers) == Qt::ShiftModifier) {
                 textCursor().insertBlock();
                 ke->accept();
+                adjustHeight();
                 return true;
 
             }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Normally you press up and down arrows to cycle through history and if you go from a command that fits in one line back to a command that fits in 2 lines, then it shows a box with just the second line visible.  You can even manage to make it not show your input.  With this change it shows the whole command same as if you were typing.
edit: Also shift-enter should expand the box now instead of leaving cursor out of view.

#### Motivation for adding to Mudlet
Fix minor annoyance #5430 and larger annoyance #5431.

#### Other info (issues closed, discussion etc)
I moved a single function call outside of an if statement, but I did not fully wrap my head around what the if statement does.  More familiar people will be reviewing so I'm submitting anyway.
edit: Then I added it to the shift-return also.

#### Release post highlight
Resize command box when cycling through history, or typing with shift-enter.
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
