### PR TITLE
Revert "Cleanup: remove some warnings in uses of QKeySequence"

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -486,7 +486,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     QAction* deleteTriggerAction = new QAction(QIcon::fromTheme(QStringLiteral(":/icons/edit-delete"), QIcon(QStringLiteral(":/icons/edit-delete.png"))), tr("Delete Item"), this);
     deleteTriggerAction->setStatusTip(tr("Delete Trigger, Script, Alias or Filter"));
-    deleteTriggerAction->setToolTip(QStringLiteral("<p>%1 (%2)</p>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
+    deleteTriggerAction->setToolTip(QStringLiteral("<html><head/><body><p>%1 (%2)</p></body></html>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
     deleteTriggerAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     deleteTriggerAction->setShortcut(QKeySequence(QKeySequence::Delete));
     frame_left->addAction(deleteTriggerAction);
@@ -557,13 +557,13 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mProfileSaveAsAction->setEnabled(true);
     connect(mProfileSaveAsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_profileSaveAsAction);
 
-    auto *nextSectionShortcut = new QShortcut(QKeySequence(Qt::Key_Tab, Qt::CTRL), this);
+    auto *nextSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Tab), this);
     QObject::connect(nextSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_next_section);
 
-    auto *previousSectionShortcut = new QShortcut(QKeySequence(Qt::Key_Tab, Qt::CTRL, Qt::SHIFT), this);
+    QShortcut *previousSectionShortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab), this);
     QObject::connect(previousSectionShortcut, &QShortcut::activated, this, &dlgTriggerEditor::slot_previous_section);
 
-    auto *activateMainWindowAction = new QShortcut(QKeySequence(Qt::Key_E, Qt::ALT), this);
+    QShortcut *activateMainWindowAction = new QShortcut(QKeySequence((Qt::ALT | Qt::Key_E)), this);
     QObject::connect(activateMainWindowAction, &QShortcut::activated, this, &dlgTriggerEditor::slot_activateMainWindow);
 
     toolBar = new QToolBar();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -594,29 +594,29 @@ mudlet::mudlet()
 
     // we historically use Alt on Windows and Linux, but that is uncomfortable on macOS
 #if defined(Q_OS_MACOS)
-    triggersKeySequence = QKeySequence(Qt::Key_E, Qt::CTRL);
-    showMapKeySequence = QKeySequence(Qt::Key_M, Qt::CTRL);
-    inputLineKeySequence = QKeySequence(Qt::Key_L, Qt::CTRL);
-    optionsKeySequence = QKeySequence(Qt::Key_P, Qt::CTRL);
-    notepadKeySequence = QKeySequence(Qt::Key_N, Qt::CTRL);
-    packagesKeySequence = QKeySequence(Qt::Key_O, Qt::CTRL);
-    modulesKeySequence = QKeySequence(Qt::Key_I, Qt::CTRL);
-    multiViewKeySequence = QKeySequence(Qt::Key_V, Qt::CTRL, Qt::ALT);
-    connectKeySequence = QKeySequence(Qt::Key_C, Qt::CTRL, Qt::ALT);
-    disconnectKeySequence = QKeySequence(Qt::Key_D, Qt::CTRL);
-    reconnectKeySequence = QKeySequence(Qt::Key_R, Qt::CTRL);
+    triggersKeySequence = QKeySequence(Qt::CTRL | Qt::Key_E);
+    showMapKeySequence = QKeySequence(Qt::CTRL | Qt::Key_M);
+    inputLineKeySequence = QKeySequence(Qt::CTRL | Qt::Key_L);
+    optionsKeySequence = QKeySequence(Qt::CTRL | Qt::Key_P);
+    notepadKeySequence = QKeySequence(Qt::CTRL | Qt::Key_N);
+    packagesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_O);
+    modulesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_I);
+    multiViewKeySequence = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_V);
+    connectKeySequence = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_C);
+    disconnectKeySequence = QKeySequence(Qt::CTRL | Qt::Key_D);
+    reconnectKeySequence = QKeySequence(Qt::CTRL | Qt::Key_R);
 #else
-    triggersKeySequence = QKeySequence(Qt::Key_E, Qt::ALT);
-    showMapKeySequence = QKeySequence(Qt::Key_M, Qt::ALT);
-    inputLineKeySequence = QKeySequence(Qt::Key_L, Qt::ALT);
-    optionsKeySequence = QKeySequence(Qt::Key_P, Qt::ALT);
-    notepadKeySequence = QKeySequence(Qt::Key_N, Qt::ALT);
-    packagesKeySequence = QKeySequence(Qt::Key_O, Qt::ALT);
-    modulesKeySequence = QKeySequence(Qt::Key_I, Qt::ALT);
-    multiViewKeySequence = QKeySequence(Qt::Key_V, Qt::ALT);
-    connectKeySequence = QKeySequence(Qt::Key_C, Qt::ALT);
-    disconnectKeySequence = QKeySequence(Qt::Key_D, Qt::ALT);
-    reconnectKeySequence = QKeySequence(Qt::Key_R, Qt::ALT);
+    triggersKeySequence = QKeySequence(Qt::ALT | Qt::Key_E);
+    showMapKeySequence = QKeySequence(Qt::ALT | Qt::Key_M);
+    inputLineKeySequence = QKeySequence(Qt::ALT | Qt::Key_L);
+    optionsKeySequence = QKeySequence(Qt::ALT | Qt::Key_P);
+    notepadKeySequence = QKeySequence(Qt::ALT | Qt::Key_N);
+    packagesKeySequence = QKeySequence(Qt::ALT | Qt::Key_O);
+    modulesKeySequence = QKeySequence(Qt::ALT | Qt::Key_I);
+    multiViewKeySequence = QKeySequence(Qt::ALT | Qt::Key_V);
+    connectKeySequence = QKeySequence(Qt::ALT | Qt::Key_C);
+    disconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_D);
+    reconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_R);
 #endif
     connect(this, &mudlet::signal_menuBarVisibilityChanged, this, &mudlet::slot_update_shortcuts);
 


### PR DESCRIPTION
Reverts Mudlet/Mudlet#5458

![image](https://user-images.githubusercontent.com/110988/134863885-f653bfbd-0417-490e-bae6-48ce56b69fb1.png)

Let's revert so PTB's are working okay and there's no time pressure to fix it fast. Can always re-PR the original improvements, but fixed.