### PR TITLE
Fix copy2decho() on empty lines

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2179,6 +2179,10 @@ local function copy2color(name,win,str,inst)
   win = win or "main"
   str = str or line
   inst = inst or 1
+  if str == "" then
+    -- happens when you try to use copy2decho() on an empty line
+    return ""
+  end
   local start, len = selectString(win, str, inst), #str
   if not start then
     error(name..": string not found",3)

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -256,6 +256,19 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
   end)
 
+  describe("Tests the functionality of copy2decho", function()
+    it ("Should return an empty string if line == ''", function()
+      local oldgcl = getCurrentLine
+      _G.getCurrentLine = spy.new(function()
+        return ""
+      end)
+      local expected = ""
+      local actual = copy2decho()
+      assert.equals(expected, actual)
+      _G.getCurrentLine = oldgcl
+    end)
+  end)
+
   describe("Tests the functionality of _Echoes.Process()", function()
     it("Should parse hex patterns correctly", function()
       assert.are.same(

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -265,6 +265,7 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       local expected = ""
       local actual = copy2decho()
       assert.equals(expected, actual)
+      assert.spy(_G.getCurrentLine).was.called()
       _G.getCurrentLine = oldgcl
     end)
   end)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Someone in the Lusternia discord was having an issue with a prompt type trigger erroring on a copy2decho() call to grab the entire line. Upon investigation it was discovered this was causing the scanning to not take place. Since they're trying to copy an empty string any way, this change just returns to them that empty string.

#### Motivation for adding to Mudlet

Less errors

#### Other info (issues closed, discussion etc)



#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
