### PR TITLE
Add option for secure IRC connections

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10859,17 +10859,21 @@ int TLuaInterpreter::getIrcServer(lua_State* L)
     Host* pHost = &getHostFromLua(L);
     QString hname;
     int hport;
+    bool hsecure;
     if (pHost->mpDlgIRC) {
         hname = pHost->mpDlgIRC->getHostName();
         hport = pHost->mpDlgIRC->getHostPort();
+        hsecure = pHost->mpDlgIRC->getHostSecure();
     } else {
         hname = dlgIRC::readIrcHostName(pHost);
         hport = dlgIRC::readIrcHostPort(pHost);
+        hsecure = dlgIRC::readIrcHostSecure(pHost);
     }
 
     lua_pushstring(L, hname.toUtf8().constData());
     lua_pushinteger(L, hport);
-    return 2;
+    lua_pushboolean(L, hsecure);
+    return 3;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getIrcChannels

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10969,6 +10969,11 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
         return warnArgumentValue(L, __func__, QStringLiteral("unable to save port, reason: %1").arg(result.second));
     }
 
+    result = dlgIRC::writeIrcHostSecure(pHost, secure);
+    if (!result.first) {
+        return warnArgumentValue(L, __func__, QStringLiteral("unable to save secure, reason: %1").arg(result.second));
+    }
+
     lua_pushboolean(L, true);
     lua_pushnil(L);
     return 2;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10943,8 +10943,8 @@ int TLuaInterpreter::getIrcServer(lua_State* L)
 {
     Host* pHost = &getHostFromLua(L);
     QString hname;
-    int hport;
-    bool hsecure;
+    int hport = 0;
+    bool hsecure = false;
     if (pHost->mpDlgIRC) {
         hname = pHost->mpDlgIRC->getHostName();
         hport = pHost->mpDlgIRC->getHostPort();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10941,6 +10941,8 @@ int TLuaInterpreter::setIrcNick(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setIrcServer
 int TLuaInterpreter::setIrcServer(lua_State* L)
 {
+    int args = lua_gettop(L);
+    int secure = false;
     int port = 6667;
     std::string addr = getVerifiedString(L, __func__, 1, "hostname").toStdString();
     if (addr.empty()) {
@@ -10951,6 +10953,9 @@ int TLuaInterpreter::setIrcServer(lua_State* L)
         if (port > 65535 || port < 1) {
             return warnArgumentValue(L, __func__, QStringLiteral("invalid port number %1 given, if supplied it must be in range 1 to 65535").arg(port));
         }
+    }
+    if (args > 2) {
+        secure = getVerifiedBool(L, __func__, 3, "secure {default = false}", true);
     }
 
     Host* pHost = &getHostFromLua(L);

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -761,13 +761,7 @@ int dlgIRC::readIrcHostPort(Host* pH)
 bool dlgIRC::readIrcHostSecure(Host* pH)
 {
     QString secureStr = pH->readProfileData(dlgIRC::HostSecureCfgItem);
-    bool secure;
-    if (secureStr.toInt()) {
-        secure = true;
-    } else {
-        secure = false;
-    }
-    return secure;
+    return secureStr.contains(QLatin1String("true"), Qt::CaseInsensitive);
 }
 
 QString dlgIRC::readIrcNickName(Host* pH)
@@ -842,7 +836,7 @@ QPair<bool, QString> dlgIRC::writeIrcHostPort(Host* pH, int port)
 
 QPair<bool, QString> dlgIRC::writeIrcHostSecure(Host* pH, bool secure)
 {
-    return pH->writeProfileData(dlgIRC::HostSecureCfgItem, QString::number(secure));
+    return pH->writeProfileData(dlgIRC::HostSecureCfgItem, (secure ? QLatin1String("true") : QLatin1String("false")));
 }
 
 QPair<bool, QString> dlgIRC::writeIrcNickName(Host* pH, const QString& nickname)

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -238,6 +238,7 @@ void dlgIRC::ircRestart(bool reloadConfigs)
         connection->setNickName(mNickName);
         connection->setHost(mHostName);
         connection->setPort(mHostPort);
+        connection->setSecure(mHostSecure);
     }
 
     // queue auto-joined channels and reopen the connection.

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -38,10 +38,12 @@
 
 QString dlgIRC::HostNameCfgItem = QStringLiteral("irc_host");
 QString dlgIRC::HostPortCfgItem = QStringLiteral("irc_port");
+QString dlgIRC::HostSecureCfgItem = QStringLiteral("irc_secure");
 QString dlgIRC::NickNameCfgItem = QStringLiteral("irc_nick");
 QString dlgIRC::ChannelsCfgItem = QStringLiteral("irc_channels");
 QString dlgIRC::DefaultHostName = QStringLiteral("irc.libera.chat");
 int dlgIRC::DefaultHostPort = 6667;
+bool dlgIRC::DefaultHostSecure = false;
 QString dlgIRC::DefaultNickName = QStringLiteral("Mudlet");
 QStringList dlgIRC::DefaultChannels = QStringList() << QStringLiteral("#mudlet");
 int dlgIRC::DefaultMessageBufferLimit = 5000;
@@ -98,6 +100,7 @@ dlgIRC::dlgIRC(Host* pHost)
     mRealName = mudlet::self()->version;
     mHostName = readIrcHostName(mpHost);
     mHostPort = readIrcHostPort(mpHost);
+    mHostSecure = readIrcHostSecure(mpHost);
     mNickName = readIrcNickName(mpHost);
     mChannels = readIrcChannels(mpHost);
 
@@ -106,6 +109,7 @@ dlgIRC::dlgIRC(Host* pHost)
     connection->setRealName(mRealName);
     connection->setHost(mHostName);
     connection->setPort(mHostPort);
+    connection->setSecure(mHostSecure);
 
     // set the title here to pick up the previously loaded nick and host values.
     setClientWindowTitle();
@@ -227,6 +231,7 @@ void dlgIRC::ircRestart(bool reloadConfigs)
     if (reloadConfigs) {
         mHostName = readIrcHostName(mpHost);
         mHostPort = readIrcHostPort(mpHost);
+        mHostSecure = readIrcHostSecure(mpHost);
         mNickName = readIrcNickName(mpHost);
         mChannels = readIrcChannels(mpHost);
 
@@ -753,6 +758,18 @@ int dlgIRC::readIrcHostPort(Host* pH)
     return port;
 }
 
+bool dlgIRC::readIrcHostSecure(Host* pH)
+{
+    QString secureStr = pH->readProfileData(dlgIRC::HostSecureCfgItem);
+    bool secure;
+    if (secureStr.toInt()) {
+        secure = true;
+    } else {
+        secure = false;
+    }
+    return secure;
+}
+
 QString dlgIRC::readIrcNickName(Host* pH)
 {
     QString nick = pH->readProfileData(dlgIRC::NickNameCfgItem);
@@ -821,6 +838,11 @@ QPair<bool, QString> dlgIRC::writeIrcHostName(Host* pH, const QString& hostname)
 QPair<bool, QString> dlgIRC::writeIrcHostPort(Host* pH, int port)
 {
     return pH->writeProfileData(dlgIRC::HostPortCfgItem, QString::number(port));
+}
+
+QPair<bool, QString> dlgIRC::writeIrcHostSecure(Host* pH, bool secure)
+{
+    return pH->writeProfileData(dlgIRC::HostSecureCfgItem, QString::number(secure));
 }
 
 QPair<bool, QString> dlgIRC::writeIrcNickName(Host* pH, const QString& nickname)

--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -53,20 +53,24 @@ public:
 
     static QString HostNameCfgItem;
     static QString HostPortCfgItem;
+    static QString HostSecureCfgItem;
     static QString NickNameCfgItem;
     static QString ChannelsCfgItem;
     static QString DefaultHostName;
     static int DefaultHostPort;
+    static bool DefaultHostSecure;
     static QString DefaultNickName;
     static QStringList DefaultChannels;
     static int DefaultMessageBufferLimit;
 
     static QString readIrcHostName(Host* pH);
     static int readIrcHostPort(Host* pH);
+    static bool readIrcHostSecure(Host* pH);
     static QString readIrcNickName(Host* pH);
     static QStringList readIrcChannels(Host* pH);
     static QPair<bool, QString> writeIrcHostName(Host* pH, const QString& hostname);
     static QPair<bool, QString> writeIrcHostPort(Host* pH, int port);
+    static QPair<bool, QString> writeIrcHostSecure(Host* pH, bool secure);
     static QPair<bool, QString> writeIrcNickName(Host* pH, const QString& nickname);
     static QPair<bool, QString> writeIrcChannels(Host* pH, const QStringList& channels);
 
@@ -75,6 +79,7 @@ public:
     QPair<bool, QString> sendMsg(const QString& target, const QString& message);
     QString getHostName() { return mHostName; }
     int getHostPort() { return mHostPort; }
+    bool getHostSecure() { return mHostSecure; }
     QString getNickName() { return mNickName; }
     QStringList getChannels() { return mChannels; }
     QString getConnectedHost() { return mConnectedHostName; }
@@ -132,6 +137,7 @@ private:
     QString mConnectedHostName;
     QString mHostName;
     int mHostPort;
+    bool mHostSecure;
     QString mNickName;
     QString mUserName;
     QString mRealName;

--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -77,12 +77,12 @@ public:
     IrcConnection* connection;
     bool mReadyForSending;
     QPair<bool, QString> sendMsg(const QString& target, const QString& message);
-    QString getHostName() { return mHostName; }
-    int getHostPort() { return mHostPort; }
-    bool getHostSecure() { return mHostSecure; }
-    QString getNickName() { return mNickName; }
-    QStringList getChannels() { return mChannels; }
-    QString getConnectedHost() { return mConnectedHostName; }
+    QString getHostName() const { return mHostName; }
+    int getHostPort() const { return mHostPort; }
+    bool getHostSecure() const { return mHostSecure; }
+    QString getNickName() const { return mNickName; }
+    QStringList getChannels() const { return mChannels; }
+    QString getConnectedHost() const { return mConnectedHostName; }
     void ircRestart(bool reloadConfigs = true);
 
 private slots:

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -537,6 +537,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     ircHostName->setText(dlgIRC::readIrcHostName(pHost));
     ircHostPort->setText(QString::number(dlgIRC::readIrcHostPort(pHost)));
+    ircHostSecure->setChecked(dlgIRC::readIrcHostSecure(pHost));
     ircChannels->setText(dlgIRC::readIrcChannels(pHost).join(" "));
     ircNick->setText(dlgIRC::readIrcNickName(pHost));
 
@@ -2504,11 +2505,13 @@ void dlgProfilePreferences::slot_save_and_exit()
         QString oldIrcNick = dlgIRC::readIrcNickName(pHost);
         QString oldIrcHost = dlgIRC::readIrcHostName(pHost);
         QString oldIrcPort = QString::number(dlgIRC::readIrcHostPort(pHost));
+        bool oldIrcSecure = dlgIRC::readIrcHostSecure(pHost);
         QString oldIrcChannels = dlgIRC::readIrcChannels(pHost).join(" ");
 
         QString newIrcNick = ircNick->text();
         QString newIrcHost = ircHostName->text();
         QString newIrcPort = ircHostPort->text();
+        bool newIrcSecure = ircHostSecure->isChecked();
         QString newIrcChannels = ircChannels->text();
         QStringList newChanList;
         int nIrcPort = dlgIRC::DefaultHostPort;
@@ -2569,6 +2572,11 @@ void dlgProfilePreferences::slot_save_and_exit()
 
         if (oldIrcPort != newIrcPort) {
             dlgIRC::writeIrcHostPort(pHost, nIrcPort);
+            restartIrcClient = true;
+        }
+
+        if (oldIrcSecure != newIrcSecure) {
+            dlgIRC::writeIrcHostSecure(pHost, newIrcSecure);
             restartIrcClient = true;
         }
 

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -399,7 +399,7 @@
     "setHexFgColor": "setHexFgColor([windowName], hexColorString)",
     "setIrcChannels": "setIrcChannels(channels)",
     "setIrcNick": "setIrcNick(nickname)",
-    "setIrcServer": "setIrcServer(hostname, port)",
+    "setIrcServer": "setIrcServer(hostname, port, [secure])",
     "setItalics": "setItalics(windowName, bool)",
     "setLabelClickCallback": "setLabelClickCallback(labelName, luaFunctionName, [any arguments])",
     "setLabelCursor": "setLabelCursor(labelName, cursorShape)",

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2626,6 +2626,13 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="ircHostSecure">
+            <property name="text">
+             <string>TLS/SSL secure connection</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -3718,6 +3725,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>ircNick</tabstop>
   <tabstop>ircHostPort</tabstop>
   <tabstop>ircChannels</tabstop>
+  <tabstop>ircHostSecure</tabstop>
   <tabstop>comboBox_discordLargeIconPrivacy</tabstop>
   <tabstop>comboBox_discordSmallIconPrivacy</tabstop>
   <tabstop>checkBox_discordServerAccessToPartyInfo</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2638,8 +2638,11 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="ircHostSecure">
+            <property name="toolTip">
+             <string>&lt;p&gt;TLS/SSL is usually on port 6697. IRC networks often use a &lt;b&gt;+&lt;/b&gt; when listing secure ports offered.&lt;/p&gt;</string>
+            </property>
             <property name="text">
-             <string>TLS/SSL secure connection</string>
+             <string>Use a secure connection</string>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2636,7 +2636,7 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="ircHostSecure">
             <property name="text">
              <string>TLS/SSL secure connection</string>
@@ -3734,9 +3734,9 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>reset_colors_button_2</tabstop>
   <tabstop>ircHostName</tabstop>
   <tabstop>ircNick</tabstop>
+  <tabstop>ircHostSecure</tabstop>
   <tabstop>ircHostPort</tabstop>
   <tabstop>ircChannels</tabstop>
-  <tabstop>ircHostSecure</tabstop>
   <tabstop>comboBox_discordLargeIconPrivacy</tabstop>
   <tabstop>comboBox_discordSmallIconPrivacy</tabstop>
   <tabstop>checkBox_discordServerAccessToPartyInfo</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Now it can connect to IRC servers using Transport Layer Security.  `setIrcServer` includes optional boolean argument.  `getIrcServer` returns an extra boolean.  New checkbox on preferences.
#### Motivation for adding to Mudlet
Allows secure connection to IRC servers.
#### Other info (issues closed, discussion etc)
Closes #5345 
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
IRC client can connect to secure servers