### PR TITLE
do not trim whitespace for tab completion

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -978,7 +978,7 @@ void TCommandLine::handleTabCompletion(bool direction)
             }
             QString proposal = filterList[mTabCompletionCount];
             QString userWords = mTabCompletionTyped.left(typePosition);
-            setPlainText(QString(userWords + proposal).trimmed());
+            setPlainText(QString(userWords + proposal));
             moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
             mTabCompletionOld = toPlainText();
         }


### PR DESCRIPTION

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Tab key to autocomplete was removing leading spaces.  Some people use a leading space to bypass aliases and would prefer to preserve it when using autocomplete.  
Remove trimmed() from one spot in the tab completion.  The list of proposed words I think will not have spaces at the end, so trimming the result only really touches the front.

#### Motivation for adding to Mudlet
Trimming front is not a necessary or expected part of autocompletion.
#### Other info (issues closed, discussion etc)
Closes #579
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
Leading whitespace no longer stripped by tab autocomplete.