### PR TITLE
Git Ignore Mac 3rdparty boost and cocoapods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ qrc_*.cpp
 mudlet
 
 # ignore macOS apps in general, but keep the Autoupdater from Sparkle
+3rdparty/boost/*
+3rdparty/cocoapods/*
 !3rdparty/sparkle/Sparkle.framework/Versions/A/Resources/Autoupdate.app
 
 translations/translated/lrelease_output.txt


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Per compilation instructions for Compiling Mudlet page on the wiki, MacOS for Big Sur creates boost and cocoapods directories and files.  Updated .gitignore to ignore boost and cocoapods files.
#### Motivation for adding to Mudlet
Difficult to develop on MacOS with git and vscode when boost and cocoapods want to be added to source control, however they do not belong there.
#### Other info (issues closed, discussion etc)
by Tamarindo@StickMUD
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
MacOS dependencies of boost and cocoapods skipped from source control addition. 

c/o Tamarindo@StickMUD