### PR TITLE
Unregister fonts upon package/module uninstall

### DIFF
--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -107,5 +107,5 @@ void FontManager::unloadFonts(const QString& belongsTo)
     for (const int id : fontIds) {
         QFontDatabase::removeApplicationFont(id);
     }
-    loadedFontAffiliation.remove(belongsTo);   
+    loadedFontAffiliation.remove(belongsTo);
 }

--- a/src/FontManager.cpp
+++ b/src/FontManager.cpp
@@ -61,7 +61,7 @@ void FontManager::loadFonts(const QString& folder)
     }
 }
 
-void FontManager::loadFont(const QString& filePath)
+void FontManager::loadFont(const QString& filePath, const QString& belongsTo)
 {
     if (fontAlreadyLoaded(filePath)) {
         return;
@@ -70,7 +70,7 @@ void FontManager::loadFont(const QString& filePath)
     auto fontID = QFontDatabase::addApplicationFont(filePath);
 
     // remember even if the font failed to load so we don't spam messages on fonts that repeat
-    rememberFont(filePath, fontID);
+    rememberFont(filePath, fontID, belongsTo);
 
     if (fontID == -1) {
         qWarning() << "FontManager::loadFont() WARNING - Could not load the font(s) in the file: " << filePath;
@@ -85,17 +85,27 @@ bool FontManager::fontAlreadyLoaded(const QString& filePath)
     QFileInfo fontFile(filePath);
     auto fileName = fontFile.fileName();
 
-    return loadedFonts.contains(fileName);
+    return loadedFontPaths.contains(fileName);
 }
 
-void FontManager::rememberFont(const QString& filePath, int fontID)
+void FontManager::rememberFont(const QString& filePath, int fontID, const QString& belongsTo)
 {
     QFileInfo fontFile(filePath);
     auto fileName = fontFile.fileName();
 
-    if (loadedFonts.contains(fileName)) {
+    if (loadedFontPaths.contains(fileName)) {
         return;
     }
 
-    loadedFonts.insert(fileName, fontID);
+    loadedFontPaths.insert(fileName, fontID);
+    loadedFontAffiliation.insert(belongsTo, fontID);
+}
+
+void FontManager::unloadFonts(const QString& belongsTo)
+{
+    const auto fontIds = loadedFontAffiliation.values(belongsTo);
+    for (const int id : fontIds) {
+        QFontDatabase::removeApplicationFont(id);
+    }
+    loadedFontAffiliation.remove(belongsTo);   
 }

--- a/src/FontManager.h
+++ b/src/FontManager.h
@@ -23,6 +23,7 @@
 
 #include "pre_guard.h"
 #include <QMap>
+#include <QMultiMap>
 #include "post_guard.h"
 
 class QString;
@@ -32,15 +33,18 @@ class FontManager
 {
 public:
     void addFonts();
-    void loadFont(const QString& filePath);
+    void loadFont(const QString& filePath, const QString& belongsTo = "main");
     bool fontAlreadyLoaded(const QString& filePath);
+    void unloadFonts(const QString& belongsTo);
 
 private:
     void loadFonts(const QString& folder);
-    void rememberFont(const QString& fileName, int fontID);
+    void rememberFont(const QString& fileName, int fontID, const QString& belongsTo);
 
-    QMap<QString, int> loadedFonts;
-
+    // map of font file path & font ID
+    QMap<QString, int> loadedFontPaths;
+    // map of font affiliation ("main" or a specific package) & font IDs
+    QMultiMap<QString, int> loadedFontAffiliation;
 };
 
 #endif // MUDLET_FONTMANAGER_H

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1917,6 +1917,7 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     mActionUnit.uninstall(packageName);
     mScriptUnit.uninstall(packageName);
     mKeyUnit.uninstall(packageName);
+    mudlet::self()->mFontManager.unloadFonts(packageName);
     if (module) {
         //if module == 2, this is a temporary uninstall for reloading so we exit here
         QStringList entry = mInstalledModules[packageName];
@@ -2115,7 +2116,7 @@ void Host::installPackageFonts(const QString &packageName)
         if (filePath.endsWith(QLatin1String(".otf"), Qt::CaseInsensitive) || filePath.endsWith(QLatin1String(".ttf"), Qt::CaseInsensitive) ||
             filePath.endsWith(QLatin1String(".ttc"), Qt::CaseInsensitive) || filePath.endsWith(QLatin1String(".otc"), Qt::CaseInsensitive)) {
 
-            mudlet::self()->mFontManager.loadFont(filePath);
+            mudlet::self()->mFontManager.loadFont(filePath, packageName);
         }
     }
 }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Unregister fonts upon package/module uninstall.
#### Motivation for adding to Mudlet
So packages/modules containing custom fonts can be reinstalled w/o having to restart Mudlet on Windows.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5479.

I suspect the issue is that Qt is hanging onto a file handle to the font file - so let's try calling the complementary [QFontDatabase::removeApplicationFont](https://doc.qt.io/qt-5/qfontdatabase.html#removeApplicationFont) function.

@demonnic can you test if this fixes it on Windows?