### PR TITLE
use painter event instead of proxystyle for tab style change

### DIFF
--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -188,7 +188,7 @@ void TTabBar::paintEvent(QPaintEvent* event)
     QStylePainter painter(this);
     QStyleOptionTab opt;
 
-    for (int i = 0; i < count(); i++)
+    for (int i = 0, total = count(); i < total; ++i)
     {
         QFont font = painter.font();
         initStyleOption(&opt, i);

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -31,11 +31,11 @@
 #include "post_guard.h"
 
 
-void TStyle::setNamedTabState(const QString& tabName, const bool state, QSet<QString>& effect)
+void TTabBar::setNamedTabState(const QString& tabName, const bool state, QSet<QString>& effect)
 {
     bool textIsInATab = false;
-    for (int i = 0, total = mpTabBar->count(); i < total; ++i) {
-        if (mpTabBar->tabData(i).toString() == tabName) {
+    for (int i = 0, total = count(); i < total; ++i) {
+        if (tabData(i).toString() == tabName) {
             textIsInATab = true;
             break;
         }
@@ -52,24 +52,24 @@ void TStyle::setNamedTabState(const QString& tabName, const bool state, QSet<QSt
     }
 }
 
-void TStyle::setIndexedTabState(const int index, const bool state, QSet<QString>& effect)
+void TTabBar::setIndexedTabState(const int index, const bool state, QSet<QString>& effect)
 {
-    if (index < 0 || index >= mpTabBar->count()) {
+    if (index < 0 || index >= count()) {
         return;
     }
 
     if (state) {
-        effect.insert(mpTabBar->tabData(index).toString());
+        effect.insert(tabData(index).toString());
     } else {
-        effect.remove(mpTabBar->tabData(index).toString());
+        effect.remove(tabData(index).toString());
     }
 }
 
-bool TStyle::namedTabState(const QString& tabName, const QSet<QString>& effect) const
+bool TTabBar::namedTabState(const QString& tabName, const QSet<QString>& effect) const
 {
     bool textIsInATab = false;
-    for (int i = 0, total = mpTabBar->count(); i < total; ++i) {
-        if (mpTabBar->tabData(i).toString() == tabName) {
+    for (int i = 0, total = count(); i < total; ++i) {
+        if (tabData(i).toString() == tabName) {
             textIsInATab = true;
             break;
         }
@@ -82,18 +82,18 @@ bool TStyle::namedTabState(const QString& tabName, const QSet<QString>& effect) 
     return effect.contains(tabName);
 }
 
-bool TStyle::indexedTabState(const int index, const QSet<QString>& effect) const
+bool TTabBar::indexedTabState(const int index, const QSet<QString>& effect) const
 {
-    if (index < 0 || index >= mpTabBar->count()) {
+    if (index < 0 || index >= count()) {
         return false;
     }
 
-    return effect.contains(mpTabBar->tabData(index).toString());
+    return effect.contains(tabData(index).toString());
 }
 
 QSize TTabBar::tabSizeHint(int index) const
 {
-    if (mStyle.tabBold(index) || mStyle.tabItalic(index) || mStyle.tabUnderline(index)) {
+    if (tabBold(index) || tabItalic(index) || tabUnderline(index)) {
         const QSize s = QTabBar::tabSizeHint(index);
         const QFontMetrics fm(font());
         // Note that this method must use (because it is associated with sizing
@@ -103,9 +103,9 @@ QSize TTabBar::tabSizeHint(int index) const
         const int w = fm.horizontalAdvance(tabText(index));
 
         QFont f = font();
-        f.setBold(mStyle.tabBold(index));
-        f.setItalic(mStyle.tabItalic(index));
-        f.setUnderline(mStyle.tabUnderline(index));
+        f.setBold(tabBold(index));
+        f.setItalic(tabItalic(index));
+        f.setUnderline(tabUnderline(index));
         const QFontMetrics bfm(f);
 
         const int bw = bfm.horizontalAdvance(tabText(index));

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -181,3 +181,24 @@ void TTabBar::applyPrefixToDisplayedText(int index, const QString& prefix)
         QTabBar::setTabText(index, QStringLiteral("%1%2").arg(prefix, tabData(index).toString()));
     }
 }
+
+void TTabBar::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+    QStylePainter painter(this);
+    QStyleOptionTab opt;
+
+    for (int i = 0; i < count(); i++)
+    {
+        QFont font = painter.font();
+        initStyleOption(&opt, i);
+        painter.save();
+        font.setBold(tabBold(i));
+        font.setItalic(tabItalic(i));
+        font.setUnderline(tabUnderline(i));
+        painter.setFont(font);
+        painter.drawControl(QStyle::CE_TabBarTabShape, opt);
+        painter.drawControl(QStyle::CE_TabBarTabLabel, opt);
+        painter.restore();
+    }
+}

--- a/src/TTabBar.cpp
+++ b/src/TTabBar.cpp
@@ -25,38 +25,11 @@
  ***************************************************************************/
 
 #include "TTabBar.h"
-
 #include "pre_guard.h"
-#include <QStyleOption>
 #include <QPainter>
 #include <QVariant>
 #include "post_guard.h"
 
-void TStyle::drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const
-{
-    if (element == QStyle::CE_TabBarTab) {
-        QString tabName = mpTabBar->tabData(mpTabBar->tabAt(option->rect.center())).toString();
-        QFont font = widget->font();
-        bool isStyleChanged = false;
-        if (mBoldTabsSet.contains(tabName) || mItalicTabsSet.contains(tabName) || mUnderlineTabsSet.contains(tabName)) {
-            painter->save();
-            font.setBold(mBoldTabsSet.contains(tabName));
-            font.setItalic(mItalicTabsSet.contains(tabName));
-            font.setUnderline(mUnderlineTabsSet.contains(tabName));
-            isStyleChanged = true;
-            painter->setFont(font);
-        }
-
-        QProxyStyle::drawControl(element, option, painter, widget);
-
-        if (isStyleChanged) {
-            painter->restore();
-        }
-
-    } else {
-        QProxyStyle::drawControl(element, option, painter, widget);
-    }
-}
 
 void TStyle::setNamedTabState(const QString& tabName, const bool state, QSet<QString>& effect)
 {

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -108,17 +108,17 @@ protected:
         QStylePainter painter(this);
         QStyleOptionTab opt;
 
-        for(int i = 0;i < count();i++)
+        for (int i = 0; i < count(); i++)
         {
             QFont font = painter.font();
-            initStyleOption(&opt,i);
+            initStyleOption(&opt, i);
             painter.save();
             font.setBold(tabBold(i));
             font.setItalic(tabItalic(i));
             font.setUnderline(tabUnderline(i));
             painter.setFont(font);
             painter.drawControl(QStyle::CE_TabBarTabShape, opt);
-            painter.drawControl(QStyle::CE_TabBarTabLabel,opt);
+            painter.drawControl(QStyle::CE_TabBarTabLabel, opt);
             painter.restore();
         }
     }

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -34,7 +34,7 @@ class TTabBar : public QTabBar
     Q_OBJECT
 
 public:
-    TTabBar(QWidget* parent) : QTabBar(parent) {}
+    explicit TTabBar(QWidget* parent) : QTabBar(parent) {}
     ~TTabBar() = default;
     TTabBar() = delete;
     QSize tabSizeHint(int index) const override;

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -103,25 +103,8 @@ private:
     TStyle mStyle;
 
 protected:
-    void paintEvent(QPaintEvent */*event*/){
+    void paintEvent(QPaintEvent*) override;
 
-        QStylePainter painter(this);
-        QStyleOptionTab opt;
-
-        for (int i = 0; i < count(); i++)
-        {
-            QFont font = painter.font();
-            initStyleOption(&opt, i);
-            painter.save();
-            font.setBold(tabBold(i));
-            font.setItalic(tabItalic(i));
-            font.setUnderline(tabUnderline(i));
-            painter.setFont(font);
-            painter.drawControl(QStyle::CE_TabBarTabShape, opt);
-            painter.drawControl(QStyle::CE_TabBarTabLabel, opt);
-            painter.restore();
-        }
-    }
 };
 
 #endif // TTABBAR_H

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -29,14 +29,16 @@
 #include <QTabBar>
 #include "post_guard.h"
 
-class TStyle
+class TTabBar : public QTabBar
 {
-public:
-    explicit TStyle(QTabBar* bar)
-    : mpTabBar(bar)
-    {}
+    Q_OBJECT
 
-    ~TStyle() = default;
+public:
+    TTabBar(QWidget* parent) : QTabBar(parent) {}
+    ~TTabBar() = default;
+    QSize tabSizeHint(int index) const;
+    void applyPrefixToDisplayedText(const int index, const QString& prefix = QString());
+    void applyPrefixToDisplayedText(const QString& tabName, const QString& prefix = QString());
     void setTabBold(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mBoldTabsSet); }
     void setTabBold(const int index, const bool state) { setIndexedTabState(index, state, mBoldTabsSet); }
     void setTabItalic(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mItalicTabsSet); }
@@ -49,6 +51,11 @@ public:
     bool tabItalic(const int index) const { return indexedTabState(index, mItalicTabsSet); }
     bool tabUnderline(const QString& tabName) const { return namedTabState(tabName, mUnderlineTabsSet); }
     bool tabUnderline(const int index) const { return indexedTabState(index, mUnderlineTabsSet); }
+    QString tabName(const int index) const;
+    int tabIndex(const QString& tabName) const;
+    void removeTab(const QString& tabName);
+    void removeTab(int);
+    QStringList tabNames() const;
 
 private:
     bool indexedTabState(int index, const QSet<QString>& effect) const;
@@ -56,8 +63,6 @@ private:
     void setNamedTabState(const QString& tabName, bool state, QSet<QString>& effect);
     void setIndexedTabState(int index, bool state, QSet<QString>& effect);
 
-
-    QTabBar * mpTabBar;
     // The sets that hold the tab names that have the particular effect, we
     // use the text rather than the indexes because the tabs could be capable of
     // being reordered, but the names are expected to be constant (or if the
@@ -66,44 +71,9 @@ private:
     QSet<QString> mBoldTabsSet;
     QSet<QString> mItalicTabsSet;
     QSet<QString> mUnderlineTabsSet;
-};
-
-class TTabBar : public QTabBar
-{
-public:
-    TTabBar(QWidget* parent)
-    : QTabBar(parent)
-    , mStyle(qobject_cast<QTabBar*>(this))
-    {}
-    ~TTabBar() = default;
-
-    QSize tabSizeHint(int index) const;
-    void applyPrefixToDisplayedText(const int index, const QString& prefix = QString());
-    void applyPrefixToDisplayedText(const QString& tabName, const QString& prefix = QString());
-    void setTabBold(const QString& tabName, const bool state) {mStyle.setTabBold(tabName, state); }
-    void setTabBold(const int index, const bool state) {mStyle.setTabBold(index, state); }
-    void setTabItalic(const QString& tabName, const bool state) {mStyle.setTabItalic(tabName, state); }
-    void setTabItalic(const int index, const bool state) {mStyle.setTabItalic(index, state); }
-    void setTabUnderline(const QString& tabName, const bool state) {mStyle.setTabUnderline(tabName, state); }
-    void setTabUnderline(const int index, const bool state) {mStyle.setTabUnderline(index, state); }
-    bool tabBold(const QString& tabName) const {return mStyle.tabBold(tabName);}
-    bool tabBold(const int index) const {return mStyle.tabBold(index);}
-    bool tabItalic(const QString& tabName) const {return mStyle.tabItalic(tabName);}
-    bool tabItalic(const int index) const {return mStyle.tabItalic(index);}
-    bool tabUnderline(const QString& tabName) const {return mStyle.tabUnderline(tabName);}
-    bool tabUnderline(const int index) const {return mStyle.tabUnderline(index);}
-    QString tabName(const int index) const;
-    int tabIndex(const QString& tabName) const;
-    void removeTab(const QString& tabName);
-    void removeTab(int);
-    QStringList tabNames() const;
-
-private:
-    // This instance of TStyle needs a pointer to a QTabBar on instantiation:
-    TStyle mStyle;
 
 protected:
-    void paintEvent(QPaintEvent*) override;
+    void paintEvent(QPaintEvent* event) override;
 
 };
 

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -36,7 +36,8 @@ class TTabBar : public QTabBar
 public:
     TTabBar(QWidget* parent) : QTabBar(parent) {}
     ~TTabBar() = default;
-    QSize tabSizeHint(int index) const;
+    TTabBar() = delete;
+    QSize tabSizeHint(int index) const override;
     void applyPrefixToDisplayedText(const int index, const QString& prefix = QString());
     void applyPrefixToDisplayedText(const QString& tabName, const QString& prefix = QString());
     void setTabBold(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mBoldTabsSet); }

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -22,13 +22,14 @@
  ***************************************************************************/
 
 #include "pre_guard.h"
-#include <QProxyStyle>
+#include <QStylePainter>
+#include <QStyleOptionTab>
 #include <QSet>
 #include <QString>
 #include <QTabBar>
 #include "post_guard.h"
 
-class TStyle : public QProxyStyle
+class TStyle
 {
 public:
     explicit TStyle(QTabBar* bar)
@@ -36,8 +37,6 @@ public:
     {}
 
     ~TStyle() = default;
-
-    void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr) const;
     void setTabBold(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mBoldTabsSet); }
     void setTabBold(const int index, const bool state) { setIndexedTabState(index, state, mBoldTabsSet); }
     void setTabItalic(const QString& tabName, const bool state) { setNamedTabState(tabName, state, mItalicTabsSet); }
@@ -75,9 +74,7 @@ public:
     TTabBar(QWidget* parent)
     : QTabBar(parent)
     , mStyle(qobject_cast<QTabBar*>(this))
-    {
-        setStyle(&mStyle);
-    }
+    {}
     ~TTabBar() = default;
 
     QSize tabSizeHint(int index) const;
@@ -104,6 +101,27 @@ public:
 private:
     // This instance of TStyle needs a pointer to a QTabBar on instantiation:
     TStyle mStyle;
+
+protected:
+    void paintEvent(QPaintEvent */*event*/){
+
+        QStylePainter painter(this);
+        QStyleOptionTab opt;
+
+        for(int i = 0;i < count();i++)
+        {
+            QFont font = painter.font();
+            initStyleOption(&opt,i);
+            painter.save();
+            font.setBold(tabBold(i));
+            font.setItalic(tabItalic(i));
+            font.setUnderline(tabUnderline(i));
+            painter.setFont(font);
+            painter.drawControl(QStyle::CE_TabBarTabShape, opt);
+            painter.drawControl(QStyle::CE_TabBarTabLabel,opt);
+            painter.restore();
+        }
+    }
 };
 
 #endif // TTABBAR_H


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This uses the painter event instead of the previously used proxystyle to change font styles of single tabs.

#### Motivation for adding to Mudlet
There were some issues with the new Darktheme.
Tabs weren't dark (especially on windows)

#### Other info (issues closed, discussion etc)
I got the idea from https://stackoverflow.com/questions/47094871/how-to-custom-qtabwidget-tab

#### Release post highlight
-
