### PR TITLE
delete internal/local shrink_title function in Adjustable.Containers + add position as option for setTitle

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -77,6 +77,8 @@ end
 --- function to reset your adjustable containers title to default
 function Adjustable.Container:resetTitle()
     self.titleText = nil
+    self.titleTxtColor = nil
+    self.titleFormat = nil
     self:setTitle()
 end
 

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -62,15 +62,15 @@ end
 --- function to give your adjustable container a new title
 -- @param text new title text
 -- @param color title text color
--- @param position title position
-function Adjustable.Container:setTitle(text, color, position)
-    self.titlePosition = position or self.titlePosition or "l"
+-- @param format title format
+function Adjustable.Container:setTitle(text, color, format)
+    self.titleFormat = format or self.titleFormat or "l"
     self.titleText = text or self.titleText or string.format("%s - Adjustable Container")
     self.titleTxtColor = color or self.titleTxtColor or "green"
     if self.locked and self.connectedContainers then
         return
     end
-    self.adjLabel:echo(string.format("&nbsp;&nbsp;%s", self.titleText), self.titleTxtColor, self.titlePosition)
+    self.adjLabel:echo(string.format("&nbsp;&nbsp;%s", self.titleText), self.titleTxtColor, self.titleFormat)
 end
 
 

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -1100,7 +1100,6 @@ function Adjustable.Container:new(cons,container)
     me.goInside = true
     me.titleTxtColor = me.titleTxtColor or "green"
     me.titleText = me.titleText or me.name.." - Adjustable Container"
-    me.titleText = "&nbsp;&nbsp; "..me.titleText
     me:setTitle()
     me.lockStyle = me.lockStyle or "standard"
     me.noLimit = me.noLimit or false

--- a/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserAdjustableContainer.lua
@@ -59,32 +59,26 @@ local function adjust_Info(self, label, event)
     adjustInfo = {name = adjustInfo.name, top = top, bottom = bottom, left = left, right = right, x = x, y = y, move = adjustInfo.move}
 end
 
--- Internal function: hides the window title if the window gets smaller
--- @param lbl the Label which allows the Container to be adjustable and where the title text is on
-local function shrink_title(lbl)
-    if lbl.locked and lbl.connectedContainers then
-        return
-    end
-    local  w  =  lbl:get_width()
-    local titleText = lbl.titleText
-    if #titleText <= 15 then titleText = titleText.."   " end
-    if w < (#titleText-10)*6.6+20 then
-        titleText = string.sub(lbl.titleText, 0, math.floor(w/6)).."..."
-    end
-    if #titleText <= 15 then titleText = "" end
-    lbl.adjLabel:echo(titleText, lbl.titleTxtColor, "l")
-end
-
 --- function to give your adjustable container a new title
 -- @param text new title text
 -- @param color title text color
-function Adjustable.Container:setTitle(text, color)
-    text = text or self.name.." - Adjustable Container"
-    self.titleTxtColor = color or "green"
-    self.titleText = "&nbsp;&nbsp;"..text
-    shrink_title(self)
+-- @param position title position
+function Adjustable.Container:setTitle(text, color, position)
+    self.titlePosition = position or self.titlePosition or "l"
+    self.titleText = text or self.titleText or string.format("%s - Adjustable Container")
+    self.titleTxtColor = color or self.titleTxtColor or "green"
+    if self.locked and self.connectedContainers then
+        return
+    end
+    self.adjLabel:echo(string.format("&nbsp;&nbsp;%s", self.titleText), self.titleTxtColor, self.titlePosition)
 end
 
+
+--- function to reset your adjustable containers title to default
+function Adjustable.Container:resetTitle()
+    self.titleText = nil
+    self:setTitle()
+end
 
 -- internal function to handle the onClick event of main Adjustable.Container Label
 -- @param label the main Adjustable.Container Label
@@ -213,7 +207,6 @@ function Adjustable.Container:onMove (label, event)
             tw,th = max(minw,tw), max(minh,th)
             tw,th = make_percent(tw/winw), make_percent(th/winh)
             self:resize(tw, th)
-            shrink_title(self)
             if self.connectedContainers then
                 self:adjustConnectedContainers()
             end
@@ -520,7 +513,7 @@ function Adjustable.Container:unlockContainer()
     self.exitLabel:show()
     self.minimizeLabel:show()
     self.locked = false
-    shrink_title(self)
+    self:setTitle()
 end
 
 --- sets the padding of your container
@@ -835,7 +828,7 @@ function Adjustable.Container:load(slot, dir)
     return true
 end
 
---- overridden reposition function to raise an "AdjustableContainerReposition" event and call the shrink_title function
+--- overridden reposition function to raise an "AdjustableContainerReposition" event
 --- Event: "AdjustableContainerReposition" passed values (name, width, height, x, y, isMouseAction)
 --- (the isMouseAction property is true if the reposition is an effect of user dragging/resizing the window,
 --- and false if the reposition event comes as effect of external action, such as resizing of main window)
@@ -850,9 +843,6 @@ function Adjustable.Container:reposition()
       self.get_y(),
       adjustInfo.name == self.adjLabel.name and (adjustInfo.move or adjustInfo.right or adjustInfo.left or adjustInfo.top or adjustInfo.bottom)
     )
-    if self.titleText and not(self.locked) then
-        shrink_title(self)
-    end
 end
 
 --- deletes the file where your saved settings are stored
@@ -967,7 +957,7 @@ function Adjustable.Container:globalLockStyles()
     end)
 
     self:newLockStyle("light", function (s)
-        shrink_title(s)
+        s:setTitle()
         s.Inside:resize("-"..s.padding,"-"..s.padding)
         s.Inside:move(s.padding, s.padding*2)
         s.adjLabel:setStyleSheet(s.adjLabelstyle)
@@ -1111,7 +1101,7 @@ function Adjustable.Container:new(cons,container)
     me.titleTxtColor = me.titleTxtColor or "green"
     me.titleText = me.titleText or me.name.." - Adjustable Container"
     me.titleText = "&nbsp;&nbsp; "..me.titleText
-    shrink_title(me)
+    me:setTitle()
     me.lockStyle = me.lockStyle or "standard"
     me.noLimit = me.noLimit or false
     if not(me.raiseOnClick == false) then


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Gets rid of internal shrink_title function.
Adds the format/position parameter for Adjustable.Container:setTitle(title,colour, format)
for example:
```lua
myContainer:setTitle("TestTitle","yellow","c")

```

Also adds Adjustable.Container:resetTitle() to set the title to the default one.

#### Motivation for adding to Mudlet
shrink_title caused weird issues for example #5318 and it never worked as expected.
I saw many screenshot of adjustable container where it simply didn't do what is should have (delete the last letters of the text
and replace it with ... to prevent text behind the minimize and close buttons)
fix #5318 

#### Other info (issues closed, discussion etc)
it will also allow more flexibility for advanced users which will be able to override the setTitle function if wanted.

#### Release post highlight
-Adjustable container won't reveal html entities in title any-more if shrinking container
-Adjustable container setTitle functions gets a format parameter, title can be centered now.
-Adjustable container new function resetTitle to set the title to the default one
