### PR TITLE
Fix: eliminate a load of warnings about missing-field-initializers

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -487,7 +487,7 @@ public:
                                  "<center><a href='https://www.reinosdeleyenda.es/foro/'>Forums</a></center>\n"
                                  "<center><a href='https://wiki.reinosdeleyenda.es/'>Wiki</a></center>\n", ":/icons/reinosdeleyenda_mud.png"}},
         {"Fierymud", {"fierymud.org", 4000, false, "<center><a href='https://www.fierymud.org/'>https://www.fierymud.org</a></center>", ":/icons/fiery_mud.png"}},
-        {"Mudlet self-test", {"mudlet.org", 23, false,}},
+        {"Mudlet self-test", {"mudlet.org", 23, false, "", ""}},
         {"Carrion Fields", {"carrionfields.net", 4449, false, "<center><a href='http://www.carrionfields.net'>www.carrionfields.net</a></center>", ":/icons/carrionfields.png"}},
         {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<center><a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a></center>", ":/icons/cleftofdimensions.png"}},
         {"Legends of the Jedi", {"legendsofthejedi.com", 5656, false, "<center><a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a></center>", ":/icons/legendsofthejedi_120x30.png"}},


### PR DESCRIPTION
As the header file that contains the structure: `inline static const OrderedMap<QString, GameDetails> scmDefaultGames` is used by so many other classes it causes nearly one hundred compile time warnings (50 each) of these:
`missing initializer for member 'mudlet::GameDetails::websiteInfo' [-Wmissing-field-initializers]`
`missing initializer for member 'mudlet::GameDetails::icon' [-Wmissing-field-initializers]`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Not sure that this is something we need to mention?