### PR TITLE
fix emptying of module during saveProfile

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -610,6 +610,16 @@ void Host::updateModuleZips() const
 
 void Host::reloadModule(const QString& reloadModuleName)
 {
+    //Wait till profile is finished saving
+    if (currentlySavingProfile()) {
+        //create a dummy object to singleshot connect (disconnect/delete after execution)
+        QObject *obj = new QObject(this);
+        connect(this, &Host::profileSaveFinished, obj, [=](){
+            reloadModule(reloadModuleName);
+            obj->deleteLater();
+        });
+        return;
+    }
     QMap<QString, QStringList> installedModules = mInstalledModules;
     QMapIterator<QString, QStringList> moduleIterator(installedModules);
     while (moduleIterator.hasNext()) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Module got emptied if reloaded during a ongoing profile save.

#### Motivation for adding to Mudlet
fix #5476

#### Other info (issues closed, discussion etc)

#### Release post highlight
-emptying of module during a profile save got fixed
