### PR TITLE
Improve: cleanup room_exits.ui file

### DIFF
--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1665,6 +1665,145 @@
         </layout>
        </widget>
       </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QFrame" name="frame_key">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="cursor">
+         <cursorShape>WhatsThisCursor</cursorShape>
+        </property>
+        <layout class="QGridLayout_key">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_key">
+           <property name="text">
+            <string>Key:</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="noroute_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
+           <property name="text">
+            <string>No route</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="stub_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Stub Exit</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2" colspan="4">
+          <widget class="QLineEdit" name="key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>&lt;p&gt;Set the number of the room that's to the southwest here.&lt;/p&gt;</string>
+           </property>
+           <property name="placeholderText">
+            <string>Exit RoomID number</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QSpinBox" name="weight_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="specialValueText">
+            <string>Exit Weight (0=No override)</string>
+           </property>
+           <property name="maximum">
+            <number>9999</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QRadioButton" name="doortype_none_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>No door</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QRadioButton" name="doortype_open_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Open door</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="4">
+          <widget class="QRadioButton" name="doortype_closed_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Closed door</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="5">
+          <widget class="QRadioButton" name="doortype_locked_key">
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Locked door</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item row="3" column="3">
        <widget class="QFrame" name="frame_out">
         <property name="sizePolicy">
@@ -1805,194 +1944,7 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
-       <widget class="QFrame" name="frame_key">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="cursor">
-         <cursorShape>WhatsThisCursor</cursorShape>
-        </property>
-        <layout class="QGridLayout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_key">
-           <property name="text">
-            <string>Key:</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="noroute_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::NoFocus</enum>
-           </property>
-           <property name="text">
-            <string>No route</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="stub_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Stub Exit</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2" colspan="4">
-          <widget class="QLineEdit" name="key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string>&lt;p&gt;Set the number of the room that's to the southwest here.&lt;/p&gt;</string>
-           </property>
-           <property name="placeholderText">
-            <string>Exit RoomID number</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
-          <widget class="QSpinBox" name="weight_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="specialValueText">
-            <string>Exit Weight (0=No override)</string>
-           </property>
-           <property name="maximum">
-            <number>9999</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="2">
-          <widget class="QRadioButton" name="doortype_none_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>No door</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="3">
-          <widget class="QRadioButton" name="doortype_open_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Open door</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="4">
-          <widget class="QRadioButton" name="doortype_closed_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Closed door</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="5">
-          <widget class="QRadioButton" name="doortype_locked_key">
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Locked door</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <spacer name="horizontalSpacer_controlButtons">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="3">
-    <widget class="QPushButton" name="button_save">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>140</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>&lt;p&gt;Use this button to save any changes, will also remove any invalid Special exits.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string>&amp;Save</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="QPushButton" name="button_cancel">
-     <property name="minimumSize">
-      <size>
-       <width>140</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string>&lt;p&gt;Use this button to close the dialogue without changing anything.&lt;/p&gt;</string>
-     </property>
-     <property name="text">
-      <string>&amp;Cancel</string>
-     </property>
     </widget>
    </item>
    <item row="1" column="0" colspan="5">
@@ -2000,8 +1952,8 @@
      <property name="title">
       <string>Special exits:</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_specialExits">
-      <item row="0" column="0">
+     <layout class="QVBoxLayout" name="vBoxLayout_specialExits">
+      <item>
        <widget class="ExitsTreeWidget" name="specialExits">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
@@ -2148,6 +2100,54 @@ or LUA script</string>
      </property>
      <property name="text">
       <string>&amp;End S. Exits editing</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <spacer name="horizontalSpacer_controlButtons">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="3">
+    <widget class="QPushButton" name="button_save">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;p&gt;Use this button to save any changes, will also remove any invalid Special exits.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string>&amp;Save</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QPushButton" name="button_cancel">
+     <property name="minimumSize">
+      <size>
+       <width>140</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;p&gt;Use this button to close the dialogue without changing anything.&lt;/p&gt;</string>
+     </property>
+     <property name="text">
+      <string>&amp;Cancel</string>
      </property>
     </widget>
    </item>

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1679,7 +1679,7 @@
         <property name="cursor">
          <cursorShape>WhatsThisCursor</cursorShape>
         </property>
-        <layout class="QGridLayout_key">
+        <layout class="QGridLayout" name="gridLayout_key">
          <item row="0" column="0">
           <widget class="QLabel" name="label_key">
            <property name="text">


### PR DESCRIPTION
This reorders the elements of two (nested as it happens) `QGridLayout`s so that their elements are in ascending row then column order. It also converts another one that only contains a single element to a `QVBoxLayout`. This is so that a change to be made by another PR that will also be extracted from the draft PR #5308 is easier to review.

This PR should not produce any functional changes.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
None!