### PR TITLE
Infra: Cleanup the change logs even more

### DIFF
--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -132,19 +132,38 @@ function convert_to_html(text)
   return table.concat(t, "\n")
 end
 
+function create_category_pattern(category)
+  if not category then return end
+  local nocase = category:genNocasePattern()
+  local res = f[[^{nocase}%w*:*%s*(.*)]]
+  return res
+end
+
 function print_sorted_changelog(changelog)
   local chgtbl = changelog:split("\n")
   local add, improve, fix, infra, other = {}, {}, {}, {}, {}
   for _,line in ipairs(chgtbl) do
-    local testline = line:lower()
-    if testline:match("^add") then
-      add[#add+1] = line
-    elseif testline:match("^improve") then
-      improve[#improve+1] = line
-    elseif testline:match("^fix") then
-      fix[#fix+1] = line
-    elseif testline:match("^infra") or testline:match("^%(autocommit%)") then --"(autocommit)" to catch bot PRs which may not start with "infra"
-      infra[#infra+1] = line
+    local trimmedLine
+    local addPattern = create_category_pattern("add")
+    local improvePattern = create_category_pattern("improve")
+    local fixPattern = create_category_pattern("fix")
+    local infraPattern = create_category_pattern("infra")
+    local autoPattern = "^%(autocommit%) (.*)"
+    if line:match(addPattern) then
+      trimmedLine = line:match(addPattern)
+      add[#add+1] = trimmedLine
+    elseif line:match(improvePattern) then
+      trimmedLine = line:match(improvePattern)
+      improve[#improve+1] = trimmedLine
+    elseif line:match(fixPattern) then
+      trimmedLine = line:match(fixPattern)
+      fix[#fix+1] = trimmedLine
+    elseif line:match(infraPattern) then
+      trimmedLine = line:match(infraPattern)
+      infra[#infra+1] = trimmedLine
+    elseif line:match(autoPattern) then --"(autocommit)" to catch bot PRs which may not start with "infra"
+      trimmedLine = line:match(autoPattern)
+      infra[#infra+1] = trimmedLine
     else
       other[#other+1] = line
     end


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adjusts the changelog generation to make it look even cleaner still by removing the "infra" or "Fixes" etc from the front of the line, since they're listed by category now.

#### Motivation for adding to Mudlet

Make automated changelogs useful and nice looking.

#### Other info (issues closed, discussion etc)
Rendered by Chrome. Looks like a long list because I didn't download a newer json file for testing this time.

![image](https://user-images.githubusercontent.com/3660/137558536-8827e695-0d4f-4ab4-82f3-e80ed90b9978.png)
