### PR TITLE
Add IDManager and named tempTimers/event handlers from script

### DIFF
--- a/src/mudlet-lua/lua/IDManager.lua
+++ b/src/mudlet-lua/lua/IDManager.lua
@@ -1,0 +1,276 @@
+local IDMgr = {}
+local function makeObject(trigger, func, oneShot)
+  local object = {
+    trigger = trigger,
+    func    = func,
+    oneShot = oneShot,
+  }
+  return object
+end
+
+-- internal function, not documented
+function IDMgr:register(name, typ, object)
+  local reg = {
+    timers = tempTimer,
+    events = registerAnonymousEventHandler
+  }
+  self:stop(name, typ)
+  local trigger, func, oneShot = object.trigger, object.func, object.oneShot
+  local register = reg[typ]
+  local ok, err = pcall(register, trigger, func, oneShot)
+  if not ok then
+    return nil, err
+  end
+  object.handlerID = err
+  self[typ][name] = object
+  return true
+end
+
+-- internal function, not documented
+function IDMgr:stop(name, typ)
+  local killfuncs = {
+    timers = killTimer,
+    events = killAnonymousEventHandler
+  }
+  local object = self[typ][name]
+  if not object then
+    return false
+  end
+  local kill = killfuncs[typ]
+  kill(object.handlerID)
+  object.handlerID = -1
+  return true
+end
+
+-- internal function, not documented
+function IDMgr:resume(name, typ)
+  local object = self[typ][name]
+  if not object then
+    return false
+  end
+  return self:register(name, typ, object)
+end
+
+-- internal function, not documented
+function IDMgr:stopAll(typ)
+  for name,_ in pairs(self[typ]) do
+    self:stop(name, typ)
+  end
+  return true
+end
+
+-- internal function, not documented
+function IDMgr:delete(name, typ)
+  local object = self[typ][name]
+  if not object then
+    return false
+  end
+  self:stop(name, typ)
+  self[typ][name] = nil
+  return true
+end
+
+-- internal function, not documented
+function IDMgr:deleteAll(typ)
+  for name,_ in pairs(self[typ]) do
+    self:delete(name, typ)
+  end
+  return true
+end
+
+function IDMgr:stopAllEvents()
+  return self:stopAll("events")
+end
+
+function IDMgr:stopAllTimers()
+  return self:stopAll("timers")
+end
+
+function IDMgr:deleteAllEvents()
+  return self:deleteAll("events")
+end
+
+function IDMgr:deleteAllTimers()
+  return self:deleteAll("timers")
+end
+
+function IDMgr:registerTimer(name, time, func, oneShot)
+  local object = makeObject(time, func, oneShot or false)
+  return self:register(name, "timers", object)
+end
+
+function IDMgr:registerEvent(name, event, func, oneShot)
+  local object = makeObject(event, func, oneShot or false)
+  return self:register(name, "events", object)
+end
+
+function IDMgr:stopTimer(name)
+  return self:stop(name, "timers")
+end
+
+function IDMgr:stopEvent(name)
+  return self:stop(name, "events")
+end
+
+function IDMgr:resumeTimer(name)
+  return self:resume(name, "timers")
+end
+
+function IDMgr:resumeEvent(name)
+  return self:resume(name, "events")
+end
+
+function IDMgr:deleteTimer(name)
+  return self:delete(name, "timers")
+end
+
+function IDMgr:deleteEvent(name)
+  return self:delete(name, "events")
+end
+
+function IDMgr:emergencyStop()
+  self:stopAll("events")
+  self:stopAll("timers")
+  return true
+end
+
+function IDMgr:getEvents()
+  local eventNames = table.keys(self.events)
+  table.sort(eventNames)
+  return eventNames
+end
+
+function IDMgr:getTimers()
+  local timerNames = table.keys(self.timers)
+  table.sort(timerNames)
+  return timerNames
+end
+
+function IDMgr:new()
+  local mgr = {
+    events = {},
+    timers = {}
+  }
+  setmetatable(mgr, self)
+  self.__index = self
+  return mgr
+end
+
+local mgr = IDMgr:new()
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getNewIDManager
+function getNewIDManager()
+  return IDMgr:new()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#registerNamedEventHandler
+function registerNamedEventHandler(name, eventName, handler, oneShot)
+  local ok, err = mgr:registerEvent(name, eventName, handler, oneShot)
+  if ok then
+    return true
+  end
+  local errMsg = err:split("registerAnonymousEventHandler: ")[2]
+  local argNumber = tonumber(errMsg:match("#(%d+)"))
+  if argNumber then
+    errMsg = errMsg:gsub("#" .. argNumber, "#" .. (argNumber + 1))
+  end
+  printError("registerNamedEventHandler: " .. errMsg, true, true)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopNamedEventHandler
+function stopNamedEventHandler(name)
+  local nameType = type(name)
+  if nameType ~= "string" then
+    return nil, "name as string expected, got " .. nameType
+  end
+  return mgr:stopEvent(name)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resumeNamedEventHandler
+function resumeNamedEventHandler(name)
+  local nameType = type(name)
+  if nameType ~= "string" then
+    return nil, "name as string expected, got " .. nameType
+  end
+  return mgr:resumeEvent(name)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteNamedEventHandler
+function deleteNamedEventHandler(name)
+  local nameType = type(name)
+  if nameType ~= "string" then
+    return nil, "name as string expected, got " .. nameType
+  end
+  return mgr:deleteEvent(name)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getNamedEventHandlers
+function getNamedEventHandlers()
+  return mgr:getEvents()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopAllNamedEventHandlers
+function stopAllNamedEventHandlers()
+  return mgr:stopAllEvents()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteAllNamedEventHandlers
+function deleteAllNamedEventHandlers()
+  return mgr:deleteAllEvents()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#registerNamedTimer
+function registerNamedTimer(name, time, handler, oneShot)
+  local ok, err = mgr:registerTimer(name, time, handler, oneShot)
+  if ok then
+    return true
+  end
+  local errMsg = err:split("tempTimer: ")[2]
+  local argNumber = tonumber(err:match("#(%d+)"))
+  if argNumber then
+    errMsg = errMsg:gsub("#" .. argNumber, "#" .. (argNumber + 1))
+  end
+  printError("registerNamedTimer: " .. errMsg, true, true)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopNamedTimer
+function stopNamedTimer(name)
+  local nameType = type(name)
+  if nameType ~= "string" then
+    return nil, "name as string expected, got " .. nameType
+  end
+  return mgr:stopTimer(name)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#resumeNamedTimer
+function resumeNamedTimer(name)
+  local nameType = type(name)
+  if nameType ~= "string" then
+    return nil, "name as string expected, got " .. nameType
+  end
+  return mgr:resumeTimer(name)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteNamedTimer
+function deleteNamedTimer(name)
+  local nameType = type(name)
+  if nameType ~= "string" then
+    return nil, "name as string expected, got " .. nameType
+  end
+  return mgr:deleteTimer(name)
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getNamedTimers
+function getNamedTimers()
+  return mgr:getTimers()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#stopAllNamedTimers
+function stopAllNamedTimers()
+  return mgr:stopAllTimers()
+end
+
+-- Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#deleteAllNamedTimers
+function deleteAllNamedTimers()
+  return mgr:deleteAllTimers()
+end

--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -136,7 +136,8 @@ local packages = {
   "GMCP.lua",
   "KeyCodes.lua",
   "CursorShapes.lua",
-  "TTSValues.lua"
+  "TTSValues.lua",
+  "IDManager.lua",
 }
 
 if debugLoading then

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -1,0 +1,132 @@
+describe("Tests the functionality of IDMgr", function()
+  describe("Test the event functionality", function()
+    local RESpy
+    local KESpy
+    local eventName = "testEvent"
+    local handlerName = "tester"
+    local func
+    before_each(function()
+      RESpy = spy.on(_G, "registerAnonymousEventHandler")
+      KESpy = spy.on(_G, "killAnonymousEventHandler")
+      handlerSpy = spy.new(function() end)
+      func = function() handlerSpy() end
+    end)
+    after_each(function()
+      registerAnonymousEventHandler:revert()
+      killAnonymousEventHandler:revert()
+      handlerSpy = nil
+      func = nil
+      deleteAllNamedEventHandlers()
+    end)
+
+    it("Should register an event handler", function()
+      local ok = registerNamedEventHandler(handlerName, eventName, func)
+      assert.is_true(ok)
+      assert.spy(RESpy).was_called(1)
+      assert.spy(RESpy).was_called_with(eventName, func, false)
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_called(1)
+    end)
+
+    it("Should kill the old handler and reregister a new one if you register to the same name more than once", function()
+      local ok = registerNamedEventHandler(handlerName, eventName, func)
+      assert.is_true(ok)
+      ok = registerNamedEventHandler(handlerName, eventName, func)
+      assert.is_true(ok)
+      assert.spy(RESpy).was_called(2)
+      assert.spy(RESpy).was_called_with(eventName, func, false)
+      assert.spy(KESpy).was_called(1)
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_called(1)
+    end)
+
+    it("Should allow for you to stop a handler", function()
+      registerNamedEventHandler(handlerName, eventName, func)
+      local ok = stopNamedEventHandler(handlerName)
+      assert.is_true(ok)
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_not_called()
+    end)
+
+    it("Should allow you to resume a stopped handler", function()
+      registerNamedEventHandler(handlerName, eventName, func)
+      stopNamedEventHandler(handlerName)
+      raiseEvent(eventName)
+      local ok = resumeNamedEventHandler(handlerName)
+      assert.is_true(ok)
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_called(1)
+    end)
+
+    it("Should provide a list of registered named handlers", function()
+      registerNamedEventHandler(handlerName, eventName, func)
+      local handlers = getNamedEventHandlers()
+      assert.are.same({handlerName}, handlers)
+    end)
+
+    it("Should allow for deleting a handler entirely", function()
+      registerNamedEventHandler(handlerName, eventName, func)
+      deleteNamedEventHandler(handlerName)
+      local handlers = getNamedEventHandlers()
+      assert.are.same(handlers, {})
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_not_called()
+    end)
+
+    it("Should stop all handlers when asked", function()
+      local handlerName2 = handlerName .. "2"
+      registerNamedEventHandler(handlerName, eventName, func)
+      registerNamedEventHandler(handlerName2, eventName, func)
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_called(2)
+      stopAllNamedEventHandlers()
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_called(2) -- remains at 2
+      resumeNamedEventHandler(handlerName)
+      resumeNamedEventHandler(handlerName2)
+      raiseEvent(eventName)
+      assert.spy(handlerSpy).was_called(4)
+    end)
+
+    it("Should delete all handlers when asked", function()
+      local handlerName2 = handlerName .. "2"
+      registerNamedEventHandler(handlerName, eventName, func)
+      registerNamedEventHandler(handlerName2, eventName, func)
+      local handlers_before = getNamedEventHandlers()
+      assert.are.same({handlerName, handlerName2}, handlers_before)
+      deleteAllNamedEventHandlers()
+      local handlers_after = getNamedEventHandlers()
+      assert.are.same({}, handlers_after)
+    end)
+
+    it("Should consume and pass along the modified error message on error", function()
+      local exec = function()
+        registerNamedEventHandler(name, eventName)
+      end
+      local exec2 = function()
+        registerNamedEventHandler(name)
+      end
+      -- since we pass along all the parameters to registerAnonymousEventHandler
+      -- we have to catch the error, bump the arg# up by one, and rebrand it so
+      -- the error origin isn't confusing to the end user.
+      assert.error_matches(exec, "registerNamedEventHandler: bad argument #3 type")
+      assert.error_matches(exec2, "registerNamedEventHandler: bad argument #2 type")
+    end)
+  end)
+
+  -- timer functionality tests awaiting me figuring out async tests in busted
+  -- functional testing shows it works, and the code paths are the same for timers as
+  -- for events in the underlying IDMgr, just using different core Mudlet API functions
+  -- I have personally functionally tested this though. -- Demonnic
+  -- TODO: write timer tests
+  describe("Tests the timer functionality", function()
+    pending("Should register a named timer")
+    pending("Should reset a named timer if it is registered a second+ time")
+    pending("Should allow you to stop a named timer")
+    pending("Should allow you to resume a named timer")
+    pending("Should allow you to stop all named timers")
+    pending("Should allow you to delete a named timer")
+    pending("Should allow you to delete all named timers")
+    pending("Should consume and raise modified tempTimer error message on error")
+  end)
+end)

--- a/src/mudlet-lua/tests/IDManager_spec.lua
+++ b/src/mudlet-lua/tests/IDManager_spec.lua
@@ -118,7 +118,7 @@ describe("Tests the functionality of IDMgr", function()
   -- functional testing shows it works, and the code paths are the same for timers as
   -- for events in the underlying IDMgr, just using different core Mudlet API functions
   -- I have personally functionally tested this though. -- Demonnic
-  -- TODO: write timer tests
+  -- TODO: write timer tests https://github.com/Mudlet/Mudlet/issues/5520
   describe("Tests the timer functionality", function()
     pending("Should register a named timer")
     pending("Should reset a named timer if it is registered a second+ time")


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adds named tempTimers and event handlers to the Lua API. If you register to the same name more than once, it handles the details of killing the previous timer or handler and reregistering rather than allowing duplication. Works with oneShot handlers and timers, as it's still using tempTimer() and registerAnonymouseEventHandler() under the hood.

Also adds an IDManager class which is what actually handles all of this, and allows script authors to get their own IDManager if they want using getNewIDManager(). I still need to write a wiki page around the manager. 

Also adds the following functions for events. These all use a default IDManager which is created during profile load, so do not touch any other IDManager which may have been created, they're fully independent.
  * registerNamedEventHandler(handlerName, eventName, funcreference or string, oneShot)
    * registers a named event handler. Returns true if it worked, otherwise printErrors
  * stopNamedEventHandler(handlerName)
    * kills the named handler but holds on to the information for resuming
  * resumeNamedEventHandler(handlerName)
    * re-registers the event handler with the stored information
  * deleteNamedEventHandler(handlerName)
    * kills the named handler and removes it from the manager entirely, as though it never happened
  * deleteAllNamedEventHandlers()
    * I too like to live dangerously: deletes all named event handlers from the default manager
  
There is a full complement of the same for timers as registerNamedTimer(), resumeNamedTimer() etc.

#### Motivation for adding to Mudlet

One of the most common mistakes for new Mudlet scripters is not catching and handling the return ID from tempTimer or registerAnonymousEventHandler. They end up with a bunch of duplicates they can't stop and have to restart their profile, and get help from us, and then get told there's all this scaffolding code they have to do for each tempTimer or eventHandler they want.

So I thought
![image](https://user-images.githubusercontent.com/3660/137595424-8ff779b6-f62b-4c0d-a31b-89a494cf9031.png)

When someone asked about named event handlers and such again last night, and wrote the IDManager and the functions to use a default one.

#### Other info (issues closed, discussion etc)

I wrote tests for the entire event pathway, but the tests for the timers are pending me figuring out async busted tests and I wanted to go ahead and get the PR opened. I also added a TODO for it, will open the issue to track it with.