### PR TITLE
Improve: Properly announce Discord failing on length 1 texts

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10243,7 +10243,11 @@ int TLuaInterpreter::setDiscordState(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord state is disabled in settings for privacy");
     }
 
-    mudlet::self()->mDiscord.setStateText(&host, getVerifiedString(L, __func__, 1, "text"));
+    auto discordText = getVerifiedString(L, __func__, 1, "text");
+    if (discordText.size() == 1) {
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+
+    mudlet::self()->mDiscord.setStateText(&host, discordText);
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10082,7 +10082,11 @@ int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord large icon text is disabled in settings for privacy");
     }
 
-    pMudlet->mDiscord.setLargeImageText(&host, getVerifiedString(L, __func__, 1, "text"));
+    auto discordText = getVerifiedString(L, __func__, 1, "text");
+    if (discordText.size() == 1) {
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+
+    pMudlet->mDiscord.setLargeImageText(&host, discordText);
     lua_pushboolean(L, true);
     return 1;
 }
@@ -10152,7 +10156,11 @@ int TLuaInterpreter::setDiscordSmallIconText(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord small icon text is disabled in settings for privacy");
     }
 
-    pMudlet->mDiscord.setSmallImageText(&host, getVerifiedString(L, __func__, 1, "text"));
+    auto discordText = getVerifiedString(L, __func__, 1, "text");
+    if (discordText.size() == 1) {
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+
+    pMudlet->mDiscord.setSmallImageText(&host, discordText);
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10084,7 +10084,7 @@ int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
 
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
-        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
     pMudlet->mDiscord.setLargeImageText(&host, discordText);
@@ -10159,7 +10159,7 @@ int TLuaInterpreter::setDiscordSmallIconText(lua_State* L)
 
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
-        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
     pMudlet->mDiscord.setSmallImageText(&host, discordText);
@@ -10199,7 +10199,7 @@ int TLuaInterpreter::setDiscordDetail(lua_State* L)
 
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
-        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
     pMudlet->mDiscord.setDetailText(&host, discordText);
@@ -10260,7 +10260,7 @@ int TLuaInterpreter::setDiscordState(lua_State* L)
 
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
-        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed by Discord");
     }
 
     mudlet::self()->mDiscord.setStateText(&host, discordText);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10085,6 +10085,7 @@ int TLuaInterpreter::setDiscordLargeIconText(lua_State* L)
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
         return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+    }
 
     pMudlet->mDiscord.setLargeImageText(&host, discordText);
     lua_pushboolean(L, true);
@@ -10159,6 +10160,7 @@ int TLuaInterpreter::setDiscordSmallIconText(lua_State* L)
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
         return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+    }
 
     pMudlet->mDiscord.setSmallImageText(&host, discordText);
     lua_pushboolean(L, true);
@@ -10198,6 +10200,7 @@ int TLuaInterpreter::setDiscordDetail(lua_State* L)
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
         return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+    }
 
     pMudlet->mDiscord.setDetailText(&host, discordText);
     lua_pushboolean(L, true);
@@ -10258,6 +10261,7 @@ int TLuaInterpreter::setDiscordState(lua_State* L)
     auto discordText = getVerifiedString(L, __func__, 1, "text");
     if (discordText.size() == 1) {
         return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+    }
 
     mudlet::self()->mDiscord.setStateText(&host, discordText);
     lua_pushboolean(L, true);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10187,7 +10187,11 @@ int TLuaInterpreter::setDiscordDetail(lua_State* L)
         return warnArgumentValue(L, __func__, "access to Discord detail is disabled in settings for privacy");
     }
 
-    pMudlet->mDiscord.setDetailText(&host, getVerifiedString(L, __func__, 1, "text"));
+    auto discordText = getVerifiedString(L, __func__, 1, "text");
+    if (discordText.size() == 1) {
+        return warnArgumentValue(L, __func__, "text of length 1 not allowed");
+
+    pMudlet->mDiscord.setDetailText(&host, discordText);
     lua_pushboolean(L, true);
     return 1;
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Just check if a text of size 1 is given to Discord, then give warning instead

#### Motivation for adding to Mudlet
Fix #5305

#### Other info (issues closed, discussion etc)
Not sure why Discord silently ignores texts of size 1 while size 0 and larger work fine.

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
