### PR TITLE
Improve map context item names

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2808,13 +2808,13 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize > 0) {
-                    auto moveRoom = new QAction(tr("Move room(s)", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
                     connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
                     popup->addAction(moveRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomExits = new QAction(tr("Set room exits...", "2D Mapper context menu (room) item"), this);
+                    auto roomExits = new QAction(tr("Set exits...", "2D Mapper context menu (room) item"), this);
                     connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
                     popup->addAction(roomExits);
                 }
@@ -2833,27 +2833,27 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize > 0) {
-                    auto recolorRoom = new QAction(tr("Set room's/rooms' color...", "2D Mapper context menu (room) item.\nThere can be 1 or more room selected, but all rooms will receive their same setting, which the player can select here.", selectionSize), this);
+                    auto recolorRoom = new QAction(tr("Set color...", "2D Mapper context menu (room) item"), this);
                     connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
                     popup->addAction(recolorRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomSymbol = new QAction(tr("Set room's/rooms' symbol...", "2D Mapper context menu (room) item.\nThere can be 1 or more room selected, but all rooms will receive their same setting, which the player can select here.", selectionSize), this);
+                    auto roomSymbol = new QAction(tr("Set symbol...", "2D Mapper context menu (room) item"), this);
                     roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
                     popup->addAction(roomSymbol);
                 }
 
                 if (selectionSize > 1) {
-                    auto spreadRooms = new QAction(tr("Spread rooms...", "2D Mapper context menu (room) item.\nThere will always be more than 1 room selected, so smaller quantities need no plural forms translated.", selectionSize), this);
+                    auto spreadRooms = new QAction(tr("Spread...", "2D Mapper context menu (room) item"), this);
                     spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
                     popup->addAction(spreadRooms);
                 }
 
                 if (selectionSize > 1) {
-                    auto shrinkRooms = new QAction(tr("Shrink rooms...", "2D Mapper context menu (room) item.\nThere will always be more than 1 room selected, so smaller quantities need no plural forms translated.", selectionSize), this);
+                    auto shrinkRooms = new QAction(tr("Shrink...", "2D Mapper context menu (room) item"), this);
                     shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
                     popup->addAction(shrinkRooms);
@@ -2862,43 +2862,43 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 if (selectionSize > 0) {
                     // TODO: Do not show both action simultaneously, if all selected rooms have same status.
 
-                    auto lockRoom = new QAction(tr("Lock room(s)", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
                     lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
                     connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
                     popup->addAction(lockRoom);
 
-                    auto unlockRoom = new QAction(tr("Unlock room(s)", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
                     unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
                     connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
                     popup->addAction(unlockRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto weightRoom = new QAction(tr("Set room's/rooms' weight...", "2D Mapper context menu (room) item.\nThere can be 1 or more room selected, but all rooms will receive their same setting, which the player can select here.", selectionSize), this);
+                    auto weightRoom = new QAction(tr("Set weight...", "2D Mapper context menu (room) item"), this);
                     connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
                     popup->addAction(weightRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto deleteRoom = new QAction(tr("Delete room(s)", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
                     connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
                     popup->addAction(deleteRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto moveRoomXY = new QAction(tr("Move room(s) to position...", "2D Mapper context menu (room) item", selectionSize), this);
-                    moveRoomXY->setToolTip(tr("Move selected room or group of rooms to a given position", "2D Mapper context menu (room) item tooltip"));
+                    auto moveRoomXY = new QAction(tr("Move to position...", "2D Mapper context menu (room) item"), this);
+                    moveRoomXY->setToolTip(tr("Move selected room or group of rooms to the given coordinates in this area", "2D Mapper context menu (room) item tooltip"));
                     connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
                     popup->addAction(moveRoomXY);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomArea = new QAction(tr("Move room(s) to area...", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto roomArea = new QAction(tr("Move to area...", "2D Mapper context menu (room) item"), this);
                     connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
                     popup->addAction(roomArea);
                 }
 
-                auto createLabel = new QAction(tr("Create new label...", "2D Mapper context menu (room) item"), this);
+                auto createLabel = new QAction(tr("Create label...", "2D Mapper context menu (room) item"), this);
                 createLabel->setToolTip(tr("Create label to show text or an image", "2D Mapper context menu (room) item tooltip"));
                 connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
                 popup->addAction(createLabel);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2800,28 +2800,25 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             if (!mMapViewOnly) {
                 if (selectionSize == 0) {
-                    mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
-                    mpCreateRoomAction->setToolTip(tr("Create a new room here"));
+                    mpCreateRoomAction = new QAction(tr("Create new room here", "Menu option to create a new room in the mapper"), this);
                     connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
                     popup->addAction(mpCreateRoomAction);
                 }
 
                 if (selectionSize > 0) {
-                    auto moveRoom = new QAction(tr("Move", "2D Mapper context menu (room) item"), this);
-                    moveRoom->setToolTip(tr("Move room", "2D Mapper context menu (room) item tooltip"));
+                    auto moveRoom = new QAction(tr("Move room(s)", "2D Mapper context menu (room) item", selectionSize), this);
                     connect(moveRoom, &QAction::triggered, this, &T2DMap::slot_moveRoom);
                     popup->addAction(moveRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomExits = new QAction(tr("Exits", "2D Mapper context menu (room) item"), this);
-                    roomExits->setToolTip(tr("Set room exits", "2D Mapper context menu (room) item tooltip"));
+                    auto roomExits = new QAction(tr("Set room exits...", "2D Mapper context menu (room) item"), this);
                     connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
                     popup->addAction(roomExits);
                 }
 
                 if (selectionSize == 1) {
-                    auto customExitLine = new QAction(tr("Custom exit line", "2D Mapper context menu (room) item"), this);
+                    auto customExitLine = new QAction(tr("Create exit line", "2D Mapper context menu (room) item"), this);
                     if (pArea && !pArea->gridMode) {
                         customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
                         connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
@@ -2834,28 +2831,27 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize > 0) {
-                    auto recolorRoom = new QAction(tr("Color", "2D Mapper context menu (room) item"), this);
-                    recolorRoom->setToolTip(tr("Change room color", "2D Mapper context menu (room) item tooltip"));
+                    auto recolorRoom = new QAction(tr("Set room color...", "2D Mapper context menu (room) item, selectionSize"), this);
                     connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
                     popup->addAction(recolorRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomSymbol = new QAction(tr("Symbol", "2D Mapper context menu (room) item"), this);
+                    auto roomSymbol = new QAction(tr("Set room symbol...", "2D Mapper context menu (room) item", selectionSize), this);
                     roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
                     popup->addAction(roomSymbol);
                 }
 
                 if (selectionSize > 1) {
-                    auto spreadRooms = new QAction(tr("Spread", "2D Mapper context menu (room) item"), this);
+                    auto spreadRooms = new QAction(tr("Spread rooms...", "2D Mapper context menu (room) item", selectionSize), this);
                     spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
                     popup->addAction(spreadRooms);
                 }
 
                 if (selectionSize > 1) {
-                    auto shrinkRooms = new QAction(tr("Shrink", "2D Mapper context menu (room) item"), this);
+                    auto shrinkRooms = new QAction(tr("Shrink rooms...", "2D Mapper context menu (room) item", selectionSize), this);
                     shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
                     popup->addAction(shrinkRooms);
@@ -2864,54 +2860,51 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 if (selectionSize > 0) {
                     // TODO: Do not show both action simultaneously, if all selected rooms have same status.
 
-                    auto lockRoom = new QAction(tr("Lock", "2D Mapper context menu (room) item"), this);
+                    auto lockRoom = new QAction(tr("Lock room(s)", "2D Mapper context menu (room) item", selectionSize), this);
                     lockRoom->setToolTip(tr("Lock room for speed walks", "2D Mapper context menu (room) item tooltip"));
                     connect(lockRoom, &QAction::triggered, this, &T2DMap::slot_lockRoom);
                     popup->addAction(lockRoom);
 
-                    auto unlockRoom = new QAction(tr("Unlock", "2D Mapper context menu (room) item"), this);
+                    auto unlockRoom = new QAction(tr("Unlock room(s)", "2D Mapper context menu (room) item", selectionSize), this);
                     unlockRoom->setToolTip(tr("Unlock room for speed walks", "2D Mapper context menu (room) item tooltip"));
                     connect(unlockRoom, &QAction::triggered, this, &T2DMap::slot_unlockRoom);
                     popup->addAction(unlockRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto weightRoom = new QAction(tr("Weight", "2D Mapper context menu (room) item"), this);
-                    weightRoom->setToolTip(tr("Set room weight", "2D Mapper context menu (room) item tooltip"));
+                    auto weightRoom = new QAction(tr("Set room weight...", "2D Mapper context menu (room) item", selectionSize), this);
                     connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
                     popup->addAction(weightRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto deleteRoom = new QAction(tr("Delete", "2D Mapper context menu (room) item"), this);
-                    deleteRoom->setToolTip(tr("Delete room", "2D Mapper context menu (room) item tooltip"));
+                    auto deleteRoom = new QAction(tr("Delete room(s)", "2D Mapper context menu (room) item", selectionSize), this);
                     connect(deleteRoom, &QAction::triggered, this, &T2DMap::slot_deleteRoom);
                     popup->addAction(deleteRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto moveRoomXY = new QAction(tr("Move to", "2D Mapper context menu (room) item"), this);
-                    moveRoomXY->setToolTip(tr("Move selected group to a given position", "2D Mapper context menu (room) item tooltip"));
+                    auto moveRoomXY = new QAction(tr("Move room(s) to position...", "2D Mapper context menu (room) item", selectionSize), this);
+                    moveRoomXY->setToolTip(tr("Move selected room or group of rooms to a given position", "2D Mapper context menu (room) item tooltip"));
                     connect(moveRoomXY, &QAction::triggered, this, &T2DMap::slot_movePosition);
                     popup->addAction(moveRoomXY);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomArea = new QAction(tr("Area", "2D Mapper context menu (room) item"), this);
-                    roomArea->setToolTip(tr("Set room's area number", "2D Mapper context menu (room) item tooltip"));
+                    auto roomArea = new QAction(tr("Move room(s) to area...", "2D Mapper context menu (room) item", selectionSize), this);
                     connect(roomArea, &QAction::triggered, this, &T2DMap::slot_setArea);
                     popup->addAction(roomArea);
                 }
 
-                auto createLabel = new QAction(tr("Create Label", "2D Mapper context menu (room) item"), this);
+                auto createLabel = new QAction(tr("Create new label...", "2D Mapper context menu (room) item"), this);
                 createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));
                 connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
                 popup->addAction(createLabel);
             }
 
             if (selectionSize == 1) {
-                auto setPlayerLocation = new QAction(tr("Set location", "2D Mapper context menu (room) item"), this);
-                setPlayerLocation->setToolTip(tr("Set player current location to here", "2D Mapper context menu (room) item tooltip (enabled state)"));
+                auto setPlayerLocation = new QAction(tr("Set player location", "2D Mapper context menu (room) item"), this);
+                setPlayerLocation->setToolTip(tr("Set the player's current location to here", "2D Mapper context menu (room) item tooltip (enabled state)"));
                 connect(setPlayerLocation, &QAction::triggered, this, &T2DMap::slot_setPlayerLocation);
                 popup->addAction(setPlayerLocation);
             }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2820,7 +2820,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize == 1) {
-                    auto customExitLine = new QAction(tr("Customize exit line...", "2D Mapper context menu (room) item"), this);
+                    auto customExitLine = new QAction(tr("Create exit line...", "2D Mapper context menu (room) item"), this);
                     if (pArea && !pArea->gridMode) {
                         customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
                         connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);
@@ -2833,27 +2833,27 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize > 0) {
-                    auto recolorRoom = new QAction(tr("Set room color...", "2D Mapper context menu (room) item, selectionSize"), this);
+                    auto recolorRoom = new QAction(tr("Set room's/rooms' color...", "2D Mapper context menu (room) item.\nThere can be 1 or more room selected, but all rooms will receive their same setting, which the player can select here.", selectionSize), this);
                     connect(recolorRoom, &QAction::triggered, this, &T2DMap::slot_changeColor);
                     popup->addAction(recolorRoom);
                 }
 
                 if (selectionSize > 0) {
-                    auto roomSymbol = new QAction(tr("Set room symbol...", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto roomSymbol = new QAction(tr("Set room's/rooms' symbol...", "2D Mapper context menu (room) item.\nThere can be 1 or more room selected, but all rooms will receive their same setting, which the player can select here.", selectionSize), this);
                     roomSymbol->setToolTip(tr("Set one or more symbols or letters to mark special rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(roomSymbol, &QAction::triggered, this, &T2DMap::slot_showSymbolSelection);
                     popup->addAction(roomSymbol);
                 }
 
                 if (selectionSize > 1) {
-                    auto spreadRooms = new QAction(tr("Spread rooms...", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto spreadRooms = new QAction(tr("Spread rooms...", "2D Mapper context menu (room) item.\nThere will always be more than 1 room selected, so smaller quantities need no plural forms translated.", selectionSize), this);
                     spreadRooms->setToolTip(tr("Increase map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(spreadRooms, &QAction::triggered, this, &T2DMap::slot_spread);
                     popup->addAction(spreadRooms);
                 }
 
                 if (selectionSize > 1) {
-                    auto shrinkRooms = new QAction(tr("Shrink rooms...", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto shrinkRooms = new QAction(tr("Shrink rooms...", "2D Mapper context menu (room) item.\nThere will always be more than 1 room selected, so smaller quantities need no plural forms translated.", selectionSize), this);
                     shrinkRooms->setToolTip(tr("Decrease map X-Y spacing for the selected group of rooms", "2D Mapper context menu (room) item tooltip"));
                     connect(shrinkRooms, &QAction::triggered, this, &T2DMap::slot_shrink);
                     popup->addAction(shrinkRooms);
@@ -2874,7 +2874,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize > 0) {
-                    auto weightRoom = new QAction(tr("Set room weight...", "2D Mapper context menu (room) item", selectionSize), this);
+                    auto weightRoom = new QAction(tr("Set room's/rooms' weight...", "2D Mapper context menu (room) item.\nThere can be 1 or more room selected, but all rooms will receive their same setting, which the player can select here.", selectionSize), this);
                     connect(weightRoom, &QAction::triggered, this, &T2DMap::slot_setRoomWeight);
                     popup->addAction(weightRoom);
                 }
@@ -2899,7 +2899,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 auto createLabel = new QAction(tr("Create new label...", "2D Mapper context menu (room) item"), this);
-                createLabel->setToolTip(tr("Create labels to show text or images", "2D Mapper context menu (room) item tooltip"));
+                createLabel->setToolTip(tr("Create label to show text or an image", "2D Mapper context menu (room) item tooltip"));
                 connect(createLabel, &QAction::triggered, this, &T2DMap::slot_createLabel);
                 popup->addAction(createLabel);
             }

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2818,7 +2818,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                 }
 
                 if (selectionSize == 1) {
-                    auto customExitLine = new QAction(tr("Create exit line", "2D Mapper context menu (room) item"), this);
+                    auto customExitLine = new QAction(tr("Customize exit line...", "2D Mapper context menu (room) item"), this);
                     if (pArea && !pArea->gridMode) {
                         customExitLine->setToolTip(tr("Replace an exit line with a custom line", "2D Mapper context menu (room) item tooltip (enabled state)"));
                         connect(customExitLine, &QAction::triggered, this, &T2DMap::slot_setCustomLine);


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Add "..." ellipsis after name if popup follows, no ellipsis if action happens immediately
- Move some short info from tooltip into the items' proper name
- ~Improve i18n in cases of one or more room(s) selected~

#### Motivation for adding to Mudlet
Fix #5219
More details and discussion there.

#### Other info (issues closed, discussion etc)
Most comments for translation seem superfluous and repetitive. Did not touch those though.

What it looks like then (third iteration)
![image](https://user-images.githubusercontent.com/117238/137999102-d23b8206-6d6c-41bd-a085-954a8e85d4ba.png)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
