### PR TITLE
Improve: Create room at right-click position

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2800,6 +2800,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             if (!mMapViewOnly) {
                 if (selectionSize == 0) {
+                    mContextMenuClickPosition = getMousePosition(); // Remember position of original right-click to create room there!
                     mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
                     mpCreateRoomAction->setToolTip(tr("Create a new room here"));
                     connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
@@ -3130,9 +3131,7 @@ void T2DMap::slot_createRoom()
     }
 
     mpMap->setRoomArea(roomID, mAreaID, false);
-
-    auto mousePosition = getMousePosition();
-    mpMap->setRoomCoordinates(roomID, mousePosition.first, mousePosition.second, mOz);
+    mpMap->setRoomCoordinates(roomID, mContextMenuClickPosition.first, mContextMenuClickPosition.second, mOz);
 
     mpMap->mMapGraphNeedsUpdate = true;
 #if defined(INCLUDE_3DMAPPER)

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2800,7 +2800,8 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
 
             if (!mMapViewOnly) {
                 if (selectionSize == 0) {
-                    mContextMenuClickPosition = getMousePosition(); // Remember position of original right-click to create room there!
+                    auto [x, y] = getMousePosition();
+                    mContextMenuClickPosition = {x, y}; // Remember position of original right-click to create room there!
                     mpCreateRoomAction = new QAction(tr("Create room", "Menu option to create a new room in the mapper"), this);
                     mpCreateRoomAction->setToolTip(tr("Create a new room here"));
                     connect(mpCreateRoomAction.data(), &QAction::triggered, this, &T2DMap::slot_createRoom);
@@ -3131,7 +3132,7 @@ void T2DMap::slot_createRoom()
     }
 
     mpMap->setRoomArea(roomID, mAreaID, false);
-    mpMap->setRoomCoordinates(roomID, mContextMenuClickPosition.first, mContextMenuClickPosition.second, mOz);
+    mpMap->setRoomCoordinates(roomID, mContextMenuClickPosition.x, mContextMenuClickPosition.y, mOz);
 
     mpMap->mMapGraphNeedsUpdate = true;
 #if defined(INCLUDE_3DMAPPER)

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -234,6 +234,7 @@ private:
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
 
     bool mDialogLock;
+    std::pair<int, int> mContextMenuClickPosition;
 
     // When more than zero rooms are selected this
     // is either the first (only) room in the set

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -234,7 +234,10 @@ private:
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
 
     bool mDialogLock;
-    std::pair<int, int> mContextMenuClickPosition;
+    struct ClickPosition {
+        int x;
+        int y;
+    } mContextMenuClickPosition;
 
     // When more than zero rooms are selected this
     // is either the first (only) room in the set


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Room created at initial right-click on the map, not where you select the "Create room" entry from emerging context-menu.

#### Motivation for adding to Mudlet
Fix #5217 

#### Other info (issues closed, discussion etc)


#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
