### PR TITLE
Infrastructure: fixed autoupdate workflows to trigger checks 

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -34,7 +34,7 @@ jobs:
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
           title: "Infrastructure: Update bundled IRE mapper script to latest upstream"
           body: |
@@ -76,7 +76,7 @@ jobs:
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
           title: "Infrastructure: Update sparkle-glue to latest in our fork"
           body: |
@@ -117,7 +117,7 @@ jobs:
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
           title: "Infrastructure: Update dblsqd to latest in our fork"
           body: |
@@ -161,7 +161,7 @@ jobs:
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
           title: "Infrastructure: Update Lua code formatter to latest upstream 5.1 branch"
           body: |
@@ -202,7 +202,7 @@ jobs:
         uses: gr2m/create-or-update-pull-request-action@v1.x
         if: steps.getdiff.outputs.lines_changed > 0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
           title: "Infrastructure: Update widechar_width.h to latest upstream"
           body: |

--- a/.github/workflows/update-autocompletion.yml
+++ b/.github/workflows/update-autocompletion.yml
@@ -52,7 +52,7 @@ jobs:
       uses: gr2m/create-or-update-pull-request-action@v1.x
       if: steps.getdiff.outputs.lines_changed > 0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
       with:
         title: "Infrastructure: Update autocompletion data in Mudlet"
         body: |

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -34,7 +34,7 @@ jobs:
       uses: gr2m/create-or-update-pull-request-action@v1.x
       if: steps.getdiff.outputs.lines_changed > 0
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
       with:
         title: "Infrastructure: Update text for translation in Crowdin"
         body: |


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed autoupdate workflows to trigger checks, which they stopped a while ago due to security changes in Github. This meant that every week I had to disable branch protection, merge PRs like https://github.com/Mudlet/Mudlet/pull/5514 manually, and re-enable it again.
#### Motivation for adding to Mudlet
Reduce maintainer overhead, which is the original point of these automated workflows.
#### Other info (issues closed, discussion etc)
See https://github.community/t/actions-not-running-for-prs-made-by-another-workflow/202763/5 for background. I created a PAT with the `workflow` permission.