### PR TITLE
Infrastructure: More adjustments to the changelog styling

### DIFF
--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -126,7 +126,7 @@ function convert_to_html(text)
   for s in string.gmatch(text, "(.-)\n") do
     s = escape_for_html(s)
     s = s:gsub("%(#(.-)%)", [[<a href="https://github.com/Mudlet/Mudlet/pull/%1">(#%1)</a>]])
-		t[#t+1] = string.format('<p>%s</p>', s)
+		t[#t+1] = string.format("<p>%s</p>", s)
   end
 
   return table.concat(t, "\n")

--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -126,7 +126,7 @@ function convert_to_html(text)
   for s in string.gmatch(text, "(.-)\n") do
     s = escape_for_html(s)
     s = s:gsub("%(#(.-)%)", [[<a href="https://github.com/Mudlet/Mudlet/pull/%1">(#%1)</a>]])
-		t[#t+1] = string.format('<p style="font-size: small">%s</p>', s)
+		t[#t+1] = string.format('<p>%s</p>', s)
   end
 
   return table.concat(t, "\n")

--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -126,7 +126,7 @@ function convert_to_html(text)
   for s in string.gmatch(text, "(.-)\n") do
     s = escape_for_html(s)
     s = s:gsub("%(#(.-)%)", [[<a href="https://github.com/Mudlet/Mudlet/pull/%1">(#%1)</a>]])
-		t[#t+1] = string.format("<p>%s</p>", s)
+		t[#t+1] = string.format('<p style="font-size: small">%s</p>', s)
   end
 
   return table.concat(t, "\n")
@@ -169,16 +169,18 @@ function print_sorted_changelog(changelog)
       other[#other+1] = prefix .. line
     end
   end
+  local hopen = [[<h5 style="margin-top: 1em;margin-bottom: 1em;">]]
+  local hclose = "</h5>"
   local addLines = lines_to_html(table.concat(add, "\n"))
-  addLines = addLines and f"<h3>Added:</h3>\n{addLines}\n" or ""
+  addLines = addLines and f"{hopen}Added:{hclose}\n{addLines}\n" or ""
   local improveLines = lines_to_html(table.concat(improve, "\n"))
-  improveLines = improveLines and f"<h3>Improved:</h3>\n{improveLines}\n" or ""
+  improveLines = improveLines and f"{hopen}Improved:{hclose}\n{improveLines}\n" or ""
   local fixLines = lines_to_html(table.concat(fix, "\n"))
-  fixLines = fixLines and f"<h3>Fixed:</h3>\n{fixLines}\n" or ""
+  fixLines = fixLines and f"{hopen}Fixed:{hclose}\n{fixLines}\n" or ""
   local infraLines = lines_to_html(table.concat(infra, "\n"))
-  infraLines = infraLines and f"<h3>Infrastructure:</h3>\n{infraLines}\n" or ""
+  infraLines = infraLines and f"{hopen}Infrastructure:{hclose}\n{infraLines}\n" or ""
   local otherLines = lines_to_html(table.concat(other, "\n"))
-  otherLines = otherLines and f"<h3>Other:</h3>\n{otherLines}\n" or ""
+  otherLines = otherLines and f"{hopen}Other:{hclose}\n{otherLines}\n" or ""
   local final_changelog = f"{addLines}{improveLines}{fixLines}{infraLines}{otherLines}"
   print(final_changelog)
 end


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

@Kebap noticed the categories looked bigger than the version headings, which was off. So we are adjusting the header style to h5 rather than h3. 

#### Motivation for adding to Mudlet

Nice looking changelogs.

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
