### PR TITLE
Infrastructure: added label for port in Github Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,10 +24,10 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [5900, 5901, 6080],
-		
+
 	"portsAttributes": {
 		"6080": {
-			"label": "Open in a browser"
+			"label": "Open Mudlet"
 		}
 	}
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,12 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [5900, 5901, 6080],
+		
+	"portsAttributes": {
+		"6080": {
+			"label": "Open in a browser"
+		}
+	}
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "git submodule update --init",


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add label for port in Github Codespaces
#### Motivation for adding to Mudlet
So it's easier to tell which of the 3 ports is the right one:

![image](https://user-images.githubusercontent.com/110988/138457466-36d6090b-4841-4fdc-954e-0d9fe3420154.png)
