### PR TITLE
Infrastructure: read error log correctly from Windows installer tool

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -112,7 +112,14 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
 
   if (-not (Test-Path -Path "${Env:APPVEYOR_BUILD_FOLDER}\src\release\Setup.exe" -PathType Leaf)) {
     Write-Output "=== ERROR: Squirrel failed to generate the installer! Build aborted. Squirrel log is:"
-    Get-Content -Path .\squirrel.windows\tools\SquirrelSetup.log
+    if (Test-Path -Path ".\squirrel.windows\tools\SquirrelSetup.log" -PathType Leaf) {
+      echo "SquirrelSetup.log: "
+      Get-Content -Path .\squirrel.windows\tools\SquirrelSetup.log
+    }
+    if (Test-Path -Path ".\squirrel.windows\tools\Squirrel-Releasify.log" -PathType Leaf) {
+      echo "Squirrel-Releasify.log: "
+      Get-Content -Path .\squirrel.windows\tools\Squirrel-Releasify.log
+    }
     exit 1
   }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Read error log correctly from Squirrel
#### Motivation for adding to Mudlet
So we can see the error log right in the build logs
#### Other info (issues closed, discussion etc)
Fixes https://ci.appveyor.com/project/Mudlet/mudlet/builds/41261297#L1540

![image](https://user-images.githubusercontent.com/110988/138582844-d02b28c5-f43e-49d9-867f-0e11324786e7.png)
