### PR TITLE
improve custom button text by limiting it with elidedText function

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -406,7 +406,7 @@ mudlet::mudlet()
     mpActionDiscord->setIconText(QStringLiteral("Discord"));
     mpActionDiscord->setObjectName(QStringLiteral("openDiscord"));
 
-    mpActionMudletDiscord = new QAction(QIcon(QStringLiteral(":/icons/mudlet_discord.png")), tr("Mudlet Discord"), this);
+    mpActionMudletDiscord = new QAction(QIcon(QStringLiteral(":/icons/mudlet_discord.png")), tr("Mudlet chat"), this);
     mpActionMudletDiscord->setToolTip(tr("Open a link to the Mudlet server on Discord"));
     mpMainToolBar->addAction(mpActionMudletDiscord);
     mpActionMudletDiscord->setObjectName(QStringLiteral("mudlet_discord"));

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2401,7 +2401,7 @@ void mudlet::updateDiscordNamedIcon()
 
     bool hasCustom = !pHost->getDiscordInviteURL().isEmpty();
     
-    mpActionDiscord->setIconText(gameName.isEmpty() ? QStringLiteral("Discord") : gameName);
+    mpActionDiscord->setIconText(gameName.isEmpty() ? QStringLiteral("Discord") : QFontMetrics(mpActionDiscord->font()).elidedText(gameName, Qt::ElideRight, 90));
 
     if (mpActionMudletDiscord->isVisible() != hasCustom) {
         mpActionMudletDiscord->setVisible(hasCustom);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Game names are defined by users and they update a button text.  This will limit the button text to 90 pixels.  That's on par with the `Packages (exp.)` button.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
