### PR TITLE
Add: Save/Load map as .json from preferences dialog

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2035,7 +2035,6 @@ void dlgProfilePreferences::loadMap()
     label_mapFileActionResult->setText(tr("Loading map - please wait..."));
     qApp->processEvents(); // Needed to make the above message show up when loading big maps
     if (fileName.endsWith(QStringLiteral(".xml"), Qt::CaseInsensitive)) {
-        label_mapFileActionResult->setText(tr("Importing map - please wait..."));
         qApp->processEvents(); // Needed to make the above message show up when loading big maps
         success = pHost->mpConsole->importMap(fileName);
     } else if (fileName.endsWith(QStringLiteral(".json"), Qt::CaseInsensitive)) {
@@ -2045,9 +2044,9 @@ void dlgProfilePreferences::loadMap()
     }
 
     if (success) {
-        label_mapFileActionResult->setText(tr("Imported map from %1.").arg(fileName));
+        label_mapFileActionResult->setText(tr("Loaded map from %1.").arg(fileName));
     } else {
-        label_mapFileActionResult->setText(tr("Could not import map from %1.").arg(fileName));
+        label_mapFileActionResult->setText(tr("Could not load map from %1.").arg(fileName));
     }
 
     QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Saving/Loading map from preferences dialog will allow using of .json extension. Extensions is hint for Mudlet which format to use.

#### Motivation for adding to Mudlet

JSON map functionality was available only via Lua API.
Do not force users to use Lua api.

#### Other info (issues closed, discussion etc)

Closes #4808 

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
