### PR TITLE
Improve: Create map / Load map dialog will be again present for empty map

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2781,7 +2781,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     getCenterSelection();
             }
 
-            if (!mpMap->mpRoomDB) {
+            if (mpMap->mpRoomDB->isEmpty()) {
                 // No map loaded
                 auto createMap = new QAction(tr("Create new map", "2D Mapper context menu (no map found) item"), this);
                 connect(createMap, &QAction::triggered, this, &T2DMap::slot_newMap);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2781,7 +2781,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     getCenterSelection();
             }
 
-            if (mpMap->mpRoomDB->isEmpty()) {
+            if (!mpMap->mpRoomDB || mpMap->mpRoomDB->isEmpty()) {
                 // No map loaded
                 auto createMap = new QAction(tr("Create new map", "2D Mapper context menu (no map found) item"), this);
                 connect(createMap, &QAction::triggered, this, &T2DMap::slot_newMap);
@@ -4120,6 +4120,7 @@ void T2DMap::slot_newMap()
 
     mpMap->mRoomIdHash[mpMap->mProfileName] = roomID;
     mpMap->mNewMove = true;
+    slot_toggleMapViewOnly();
 
 #if defined(INCLUDE_3DMAPPER)
     if (mpMap->mpM) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Restore previously present Create new map / Load map on empty map.
Create map - will create first room and center on it.

#### Motivation for adding to Mudlet

Better user experience.

#### Other info (issues closed, discussion etc)

closes #5239  

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
