### PR TITLE
Add: offer to update editor theme as well for dark theme

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -216,3 +216,43 @@ jobs:
           path: src/
           commit-message: (autocommit) Update widechar_width.h to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-singleshot-connect-source:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Mudlet' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: development
+
+      - name: download latest from source repo
+        run: |
+          curl -o 3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h https://raw.githubusercontent.com/KDAB/KDToolBox/master/qt/singleshot_connect/singleshot_connect.h
+
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
+        with:
+          title: "Infrastructure: Update singleshot_connect.h to latest upstream"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update the built-in `3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h` to its latest version in upstream. We don't include it as a submodule as we're using tools from the KDToolBox as we need them.
+            #### Motivation for adding to Mudlet
+            Latest version of the Qt utility feature that allows singleshot connections.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-widechar-width-${{ github.sha }}
+          path: src/
+          commit-message: (autocommit) Update singleshot_connect.h to latest upstream
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"

--- a/3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h
+++ b/3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h
@@ -1,0 +1,120 @@
+/****************************************************************************
+**                                MIT License
+**
+** Copyright (C) 2020-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+** Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
+**
+** This file is part of KDToolBox (https://github.com/KDAB/KDToolBox).
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, ** and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice (including the next paragraph)
+** shall be included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF ** CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+****************************************************************************/
+
+#ifndef KDTOOLBOX_SINGLESHOT_CONNECT_H
+#define KDTOOLBOX_SINGLESHOT_CONNECT_H
+
+#include <QObject>
+
+#include <memory>
+
+namespace KDToolBox {
+
+template <typename Func1, typename Func2>
+QMetaObject::Connection connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
+                                          const typename QtPrivate::FunctionPointer<Func2>::Object *receiver, Func2 slot,
+                                          Qt::ConnectionType type = Qt::AutoConnection)
+{
+    auto connection = std::make_unique<QMetaObject::Connection>();
+    auto connectionPtr = connection.get();
+
+    auto singleShot =
+            [=,
+            connection = std::move(connection),
+            receiver = const_cast<typename QtPrivate::FunctionPointer<Func2>::Object *>(receiver)]
+                (auto && ... params)
+    {
+        QObject::disconnect(*connection);
+        (receiver->*slot)(std::forward<decltype(params)>(params)...);
+    };
+
+    *connectionPtr = QObject::connect(sender, signal, receiver, std::move(singleShot), type);
+    return *connectionPtr;
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<int(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0 &&
+                        !QtPrivate::FunctionPointer<Func2>::IsPointerToMemberFunction, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
+                  const QObject *context, Func2 slot,
+                  Qt::ConnectionType type = Qt::AutoConnection)
+{
+    auto connection = std::make_unique<QMetaObject::Connection>();
+    auto connectionPtr = connection.get();
+    auto singleShot =
+            [=,
+            slot = std::move(slot),
+            connection = std::move(connection)]
+                (auto && ... params) mutable
+    {
+        QObject::disconnect(*connection);
+        slot(std::forward<decltype(params)>(params)...);
+    };
+
+    *connectionPtr = QObject::connect(sender, signal, context, std::move(singleShot), type);
+    return *connectionPtr;
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<int(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
+{
+    return connectSingleShot(sender, signal, sender, std::move(slot), Qt::DirectConnection);
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
+                  const QObject *context, Func2 slot,
+                  Qt::ConnectionType type = Qt::AutoConnection)
+{
+    auto connection = std::make_unique<QMetaObject::Connection>();
+    auto connectionPtr = connection.get();
+    auto singleShot =
+            [=,
+            slot = std::move(slot),
+            connection = std::move(connection)]
+                (auto && ... params) mutable
+    {
+        QObject::disconnect(*connection);
+        slot(std::forward<decltype(params)>(params)...);
+    };
+
+    *connectionPtr = QObject::connect(sender, signal, context, std::move(singleShot), type);
+    return *connectionPtr;
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
+{
+    return connectSingleShot(sender, signal, sender, std::move(slot), Qt::DirectConnection);
+}
+
+} // namespace KDToolBox
+
+#endif // KDTOOLBOX_SINGLESHOT_CONNECT_H

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -909,6 +909,10 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
     QString QtKeyChainHeader(tr("<h2><u>QtKeyChain - Platform-independent Qt API for storing passwords securely</u></h2>"
                                  "<h3>Copyright © 2011-2019 Frank Osterfeld &lt;frank.osterfeld@gmail.com&gt;.</h3>"));
 
+    QString SingleConnectHeader(tr("<h2><u>singleshot_connect.h - part of KDToolBox</u><br>(https://github.com/KDAB/KDToolBox).</h2>"
+                                   "<h3>Copyright © 2020-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, &lt;info@kdab.comF&gt;.</h3>"));
+
+
     // Now start to assemble the fragments above:
     QStringList license_3rdParty_texts;
     license_3rdParty_texts.append(QStringLiteral("<html>%1<body>%2<hr>")
@@ -998,6 +1002,10 @@ void dlgAboutDialog::setThirdPartyTab(const QString& htmlHead) const
                                   .arg(QtKeyChainHeader,                       // 35 - QtKeyChain header - translatable
                                        BSD2Clause_Body                         // 36 - QtKeyChain body BSD2 ("AUTHOR") - not translatable
                                        .arg(QLatin1String("AUTHOR"), QLatin1String("AUTHOR"))));
+
+    license_3rdParty_texts.append(QStringLiteral("<hr>%37%38")
+                                  .arg(SingleConnectHeader,                    // 37 - singleshot_connect header - translatable
+                                       MIT_Body));                             // 38 - singleshot_connect body MIT - not translatable
 
     license_3rdParty_texts.append(QStringLiteral("</body></html>"));
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -48,6 +48,7 @@
 #include <QTableWidget>
 #include <QToolBar>
 #include <QUiLoader>
+#include <../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h>
 #include "post_guard.h"
 
 using namespace std::chrono_literals;
@@ -3027,6 +3028,8 @@ void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
                         QObject::connect(watcher, &QFutureWatcher<bool>::finished, this, [=]() {
                             if (future.result()) {
                                 populateThemesList();
+
+                                emit signal_themeUpdateCompleted();
                             }
 
                             theme_download_label->hide();
@@ -3969,8 +3972,8 @@ void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)
             return;
         }
 
-        // unlikely, but theme index could be not yet available - wait a bit then
-        QTimer::singleShot(3s, this, [=]() {
+        // in case no theme index is available yet, so it as soon as one is available
+        KDToolBox::connectSingleShot(this, &dlgProfilePreferences::signal_themeUpdateCompleted,  [=]() {
             auto monokaiIndex = code_editor_theme_selection_combobox->findText(darkTheme);
             if (monokaiIndex != -1) {
                 code_editor_theme_selection_combobox->setCurrentIndex(monokaiIndex);

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -272,6 +272,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     connect(pMudlet, &mudlet::signal_showIconsOnMenusChanged, this, &dlgProfilePreferences::slot_changeShowIconsOnMenus);
     connect(pMudlet, &mudlet::signal_guiLanguageChanged, this, &dlgProfilePreferences::slot_guiLanguageChanged);
     connect(pMudlet, &mudlet::signal_enableDarkThemeChanged, this, &dlgProfilePreferences::slot_changeEnableDarkTheme);
+    connect(enableDarkTheme, &QCheckBox::stateChanged, this, &dlgProfilePreferences::slot_changeEnableDarkTheme);
 
     generateDiscordTooltips();
 
@@ -2723,7 +2724,6 @@ void dlgProfilePreferences::slot_save_and_exit()
     pMudlet->setEditorTextoptions(checkBox_showSpacesAndTabs->isChecked(), checkBox_showLineFeedsAndParagraphs->isChecked());
     pMudlet->setShowMapAuditErrors(checkBox_reportMapIssuesOnScreen->isChecked());
     pMudlet->setShowIconsOnMenu(checkBox_showIconsOnMenus->checkState());
-    pMudlet->setDarkTheme(enableDarkTheme->isChecked());
 
     mudlet::self()->mDiscord.UpdatePresence();
 
@@ -3760,13 +3760,13 @@ void dlgProfilePreferences::slot_changeGuiLanguage(int languageIndex)
     label_languageChangeWarning->show();
 }
 
-// This slot is called when the QComboBox for enabling DarkTheme
-// is changed by the user.
 void dlgProfilePreferences::slot_changeEnableDarkTheme(const bool state)
 {
     if (enableDarkTheme->isChecked() != state) {
         enableDarkTheme->setChecked(state);
     }
+
+    mudlet::self()->setDarkTheme(state);
 }
 
 // This slot is called when the mudlet singleton tells everything that the

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -48,7 +48,7 @@
 #include <QTableWidget>
 #include <QToolBar>
 #include <QUiLoader>
-#include <../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h>
+#include "../3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h"
 #include "post_guard.h"
 
 using namespace std::chrono_literals;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -338,6 +338,9 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     }
 
     setupPasswordsMigration();
+
+    connect(label_darkEditorPrompt, &QLabel::linkActivated, this, &dlgProfilePreferences::slot_enableDarkEditor);
+    label_darkEditorPrompt->hide();
 }
 
 void dlgProfilePreferences::setupPasswordsMigration()
@@ -3948,4 +3951,34 @@ void dlgProfilePreferences::slot_setPostingTimeout(const double timeout)
     }
 
     pHost->mTelnet.setPostingTimeout(qRound(1000.0 * timeout));
+}
+
+void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)
+{
+    if (link == QStringLiteral("dark-code-editor")) {
+        const auto darkTheme = QStringLiteral("Monokai");
+
+        label_darkEditorPrompt->hide();
+
+        // switch to code editor tab
+        tabWidget->setCurrentIndex(3);
+
+        auto monokaiIndex = code_editor_theme_selection_combobox->findText(darkTheme);
+        if (monokaiIndex != -1) {
+            code_editor_theme_selection_combobox->setCurrentIndex(monokaiIndex);
+            return;
+        }
+
+        // unlikely, but theme index could be not yet available - wait a bit then
+        QTimer::singleShot(3s, this, [=]() {
+            auto monokaiIndex = code_editor_theme_selection_combobox->findText(darkTheme);
+            if (monokaiIndex != -1) {
+                code_editor_theme_selection_combobox->setCurrentIndex(monokaiIndex);
+            }
+        });
+
+        return;
+    }
+
+    qWarning() << "unknown link clicked in profile preferences:" << link;
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -159,6 +159,7 @@ private slots:
     void slot_setPlayerRoomOuterDiameter(const int);
     void slot_setPlayerRoomInnerDiameter(const int);
     void slot_setPostingTimeout(const double);
+    void slot_enableDarkEditor(const QString&);
 
 private:
     void setColors();

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -161,6 +161,9 @@ private slots:
     void slot_setPostingTimeout(const double);
     void slot_enableDarkEditor(const QString&);
 
+signals:
+    void signal_themeUpdateCompleted();
+
 private:
     void setColors();
     void setColors2();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -106,7 +106,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
                          "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
                          "<li><strong>Activate</strong> the alias.</li></ol></p>"
-                         "<p>That's it! If you'd like to be able to create aliases from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
+                         "<p>That's it! If you'd like to be able to create aliases from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
@@ -115,7 +115,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                            "<li>Select the appropriate pattern <strong>type</strong>.</li>"
                            "<li>Define a clear text <strong>command</strong> that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..</li>"
                            "<li><strong>Activate</strong> the trigger.</li></ol></p>"
-                           "<p>That's it! If you'd like to be able to create triggers from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
+                           "<p>That's it! If you'd like to be able to create triggers from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
 
     msgInfoAddScript = tr("<p>Scripts organize code and can react to events. To add a new script:"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -106,10 +106,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
                          "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
                          "<li><strong>Activate</strong> the alias.</li></ol></p>"
-                         "<p><strong>Note:</strong> Aliases can also be defined from the command line in the main profile window like this:</p>"
-                         "<p><code>lua permAlias(&quot;my greets&quot;, &quot;&quot;, &quot;^hi$&quot;, [[send (&quot;say Greetings, traveller!&quot;) echo (&quot;We said hi!&quot;)]])</code></p>"
-                         "<p>You can now greet by typing 'hi'</p>"
-                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Contents'>more information</a>.</p>");
+                         "<p>That's it! If you'd like to be able to create aliases from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
+                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -115,10 +115,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                            "<li>Select the appropriate pattern <strong>type</strong>.</li>"
                            "<li>Define a clear text <strong>command</strong> that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..</li>"
                            "<li><strong>Activate</strong> the trigger.</li></ol></p>"
-                           "<p><strong>Note:</strong> Triggers can also be defined from the command line in the main profile window like this:</p>"
-                           "<p><code>lua permSubstringTrigger(&quot;My drink trigger&quot;, &quot;&quot;, &quot;You are thirsty.&quot;, function() send(&quot;drink water&quot;) end)</code></p>"
-                           "<p>This will keep you refreshed.</p>"
-                           "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Contents'>more information</a>.</p>");
+                           "<p>That's it! If you'd like to be able to create triggers from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
+                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
 
     msgInfoAddScript = tr("<p>Scripts organize code and can react to events. To add a new script:"
                           "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -106,7 +106,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
                          "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
                          "<li><strong>Activate</strong> the alias.</li></ol></p>"
-                         "<p>That's it! If you'd like to be able to create aliases from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
+                         "<p>That's it! If you'd like to be able to create aliases from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                          "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
@@ -115,7 +115,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                            "<li>Select the appropriate pattern <strong>type</strong>.</li>"
                            "<li>Define a clear text <strong>command</strong> that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..</li>"
                            "<li><strong>Activate</strong> the trigger.</li></ol></p>"
-                           "<p>That's it! If you'd like to be able to create triggers from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
+                           "<p>That's it! If you'd like to be able to create triggers from the input line, there are a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
 
     msgInfoAddScript = tr("<p>Scripts organize code and can react to events. To add a new script:"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -115,8 +115,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                            "<li>Select the appropriate pattern <strong>type</strong>.</li>"
                            "<li>Define a clear text <strong>command</strong> that you want to send to the game if the trigger finds the pattern in the text from the game, or write a script for more complicated needs..</li>"
                            "<li><strong>Activate</strong> the trigger.</li></ol></p>"
-                           "<p>That's it! If you'd like to be able to create triggers from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
-                        "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Triggers'>more information</a>.</p>");
+                           "<p><strong>Note:</strong> Triggers can also be defined from the command line in the main profile window like this:</p>"
+                           "<p><code>lua permSubstringTrigger(&quot;My drink trigger&quot;, &quot;&quot;, &quot;You are thirsty.&quot;, function() send(&quot;drink water&quot;) end)</code></p>"
+                           "<p>This will keep you refreshed.</p>"
+                           "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Contents'>more information</a>.</p>");
 
     msgInfoAddScript = tr("<p>Scripts organize code and can react to events. To add a new script:"
                           "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -106,8 +106,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                          "<li>Define an input <strong>pattern</strong> either literally or with a Perl regular expression.</li>"
                          "<li>Define a 'substitution' <strong>command</strong> to send to the game in clear text <strong>instead of the alias pattern</strong>, or write a script for more complicated needs.</li>"
                          "<li><strong>Activate</strong> the alias.</li></ol></p>"
-                         "<p>That's it! If you'd like to be able to create aliases from the input line, there's a <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=22609'>couple</a> of <a href='https://forums.mudlet.org/viewtopic.php?f=6&t=16462'>packages</a> that can help you."
-                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Introduction#Aliases'>more information</a>.</p>");
+                         "<p><strong>Note:</strong> Aliases can also be defined from the command line in the main profile window like this:</p>"
+                         "<p><code>lua permAlias(&quot;my greets&quot;, &quot;&quot;, &quot;^hi$&quot;, [[send (&quot;say Greetings, traveller!&quot;) echo (&quot;We said hi!&quot;)]])</code></p>"
+                         "<p>You can now greet by typing 'hi'</p>"
+                         "<p>Check the manual for <a href='http://wiki.mudlet.org/w/Manual:Contents'>more information</a>.</p>");
 
     msgInfoAddTrigger = tr("<p>Triggers react on game output. To add a new trigger:"
                            "<ol><li>Click on the 'Add Item' icon above.</li>"

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2400,7 +2400,7 @@ void mudlet::updateDiscordNamedIcon()
     QString gameName = pHost->getDiscordGameName();
 
     bool hasCustom = !pHost->getDiscordInviteURL().isEmpty();
-    
+
     mpActionDiscord->setIconText(gameName.isEmpty() ? QStringLiteral("Discord") : QFontMetrics(mpActionDiscord->font()).elidedText(gameName, Qt::ElideRight, 90));
 
     if (mpActionMudletDiscord->isVisible() != hasCustom) {
@@ -3864,8 +3864,13 @@ void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
         emit signal_showIconsOnMenusChanged(state);
     }
 }
+
 void mudlet::setDarkTheme(const bool& state)
 {
+    if (mDarkTheme == state) {
+        return;
+    }
+
     if (state) {
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
         qApp->setStyle(new DarkTheme);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -260,7 +260,7 @@ mudlet::mudlet()
     }
     if (QStringList{"windowsvista", "macintosh"}.contains(mDefaultStyle, Qt::CaseInsensitive)) {
         qDebug().nospace().noquote() << "mudlet::mudlet() INFO - '" << mDefaultStyle << "' has been detected as the style factory in use - QPushButton styling fix applied!";
-        mBG_ONLY_STYLESHEET = QStringLiteral("QPushButto`n {background-color: %1; border: 1px solid #8f8f91;}");
+        mBG_ONLY_STYLESHEET = QStringLiteral("QPushButton {background-color: %1; border: 1px solid #8f8f91;}");
         mTEXT_ON_BG_STYLESHEET = QStringLiteral("QPushButton {color: %1; background-color: %2; border: 1px solid #8f8f91;}");
     } else {
         qDebug().nospace().noquote() << "mudlet::mudlet() INFO - '" << mDefaultStyle << "' has been detected as the style factory in use - no styling fixes applied.";

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -256,11 +256,11 @@ mudlet::mudlet()
     scanForQtTranslations(getMudletPath(qtTranslationsPath));
     loadTranslators(mInterfaceLanguage);
     if (mDarkTheme) {
-        setDarkTheme(mDarkTheme);
+        setDarkTheme(mDarkTheme, true);
     }
     if (QStringList{"windowsvista", "macintosh"}.contains(mDefaultStyle, Qt::CaseInsensitive)) {
         qDebug().nospace().noquote() << "mudlet::mudlet() INFO - '" << mDefaultStyle << "' has been detected as the style factory in use - QPushButton styling fix applied!";
-        mBG_ONLY_STYLESHEET = QStringLiteral("QPushButton {background-color: %1; border: 1px solid #8f8f91;}");
+        mBG_ONLY_STYLESHEET = QStringLiteral("QPushButto`n {background-color: %1; border: 1px solid #8f8f91;}");
         mTEXT_ON_BG_STYLESHEET = QStringLiteral("QPushButton {color: %1; background-color: %2; border: 1px solid #8f8f91;}");
     } else {
         qDebug().nospace().noquote() << "mudlet::mudlet() INFO - '" << mDefaultStyle << "' has been detected as the style factory in use - no styling fixes applied.";
@@ -3865,9 +3865,11 @@ void mudlet::setShowIconsOnMenu(const Qt::CheckState state)
     }
 }
 
-void mudlet::setDarkTheme(const bool& state)
+// during Mudlet load, darktheme will already be set to 'true' -
+// so pass a separate flag to override the state check
+void mudlet::setDarkTheme(const bool& state, const bool& loading)
 {
-    if (mDarkTheme == state) {
+    if (mDarkTheme == state && !loading) {
         return;
     }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -300,7 +300,7 @@ public:
     bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
     void show_options_dialog(const QString& tab);
     void setInterfaceLanguage(const QString &languageCode);
-    void setDarkTheme(const bool &state);
+    void setDarkTheme(const bool &state, const bool &loading = false);
     const QString& getInterfaceLanguage() const { return mInterfaceLanguage; }
     const QLocale& getUserLocale() const { return mUserLocale; }
     QList<QString> getAvailableTranslationCodes() const { return mTranslationsMap.keys(); }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -434,7 +434,7 @@ public:
 
     // Options dialog when there's no active host
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
-    bool mDarkTheme;
+    bool mDarkTheme = false;
 
     // mirror everything shown in any console to stdout. Helpful for CI environments
     inline static bool mMirrorToStdOut;

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -225,45 +225,60 @@
          <layout class="QGridLayout" name="gridLayout_groupBox_miscellaneous">
           <item row="0" column="0">
            <widget class="QCheckBox" name="enableDarkTheme">
-            <property name="text">
-             <string>Use a dark theme</string>
-            </property>
             <property name="toolTip">
              <string>&lt;p&gt;Changes your Mudlet Style to a Dark Fusion Style.&lt;/p&gt;</string>
             </property>
+            <property name="text">
+             <string>Use a dark theme</string>
+            </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QCheckBox" name="mAlertOnNewData">
-            <property name="text">
-             <string>Notify on new data</string>
-            </property>
             <property name="toolTip">
              <string>&lt;p&gt;Show a toolbar notification if Mudlet is minimized and new data arrives.&lt;/p&gt;</string>
             </property>
+            <property name="text">
+             <string>Notify on new data</string>
+            </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QCheckBox" name="acceptServerGUI">
             <property name="text">
              <string>Allow server to install script packages</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QCheckBox" name="mFORCE_SAVE_ON_EXIT">
             <property name="text">
              <string>Auto save on exit</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QCheckBox" name="acceptServerMedia">
+            <property name="toolTip">
+             <string>&lt;p&gt;This also needs GMCP to be enabled in the next group below.&lt;/p&gt;</string>
+            </property>
             <property name="text">
              <string>Allow server to download and play media</string>
             </property>
-            <property name="toolTip">
-             <string>&lt;p&gt;This also needs GMCP to be enabled in the next group below.&lt;/p&gt;</string>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_darkEditorPrompt">
+            <property name="font">
+             <font>
+              <pointsize>8</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Set dark theme in &lt;a href=&quot;dark-code-editor&quot;&gt;code editor&lt;/a&gt; as well?</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::RichText</enum>
             </property>
            </widget>
           </item>
@@ -2573,7 +2588,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>IRC client options</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_groupBox_ircOptions" rowstretch="0,0">
+         <layout class="QGridLayout" name="gridLayout_groupBox_ircOptions" rowstretch="0,0,0">
           <item row="0" column="0">
            <widget class="QLabel" name="lblIrcHostName">
             <property name="text">
@@ -3455,14 +3470,14 @@ you can use it but there could be issues with aligning columns of text</string>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
+               <property name="toolTip">
+                <string comment="The term in '...' refer to a Mudlet specific thing and ought to match the corresponding translation elsewhere.">&lt;p&gt;Show 'LUA OK' messages for Timers with the specified minimum interval (h:mm:ss.zzz), the minimum value (the default) shows all such messages but can render the &lt;i&gt;Central Debug Console&lt;/i&gt; useless if there is a very small interval timer running.&lt;/p&gt;</string>
+               </property>
                <property name="text">
                 <string>Show debug messages for timers not smaller than:</string>
                </property>
                <property name="buddy">
                 <cstring>timeEdit_timerDebugOutputMinimumInterval</cstring>
-               </property>
-               <property name="toolTip">
-                <string comment="The term in '...' refer to a Mudlet specific thing and ought to match the corresponding translation elsewhere.">&lt;p&gt;Show 'LUA OK' messages for Timers with the specified minimum interval (h:mm:ss.zzz), the minimum value (the default) shows all such messages but can render the &lt;i&gt;Central Debug Console&lt;/i&gt; useless if there is a very small interval timer running.&lt;/p&gt;</string>
                </property>
               </widget>
              </item>
@@ -3775,5 +3790,22 @@ you can use it but there could be issues with aligning columns of text</string>
  <resources>
   <include location="../mudlet.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>enableDarkTheme</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_darkEditorPrompt</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>81</x>
+     <y>278</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>82</x>
+     <y>305</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Offer to update editor theme as well when dark theme is enabled, since you really need both for the full experience.

Before:

https://user-images.githubusercontent.com/110988/139585757-778f9595-5d83-43db-94fa-1a2ce7dee2db.mp4



After:

https://user-images.githubusercontent.com/110988/139585764-6b68b120-efa5-4fc0-ba16-27ab68948678.mp4


#### Motivation for adding to Mudlet
Better user experience.
#### Other info (issues closed, discussion etc)
Dark theme is applied instantly, as opposed only on 'Save' as before.

Added a header-only single-shot `QObject::connect` version from [KDToolBox](https://github.com/KDAB/KDToolBox/tree/master/qt/singleshot_connect) as well - we've needed such a feature in several scenarios now.

This update also works out how to make clickable text in QLabels in C++ and get code to act on it which is a new pattern to Mudlet's codebase. Could be useful in other scenarios as well!