### PR TITLE
Infrastructure: exclude tests/ and 3rdparty/ from clang-tidy analysis

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -121,7 +121,7 @@ jobs:
         clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
         # the action doesn't see system-level libraries, need to replicate them here
         apt_packages: 'pkg-config,libzip-dev,libglu1-mesa-dev,libpulse-dev'
-        exclude: "test,3rdparty"
+        exclude: '3rdparty'
 
     - name: Passed C++ style guide checks
       if: steps.static_analysis.outputs.total_comments > 0

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -121,6 +121,7 @@ jobs:
         clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
         # the action doesn't see system-level libraries, need to replicate them here
         apt_packages: 'pkg-config,libzip-dev,libglu1-mesa-dev,libpulse-dev'
+        exclude: "test,3rdparty"
 
     - name: Passed C++ style guide checks
       if: steps.static_analysis.outputs.total_comments > 0

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -121,7 +121,7 @@ jobs:
         clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
         # the action doesn't see system-level libraries, need to replicate them here
         apt_packages: 'pkg-config,libzip-dev,libglu1-mesa-dev,libpulse-dev'
-        exclude: '3rdparty'
+        excludetest: '3rdparty'
 
     - name: Passed C++ style guide checks
       if: steps.static_analysis.outputs.total_comments > 0

--- a/3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h
+++ b/3rdparty/kdtoolbox/singleshot_connect/singleshot_connect.h
@@ -1,0 +1,120 @@
+/****************************************************************************
+**                                MIT License
+**
+** Copyright (C) 2020-2021 Klarälvdalens Datakonsult AB, a KDAB Group company, info@kdab.com
+** Author: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
+**
+** This file is part of KDToolBox (https://github.com/KDAB/KDToolBox).
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and associated documentation files (the "Software"), to deal
+** in the Software without restriction, including without limitation the rights
+** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+** copies of the Software, ** and to permit persons to whom the Software is
+** furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice (including the next paragraph)
+** shall be included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF ** CONTRACT, TORT OR OTHERWISE,
+** ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+****************************************************************************/
+
+#ifndef KDTOOLBOX_SINGLESHOT_CONNECT_H
+#define KDTOOLBOX_SINGLESHOT_CONNECT_H
+
+#include <QObject>
+
+#include <memory>
+
+namespace KDToolBox {
+
+template <typename Func1, typename Func2>
+QMetaObject::Connection connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
+                                          const typename QtPrivate::FunctionPointer<Func2>::Object *receiver, Func2 slot,
+                                          Qt::ConnectionType type = Qt::AutoConnection)
+{
+    auto connection = std::make_unique<QMetaObject::Connection>();
+    auto connectionPtr = connection.get();
+
+    auto singleShot =
+            [=,
+            connection = std::move(connection),
+            receiver = const_cast<typename QtPrivate::FunctionPointer<Func2>::Object *>(receiver)]
+                (auto && ... params)
+    {
+        QObject::disconnect(*connection);
+        (receiver->*slot)(std::forward<decltype(params)>(params)...);
+    };
+
+    *connectionPtr = QObject::connect(sender, signal, receiver, std::move(singleShot), type);
+    return *connectionPtr;
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<int(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0 &&
+                        !QtPrivate::FunctionPointer<Func2>::IsPointerToMemberFunction, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
+                  const QObject *context, Func2 slot,
+                  Qt::ConnectionType type = Qt::AutoConnection)
+{
+    auto connection = std::make_unique<QMetaObject::Connection>();
+    auto connectionPtr = connection.get();
+    auto singleShot =
+            [=,
+            slot = std::move(slot),
+            connection = std::move(connection)]
+                (auto && ... params) mutable
+    {
+        QObject::disconnect(*connection);
+        slot(std::forward<decltype(params)>(params)...);
+    };
+
+    *connectionPtr = QObject::connect(sender, signal, context, std::move(singleShot), type);
+    return *connectionPtr;
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<int(QtPrivate::FunctionPointer<Func2>::ArgumentCount) >= 0, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
+{
+    return connectSingleShot(sender, signal, sender, std::move(slot), Qt::DirectConnection);
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal,
+                  const QObject *context, Func2 slot,
+                  Qt::ConnectionType type = Qt::AutoConnection)
+{
+    auto connection = std::make_unique<QMetaObject::Connection>();
+    auto connectionPtr = connection.get();
+    auto singleShot =
+            [=,
+            slot = std::move(slot),
+            connection = std::move(connection)]
+                (auto && ... params) mutable
+    {
+        QObject::disconnect(*connection);
+        slot(std::forward<decltype(params)>(params)...);
+    };
+
+    *connectionPtr = QObject::connect(sender, signal, context, std::move(singleShot), type);
+    return *connectionPtr;
+}
+
+template <typename Func1, typename Func2>
+typename std::enable_if<QtPrivate::FunctionPointer<Func2>::ArgumentCount == -1, QMetaObject::Connection>::type
+connectSingleShot(const typename QtPrivate::FunctionPointer<Func1>::Object *sender, Func1 signal, Func2 slot)
+{
+    return connectSingleShot(sender, signal, sender, std::move(slot), Qt::DirectConnection);
+}
+
+} // namespace KDToolBox
+
+#endif // KDTOOLBOX_SINGLESHOT_CONNECT_H


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Exclude tests/ and 3rdparty/ from clang-tidy analysis
#### Motivation for adding to Mudlet
Reduce false positives