### PR TITLE
Fix: remove stray debug timer messages

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5805,12 +5805,6 @@ void dlgTriggerEditor::slot_timer_selected(QTreeWidgetItem* pItem)
     int ID = pItem->data(0, Qt::UserRole).toInt();
     TTimer* pT = mpHost->getTimerUnit()->getTimer(ID);
     if (pT) {
-        if (pT->getParent()) {
-            qDebug() << "[STATUS]: timer ID=" << pT->getID() << " name=" << pT->getName() << " mActive = " << pT->isActive() << " mUserActiveState=" << pT->shouldBeActive()
-                     << " parent=" << pT->getParent()->getName();
-        } else {
-            qDebug() << "[STATUS]: timer ID=" << pT->getID() << " name=" << pT->getName() << "> mActive = " << pT->isActive() << " mUserActiveState=" << pT->shouldBeActive() << " parent=0";
-        }
         QString command = pT->getCommand();
         QString name = pT->getName();
         mpTimersMainArea->lineEdit_timer_command->setText(command);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: remove stray debug timer messages
#### Motivation for adding to Mudlet
They don't seem to be necessary for anything, and can be re-created very fast if needed.
#### Other info (issues closed, discussion etc)
Github copilot is great for constructing debug messages like this.