### PR TITLE
Fix copy2decho, copy2html to work for all international text

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1786,7 +1786,7 @@ function ansi2decho(text, ansi_default_color)
       elseif tag < 16 then
         rgb = lightColours[tag - 8]
       elseif tag < 232 then
-        tag = tag - 16 -- because color 1-15 behave like normal ANSI colors      
+        tag = tag - 16 -- because color 1-15 behave like normal ANSI colors
         local b = tag % 6
         local g = (tag - b) / 6 % 6
         local r = (tag - b - g * 6) / 36 % 6
@@ -2176,6 +2176,7 @@ local function copy2color(name,win,str,inst)
       error(err)
     end
   end
+
   win = win or "main"
   str = str or line
   inst = inst or 1
@@ -2183,7 +2184,7 @@ local function copy2color(name,win,str,inst)
     -- happens when you try to use copy2decho() on an empty line
     return ""
   end
-  local start, len = selectString(win, str, inst), #str
+  local start, len = selectString(win, str, inst), utf8.len(str)
   if not start then
     error(name..": string not found",3)
   end
@@ -2209,9 +2210,9 @@ local function copy2color(name,win,str,inst)
 
     if r ~= cr or g ~= cg or b ~= cb or rb ~= crb or gb ~= cgb or bb ~= cbb then
       cr,cg,cb,crb,cgb,cbb = r,g,b,rb,gb,bb
-      result = string.format(style, result and (result..endspan) or "", r, g, b, rb, gb, bb, line:sub(index, index))
+      result = string.format(style, result and (result..endspan) or "", r, g, b, rb, gb, bb, utf8.sub(line, index, index))
     else
-      result = result .. line:sub(index, index)
+      result = result .. utf8.sub(line, index, index)
     end
   end
   result = result .. endspan

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -1,0 +1,24 @@
+-- https://wiki.mudlet.org/w/Manual:UI_Functions
+describe("Tests UI functions", function()
+
+  describe("Test the operation of the copy2decho function", function()
+    setup(function()
+      -- create Mudlet miniconsole top-left
+      createMiniConsole("testing", 0,0,650,300)
+      setMiniConsoleFontSize("testing", 10)
+      setWindowWrap("testing", 40)
+    end)
+
+    -- clear miniconsole before each test
+    before_each(function()
+      clearWindow("testing")
+    end)
+
+    it("Should copy2decho colored English text", function()
+      local testdecho = "<50,50,0:0,255,0>test <255,0,0>red <0,255,0>green <0,0,255>blue"
+      decho("testing", testdecho)
+
+      assert.are.equal(testdecho, copy2decho("testing"))
+    end)
+  end)
+end)

--- a/src/mudlet-lua/tests/UI_spec.lua
+++ b/src/mudlet-lua/tests/UI_spec.lua
@@ -4,21 +4,81 @@ describe("Tests UI functions", function()
   describe("Test the operation of the copy2decho function", function()
     setup(function()
       -- create Mudlet miniconsole top-left
-      createMiniConsole("testing", 0,0,650,300)
-      setMiniConsoleFontSize("testing", 10)
-      setWindowWrap("testing", 40)
+      createMiniConsole("testconsole", 0,0,800,100)
+      setMiniConsoleFontSize("testconsole", 10)
+      setBackgroundColor("testconsole", unpack(color_table.DarkSlateGray))
+      setWindowWrap("testconsole", 100)
     end)
 
     -- clear miniconsole before each test
     before_each(function()
-      clearWindow("testing")
+      clearWindow("testconsole")
     end)
 
-    it("Should copy2decho colored English text", function()
-      local testdecho = "<50,50,0:0,255,0>test <255,0,0>red <0,255,0>green <0,0,255>blue"
-      decho("testing", testdecho)
+    teardown(function()
+      hideWindow("testconsole")
+    end)
 
-      assert.are.equal(testdecho, copy2decho("testing"))
+    it("Should copy colored English text", function()
+      local testdecho = "<50,50,0:0,255,0>test<r><192,192,192:0,0,0> <r><255,0,0:0,0,0>red <r><0,255,0:0,0,0>green<r><0,0,255:0,0,0>blue<r>"
+      decho("testconsole", testdecho)
+
+      assert.are.equal(testdecho, copy2decho("testconsole"))
+    end)
+
+    -- TODO: https://github.com/Mudlet/Mudlet/issues/5590
+    -- it("Should copy text with background transparency", function()
+    --   local testdecho = "<50,50,0:0,255,0,100>semi-transparent"
+    --   decho("testconsole", testdecho)
+
+    --   assert.are.equal(testdecho, copy2decho("testconsole", true))
+    -- end)
+
+    it("Should copy colored Chinese text", function()
+      local testdecho = "<50,50,0:0,255,0>测试<r><192,192,192:0,0,0> <r><255,0,0:0,0,0>红色<r><0,255,0:0,0,0>绿色<r><0,0,255:0,0,0>蓝色<r>"
+      decho("testconsole", testdecho)
+
+      assert.are.equal(testdecho, copy2decho("testconsole"))
+    end)
+
+    -- TODO: https://github.com/Mudlet/Mudlet/issues/5589
+    -- it("Should copy2decho text with italics, bold, and underline", function()
+    --   local testdecho = "separate: <i>italic</i>, <b>bold</b>, <u>underline</u>. all together: <i>italic<b>bold<u>underline<r>"
+    --   decho("testconsole", testdecho)
+
+    --   assert.are.equal(testdecho, copy2decho("testconsole"))
+    -- end)
+  end)
+
+  describe("Test the operation of the copy2html function", function()
+    setup(function()
+      -- create Mudlet miniconsole top-left
+      createMiniConsole("testconsole", 0,0,800,100)
+      setMiniConsoleFontSize("testconsole", 10)
+      setBackgroundColor("testconsole", unpack(color_table.DarkSlateGray))
+      setWindowWrap("testconsole", 100)
+    end)
+
+    -- clear miniconsole before each test
+    before_each(function()
+      clearWindow("testconsole")
+    end)
+
+    it("Should copy colored English text", function()
+      local testdecho = "<50,50,0:0,255,0>test<r><192,192,192:0,0,0> <r><255,0,0:0,0,0>red <r><0,255,0:0,0,0>green<r><0,0,255:0,0,0>blue<r>"
+      local outputhtml = [[<span style='color: rgb(50,50,0);background: rgb(0,255,0);'>test</span><span style='color: rgb(192,192,192);background: rgb(0,0,0);'> </span><span style='color: rgb(255,0,0);background: rgb(0,0,0);'>red </span><span style='color: rgb(0,255,0);background: rgb(0,0,0);'>green</span><span style='color: rgb(0,0,255);background: rgb(0,0,0);'>blue</span>]]
+      decho("testconsole", testdecho)
+
+      assert.are.equal(outputhtml, copy2html("testconsole"))
+    end)
+
+    it("Should copy colored Chinese text", function()
+      local testdecho = "<50,50,0:0,255,0>测试<r><192,192,192:0,0,0> <r><255,0,0:0,0,0>红色<r><0,255,0:0,0,0>绿色<r><0,0,255:0,0,0>蓝色<r>"
+      local outputhtml = [[<span style='color: rgb(50,50,0);background: rgb(0,255,0);'>测试</span><span style='color: rgb(192,192,192);background: rgb(0,0,0);'> </span><span style='color: rgb(255,0,0);background: rgb(0,0,0);'>红色</span><span style='color: rgb(0,255,0);background: rgb(0,0,0);'>绿色</span><span style='color: rgb(0,0,255);background: rgb(0,0,0);'>蓝色</span>]]
+
+      decho("testconsole", testdecho)
+
+      assert.are.equal(outputhtml, copy2html("testconsole"))
     end)
   end)
 end)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix copy2decho, copy2html to work for all international text
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/5565

The fix is simple - use `utf8.*` equivalents instead of Lua's built-in `string.*` library. Should check other functions for cases like this as well.

This should have tests as well but all energy went on cracking the problem.

That said, for better performance it's better to avoid `copy2decho` which goes out to Lua and uses a lot of C++ functions and just do it all within the C++ core with:

```
selectCurrentLine()
copy()
appendBuffer("my miniconsole")
```