### PR TITLE
Improve logic in button setup to use names instead of indexes

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1578,19 +1578,17 @@ void mudlet::slot_timer_fires()
 
 void mudlet::disableToolbarButtons()
 {
-    mpMainToolBar->actions()[1]->setEnabled(false);
-    mpMainToolBar->actions()[2]->setEnabled(false);
-    mpMainToolBar->actions()[3]->setEnabled(false);
-    mpMainToolBar->actions()[4]->setEnabled(false);
-    mpMainToolBar->actions()[5]->setEnabled(false);
-    mpMainToolBar->actions()[6]->setEnabled(false);
-    mpMainToolBar->actions()[7]->setEnabled(false);
-    mpMainToolBar->actions()[9]->setEnabled(false);
-    mpMainToolBar->actions()[10]->setEnabled(false);
-    mpMainToolBar->actions()[12]->setEnabled(false);
-    mpMainToolBar->actions()[13]->setEnabled(false);
-    mpMainToolBar->actions()[14]->setEnabled(false);
-
+    mpActionTriggers->setEnabled(false);
+    mpActionAliases->setEnabled(false);
+    mpActionTimers->setEnabled(false);
+    mpActionButtons->setEnabled(false);
+    mpActionScripts->setEnabled(false);
+    mpActionKeys->setEnabled(false);
+    mpActionVariables->setEnabled(false);
+    mpActionMudletDiscord->setEnabled(false);
+    mpActionMapper->setEnabled(false);
+    mpActionNotes->setEnabled(false);
+    mpButtonPackageManagers->setEnabled(false);
     mpActionIRC->setEnabled(false);
     mpActionReplay->setEnabled(false);
     mpActionReplay->setToolTip(QStringLiteral("<html><head/><body>%1</body></html>")
@@ -1609,18 +1607,17 @@ void mudlet::disableToolbarButtons()
 
 void mudlet::enableToolbarButtons()
 {
-    mpMainToolBar->actions()[1]->setEnabled(true);
-    mpMainToolBar->actions()[2]->setEnabled(true);
-    mpMainToolBar->actions()[3]->setEnabled(true);
-    mpMainToolBar->actions()[4]->setEnabled(true);
-    mpMainToolBar->actions()[5]->setEnabled(true);
-    mpMainToolBar->actions()[6]->setEnabled(true);
-    mpMainToolBar->actions()[7]->setEnabled(true);
-    mpMainToolBar->actions()[9]->setEnabled(true);
-    mpMainToolBar->actions()[10]->setEnabled(true);
-    mpMainToolBar->actions()[12]->setEnabled(true);
-    mpMainToolBar->actions()[13]->setEnabled(true);
-    mpMainToolBar->actions()[14]->setEnabled(true);
+    mpActionTriggers->setEnabled(true);
+    mpActionAliases->setEnabled(true);
+    mpActionTimers->setEnabled(true);
+    mpActionButtons->setEnabled(true);
+    mpActionScripts->setEnabled(true);
+    mpActionKeys->setEnabled(true);
+    mpActionVariables->setEnabled(true);
+    mpActionMudletDiscord->setEnabled(true);
+    mpActionMapper->setEnabled(true);
+    mpActionNotes->setEnabled(true);
+    mpButtonPackageManagers->setEnabled(true);
     mpActionIRC->setEnabled(true);
 
     if (!mpToolBarReplay) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Currently the Triggers button is disabled to start off (prior to loading a profile) using `mpMainToolBar->actions()[1]->setEnabled(false);`, and all but the newest ones are similar.  This is problematic for development if you make any new buttons that aren't at the end of the list.  I'm changing it to `mpActionTriggers->setEnabled(false);`

Also, I'm going to skip the Manual button, while I'm at it.  The Manual button opens web browser to the wiki.  I think it got swept up with the others in a large edit and didn't mean to disable it.

#### Motivation for adding to Mudlet
Development is aided.
#### Other info (issues closed, discussion etc)
Fix #5568
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
