### PR TITLE
fix Discord logo dimensions on profiles screen

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -778,7 +778,7 @@
               </property>
               <property name="iconSize">
                <size>
-                <width>65</width>
+                <width>80</width>
                 <height>22</height>
                </size>
               </property>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -778,8 +778,8 @@
               </property>
               <property name="iconSize">
                <size>
-                <width>80</width>
-                <height>22</height>
+                <width>65</width>
+                <height>18</height>
                </size>
               </property>
              </widget>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Correct the dimensions of Discord logo on connect dialog.

I did not notice that the UI was doing something other than just resizing this image dynamically to be the same height as text.  It was set to have a box that it goes on with specific dimensions.  So the new wider but shorter image was being constrained by the width.

The old logo was 800x272, which had ratio of roughly 65:22
New logo is 876x240, which is ratio of roughly ~~80:22 to match height as in third picture~~ 65:18 to match width to keep it like second picture but have the code be more accurate.

![image](https://user-images.githubusercontent.com/29287358/140424791-6c2ae377-9210-472f-bc7c-19e097907e2e.png)

#### Motivation for adding to Mudlet
Tim would feel bad writing up this description and taking screenshots and all that just for 2 character edit to be wasted.
#### Other info (issues closed, discussion etc)
Fix #5569 
#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
