### PR TITLE
Add: Custom right click menu items for command lines

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -53,7 +53,6 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
 , mUserDictionarySuggestionsCount()
 , mpSystemSuggestionsList()
 , mpUserSuggestionsList()
-, contextMenuItems()
 {
     setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -22,13 +22,13 @@
 
 #include "TCommandLine.h"
 
-
 #include "Host.h"
 #include "TConsole.h"
 #include "TMainConsole.h"
 #include "TSplitter.h"
 #include "TTabBar.h"
 #include "TTextEdit.h"
+#include "TEvent.h"
 #include "mudlet.h"
 
 #include "pre_guard.h"
@@ -831,15 +831,21 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
             } else {
                 popup->insertActions(separator_aboveStandardMenu, spellings_system);
             }
-            // else the word is in the dictionary - in either case show the context
+            // else the word is in the dictionary - in either ca`se show the context
             // menu - either the one with the prefixed spellings, or the standard
             // one:
         }
 
         popup->addSeparator();
         foreach(auto label, contextMenuItems.keys()) {
+            auto eventName = contextMenuItems.value(label);
             auto action = new QAction(label, this);
-            connect(action, &QAction::triggered, [=]() { contextMenuItems.value(label)(); });
+            connect(action, &QAction::triggered, [=]() {
+                TEvent event = {};
+                event.mArgumentList << eventName;
+                event.mArgumentTypeList << ARGUMENT_TYPE_STRING;
+                mpHost->raiseEvent(event);
+            });
             popup->addAction(action);
         }
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -53,6 +53,7 @@ TCommandLine::TCommandLine(Host* pHost, CommandLineType type, TConsole* pConsole
 , mUserDictionarySuggestionsCount()
 , mpSystemSuggestionsList()
 , mpUserSuggestionsList()
+, contextMenuItems()
 {
     setAutoFillBackground(true);
     setFocusPolicy(Qt::StrongFocus);
@@ -834,6 +835,13 @@ void TCommandLine::mousePressEvent(QMouseEvent* event)
             // else the word is in the dictionary - in either case show the context
             // menu - either the one with the prefixed spellings, or the standard
             // one:
+        }
+
+        popup->addSeparator();
+        foreach(auto label, contextMenuItems.keys()) {
+            auto action = new QAction(label, this);
+            connect(action, &QAction::triggered, [=]() { contextMenuItems.value(label)(); });
+            popup->addAction(action);
         }
 
         mPopupPosition = event->pos();

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -36,8 +36,6 @@ class TConsole;
 class KeyUnit;
 class Host;
 
-using CustomMenuItem = QMap<QString, std::function<void()>>;
-
 class TCommandLine : public QPlainTextEdit //QLineEdit
 {
     Q_OBJECT
@@ -77,7 +75,7 @@ public:
     QPalette mRegularPalette;
     QString mCommandLineName;
 
-    CustomMenuItem contextMenuItems;
+    QMap<QString, QString> contextMenuItems;
 
 public slots:
     void slot_popupMenu();

--- a/src/TCommandLine.h
+++ b/src/TCommandLine.h
@@ -36,6 +36,7 @@ class TConsole;
 class KeyUnit;
 class Host;
 
+using CustomMenuItem = QMap<QString, std::function<void()>>;
 
 class TCommandLine : public QPlainTextEdit //QLineEdit
 {
@@ -75,6 +76,8 @@ public:
     int mActionFunction = 0;
     QPalette mRegularPalette;
     QString mCommandLineName;
+
+    CustomMenuItem contextMenuItems;
 
 public slots:
     void slot_popupMenu();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -16028,7 +16028,7 @@ int TLuaInterpreter::addCommandLineMenu(lua_State * L)
     }
     int callback = luaL_ref(L, LUA_REGISTRYINDEX);
 
-    auto commandline = COMMANDLINE(L, commandLineName);
+    const auto& commandline = COMMANDLINE(L, commandLineName);
 
     commandline->contextMenuItems.insert(menuLabel, [=]() {
         lua_rawgeti(L, LUA_REGISTRYINDEX, callback);
@@ -16065,7 +16065,7 @@ int TLuaInterpreter::removeCommandLineMenu(lua_State * L)
     }
     auto menuLabel = getVerifiedString(L, __func__, args++, "menu label");
 
-    auto commandline = COMMANDLINE(L, commandLineName);
+    const auto& commandline = COMMANDLINE(L, commandLineName);
 
     if (commandline->contextMenuItems.remove(menuLabel) == 0) {
         lua_pushboolean(L, false);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -16017,7 +16017,7 @@ int TLuaInterpreter::addCommandLineMenu(lua_State * L)
 
     QString consoleName;
     if (argsCount == 3) {
-        consoleName = getVerifiedString(L, __func__, args++, "console name");
+        consoleName = getVerifiedString(L, __func__, args++, "window name");
     } else {
         consoleName = QStringLiteral("main");
     }
@@ -16031,7 +16031,7 @@ int TLuaInterpreter::addCommandLineMenu(lua_State * L)
 
     auto console = host.findConsole(consoleName);
     if(!console) {
-        lua_pushfstring(L, "addCommandLineMenu: bad argument #1 (no console named %s!)", consoleName.toUtf8().constData());
+        lua_pushfstring(L, "addCommandLineMenu: bad argument #1 (no window named %s!)", consoleName.toUtf8().constData());
         return lua_error(L);
     }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -164,7 +164,7 @@ static const char *bad_cmdline_value = "command line \"%s\" not found";
 
 #define COMMANDLINE(_L, _name)                                                                 \
     ({                                                                                         \
-        const QString& name_ = (_name);                                                         \
+        const QString& name_ = (_name);                                                        \
         auto console_ = getHostFromLua(_L).mpConsole;                                          \
         auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
                                     : console_->mSubCommandLineMap.value(name_);               \

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -164,7 +164,7 @@ static const char *bad_cmdline_value = "command line \"%s\" not found";
 
 #define COMMANDLINE(_L, _name)                                                                 \
     ({                                                                                         \
-        const QString name_ = (_name);                                                         \
+        const QString& name_ = (_name);                                                         \
         auto console_ = getHostFromLua(_L).mpConsole;                                          \
         auto cmdLine_ = isMain(name_) ? &*console_->mpCommandLine                              \
                                     : console_->mSubCommandLineMap.value(name_);               \

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -618,6 +618,8 @@ public:
     static int addMouseEvent(lua_State* L);
     static int removeMouseEvent(lua_State* L);
     static int getMouseEvents(lua_State* L);
+    static int addCommandLineMenu(lua_State* L);
+    static int removeCommandLineMenu(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -618,8 +618,8 @@ public:
     static int addMouseEvent(lua_State* L);
     static int removeMouseEvent(lua_State* L);
     static int getMouseEvents(lua_State* L);
-    static int addCommandLineMenu(lua_State* L);
-    static int removeCommandLineMenu(lua_State* L);
+    static int addCommandLineMenuEvent(lua_State* L);
+    static int removeCommandLineMenuEvent(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adds two functions for adding and removing command line entries.
```
addCommandLineMenuEvent([window], label, eventName)
removeCommandLineMenuEvent([window], label)
```

```lua
addCommandLineMenuEvent("My very own special paste from clipboard", "pasteFromCliboardWithoutLineBreaks" )
registerAnynomousEventListener("pasteFromCliboardWithoutLineBreaks", function()
  local text = string.gsub(getClipboardText(), "[\r|\n]", "")
  appendCmdLine(text)
end
```

#### Motivation for adding to Mudlet

Personally I need way to paste anything to console without line breaks, but I can see already some other options.
Windows do have their menus, time for command lines.

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
