### PR TITLE
Infrastructure: add 'Chancel' as an allowed codespell - it's an area in Lusternia

### DIFF
--- a/.github/codespell-wordlist.txt
+++ b/.github/codespell-wordlist.txt
@@ -20,3 +20,4 @@ ot
 curren
 sais
 keep-alives
+chancel


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
`the Chancel of Clangoran Mysteries` is a name of an area in Lusternia in the IRE mapper

#### Motivation for adding to Mudlet
Fixes this error: https://github.com/Mudlet/Mudlet/pull/5585/files#diff-def621a83fc2ea3416ff2c7395df3d26d18921c1cf68afba1e9cab1a96073e0fR10899

Allows https://github.com/Mudlet/Mudlet/pull/5587 to merge cleanly