### PR TITLE
Fix: disable more controls in preferences when there is no host

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -427,6 +427,8 @@ void dlgProfilePreferences::disableHostDetails()
     // ----- groupbox_codeEditorThemeSelection -----
     theme_download_label->hide();
 
+    groupBox_autoComplete->setEnabled(false);
+
     // ===== tab_displayColors =====
     groupBox_displayColors->setEnabled(false);
 
@@ -479,9 +481,13 @@ void dlgProfilePreferences::disableHostDetails()
 
     groupbox_searchEngineSelection->setEnabled(false);
     // ----- groupBox_debug -----
+    checkBox_expectCSpaceIdInColonLessMColorCode->setEnabled(false);
     // This acts on a label within this groupBox:
     hidePasswordMigrationLabel();
+    checkBox_debugShowAllCodepointProblems->setEnabled(false);
     widget_timerDebugOutputMinimumInterval->setEnabled(false);
+    label_networkPacketTimeout->setEnabled(false);
+    doubleSpinBox_networkPacketTimeout->setEnabled(false);
 }
 
 void dlgProfilePreferences::enableHostDetails()
@@ -524,6 +530,7 @@ void dlgProfilePreferences::enableHostDetails()
     // ===== tab_codeEditor =====
     groupbox_codeEditorThemeSelection->setEnabled(true);
 
+    groupBox_autoComplete->setEnabled(true);
 
     // ===== tab_displayColors =====
     groupBox_displayColors->setEnabled(true);
@@ -563,8 +570,11 @@ void dlgProfilePreferences::enableHostDetails()
 
     groupbox_searchEngineSelection->setEnabled(true);
     // ----- groupBox_debug -----
+    checkBox_expectCSpaceIdInColonLessMColorCode->setEnabled(true);
     widget_timerDebugOutputMinimumInterval->setEnabled(true);
     checkBox_debugShowAllCodepointProblems->setEnabled(true);
+    label_networkPacketTimeout->setEnabled(true);
+    doubleSpinBox_networkPacketTimeout->setEnabled(true);
 }
 
 void dlgProfilePreferences::initWithHost(Host* pHost)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -377,45 +377,64 @@ void dlgProfilePreferences::disableHostDetails()
 {
     // The Host pointer is a nullptr so disable every control that depends on it
 
-    // on tab_general:
+    // Controls are (or should be) sorted by tab and then group in which they appear:
+    // ===== tab_general =====
     // groupBox_iconsAndToolbars is NOT dependent on pHost - so leave it alone
+    // ----- groupBox_encoding -----
     label_encoding->setEnabled(false);
     comboBox_encoding->setEnabled(false);
+
+    // ----- groupBox_miscellaneous -----
     mAlertOnNewData->setEnabled(false);
     acceptServerGUI->setEnabled(false);
     mFORCE_SAVE_ON_EXIT->setEnabled(false);
     acceptServerMedia->setEnabled(false);
+
     groupBox_protocols->setEnabled(false);
+    // ----- groupBox_protocols -----
     need_reconnect_for_data_protocol->hide();
 
-    // on tab_inputLine:
+    groupBox_logOptions->setEnabled(false);
+    // ----- groupBox_logOptions -----
+    lineEdit_logFileName->setVisible(false);
+    label_logFileName->setVisible(false);
+    label_logFileNameExtension->setVisible(false);
+
+    // ===== tab_inputLine =====
     groupBox_input->setEnabled(false);
+
     groupBox_spellCheck->setEnabled(false);
 
-    // on tab_display:
+    // ===== tab_display =====
     groupBox_font->setEnabled(false);
+
     groupBox_borders->setEnabled(false);
+
     groupBox_wrapping->setEnabled(false);
+
     groupBox_doubleClick->setEnabled(false);
+
     // Some of groupBox_displayOptions are usable, so must pick out and
     // disable the others:
+    // ----- groupBox_displayOptions -----
     checkBox_USE_IRE_DRIVER_BUGFIX->setEnabled(false);
     checkBox_enableTextAnalyzer->setEnabled(false);
     checkBox_echoLuaErrors->setEnabled(false);
     checkBox_useWideAmbiguousEastAsianGlyphs->setEnabled(false);
-    widget_timerDebugOutputMinimumInterval->setEnabled(false);
 
-    // on tab_codeEditor:
+    // ===== tab_codeEditor =====
     groupbox_codeEditorThemeSelection->setEnabled(false);
+    // ----- groupbox_codeEditorThemeSelection -----
     theme_download_label->hide();
 
-    // on tab_displayColors:
+    // ===== tab_displayColors =====
     groupBox_displayColors->setEnabled(false);
 
-    // on tab_mapper:
+    // ===== tab_mapper =====
     // most of groupBox_mapFiles is disabled but there is ONE checkBox that
     // is accessible because it is application wide - so disable EVERYTHING
     // else that is not already disabled:
+    // ----- groupBox_mapFiles -----
     label_saveMap->setEnabled(false);
     pushButton_saveMap->setEnabled(false);
     label_loadMap->setEnabled(false);
@@ -425,79 +444,95 @@ void dlgProfilePreferences::disableHostDetails()
     comboBox_mapFileSaveFormatVersion->setEnabled(false);
     comboBox_mapFileSaveFormatVersion->clear();
     label_mapFileActionResult->hide();
-    hidePasswordMigrationLabel();
+
+    groupBox_downloadMapOptions->setEnabled(false);
+
+    groupBox_mapViewOptions->setEnabled(false);
+    // ----- groupBox_mapViewOptions -----
     label_mapSymbolsFont->setEnabled(false);
     fontComboBox_mapSymbols->setEnabled(false);
     checkBox_isOnlyMapSymbolFontToBeUsed->setEnabled(false);
     pushButton_showGlyphUsage->setEnabled(false);
 
-    groupBox_downloadMapOptions->setEnabled(false);
+
     // The above is actually normally hidden:
     groupBox_downloadMapOptions->hide();
-    groupBox_mapOptions->setEnabled(false);
+
     // This is actually normally hidden until a map is loaded:
     checkBox_showDefaultArea->hide();
 
-    // on tab_mapperColors:
+    // ===== tab_mapperColors =====
     groupBox_mapperColors->setEnabled(false);
 
-    // on groupBox_logOptions:
-    groupBox_logOptions->setEnabled(false);
-    lineEdit_logFileName->setVisible(false);
-    label_logFileName->setVisible(false);
-    label_logFileNameExtension->setVisible(false);
+    // ===== tab security =====
+    groupBox_ssl->setEnabled(false);
 
-    // on groupBox_specialOptions:
-    groupBox_specialOptions->setEnabled(false);
-
+    // ===== tab_chat =====
     groupBox_ircOptions->setEnabled(false);
-
-    need_reconnect_for_specialoption->hide();
-    groupbox_searchEngineSelection->setEnabled(false);
 
     groupBox_discordPrivacy->hide();
 
-    // tab security
-    groupBox_ssl->setEnabled(false);
+    // ===== tab_specialOptions =====
+    groupBox_specialOptions->setEnabled(false);
+    // ----- groupBox_specialOptions -----
+    need_reconnect_for_specialoption->hide();
+
+    groupbox_searchEngineSelection->setEnabled(false);
+    // ----- groupBox_debug -----
+    // This acts on a label within this groupBox:
+    hidePasswordMigrationLabel();
+    widget_timerDebugOutputMinimumInterval->setEnabled(false);
 }
 
 void dlgProfilePreferences::enableHostDetails()
 {
-    // on tab_general:
+    // ===== tab_general =====
+    // ----- groupBox_encoding -----
     label_encoding->setEnabled(true);
     comboBox_encoding->setEnabled(true);
+
+    // ----- groupBox_miscellaneous -----
     mAlertOnNewData->setEnabled(true);
     acceptServerGUI->setEnabled(true);
     mFORCE_SAVE_ON_EXIT->setEnabled(true);
     acceptServerMedia->setEnabled(true);
+
     groupBox_protocols->setEnabled(true);
 
-    // on tab_inputLine:
+    groupBox_logOptions->setEnabled(true);
+
+    // ===== tab_inputLine =====
     groupBox_input->setEnabled(true);
+
     groupBox_spellCheck->setEnabled(true);
 
-    // on tab_display:
+    // ===== tab_display =====
     groupBox_font->setEnabled(true);
+
     groupBox_borders->setEnabled(true);
+
     groupBox_wrapping->setEnabled(true);
+
     groupBox_doubleClick->setEnabled(true);
 
+    // ----- groupBox_displayOptions -----
     checkBox_USE_IRE_DRIVER_BUGFIX->setEnabled(true);
     checkBox_enableTextAnalyzer->setEnabled(true);
     checkBox_echoLuaErrors->setEnabled(true);
     checkBox_useWideAmbiguousEastAsianGlyphs->setEnabled(true);
-    widget_timerDebugOutputMinimumInterval->setEnabled(true);
 
-    // on tab_codeEditor:
+    // ===== tab_codeEditor =====
     groupbox_codeEditorThemeSelection->setEnabled(true);
 
-    // on tab_displayColors:
+
+    // ===== tab_displayColors =====
     groupBox_displayColors->setEnabled(true);
 
-    // on tab_mapper:
+    // ===== tab_mapper =====
     // most of groupBox_mapFiles is disabled but there is ONE checkBox that
-    // is accessible because it is application wide - so disable EVERYTHING
-    // else that is not already disabled:
+    // is accessible because it is application wide - so enable EVERYTHING
+    // else:
+    // ----- groupBox_mapFiles -----
     label_saveMap->setEnabled(true);
     pushButton_saveMap->setEnabled(true);
     label_loadMap->setEnabled(true);
@@ -505,27 +540,31 @@ void dlgProfilePreferences::enableHostDetails()
     label_copyMap->setEnabled(true);
     label_mapFileSaveFormatVersion->setEnabled(true);
 
-    groupBox_downloadMapOptions->setEnabled(true);
-    groupBox_mapOptions->setEnabled(true);
 
-    // on tab_mapperColors:
+    groupBox_downloadMapOptions->setEnabled(true);
+
+    groupBox_mapViewOptions->setEnabled(true);
+
+    // ===== tab_mapperColors =====
     groupBox_mapperColors->setEnabled(true);
 
-    // on tab_logging:
-    groupBox_logOptions->setEnabled(true);
-
-    // on groupBox_specialOptions:
-    groupBox_specialOptions->setEnabled(true);
-
-    groupBox_ircOptions->setEnabled(true);
-
-    groupbox_searchEngineSelection->setEnabled(true);
-
+    // ===== tab security =====
 #if defined(QT_NO_SSL)
     groupBox_ssl->setEnabled(false);
 #else
     groupBox_ssl->setEnabled(QSslSocket::supportsSsl());
 #endif
+
+    // ===== tab_chat =====
+    groupBox_ircOptions->setEnabled(true);
+
+    // ===== tab_specialOptions =====
+    groupBox_specialOptions->setEnabled(true);
+
+    groupbox_searchEngineSelection->setEnabled(true);
+    // ----- groupBox_debug -----
+    widget_timerDebugOutputMinimumInterval->setEnabled(true);
+    checkBox_debugShowAllCodepointProblems->setEnabled(true);
 }
 
 void dlgProfilePreferences::initWithHost(Host* pHost)
@@ -929,7 +968,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     }
 
     timeEdit_timerDebugOutputMinimumInterval->setTime(pHost->mTimerDebugOutputSuppressionInterval);
-    notificationArea->hide();
+    frame_notificationArea->hide();
     notificationAreaIconLabelWarning->hide();
     notificationAreaIconLabelError->hide();
     notificationAreaIconLabelInformation->hide();
@@ -953,7 +992,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             if (!pHost->mTelnet.getSslErrors().empty()) {
                 // handle ssl errors
                 notificationAreaIconLabelWarning->show();
-                notificationArea->show();
+                frame_notificationArea->show();
                 notificationAreaMessageBox->show();
                 //notificationAreaMessageBox->setText(pHost->mTelnet.errorString());
 
@@ -976,21 +1015,21 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             } else if (pHost->mTelnet.error() == QAbstractSocket::SslHandshakeFailedError) {
                 // handle failed handshake, likely not ssl socket
                 notificationAreaIconLabelError->show();
-                notificationArea->show();
+                frame_notificationArea->show();
                 notificationAreaMessageBox->show();
                 notificationAreaMessageBox->setText(pHost->mTelnet.errorString());
             }
             if (pHost->mTelnet.error() == QAbstractSocket::SslInternalError) {
                 // handle ssl library error
                 notificationAreaIconLabelError->show();
-                notificationArea->show();
+                frame_notificationArea->show();
                 notificationAreaMessageBox->show();
                 notificationAreaMessageBox->setText(pHost->mTelnet.errorString());
             }
             if (pHost->mTelnet.error() == QAbstractSocket::SslInvalidUserDataError) {
                 // handle invalid data (certificate, key, cypher, etc.)
                 notificationAreaIconLabelError->show();
-                notificationArea->show();
+                frame_notificationArea->show();
                 notificationAreaMessageBox->show();
                 notificationAreaMessageBox->setText(pHost->mTelnet.errorString());
             }
@@ -1295,7 +1334,7 @@ void dlgProfilePreferences::clearHostDetails()
     checkBox_debugShowAllCodepointProblems->setChecked(false);
 
     groupBox_ssl_certificate->hide();
-    notificationArea->hide();
+    frame_notificationArea->hide();
     groupBox_proxy->setDisabled(true);
 
     // Remove the reference to the Host/profile in the title:

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3357,7 +3357,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>Search Engine</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_groupBox_searchEngineSelection">
+         <layout class="QVBoxLayout" name="verticalLayout_searchEngineSelection">
           <item>
            <widget class="QComboBox" name="search_engine_combobox"/>
           </item>
@@ -3434,7 +3434,7 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="4" column="0" colspan="2">
            <widget class="QWidget" name="widget_timerDebugOutputMinimumInterval" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_widget_timerDebugOutputMinimumInterval" stretch="0,1">
+            <layout class="QHBoxLayout" name="horizontalLayout_timerDebugOutputMinimumInterval" stretch="0,1">
              <property name="leftMargin">
               <number>0</number>
              </property>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -684,7 +684,7 @@
          <property name="title">
           <string>Font</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout">
+         <layout class="QGridLayout" name="gridLayout_groupBox_font">
           <item row="0" column="0">
            <widget class="QLabel" name="label_30">
             <property name="text">
@@ -967,7 +967,7 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_wrap_at">
+            <layout class="QHBoxLayout" name="horizontalLayout_frame_wrap_at">
              <item>
               <widget class="QLabel" name="label_wrap_at_spinBox">
                <property name="sizePolicy">
@@ -1185,7 +1185,7 @@ you can use it but there could be issues with aligning columns of text</string>
       <attribute name="title">
        <string>Editor</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QVBoxLayout" name="verticalLayout_tab_codeEditor">
        <item>
         <widget class="QGroupBox" name="groupbox_codeEditorThemeSelection">
          <property name="title">
@@ -1206,7 +1206,7 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
             </property>
-            <layout class="QGridLayout" name="gridLayout_frame_edbeePreviewWidget">
+            <layout class="QVBoxLayout" name="verticalLayout_frame_edbeePreviewWidget">
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -1222,7 +1222,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <property name="spacing">
               <number>0</number>
              </property>
-             <item row="0" column="0">
+             <item>
               <widget class="edbee::TextEditorWidget" name="edbeePreviewWidget" native="true">
                <property name="font">
                 <font>
@@ -1267,11 +1267,11 @@ you can use it but there could be issues with aligning columns of text</string>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="groupBox_autoComplete">
          <property name="title">
           <string>Autocomplete</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <layout class="QVBoxLayout" name="verticalLayout_groupBox_autoComplete">
           <item>
            <widget class="QCheckBox" name="checkBox_autocompleteLuaCode">
             <property name="text">
@@ -1986,11 +1986,11 @@ you can use it but there could be issues with aligning columns of text</string>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_mapOptions">
+        <widget class="QGroupBox" name="groupBox_mapViewOptions">
          <property name="title">
           <string>Map view</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_groupBox_mapOptions">
+         <layout class="QGridLayout" name="gridLayout_groupBox_mapViewOptions">
           <item row="0" column="0">
            <widget class="QCheckBox" name="mMapperUseAntiAlias">
             <property name="toolTip">
@@ -2053,7 +2053,7 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="4" column="0" colspan="2">
            <widget class="QWidget" name="widget_playerRoomStyle" native="true">
-            <layout class="QGridLayout" name="gridLayout_playerRoomStyle">
+            <layout class="QGridLayout" name="gridLayout_widget_playerRoomStyle">
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -2573,7 +2573,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>IRC client options</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_groupBox_ircOptions" rowstretch="0,0">
+         <layout class="QGridLayout" name="gridLayout_groupBox_ircOptions" rowstretch="0,0,0">
           <item row="0" column="0">
            <widget class="QLabel" name="lblIrcHostName">
             <property name="text">
@@ -2742,7 +2742,7 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="toolTip">
              <string>&lt;p&gt;Mudlet will only show Rich Presence information while you use this Discord username (useful if you have multiple Discord accounts). Leave empty to show it for any Discord account you log in to.&lt;/p&gt;</string>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_discordUser">
+            <layout class="QHBoxLayout" name="horizontalLayout_widget_discordUser">
              <item>
               <widget class="QLabel" name="label_discordUserName">
                <property name="text">
@@ -2959,7 +2959,7 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
-           <widget class="QFrame" name="notificationArea">
+           <widget class="QFrame" name="frame_notificationArea">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -3003,7 +3003,7 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="midLineWidth">
              <number>3</number>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_notificationArea">
+            <layout class="QHBoxLayout" name="horizontalLayout_frame_notificationArea">
              <property name="spacing">
               <number>0</number>
              </property>
@@ -3269,7 +3269,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>Special options needed for some older game drivers (needs client restart to take effect)</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_older_game_options">
+         <layout class="QGridLayout" name="gridLayout_groupBox_specialOptions">
           <item row="0" column="0">
            <widget class="QCheckBox" name="mFORCE_MCCP_OFF">
             <property name="text">
@@ -3357,7 +3357,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>Search Engine</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_searchEngineSelection">
+         <layout class="QVBoxLayout" name="verticalLayout_groupBox_searchEngineSelection">
           <item>
            <widget class="QComboBox" name="search_engine_combobox"/>
           </item>
@@ -3434,7 +3434,7 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="4" column="0" colspan="2">
            <widget class="QWidget" name="widget_timerDebugOutputMinimumInterval" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_timerDebugOutputMinimumInterval" stretch="0,1">
+            <layout class="QHBoxLayout" name="horizontalLayout_widget_timerDebugOutputMinimumInterval" stretch="0,1">
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -3511,7 +3511,7 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item row="6" column="0">
-           <widget class="QLabel" name="label_networkPackerTimeout">
+           <widget class="QLabel" name="label_networkPacketTimeout">
             <property name="text">
              <string>Additional text wait time:</string>
             </property>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Some knobs (and their labels) were not being disabled if the preferences dialogue was opened without a profile being loaded.

#### Other info (issues closed, discussion etc)
The first part is preparation work to make it easier to keep track of which things are being worked on in the future  - and to help spot elements that are missing. The second is the actual changes for this PR.

It also renames some elements on the form, either to have less generic names and be more identifyable - or to make them conform to patterns used for other elements:
* `(QGridLayout) gridLayout` ==> `gridLayout_groupBox_font`
* `(QHBoxLayout) horizontalLayout_wrap_at` ==> `horizontalLayout_frame_wrap_at`
* `(QVBoxLayout) verticalLayout_3` ==> `verticalLayout_tab_codeEditor`
* `(QGroupBox) groupBox` ==> `groupBox_autoComplete`
* `(QVBoxLayout) verticalLayout_4` ==> `verticalLayout_groupBox_autoComplete`
* `(QGroupBox) groupBox_mapOptions` ==> `groupBox_mapViewOptions`
* `(QGridLayout) gridLayout_groupBox_mapOptions` ==> `gridLayout_groupBox_mapViewOptions`
* `(QGridLayout) gridLayout_playerRoomStyle` ==> `gridLayout_widget_playerRoomStyle`
* `(QHBoxLayout) horizontalLayout_discordUser` ==> `horizontalLayout_widget_discordUser`
* `(QFrame) notificationArea` ==> `frame_notificationArea`
* `(QHBoxLayout) horizontalLayout_notificationArea` ==> `horizontalLayout_frame_notificationArea`
* `(QGridLayout) gridLayout_older_game_options` ==> `gridLayout_groupBox_specialOptions`
* `(QVBoxLayout) verticalLayout_searchEngineSelection` ==> `verticalLayout_groupBox_searchEngineSelection`
* `(QHBoxLayout) horizontalLayout_timerDebugOutputMinimumInterval` ==> `horizontalLayout_widget_timerDebugOutputMinimumInterval`

Also one single element layout was converted from a QGridLayout to a (simpler to administer) `QVBoxLayout`
* `(QGridLayout) gridLayout_frame_edbeePreviewWidget`  ==> `(QVBoxLayout) verticalLayout_frame_edbeePreviewWidget`

Also renmame a control that was misspelt:
* `(QLabel) label_networkPackerTimeout` ==> `label_networkPacketTimeout`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Some settings' controls that only work when there is a profile active are now correctly disabled when there isn't one.