### PR TITLE
Fix: correct a missing `override` that showed up during CI

### DIFF
--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -55,7 +55,7 @@ public:
     bool showWindow(const QString& name);
     bool hideWindow(const QString& name);
     bool printWindow(const QString& name, const QString& text);
-    void setProfileName(const QString&);
+    void setProfileName(const QString&) override;
     void selectCurrentLine(std::string&);
     std::list<int> getFgColor(std::string& buf);
     std::list<int> getBgColor(std::string& buf);


### PR DESCRIPTION
Specifically:
src/TMainConsole.h#L58

'setProfileName' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight

None.