### PR TITLE
Infrastructure: update PCRE download source to one that still exists

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -289,9 +289,9 @@ function InstallLua() {
 }
 
 function InstallPcre() {
-  DownloadFile "https://ftp.pcre.org/pub/pcre/pcre-8.43.zip" "pcre.zip"
+  DownloadFile "https://deac-fra.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip" "pcre.zip"
   ExtractZip "pcre.zip" "pcre"
-  Set-Location pcre\pcre-8.43
+  Set-Location pcre\pcre-8.45
   RunConfigure "--enable-utf --enable-unicode-properties --prefix=$Env:MINGW_BASE_DIR_BASH"
   RunMake
   RunMakeInstall


### PR DESCRIPTION
The original "Official" site is no longer serving the old version 8.x library up - instead they now point downloaders to an unoffical Source Forge listing - it is not clear whether the particular URL I have put in is a mirror that happened to be selected for me based on my geo-locaation, this might not be optimum but it should at least work - to allow Windows CI builds to resume.

As it happens this also brings in two minor version increments in the library version from 8.43 to 8.45 though this library is now believed to be frozen for any development.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>