### PR TITLE
Infrastructure: disable Windows builds in GHA

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -40,11 +40,11 @@ jobs:
             compiler: clang_64
             qt: '5.14.2'
             deploy: 'deploy'
-          - os: windows-2019
-            buildname: 'windows'
-            triplet: x64-mingw-dynamic
-            # compiler: flag not used in windows pipeline
-            qt: '5.14.2'
+#          - os: windows-2019
+#            buildname: 'windows'
+#            triplet: x64-mingw-dynamic
+#            # compiler: flag not used in windows pipeline
+#            qt: '5.14.2'
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable Windows builds in GHA
#### Motivation for adding to Mudlet
Broken due to PCRE dropping FTP
#### Other info (issues closed, discussion etc)
Requires an update to vcpkg submodule to fix. Disabling for the time being as this build is not strictly necessary and we can do with less red X's.
