### PR TITLE
Infrastructure: Add 'nd' as an allowed word - Chinese games have 'northdown' exits

### DIFF
--- a/.github/codespell-wordlist.txt
+++ b/.github/codespell-wordlist.txt
@@ -21,3 +21,4 @@ curren
 sais
 keep-alives
 chancel
+nd


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add 'nd' as an allowed word - Chinese games have 'northdown' exits

![image](https://user-images.githubusercontent.com/110988/140899445-ed631391-9d88-4837-8adb-56172fca2f4c.png)
