### PR TITLE
Fix: added missing space in telnet negotiation warning

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2891,7 +2891,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
                         if (!mIncompleteSB) {
                             mIncompleteSB = true;
                             qWarning(R"("TELNET: the server did not properly complete a subnegotiation (code %02x).
-Some data loss is likely - please mention this problem to the game admins.)",command[2]);
+Some data loss is likely - please mention this problem to the game admins.)", command[2]);
                         }
 
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix missing space in telnet negotiation warning
#### Motivation for adding to Mudlet
So CodeFactor is happy