### PR TITLE
fix buttontoolbar resizing on start

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -543,6 +543,11 @@ void ActionUnit::updateToolbar()
 {
     //get the non-thread safe functions to always execute in the main thread
     //solution from https://stackoverflow.com/questions/21646467/how-to-execute-a-functor-or-a-lambda-in-a-given-thread-in-qt-gcd-style/21653558#21653558
-    QTimer::singleShot(0, qApp, [=]() { getToolBarList(); });
-    QTimer::singleShot(0, qApp, [=]() { getEasyButtonBarList(); });
+    if (qApp->thread() == QThread::currentThread()) {
+        getToolBarList();
+        getEasyButtonBarList();
+    } else {
+        QTimer::singleShot(0, qApp, [=]() { getToolBarList(); });
+        QTimer::singleShot(0, qApp, [=]() { getEasyButtonBarList(); });
+    }
 }

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -541,13 +541,6 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 
 void ActionUnit::updateToolbar()
 {
-    //get the non-thread safe functions to always execute in the main thread
-    //solution from https://stackoverflow.com/questions/21646467/how-to-execute-a-functor-or-a-lambda-in-a-given-thread-in-qt-gcd-style/21653558#21653558
-    if (qApp->thread() == QThread::currentThread()) {
         getToolBarList();
         getEasyButtonBarList();
-    } else {
-        QTimer::singleShot(0, qApp, [=]() { getToolBarList(); });
-        QTimer::singleShot(0, qApp, [=]() { getEasyButtonBarList(); });
-    }
 }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -533,7 +533,7 @@ void Host::waitForAsyncXmlSave()
     }
 }
 
-void Host::saveModules(int sync, bool backup)
+void Host::saveModules(bool backup)
 {
     QMapIterator<QString, QStringList> it(modulesToWrite);
     mModulesToSync.clear();
@@ -557,10 +557,6 @@ void Host::saveModules(int sync, bool backup)
         }
     }
     modulesToWrite.clear();
-    // reload, or queue module reload for when xml is ready
-    if (sync) {
-        reloadModules();
-    }
 }
 
 void Host::reloadModules()
@@ -639,8 +635,8 @@ void Host::reloadModule(const QString& syncModuleName, const QString& syncingFro
     //Wait till profile is finished saving
     if (syncingFromHost.isEmpty() && currentlySavingProfile()) {
         //create a dummy object to singleshot connect (disconnect/delete after execution)
-        QObject *obj = new QObject(this);
-        connect(this, &Host::profileSaveFinished, obj, [=](){
+        QObject* obj = new QObject(this);
+        connect(this, &Host::profileSaveFinished, obj, [=]() {
             reloadModule(syncModuleName);
             obj->deleteLater();
         });
@@ -666,7 +662,7 @@ void Host::reloadModule(const QString& syncModuleName, const QString& syncingFro
                 fileName = mudlet::getMudletPath(mudlet::profilePackagePathFileName, mHostName, moduleName);
                 auto writer = new XMLexport(this);
                 writers.insert(fileName, writer);
-                writer->writeModuleXML(moduleName, fileName);
+                writer->writeModuleXML(moduleName, fileName, true);
             } else {
                 uninstallPackage(moduleName, 2);
                 installPackage(fileName, 2);
@@ -814,9 +810,15 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     mModuleFuture = QtConcurrent::run([=]() {
         //wait for the host xml to be ready before starting to sync modules
         waitForAsyncXmlSave();
-        saveModules(syncModules ? 1 : 0, saveName != QStringLiteral("autosave"));
+        saveModules(saveName != QStringLiteral("autosave"));
     });
-    QObject::connect(watcher, &QFutureWatcher<void>::finished, this, [=]() { mWritingHostAndModules = false; });
+    QObject::connect(watcher, &QFutureWatcher<void>::finished, this, [=]() {
+        // reload, or queue module reload for when xml is ready
+        if (syncModules) {
+            reloadModules();
+        }
+        mWritingHostAndModules = false;
+    });
     watcher->setFuture(mModuleFuture);
     return std::make_tuple(true, filename_xml, QString());
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -652,7 +652,7 @@ private:
     static void createModuleBackup(const QString &filename, const QString& saveName);
     void writeModule(const QString &moduleName, const QString &filename);
     void waitForAsyncXmlSave();
-    void saveModules(int sync, bool backup = true);
+    void saveModules(bool backup = true);
     void updateModuleZips(const QString &zipName, const QString &moduleName);
     void reloadModules();
 

--- a/src/XMLexport.h
+++ b/src/XMLexport.h
@@ -65,7 +65,7 @@ public:
     void writeScript(TScript*, pugi::xml_node xmlParent);
     void writeKey(TKey*, pugi::xml_node xmlParent);
     void writeVariable(TVar*, LuaInterface*, VarUnit*, pugi::xml_node xmlParent);
-    void writeModuleXML(const QString& moduleName, const QString& fileName);
+    void writeModuleXML(const QString& moduleName, const QString& fileName, bool async = false);
 
     void exportHost(const QString& filename_pugi_xml);
     bool writeGenericPackage(Host* pHost, pugi::xml_node& mMudletPackage, bool ignoreModuleMember = true);


### PR DESCRIPTION
#### Brief overview of PR changes/additions

When making syncing mpackage/xml modules asynchronous there was an issue with updating the button toolbar, as it can create issues (and is just wrong) to update gui elements from another thread.

I took a solution from https://stackoverflow.com/questions/21646467/how-to-execute-a-functor-or-a-lambda-in-a-given-thread-in-qt-gcd-style/21653558#21653558 to fix that problem by using a Timer set to 0 and executing in the main thread, but that seems to cause an issue when the toolbar has to be updated directly from the main thread.

So I decided to run the whole reloadModule function in the main thread to prevent this and other issues with calling gui elements from another thread.

This shouldn't make module syncing much slower (or hang mudlet) as the slowest functions (writing backups, zipping, writing module xmls) still run in another thread.

#### Motivation for adding to Mudlet
fix #5626 and a few other issues
#### Other info (issues closed, discussion etc)

#### Release post highlight
fix issue with button-toolbar on start