### PR TITLE
Infrastructure: Add Danger-friendly label to dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    commit-message:
+      prefix: "Infrastructure:"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
@@ -13,3 +15,5 @@ updates:
     ignore:
       # ignore vcpkg as it is updated often, and this goes off commits, not releases
       - dependency-name: "3rdparty/vcpkg"
+    commit-message:
+      prefix: "Infrastructure:"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Infrastructure: Add Danger-friendly label to dependabot commits
#### Motivation for adding to Mudlet
Make changelog generation happy
#### Other info
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message