### PR TITLE
Add Asteria as a known game with Discord Rich Presence

### DIFF
--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -58,7 +58,8 @@ Discord::Discord(QObject* parent)
               {"starmourn", {"starmourn.com"}},
               {"stickmud", {"stickmud.com"}},
               {"clessidra", {"clessidra.it", "mud.clessidra.it"}},
-              {"mume", {"mume.org"}}
+              {"mume", {"mume.org"}},
+              {"asteria", {"asteriamud.com"}},
             }
 {
 #if defined(Q_OS_WIN64)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add Asteria as a known game with Discord Rich Presence
#### Motivation for adding to Mudlet
So players don't have to connect to a profile first before being able to enable Discord support