### PR TITLE
Infrastructure: update to latest vcpkg for PCRE FTP fix

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -40,11 +40,11 @@ jobs:
             compiler: clang_64
             qt: '5.14.2'
             deploy: 'deploy'
-#          - os: windows-2019
-#            buildname: 'windows'
-#            triplet: x64-mingw-dynamic
-#            # compiler: flag not used in windows pipeline
-#            qt: '5.14.2'
+          - os: windows-2019
+            buildname: 'windows'
+            triplet: x64-mingw-dynamic
+            # compiler: flag not used in windows pipeline
+            qt: '5.14.2'
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
update to latest vcpkg for PCRE FTP download location fix.
#### Motivation for adding to Mudlet
So we can re-enable Windows builds in GHA again.
#### Other info
https://github.com/microsoft/vcpkg/issues/21201