### PR TITLE
fix faulty regular expression error message

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -266,7 +266,7 @@ void TAlias::compileRegex()
             TDebug(Qt::white, Qt::red) << "REGEX ERROR: failed to compile, reason:\n" << error << "\n" >> mpHost;
             TDebug(Qt::red, Qt::gray) << TDebug::csmContinue << R"(in: ")" << mRegexCode << "\"\n" >> mpHost;
         }
-        setError(QStringLiteral("<b><font color='blue'>%1</font></b>").arg(tr(R"(Error: in "Pattern:", faulty regular expression, reason: "%1".)", error)));
+        setError(QStringLiteral("<b><font color='blue'>%1</font></b>").arg(tr(R"(Error: in "Pattern:", faulty regular expression, reason: "%1".)").arg(error)));
     } else {
         mOK_init = true;
     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Alias editing window has an error message if you make faulty regular expression, and it shows `%1` instead of intended message.  Parentheses got mixed up in #1018.
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
![image](https://user-images.githubusercontent.com/29287358/142222697-a358b973-a5be-40a7-886e-e22c20128716.png)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
