### PR TITLE
Add IDManager.lua to mudlet.pro

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -880,6 +880,7 @@ LUA.files = \
     $${PWD}/mudlet-lua/lua/DebugTools.lua \
     $${PWD}/mudlet-lua/lua/GMCP.lua \
     $${PWD}/mudlet-lua/lua/GUIUtils.lua \
+    $${PWD}/mudlet-lua/lua/IDManager.lua \
     $${PWD}/mudlet-lua/lua/KeyCodes.lua \
     $${PWD}/mudlet-lua/lua/TTSValues.lua \
     $${PWD}/mudlet-lua/lua/LuaGlobal.lua \


### PR DESCRIPTION
Fixes buiding with qmake, otherwise IDManager.lua does not get installed with the rest of mudlet-lua files. 