### PR TITLE
Fix ansi2decho to respect custom colors

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1759,11 +1759,11 @@ function ansi2decho(text, ansi_default_color)
       return color_table[ansi] or false
     end
     local colours = {}
-    for i=0,7 do
+    for i = 0, 7 do
       colours[i] = convertindex(i)
     end
     local lightColours = {}
-    for i=0,7 do
+    for i = 0, 7 do
       lightColours[i] = convertindex(i+8)
     end
     local coloursToUse = colours

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -50,10 +50,10 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
 
     it("Should match the user's custom colours if they've changed them", function()
-      color_table.ansi_000 = {0,0,1}
+      color_table.ansi_000 = { 0, 0, 1 }
       local expected = "<0,0,1>"
       local actual = ansi2decho("\27[30m", "<0,0,0>")
-      color_table.ansi_000= {0,0,0}
+      color_table.ansi_000= { 0, 0, 0 }
       assert.are.same(expected, actual)
     end)
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -49,6 +49,14 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       end
     end)
 
+    it("Should match the user's custom colours if they've changed them", function()
+      color_table.ansi_000 = {0,0,1}
+      local expected = "<0,0,1>"
+      local actual = ansi2decho("\27[30m", "<0,0,0>")
+      color_table.ansi_000= {0,0,0}
+      assert.are.same(expected, actual)
+    end)
+
     it("Should combine tags correctly", function()
       local sequences = {
         {"\27[0;30m", "<r><0,0,0>"},


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Changes ansi2decho to look up the ansi colors from color_table, since we have the colors from 0-255 defined there already. This also ensures ansi2decho respects any custom configuration done by the user in settings->colorview

#### Motivation for adding to Mudlet

More consistent experience.

#### Other info (issues closed, discussion etc)

Fixes https://github.com/Mudlet/Mudlet/issues/5667
Also adds a test to make sure the colors Mudlet fills the color_table with match the output to prevent regression.
