### PR TITLE
Improvement: c/d/hecho now support strikethrough

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -981,11 +981,11 @@ if rex then
   _Echos = {
     Patterns = {
       Hex = {
-        [[(\x5c?(?:#|\|c)?(?:[0-9a-fA-F]{6}|(?:#,|\|c,)[0-9a-fA-F]{6,8})(?:,[0-9a-fA-F]{6,8})?)|(?:\||#)(\/?[biru])]],
+        [[(\x5c?(?:#|\|c)?(?:[0-9a-fA-F]{6}|(?:#,|\|c,)[0-9a-fA-F]{6,8})(?:,[0-9a-fA-F]{6,8})?)|(?:\||#)(\/?[birus])]],
         rex.new [[(?:#|\|c)(?:([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2}))?(?:,([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?)?]],
       },
       Decimal = {
-        [[(<[0-9,:]+>)|<(/?[biru])>]],
+        [[(<[0-9,:]+>)|<(/?[birus])>]],
         rex.new [[<(?:([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}))?(?::(?=>))?(?::([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),?([0-9]{1,3})?)?>]],
       },
       Color = {
@@ -1029,6 +1029,10 @@ if rex then
           t[#t + 1] = "\27underline"
         elseif r == "/u" then
           t[#t + 1] = "\27underlineoff"
+        elseif r == "s" then
+          t[#t + 1] = "\27strikethrough"
+        elseif r == "/s" then
+          t[#t + 1] = "\27strikethroughoff"
         end
         if c then
           if style == 'Hex' or style == 'Decimal' then
@@ -1078,6 +1082,10 @@ if rex then
               t[#t + 1] = "\27underline"
             elseif c == "</u>" then
               t[#t + 1] = "\27underlineoff"
+            elseif c == "<s>" then
+              t[#t + 1] = "\27strikethrough"
+            elseif c == "</s>" then
+              t[#t + 1] = "\27strikethroughoff"
             else
               local fcolor, bcolor = _Echos.Patterns[style][2]:match(c)
               local color = {}
@@ -1188,6 +1196,10 @@ if rex then
         setUnderline(win, true)
       elseif v == "\27underlineoff" then
         setUnderline(win, false)
+      elseif v == "\27strikethrough" then
+        setStrikeOut(win, true)
+      elseif v == "\27strikethroughoff" then
+        setStrikeOut(win, false)
       elseif v == "\27reset" then
         resetFormat(win)
       else

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -296,6 +296,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
         _Echos.Process('#uUnderline#/u', 'Hex'),
         { "", "\27underline", "Underline", "\27underlineoff", "" }
       )
+
+      assert.are.same(
+        _Echos.Process('#sStrikethrough#/s', 'Hex'),
+        { "", "\27strikethrough", "Strikethrough", "\27strikethroughoff", "" }
+      )
     end)
 
     it("Should parse decimal patterns correctly", function()
@@ -323,6 +328,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
         _Echos.Process('<u>Underline</u>', 'Decimal'),
         { "", "\27underline", "Underline", "\27underlineoff", "" }
       )
+
+      assert.are.same(
+        _Echos.Process('<s>Strikethrough</s>', 'Decimal'),
+        { "", "\27strikethrough", "Strikethrough", "\27strikethroughoff", "" }
+      )
     end)
 
     it("Should parse color patterns correctly", function()
@@ -349,6 +359,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.are.same(
         _Echos.Process('<u>Underline</u>', 'Color'),
         { "", "\27underline", "Underline", "\27underlineoff", "" }
+      )
+
+      assert.are.same(
+        _Echos.Process('<s>Strikethrough</s>', 'Color'),
+        { "", "\27strikethrough", "Strikethrough", "\27strikethroughoff", "" }
       )
     end)
   end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions

While improving ansi2decho to support italics, underline, and strikethrough I realized that the xEcho driven functions did not yet support strikethrough. 

#### Motivation for adding to Mudlet

Support more options

#### Other info (issues closed, discussion etc)

