### PR TITLE
Improvement: ansi2decho now supports italics, underline, and strikethrough

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1824,6 +1824,30 @@ function ansi2decho(text, ansi_default_color)
       elseif code == "22" then
         -- not light or bold
         coloursToUse = colours
+      elseif code == "3" then
+        -- italics, but we set isColorCode to true to avoid repeating the fg color below
+        isColorCode = true
+        output[#output+1] = "<i>"
+      elseif code == "23" then
+        -- turn off italics
+        isColorCode = true
+        output[#output+1] = "</i>"
+      elseif code == "4" then
+        -- underline
+        isColorCode = true
+        output[#output+1] = "<u>"
+      elseif code == "24" then
+        -- turn off underline
+        isColorCode = true
+        output[#output+1] = "</u>"
+      elseif code == "9" then
+        -- strikethrough
+        isColorCode = true
+        output[#output+1] = "<s>"
+      elseif code == "29" then
+        -- turn off strikethrough
+        isColorCode = true
+        output[#output+1] = "</s>"
       else
         isColorCode = true
         local layerCode = floor(code / 10)  -- extract the "layer": 3 is fore

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -64,6 +64,27 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       end
     end)
 
+    it("Should handle italics", function()
+      local sample = "\27[3mitalics\27[23m"
+      local expected = "<i>italics</i>"
+      local actual = ansi2decho(sample)
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle underline", function()
+      local sample = "\27[4munderline\27[24m"
+      local expected = "<u>underline</u>"
+      local actual = ansi2decho(sample)
+      assert.equals(expected, actual)
+    end)
+
+    it("Should handle strikethrough", function()
+      local sample = "\27[9mstrikethrough\27[29m"
+      local expected = "<s>strikethrough</s>"
+      local actual = ansi2decho(sample)
+      assert.equals(expected, actual)
+    end)
+
     it("Should leave normal text and other escape sequences alone", function()
       local sequences = {
         {"Hello World", "Hello World"},


### PR DESCRIPTION
#### Brief overview of PR changes/additions

While working on color consistency for ansi2decho I realized that we hadn't updated the support for the additional text modifiers supported by decho now. This fixes that

#### Motivation for adding to Mudlet

Better support and more consistency

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
