### PR TITLE
Fix: correct placement of const in a function declaration/definition

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -441,7 +441,7 @@ public:
     };
     Appearance mAppearance = Appearance::system;
     void setAppearance(Appearance, const bool& loading = false);
-    const bool inDarkMode() { return mDarkMode; };
+    bool inDarkMode() const { return mDarkMode; }
 
     // mirror everything shown in any console to stdout. Helpful for CI environments
     inline static bool mMirrorToStdOut;


### PR DESCRIPTION
As this was in the `mudlet` class header file and it produced a warning each time it was included in a class this produced a lot of warnings!

Also remove a redundant semi-colon in the same line.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
None - just an internal clean-up.