### PR TITLE
Infrastructure: prevent unwanted and unneeded copying of an item in a container

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11191,7 +11191,7 @@ int TLuaInterpreter::ttsSpeak(lua_State* L)
     }
 
     std::vector<QString> dontSpeak = {"<", ">", "&lt;", "&gt;"}; // discussion: https://github.com/Mudlet/Mudlet/issues/4689
-    for (const QString dropThis : dontSpeak) {
+    for (const QString& dropThis : dontSpeak) {
         if (textToSay.contains(dropThis)) {
             textToSay.replace(dropThis, QString());
             if (mudlet::debugMode) {
@@ -11468,7 +11468,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
     }
 
     std::vector<QString> dontSpeak = {"<", ">", "&lt;", "&gt;"}; // discussion: https://github.com/Mudlet/Mudlet/issues/4689
-    for (const QString dropThis : dontSpeak) {
+    for (const QString& dropThis : dontSpeak) {
         if (inputText.contains(dropThis)) {
             inputText.replace(dropThis, QString());
             if (mudlet::debugMode) {


### PR DESCRIPTION
This was provoking a warning in two places that could be fixed by converting from using a value to using a reference to that value.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
None - I think this is just an internal clean-up.