### PR TITLE
Improve: do not try loading or saving password securely when storing them portably

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2700,7 +2700,6 @@ void Host::setDisplayFontFixedPitch(bool enable)
     mDisplayFont.setFixedPitch(enable);
 }
 
-// Only used in the constructor - and only when passwords are stored securely
 void Host::loadSecuredPassword()
 {
     auto *job = new QKeychain::ReadPasswordJob(QStringLiteral("Mudlet profile"));

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -460,7 +460,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     }
 
     if (mudlet::self()->storingPasswordsSecurely()) {
-        // This will not insert the password into the mPass member immediately:
         loadSecuredPassword();
     } else {
         QString password{readProfileData(QStringLiteral("password"))};
@@ -2713,7 +2712,6 @@ void Host::loadSecuredPassword()
     connect(job, &QKeychain::ReadPasswordJob::finished, this, [=](QKeychain::Job* job) {
         if (job->error()) {
             const auto error = job->errorString();
-            // Report to debug output the problem if it was something other than the password not being found
             if (error != QStringLiteral("Entry not found") && error != QStringLiteral("No match")) {
                 qDebug().nospace().noquote() << "Host::loadSecuredPassword() ERROR - could not retrieve secure password for \"" << getName() << "\", error is: " << error << ".";
             }

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -338,7 +338,6 @@ void dlgConnectionProfiles::writeSecurePassword(const QString& profile, const QS
     job->start();
 }
 
-// Only used by migrateSecuredPassword(...)
 void dlgConnectionProfiles::deleteSecurePassword(const QString& profile) const
 {
     auto* job = new QKeychain::DeletePasswordJob(QStringLiteral("Mudlet profile"));
@@ -1238,8 +1237,6 @@ void dlgConnectionProfiles::setCustomIcon(const QString& profileName, QListWidge
 }
 
 // When a profile is renamed, migrate password storage to the new profile.
-// This is only used by slot_save_name(...) and that now only when passwords
-// are stored securely:
 void dlgConnectionProfiles::migrateSecuredPassword(const QString& oldProfile, const QString& newProfile)
 {
     const auto& password = character_password_entry->text().trimmed();
@@ -1263,7 +1260,6 @@ void dlgConnectionProfiles::loadSecuredPassword(const QString& profile, L callba
         if (job->error()) {
             const auto error = job->errorString();
             if (error != QStringLiteral("Entry not found") && error != QStringLiteral("No match")) {
-                // Report to debug output the problem if it was something other than a couple of 'normal' failure mechanisms:
                 qDebug().nospace().noquote() << "dlgConnectionProfiles::loadSecuredPassword() ERROR - could not retrieve secure password for \"" << profile << "\", error is: " << error << ".";
             }
 

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1236,7 +1236,7 @@ void dlgConnectionProfiles::setCustomIcon(const QString& profileName, QListWidge
     profile->setIcon(icon);
 }
 
-// When a profile is renamed, migrate password storage to the new profile.
+// When a profile is renamed, migrate password storage to the new profile
 void dlgConnectionProfiles::migrateSecuredPassword(const QString& oldProfile, const QString& newProfile)
 {
     const auto& password = character_password_entry->text().trimmed();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3804,7 +3804,7 @@ void mudlet::slot_password_migrated_to_secure(QKeychain::Job* job)
 bool mudlet::migratePasswordsToProfileStorage()
 {
     if (!mProfilePasswordsToMigrate.isEmpty()) {
-        qWarning() << "mudlet::migratePasswordsToProfileStorage() WARMING - password migration is already in progress, so not starting a duplicate action.";
+        qWarning() << "mudlet::migratePasswordsToProfileStorage() WARNING - password migration is already in progress, so not starting a duplicate action.";
         return false;
     }
     mStorePasswordsSecurely = false;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3804,7 +3804,7 @@ void mudlet::slot_password_migrated_to_secure(QKeychain::Job* job)
 bool mudlet::migratePasswordsToProfileStorage()
 {
     if (!mProfilePasswordsToMigrate.isEmpty()) {
-        qWarning() << "mudlet::migratePasswordsToProfileStorage() warning: password migration is already in progress, won't start another.";
+        qWarning() << "mudlet::migratePasswordsToProfileStorage() WARMING - password migration is already in progress, so not starting a duplicate action.";
         return false;
     }
     mStorePasswordsSecurely = false;
@@ -3838,8 +3838,9 @@ void mudlet::slot_password_migrated_to_profile(QKeychain::Job* job)
     if (job->error()) {
         const auto error = job->errorString();
         if (error != QStringLiteral("Entry not found") && error != QStringLiteral("No match")) {
-            qWarning() << "mudlet::slot_password_migrated_to_profile ERROR: couldn't migrate for" << profileName << "; error was:" << error;
+            qWarning().nospace().noquote() << "mudlet::slot_password_migrated_to_profile(...) ERROR - could not migrate for \"" << profileName << "\"; error was: " << error << ".";
         }
+
     } else {
         auto readJob = static_cast<QKeychain::ReadPasswordJob*>(job);
         writeProfileData(profileName, QStringLiteral("password"), readJob->textData());


### PR DESCRIPTION
I was annoyed by all the error messages - both on command line from Mudlet itself and also from (on Linux/FreeBSD) the "wallet" system about not finding passwords from the secure storage system when I have explicitly said that Mudlet is to use the (insecure) PORTABLE method. It is worth noting that the second type of warnings (from the DE/OS) can be highly noticeably as they are popups that require clicking to dismiss them!

I also took the liberty of tweaking related command line debugging texts to be formatted slightly differently so that they matched the format I now tend to use: `class::method_name(...) WORD - text.` with terminal punctuation; insertion of double quotes around strings; and spaces as required manually rather than letting the Qt `QDebug` class doing it on every element of a
message.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Should no longer cause OS/DE warnings about missing passwords in "Wallet"/"Keyring" systems on some Linux/FreeBSD desktops when the user has selected ***Portable* password storage**

##### Note to self: fix spellings in commit message when squash/merging PR of:
* noticably (noticeably)
* punctation (punctuation)