### PR TITLE
Fix the label for dark theme

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -262,7 +262,7 @@
           <item row="0" column="0">
            <widget class="QLabel" name="label_appearance">
             <property name="text">
-             <string>Use a dark theme</string>
+             <string>Appearance</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix the label for dark theme to say `Appearance`: system/light/dark as it should have.
#### Motivation for adding to Mudlet
So it makes more sense.