### PR TITLE
Add color `echo aliases for testing triggers

### DIFF
--- a/src/echo.xml
+++ b/src/echo.xml
@@ -26,6 +26,28 @@ echo("\n")</script>
 			<packageName></packageName>
 			<regex>`cecho (.+)</regex>
 		</Alias>
+		<Alias isActive="yes" isFolder="no">
+			<name>`decho</name>
+			<script>local s = matches[2]
+
+s = string.gsub(s, "%$", "\n")
+dfeedTriggers("\n" .. s .. "\n")
+echo("\n")</script>
+			<command></command>
+			<packageName></packageName>
+			<regex>`decho (.+)</regex>
+		</Alias>
+		<Alias isActive="yes" isFolder="no">
+			<name>`hecho</name>
+			<script>local s = matches[2]
+
+s = string.gsub(s, "%$", "\n")
+hfeedTriggers("\n" .. s .. "\n")
+echo("\n")</script>
+			<command></command>
+			<packageName></packageName>
+			<regex>`hecho (.+)</regex>
+		</Alias>
 	</AliasPackage>
 	<ActionPackage />
 	<ScriptPackage />

--- a/src/echo.xml
+++ b/src/echo.xml
@@ -1,16 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE MudletPackage>
-<MudletPackage version="1.0">
-    <AliasPackage>
-        <Alias isActive="yes" isFolder="no">
-            <name>`echo</name>
-            <script>local s = matches[2]
+<MudletPackage version="1.001">
+	<TriggerPackage />
+	<TimerPackage />
+	<AliasPackage>
+		<Alias isActive="yes" isFolder="no">
+			<name>`echo</name>
+			<script>local s = matches[2]
 
-s = string.gsub(s, &quot;%$&quot;, &quot;\n&quot;)
-feedTriggers(&quot;\n&quot; .. s .. &quot;\n&quot;)
-echo(&quot;\n&quot;)</script>
-            <command></command>
-            <regex>`echo (.+)</regex>
-        </Alias>
-    </AliasPackage>
+s = string.gsub(s, "%$", "\n")
+feedTriggers("\n" .. s .. "\n")
+echo("\n")</script>
+			<command></command>
+			<packageName></packageName>
+			<regex>`echo (.+)</regex>
+		</Alias>
+		<Alias isActive="yes" isFolder="no">
+			<name>`cecho</name>
+			<script>local s = matches[2]
+
+s = string.gsub(s, "%$", "\n")
+cfeedTriggers("\n" .. s .. "\n")
+echo("\n")</script>
+			<command></command>
+			<packageName></packageName>
+			<regex>`cecho (.+)</regex>
+		</Alias>
+	</AliasPackage>
+	<ActionPackage />
+	<ScriptPackage />
+	<KeyPackage />
+	<HelpPackage>
+		<helpURL></helpURL>
+	</HelpPackage>
 </MudletPackage>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds \`cecho, \`decho, and \`hecho aliases for more easily testing triggers with color or bold/underline/etc components.

#### Motivation for adding to Mudlet
More featureful testing of features

#### Other info (issues closed, discussion etc)
Alternately, we could consider using cfeedTriggers or dfeedTriggers for the main \`echo alias, since it would only be adding functionality. An argument against that could be if you were expecting `<b>` to actually go through but it didn't because cfeedTriggers consumed it, for example. 

Either way I think we need at least one alias in this package that can include colors and the like.

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
