### PR TITLE
Fix: windowvista and Mactintosh styles not colouring PushButtons (again)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -487,7 +487,7 @@ int main(int argc, char* argv[])
         QFile::link(homeDirectory, homeLink);
     }
 #endif
-    app->setStyle(new AltFocusMenuBarDisable);
+
     mudlet::start();
 
     if (first_launch) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -267,14 +267,16 @@ mudlet::mudlet()
     }
 
     qApp->setAttribute(Qt::AA_UseHighDpiPixmaps);
-    setAppearance(mAppearance, true);
+    // We need to record this before we clobber it with our own substitute...
     mDefaultStyle = qApp->style()->objectName();
+    // ... which is applied here:
+    setAppearance(mAppearance, true);
 
     scanForMudletTranslations(QStringLiteral(":/lang"));
     scanForQtTranslations(getMudletPath(qtTranslationsPath));
     loadTranslators(mInterfaceLanguage);
 
-  if (QStringList{"windowsvista", "macintosh"}.contains(mDefaultStyle, Qt::CaseInsensitive)) {
+    if (QStringList{"windowsvista", "macintosh"}.contains(mDefaultStyle, Qt::CaseInsensitive)) {
         qDebug().nospace().noquote() << "mudlet::mudlet() INFO - '" << mDefaultStyle << "' has been detected as the style factory in use - QPushButton styling fix applied!";
         mBG_ONLY_STYLESHEET = QStringLiteral("QPushButton {background-color: %1; border: 1px solid #8f8f91;}");
         mTEXT_ON_BG_STYLESHEET = QStringLiteral("QPushButton {color: %1; background-color: %2; border: 1px solid #8f8f91;}");


### PR DESCRIPTION
This has come about because of #4984 (and then #5574) setting our own style-factory before the original code (I put in as #4846) could determine the original that Qt (or the user with a `--style xxxx` command line argument) was going to use.

TODO: Add meaningful `objectName`s to the styles we impose that give an indication of what has been selected. As it happens I got a big clue as to why the `windowsvista` style was (again) not colouring the backgrounds of `QPushButton`s was because the debug output that reported the "Style factory" that was being used was consistently returning an empty string (`""`) for that detail - and the #4846 code needed to see one of the style-factories that were buggy in order to insert the workaround.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Other info (issues closed, discussion etc)

#### Release post highlight

Restore the (background) color on push-button controls for users who are using the standard (native) "Light" themed Style on Windows or MacOs. This had previous gotten broken in Mudlet version **4.14.0**.

#### Note to self: correct spelling in commit message:
* orginal ==> original