### PR TITLE
Infrastructure: update development/ptb version to 4.14.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 # IMPORTANT: To insure consistency please ensure the SAME of the first two
 # values are also assigned to the "VERSION" and "BUILD" variables in the native
 # qmake project file, which is NOW called: ./src/mudlet.pro
-set(APP_VERSION 4.13.1)
+set(APP_VERSION 4.14.1)
 if(DEFINED ENV{MUDLET_VERSION_BUILD} AND NOT $ENV{MUDLET_VERSION_BUILD}
                                          STREQUAL "")
   set(APP_BUILD $ENV{MUDLET_VERSION_BUILD})

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -89,7 +89,7 @@ TEMPLATE = app
 ########################## Version and Build setting ###########################
 # Set the current Mudlet Version, unfortunately the Qt documentation suggests
 # that only a #.#.# form without any other alphanumberic suffixes is required:
-VERSION = 4.13.1
+VERSION = 4.14.1
 
 # if you are distributing modified code, it would be useful if you
 # put something distinguishing into the MUDLET_VERSION_BUILD environment


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update development version to 4.14.1
#### Motivation for adding to Mudlet
So PTBs have the right version
#### Other info (issues closed, discussion etc)
Merging `release-4.14` back into `development` isn't possible due to the number of conflicts involved. I believe @keneanung pointed this out earlier, but afaik there is no better way to do this if we actually want to be able to do feature freezes without stopping development entirely for two weeks.