### PR TITLE
Add overline support to c/d/hecho, ansi2decho, and c/d/hecho2ansi functions

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -981,11 +981,11 @@ if rex then
   _Echos = {
     Patterns = {
       Hex = {
-        [[(\x5c?(?:#|\|c)?(?:[0-9a-fA-F]{6}|(?:#,|\|c,)[0-9a-fA-F]{6,8})(?:,[0-9a-fA-F]{6,8})?)|(?:\||#)(\/?[birus])]],
+        [[(\x5c?(?:#|\|c)?(?:[0-9a-fA-F]{6}|(?:#,|\|c,)[0-9a-fA-F]{6,8})(?:,[0-9a-fA-F]{6,8})?)|(?:\||#)(\/?[biruso])]],
         rex.new [[(?:#|\|c)(?:([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2}))?(?:,([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?)?]],
       },
       Decimal = {
-        [[(<[0-9,:]+>)|<(/?[birus])>]],
+        [[(<[0-9,:]+>)|<(/?[biruso])>]],
         rex.new [[<(?:([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}))?(?::(?=>))?(?::([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),?([0-9]{1,3})?)?>]],
       },
       Color = {
@@ -1033,6 +1033,10 @@ if rex then
           t[#t + 1] = "\27strikethrough"
         elseif r == "/s" then
           t[#t + 1] = "\27strikethroughoff"
+        elseif r == "o" then
+          t[#t + 1] = "\27overline"
+        elseif r == "/o" then
+          t[#t + 1] = "\27overlineoff"
         end
         if c then
           if style == 'Hex' or style == 'Decimal' then
@@ -1086,6 +1090,10 @@ if rex then
               t[#t + 1] = "\27strikethrough"
             elseif c == "</s>" then
               t[#t + 1] = "\27strikethroughoff"
+            elseif c == "<o>" then
+              t[#t + 1] = "\27overline"
+            elseif c == "</o>" then
+              t[#t + 1] = "\27overlineoff"
             else
               local fcolor, bcolor = _Echos.Patterns[style][2]:match(c)
               local color = {}
@@ -1200,6 +1208,10 @@ if rex then
         setStrikeOut(win, true)
       elseif v == "\27strikethroughoff" then
         setStrikeOut(win, false)
+      elseif v == "\27overline" then
+        setOverline(win, true)
+      elseif v == "\27overlineoff" then
+        setOverline(win, false)
       elseif v == "\27reset" then
         resetFormat(win)
       else

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -93,6 +93,13 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.equals(expected, actual)
     end)
 
+    it("Should handle overline", function()
+      local sample = "\27[53moverline\27[55m"
+      local expected = "<o>overline</o>"
+      local actual = ansi2decho(sample)
+      assert.equals(expected, actual)
+    end)
+
     it("Should leave normal text and other escape sequences alone", function()
       local sequences = {
         {"Hello World", "Hello World"},
@@ -183,6 +190,12 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       local actual = decho2ansi("<s>strikeout</s>")
       assert.equals(expected, actual)
     end)
+
+    it("should handle overline", function()
+      local expected = "\27[53moverline\27[55m"
+      local actual = decho2ansi("<o>overline</o>")
+      assert.equals(expected, actual)
+    end)
   end)
 
   describe("Tests the functionality of hecho2ansi()", function()
@@ -215,6 +228,12 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     it("should handle strikeout", function()
       local expected = "\27[9mstrikeout\27[29m"
       local actual = hecho2ansi("#sstrikeout#/s")
+      assert.equals(expected, actual)
+    end)
+
+    it("should handle overline", function()
+      local expected = "\27[53moverline\27[55m"
+      local actual = hecho2ansi("#ooverline#/o")
       assert.equals(expected, actual)
     end)
   end)
@@ -254,6 +273,12 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     it("should handle strikeout", function()
       local expected = "\27[9mstrikeout\27[29m"
       local actual = cecho2ansi("<s>strikeout</s>")
+      assert.equals(expected, actual)
+    end)
+
+    it("should handle overline", function()
+      local expected = "\27[53moverline\27[55m"
+      local actual = cecho2ansi("<o>overline</o>")
       assert.equals(expected, actual)
     end)
   end)

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -429,6 +429,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
         _Echos.Process('#sStrikethrough#/s', 'Hex'),
         { "", "\27strikethrough", "Strikethrough", "\27strikethroughoff", "" }
       )
+
+      assert.are.same(
+        _Echos.Process('#oOverline#/o', 'Hex'),
+        { "", "\27overline", "Overline", "\27overlineoff", "" }
+      )
     end)
 
     it("Should parse decimal patterns correctly", function()
@@ -461,6 +466,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
         _Echos.Process('<s>Strikethrough</s>', 'Decimal'),
         { "", "\27strikethrough", "Strikethrough", "\27strikethroughoff", "" }
       )
+
+      assert.are.same(
+        _Echos.Process('<o>Overline</o>', 'Decimal'),
+        { "", "\27overline", "Overline", "\27overlineoff", "" }
+      )
     end)
 
     it("Should parse color patterns correctly", function()
@@ -492,6 +502,11 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.are.same(
         _Echos.Process('<s>Strikethrough</s>', 'Color'),
         { "", "\27strikethrough", "Strikethrough", "\27strikethroughoff", "" }
+      )
+
+      assert.are.same(
+        _Echos.Process('<o>Overline</o>', 'Color'),
+        { "", "\27overline", "Overline", "\27overlineoff", "" }
       )
     end)
   end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds support for overline in our formatted echo functions and ansi conversion functions
#### Motivation for adding to Mudlet
More feature completeness
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/5716

Also renames a variable whose name no longer makes sense in the ansi2decho code. 

