### PR TITLE
Fix: get menu shortcuts and their key sequences working all the time again

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -742,6 +742,11 @@ private:
     // read-only value to see if the interface is light or dark. To set the value,
     // use setAppearance instead
     bool mDarkMode = false;
+
+    // Used to ensure that mudlet::slot_update_shortcuts() only runs once each
+    // time the main if () logic changes state - will be true if the menu is
+    // supposed to be visible, false if not and not have a value initially:
+    std::optional<bool> mMenuVisibleState;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)


### PR DESCRIPTION
This should close #3985, and *finally* close #649! I was prompted to look into this as a result of what @demonnic reported in: https://github.com/Mudlet/Mudlet/pull/5715#discussion_r760282302

Previously the code was attempting to detect whether the main menu bar itself was actually visible and using that to determine whether
EITHER: "key sequences" should be assigned to menu items and have the menu items activate the desired slots (menu bar shown)
OR: "key sequences" should themselves be assigned to shortcuts that directly call the desired slots (menu bar hidden)

This PR instead uses a state variable `(std::optional<bool>) mMenuVisibleState` and uses that to record whether the menu bar is supposed to be visible and only perform the changes required for the above alternatives if the state is changed (or has not previously been performed).

There have been several past attempts to get the short-cuts working:
* #2071 monitored the state of the main toolbar and NOT the menu bar
* #3994 changed to monitor the state of the menu bar but only enabled (menu shown) or disabled (menu hidden) shortcuts that were assigned key sequences and those shortcuts were connected directly to slots yet the key sequences were assigned to menu items that themselves were ALSo connected to the same slots.
* #5427 reverted # 3994 so the code went back to that of # 2071

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Other info (issues closed, discussion etc)
When the main menu bar is visible the previous code `.clear()`ed the `QPointer<QShortcut>`s but that was not `delete`-ing the `QShortCut` objects that had previously been `new`ed when the main menu was not visible - this PR changes things so they are deleted - and as the pointers are `QPointer`s those will automatically `.clear()` themselves.

#### Release post highlight
Mudlet application shortcuts finally now work all the time, whether the main menu-bar is visible or not.