### PR TITLE
Infrastructure: speed up Mudlet cmake builds by 50% (enable unity builds)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 if(APPLE)
-  # needed for fetching Spark
+  # needed for fetching Sparkle
   cmake_minimum_required(VERSION 3.18)
   # minimum supported version by Apple
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,10 @@
 ############################################################################
 
 # Should be called before PROJECT.
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.16)
 
 if(APPLE)
-  # needed for fetching Sparkle
+  # needed for fetching Spark
   cmake_minimum_required(VERSION 3.18)
   # minimum supported version by Apple
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -369,7 +369,8 @@ target_sources(mudlet PRIVATE "${mudlet_BINARY_DIR}/translations/translated/qm.q
 set_target_properties(mudlet PROPERTIES
   AUTOUIC ON AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/ui"
   AUTOMOC ON AUTORCC ON POSITION_INDEPENDENT_CODE ON
-  AUTOGEN_ORIGIN_DEPENDS OFF)
+  AUTOGEN_ORIGIN_DEPENDS OFF
+  UNITY_BUILD ON)
 
 if(USE_FONTS)
   target_compile_definitions(mudlet PRIVATE INCLUDE_FONTS)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Enable [Unity builds](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) in cmake.
#### Motivation for adding to Mudlet
2x faster cmake builds!!

**Unity builds (3 core)**
```
real    3m46.485s
user    7m58.858s
sys     1m52.919s

real    3m48.398s
user    7m58.183s
sys     1m51.872s

real    3m47.693s
user    8m0.200s
sys     1m52.381s
```

**Non-unity builds (3 core)**
```
real    7m2.257s
user    15m3.199s
sys     4m42.454s

real    7m32.812s
user    15m47.736s
sys     4m53.287s

real    7m6.589s
user    15m43.137s
sys     4m22.160s
```
Caching was of course disabled for all of the tests.
#### Other info (issues closed, discussion etc)
Requires CMake 3.13, which is fine as CMake 3.18 is available in Debian Stable.

Didn't enable it for tests - it seems like we'd have a ton of target properties for every little test binary then, and the tests don't take all that long to build right now.