### PR TITLE
Fix empty newline on send with no command separator

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1135,18 +1135,17 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
 #else
         commandList = cmd.split(QString(mCommandSeparator), QString::SkipEmptyParts);
 #endif
-    } else {
+    } else if (!cmd.isEmpty()) {
         // don't split command if the command separator is blank
         commandList << cmd;
     }
 
-    if (!dontExpandAliases) {
         // allow sending blank commands
-        if (commandList.empty()) {
-            QString payload(QChar::LineFeed);
-            mTelnet.sendData(payload);
-            return;
-        }
+
+    if (!dontExpandAliases && commandList.empty()) {
+        QString payload(QChar::LineFeed);
+        mTelnet.sendData(payload);
+        return;
     }
 
     for (int i = 0, total = commandList.size(); i < total; ++i) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix empty newline on send to still fire with no command separator.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/2227
#### Other info (issues closed, discussion etc)
There was a logic error that prevented `if (commandList.empty()) {` from ever being true - empty commands were still being added to the commandList.