### PR TITLE
Improve: Announce how to undo it when hiding the input line buttons

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2921,6 +2921,12 @@ void mudlet::slot_compact_input_line(const bool state)
     }
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->setCompactInputLine(state);
+        // Make sure players don't get confused when accidentally hiding buttons.
+        if (state) {
+            QKeySequence* shortcut = mShortcutsManager->getSequence(tr("Compact input line"));
+            QString infoMsg = tr("[  OK  ]  - Compact input line activated. Press %1 to deactivate.").arg(shortcut->toString());
+            mpCurrentActiveHost->postMessage(infoMsg);
+        }
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2924,7 +2924,8 @@ void mudlet::slot_compact_input_line(const bool state)
         // Make sure players don't get confused when accidentally hiding buttons.
         if (state) {
             QKeySequence* shortcut = mShortcutsManager->getSequence(tr("Compact input line"));
-            QString infoMsg = tr("[  OK  ]  - Compact input line activated. Press %1 to deactivate.").arg(shortcut->toString());
+            QString infoMsg = tr("[  OK  ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
+                                 "Here %1 will be replaced with the keyboard shortcut, default is ALT+L.").arg(shortcut->toString());
             mpCurrentActiveHost->postMessage(infoMsg);
         }
     }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Give a brief info in main window when compact input line gets activated.

#### Motivation for adding to Mudlet
Players hid buttons by accident and were confused how to get them back.

#### Other info (issues closed, discussion etc)
This will name the keyboard shortcut used to enlarge the input line again.
