### PR TITLE
Improve: Announce compact line only once

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -402,6 +402,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mPlayerRoomInnerDiameterPercentage(70)
 , mDebugShowAllProblemCodepoints(false)
 , mCompactInputLine(false)
+, mTutorialForCompactLineAlreadyShown(false)
 {
     TDebug::addHost(this);
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -633,6 +633,8 @@ public:
 
     QMap<QString, QKeySequence*> profileShortcuts;
 
+    bool mTutorialForCompactLineAlreadyShown;
+
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous
     // width characters:

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2927,7 +2927,7 @@ void mudlet::slot_compact_input_line(const bool state)
             QString infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
                                  "Here %1 will be replaced with the keyboard shortcut, default is ALT+L.").arg(shortcut->toString());
             mpCurrentActiveHost->postMessage(infoMsg);
-            mTutorialForCompactLineAlreadyShown = true;
+            mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown = true;
         }
     }
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2922,11 +2922,12 @@ void mudlet::slot_compact_input_line(const bool state)
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
-        if (state) {
+        if (state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown) {
             QKeySequence* shortcut = mShortcutsManager->getSequence(tr("Compact input line"));
-            QString infoMsg = tr("[  OK  ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
+            QString infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
                                  "Here %1 will be replaced with the keyboard shortcut, default is ALT+L.").arg(shortcut->toString());
             mpCurrentActiveHost->postMessage(infoMsg);
+            mTutorialForCompactLineAlreadyShown = true;
         }
     }
 }


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remember if tutorial for compact line was already shown.
Change "OK" message to "INFO" message style.

#### Motivation for adding to Mudlet
During discussion of message content for #5741 a few players hinted, reading this message every time the buttons are hidden, would be quite too often. Trying this approach as a nice balance then.

#### Other info (issues closed, discussion etc)
Another idea is to also show the message up front during profile load, if the buttons are set to be hidden at that time already, but I did not find a nice hook for that, yet.
Therefore still draft.
