### PR TITLE
infra Win10 fix dependency installation script to handle null paths

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -87,7 +87,7 @@ function script:exec {
 
 # Checks, whether sh.exe is found in the PATH. If so, these parts get filtered out and the remaining PATH gets returned.
 function filterPathForSh {
-    $noShPath = ($Env:PATH.Split(';') | Where-Object { -NOT (Test-Path (Join-Path $_ "sh.exe") -PathType Leaf) }) -join ';'
+    $noShPath = ($Env:PATH.Split(';') | Where-Object { -NOT (Test-Path ([System.IO.Path]::Combine($_, "sh.exe")) -PathType Leaf) }) -join ';'
     return $noShPath
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6659,7 +6659,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         lua_settable(L, LUA_REGISTRYINDEX);
     }
 
-    lua_pushstring(L, pattern.toUtf8().constData());
+    lua_pushnumber(L, pt->getID());
     return 1;
 }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -6659,7 +6659,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         lua_settable(L, LUA_REGISTRYINDEX);
     }
 
-    lua_pushnumber(L, pt->getID());
+    lua_pushstring(L, pattern.toUtf8().constData());
     return 1;
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
 `filterPathForSh` fails silently at https://github.com/Mudlet/Mudlet/blob/development/CI/appveyor.install.ps1#L30 due to a null path entry on my system. The `Join-Path` functionality of powershell won't handle null path entries but the `Combine` function works.


Here is a minimal example to verify:
`demonstrate_issue.ps1`:
```
$dummyPath = "/bin;;/usr/bin"
Write-Output $dummyPath

$noShPath = ($dummPath.Split(';') | Where-Object { -NOT (Test-Path (Join-Path $_ "sh.exe") -PathType Leaf) }) -join ';'
Write-Output $noShPath

$noShPath = ($dummyPath.Split(';') | Where-Object { -NOT (Test-Path ([System.IO.Path]::Combine($_, "sh.exe")) -PathType Leaf) }) -join ';'
Write-Output $noShPath
```

`powershell ./demonstrate_powershell_nullpath.ps1`
```
$ powershell ./demonstrate_powershell_nullpath.ps1
/bin;;/usr/bin
You cannot call a method on a null-valued expression.
At C:\Users\atn\code\moot\demonstrate_powershell_nullpath.ps1:4 char:1
+ $noShPath = ($dummPath.Split(';') | Where-Object { -NOT (Test-Path (J ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

/bin;;/usr/bin
```

If we comment out the line using `Join-Path` and its `Write-Output` we get the expected output:
```
$ powershell ./demonstrate_powershell_nullpath.ps1
/bin;;/usr/bin
/bin;;/usr/bin
```
