### PR TITLE
Improve: allow profiles to be individually resized when multi-playing

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -339,11 +339,11 @@ mudlet::mudlet()
     mpHBoxLayout_profileContainer = new QHBoxLayout(mpWidget_profileContainer);
     mpHBoxLayout_profileContainer->setContentsMargins(0, 0, 0, 0);
 
-    mpSpltter_profileContainer = new QSplitter(Qt::Horizontal, mpWidget_profileContainer);
-    mpSpltter_profileContainer->setContentsMargins(0, 0, 0, 0);
-    mpSpltter_profileContainer->setChildrenCollapsible(false);
+    mpSplitter_profileContainer = new QSplitter(Qt::Horizontal, mpWidget_profileContainer);
+    mpSplitter_profileContainer->setContentsMargins(0, 0, 0, 0);
+    mpSplitter_profileContainer->setChildrenCollapsible(false);
 
-    mpHBoxLayout_profileContainer->addWidget(mpSpltter_profileContainer);
+    mpHBoxLayout_profileContainer->addWidget(mpSplitter_profileContainer);
 
     QFile file_autolog(getMudletPath(mainDataItemPath, qsl("autolog")));
     if (file_autolog.exists()) {
@@ -1537,7 +1537,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     //update the main window title when we spawn a new tab
     setWindowTitle(pH->getName() + " - " + version);
 
-    mpSpltter_profileContainer->addWidget(pConsole);
+    mpSplitter_profileContainer->addWidget(pConsole);
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->mpConsole->hide();
     }
@@ -4601,16 +4601,14 @@ void mudlet::setupTrayIcon()
 
 void mudlet::slot_tabMoved(const int oldPos, const int newPos)
 {
-    Q_UNUSED(newPos)
-    Q_UNUSED(oldPos)
     const QStringList& tabNamesInOrder = mpTabBar->tabNames();
-    int itemsCount = mpSpltter_profileContainer->count();
+    int itemsCount = mpSplitter_profileContainer->count();
     Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "mismatch in count of tabs and TMainConsoles");
     QMap<QString, QWidget*> widgetMap;
     // Gather the QWidget pointers for each TMainConsole and store them
     // against their profile name:
     for (int profileIndex = 0; profileIndex < itemsCount; ++profileIndex) {
-        auto pWidget = mpSpltter_profileContainer->widget(profileIndex);
+        auto pWidget = mpSplitter_profileContainer->widget(profileIndex);
         if (pWidget) {
             auto name = pWidget->property("HostName").toString();
             widgetMap.insert(name, pWidget);
@@ -4624,7 +4622,7 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
     // tabs:
     for (int index = 0; index < itemsCount; ++index) {
         const auto& wantedTabName = tabNamesInOrder.at(index);
-        mpSpltter_profileContainer->addWidget(widgetMap.value(wantedTabName));
+        mpSplitter_profileContainer->addWidget(widgetMap.value(wantedTabName));
     }
 }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -71,6 +71,7 @@
 #include <QNetworkDiskCache>
 #include <QScrollBar>
 #include <QShortcut>
+#include <QSplitter>
 #include <QStyleFactory>
 #include <QTableWidget>
 #include <QTextStream>
@@ -333,10 +334,16 @@ mudlet::mudlet()
     mpWidget_profileContainer->setSizePolicy(sizePolicy);
     mpWidget_profileContainer->setFocusPolicy(Qt::NoFocus);
     mpWidget_profileContainer->setAutoFillBackground(true);
+
     layoutTopLevel->addWidget(mpWidget_profileContainer);
     mpHBoxLayout_profileContainer = new QHBoxLayout(mpWidget_profileContainer);
     mpHBoxLayout_profileContainer->setContentsMargins(0, 0, 0, 0);
 
+    mpSpltter_profileContainer = new QSplitter(Qt::Horizontal, mpWidget_profileContainer);
+    mpSpltter_profileContainer->setContentsMargins(0, 0, 0, 0);
+    mpSpltter_profileContainer->setChildrenCollapsible(false);
+
+    mpHBoxLayout_profileContainer->addWidget(mpSpltter_profileContainer);
 
     QFile file_autolog(getMudletPath(mainDataItemPath, qsl("autolog")));
     if (file_autolog.exists()) {
@@ -1530,7 +1537,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
     //update the main window title when we spawn a new tab
     setWindowTitle(pH->getName() + " - " + version);
 
-    mpHBoxLayout_profileContainer->addWidget(pConsole);
+    mpSpltter_profileContainer->addWidget(pConsole);
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->mpConsole->hide();
     }
@@ -4597,30 +4604,27 @@ void mudlet::slot_tabMoved(const int oldPos, const int newPos)
     Q_UNUSED(newPos)
     Q_UNUSED(oldPos)
     const QStringList& tabNamesInOrder = mpTabBar->tabNames();
-    int itemsCount = mpHBoxLayout_profileContainer->count();
+    int itemsCount = mpSpltter_profileContainer->count();
     Q_ASSERT_X(itemsCount == tabNamesInOrder.count(), "mudlet::slot_tabMoved(...)", "mismatch in count of tabs and TMainConsoles");
-    QMap<QString, QLayoutItem*> layoutItemMap;
-    // Gather the QLayoutItem pointers for each TMainConsole and store them
+    QMap<QString, QWidget*> widgetMap;
+    // Gather the QWidget pointers for each TMainConsole and store them
     // against their profile name:
-    for (int profileIndex = 0, total = mpHBoxLayout_profileContainer->count(); profileIndex < total; ++profileIndex) {
-        auto pLayoutItem = mpHBoxLayout_profileContainer->itemAt(profileIndex);
-        auto pWidget = pLayoutItem->widget();
+    for (int profileIndex = 0; profileIndex < itemsCount; ++profileIndex) {
+        auto pWidget = mpSpltter_profileContainer->widget(profileIndex);
         if (pWidget) {
             auto name = pWidget->property("HostName").toString();
-            layoutItemMap.insert(name, pLayoutItem);
+            widgetMap.insert(name, pWidget);
+        } else {
+            qWarning().nospace().noquote() << "mudlet::slot_tabMoved(" << oldPos<< ", " << newPos << ") WARNING - nullptr for pointer to TMainConsole at 'profileIndex': " << profileIndex << ".";
         }
     }
-    // Now go through all the names, pull the associated QLayoutItem from the
-    // layout and then re-add each of them at the end in turn - once we have
+    // Now go through all the names, pull the associated TMainConsoles from the
+    // splitter and then re-add each of them at the end in turn - once we have
     // gone through them all it will mean that they are in the same order as the
     // tabs:
     for (int index = 0; index < itemsCount; ++index) {
         const auto& wantedTabName = tabNamesInOrder.at(index);
-        auto pLayoutItem = layoutItemMap.value(wantedTabName);
-        // This will remove the item from wherever it is in the layout:
-        mpHBoxLayout_profileContainer->removeItem(pLayoutItem);
-        // This will re-add the item to the end of the layout:
-        mpHBoxLayout_profileContainer->addItem(pLayoutItem);
+        mpSpltter_profileContainer->addWidget(widgetMap.value(wantedTabName));
     }
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -625,7 +625,7 @@ private:
 
     QWidget* mpWidget_profileContainer;
     QHBoxLayout* mpHBoxLayout_profileContainer;
-    QSplitter* mpSpltter_profileContainer;
+    QSplitter* mpSplitter_profileContainer;
 
     static QPointer<mudlet> _self;
     QMap<Host*, QToolBar*> mUserToolbarMap;

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -100,6 +100,7 @@ class QLabel;
 class QListWidget;
 class QPushButton;
 class QShortcut;
+class QSplitter;
 class QTableWidget;
 class QTableWidgetItem;
 class QTextEdit;
@@ -624,6 +625,7 @@ private:
 
     QWidget* mpWidget_profileContainer;
     QHBoxLayout* mpHBoxLayout_profileContainer;
+    QSplitter* mpSpltter_profileContainer;
 
     static QPointer<mudlet> _self;
     QMap<Host*, QToolBar*> mUserToolbarMap;


### PR DESCRIPTION
This is for when multi-view mode is activated.

It was suggested in our [Discord **#help** channel recently](https://www.discord.com/channels/283581582550237184/283582068334526464/918258911289696257) but in fact is a *Launchpad* issue first raised in 2013! As such this PR should close #671...!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Improvement: when multi-playing and *multiview* mode is active the horizontal space allocated to each profile can now be adjusted by dragging the separator between each profile's main window.