### PR TITLE
Improve: add a QSpinWidget for adjusting special exit weight in exit dialogue

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -49,6 +49,43 @@
 const QString singleParagraph{qsl("<p>%1</p>")};
 const QString doubleParagraph{qsl("<p>%1</p><p>%2</p>")};
 
+WeightSpinBoxDelegate::WeightSpinBoxDelegate(QObject* parent)
+: QStyledItemDelegate(parent)
+{}
+
+QWidget* WeightSpinBoxDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /* option */, const QModelIndex& /* index */) const
+{
+    auto* pEditor = new QSpinBox(parent);
+    pEditor->setFrame(false);
+    pEditor->setMinimum(0);
+    pEditor->setMaximum(9999);
+    // Need to use this to hide anything in the original QLineEdit that this
+    // sits on top of:
+    pEditor->setAutoFillBackground(true);
+
+    return pEditor;
+}
+
+void WeightSpinBoxDelegate::setEditorData(QWidget* pEditor, const QModelIndex& index) const
+{
+    auto value = index.model()->data(index, Qt::EditRole).toInt();
+    auto* pSpinBox = static_cast<QSpinBox*>(pEditor);
+    pSpinBox->setValue(value);
+}
+
+void WeightSpinBoxDelegate::setModelData(QWidget* pEditor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+    auto* pSpinBox = static_cast<QSpinBox*>(pEditor);
+    pSpinBox->interpretText();
+    auto value = pSpinBox->value();
+    model->setData(index, value, Qt::EditRole);
+}
+
+void WeightSpinBoxDelegate::updateEditorGeometry(QWidget* pEditor, const QStyleOptionViewItem& option, const QModelIndex& /* index */) const
+{
+    pEditor->setGeometry(option.rect);
+}
+
 RoomIdLineEditDelegate::RoomIdLineEditDelegate(QObject* parent)
 : QStyledItemDelegate(parent)
 {}
@@ -235,6 +272,7 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
     init();
 
     specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitRoomId, new RoomIdLineEditDelegate);
+    specialExits->setItemDelegateForColumn(ExitsTreeWidget::colIndex_exitWeight, new WeightSpinBoxDelegate);
 }
 
 dlgRoomExits::~dlgRoomExits()
@@ -1481,7 +1519,7 @@ void dlgRoomExits::init()
 
         //ExitsTreeWidget::colIndex_exitRoomId
         pI->setText(ExitsTreeWidget::colIndex_exitRoomId, QString::number(id_to));
-        pI->setTextAlignment(ExitsTreeWidget::colIndex_exitRoomId, Qt::AlignRight);
+        pI->setTextAlignment(ExitsTreeWidget::colIndex_exitRoomId, Qt::AlignLeft);
         //Tooltip generation for this column is done in
         //setIconAndToolTipsOnSpecialExit(...) at end of this while() loop
 
@@ -1504,7 +1542,7 @@ void dlgRoomExits::init()
 
         //ExitsTreeWidget::colIndex_exitWeight
         pI->setData(ExitsTreeWidget::colIndex_exitWeight, Qt::EditRole, pR->hasExitWeight(dir) ? pR->getExitWeight(dir) : 0);
-        pI->setTextAlignment(ExitsTreeWidget::colIndex_exitWeight, Qt::AlignRight);
+        pI->setTextAlignment(ExitsTreeWidget::colIndex_exitWeight, Qt::AlignLeft);
         pSpecialExit->weight = pI->data(ExitsTreeWidget::colIndex_exitWeight, Qt::EditRole).toInt();
         pI->setToolTip(ExitsTreeWidget::colIndex_exitWeight, singleParagraph.arg(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
 

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -40,6 +40,19 @@ class TRoom;
 // classes can refer to it:
 class dlgRoomExits;
 
+class WeightSpinBoxDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit WeightSpinBoxDelegate(QObject* parent = nullptr);
+
+    QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+    void setEditorData(QWidget* editor, const QModelIndex& index) const override;
+    void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const override;
+    void updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+};
+
 class RoomIdLineEditDelegate : public QStyledItemDelegate
 {
     Q_OBJECT


### PR DESCRIPTION
This uses the same method of providing a custom item delegate has been used for the special exit roomID column in the `QTreeWidget` derived `ExitsTreeWidget` in PR #5543 but instead of making use of an enhanced `QlineEdit` this will replace the standard `QLineEdit` with a `QSpinBox` whilst the special exit's weight is being modified.

This concludes the generation of separate chunks of code that was originally in #5308 but which was overlarge.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Improve: the control to set a special exit's weighting is now a spinbox whilst it is being edited which can be adjusted between 0 and 9999 - like the controls for normal exits.