### PR TITLE
Fix: get dark-desktop detection working also on FreeBSD

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4719,7 +4719,7 @@ bool mudlet::desktopInDarkMode()
         coreMacOS::CFRelease(uiStyle);
     }
     return isDark;
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
     QProcess process;
     process.start(qsl("gsettings"), QStringList() << qsl("get") << qsl("org.gnome.desktop.interface") << qsl("gtk-theme"));
     process.waitForFinished();


### PR DESCRIPTION
It can use the same code as GNU/Linux...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix - dark desktop detection also now working on FreeBSD.