### PR TITLE
Fix: draw stub exits with a circular ending to make them more noticeable

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1628,6 +1628,11 @@ void T2DMap::paintEvent(QPaintEvent* e)
     }
 }
 
+// This draws two lines at angles to the "exitLine" so as to form what would be
+// an "arrow head" if they were to be extended so as to meet (at the "end" of
+// the "exitLine". Various features of the QPen that is used are redefined
+// as appropriate - but they are restored afterwards so there should be
+// no change to the QPainter as a result of calling this method.
 void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKey, const QLineF& exitLine)
 {
     // A set of numbers that can be converted to "static" type and be frobbed
@@ -2081,24 +2086,34 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 
         // draw exit stubs
         QMap<int, QVector3D> unitVectors = mpMap->unitVectors;
-        painter.save();
         for (int direction : qAsConst(room->exitStubs)) {
             if (direction >= DIR_NORTH && direction <= DIR_SOUTHWEST) {
                 // Stubs on non-XY plane exits are handled differently and we
                 // do not support special exit stubs (yet?)
                 QVector3D uDirection = unitVectors[direction];
                 QLineF stubLine(rx, ry, rx + uDirection.x() * 0.5 * mRoomWidth, ry + uDirection.y() * 0.5 * mRoomHeight);
-                QPen doorPen = painter.pen();
-                doorPen.setCapStyle(Qt::RoundCap);
-                painter.setPen(doorPen);
-                painter.drawLine(stubLine);
                 const QString doorKey{TRoom::dirCodeToShortString(direction)};
+                // Draw the door lines before we draw the stub or the filled
+                // circle on the end - so that the latter overlays the doors
+                // if they get a bit large (at low exit size numbers)
                 if (room->doors.value(doorKey)) {
                     drawDoor(painter, *room, doorKey, stubLine);
                 }
+                painter.save();
+                painter.drawLine(stubLine);
+                // Set the fill colour to be what is used for exit lines
+                painter.setBrush(painter.pen().color());
+                // And turn off drawing the border (outline):
+                painter.setPen(Qt::NoPen);
+                QPainterPath stubMarkingCirclePath;
+                QRectF surroundingRectF(stubLine.p2().x() - 0.1 * mRoomWidth, stubLine.p2().y() - 0.1 * mRoomHeight, 0.2 * mRoomWidth, 0.2 * mRoomHeight);
+                stubMarkingCirclePath.arcTo(surroundingRectF, 0.0, 360.0);
+                // So this should draw a solid filled circle whose diameter
+                // is fixed and not dependent on the exit line thickness:
+                painter.drawPath(stubMarkingCirclePath);
+                painter.restore();
             }
         }
-        painter.restore();
 
         for (int& k : exitList) {
             int rID = k;


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This helps by adding a round blob on the end of stub exit lines so it more obvious that they are there - and it makes them clearly different on pairs of stubs on adjacent rooms then a pair of real exits between such rooms.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Other info (issues closed, discussion etc)
This should close #5768.

I am only expecting one of this and #5771 to be selected and merged.

#### Release post highlight
Enhance - stub exits (in the XY-plane) are now drawn with a circular "blob" on their end so that they can be distinguished from real exits between rooms when those rooms are right next to each other. It also makes them more noticeable even when the room size is set to larger values. 
