### PR TITLE
Fix: avoid unbalanced `QPainter` `save()` and `restore()` calls

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2402,12 +2402,12 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
 
 int T2DMap::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset, const MapInfoProperties& properties)
 {
-    painter.save();
 
     if (properties.text.isEmpty()) {
         return 0;
     }
 
+    painter.save();
     auto infoText = properties.text.trimmed();
 
     auto font = painter.font();


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Due to the existing code ordering it was possible that a `QPainter::save()` was performed ***without*** the matching `QPainter::restore()` if a condition was met that caused a premature `return` from a method - the Qt library code does not like this and moans about it.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Motivation for adding to Mudlet
This was spamming the debug output with messages of the form:
"`QPainter::end: Painter ended with 2 saved states`"

#### Release post highlight
Fix: 2D mapper code revised to stop spammy output of debug "`QPainter::end: Painter ended with X saved states`" messages.
