### PR TITLE
Fix: get replays working again

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2749,7 +2749,7 @@ void cTelnet::loadReplayChunk()
         if (mReplayHasFaultyFormat) {
             qint64 temp = 0;
             replayStream >> temp;
-            // 2^30 millseconds is over 12 days so that sort of delay between
+            // 2^30 milliseconds is over 12 days so that sort of delay between
             // steps is not likely - and only using a 32 bit integer type is
             // going to be okay:
             offset = static_cast<qint32>(temp);

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2694,9 +2694,9 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
-            std::pair results = preparseReplayFile();
-            if (Q_LIKELY(std::get<0>(results))) {
-                mReplayHasFaultyFormat = std::get<1>(results);
+            auto[ok, modifiedFormat] = preparseReplayFile();
+            if (ok) {
+                mReplayHasFaultyFormat = modifiedFormat;
                 // This initiates the replay chunk reading/processing cycle:
                 loadReplayChunk();
             } else {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2691,7 +2691,7 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
-            if(parseReplayFile()) {
+            if (parseReplayFile()) {
                 // This wiil point at the first chunk (if there is one):
                 mpItReplayChunk = mReplayChunks.constBegin();
                 // These test avoids problems in the event of an empty replay

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2618,11 +2618,11 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
                 // Amelioration code should now prevent this from happening
                 loadingReplay = false;
                 replayFile.close();
-                if (!mIsReplayRunFromLua) {
-                    postMessage(tr("[ WARN ]  - The replay has been aborted as the file seems to be corrupt."));
-                } else {
+                if (pErrMsg) {
                     // Called from lua case:
                     *pErrMsg = tr("Cannot replay file \"%1\", error message was: \"replay file seems to be corrupt\".").arg(name);
+                } else {
+                    postMessage(tr("[ WARN ]  - The replay has been aborted as the file seems to be corrupt."));
                 }
                 mudlet::self()->replayOver();
                 return false;
@@ -3135,7 +3135,7 @@ void cTelnet::setPostingTimeout(const int timeout)
 // bytes - as an unintended side effect of https://github.com/Mudlet/Mudlet/pull/4400
 // - returns two booleans, the first is true if the file can be read and the
 // second true if it is in the modified format:
-std::pair<bool, bool> cTelnet::testReadReplayFile()
+/*static*/ std::pair<bool, bool> cTelnet::testReadReplayFile()
 {
     // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (5 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char replayBuffer[BUFFER_SIZE+1];

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2694,7 +2694,6 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
-            // TODO: https://github.com/Mudlet/Mudlet/issues/5779 - consider enhancing replay system, possibly using the QTimeLine class
             std::pair results = preparseReplayFile();
             if (Q_LIKELY(std::get<0>(results))) {
                 mReplayHasFaultyFormat = std::get<1>(results);
@@ -2740,8 +2739,7 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
     return true;
 }
 
-// TODO: Revise replay process to use the already read and stored
-// QMap<quint64, QByteArray> mReplayChunks;
+// TODO: https://github.com/Mudlet/Mudlet/issues/5779 - consider enhancing replay system, possibly using the QTimeLine class, to use the already read and stored QMap<quint64, QByteArray> mReplayChunks
 void cTelnet::loadReplayChunk()
 {
     if (!replayStream.atEnd()) {

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2694,7 +2694,7 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
-            auto[ok, modifiedFormat] = preparseReplayFile();
+            auto [ok, modifiedFormat] = preparseReplayFile();
             if (ok) {
                 mReplayHasFaultyFormat = modifiedFormat;
                 // This initiates the replay chunk reading/processing cycle:

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2692,7 +2692,7 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
             if (parseReplayFile()) {
-                // This wiil point at the first chunk (if there is one):
+                // This will point at the first chunk (if there is one):
                 mpItReplayChunk = mReplayChunks.constBegin();
                 // These test avoids problems in the event of an empty replay
                 // file:

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2002-2005 by Tomas Mecir - kmuddy@kmuddy.com            *
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2014, 2017-2019, 2021 by Stephen Lyons             *
+ *   Copyright (C) 2013-2014, 2017-2019, 2021-2022 by Stephen Lyons        *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2015 by Florian Scheel - keneanung@googlemail.com       *
@@ -60,13 +60,11 @@ using namespace std::chrono_literals;
 // of the messages
 #define DEBUG_TELNET 1
 
-// Uncomment this to report details about each replay chunk as it is recorded:
-// #define DEBUG_RECORDING 1
-
-// Uncomment this to report details about the replay data as it is replayed:
-// #define DEBUG_PLAYBACK 1
 
 constexpr size_t BUFFER_SIZE = 100000L;
+// TODO: https://github.com/Mudlet/Mudlet/issues/5780 (1 of 7) - investigate switching from using `char[]` to `std::array<char>`
+char loadBuffer[BUFFER_SIZE + 1];
+int loadedBytes;
 QDataStream replayStream;
 QFile replayFile;
 
@@ -169,11 +167,6 @@ cTelnet::cTelnet(Host* pH, const QString& profileName)
 
     mpDownloader = new QNetworkAccessManager(this);
     connect(mpDownloader, &QNetworkAccessManager::finished, this, &cTelnet::slot_replyFinished);
-
-#if defined(DEBUG_PLAYBACK)
-    mDumpReplayChunkContents = true;
-    mZeroReplayChunkDelays = true;
-#endif
 }
 
 void cTelnet::reset()
@@ -970,81 +963,6 @@ std::tuple<QString, int, bool> cTelnet::getConnectionInfo() const
     } else {
         return {hostName, hostPort, connected};
     }
-}
-
-/*static*/ QString cTelnet::dumpHexDecodedText(const QByteArray& msg)
-{
-    QString output;
-    for (int i = 0, total = msg.length(); i < total; ++i) {
-        if (static_cast<unsigned char>(msg.at(i)) >= 0x20 && static_cast<unsigned char>(msg.at(i)) < 0x7f) {
-            output.append(msg.at(i));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x00) {
-            output.append(QLatin1String("<NUL/O_BIN/SEND>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x01) {
-            output.append(QLatin1String("<O_ECHO/IS/M[SD]VAR>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x02) {
-            output.append(QLatin1String("<M[SD]VAL>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x03) {
-            output.append(QLatin1String("<O_SGA/MSDP_T_O>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x04) {
-            output.append(QLatin1String("<MSDP_T_C>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x05) {
-            output.append(QLatin1String("<O_STAT/MSDP_A_O>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x06) {
-            output.append(QLatin1String("<O_TM/MSDP_A_C>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x09) {
-            output.append(QLatin1String("<TAB>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x0A) {
-            output.append(QLatin1String("<CR>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x0C) {
-            output.append(QLatin1String("<FF>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x0D) {
-            output.append(QChar::LineFeed);
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x18) {
-            output.append(QLatin1String("<O_TTYPE>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x19) {
-            output.append(QLatin1String("<O_EOR>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0x1b) {
-            output.append(QLatin1String("<ESC>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xff) {
-            output.append(QLatin1String("<IAC>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xfe) {
-            output.append(QLatin1String("<DONT>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xfd) {
-            output.append(QLatin1String("<DO>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xfc) {
-            output.append(QLatin1String("<WONT>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xfb) {
-            output.append(QLatin1String("<WILL>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xfa) {
-            output.append(QLatin1String("<SB>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf9) {
-            output.append(QLatin1String("<GA>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf8) {
-            output.append(QLatin1String("<EL>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf7) {
-            output.append(QLatin1String("<EC>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf6) {
-            output.append(QLatin1String("<AYT>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf5) {
-            output.append(QLatin1String("<AO>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf4) {
-            output.append(QLatin1String("<IP>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf3) {
-            output.append(QLatin1String("<BRK>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf2) {
-            output.append(QLatin1String("<DM>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf1) {
-            output.append(QLatin1String("<NOP>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xf0) {
-            output.append(QLatin1String("<SE>"));
-        } else if (static_cast<unsigned char>(msg.at(i)) == 0xef) {
-            output.append(QLatin1String("<EOR>"));
-        } else {
-            output.append(QString("<%1>").arg(static_cast<unsigned char>(msg.at(i)), 3, 10, QChar('0')).toUpper());
-        }
-    }
-    return output;
 }
 
 void cTelnet::processTelnetCommand(const std::string& command)
@@ -2691,26 +2609,11 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
         }
         loadingReplay = true;
         if (mudlet::self()->replayStart()) {
-            if (parseReplayFile()) {
-                // This will point at the first chunk (if there is one):
-                mpItReplayChunk = mReplayChunks.constBegin();
-                // These test avoids problems in the event of an empty replay
-                // file:
-                if ((mpItReplayChunk != nullptr) && (mpItReplayChunk != mReplayChunks.constEnd())) {
-                    // This initiates the replay chunk reading/processing cycle:
-                    loadReplayChunk();
-                } else {
-                    loadingReplay = false;
-                    replayFile.close();
-                    if (!mIsReplayRunFromLua) {
-                        postMessage(tr("[ WARN ]  - The replay has been aborted as the file seems to be empty."));
-                    } else {
-                        // Called from lua case:
-                        *pErrMsg = tr("Cannot replay file \"%1\", error message was: \"replay file seems to be empty\".").arg(name);
-                    }
-                    mudlet::self()->replayOver();
-                    return false;
-                }
+            auto [ok, modifiedFormat] = testReadReplayFile();
+            if (Q_LIKELY(ok)) {
+                mReplayHasFaultyFormat = modifiedFormat;
+                // This initiates the replay chunk reading/processing cycle:
+                loadReplayChunk();
             } else {
                 // Amelioration code should now prevent this from happening
                 loadingReplay = false;
@@ -2751,139 +2654,131 @@ bool cTelnet::loadReplay(const QString& name, QString* pErrMsg)
     return true;
 }
 
-// TODO: https://github.com/Mudlet/Mudlet/issues/5779 - consider enhancing replay system, possibly using the QTimeLine class, to use the already read and stored QMap<quint64, QByteArray> mReplayChunks
+// TODO: https://github.com/Mudlet/Mudlet/issues/5779 - consider enhancing replay system, possibly using the QTimeLine class
 void cTelnet::loadReplayChunk()
 {
-    // Check that the iterator is assigned and valid - it gets advanced elsewhere:
-    if ((mpItReplayChunk != nullptr) && (mpItReplayChunk != mReplayChunks.constEnd())) {
-        qint64 offset = mpItReplayChunk.key();
-        mudlet::self()->mReplayTime = QTime::fromMSecsSinceStartOfDay(offset);
-        if (mpItReplayChunk != mReplayChunks.constBegin()) {
-            // This is NOT the first chunk, so the offset is the increment from
-            // the last key():
-            offset -= (mpItReplayChunk-1).key();
-        }
-        // Otherwise the offset is just the key():
-
-        if (Q_UNLIKELY(mZeroReplayChunkDelays)) {
-            QTimer::singleShot(0, this, &cTelnet::slot_processReplayChunk);
+    if (!replayStream.atEnd()) {
+        qint32 amount = 0;
+        qint32 offset = 0;
+        if (mReplayHasFaultyFormat) {
+            qint64 temp = 0;
+            replayStream >> temp;
+            // 2^30 milliseconds is over 12 days so that sort of delay between
+            // steps is not likely - and only using a 32 bit integer type is
+            // going to be okay:
+            offset = static_cast<qint32>(temp);
         } else {
-            QTimer::singleShot(offset / mudlet::self()->mReplaySpeed, this, &cTelnet::slot_processReplayChunk);
+            replayStream >> offset;
         }
-        // Replay is still running - the timer above will handle the chunk we
-        // have just loaded into the buffer at the right time in the future:
-        return;
-    }
 
-    if (mpItReplayChunk != nullptr) {
-        // This will still point to something at the end of replay, so clean it up:
-        mpItReplayChunk = nullptr;
+        replayStream >> amount;
+
+        loadedBytes = replayStream.readRawData(loadBuffer, amount);
+        // Previous use of loadedBytes + 1 caused a spurious character at end of
+        // string display by a qDebug of the loadBuffer contents
+        loadBuffer[loadedBytes] = '\0';
+        mudlet::self()->mReplayTime = mudlet::self()->mReplayTime.addMSecs(offset);
+        QTimer::singleShot(offset / mudlet::self()->mReplaySpeed, this, &cTelnet::slot_processReplayChunk);
+    } else {
+        loadingReplay = false;
+        replayFile.close();
+        if (!mIsReplayRunFromLua) {
+            postMessage(tr("[  OK  ]  - The replay has ended."));
+        }
+        mudlet::self()->replayOver();
     }
-    loadingReplay = false;
-    if (!mIsReplayRunFromLua) {
-        postMessage(tr("[  OK  ]  - The replay has ended."));
-    }
-    mudlet::self()->replayOver();
 }
 
 void cTelnet::slot_processReplayChunk()
 {
-    // Check that the iterator is assigned and valid:
-    if ((mpItReplayChunk != nullptr) && (mpItReplayChunk != mReplayChunks.constEnd())) {
-        const QByteArray& replayChunkBuffer = mpItReplayChunk.value();
-        std::string cleandata = "";
-        recvdGA = false;
-        for (const char& ch : replayChunkBuffer) {
-            if (iac || iac2 || insb || (ch == TN_IAC)) {
-                if (!(iac || iac2 || insb) && (ch == TN_IAC)) {
-                    iac = true;
-                    command += ch;
-                } else if (iac && (ch == TN_IAC) && (!insb)) {
-                    //2. seq. of two IACs
-                    iac = false;
-                    cleandata += ch;
-                    command = "";
-                } else if (iac && (!insb) && ((ch == TN_WILL) || (ch == TN_WONT) || (ch == TN_DO) || (ch == TN_DONT))) {
-                    //3. IAC DO/DONT/WILL/WONT
-                    iac = false;
-                    iac2 = true;
-                    command += ch;
-                } else if (iac2) {
-                    //4. IAC DO/DONT/WILL/WONT <command code>
-                    iac2 = false;
-                    command += ch;
-                    processTelnetCommand(command);
-                    command = "";
-                } else if (iac && (!insb) && (ch == TN_SB)) {
-                    //5. IAC SB
-                    iac = false;
-                    insb = true;
-                    command += ch;
-                } else if (iac && (!insb) && (ch == TN_SE)) {
-                    //6. IAC SE without IAC SB - error - ignored
-                    command = "";
-                    iac = false;
-                } else if (insb) {
-                    //7. inside IAC SB
-                    command += ch;
-                    if (iac && (ch == TN_SE)) //IAC SE - end of subcommand
-                    {
-                        processTelnetCommand(command);
-                        command = "";
-                        iac = false;
-                        insb = false;
-                    }
-                    if (iac) {
-                        iac = false;
-                    } else if (ch == TN_IAC) {
-                        iac = true;
-                    }
-                } else
-                //8. IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
+    int datalen = loadedBytes;
+    std::string cleandata = "";
+    recvdGA = false;
+    for (int i = 0; i < datalen; ++i) {
+        char ch = loadBuffer[i];
+        if (iac || iac2 || insb || (ch == TN_IAC)) {
+            if (!(iac || iac2 || insb) && (ch == TN_IAC)) {
+                iac = true;
+                command += ch;
+            } else if (iac && (ch == TN_IAC) && (!insb)) {
+                //2. seq. of two IACs
+                iac = false;
+                cleandata += ch;
+                command = "";
+            } else if (iac && (!insb) && ((ch == TN_WILL) || (ch == TN_WONT) || (ch == TN_DO) || (ch == TN_DONT))) {
+                //3. IAC DO/DONT/WILL/WONT
+                iac = false;
+                iac2 = true;
+                command += ch;
+            } else if (iac2) {
+                //4. IAC DO/DONT/WILL/WONT <command code>
+                iac2 = false;
+                command += ch;
+                processTelnetCommand(command);
+                command = "";
+            } else if (iac && (!insb) && (ch == TN_SB)) {
+                //5. IAC SB
+                iac = false;
+                insb = true;
+                command += ch;
+            } else if (iac && (!insb) && (ch == TN_SE)) {
+                //6. IAC SE without IAC SB - error - ignored
+                command = "";
+                iac = false;
+            } else if (insb) {
+                //7. inside IAC SB
+                command += ch;
+                if (iac && (ch == TN_SE)) //IAC SE - end of subcommand
                 {
-                    iac = false;
-                    command += ch;
                     processTelnetCommand(command);
-                    //this could have set receivedGA to true; we'll handle that later
                     command = "";
+                    iac = false;
+                    insb = false;
                 }
-            } else {
-                if (ch != '\r' && ch != '\0') {
-                    cleandata += ch;
+                if (iac) {
+                    iac = false;
+                } else if (ch == TN_IAC) {
+                    iac = true;
+                }
+            } else
+            //8. IAC fol. by something else than IAC, SB, SE, DO, DONT, WILL, WONT
+            {
+                iac = false;
+                command += ch;
+                processTelnetCommand(command);
+                //this could have set receivedGA to true; we'll handle that later
+                command = "";
+            }
+        } else {
+            if (ch != '\r' && ch != '\0') {
+                cleandata += ch;
+            }
+        }
+
+        if (recvdGA) {
+            mGA_Driver = true;
+            if (mCommands > 0) {
+                mCommands--;
+                if (networkLatencyTimer.elapsed() > 2000) {
+                    mCommands = 0;
                 }
             }
 
-            if (recvdGA) {
-                mGA_Driver = true;
-                if (mCommands > 0) {
-                    mCommands--;
-                    if (networkLatencyTimer.elapsed() > 2000) {
-                        mCommands = 0;
-                    }
-                }
-
-                cleandata.push_back('\n');
-                recvdGA = false;
-                gotPrompt(cleandata);
-                cleandata = "";
-            }
-        } //for
-
-        if (!cleandata.empty()) {
-            gotRest(cleandata);
+            cleandata.push_back('\n');
+            recvdGA = false;
+            gotPrompt(cleandata);
+            cleandata = "";
         }
+    } //for
 
-        mpHost->mpConsole->finalize();
-
-        // We must advance the iterator to the next chunk, if there isn't one it'll
-        // be handled in loadReplayChunk(); however in some cases we might not want
-        // the advance (if the flag has been reset):
-        if (loadingReplay) {
-            ++mpItReplayChunk;
-        }
+    if (!cleandata.empty()) {
+        gotRest(cleandata);
     }
 
-    loadReplayChunk();
+    mpHost->mpConsole->finalize();
+    if (loadingReplay) {
+        loadReplayChunk();
+    }
 }
 
 void cTelnet::handle_socket_signal_readyRead()
@@ -2893,7 +2788,7 @@ void cTelnet::handle_socket_signal_readyRead()
         mWaitingForResponse = false;
     }
 
-    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (1 of 6) - investigate switching from using `char[]` to `std::array<char>`
+    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (2 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char in_buffer[BUFFER_SIZE + 10];
 
     int amount = socket.read(in_buffer, BUFFER_SIZE);
@@ -2902,7 +2797,7 @@ void cTelnet::handle_socket_signal_readyRead()
 
 void cTelnet::processSocketData(char* in_buffer, int amount)
 {
-    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (2 of 6) - investigate switching from using `char[]` to `std::array<char>`
+    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (3 of 7) - investigate switching from using `char[]` to `std::array<char>`
     char out_buffer[BUFFER_SIZE + 10];
 
     in_buffer[amount + 1] = '\0';
@@ -2922,7 +2817,7 @@ void cTelnet::processSocketData(char* in_buffer, int amount)
             datalen = decompressBuffer(in_buffer, amount, out_buffer);
             buffer = out_buffer;
         }
-        // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (3 of 6) - investigate switching from using `char[]` to `std::array<char>`
+        // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (4 of 7) - investigate switching from using `char[]` to `std::array<char>`
         buffer[static_cast<size_t>(datalen)] = '\0';
         if (mpHost->mpConsole->mRecordReplay) {
             ++mRecordingChunkCount;
@@ -3238,16 +3133,15 @@ void cTelnet::setPostingTimeout(const int timeout)
 // Tries reading the replay in two different manners depending on whether the
 // the first integer value in the chunk data uses 4 (original) or 8 (modified)
 // bytes - as an unintended side effect of https://github.com/Mudlet/Mudlet/pull/4400
-// - returns true if the file can be read:
-bool cTelnet::parseReplayFile()
+// - returns two booleans, the first is true if the file can be read and the
+// second true if it is in the modified format:
+std::pair<bool, bool> cTelnet::testReadReplayFile()
 {
-    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (4 of 6) - investigate switching from using `char[]` to `std::array<char>`
-    char replayBuffer[BUFFER_SIZE];
-    if (!mReplayChunks.isEmpty()) {
-        mReplayChunks.clear();
-    }
+    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (5 of 7) - investigate switching from using `char[]` to `std::array<char>`
+    char replayBuffer[BUFFER_SIZE+1];
 
     quint64 totalElapsed = 0;
+    int replayChunks = 0;
     bool readableAsOriginalFormat = true;
     // Don't set this until we try it:
     bool readableAsModifiedFormat = false;
@@ -3259,15 +3153,14 @@ bool cTelnet::parseReplayFile()
         while (readableAsOriginalFormat && !replayStream.atEnd()) {
             replayStream >> offset;
             replayStream >> amount;
-            if (amount < 1 || offset < 0 || amount >= static_cast<qint32>(BUFFER_SIZE)) {
+            if (amount < 1 || offset < 0 || amount > static_cast<qint32>(BUFFER_SIZE)) {
                 readableAsOriginalFormat = false;
             } else {
                 int replayloadedBytes = replayStream.readRawData(replayBuffer, amount);
                 if (replayloadedBytes > -1) {
-                    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (5 of 6) - investigate switching from using `char[]` to `std::array<char>`
+                    ++replayChunks;
+                    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (6 of 7) - investigate switching from using `char[]` to `std::array<char>`
                     replayBuffer[replayloadedBytes] = '\0';
-                    QByteArray chunkData(replayBuffer, replayloadedBytes);
-                    mReplayChunks.insert(totalElapsed, chunkData);
                     totalElapsed += static_cast<quint64>(offset);
                 }
             }
@@ -3279,11 +3172,8 @@ bool cTelnet::parseReplayFile()
 
     if (!readableAsOriginalFormat) {
         readableAsModifiedFormat = true;
-        if (!mReplayChunks.isEmpty()) {
-            mReplayChunks.clear();
-        }
-
         totalElapsed = 0;
+        replayChunks = 0;
         // Try with first number being an 8 byte signed integer
         // (was int type prior to that PR):
         qint64 offset = 0;
@@ -3291,15 +3181,14 @@ bool cTelnet::parseReplayFile()
         while (readableAsModifiedFormat && !replayStream.atEnd()) {
             replayStream >> offset;
             replayStream >> amount;
-            if ((amount < 1) || (offset < 0) || (amount >= static_cast<qint32>(BUFFER_SIZE)) || (offset > INT32_MAX)) {
+            if (amount < 1 || offset < 0 || amount > static_cast<qint32>(BUFFER_SIZE) || offset > INT32_MAX) {
                 readableAsModifiedFormat = false;
             } else {
                 int replayloadedBytes = replayStream.readRawData(replayBuffer, amount);
                 if (replayloadedBytes > -1) {
-                    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (6 of 6) - investigate switching from using `char[]` to `std::array<char>`
+                    ++replayChunks;
+                    // TODO: https://github.com/Mudlet/Mudlet/issues/5780 (7 of 7) - investigate switching from using `char[]` to `std::array<char>`
                     replayBuffer[replayloadedBytes] = '\0';
-                    QByteArray chunkData(replayBuffer, replayloadedBytes);
-                    mReplayChunks.insert(totalElapsed, chunkData);
                     totalElapsed += static_cast<quint64>(offset);
                 }
             }
@@ -3309,29 +3198,11 @@ bool cTelnet::parseReplayFile()
     }
 
     if (readableAsOriginalFormat | readableAsModifiedFormat) {
-        qDebug().nospace().noquote() << "cTelnet::parseReplayFile() INFO - The " << (readableAsOriginalFormat ? "original" : "modified") << " format replay has: " << mReplayChunks.count()
-                                     << " chunks and covers a period of: " << QTime(0, 0).addMSecs(static_cast<int>(totalElapsed)).toString(QStringLiteral("hh:mm:ss.zzz")) << " (h:m:s).";
+        qDebug().nospace().noquote() << "cTelnet::testReadReplayFile() INFO - The " << (readableAsOriginalFormat ? "original" : "modified") << " format replay has: " << replayChunks
+                                     << " chunks and covers a period of: " << QTime(0, 0).addMSecs(static_cast<int>(totalElapsed)).toString(QStringLiteral("hh:mm:ss.zzz")) << " (hh:mm:ss).";
 
-        if (mDumpReplayChunkContents) {
-            QMapIterator<quint64, QByteArray> itChunk(mReplayChunks);
-            unsigned int index = 0;
-            while (itChunk.hasNext()) {
-                itChunk.next();
-                QTime offsetTime = QTime::fromMSecsSinceStartOfDay(static_cast<int>(itChunk.key()));
-                auto chunkData{itChunk.value()};
-                QString displayData;
-                for (int i = 0, total = chunkData.size(); i < total; ++i) {
-                    if (static_cast<unsigned char>(chunkData.at(i)) >= 0x20 && static_cast<unsigned char>(chunkData.at(i)) <= 0x7F) {
-                        displayData.append(chunkData.at(i));
-                    } else {
-                        displayData.append(QStringLiteral("<%1>").arg(static_cast<quint8>(chunkData.at(i)), 2, 16, QLatin1Char('0')).toUpper());
-                    }
-                }
-                qDebug().nospace().noquote() << "Chunk " << ++index << " (offset: " << offsetTime.toString("hh:mm:ss.zzz") << "):\n\"" << displayData << "\"";
-            }
-        }
-        return true;
+        return {true, readableAsModifiedFormat};
     }
 
-    return false;
+    return {false, false};
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3330,7 +3330,7 @@ bool cTelnet::parseReplayFile()
                 qDebug().nospace().noquote() << "Chunk " << ++index << " (offset: " << offsetTime.toString("hh:mm:ss.zzz") << "):\n\"" << displayData << "\"";
             }
         }
-        return true
+        return true;
     }
 
     return false;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -6,7 +6,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2014-2015 by Florian Scheel - keneanung@googlemail.com  *
- *   Copyright (C) 2015, 2017-2019, 2021 by Stephen Lyons                  *
+ *   Copyright (C) 2015, 2017-2019, 2021-2022 by Stephen Lyons             *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -242,8 +242,7 @@ private:
     void setKeepAlive(int socketHandle);
     void processChunks();
     void sendNAWS(int x, int y);
-    bool parseReplayFile();
-    static QString dumpHexDecodedText(const QByteArray&);
+    std::pair<bool, bool> testReadReplayFile();
 
 
     QPointer<Host> mpHost;
@@ -308,6 +307,7 @@ private:
     QElapsedTimer mConnectionTimer;
     qint32 mRecordLastChunkMSecTimeOffset = 0;
     int mRecordingChunkCount = 0;
+    bool mReplayHasFaultyFormat = false;
     bool enableCHARSET;
     bool enableATCP;
     bool enableGMCP;
@@ -340,22 +340,6 @@ private:
     // we can send NAWS data when it changes:
     int mNaws_x = 0;
     int mNaws_y = 0;
-
-    // Holds the replay data, Key: elapsed time in milliseconds, Value: raw data
-    QMap<quint64, QByteArray> mReplayChunks;
-
-    // Used to iterate over the above - only points to an iterator during a
-    // replay - however due to the way a QMap works we can't declare a Java
-    // style QMapIterator without constructing it - and that would break the ODR
-    // requirement by doing it here - so we have to use the STL type:
-    QMap<quint64, QByteArray>::const_iterator mpItReplayChunk = nullptr;
-
-    // Can be used (set in debugging environment) during debugging of replay files
-    // Include a fully visual display of ALL bytes in replay data in debug output:
-    bool mDumpReplayChunkContents = false;
-    // Ignore the delays when replaying replay - process the whole lot at maximum
-    // speed:
-    bool mZeroReplayChunkDelays = false;
 
 private slots:
 #if !defined(QT_NO_SSL)

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -243,7 +243,7 @@ private:
     void processChunks();
     void sendNAWS(int x, int y);
     std::pair<bool, bool> preparseReplayFile();
-    QString dumpHexDecodedText(const QByteArray&) const;
+    static QString dumpHexDecodedText(const QByteArray&);
 
 
     QPointer<Host> mpHost;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -242,6 +242,8 @@ private:
     void setKeepAlive(int socketHandle);
     void processChunks();
     void sendNAWS(int x, int y);
+    std::pair<bool, bool> preparseReplayFile();
+    QString dumpHexDecodedText(const QByteArray&) const;
 
 
     QPointer<Host> mpHost;
@@ -304,7 +306,9 @@ private:
     QTimer* mTimerPass;
     QElapsedTimer mRecordingChunkTimer;
     QElapsedTimer mConnectionTimer;
-    int mRecordLastChunkMSecTimeOffset;
+    qint32 mRecordLastChunkMSecTimeOffset = 0;
+    int mRecordingChunkCount = 0;
+    bool mReplayHasFaultyFormat = false;
     bool enableCHARSET;
     bool enableATCP;
     bool enableGMCP;
@@ -337,6 +341,16 @@ private:
     // we can send NAWS data when it changes:
     int mNaws_x = 0;
     int mNaws_y = 0;
+
+    // Holds the replay data, Key: elapsed time in milliseconds, Value: raw data
+    QMap<quint64, QByteArray> mReplayChunks;
+
+    // Can be used (set in debugging environment) during debugging of replay files
+    // Include a fully visual display of ALL bytes in replay data in debug output:
+    bool mDumpReplayChunkContents = false;
+    // Ignore the delays when replaying replay - process the whole lot at maximum
+    // speed:
+    bool mZeroReplayChunkDelays = false;
 
 private slots:
 #if !defined(QT_NO_SSL)

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -242,7 +242,7 @@ private:
     void setKeepAlive(int socketHandle);
     void processChunks();
     void sendNAWS(int x, int y);
-    std::pair<bool, bool> testReadReplayFile();
+    static std::pair<bool, bool> testReadReplayFile();
 
 
     QPointer<Host> mpHost;

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -242,7 +242,7 @@ private:
     void setKeepAlive(int socketHandle);
     void processChunks();
     void sendNAWS(int x, int y);
-    std::pair<bool, bool> preparseReplayFile();
+    bool parseReplayFile();
     static QString dumpHexDecodedText(const QByteArray&);
 
 
@@ -308,7 +308,6 @@ private:
     QElapsedTimer mConnectionTimer;
     qint32 mRecordLastChunkMSecTimeOffset = 0;
     int mRecordingChunkCount = 0;
-    bool mReplayHasFaultyFormat = false;
     bool enableCHARSET;
     bool enableATCP;
     bool enableGMCP;
@@ -344,6 +343,12 @@ private:
 
     // Holds the replay data, Key: elapsed time in milliseconds, Value: raw data
     QMap<quint64, QByteArray> mReplayChunks;
+
+    // Used to iterate over the above - only points to an iterator during a
+    // replay - however due to the way a QMap works we can't declare a Java
+    // style QMapIterator without constructing it - and that would break the ODR
+    // requirement by doing it here - so we have to use the STL type:
+    QMap<quint64, QByteArray>::const_iterator mpItReplayChunk = nullptr;
 
     // Can be used (set in debugging environment) during debugging of replay files
     // Include a fully visual display of ALL bytes in replay data in debug output:


### PR DESCRIPTION
~~Add in some code I had to pre-parse ALL the replay data into an ordered container (a `QMap<quint64, QByteArray>`) -~~ *Fix* the defect in the existing replay code ~~was that~~ *made* when I switched from use a `QTime` to a `QElapsedTimer` in PR #4400 I neglected to account for the `elapsed()` method's return type changing from an `int` (effectively a `int32_t`) to a `qint64` (a.k.a. `int64_t`). This commit attempts to get around the issue by trying to read the two integer values that preceed each "chunk" of replay data in the recording first as two 4 byte `int32_t`s (actually  `qint32`s) and if that does not work (because it produces obviously wrong values - negative or overlarge) to try again with the first of the values as an 8 byte `qint64`.

This commit also corrects the code that produces a recording file to use a 4 byte `qint32` as the first value, restoring the format to that used prior to the altered form in the original PR - which was introduced ***after*** Mudlet **4.10.1** was released.

~~TODO: Enhance the actual playback code so as to make use of the preparsed recording data.~~

This should close #5770.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix: repair replay functionality to work again - and prevent Mudlet crashing when trying to replay a recording made in Mudlet versions after Mudlet 4.10.1. Replay made **in the intervening period will be safe to load in Mudlet versions *after*** this fix is introduced; also replays made **after this will also be safe to load in Mudlet versions of that period**.

***Edited: to reflect changes in PR that dropped an initial idea...***