### PR TITLE
Fix datetime:parse and :calculcate_UTCdiff to account for DST

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -88,7 +88,7 @@ function datetime:calculate_UTCdiff(ts)
   local date, time = os.date, os.time
   local utc = date('!*t', ts)
   local lcl = date('*t', ts)
-  lcl.isdst = false
+  lcl.isdst = os.date("*t")["isdst"]
   return os.difftime(time(lcl), time(utc))
 end
 
@@ -176,7 +176,7 @@ function datetime:parse(source, format, as_epoch)
 
     dt.min = tonumber(m.minute)
     dt.sec = tonumber(m.second)
-    dt.isdst = false
+    dt.isdst = os.date("*t")["isdst"]
 
     if as_epoch then
       return os.time(dt)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix datetime:parse and :calculcate_UTCdiff to account for DST
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/2514

#### Other info (issues closed, discussion etc)
Just applying the existing solution already worked out in the issue, which seems reasonable to me.