### PR TITLE
Add Geyser.StyleSheet for managing stylesheets with inheritance

### DIFF
--- a/src/mudlet-lua/lua/LuaGlobal.lua
+++ b/src/mudlet-lua/lua/LuaGlobal.lua
@@ -116,6 +116,7 @@ local packages = {
   "geyser/GeyserUtil.lua",
   "geyser/GeyserColor.lua",
   "geyser/GeyserSetConstraints.lua",
+  "geyser/GeyserStyleSheet.lua",
   "geyser/GeyserContainer.lua",
   "geyser/GeyserWindow.lua",
   "geyser/GeyserLabel.lua",

--- a/src/mudlet-lua/lua/geyser/GeyserStyleSheet.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserStyleSheet.lua
@@ -24,7 +24,7 @@ function Geyser.StyleSheet:new(stylesheet, parent, target)
   elseif styleType == "table" then
     styleTable = table.deepcopy(stylesheet)
   else
-    printError("Geyser.StyleSheet:new stylesheet as string or table expected, got " .. styleType, true, true)
+    printError("Geyser.StyleSheet:new: stylesheet as string or table expected, got " .. styleType, true, true)
   end
   obj:setStyleTable(styleTable or {})
   obj:setParent(parent)
@@ -41,11 +41,11 @@ function Geyser.StyleSheet:parseCSS(stylesheet)
   end
   local stylesheetType = type(stylesheet)
   if type(stylesheet) ~= "string" then
-    printError("parseCss: stylesheet as string expected, got " .. stylesheetType, true, true)
+    printError("parseCSS: stylesheet as string expected, got " .. stylesheetType, true, true)
   end
   local styleTable = {}
   if not stylesheet:find(";") then
-    return nil, "No valid lines found in stylesheet. Lines must be terminated by a ;"
+    return nil, "no valid lines found in stylesheet. Lines must be terminated by a ;"
   end
   local target, styles = match(stylesheet,"(%w+)%s*{(.*)}")
   if styles then stylesheet = styles end
@@ -102,7 +102,7 @@ function Geyser.StyleSheet:setCSS(css)
   end
   local styleTable, target = self:parseCSS(css)
   if not styleTable then
-    return nil, f"Error parsing css: {target}"
+    return nil, f"error parsing css: {target}"
   end
   if target then
     self:setTarget(target)

--- a/src/mudlet-lua/lua/geyser/GeyserStyleSheet.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserStyleSheet.lua
@@ -1,0 +1,163 @@
+--- Represents a stylesheet used for styling Labels
+-- Based primarily off the work of Vadi on CSSMan (https://forums.mudlet.org/viewtopic.php?f=6&t=3502)
+-- This version extends it with recursive inheritance of properties, storing the target of the stylesheet (QLabel, QPlainTextEdit, etc), and parsing string stylesheets for them.
+-- @module Geyser.StyleSheet
+Geyser.StyleSheet = {}
+Geyser.StyleSheet.__index = Geyser.StyleSheet
+
+-- create locals for things we use in loops or recursively (speed optimization)
+local trim, match, gsub, split, update, format = string.trim, string.match, string.gsub, string.split, table.update, string.format
+
+--- Creates a new StyleSheet
+-- @param stylesheet the stylesheet to start off with
+-- @param parent if provided, this stylesheet will inherit values for keys it does not set from its parent
+-- @param target if provided, will enclose the stylesheet in "category { stylesheet }". Will also extract this information from a stylesheet formatted in this way.
+function Geyser.StyleSheet:new(stylesheet, parent, target)
+  local obj = {}
+  setmetatable(obj, Geyser.StyleSheet)
+  local styleType = type(stylesheet)
+  local styleTable
+  if styleType == "string" then
+    local tgt
+    styleTable, tgt = self:parseCSS(stylesheet)
+    if not target then target = tgt end
+  elseif styleType == "table" then
+    styleTable = table.deepcopy(stylesheet)
+  else
+    printError("Geyser.StyleSheet:new stylesheet as string or table expected, got " .. styleType, true, true)
+  end
+  obj:setStyleTable(styleTable or {})
+  obj:setParent(parent)
+  obj:setTarget(target)
+  return obj
+end
+
+--- Parses a text stylesheet into a property:value table
+-- @param stylesheet the stylesheet(as a string) to parse
+-- @return table of stylesheet properties with their values
+function Geyser.StyleSheet:parseCSS(stylesheet)
+  if stylesheet == "" then
+    return {}, nil
+  end
+  local stylesheetType = type(stylesheet)
+  if type(stylesheet) ~= "string" then
+    printError("parseCss: stylesheet as string expected, got " .. stylesheetType, true, true)
+  end
+  local styleTable = {}
+  if not stylesheet:find(";") then
+    return nil, "No valid lines found in stylesheet. Lines must be terminated by a ;"
+  end
+  local target, styles = match(stylesheet,"(%w+)%s*{(.*)}")
+  if styles then stylesheet = styles end
+  stylesheet = gsub(stylesheet, "[\r\n]", "")
+  for _,element in ipairs(split(stylesheet, ";")) do
+    element = trim(element)
+    local property, value = match(element, "^(.-):(.+)$")
+    if property and value then
+      styleTable[trim(property)] = trim(value)
+    end
+  end
+  return styleTable, target
+end
+
+--- Sets the value of a stylesheet property
+-- @param property the property to set the value for, as a string
+-- @param value the value to set for the property, as a string
+function Geyser.StyleSheet:set(property, value)
+  self.styleTable[trim(property)] = trim(value)
+end
+
+--- Returns the value of a stylesheet property
+-- @param property the property to return the value of
+function Geyser.StyleSheet:get(property)
+  return self.styleTable[property]
+end
+
+--- Returns the stylesheet as a string for use in set*StyleSheet functions.
+-- @param inherit Defaults to true. If true, returns table with properties inherited from its parent (if any). If false will only return the properties set in this StyleSheet
+-- @return stylesheet as a string, suitable for passing in to set*StyleSheet() functions
+function Geyser.StyleSheet:getCSS(inherit)
+  inherit = type(inherit) == "nil" and true or inherit
+  local styleTable = self:getStyleTable(inherit)
+  local styleString = ""
+  for prop, val in spairs(styleTable) do
+    styleString = format("%s%s: %s;\n", styleString, prop, val)
+  end
+  if self.target then
+    styleString = format("%s {\n%s}", self.target, styleString)
+  end
+  return styleString
+end
+
+--- Set the style for this StyleSheet using the text stylesheet.
+-- @param css the stylesheet to parse. If not provided will clear the style
+function Geyser.StyleSheet:setCSS(css)
+  if css == nil then
+    self.styleTable = {}
+    return
+  end
+  local cssType = type(css)
+  if cssType ~= "string" then
+    printError(f"Geyser.StyleSheet:setCSS: bad argument #1 type (css as string expected, got {cssType})", true, true)
+  end
+  local styleTable, target = self:parseCSS(css)
+  if not styleTable then
+    return nil, f"Error parsing css: {target}"
+  end
+  if target then
+    self:setTarget(target)
+  end
+  self:setStyleTable(styleTable)
+end
+
+--- Returns the stylesheet as a table with the properties as keys which hold the value they've had set. Inherits property:values for unset properties from its parent stylesheet, if set.
+-- @param inherit Defaults to true. If true, returns table with properties inherited from its parent (if any). If false will only return the properties set in this StyleSheet
+-- @return StyleSheet as a property:value table
+function Geyser.StyleSheet:getStyleTable(inherit)
+  inherit = type(inherit) == "nil" and true or inherit
+  local styleTable = {}
+  if self.parent and inherit then
+    styleTable = self.parent:getStyleTable()
+  end
+  styleTable = update(styleTable, self.styleTable)
+  return styleTable
+end
+
+--- Allows you to set the styleTable directly with the properties as keys which hold the value to set for the property.
+-- @param styleTable table with properties for keys and their values as the value. If not provided will clear the style.
+function Geyser.StyleSheet:setStyleTable(styleTable)
+  styleTable = styleTable or {}
+  local styleTableType = type(styleTable)
+  if styleTableType ~= "table" then
+    printError(f"Geyser.StyleSheet:setStyleTable: bad argument #1 type (styleTable as table expected, got {styleTableType}!)", true, true)
+  end
+  self.styleTable = styleTable
+end
+
+--- Allows you to set the parent for this stylesheet. Any properties set in the parent will be used by this stylesheet unless it has a value set for that property itself.
+-- @param parent a Geyser.StyleSheet to inherit from. If not provided, clears the parent.
+function Geyser.StyleSheet:setParent(parent)
+  if not parent then
+    self.parent = nil
+    return
+  end
+  if getmetatable(parent) == Geyser.StyleSheet then
+    self.parent = parent
+    return
+  end
+  printError(f"Geyser.StyleSheet:setParent: bad argument #1 type (Geyser.StyleSheet expected, got {type(parent)})", true, true)
+end
+
+--- Allows you to set a target for this stylesheet to effect, such as "QPlainTextEdit" etc.
+-- @param The target to apply this stylesheet to. if not provided will clear the target.
+function Geyser.StyleSheet:setTarget(target)
+  if target == nil then
+    self.target = nil
+    return
+  end
+  local targetType = type(target)
+  if targetType ~= "string" then
+    printError(f"Geyser.StyleSheet:setTarget: bad argument #1 type (optional target as string expected, got {targetType})", true, true)
+  end
+  self.target = target
+end

--- a/src/mudlet-lua/tests/GeyserStyleSheet_spec.lua
+++ b/src/mudlet-lua/tests/GeyserStyleSheet_spec.lua
@@ -1,0 +1,306 @@
+describe("Tests functionality of Geyser.StyleSheet", function()
+
+  describe("Tests the functionality of Geyser.StyleSheet:parseCSS", function()
+    it("Should convert a string stylesheet into a table of properties", function()
+      local sheet = [[
+        background-color: black;
+        color: green;
+      ]]
+      local expected = {
+        ['background-color'] = "black",
+        color = "green",
+      }
+      local actual = Geyser.StyleSheet:parseCSS(sheet)
+      assert.are.same(expected, actual)
+    end)
+
+    it("Should extract the style and target if both are provided in the stylesheet", function()
+      local sheet = [[
+        QPlainTextEdit  { 
+          background-color: black;
+          color: green;
+        }
+      ]]
+      local styleTable, target = Geyser.StyleSheet:parseCSS(sheet)
+      local expectedTarget = "QPlainTextEdit"
+      local expectedTable = {
+        ['background-color'] = "black",
+        color = "green",
+      }
+      assert.equal(expectedTarget, target)
+      assert.are.same(expectedTable, styleTable)
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:get", function()
+    local sheet = Geyser.StyleSheet:new([[
+      background-color: black;
+      color: green;
+    ]])
+
+    it("Should return nil if a property is not set", function()
+      local actual = sheet:get("bobble")
+      assert.is_nil(actual)
+    end)
+
+    it("Should return the property's value", function()
+      local expected = "green"
+      local actual = sheet:get("color")
+      assert.equal(expected, actual)
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:set", function()
+    local sheet
+
+    before_each(function()
+      sheet = Geyser.StyleSheet:new([[
+        background-color: black;
+        color: green;
+      ]])
+    end)
+
+    it("Should change a property's value", function()
+      assert.equal("green", sheet:get("color"))
+      sheet:set("color", "blue")
+      local expected = "blue"
+      local actual = sheet:get("color")
+      assert.equal(expected, actual)
+    end)
+
+    it("Should add a new property", function()
+      assert.is_nil(sheet:get("bobble"))
+      sheet:set("bobble", "babble")
+      local expected = "babble"
+      local actual = sheet:get("bobble")
+      assert.equal(expected, actual)
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:getStyleTable", function()
+    local parent, child
+    before_each(function()
+      parent = Geyser.StyleSheet:new([[
+        background-color: black;
+        color: green;
+      ]])
+      child = Geyser.StyleSheet:new([[
+        color: blue;
+        font: "Ubuntu Mono";
+      ]], parent)
+    end)
+
+    it("Should return the combined/inherited stylesheet by default", function()
+      local expected = {
+        ['background-color'] = "black",
+        ['color'] = "blue",
+        ['font'] = '"Ubuntu Mono"'
+      }
+      local actual = child:getStyleTable()
+      assert.are.same(expected, actual)
+    end)
+
+    it("Should return only its own properties if passed false as a parameter", function()
+      local expected = {
+        color = "blue",
+        font = '"Ubuntu Mono"'
+      }
+      local actual = child:getStyleTable(false)
+      assert.are.same(expected, actual)
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:setStyleTable", function()
+    local parent, child
+    before_each(function()
+      parent = Geyser.StyleSheet:new([[
+        background-color: black;
+        color: green;
+      ]])
+      child = Geyser.StyleSheet:new([[
+        color: blue;
+        font: "Ubuntu Mono";
+      ]], parent)
+    end)
+
+    it("Should replace the existing style table", function()
+      local expected = {
+        color = "purple"
+      }
+      child:setStyleTable({color = "purple"})
+      local actual = child:getStyleTable(false)
+      assert.are.same(expected, actual)
+    end)
+
+    it("Should clear the style table if called with no parameters", function()
+      local expected = {}
+      child:setStyleTable()
+      local actual = child:getStyleTable(false)
+      assert.are.same(expected, actual)
+    end)
+
+    it("Should raise an error if passed anything other than a table", function()
+      local stt = function()
+        child:setStyleTable(4)
+      end
+      assert.error_matches(stt, "bad argument #1 type")
+    end)
+
+    it("Should not effect the parent", function()
+      child:setStyleTable({color = "purple"})
+      local expected = "green"
+      local actual = parent:getStyleTable().color
+      assert.equal(expected, actual)
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:setParent", function()
+    local parent, child
+    before_each(function()
+      parent = Geyser.StyleSheet:new([[
+        background-color: black;
+        color: green;
+      ]])
+      child = Geyser.StyleSheet:new([[
+        color: blue;
+        font: "Ubuntu Mono";
+      ]])
+    end)
+
+    it("Should set the parent for your stylesheet", function()
+      child:setParent(parent)
+      assert.equal(parent, child.parent)
+    end)
+
+    it("Should clear the parent if no parent is passed in", function()
+      child:setParent(parent) -- give it something to clear
+      child:setParent()       -- and clear it
+      assert.is_nil(child.parent)
+    end)
+
+    it("Should throw an error if passed anything but a Geyser.StyleSheet", function()
+      local sp = function()
+        child:setParent("Not proper")
+      end
+      assert.error_matches(sp, "bad argument #1 type")
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:setTarget", function()
+    local stylesheet
+    before_each(function()
+      stylesheet = Geyser.StyleSheet:new([[
+        background-color: black;
+        color: green;
+      ]])
+    end)
+
+    it("Should set the target", function()
+      stylesheet:setTarget("QPlainTextEdit")
+      local expected = "QPlainTextEdit"
+      local actual = stylesheet.target
+      assert.equal(expected, actual)
+    end)
+
+    it("Should clear the target if no target is passed in", function()
+      stylesheet:setTarget("QPlainTextEdit") -- set it
+      stylesheet:setTarget()                 -- and clear it
+      assert.is_nil(stylesheet.target)
+    end)
+
+    it("Should throw an error if anything besides a string is passed in", function()
+      local st = function()
+        stylesheet:setTarget(4)
+      end
+      assert.error_matches(st, "bad argument #1 type")
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:setCSS", function()
+    local stylesheet
+    before_each(function()
+      stylesheet = Geyser.StyleSheet:new("")
+    end)
+
+    it("Should configure the stylesheet the same as passing the css to new", function()
+      local sheet = [[
+        background-color: black;
+        color: green;
+      ]]
+      local stylesheet2 = Geyser.StyleSheet:new(sheet)
+      stylesheet:setCSS(sheet)
+      local expected = stylesheet2:getStyleTable()
+      local actual = stylesheet:getStyleTable()
+      assert.are.same(expected, actual)
+    end)
+
+    it("Should configure the target if it's included in the css", function()
+      local sheet = [[QLabel {
+        background-color: black;
+        color: green;
+      }]]
+      stylesheet:setCSS(sheet)
+      local expected = "QLabel"
+      local actual = stylesheet.target
+      assert.equal(expected, actual)
+    end)
+
+    it("Should clear the stylesheet if passed an empty string", function()
+      local sheet = [[
+        background-color: black;
+        color: green;
+      ]]
+      stylesheet:setCSS(sheet) -- give it something to clear
+      stylesheet:setCSS()      -- and clear it
+      local expected = {}
+      local actual = stylesheet:getStyleTable()
+      assert.are.same(expected, actual)
+    end)
+
+    it("Should throw an error if passed something besides a string", function()
+      local sc = function()
+        stylesheet:setCSS(5)
+      end
+      assert.error_matches(sc, "bad argument #1 type")
+    end)
+  end)
+
+  describe("Tests the functionality of Geyser.StyleSheet:getCSS", function()
+    local parent, child
+    before_each(function()
+      parent = Geyser.StyleSheet:new([[
+        background-color: black;
+        color: green;
+      ]])
+      child = Geyser.StyleSheet:new([[
+        color: blue;
+        font: "Ubuntu Mono";
+      ]], parent)
+    end)
+
+    it("Should assemble the string stylesheet", function()
+      local expected = "background-color: black;\ncolor: green;\n"
+      local actual = parent:getCSS()
+      assert.equal(expected, actual)
+    end)
+
+    it("Should include values inherited from the parent by default", function()
+      local expected = 'background-color: black;\ncolor: blue;\nfont: "Ubuntu Mono";\n'
+      local actual = child:getCSS()
+      assert.equal(expected, actual)
+    end)
+
+    it("Should ignore values inherited from the parent if passed false as a parameter", function()
+      local expected = 'color: blue;\nfont: "Ubuntu Mono";\n'
+      local actual = child:getCSS(false)
+      assert.equal(expected, actual)
+    end)
+
+    it("Should wrap it in 'target { }' if a target is set", function()
+      child:setTarget("QLabel")
+      local expected = 'QLabel {\nbackground-color: black;\ncolor: blue;\nfont: "Ubuntu Mono";\n}'
+      local actual = child:getCSS()
+      assert.equal(expected, actual)
+    end)
+  end)
+end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
[CSSMan](https://forums.mudlet.org/viewtopic.php?f=6&t=3502) has been around for a while now and does a pretty good job, but it's not included as part of Mudlet and it doesn't support a way to combine stylesheets/represent inheritance. And since the C in CSS is meant to be 'cascading' I thought it was time to fix that.

This PR adds Geyser.StyleSheet, which mostly functions like CSSMan but with the following additions:

* It will parse and remember for the 'target' of the stylesheet. IE our example for setCmdLineStyleSheet points to `QPlainTextEdit { style }` and this will now parse and remember the QPlainTextEdit, and include it in the stylesheet produced by :getCSS()
* It can receive a parent stylesheet as the second argument to :new. If it is given then the stylesheet will inherit any properties and their values from their parent (and its parent, etc recursively) and overwrite the value of any property it has explicitly set. This means if you have a bunch of things with the same stylesheet except for the color, you can create a parent stylesheet, and then only assign the color to each of the child sheets. If you adjust the parent, the children will pick up this change.
* It provides a way to set/reset the entire style after creation either with a new string stylesheet(:setCSS), or with a table of properties and values(:setStyleTable). This is so that you can reset the style of a parent all at once without breaking inheritance by creating an entirely new object via :new

Example:

```lua
local parent = Geyser.StyleSheet:new([[
    background-color: black;
    color: green;
]])
local child = Geyser.StyleSheet:new([[
  color: blue;
  font: "Ubuntu Mono";
]], parent)

parent:getCSS()
-- "background-color: black;\ncolor: green;\n"
child:getCSS()
-- 'background-color: black;\ncolor: blue;\nfont: "Ubuntu Mono";\n"
child:setTarget("QPlainTextEdit")
child:getCSS()
-- 'QPlainTextEdit {\nbackground-color: black;\ncolor: blue;\nfont: "Ubuntu Mono";\n}'
child:getCSS(false) -- do not inherit
-- 'QPlainTextEdit {\ncolor: blue;\nfont: "Ubuntu Mono";\n}'

child:getStyleTable()
--[=[
{
  ['background-color'] = "black",
  ['color'] = "blue",
  ['font'] = '"Ubuntu Mono"'
}
--]=]
child:getStyleTable(false) -- do not inherit
--[=[
{
  ['color'] = "blue",
  ['font']  = '"Ubuntu Mono"'
}
--]=]
```

#### Motivation for adding to Mudlet

Been doing work with Label stylesheets more lately, which prompted me to look at CSSMan again. And in that very thread are several calls for it to be added to Geyser, and an unresolved question on how to handle similar stylesheets with minor differences. So this seemed like a decent next thing to add after the c/d/hecho for Labels.
#### Other info (issues closed, discussion etc)

Docs staged at https://wiki.mudlet.org/w/Area_51/GeyserStyleSheet

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
