### PR TITLE
Add failure reasons to `installPackage` and `installModule`

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1695,7 +1695,7 @@ std::pair<bool, QString> Host::installPackage(const QString& fileName, int modul
         if ((module == 2) && (mActiveModules.contains(packageName))) {
             uninstallPackage(packageName, 2);
         } else if ((module == 3) && (mActiveModules.contains(packageName))) {
-            return {false, qsl("module %1 is already installed").arg(packageName))}; //we're already installed
+            return {false, qsl("module %1 is already installed").arg(packageName)}; //we're already installed
         }
     } else {
         if (mInstalledPackages.contains(packageName)) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1661,7 +1661,7 @@ bool Host::isClosingDown()
     return mIsClosingDown;
 }
 
-bool Host::installPackage(const QString& fileName, int module)
+std::pair<bool, QString> Host::installPackage(const QString& fileName, int module)
 {
     // As the pointed to dialog is only used now WITHIN this method and this
     // method can be re-entered, it is best to use a local rather than a class
@@ -1676,12 +1676,12 @@ bool Host::installPackage(const QString& fileName, int module)
     //     This separation is necessary to be able to reuse code while avoiding infinite loops from script installations.
 
     if (fileName.isEmpty()) {
-        return false;
+        return {false, qsl("no package file was actually given")};
     }
 
     QFile file(fileName);
     if (!file.open(QFile::ReadOnly | QFile::Text)) {
-        return false;
+        return {false, qsl("could not open file '%1").arg(fileName)};
     }
 
     QString packageName = fileName.section(qsl("/"), -1);
@@ -1695,11 +1695,11 @@ bool Host::installPackage(const QString& fileName, int module)
         if ((module == 2) && (mActiveModules.contains(packageName))) {
             uninstallPackage(packageName, 2);
         } else if ((module == 3) && (mActiveModules.contains(packageName))) {
-            return false; //we're already installed
+            return {false, qsl("module %1 is already installed").arg(packageName))}; //we're already installed
         }
     } else {
         if (mInstalledPackages.contains(packageName)) {
-            return false;
+            return {false, qsl("package %1 is already installed").arg(packageName)};
         }
     }
     //the extra module check is needed here to prevent infinite loops from script loaded modules
@@ -1723,7 +1723,7 @@ bool Host::installPackage(const QString& fileName, int module)
         pUnzipDialog = dynamic_cast<QDialog*>(loader.load(&uiFile, nullptr));
         uiFile.close();
         if (!pUnzipDialog) {
-            return false;
+            return {false, qsl("could not load unpacking progress dialog")};
         }
 
         auto * pLabel = pUnzipDialog->findChild<QLabel*>(qsl("label"));
@@ -1747,7 +1747,7 @@ bool Host::installPackage(const QString& fileName, int module)
         pUnzipDialog->deleteLater();
         pUnzipDialog = nullptr;
         if (!successful) {
-            return false;
+            return {false, qsl("could not unzip package")};
         }
 
         // requirements for zip packages:
@@ -1771,7 +1771,7 @@ bool Host::installPackage(const QString& fileName, int module)
                 if (mInstalledPackages.contains(packageName)) {
                     // cleanup and quit if already installed
                     removeDir(_dir.absolutePath(), _dir.absolutePath());
-                    return false;
+                    return {false, qsl("package %1 is already installed").arg(packageName)};
                 }
             }
             // continuing, so update the folder name on disk
@@ -1880,7 +1880,7 @@ bool Host::installPackage(const QString& fileName, int module)
     }
 
 
-    return true;
+    return {true, QString()};
 }
 
 // credit: http://john.nachtimwald.com/2010/06/08/qt-remove-directory-and-its-contents/

--- a/src/Host.h
+++ b/src/Host.h
@@ -298,7 +298,7 @@ public:
 
     void updateDisplayDimensions();
 
-    bool installPackage(const QString&, int);
+    std::pair<bool, QString> installPackage(const QString&, int);
     bool uninstallPackage(const QString&, int);
     bool removeDir(const QString&, const QString&);
     void readPackageConfig(const QString&, QString&, bool);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -10665,7 +10665,9 @@ int TLuaInterpreter::installPackage(lua_State* L)
 {
     QString location = getVerifiedString(L, __func__, 1, "package location path and file name");
     Host& host = getHostFromLua(L);
-    lua_pushboolean(L, host.installPackage(location, 0));
+    if (auto [success, message] = host.installPackage(location, 0); !success) {
+        return warnArgumentValue(L, __func__, message);
+    }
     return 1;
 }
 
@@ -10685,9 +10687,8 @@ int TLuaInterpreter::installModule(lua_State* L)
     Host& host = getHostFromLua(L);
     QString module = QDir::fromNativeSeparators(modName);
 
-    if (!host.installPackage(module, 3)) {
-        lua_pushboolean(L, false);
-        return 1;
+    if (auto [success, message] = host.installPackage(module, 3); !success) {
+        return warnArgumentValue(L, __func__, message);
     }
     auto moduleManager = host.mpModuleManager;
     if (moduleManager && moduleManager->mModuleTable->isVisible()) {

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1070,11 +1070,11 @@ end
 local acceptableSuffix = {"xml", "mpackage", "zip", "trigger"}
 
 function verbosePackageInstall(fileName)
-  local installationSuccessful = installPackage(fileName)
+  local ok, err = installPackage(fileName)
   local packageName = string.gsub(fileName, getMudletHomeDir() .. "/", "")
   -- That is all for installing, now to announce the result to the user:
   mudlet.Locale = mudlet.Locale or loadTranslations("Mudlet")
-  if installationSuccessful then
+  if ok then
     local successText = mudlet.Locale.packageInstallSuccess.message
     successText = string.format(successText, packageName)
     local okPrefix = mudlet.Locale.prefixOk.message
@@ -1082,7 +1082,7 @@ function verbosePackageInstall(fileName)
     -- Light Green and Orange-ish; see cTelnet::postMessage for color comparison
   else
     local failureText = mudlet.Locale.packageInstallFail.message
-    failureText = string.format(failureText, packageName)
+    failureText = string.format(failureText, packageName, err)
     local warnPrefix = mudlet.Locale.prefixWarn.message
     decho('<0,150,190>' .. warnPrefix .. '<190,150,0>' .. failureText .. '\n')
     -- Cyan and Orange; see cTelnet::postMessage for color comparison

--- a/translations/lua/mudlet-lua.json
+++ b/translations/lua/mudlet-lua.json
@@ -72,7 +72,7 @@
     "description":"Success message after drag&drop of package file onto Mudlet - %s is the file name"
   },
   "Mudlet.packageInstallFail": {
-    "message":"Package '%s' installation failed.",
+    "message":"Installing '%s' failed: %s",
     "description":"Failure message after drag&drop of package file onto Mudlet - %s is the file name"
   },
   "Mudlet.packageDownloading": {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add failure reasons to `installPackage` and `installModule`
#### Motivation for adding to Mudlet
More clarity! Dragging and dropping a package you've already got actually gives a reason now:

![image](https://user-images.githubusercontent.com/110988/147362383-d389372d-f633-40ee-9364-9739c915d6b0.png)

#### Other info (issues closed, discussion etc)
Package importer and module dialogs still need messages in them - I'll do that after this passes through.