### PR TITLE
Infrastructure: exclude 3rdparty dir for clang-tidy

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - '**.cpp'
     - '**.h'
+    - '.github/workflows/clangtidy-diff-analysis.yml'
 
 jobs:
   compile-mudlet:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -5,7 +5,6 @@ on:
     paths:
     - '**.cpp'
     - '**.h'
-    - '.github/workflows/clangtidy-diff-analysis.yml'
 
 jobs:
   compile-mudlet:
@@ -114,11 +113,11 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.6.1
+      uses: ZedThree/clang-tidy-review@v0.7.0
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory
-        excludetest: '3rdparty'
+        exclude: '3rdparty'
         # PLACEMARKER: list of clang-tidy checks
         clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
         # the action doesn't see system-level libraries, need to replicate them here

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -113,10 +113,11 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.7.0
+      uses: ZedThree/clang-tidy-review@v0.6.1
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory
+        excludetest: '3rdparty'
         # PLACEMARKER: list of clang-tidy checks
         clang_tidy_checks: '-*,performance-*,readability-*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,mpi-*,misc-*,-readability-implicit-bool-conversion,-readability-qualified-auto,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-static-accessed-through-instance,-cppcoreguidelines-pro-type-static-cast-downcast,-bugprone-suspicious-enum-usage,-readability-uppercase-literal-suffix,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-misc-no-recursion,-readability-isolate-declaration,-cppcoreguidelines-pro-type-vararg,-misc-non-private-member-variables-in-classes,-performance-no-automatic-move,-readability-avoid-const-params-in-decls,-cppcoreguidelines-non-private-member-variables-in-classes'
         # the action doesn't see system-level libraries, need to replicate them here

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,8 +50,6 @@ using namespace std::chrono_literals;
 
 TConsole* spDebugConsole = nullptr;
 
-// test - delete me
-
 #if defined(Q_OS_WIN32)
 bool runUpdate();
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,8 @@ using namespace std::chrono_literals;
 
 TConsole* spDebugConsole = nullptr;
 
+// test - delete me
+
 #if defined(Q_OS_WIN32)
 bool runUpdate();
 #endif


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Exclude 3rdparty dir for clang-tidy
#### Motivation for adding to Mudlet
So it doesn't complain about code that's not relevant to us
#### Other info (issues closed, discussion etc)
I think the PR has to be merged for the changes to take effect.