### PR TITLE
Infrastructure: still run clang-tidy diff when its own workflow is modified

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - '**.cpp'
     - '**.h'
+    - '.github/workflows/clangtidy-diff-analysis.yml'
 
 jobs:
   compile-mudlet:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
clang-tidy diffs is setup to run only when C++ files are changed - which means that when working on the workflow file itself, the check wouldn't run and you aren't able to see the changes!

Fix it so editing the file itself still triggers the workflow to run.
#### Motivation for adding to Mudlet
So it's easier to work with the file and you don't have to fake changes in the C++ files.