### PR TITLE
Infrastructure: Fix Typo in qt-ordered-map submodule init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ git_submodule_init(
   READABLE_NAME "lua code formatter source code")
 
 git_submodule_init(
-  CHECK_FILE "3rdparty/qt-orordered-map/src/orderedmap.h" SUBMODULE_PATH "3rdparty/qt-ordered-map"
+  CHECK_FILE "3rdparty/qt-ordered-map/src/orderedmap.h" SUBMODULE_PATH "3rdparty/qt-ordered-map"
   READABLE_NAME "Qt ordered map source code")
 
 if(USE_UPDATER)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Fixed typo in cmakeslist that would break the nix build and probably lead to unnecessary git operations in most other environments

#### Motivation for adding to Mudlet


#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
