### PR TITLE
Infrastructure: allow alternative linkers in C++

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -315,6 +315,24 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+macro(set_alternate_linker linker)
+  find_program(LINKER_EXECUTABLE ld.${USE_ALTERNATE_LINKER} ${USE_ALTERNATE_LINKER})
+  if(LINKER_EXECUTABLE)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 12.0.0)
+      add_link_options("-ld-path=${USE_ALTERNATE_LINKER}")
+    else()
+      add_link_options("-fuse-ld=${USE_ALTERNATE_LINKER}")
+    endif()
+  else()
+    set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker" FORCE)
+  endif()
+endmacro()
+
+set(USE_ALTERNATE_LINKER "" CACHE STRING "Use alternate linker. Leave empty for system default; alternatives are 'gold', 'lld', 'bfd', 'mold'")
+if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
+  set_alternate_linker(${USE_ALTERNATE_LINKER})
+endif()
+
 find_package(
   Qt5 5.11 REQUIRED
   COMPONENTS Core


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allow alternative linkers in C++
#### Motivation for adding to Mudlet
So you can use the new [mold linker](https://github.com/rui314/mold) on Linux/macOS for really fast link times. Reduces Mudlet link times for Mudlet down to nothing, which is great when you're recompiling often.
#### Other info (issues closed, discussion etc)
Credit to https://github.com/omnisci/omniscidb/blob/master/CMakeLists.txt#L100-L114