### PR TITLE
Add string.escape for escaping special Lua pattern characters

### DIFF
--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -113,11 +113,12 @@ function string:trim()
   end
 end
 
---- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.escape
-function string:escape()
+--- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.patternEscape
+function string.patternEscape(self)
+  local gsub = string.gsub
   local selfType = type(self)
   if selfType ~= "string" then
-    printError(f"string.escape: bad argument #1 type (string to escape as string expected, got {selfType})", true, true)
+    printError(f"string.patternEscape: bad argument #1 type (string to escape as string expected, got {selfType})", true, true)
   end
   local replacements = {
     ["%"] = "%%",
@@ -133,7 +134,32 @@ function string:escape()
     ["-"] = "%-",
     ["?"] = "%?",
   }
-  local escaped = self:gsub(".", replacements)
+  local escaped = gsub(self, ".", replacements)
+  return escaped
+end
+
+--- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.patternEscape
+function utf8.patternEscape(self)
+  local gsub = utf8.gsub
+  local selfType = type(self)
+  if selfType ~= "string" then
+    printError(f"utf8.patternEscape: bad argument #1 type (string to escape as string expected, got {selfType})", true, true)
+  end
+  local replacements = {
+    ["%"] = "%%",
+    ["^"] = "%^",
+    ["$"] = "%$",
+    ["("] = "%(",
+    [")"] = "%)",
+    ["["] = "%[",
+    ["]"] = "%]",
+    ["."] = "%.",
+    ["*"] = "%*",
+    ["+"] = "%+",
+    ["-"] = "%-",
+    ["?"] = "%?",
+  }
+  local escaped = gsub(self, ".", replacements)
   return escaped
 end
 

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -113,6 +113,30 @@ function string:trim()
   end
 end
 
+--- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.escape
+function string:escape()
+  local selfType = type(self)
+  if selfType ~= "string" then
+    printError(f"string.escape: bad argument #1 type (string to escape as string expected, got {selfType})", true, true)
+  end
+  local replacements = {
+    ["%"] = "%%",
+    ["^"] = "%^",
+    ["$"] = "%$",
+    ["("] = "%(",
+    [")"] = "%)",
+    ["["] = "%[",
+    ["]"] = "%]",
+    ["."] = "%.",
+    ["*"] = "%*",
+    ["+"] = "%+",
+    ["-"] = "%-",
+    ["?"] = "%?",
+  }
+  local escaped = self:gsub(".", replacements)
+  return escaped
+end
+
 -- following functions fiddled with from https://github.com/hishamhm/f-strings/blob/master/F.lua and https://hisham.hm/2016/01/04/string-interpolation-in-lua/
 -- first bit patches load for lua 5.1.
 local load = load

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -197,6 +197,39 @@ describe("Tests StringUtils.lua functions", function()
     end)
   end)
 
+  describe("Tests the functionality of string.escape", function()
+    it("Should escape special characters in simple cases", function()
+      local replacements = {
+        ["%"] = "%%",
+        ["^"] = "%^",
+        ["$"] = "%$",
+        ["("] = "%(",
+        [")"] = "%)",
+        ["["] = "%[",
+        ["]"] = "%]",
+        ["."] = "%.",
+        ["*"] = "%*",
+        ["+"] = "%+",
+        ["-"] = "%-",
+        ["?"] = "%?",
+      }
+      for original, replacement in pairs(replacements) do
+        assert.equals(replacement, string.escape(original))
+      end
+    end)
+
+    it("Should escape special characters in some more complicated cases too", function()
+      local replacements = {
+        ["https://fern-ahead-jelly.glitch.me/time/"] = "https://fern%-ahead%-jelly%.glitch%.me/time/",
+        ["75% of things to-be have been"] = "75%% of things to%-be have been",
+        ["^%d%a$"] = "%^%%d%%a%$",
+      }
+      for original, replacement in pairs(replacements) do
+        assert.equals(replacement, string.escape(original))
+      end
+    end)
+  end)
+
   describe("Tests the functionality of f", function()
     it("should return a string with no interpolation as itself", function()
       local str = "This is a test"

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -197,7 +197,7 @@ describe("Tests StringUtils.lua functions", function()
     end)
   end)
 
-  describe("Tests the functionality of string.escape", function()
+  describe("Tests the functionality of string.patternEscape", function()
     it("Should escape special characters in simple cases", function()
       local replacements = {
         ["%"] = "%%",
@@ -214,7 +214,7 @@ describe("Tests StringUtils.lua functions", function()
         ["?"] = "%?",
       }
       for original, replacement in pairs(replacements) do
-        assert.equals(replacement, string.escape(original))
+        assert.equals(replacement, string.patternEscape(original))
       end
     end)
 
@@ -225,7 +225,40 @@ describe("Tests StringUtils.lua functions", function()
         ["^%d%a$"] = "%^%%d%%a%$",
       }
       for original, replacement in pairs(replacements) do
-        assert.equals(replacement, string.escape(original))
+        assert.equals(replacement, string.patternEscape(original))
+      end
+    end)
+  end)
+
+  describe("Tests the functionality of utf8.patternEscape", function()
+    it("Should escape special characters in simple cases", function()
+      local replacements = {
+        ["%"] = "%%",
+        ["^"] = "%^",
+        ["$"] = "%$",
+        ["("] = "%(",
+        [")"] = "%)",
+        ["["] = "%[",
+        ["]"] = "%]",
+        ["."] = "%.",
+        ["*"] = "%*",
+        ["+"] = "%+",
+        ["-"] = "%-",
+        ["?"] = "%?",
+      }
+      for original, replacement in pairs(replacements) do
+        assert.equals(replacement, utf8.patternEscape(original))
+      end
+    end)
+
+    it("Should escape special characters in some more complicated cases too", function()
+      local replacements = {
+        ["https://fern-ahead-jelly.glitch.me/time/"] = "https://fern%-ahead%-jelly%.glitch%.me/time/",
+        ["75% of things to-be have been 👊"] = "75%% of things to%-be have been 👊",
+        ["^%d%a$"] = "%^%%d%%a%$",
+      }
+      for original, replacement in pairs(replacements) do
+        assert.equals(replacement, utf8.patternEscape(original))
       end
     end)
   end)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds a string.escape function for escaping any Lua pattern matching special characters in a string.

```lua
-- searching for a url inside of a string. 
local helpString = [[
This feature can be accessed by going to https://some-url.com/athing.html?param=value and
retrieving the result!
]]
local url = "https://some-url.com/"
display(helpString:find(url))
-- nil
display(helpString:find(url:escape()))
-- 42
-- 62
display(url:escape())
-- "https://some%-url%.com/"
```

#### Motivation for adding to Mudlet
Issues with using string.find and the like with strings containing `-`'s or `%`'s 
#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
