### PR TITLE
Infrastructure: Revert "re-enable windows builds in github actions (#…

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -40,11 +40,11 @@ jobs:
             compiler: clang_64
             qt: '5.14.2'
             deploy: 'deploy'
-          - os: windows-2019
-            buildname: 'windows'
-            triplet: x64-mingw-dynamic
-            # compiler: flag not used in windows pipeline
-            qt: '5.14.2'
+#          - os: windows-2019
+#            buildname: 'windows'
+#            triplet: x64-mingw-dynamic
+#            # compiler: flag not used in windows pipeline
+#            qt: '5.14.2'
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost


### PR DESCRIPTION


<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This reverts commit 18525b3e469ce8fe8651901e58c1ba62c0e6bb76.
#### Motivation for adding to Mudlet
windows builds with vcpkg do not actually work again yet, there's a bug https://github.com/microsoft/vcpkg/issues/22301
#### Other info (issues closed, discussion etc)
I was too hasty in enabling the automerge button :(