### PR TITLE
Infrastructure: extract trigger processing logic from matching logic

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -499,7 +499,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
                     for (int i = 1; iti != posList.end(); ++iti, ++its, i++) {
                         int begin = *iti;
                         std::string& s = *its;
-                        if (total > 1) {
+                        if (total > 1 && numberOfCaptureGroups > 0) {
                             // skip complete match in Perl /g option type of triggers
                             // to enable people to highlight capture groups if there are any
                             // otherwise highlight complete expression match

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -315,14 +315,13 @@ bool TTrigger::match_perl(char* subject, const QString& toMatch, int regexNumber
         return false;
     }
 
-    return processRegexMatch(subject, toMatch, regexNumber, posOffset, re, numberOfCaptureGroups, subject_length, rc, i,
-                             captureList,
-                             posList, namePositions, nameGroups, ovector);
+    processRegexMatch(subject, toMatch, regexNumber, posOffset, re, numberOfCaptureGroups, subject_length, rc, i,
+                      captureList, posList, namePositions, nameGroups, ovector);
 
     return true;
 }
 
-bool TTrigger::processRegexMatch(const char *subject, const QString &toMatch, int regexNumber, int posOffset,
+void TTrigger::processRegexMatch(const char *subject, const QString &toMatch, int regexNumber, int posOffset,
                                  const QSharedPointer<pcre> &re, int numberOfCaptureGroups, int subject_length, int rc,
                                  int i, std::list<std::string> &captureList, std::list<int> &posList,
                                  QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches &nameGroups,
@@ -444,7 +443,7 @@ bool TTrigger::processRegexMatch(const char *subject, const QString &toMatch, in
             int total = captureList.size();
             TConsole* pC = mpHost->mpConsole;
             if (Q_UNLIKELY(!pC)) {
-                return true;
+                return;
             }
             pC->deselect();
             auto its = captureList.begin();
@@ -484,7 +483,7 @@ bool TTrigger::processRegexMatch(const char *subject, const QString &toMatch, in
         }
         if (mIsMultiline) {
             updateMultistates(regexNumber, captureList, posList, &nameGroups);
-            return true;
+            return;
         } else {
             TLuaInterpreter* pL = mpHost->getLuaInterpreter();
             pL->setCaptureGroups(captureList, posList);
@@ -512,7 +511,7 @@ bool TTrigger::processRegexMatch(const char *subject, const QString &toMatch, in
                     }
                 }
             }
-            return true;
+            return;
         }
     }
 }
@@ -520,12 +519,13 @@ bool TTrigger::processRegexMatch(const char *subject, const QString &toMatch, in
 bool TTrigger::match_begin_of_line_substring(const QString& toMatch, const QString& regex, int regexNumber, int posOffset)
 {
     if (toMatch.startsWith(regex)) {
-        return processBeginOfLine(regex, regexNumber, posOffset);
+        processBeginOfLine(regex, regexNumber, posOffset);
+        return true;
     }
     return false;
 }
 
-bool TTrigger::processBeginOfLine(const QString &regex, int regexNumber, int posOffset) {
+void TTrigger::processBeginOfLine(const QString &regex, int regexNumber, int posOffset) {
     std::list<std::string> captureList;
     std::list<int> posList;
     captureList.emplace_back(regex.toUtf8().constData());
@@ -542,7 +542,7 @@ bool TTrigger::processBeginOfLine(const QString &regex, int regexNumber, int pos
         int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
-            return true;
+            return;
         }
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
@@ -569,7 +569,7 @@ bool TTrigger::processBeginOfLine(const QString &regex, int regexNumber, int pos
     }
     if (mIsMultiline) {
         updateMultistates(regexNumber, captureList, posList);
-        return true;
+        return;
     } else {
         TLuaInterpreter* pL = mpHost->getLuaInterpreter();
         pL->setCaptureGroups(captureList, posList);
@@ -582,7 +582,6 @@ bool TTrigger::processBeginOfLine(const QString &regex, int regexNumber, int pos
                 filter(captureList.front(), posList.front());
             }
         }
-        return true;
     }
 }
 
@@ -655,12 +654,13 @@ bool TTrigger::match_substring(const QString& toMatch, const QString& regex, int
 {
     int where = toMatch.indexOf(regex);
     if (where != -1) {
-        return processSubstringMatch(toMatch, regex, regexNumber, posOffset, where);
+        processSubstringMatch(toMatch, regex, regexNumber, posOffset, where);
+        return true;
     }
     return false;
 }
 
-bool TTrigger::processSubstringMatch(const QString &toMatch, const QString &regex, int regexNumber, int posOffset,
+void TTrigger::processSubstringMatch(const QString &toMatch, const QString &regex, int regexNumber, int posOffset,
                                      int where) {
     std::list<std::string> captureList;
     std::list<int> posList;
@@ -684,7 +684,7 @@ bool TTrigger::processSubstringMatch(const QString &toMatch, const QString &rege
         int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
-            return true;
+            return;
         }
         pC->deselect();
         auto its = captureList.begin();
@@ -712,7 +712,7 @@ bool TTrigger::processSubstringMatch(const QString &toMatch, const QString &rege
     }
     if (mIsMultiline) {
         updateMultistates(regexNumber, captureList, posList);
-        return true;
+        return;
     } else {
         TLuaInterpreter* pL = mpHost->getLuaInterpreter();
         pL->setCaptureGroups(captureList, posList);
@@ -725,7 +725,6 @@ bool TTrigger::processSubstringMatch(const QString &toMatch, const QString &rege
                 filter(captureList.front(), posList.front());
             }
         }
-        return true;
     }
 }
 
@@ -795,12 +794,13 @@ bool TTrigger::match_color_pattern(int line, int regexNumber)
     }
 
     if (canExecute) {
-        return processColorPattern(regexNumber, captureList, posList);
+        processColorPattern(regexNumber, captureList, posList);
+        return true;
     }
     return false;
 }
 
-bool TTrigger::processColorPattern(int regexNumber, std::list<std::string> &captureList, std::list<int> &posList) {
+void TTrigger::processColorPattern(int regexNumber, std::list<std::string> &captureList, std::list<int> &posList) {
     if (mIsColorizerTrigger) {
         int r1 = mBgColor.red();
         int g1 = mBgColor.green();
@@ -810,7 +810,7 @@ bool TTrigger::processColorPattern(int regexNumber, std::list<std::string> &capt
         int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
-            return true;
+            return;
         }
         pC->deselect();
         auto its = captureList.begin();
@@ -839,7 +839,7 @@ bool TTrigger::processColorPattern(int regexNumber, std::list<std::string> &capt
     }
     if (mIsMultiline) {
         updateMultistates(regexNumber, captureList, posList);
-        return true;
+        return;
     } else {
         TLuaInterpreter* pL = mpHost->getLuaInterpreter();
         pL->setCaptureGroups(captureList, posList);
@@ -855,7 +855,6 @@ bool TTrigger::processColorPattern(int regexNumber, std::list<std::string> &capt
                 }
             }
         }
-        return true;
     }
 }
 
@@ -912,12 +911,13 @@ bool TTrigger::match_lua_code(int regexNumber)
 bool TTrigger::match_prompt(int patternNumber)
 {
     if (mpHost->mpConsole->mIsPromptLine) {
-        return processPromptMatch(patternNumber);
+        processPromptMatch(patternNumber);
+        return true;
     }
     return false;
 }
 
-bool TTrigger::processPromptMatch(int patternNumber) {
+void TTrigger::processPromptMatch(int patternNumber) {
     if (mudlet::debugMode) {
         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mRegexCodeList.value(patternNumber) << ") matched.\n" >> mpHost;
     }
@@ -925,10 +925,9 @@ bool TTrigger::processPromptMatch(int patternNumber) {
         std::list<std::string> captureList;
         std::list<int> posList;
         updateMultistates(patternNumber, captureList, posList);
-        return true;
+        return;
     }
     execute();
-    return true;
 }
 
 bool TTrigger::match_exact_match(const QString& toMatch, const QString& line, int regexNumber, int posOffset)
@@ -939,12 +938,13 @@ bool TTrigger::match_exact_match(const QString& toMatch, const QString& line, in
     }
 
     if (text == line) {
-        return processExactMatch(line, regexNumber, posOffset);
+        processExactMatch(line, regexNumber, posOffset);
+        return true;
     }
     return false;
 }
 
-bool TTrigger::processExactMatch(const QString &line, int regexNumber, int posOffset) {
+void TTrigger::processExactMatch(const QString &line, int regexNumber, int posOffset) {
     std::list<std::string> captureList;
     std::list<int> posList;
     captureList.emplace_back(line.toUtf8().constData());
@@ -961,7 +961,7 @@ bool TTrigger::processExactMatch(const QString &line, int regexNumber, int posOf
         int b2 = mFgColor.blue();
         TConsole* pC = mpHost->mpConsole;
         if (Q_UNLIKELY(!pC)) {
-            return true;
+            return;
         }
         auto its = captureList.begin();
         for (auto iti = posList.begin(); iti != posList.end(); ++iti, ++its) {
@@ -988,7 +988,7 @@ bool TTrigger::processExactMatch(const QString &line, int regexNumber, int posOf
     }
     if (mIsMultiline) {
         updateMultistates(regexNumber, captureList, posList);
-        return true;
+        return;
     } else {
         TLuaInterpreter* pL = mpHost->getLuaInterpreter();
         pL->setCaptureGroups(captureList, posList);
@@ -1000,7 +1000,6 @@ bool TTrigger::processExactMatch(const QString &line, int regexNumber, int posOf
                 filter(captureList.front(), posList.front());
             }
         }
-        return true;
     }
 }
 

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -299,13 +299,8 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         return false; //regex compile error
     }
 
-    int numberOfCaptureGroups = 0;
     int haystackCLength = strlen(haystackC);
     int rc = -1;
-    std::list<std::string> captureList;
-    std::list<int> posList;
-    QMap<QString, QPair<int, int>> namePositions;
-    NameGroupMatches nameGroups;
     int ovector[MAX_CAPTURE_GROUPS * 3];
 
     rc = pcre_exec(re.data(), nullptr, haystackC, haystackCLength, 0, 0, ovector, MAX_CAPTURE_GROUPS * 3);
@@ -314,17 +309,13 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         return false;
     }
 
-    processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, numberOfCaptureGroups, haystackCLength, rc,
-                      captureList, posList, namePositions, nameGroups, ovector);
+    processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, haystackCLength, rc, ovector);
 
     return true;
 }
 
 void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
-                                 const QSharedPointer<pcre>& re, int numberOfCaptureGroups, int haystackCLength, int rc,
-                                 std::list<std::string> &captureList, std::list<int>& posList,
-                                 QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches& nameGroups,
-                                 int* ovector)
+                                 const QSharedPointer<pcre>& re, int haystackCLength, int rc, int* ovector)
 {
     if (rc == 0) {
         if (mpHost->mpEditorDialog) {
@@ -338,6 +329,11 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
     }
 
     int i = 0;
+    int numberOfCaptureGroups = 0;
+    std::list<std::string> captureList;
+    std::list<int> posList;
+    QMap<QString, QPair<int, int>> namePositions;
+    NameGroupMatches nameGroups;
     for (i = 0; i < rc; i++) {
         const char *substring_start = haystackC + ovector[2 * i];
         int substring_length = ovector[2 * i + 1] - ovector[2 * i];

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -935,7 +935,7 @@ bool TTrigger::match_exact_match(const QString& haystack, const QString& needle,
 {
     QString text = haystack;
     if (text.endsWith(QChar('\n'))) {
-        text.chop(1); //TODO: speed optimization
+        text.chop(1);
     }
 
     if (text == needle) {

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -301,7 +301,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
 
     int numberOfCaptureGroups = 0;
     int haystackCLength = strlen(haystackC);
-    int rc;
+    int rc = -1;
     std::list<std::string> captureList;
     std::list<int> posList;
     QMap<QString, QPair<int, int>> namePositions;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -301,7 +301,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
 
     int numberOfCaptureGroups = 0;
     int haystackCLength = strlen(haystackC);
-    int rc, i;
+    int rc;
     std::list<std::string> captureList;
     std::list<int> posList;
     QMap<QString, QPair<int, int>> namePositions;
@@ -314,7 +314,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
         return false;
     }
 
-    processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, numberOfCaptureGroups, haystackCLength, rc, i,
+    processRegexMatch(haystackC, haystack, patternNumber, posOffset, re, numberOfCaptureGroups, haystackCLength, rc,
                       captureList, posList, namePositions, nameGroups, ovector);
 
     return true;
@@ -322,7 +322,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
 
 void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
                                  const QSharedPointer<pcre>& re, int numberOfCaptureGroups, int haystackCLength, int rc,
-                                 int i, std::list<std::string> &captureList, std::list<int>& posList,
+                                 std::list<std::string> &captureList, std::list<int>& posList,
                                  QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches& nameGroups,
                                  int* ovector)
 {
@@ -337,6 +337,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         TDebug(Qt::blue, Qt::black) << "Trigger name=" << mName << "(" << mRegexCodeList.value(patternNumber) << ") matched.\n" >> mpHost;
     }
 
+    int i = 0;
     for (i = 0; i < rc; i++) {
         const char *substring_start = haystackC + ovector[2 * i];
         int substring_length = ovector[2 * i + 1] - ovector[2 * i];

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -176,9 +176,7 @@ private:
     void filter(std::string&, int&);
     void processExactMatch(const QString& line, int patternNumber, int posOffset);
     void processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
-                           const QSharedPointer<pcre>& re, int numberOfCaptureGroups, int haystackCLength, int rc,
-                           std::list<std::string>& captureList, std::list<int>& posList,
-                           QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches& nameGroups, int* ovector);
+                           const QSharedPointer<pcre>& re, int haystackCLength, int rc, int* ovector);
     void processBeginOfLine(const QString& needle, int patternNumber, int posOffset);
     void processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where);
     void processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList);

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -174,6 +174,15 @@ private:
 
     void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
     void filter(std::string&, int&);
+    bool processExactMatch(const QString &line, int regexNumber, int posOffset);
+    bool processRegexMatch(const char *subject, const QString &toMatch, int regexNumber, int posOffset,
+                           const QSharedPointer<pcre> &re, int numberOfCaptureGroups, int subject_length, int rc, int i,
+                           std::list<std::string> &captureList, std::list<int> &posList,
+                           QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches &nameGroups, int *ovector);
+    bool processBeginOfLine(const QString &regex, int regexNumber, int posOffset);
+    bool processSubstringMatch(const QString &toMatch, const QString &regex, int regexNumber, int posOffset, int where);
+    bool processColorPattern(int regexNumber, std::list<std::string> &captureList, std::list<int> &posList);
+    bool processPromptMatch(int patternNumber);
 
 
     QList<int> mRegexCodePropertyList;

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -176,7 +176,7 @@ private:
     void filter(std::string&, int&);
     void processExactMatch(const QString& line, int patternNumber, int posOffset);
     void processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
-                           const QSharedPointer<pcre>& re, int numberOfCaptureGroups, int haystackCLength, int rc, int i,
+                           const QSharedPointer<pcre>& re, int numberOfCaptureGroups, int haystackCLength, int rc,
                            std::list<std::string>& captureList, std::list<int>& posList,
                            QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches& nameGroups, int* ovector);
     void processBeginOfLine(const QString& needle, int patternNumber, int posOffset);

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -124,9 +124,9 @@ public:
     bool match_perl(char*, const QString&, int, int posOffset = 0);
     bool match_wildcard(const QString&, int);
     bool match_exact_match(const QString&, const QString&, int, int posOffset = 0);
-    bool match_begin_of_line_substring(const QString& toMatch, const QString& regex, int regexNumber, int posOffset = 0);
+    bool match_begin_of_line_substring(const QString& haystack, const QString& needle, int patternNumber, int posOffset = 0);
     bool match_lua_code(int);
-    bool match_line_spacer(int regexNumber);
+    bool match_line_spacer(int patternNumber);
     bool match_color_pattern(int, int);
     bool match_prompt(int patternNumber);
     void setConditionLineDelta(int delta) { mConditionLineDelta = delta; }
@@ -174,14 +174,14 @@ private:
 
     void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
     void filter(std::string&, int&);
-    void processExactMatch(const QString &line, int regexNumber, int posOffset);
-    void processRegexMatch(const char *subject, const QString &toMatch, int regexNumber, int posOffset,
-                           const QSharedPointer<pcre> &re, int numberOfCaptureGroups, int subject_length, int rc, int i,
-                           std::list<std::string> &captureList, std::list<int> &posList,
-                           QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches &nameGroups, int *ovector);
-    void processBeginOfLine(const QString &regex, int regexNumber, int posOffset);
-    void processSubstringMatch(const QString &toMatch, const QString &regex, int regexNumber, int posOffset, int where);
-    void processColorPattern(int regexNumber, std::list<std::string> &captureList, std::list<int> &posList);
+    void processExactMatch(const QString& line, int patternNumber, int posOffset);
+    void processRegexMatch(const char* haystackC, const QString& haystack, int patternNumber, int posOffset,
+                           const QSharedPointer<pcre>& re, int numberOfCaptureGroups, int haystackCLength, int rc, int i,
+                           std::list<std::string>& captureList, std::list<int>& posList,
+                           QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches& nameGroups, int* ovector);
+    void processBeginOfLine(const QString& needle, int patternNumber, int posOffset);
+    void processSubstringMatch(const QString& haystack, const QString& needle, int regexNumber, int posOffset, int where);
+    void processColorPattern(int patternNumber, std::list<std::string>& captureList, std::list<int>& posList);
     void processPromptMatch(int patternNumber);
 
 

--- a/src/TTrigger.h
+++ b/src/TTrigger.h
@@ -174,15 +174,15 @@ private:
 
     void updateMultistates(int regexNumber, std::list<std::string>& captureList, std::list<int>& posList, const NameGroupMatches* nameMatches = nullptr);
     void filter(std::string&, int&);
-    bool processExactMatch(const QString &line, int regexNumber, int posOffset);
-    bool processRegexMatch(const char *subject, const QString &toMatch, int regexNumber, int posOffset,
+    void processExactMatch(const QString &line, int regexNumber, int posOffset);
+    void processRegexMatch(const char *subject, const QString &toMatch, int regexNumber, int posOffset,
                            const QSharedPointer<pcre> &re, int numberOfCaptureGroups, int subject_length, int rc, int i,
                            std::list<std::string> &captureList, std::list<int> &posList,
                            QMap<QString, QPair<int, int>> &namePositions, NameGroupMatches &nameGroups, int *ovector);
-    bool processBeginOfLine(const QString &regex, int regexNumber, int posOffset);
-    bool processSubstringMatch(const QString &toMatch, const QString &regex, int regexNumber, int posOffset, int where);
-    bool processColorPattern(int regexNumber, std::list<std::string> &captureList, std::list<int> &posList);
-    bool processPromptMatch(int patternNumber);
+    void processBeginOfLine(const QString &regex, int regexNumber, int posOffset);
+    void processSubstringMatch(const QString &toMatch, const QString &regex, int regexNumber, int posOffset, int where);
+    void processColorPattern(int regexNumber, std::list<std::string> &captureList, std::list<int> &posList);
+    void processPromptMatch(int patternNumber);
 
 
     QList<int> mRegexCodePropertyList;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Extract trigger processing logic from matching logic - so that one function doesn't handle both matching+processing anymore.
#### Motivation for adding to Mudlet
Better testability! ...and it'll aid with https://github.com/Mudlet/Mudlet/issues/5807 🤫

When reviewing in Github, I recommend the unified mode + no whitespace: https://github.com/Mudlet/Mudlet/pull/5811/files?diff=unified&w=1