### PR TITLE
improve: get Label Size hint and Geyser.Label adjustSize

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4080,6 +4080,24 @@ int TLuaInterpreter::getImageSize(lua_State* L)
     return 2;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getLabelSizeHint
+int TLuaInterpreter::getLabelSizeHint(lua_State* L)
+{
+    QString labelName = getVerifiedString(L, __func__, 1, "label name");
+    Host& host = getHostFromLua(L);
+    if (labelName.isEmpty()) {
+        return warnArgumentValue(L, __func__, "label name cannot be an empty string");
+    }
+
+    auto size = host.mpConsole->getLabelSizeHint(labelName);
+    if (!size) {
+        return warnArgumentValue(L, __func__, qsl("label '%1' does not exist").arg(labelName));
+    }
+    lua_pushnumber(L, size->width());
+    lua_pushnumber(L, size->height());
+    return 2;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCmdLineAction
 int TLuaInterpreter::setCmdLineAction(lua_State* L)
 {
@@ -14241,6 +14259,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getProfileStats", TLuaInterpreter::getProfileStats);
     lua_register(pGlobalLua, "getBackgroundColor", TLuaInterpreter::getBackgroundColor);
     lua_register(pGlobalLua, "getLabelStylesheet", TLuaInterpreter::getLabelStylesheet);
+    lua_register(pGlobalLua, "getLabelSizeHint", TLuaInterpreter::getLabelSizeHint);
     // PLACEMARKER: End of main Lua interpreter functions registration
 
     QStringList additionalLuaPaths;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -625,6 +625,7 @@ public:
     static int getProfileStats(lua_State* L);
     static int getBackgroundColor(lua_State* L);
     static int getLabelStylesheet(lua_State* L);
+    static int getLabelSizeHint(lua_State* L);
     // PLACEMARKER: End of Lua functions declarations
 
 

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -120,6 +120,16 @@ std::optional<QString> TMainConsole::getLabelStyleSheet(const QString& name) con
     return {};
 }
 
+std::optional<QSize> TMainConsole::getLabelSizeHint(const QString& name) const
+{
+    QMap<QString, TLabel*>::const_iterator it = mLabelMap.constFind(name);
+    if (it != mLabelMap.cend() && it.key() == name) {
+        return it.value()->sizeHint();
+    }
+
+    return {};
+}
+
 // NOLINTNEXTLINE(readability-make-member-function-const)
 std::pair<bool, QString> TMainConsole::setUserWindowStyleSheet(const QString& name, const QString& userWindowStyleSheet)
 {

--- a/src/TMainConsole.h
+++ b/src/TMainConsole.h
@@ -74,6 +74,7 @@ public:
     std::pair<bool, QString> setCmdLineStyleSheet(const QString& name, const QString& styleSheet);
     void setLabelStyleSheet(std::string& buf, std::string& sh);
     std::optional<QString> getLabelStyleSheet(const QString& name) const;
+    std::optional<QSize> getLabelSizeHint(const QString& name) const;
     std::pair<bool, QString> deleteLabel(const QString&);
     std::pair<bool, QString> setLabelToolTip(const QString& name, const QString& text, double duration);
     std::pair<bool, QString> setLabelCursor(const QString& name, int shape);

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -156,7 +156,7 @@ end
 function Geyser.Label:autoAdjustSize()
   local width = self.autoWidth
   local height = self.autoHeight
-  if not(width and height) then
+  if not width and not height then
     return
   end
 

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -124,6 +124,32 @@ function Geyser.Label:setFont(font)
   self:echo()
 end
 
+--- return the size hint (the suggested size) of the label
+function Geyser.Label:getSizeHint()
+  return getLabelSizeHint(self.name)
+end
+
+--- adjust size of the Label to the suggested size (probably the content size)
+function Geyser.Label:adjustSize()
+  local width, height = self:getSizeHint()
+  self:resize(width, height)
+  return true
+end
+
+--- adjust size of the Label to the suggested height (probably the content height)
+function Geyser.Label:adjustHeight()
+  local width, height = self:getSizeHint()
+  self:resize(nil, height)
+  return true
+end
+
+--- adjust size of the Label to the suggested width (probably the content width)
+function Geyser.Label:adjustWidth()
+  local width, height = self:getSizeHint()
+  self:resize(width, nil)
+  return true
+end
+
 --- Set whether or not the text in the label should be bold
 -- @param bool True for bold
 function Geyser.Label:setBold(bool)

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -64,12 +64,14 @@ function Geyser.Label:echo(message, color, format)
   message = [[<div ]] .. alignment .. color .. fs ..
   [[">]] .. message .. [[</div>]]
   echo(self.name, message)
+  self:autoAdjustSize()
 end
 
 --- raw Echo without formatting/handholding stuff that Geyser.Label:echo() does
 -- @param message The message to print. Can contain html formatting.
 function Geyser.Label:rawEcho(message)
   echo(self.name, message)
+  self:autoAdjustSize()
 end
 
 --- sets the color of the text on the label
@@ -147,6 +149,46 @@ end
 function Geyser.Label:adjustWidth()
   local width, height = self:getSizeHint()
   self:resize(width, nil)
+  return true
+end
+
+--internal function to auto adjust label size to content
+function Geyser.Label:autoAdjustSize()
+  local width = self.autoWidth
+  local height = self.autoHeight
+  if not(width and height) then
+    return
+  end
+
+  if height then
+    self:adjustHeight()
+  end
+
+  if width then
+    self:adjustWidth()
+  end
+end
+
+---Enable autoAdjustSize
+-- @param set width to false if just autoAdjust height
+-- @param set height to false if just autoAdjust width
+function Geyser.Label:enableAutoAdjustSize(width, height)
+  self.autoHeight = true
+  self.autoWidth = true
+  if width == false then
+    self.autoWidth = false
+  end
+
+  if height == false then 
+    self.autoHeight = false
+  end
+  return true
+end
+
+--- Disable autoAdjustSize 
+function Geyser.Label:disableAutoAdjustSize()
+  self.autoHeight = false
+  self.autoWidth = false
   return true
 end
 
@@ -255,6 +297,7 @@ end
 -- @param imageFileName The image to use for a background image.
 function Geyser.Label:setBackgroundImage (imageFileName)
   setBackgroundImage(self.name, imageFileName)
+  self:autoAdjustSize()
 end
 
 --- Sets a tiled background image for this label.
@@ -343,6 +386,7 @@ function Geyser.Label:setStyleSheet(css)
   css = css or self.stylesheet
   setLabelStyleSheet(self.name, css)
   self.stylesheet = css
+  self:autoAdjustSize()
 end
 --- Sets the tooltip of the label
 -- @param txt the tooltip txt
@@ -835,7 +879,7 @@ function Geyser.Label:new (cons, container)
   if cons.clickthrough then me:enableClickthrough() end
 
   if me.stylesheet then me:setStyleSheet() end
-
+  me:autoAdjustSize()
   --print("  New in " .. self.name .. " : " .. me.name)
   return me
 end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
adds the function getLabelSizeHint to get the size hint (suggested size) of a label
which is mostly the size of the content
New Functions:
primitive:
getLabelSizeHint(labelName) which returns the sizeHint as 2 integers (width and height)

Geyser:
myLabel:getSizeHint() returns the size hint
myLabel:adjustSize() resizes the label to the sizeHint
myLabel:adjustHeight() resizes the label to the suggested height
myLabel:adjustWidth() resizes the label to the suggested width

myLabel:enableAutoAdjustSize([width, height]) will autoadjust to the contents size if echo, setBackgroundImage or setStylesheet; the params are optional
myLabel:disableAutoAdjustSize() disable the autoAdjusting

Geyser Label constraints: 
autoWidth -> enables autoAdjusting of width to content if set to true
autoHeight -> enables autoAdjusting of height to content if set to true

examples:
```lua
-- primitive example
createLabel("testLabel",400,400,300,300,1)
echo("testLabel", "This is my Test.\nAnother Test")
resizeWindow("testLabel", getLabelSizeHint("testLabel"))


-- same example in Geyser
gTestLabel = gTestLabel or Geyser.Label:new({name = "gTestLabel"})
gTestLabel:echo("This is my Test.<br>Another Test")
gTestLabel:adjustSize()

```

#### Motivation for adding to Mudlet
in some situations it can be helpful to adjust the label size to the content
an example I can think of is a PlayerList.

#### Other info (issues closed, discussion etc)

#### Release post highlight
new function to get the suggested label size: getLabelSizeHint(labelName)
