### PR TITLE
Improve: add flag and getter to track whether MSDP has been negotiated

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -1062,6 +1062,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
 #endif
                 break;
             } else {
+                enableMSDP = true;
                 sendTelnetOption(TN_DO, OPT_MSDP);
                 //need to send MSDP start sequence: IAC   SB MSDP MSDP_VAR "LIST" MSDP_VAL "COMMANDS" IAC SE
                 //NOTE: MSDP does not need quotes for string/vals
@@ -1267,6 +1268,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
 
             if (option == OPT_MSDP) {
                 // MSDP got turned off
+                enableMSDP = false;
                 raiseProtocolEvent("sysProtocolDisabled", "MSDP");
             }
 
@@ -1361,6 +1363,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
 
         if (option == OPT_MSDP && mpHost->mEnableMSDP) {
             // MSDP support
+            enableMSDP = true;
             sendTelnetOption(TN_WILL, OPT_MSDP);
             raiseProtocolEvent("sysProtocolEnabled", "MSDP");
             break;
@@ -1468,6 +1471,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
 
         if (option == OPT_MSDP) {
             // MSDP got turned off
+            enableMSDP = false;
             raiseProtocolEvent("sysProtocolDisabled", "MSDP");
         }
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -180,6 +180,7 @@ public:
     bool isCHARSETEnabled() const { return enableCHARSET; }
     bool isATCPEnabled() const { return enableATCP; }
     bool isGMCPEnabled() const { return enableGMCP; }
+    bool isMSDPEnabled() const { return enableMSDP; }
     bool isMSSPEnabled() const { return enableMSSP; }
     bool isMSPEnabled() const { return enableMSP; }
     bool isChannel102Enabled() const { return enableChannel102; }
@@ -312,6 +313,7 @@ private:
     bool enableATCP;
     bool enableGMCP;
     bool enableMSSP;
+    bool enableMSDP = false;
     bool enableMSP;
     bool enableChannel102;
     bool mDontReconnect;


### PR DESCRIPTION
I am extending the statistics reporting (from the button in the editor) and was planning to display some extra tables besides the ATCP, GMCP and Channel 102 ones. I wanted to only display each table if it was in use and it seems there is not an `(bool) cTelent::isXxxxxEnabled()` getter for the MSDP OOB data channel.

As the prototype PR I had put together hit just more than 10 files I realised that I could spin this aspect out to a small precusor one for ease of reviewing.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
None - internal method addition in preparation for further work.