### PR TITLE
Improve: clean-up/unify and extend item statistics reporting system

### DIFF
--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -40,7 +41,12 @@ class AliasUnit
     friend class XMLimport;
 
 public:
-    AliasUnit(Host* pHost) : mpHost(pHost), mMaxID(0), mModuleMember() { initStats(); }
+    AliasUnit(Host* pHost)
+    : mpHost(pHost)
+    , mMaxID(0)
+    , mModuleMember()
+    {}
+
     std::list<TAlias*> getAliasRootNodeList() { return mAliasRootNodeList; }
     TAlias* getAlias(int id);
     void compileAll();
@@ -64,26 +70,14 @@ public:
 
     QMultiMap<QString, TAlias*> mLookupTable;
     std::list<TAlias*> mCleanupList;
-    int statsAliasTotal;
-    int statsTempAliases;
-    int statsActiveAliases;
-    int statsActiveAliasesMax;
-    int statsActiveAliasesMin;
-    int statsActiveAliasesAverage;
-    int statsTempAliasesCreated;
-    int statsTempAliasesKilled;
-    int statsAverageLineProcessingTime;
-    int statsMaxLineProcessingTime;
-    int statsMinLineProcessingTime;
-    int statsRegexAliases;
     QList<TAlias*> uninstallList;
 
 
 private:
     AliasUnit() = default;
 
-    void initStats();
-    void _assembleReport(TAlias*);
+    void resetStats();
+    void assembleReport(TAlias*);
     TAlias* getAliasPrivate(int id);
     void addAliasRootNode(TAlias* pT, int parentPosition = -1, int childPosition = -1, bool moveAlias = false);
     void addAlias(TAlias* pT);
@@ -95,6 +89,9 @@ private:
     std::list<TAlias*> mAliasRootNodeList;
     int mMaxID;
     bool mModuleMember;
+    int statsItemsTotal = 0;
+    int statsTempItems = 0;
+    int statsActiveItems = 0;
 };
 
 #endif // MUDLET_ALIASUNIT_H

--- a/src/AliasUnit.h
+++ b/src/AliasUnit.h
@@ -41,7 +41,7 @@ class AliasUnit
     friend class XMLimport;
 
 public:
-    AliasUnit(Host* pHost)
+    explicit AliasUnit(Host* pHost)
     : mpHost(pHost)
     , mMaxID(0)
     , mModuleMember()

--- a/src/KeyUnit.cpp
+++ b/src/KeyUnit.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2018, 2020, 2022 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,15 +28,7 @@
 #include "TKey.h"
 
 KeyUnit::KeyUnit(Host* pHost)
-: statsKeyTotal(0)
-, statsTempKeys(0)
-, statsActiveKeys(0)
-, statsActiveKeysMax(0)
-, statsActiveKeysMin(0)
-, statsActiveKeysAverage(0)
-, statsTempKeysCreated(0)
-, statsTempKeysKilled(0)
-, mRunAllKeyMatches(false)
+: mRunAllKeyMatches(false)
 , mpHost(pHost)
 , mMaxID(0)
 , mModuleMember(false)
@@ -43,6 +36,12 @@ KeyUnit::KeyUnit(Host* pHost)
     setupKeyNames();
 }
 
+void KeyUnit::resetStats()
+{
+    statsItemsTotal = 0;
+    statsTempItems = 0;
+    statsActiveItems = 0;
+}
 
 void KeyUnit::_uninstall(TKey* pChild, const QString& packageName)
 {
@@ -338,68 +337,44 @@ QString KeyUnit::getKeyName(const Qt::Key keyCode, const Qt::KeyboardModifiers m
               "that some people have.").arg(name).arg(keyCode, 4, 16, QLatin1Char('0'));
 }
 
-void KeyUnit::initStats()
+void KeyUnit::assembleReport(TKey* pItem)
 {
-    statsKeyTotal = 0;
-    statsTempKeys = 0;
-    statsActiveKeys = 0;
-    statsActiveKeysMax = 0;
-    statsActiveKeysMin = 0;
-    statsActiveKeysAverage = 0;
-    statsTempKeysCreated = 0;
-    statsTempKeysKilled = 0;
-}
-
-void KeyUnit::_assembleReport(TKey* pChild)
-{
-    std::list<TKey*>* childrenList = pChild->mpMyChildrenList;
-    for (auto pT : *childrenList) {
-        _assembleReport(pT);
-        if (pT->isActive()) {
-            statsActiveKeys++;
+    std::list<TKey*>* childrenList = pItem->mpMyChildrenList;
+    for (auto pChild : *childrenList) {
+        ++statsItemsTotal;
+        if (pChild->isActive()) {
+            ++statsActiveItems;
         }
-        if (pT->isTemporary()) {
-            statsTempKeys++;
+        if (pChild->isTemporary()) {
+            ++statsTempItems;
         }
-        statsKeyTotal++;
+        assembleReport(pChild);
     }
 }
 
 std::tuple<QString, int, int, int> KeyUnit::assembleReport()
 {
-    statsActiveKeys = 0;
-    statsKeyTotal = 0;
-    statsTempKeys = 0;
-    for (auto pChild : mKeyRootNodeList) {
-        if (pChild->isActive()) {
-            statsActiveKeys++;
+    resetStats();
+    for (auto pItem : mKeyRootNodeList) {
+        ++statsItemsTotal;
+        if (pItem->isActive()) {
+            ++statsActiveItems;
         }
-        if (pChild->isTemporary()) {
-            statsTempKeys++;
+        if (pItem->isTemporary()) {
+            ++statsTempItems;
         }
-        statsKeyTotal++;
-        std::list<TKey*>* childrenList = pChild->mpMyChildrenList;
-        for (auto pT : *childrenList) {
-            _assembleReport(pT);
-            if (pT->isActive()) {
-                statsActiveKeys++;
-            }
-            if (pT->isTemporary()) {
-                statsTempKeys++;
-            }
-            statsKeyTotal++;
-        }
+        assembleReport(pItem);
     }
     QStringList msg;
-    msg << "Keys current total: " << QString::number(statsKeyTotal) << "\n"
-        << "tempKeys current total: " << QString::number(statsTempKeys) << "\n"
-        << "active Keys: " << QString::number(statsActiveKeys) << "\n";
+    msg << QLatin1String("Keys current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
+        << QLatin1String("tempKeys current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
+        << QLatin1String("active Keys: ") << QString::number(statsActiveItems) << QLatin1String("\n");
 
     return {
         msg.join(QString()),
-        statsKeyTotal,
-        statsTempKeys,
-        statsActiveKeys
+        statsItemsTotal,
+        statsTempItems,
+        statsActiveItems
     };
 }
 

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018, 2020 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2018, 2020, 2022 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -72,38 +73,37 @@ public:
     void stopAllTriggers();
     void reenableAllTriggers();
 
+
     QMultiMap<QString, TKey*> mLookupTable;
     std::list<TKey*> mCleanupList;
-    int statsKeyTotal;
-    int statsTempKeys;
-    int statsActiveKeys;
-    int statsActiveKeysMax;
-    int statsActiveKeysMin;
-    int statsActiveKeysAverage;
-    int statsTempKeysCreated;
-    int statsTempKeysKilled;
     QList<TKey*> uninstallList;
     // Past behaviour is to only process the first key binding that matches,
     // ignoring any duplicates - but changing that behaviour unconditionally
     // could break things - so only do it if this flag is set:
     bool mRunAllKeyMatches;
 
+
 private:
     KeyUnit() = default;
 
     TKey* getKeyPrivate(int id);
-    void initStats();
-    void _assembleReport(TKey*);
+    void resetStats();
+    void assembleReport(TKey*);
     void addKeyRootNode(TKey* pT, int parentPosition = -1, int childPosition = -1, bool moveKey = false);
     void addKey(TKey* pT);
     void removeKeyRootNode(TKey* pT);
     void removeKey(TKey*);
+
+
     QPointer<Host> mpHost;
     QMap<int, TKey*> mKeyMap;
     std::list<TKey*> mKeyRootNodeList;
     int mMaxID;
     bool mModuleMember;
     QMap<int, QString> mKeys;
+    int statsItemsTotal = 0;
+    int statsTempItems = 0;
+    int statsActiveItems = 0;
 };
 
 #endif // MUDLET_KEYUNIT_H

--- a/src/KeyUnit.h
+++ b/src/KeyUnit.h
@@ -44,7 +44,7 @@ class KeyUnit : public QObject
     friend class XMLimport;
 
 public:
-    KeyUnit(Host* pHost);
+    explicit KeyUnit(Host* pHost);
 
     std::list<TKey*> getKeyRootNodeList()
     {

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2011 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -61,8 +62,12 @@ public:
     void uninstall(const QString&);
     void _uninstall(TScript* pChild, const QString& packageName);
     int getNewID();
-    QList<TScript*> uninstallList;
     QVector<int> findScriptId(const QString& name) const;
+    void resetStats();
+    std::tuple<QString, int, int, int> assembleReport();
+
+    QList<TScript*> uninstallList;
+
 
 private:
     ScriptUnit() = default;
@@ -72,10 +77,15 @@ private:
     void addScript(TScript* pT);
     void removeScriptRootNode(TScript* pT);
     void removeScript(TScript*);
+    void assembleReport(TScript*);
+
     QPointer<Host> mpHost;
     QMap<int, TScript*> mScriptMap;
     std::list<TScript*> mScriptRootNodeList;
     int mMaxID;
+    int statsItemsTotal = 0;
+    int statsTempItems = 0;
+    int statsActiveItems = 0;
 };
 
 #endif // MUDLET_SCRIPTUNIT_H

--- a/src/ScriptUnit.h
+++ b/src/ScriptUnit.h
@@ -41,7 +41,10 @@ class ScriptUnit
     friend class XMLimport;
 
 public:
-    ScriptUnit(Host* pHost) : mpHost(pHost), mMaxID(0) {}
+    explicit ScriptUnit(Host* pHost)
+    : mpHost(pHost)
+    , mMaxID(0)
+    {}
 
     std::list<TScript*> getScriptRootNodeList()
     {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2021 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
  *   Copyright (C) 2016 by Eric Wallace - eewallace@gmail.com              *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
@@ -16161,6 +16161,7 @@ int TLuaInterpreter::getProfileStats(lua_State* L)
     auto [_2, aliasesTotal, tempAliases, activeAliases] = host.getAliasUnit()->assembleReport();
     auto [_3, timersTotal, tempTimers, activeTimers] = host.getTimerUnit()->assembleReport();
     auto [_4, keysTotal, tempKeys, activeKeys] = host.getKeyUnit()->assembleReport();
+    auto [_5, scriptsTotal, tempScripts, activeScripts] = host.getScriptUnit()->assembleReport();
 
     lua_newtable(L);
 
@@ -16233,6 +16234,23 @@ int TLuaInterpreter::getProfileStats(lua_State* L)
 
     lua_pushstring(L, "active");
     lua_pushnumber(L, activeKeys);
+    lua_settable(L, -3);
+    lua_settable(L, -3);
+
+    // Scripts
+    lua_pushstring(L, "scripts");
+    lua_newtable(L);
+
+    lua_pushstring(L, "total");
+    lua_pushnumber(L, scriptsTotal);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "temp");
+    lua_pushnumber(L, tempScripts);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "active");
+    lua_pushnumber(L, activeScripts);
     lua_settable(L, -3);
     lua_settable(L, -3);
 

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -42,7 +42,7 @@ class TimerUnit
     friend class XMLimport;
 
 public:
-    TimerUnit(Host* pHost)
+    explicit TimerUnit(Host* pHost)
     : mpHost(pHost)
     , mMaxID(0)
     , mModuleMember()

--- a/src/TimerUnit.h
+++ b/src/TimerUnit.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2019 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2019, 2022 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -42,8 +42,14 @@ class TimerUnit
     friend class XMLimport;
 
 public:
-    TimerUnit(Host* pHost) : statsActiveTriggers(0), statsTriggerTotal(0), statsTempTriggers(0), mpHost(pHost), mMaxID(0), mModuleMember() {}
+    TimerUnit(Host* pHost)
+    : mpHost(pHost)
+    , mMaxID(0)
+    , mModuleMember()
+    {}
     ~TimerUnit();
+
+    void resetStats();
     void removeAllTempTimers();
     std::list<TTimer*> getTimerRootNodeList() { return mTimerRootNodeList; }
     TTimer* getTimer(int id);
@@ -70,9 +76,6 @@ public:
 
 
     QMultiMap<QString, TTimer*> mLookupTable;
-    int statsActiveTriggers;
-    int statsTriggerTotal;
-    int statsTempTriggers;
     QList<TTimer*> uninstallList;
 
     // This will contain all the QTimers associated with the TTimer instances
@@ -85,7 +88,7 @@ public:
 private:
     TimerUnit() = default;
 
-    void _assembleReport(TTimer*);
+    void assembleReport(TTimer*);
     TTimer* getTimerPrivate(int id);
     void addTimerRootNode(TTimer* pT, int parentPosition = -1, int childPosition = -1);
     void addTimer(TTimer* pT);
@@ -97,6 +100,9 @@ private:
     int mMaxID;
     bool mModuleMember;
     QSet<TTimer*> mCleanupSet;
+    int statsActiveItems = 0;
+    int statsItemsTotal = 0;
+    int statsTempItems = 0;
 };
 
 #endif // MUDLET_TIMERUNIT_H

--- a/src/TriggerUnit.cpp
+++ b/src/TriggerUnit.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,20 +27,12 @@
 #include "TConsole.h"
 #include "TTrigger.h"
 
-void TriggerUnit::initStats()
+void TriggerUnit::resetStats()
 {
-    statsTriggerTotal = 0;
-    statsTempTriggers = 0;
-    statsActiveTriggers = 0;
-    statsActiveTriggersMax = 0;
-    statsActiveTriggersMin = 0;
-    statsActiveTriggersAverage = 0;
-    statsTempTriggersCreated = 0;
-    statsTempTriggersKilled = 0;
-    statsAverageLineProcessingTime = 0;
-    statsMaxLineProcessingTime = 0;
-    statsMinLineProcessingTime = 0;
-    statsRegexTriggers = 0;
+    statsItemsTotal = 0;
+    statsTempItems = 0;
+    statsActiveItems = 0;
+    statsPatterns = 0;
 }
 
 void TriggerUnit::_uninstall(TTrigger* pChild, const QString& packageName)
@@ -344,61 +337,47 @@ bool TriggerUnit::killTrigger(const QString& name)
     return false;
 }
 
-void TriggerUnit::_assembleReport(TTrigger* pChild)
+void TriggerUnit::assembleReport(TTrigger* pItem)
 {
-    std::list<TTrigger*>* childrenList = pChild->mpMyChildrenList;
-    for (auto trigger : *childrenList) {
-        _assembleReport(trigger);
-        if (trigger->isActive()) {
-            statsActiveTriggers++;
+    std::list<TTrigger*>* childrenList = pItem->mpMyChildrenList;
+    for (auto pChild : *childrenList) {
+        ++statsItemsTotal;
+        if (pChild->isActive()) {
+            ++statsActiveItems;
         }
-        if (trigger->isTemporary()) {
-            statsTempTriggers++;
+        if (pChild->isTemporary()) {
+            ++statsTempItems;
         }
-        statsPatterns += trigger->mRegexCodeList.size();
-        statsTriggerTotal++;
+        statsPatterns += pChild->mRegexCodeList.size();
+        assembleReport(pChild);
     }
 }
 
 std::tuple<QString, int, int, int, int> TriggerUnit::assembleReport()
 {
-    statsActiveTriggers = 0;
-    statsTriggerTotal = 0;
-    statsTempTriggers = 0;
-    statsPatterns = 0;
-    for (auto rootTrigger : mTriggerRootNodeList) {
-        if (rootTrigger->isActive()) {
-            statsActiveTriggers++;
+    resetStats();
+    for (auto pItem : mTriggerRootNodeList) {
+        ++statsItemsTotal;
+        if (pItem->isActive()) {
+            ++statsActiveItems;
         }
-        if (rootTrigger->isTemporary()) {
-            statsTempTriggers++;
+        if (pItem->isTemporary()) {
+            ++statsTempItems;
         }
-        statsPatterns += rootTrigger->mRegexCodeList.size();
-        statsTriggerTotal++;
-        std::list<TTrigger*>* childrenList = rootTrigger->mpMyChildrenList;
-        for (auto childTrigger : *childrenList) {
-            _assembleReport(childTrigger);
-            if (childTrigger->isActive()) {
-                statsActiveTriggers++;
-            }
-            if (childTrigger->isTemporary()) {
-                statsTempTriggers++;
-            }
-            statsPatterns += childTrigger->mRegexCodeList.size();
-            statsTriggerTotal++;
-        }
+        statsPatterns += pItem->mRegexCodeList.size();
+        assembleReport(pItem);
     }
     QStringList msg;
-    msg << "triggers current total: " << QString::number(statsTriggerTotal) << "\n"
-        << "trigger patterns total: " << QString::number(statsPatterns) << "\n"
-        << "tempTriggers current total: " << QString::number(statsTempTriggers) << "\n"
-        << "active triggers: " << QString::number(statsActiveTriggers) << "\n";
+    msg << QLatin1String("Triggers current total: ") << QString::number(statsItemsTotal) << QLatin1String("\n")
+        << QLatin1String("Trigger patterns total: ") << QString::number(statsPatterns) << QLatin1String("\n")
+        << QLatin1String("tempTriggers current total: ") << QString::number(statsTempItems) << QLatin1String("\n")
+        << QLatin1String("active Triggers: ") << QString::number(statsActiveItems) << QLatin1String("\n");
     return {
         msg.join(QString()),
-        statsTriggerTotal,
+        statsItemsTotal,
         statsPatterns,
-        statsTempTriggers,
-        statsActiveTriggers
+        statsTempItems,
+        statsActiveItems
     };
 }
 

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -4,6 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -40,13 +41,18 @@ class TriggerUnit
     friend class XMLimport;
 
 public:
-    TriggerUnit(Host* pHost) : statsPatterns(), mpHost(pHost), mMaxID(0), mModuleMember() { initStats(); }
+    TriggerUnit(Host* pHost)
+    : mpHost(pHost)
+    , mMaxID(0)
+    , mModuleMember()
+    {}
 
     std::list<TTrigger*> getTriggerRootNodeList()
     {
         return mTriggerRootNodeList;
     }
 
+    void resetStats();
     TTrigger* getTrigger(int id);
     void removeAllTempTriggers();
     void reorderTriggersAfterPackageImport();
@@ -71,26 +77,11 @@ public:
     void uninstall(const QString&);
     void _uninstall(TTrigger* pChild, const QString& packageName);
 
-    int statsTriggerTotal;
-    int statsTempTriggers;
-    int statsPatterns;
-    int statsActiveTriggers;
-    int statsActiveTriggersMax;
-    int statsActiveTriggersMin;
-    int statsActiveTriggersAverage;
-    int statsTempTriggersCreated;
-    int statsTempTriggersKilled;
-    int statsAverageLineProcessingTime;
-    int statsMaxLineProcessingTime;
-    int statsMinLineProcessingTime;
-    int statsRegexTriggers;
     QList<TTrigger*> uninstallList;
 
 private:
     TriggerUnit() = default;
-
-    void initStats();
-    void _assembleReport(TTrigger*);
+    void assembleReport(TTrigger*);
     TTrigger* getTriggerPrivate(int id);
     void addTriggerRootNode(TTrigger* pT, int parentPosition = -1, int childPosition = -1, bool moveTrigger = false);
     void addTrigger(TTrigger* pT);
@@ -102,6 +93,10 @@ private:
     std::list<TTrigger*> mTriggerRootNodeList;
     int mMaxID;
     bool mModuleMember;
+    int statsItemsTotal = 0;
+    int statsTempItems = 0;
+    int statsActiveItems = 0;
+    int statsPatterns = 0;
 };
 
 #endif // MUDLET_TRIGGERUNIT_H

--- a/src/TriggerUnit.h
+++ b/src/TriggerUnit.h
@@ -41,7 +41,7 @@ class TriggerUnit
     friend class XMLimport;
 
 public:
-    TriggerUnit(Host* pHost)
+    explicit TriggerUnit(Host* pHost)
     : mpHost(pHost)
     , mMaxID(0)
     , mModuleMember()


### PR DESCRIPTION
Steps taken:
* removes unwise '_' prefix on `(void) _assembleReport(T*)` methods
* rename `(void) XxxxUnit::initStats()` to `(void) XxxxUnit::resetStats()` or provide it in classes without it - and use it in top-level `(std::tuple<QString, int, ...int>) XxxxUnit::assembleReport()` methods
* remove call to aforesaid method in `XxxxUnit` constructors - as that can be done more simply/cleanly as part of initialisation in the header.
* rename alias/key/timer/... etc elements in `XxxxUnit::assembleReport(...)` methods to be type neutral `item`/`pItem`/`pChild` - this reduces the typographical differences in the methods for each type - and may make it possible to abstract them to a template class later on (for **DRY** reasons!)
* after some code rearrangement it became clear that part of the: `XxxxUnit::assembleReport()` top level instance code was a recursion of the `XxxxUnit::assembleReport(...)` code - so could replaced by a call to that for more compact code!
* make the stats counters in each `XxxxUnit` private and remove the unused ones - this typically leaves only three in each class.
* refactor the reporting to the `TMainConsole` code more compact AND redesign it for I18n/L10n as it is UI text presented in the main console so should be presented in a manner appropriate to the user's locale setting.
* extend the reported statistics to include Scripts and Timers - which were previously missing - this addresses the comments around: https://github.com/Mudlet/Mudlet/pull/5706#discussion_r758632670
* extend the reporting to include other tables include MSDP, this will close #692 (specifically it adds the ones for MSSP and MSDP and if there are any others that need to be added they can probably be included with a couple of lines of code).

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Improve: more information about OOB protocols (ATCP, GMPC, Channel 102 *and now:* MSSP and MSDP event data) and Mudlet items (Aliases and Scripts)  is provided via "Statistics" editor button (empty Lua OOB data tables are no longer shown) and the additional Mudlet items are also provided via the recently added `getProfileStats()`  Lua API function.