### PR TITLE
Infrastructure: mock utf8 for changelog script (fix PTBs)

### DIFF
--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -8,6 +8,9 @@ local argparse = require "argparse"
 local lunajson = require "lunajson"
 
 -- don't load all of LuaGlobal, as that requires yajl installed
+-- mock utf8 as we don't need it here either
+utf8 = utf8 or {}
+
 local github_workspace = os.getenv("GITHUB_WORKSPACE")
 if github_workspace then
   -- the script struggles to load the load files relatively in CI


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The changelog generation script [broke](https://ci.appveyor.com/project/Mudlet/mudlet/builds/42113565#L1636) as soon as was [utf8.patternEscape](https://github.com/Mudlet/Mudlet/pull/5806) was merged because it loads `StringUtils.lua` separately without dragging in `LuaGlobal.lua` and all of the dependencies that would drag in.
#### Motivation for adding to Mudlet
Fix PTBs deployment, which rely on Windows builds to be done first. No Windows builds = no other builds either. This shouldn't be so fragile, but it's the best we've got because of how github actions work.