### PR TITLE
Improve: Enhance labels to allow animated gif

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3548,10 +3548,12 @@ std::pair<bool, QString> Host::setMovie(const QString& name, const QString& movi
         return {false, qsl("label '%1' does not exist").arg(name)};
     }
 
-    auto myMovie = pL->movie();
+    auto myMovie = pL->myMovie;
     if (!myMovie) {
         myMovie = new QMovie();
         myMovie->setCacheMode(QMovie::CacheAll);
+        pL->myMovie = myMovie;
+        myMovie->setParent(pL);
     }
 
     myMovie->setFileName(moviePath);

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3537,6 +3537,35 @@ bool Host::setLabelOnLeave(const QString& name, const int func)
     return false;
 }
 
+std::pair<bool, QString> Host::setMovie(const QString& name, const QString& moviePath)
+{
+    if (!mpConsole) {
+        return {false, QString()};
+    }
+
+    auto pL = mpConsole->mLabelMap.value(name);
+    if (!pL) {
+        return {false, qsl("label '%1' does not exist").arg(name)};
+    }
+
+    auto myMovie = pL->movie();
+    if (!myMovie) {
+        myMovie = new QMovie();
+        myMovie->setCacheMode(QMovie::CacheAll);
+    }
+
+    myMovie->setFileName(moviePath);
+
+    if (!myMovie->isValid()) {
+        return {false, qsl("no valid movie found at '%1'").arg(moviePath)};
+    }
+    myMovie->stop();
+    pL->setMovie(myMovie);
+    myMovie->start();
+    return {true, QString()};
+
+}
+
 QSize Host::calcFontSize(const QString& windowName)
 {
     if (!mpConsole) {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3548,11 +3548,11 @@ std::pair<bool, QString> Host::setMovie(const QString& name, const QString& movi
         return {false, qsl("label '%1' does not exist").arg(name)};
     }
 
-    auto myMovie = pL->myMovie;
+    auto myMovie = pL->mpMovie;
     if (!myMovie) {
         myMovie = new QMovie();
         myMovie->setCacheMode(QMovie::CacheAll);
-        pL->myMovie = myMovie;
+        pL->mpMovie = myMovie;
         myMovie->setParent(pL);
     }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -372,6 +372,7 @@ public:
     bool setLabelWheelCallback(const QString&, const int);
     bool setLabelOnEnter(const QString&, const int);
     bool setLabelOnLeave(const QString&, const int);
+    std::pair<bool, QString> setMovie(const QString& labelName, const QString& moviePath);
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
     std::optional<QColor> getBackgroundColor(const QString& name) const;
     bool setBackgroundImage(const QString& name, QString& path, int mode);

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -39,6 +39,14 @@ TLabel::TLabel(Host* pH, QWidget* pW)
     setMouseTracking(true);
 }
 
+TLabel::~TLabel()
+{
+    if (mpMovie) {
+        mpMovie->deleteLater();
+        mpMovie = nullptr;
+    }
+}
+
 void TLabel::setClick(const int func)
 {
     releaseFunc(mClickFunction, func);

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -28,6 +28,7 @@
 
 #include "pre_guard.h"
 #include <QLabel>
+#include <QMovie>
 #include <QPointer>
 #include <QString>
 #include "post_guard.h"
@@ -59,7 +60,6 @@ public:
     void enterEvent(QEvent*) override;
     void setClickThrough(bool clickthrough);
 
-
     QPointer<Host> mpHost;
     int mClickFunction = 0;
     int mDoubleClickFunction = 0;
@@ -68,6 +68,7 @@ public:
     int mWheelFunction = 0;
     int mEnterFunction = 0;
     int mLeaveFunction = 0;
+    QMovie* myMovie = nullptr;
 
 private:
     void releaseFunc(const int existingFunction, const int newFunction);

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -44,6 +44,8 @@ class TLabel : public QLabel
 public:
     Q_DISABLE_COPY(TLabel)
     explicit TLabel(Host* pH, QWidget* pW = nullptr);
+    ~TLabel();
+
     void setClick(const int func);
     void setDoubleClick(const int func);
     void setRelease(const int func);
@@ -68,7 +70,7 @@ public:
     int mWheelFunction = 0;
     int mEnterFunction = 0;
     int mLeaveFunction = 0;
-    QMovie* myMovie = nullptr;
+    QMovie* mpMovie = nullptr;
 
 private:
     void releaseFunc(const int existingFunction, const int newFunction);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4277,7 +4277,7 @@ int TLuaInterpreter::setMovie(lua_State* L)
 }
 
 // No documentation available in wiki - internal function
-int TLuaInterpreter::setMovieFunc(lua_State* L, const QString& funcName)
+int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
 {
     QString labelName = getVerifiedString(L, funcName.toUtf8().constData(), 1, "label name");
     if (labelName.isEmpty()) {
@@ -4312,25 +4312,25 @@ int TLuaInterpreter::setMovieFunc(lua_State* L, const QString& funcName)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovieStart
 int TLuaInterpreter::setMovieStart(lua_State* L)
 {
-    return setMovieFunc(L, qsl("setMovieStart"));
+    return movieFunc(L, qsl("setMovieStart"));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMoviePaused
 int TLuaInterpreter::setMoviePaused(lua_State* L)
 {
-    return setMovieFunc(L, qsl("setMoviePaused"));
+    return movieFunc(L, qsl("setMoviePaused"));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovieFrame
 int TLuaInterpreter::setMovieFrame(lua_State* L)
 {
-    return setMovieFunc(L, qsl("setMovieFrame"));
+    return movieFunc(L, qsl("setMovieFrame"));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovieSpeed
 int TLuaInterpreter::setMovieSpeed(lua_State* L)
 {
-    return setMovieFunc(L, qsl("setMovieSpeed"));
+    return movieFunc(L, qsl("setMovieSpeed"));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setTextFormat

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4284,7 +4284,6 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
         return warnArgumentValue(L, __func__, "label name cannot be an empty string");
     }
     auto pN = LABEL(L, labelName);
-    lua_remove(L, 1);
     auto movie = pN->movie();
     if (!movie) {
         return warnArgumentValue(L, __func__, qsl("no movie found at label '%1'").arg(labelName));
@@ -4295,11 +4294,11 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
     } else if (funcName == qsl("setMoviePaused")) {
         movie->setPaused(movie->state() != QMovie::Paused);
     } else if (funcName == qsl("setMovieFrame")) {
-        int frame = getVerifiedInt(L, funcName.toUtf8().constData(), 1, "movie frame number");
+        int frame = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie frame number");
         lua_pushboolean(L, movie->jumpToFrame(frame));
         return 1;
     } else if (funcName == qsl("setMovieSpeed")) {
-        int speed = getVerifiedInt(L, funcName.toUtf8().constData(), 1, "movie playback speed in %");
+        int speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
         movie->setSpeed(speed);
     } else {
         return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -391,6 +391,11 @@ public:
     static int resetBackgroundImage(lua_State*);
     static int setBackgroundColor(lua_State*);
     static int setLabelClickCallback(lua_State*);
+    static int setMovie(lua_State*);
+    static int setMovieStart(lua_State*);
+    static int setMovieSpeed(lua_State*);
+    static int setMovieFrame(lua_State*);
+    static int setMoviePaused(lua_State*);
     static int setCmdLineAction(lua_State*);
     static int resetCmdLineAction(lua_State*);
     static int setCmdLineStyleSheet(lua_State*);
@@ -652,6 +657,7 @@ private:
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);
+    static int setMovieFunc(lua_State*, const QString& funcName);
     std::pair<bool, QString> validLuaCode(const QString &code);
     std::pair<bool, QString> validateLuaCodeParam(int index);
     QByteArray encodeBytes(const char*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -657,7 +657,7 @@ private:
     void logError(std::string& e, const QString&, const QString& function);
     void logEventError(const QString& event, const QString& error);
     static int setLabelCallback(lua_State*, const QString& funcName);
-    static int setMovieFunc(lua_State*, const QString& funcName);
+    static int movieFunc(lua_State*, const QString& funcName);
     std::pair<bool, QString> validLuaCode(const QString &code);
     std::pair<bool, QString> validateLuaCodeParam(int index);
     QByteArray encodeBytes(const char*);

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -192,6 +192,29 @@ function Geyser.Label:disableAutoAdjustSize()
   return true
 end
 
+function Geyser.Label:setMovie(fileName)
+  result, error = setMovie(self.name, fileName)
+  self:autoAdjustSize()
+  return result, error
+end
+
+function Geyser.Label:setMovieStart()
+  return setMovieStart(self.name)
+end
+
+function Geyser.Label:setMoviePaused()
+  return setMoviePaused(self.name)
+end
+
+function Geyser.Label:setMovieSpeed(speed)
+  return setMovieSpeed(self.name, speed)
+end
+
+function Geyser.Label:setMovieFrame(frameNr)
+  return setMovieFrame(self.name, frameNr)
+end
+
+
 --- Set whether or not the text in the label should be bold
 -- @param bool True for bold
 function Geyser.Label:setBold(bool)

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -192,24 +192,32 @@ function Geyser.Label:disableAutoAdjustSize()
   return true
 end
 
+---setMovie allows to set a gif animation on a label
+-- @param filename the path to the gif file
 function Geyser.Label:setMovie(fileName)
   result, error = setMovie(self.name, fileName)
   self:autoAdjustSize()
   return result, error
 end
 
-function Geyser.Label:setMovieStart()
+---startMovie starts animation on label
+function Geyser.Label:startMovie()
   return setMovieStart(self.name)
 end
 
-function Geyser.Label:setMoviePaused()
+---pauseMovie pauses or resumes animation on label
+function Geyser.Label:pauseMovie()
   return setMoviePaused(self.name)
 end
 
+---setMovieSpeed change the speed of the animation
+--@param speed is the speed in percent for example 200 for 200% which means double the animation speed
 function Geyser.Label:setMovieSpeed(speed)
   return setMovieSpeed(self.name, speed)
 end
 
+---setMovieFrame jumps to the given frame of the animation
+--@param frameNr is the number of the frame to jump
 function Geyser.Label:setMovieFrame(frameNr)
   return setMovieFrame(self.name, frameNr)
 end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds functions to add animated gifs to labels.

Adds primitive and Geyser functions:
- setMovie(labelname, filePath)
- setMovieStart(labelname)
- setMoviePaused(labelname)
- setMovieFrame(labelname, frameNr)
- setMovieSpeed(labelname, speedInPercent)

Geyser Functions:
- Geyser.Label:setMovie(filePath)
- Geyser.Label:startMovie()
- Geyser.Label:pauseMovie()
- Geyser.Label:setMovieFrame(frameNr)
- Geyser.Label:setMovieSpeed(speedInPercent)

Example:
```lua
testMovie = testMovie or Geyser.Label:new({x = 300, y = 300, autoWidth = true, autoHeight = true})
testMovie:setMovie(getMudletHomeDir().."/movie.gif")
```

#### Motivation for adding to Mudlet
fix #5775 
#### Other info (issues closed, discussion etc)

#### Release post highlight
adds ability to set animated gifs on labels and start/stop the animation + set the animation speed
