### PR TITLE
fix: Don't show hidden Geyser.CommandLines in Adjustable.Containers

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserCommandLine.lua
@@ -86,10 +86,14 @@ function Geyser.CommandLine:new (cons, container)
   self.__index = self
   
   createCommandLine(me.windowname, me.name, me:get_x(), me:get_y(), me:get_width(), me:get_height())
-  
   if me.stylesheet then 
     me:setStyleSheet()
   end
+  -- This only has an effect if add2 is being used as for the standard add method me.hidden and me.auto_hidden is always false at creation/initialisation
+  if me.hidden or me.auto_hidden then
+    hideWindow(me.name)
+  end
+
   
   return me
 end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
avoids showing hidden command lines when created in Adjustable.Container
#### Motivation for adding to Mudlet
Xavious on Discord having this issue

#### Other info (issues closed, discussion etc)
Package with issue: (restart or use resetProfile())
[SpaceHud.zip](https://github.com/Mudlet/Mudlet/files/7866311/SpaceHud.zip)


#### Release post highlight

