### PR TITLE
Add autowrap capabilities to main console

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGeyser.lua
@@ -13,7 +13,7 @@
 -- of default limits for new windows, in fact, it is the root container
 -- window, and is the metatable for Geyser.Container. It has the
 -- minimum number of functions needed to behave as a Container.
-Geyser = Geyser or { i = 0, x = 0, y = 0 }
+Geyser = Geyser or { i = 0, x = 0, y = 0, autoWrapMain = false }
 
 --Layout policies. Fixed = Do not stretch/shrink, Dynamic = Do stretch/shrink
 Geyser.Fixed, Geyser.Dynamic = 0, 1
@@ -220,4 +220,26 @@ function Geyser:changeContainer (container)
   end
   -- use add2 without overwriting childrens' add functions
   container:add2(self, cons, false)
+end
+
+-- internal function which calculates the wrapwidth for the main console automatically, if configured to do so.
+function Geyser.adjustMainWrap()
+  if not Geyser.autoWrapMain then return end
+  local mwidth, _ = getMainWindowSize()
+  local borders = getBorderSizes()
+  local fwidth, _ = calcFontSize()
+  local consoleWidth = mwidth - borders.left - borders.right
+  local charWidth = math.floor(consoleWidth / fwidth)
+  setWindowWrap(charWidth)
+end
+
+--- Enables autowrapping for the main console
+function Geyser.enableMainConsoleAutoWrap()
+  Geyser.autoWrapMain = true
+  Geyser.adjustMainWrap()
+end
+
+--- Disables autowrapping for the main console
+function Geyser.disableMainConsoleAutoWrap()
+  Geyser.autoWrapMain = false
 end

--- a/src/mudlet-lua/lua/geyser/GeyserReposition.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserReposition.lua
@@ -14,6 +14,7 @@ function GeyserReposition(event, w, h, arg)
       window:reposition()
     end
   end
+  Geyser.adjustMainWrap()
 end
 
 registerAnonymousEventHandler("sysWindowResizeEvent", "GeyserReposition")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Utilizes Geyser's existing hook for resize events to allow for the automatic setting of the main window's wrap width. Off by default.

`Geyser.enableMainConsoleAutoWrap()` to turn it on, and `Geyser.dosableMainConsoleAutoWrap()` to turn it off.

#### Motivation for adding to Mudlet

Someone came through the discord today asking if there were an easy way to autowrap the main console, and I realized we probably ought to provide some way to manage that. This seemed the most expedient way to get it done, and is in keeping with Geyser adding the functionality to miniconsoles/userwindows.

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
