### PR TITLE
Improve: fixup layout and tab-ordering for preferences dialogue

### DIFF
--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -273,7 +273,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
     connect(pMudlet, &mudlet::signal_guiLanguageChanged, this, &dlgProfilePreferences::slot_guiLanguageChanged);
     connect(pMudlet, &mudlet::signal_appearanceChanged, this, &dlgProfilePreferences::slot_setAppearance);
     connect(comboBox_appearance, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int index) { dlgProfilePreferences::slot_setAppearance(mudlet::Appearance(index)); });
-    connect(pushButton_resetMainWindowShortctus, &QPushButton::released, this, [=]() {
+    connect(toolButton_resetMainWindowShortcuts, &QPushButton::released, this, [=]() {
         emit signal_resetMainWindowShortcutsToDefaults();
     });
 
@@ -435,6 +435,7 @@ void dlgProfilePreferences::disableHostDetails()
     theme_download_label->hide();
 
     groupBox_autoComplete->setEnabled(false);
+    groupBox_advancedEditor->setEnabled(false);
 
     // ===== tab_displayColors =====
     groupBox_displayColors->setEnabled(false);
@@ -448,6 +449,10 @@ void dlgProfilePreferences::disableHostDetails()
     pushButton_saveMap->setEnabled(false);
     label_loadMap->setEnabled(false);
     pushButton_loadMap->setEnabled(false);
+    label_deleteMap->setEnabled(false);
+    checkBox_enablMapDeleteButton->setEnabled(false);
+    checkBox_enablMapDeleteButton->setChecked(false);
+    pushButton_deleteMap->setEnabled(false);
     label_copyMap->setEnabled(false);
     label_mapFileSaveFormatVersion->setEnabled(false);
     comboBox_mapFileSaveFormatVersion->setEnabled(false);
@@ -480,6 +485,9 @@ void dlgProfilePreferences::disableHostDetails()
     groupBox_ircOptions->setEnabled(false);
 
     groupBox_discordPrivacy->hide();
+
+    // ===== tab_shortcuts =====
+    groupBox_main_window_shortcuts->setEnabled(false);
 
     // ===== tab_specialOptions =====
     groupBox_specialOptions->setEnabled(false);
@@ -538,6 +546,7 @@ void dlgProfilePreferences::enableHostDetails()
     groupbox_codeEditorThemeSelection->setEnabled(true);
 
     groupBox_autoComplete->setEnabled(true);
+    groupBox_advancedEditor->setEnabled(true);
 
     // ===== tab_displayColors =====
     groupBox_displayColors->setEnabled(true);
@@ -551,6 +560,8 @@ void dlgProfilePreferences::enableHostDetails()
     pushButton_saveMap->setEnabled(true);
     label_loadMap->setEnabled(true);
     pushButton_loadMap->setEnabled(true);
+    label_deleteMap->setEnabled(true);
+    checkBox_enablMapDeleteButton->setEnabled(true);
     label_copyMap->setEnabled(true);
     label_mapFileSaveFormatVersion->setEnabled(true);
 
@@ -571,6 +582,9 @@ void dlgProfilePreferences::enableHostDetails()
 
     // ===== tab_chat =====
     groupBox_ircOptions->setEnabled(true);
+
+    // ===== tab_shortcuts =====
+    groupBox_main_window_shortcuts->setEnabled(true);
 
     // ===== tab_specialOptions =====
     groupBox_specialOptions->setEnabled(true);

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -1256,9 +1256,7 @@ you can use it but there could be issues with aligning columns of text</string>
              <item>
               <widget class="edbee::TextEditorWidget" name="edbeePreviewWidget" native="true">
                <property name="font">
-                <font>
-                 <family>Bitstream Vera Sans Mono</family>
-                </font>
+                <font/>
                </property>
               </widget>
              </item>
@@ -2653,7 +2651,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>IRC client options</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_groupBox_ircOptions" rowstretch="0,0,0">
+         <layout class="QGridLayout" name="gridLayout_groupBox_ircOptions" rowstretch="0,0,0,0">
           <item row="0" column="0">
            <widget class="QLabel" name="lblIrcHostName">
             <property name="text">
@@ -3077,7 +3075,6 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
             <property name="font">
              <font>
-              <family>Arial Black</family>
               <pointsize>16</pointsize>
               <stylestrategy>PreferAntialias</stylestrategy>
              </font>
@@ -3228,7 +3225,6 @@ you can use it but there could be issues with aligning columns of text</string>
                </property>
                <property name="font">
                 <font>
-                 <family>Arial</family>
                  <pointsize>8</pointsize>
                  <stylestrategy>PreferAntialias</stylestrategy>
                 </font>
@@ -3361,9 +3357,9 @@ you can use it but there could be issues with aligning columns of text</string>
       <attribute name="title">
        <string>Shortcuts</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="verticalLayout_main_window_shortcuts">
+      <layout class="QVBoxLayout" name="vBoxLayout_tab_shortcuts">
+       <item>
+        <widget class="QGroupBox" name="groupBox_main_window_shortcuts">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -3379,7 +3375,7 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QVBoxLayout" name="verticalLayout_groupBox_mainWindowShortcuts">
           <property name="sizeConstraint">
            <enum>QLayout::SetMinimumSize</enum>
           </property>
@@ -3394,14 +3390,16 @@ you can use it but there could be issues with aligning columns of text</string>
            </widget>
           </item>
           <item>
-           <layout class="QGridLayout" name="gridLayout_groupBox_shortcuts">
-            <property name="horizontalSpacing">
-             <number>20</number>
-            </property>
-           </layout>
+           <widget class="QFrame" name="frame_shortcuts">
+            <layout class="QGridLayout" name="gridLayout_groupBox_shortcuts">
+             <property name="horizontalSpacing">
+              <number>20</number>
+             </property>
+            </layout>
+           </widget>
           </item>
           <item alignment="Qt::AlignRight">
-           <widget class="QPushButton" name="pushButton_resetMainWindowShortctus">
+           <widget class="QToolButton" name="toolButton_resetMainWindowShortcuts">
             <property name="text">
              <string>Reset to defaults</string>
             </property>
@@ -3410,8 +3408,8 @@ you can use it but there could be issues with aligning columns of text</string>
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
-        <spacer name="verticalSpacer">
+       <item>
+        <spacer name="verticalSpacer_shortcuts">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -3794,6 +3792,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>comboBox_encoding</tabstop>
   <tabstop>mAlertOnNewData</tabstop>
   <tabstop>mFORCE_SAVE_ON_EXIT</tabstop>
+  <tabstop>comboBox_appearance</tabstop>
   <tabstop>acceptServerGUI</tabstop>
   <tabstop>acceptServerMedia</tabstop>
   <tabstop>mEnableGMCP</tabstop>
@@ -3838,6 +3837,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>code_editor_theme_selection_combobox</tabstop>
   <tabstop>script_preview_combobox</tabstop>
   <tabstop>checkBox_autocompleteLuaCode</tabstop>
+  <tabstop>checkBox_showBidi</tabstop>
   <tabstop>pushButton_foreground_color</tabstop>
   <tabstop>pushButton_command_line_foreground_color</tabstop>
   <tabstop>pushButton_command_foreground_color</tabstop>
@@ -3926,6 +3926,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>lineEdit_proxyPort</tabstop>
   <tabstop>lineEdit_proxyUsername</tabstop>
   <tabstop>lineEdit_proxyPassword</tabstop>
+  <tabstop>toolButton_resetMainWindowShortcuts</tabstop>
   <tabstop>mFORCE_MCCP_OFF</tabstop>
   <tabstop>mFORCE_GA_OFF</tabstop>
   <tabstop>mFORCE_CHARSET_NEGOTIATION_OFF</tabstop>


### PR DESCRIPTION
The prior code erroneously had a `QLayout` as a display element (for the empty part of the preferences which is populated with the main window shortcuts when the dialogue is created. Whilst the C++ code to add the details for the shortcuts to that `QLayout` is correct, the layout should be attached to a parent `QWidget` derived item itself. (It was showing up in RED indicating a problem, in the Qt Designer tool/utility).

As well as fixing that by adding a `QFrame` widget for the layout, this code also converts a higher up layout from a `QGridLayout` to the easier to maintain `QVBoxLayout` and assigns some more meaningful names to some layout items, so that they can be associated with their parent widget which makes things easier when editing the file by hand...

Also fixes up the tab ordering for this and some other recently added widgets.

Also fixes up the disabling and enabling some recently added Host specific options so they are not accessible when there is not a profile loaded.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix: correct some controls being in the wrong tab order and not being disabled when there is not a profile loaded for them to work on in the profile preferences dialogue.