### PR TITLE
Infrastructure: Add simple option to use Clang sanitizers

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -49,7 +49,6 @@ jobs:
           commit-message: (autocommit) Updated IRE mapping script to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
-
   update-sparkle-glue-fork:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Mudlet' }}
@@ -255,4 +254,44 @@ jobs:
           branch: update-widechar-width-${{ github.sha }}
           path: src/
           commit-message: (autocommit) Update singleshot_connect.h to latest upstream
+          author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
+
+  update-cmakes-cripts-source:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Mudlet' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: development
+
+      - name: download latest from source repo
+        run: |
+          curl -o 3rdparty/cmake-scripts/sanitizers.cmake https://raw.githubusercontent.com/StableCoder/cmake-scripts/main/sanitizers.cmake
+
+      # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
+      # to see in github UI's if PR creation was skipped when we have an explicit pre-check
+      - name: check if we have any updates
+        id: getdiff
+        run: |
+          lines_changed=$(git diff --patch --unified=0 3rdparty/cmake-scripts/sanitizers.cmake | wc --lines)
+          echo "$lines_changed lines changed."
+          echo ::set-output name=lines_changed::$lines_changed
+
+      - name: send in a pull request
+        uses: gr2m/create-or-update-pull-request-action@v1.x
+        if: steps.getdiff.outputs.lines_changed > 0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
+        with:
+          title: "Infrastructure: Update sanitizers.cmake to latest upstream"
+          body: |
+            #### Brief overview of PR changes/additions
+            :crown: An automated PR to update the built-in `3rdparty/cmake-scripts/sanitizers.cmake` to its latest version in upstream. We don't include it as a submodule as we need just this one file from the entire repo.
+            #### Motivation for adding to Mudlet
+            Latest version of the CMake utility feature that allows use to use various CMake sanitizers via the `USE_SANITIZER` CMake variable.
+            #### Other info (issues closed, discussion etc)
+            _update triggered by ${{ github.ref }} ${{ github.sha }}_
+          branch: update-widechar-width-${{ github.sha }}
+          path: src/
+          commit-message: (autocommit) Update sanitizers.cmake to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"

--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -256,7 +256,7 @@ jobs:
           commit-message: (autocommit) Update singleshot_connect.h to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
-  update-cmakes-cripts-source:
+  update-cmakes-scripts-source:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Mudlet' }}
     steps:

--- a/3rdparty/cmake-scripts/sanitizers.cmake
+++ b/3rdparty/cmake-scripts/sanitizers.cmake
@@ -1,0 +1,151 @@
+#
+# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+include(CheckCXXSourceCompiles)
+
+set(USE_SANITIZER
+    ""
+    CACHE
+      STRING
+      "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'"
+)
+
+function(append value)
+  foreach(variable ${ARGN})
+    set(${variable}
+        "${${variable}} ${value}"
+        PARENT_SCOPE)
+  endforeach(variable)
+endfunction()
+
+function(test_san_flags return_var flags)
+    set(QUIET_BACKUP ${CMAKE_REQUIRED_QUIET})
+    set(CMAKE_REQUIRED_QUIET TRUE)
+    unset(${return_var} CACHE)
+    set(FLAGS_BACKUP ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "${flags}")
+    check_cxx_source_compiles("int main() { return 0; }" ${return_var})
+    set(CMAKE_REQUIRED_FLAGS "${FLAGS_BACKUP}")
+    set(CMAKE_REQUIRED_QUIET "${QUIET_BACKUP}")
+endfunction()
+
+if(USE_SANITIZER)
+  append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+  unset(SANITIZER_SELECTED_FLAGS)
+
+  if(UNIX)
+
+    if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+      append("-O1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Aa]ddress)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
+      message(STATUS "Testing with Address sanitizer")
+      set(SANITIZER_ADDR_FLAG "-fsanitize=address")
+      test_san_flags(SANITIZER_ADDR_AVAILABLE ${SANITIZER_ADDR_FLAG})
+      if (SANITIZER_ADDR_AVAILABLE)
+        message(STATUS "  Building with Address sanitizer")
+        append("${SANITIZER_ADDR_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Address sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
+      set(SANITIZER_MEM_FLAG "-fsanitize=memory")
+      if(USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+        message(STATUS "Testing with MemoryWithOrigins sanitizer")
+        append("-fsanitize-memory-track-origins" SANITIZER_MEM_FLAG)
+      else()
+        message(STATUS "Testing with Memory sanitizer")
+      endif()
+      test_san_flags(SANITIZER_MEM_AVAILABLE ${SANITIZER_MEM_FLAG})
+      if (SANITIZER_MEM_AVAILABLE)
+        if(USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+            message(STATUS "  Building with MemoryWithOrigins sanitizer")
+        else()
+            message(STATUS "  Building with Memory sanitizer")
+        endif()
+        append("${SANITIZER_MEM_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Memory [With Origins] sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Uu]ndefined)")
+      message(STATUS "Testing with Undefined Behaviour sanitizer")
+      set(SANITIZER_UB_FLAG "-fsanitize=undefined")
+      if(EXISTS "${BLACKLIST_FILE}")
+        append("-fsanitize-blacklist=${BLACKLIST_FILE}" SANITIZER_UB_FLAG)
+      endif()
+      test_san_flags(SANITIZER_UB_AVAILABLE ${SANITIZER_UB_FLAG})
+      if (SANITIZER_UB_AVAILABLE)
+        message(STATUS "  Building with Undefined Behaviour sanitizer")
+        append("${SANITIZER_UB_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Undefined Behaviour sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Tt]hread)")
+      message(STATUS "Testing with Thread sanitizer")
+      set(SANITIZER_THREAD_FLAG "-fsanitize=thread")
+      test_san_flags(SANITIZER_THREAD_AVAILABLE ${SANITIZER_THREAD_FLAG})
+      if (SANITIZER_THREAD_AVAILABLE)
+        message(STATUS "  Building with Thread sanitizer")
+        append("${SANITIZER_THREAD_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Thread sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Ll]eak)")
+      message(STATUS "Testing with Leak sanitizer")
+      set(SANITIZER_LEAK_FLAG "-fsanitize=leak")
+      test_san_flags(SANITIZER_LEAK_AVAILABLE ${SANITIZER_LEAK_FLAG})
+      if (SANITIZER_LEAK_AVAILABLE)
+        message(STATUS "  Building with Leak sanitizer")
+        append("${SANITIZER_LEAK_FLAG}" SANITIZER_SELECTED_FLAGS)
+      else()
+        message(FATAL_ERROR "Thread sanitizer not available for ${CMAKE_CXX_COMPILER}")
+      endif()
+    endif()
+
+    message(STATUS "Sanitizer flags: ${SANITIZER_SELECTED_FLAGS}")
+    test_san_flags(SANITIZER_SELECTED_COMPATIBLE ${SANITIZER_SELECTED_FLAGS})
+    if (SANITIZER_SELECTED_COMPATIBLE)
+      message(STATUS " Building with ${SANITIZER_SELECTED_FLAGS}")
+      append("${SANITIZER_SELECTED_FLAGS}" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(FATAL_ERROR " Sanitizer flags ${SANITIZER_SELECTED_FLAGS} are not compatible.")
+    endif()
+  elseif(MSVC)
+    if(USE_SANITIZER MATCHES "([Aa]ddress)")
+      message(STATUS "Building with Address sanitizer")
+      append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(
+        FATAL_ERROR
+          "This sanitizer not yet supported in the MSVC environment: ${USE_SANITIZER}"
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "USE_SANITIZER is not supported on this platform.")
+  endif()
+
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -331,6 +331,8 @@ if(NOT "${USE_ALTERNATE_LINKER}" STREQUAL "")
   set_alternate_linker(${USE_ALTERNATE_LINKER})
 endif()
 
+include(../3rdparty/cmake-scripts/sanitizers.cmake)
+
 find_package(
   Qt5 5.11 REQUIRED
   COMPONENTS Core


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Allows you to pass `-DUSE_SANITIZER=Leak,Address,...` to cmake to easily use the right sanitizer. See https://github.com/StableCoder/cmake-scripts#sanitizer-builds-sanitizerscmake for more.
#### Motivation for adding to Mudlet
So we can easily use them to detect memory leak issues and other programming errors - by lowering the barrier to setting up the tooling, it'll encourage them to be used more.
#### Other info (issues closed, discussion etc)
Will document this in Compiling Mudlet once its merged.