### PR TITLE
Add missing cursor and selection functionality to Geyser.MiniConsole

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserMiniConsole.lua
@@ -422,6 +422,123 @@ function Geyser.MiniConsole:display(...)
   end
 end
 
+--- gets the font size for the miniconsole
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getFontSize
+function Geyser.MiniConsole:getFontSize()
+  return getFontSize(self.name)
+end
+
+--- Moves the virtual cursor within the miniconsole
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#moveCursor
+-- @param x the horizontal position for the cursor
+-- @param y the vertical position (line) for the cursor
+function Geyser.MiniConsole:moveCursor(x, y)
+  moveCursor(self.name, x, y)
+end
+
+--- Moves the virtual cursor up 1 or more lines
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#moveCursorUp
+-- @param lines the number of lines up to move the cursor. Defaults to 1 if not provided
+-- @param keepColumn if true, will maintain the x/horizontal/columnar position of the cursor as well. Otherwise moves the cursor to the front of the line
+function Geyser.MiniConsole:moveCursorUp(lines, keepColumn)
+  moveCursorUp(self.name, lines, keepColumn)
+end
+
+--- Moves the virtual cursor down 1 or more lines
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#moveCursorDown
+-- @param lines the number of lines down to move the cursor. Defaults to 1 if not provided
+-- @param keepColumn if true, will maintain the x/horizontal/columnar position of the cursor as well. Otherwise moves the cursor to the front of the line
+function Geyser.MiniConsole:moveCursorDown(lines, keepColumn)
+  moveCursorDown(self.name, lines, keepColumn)
+end
+
+--- Moves the virtual cursor to the end of the miniconsole
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#moveCursorEnd
+function Geyser.MiniConsole:moveCursorEnd()
+  moveCursorEnd(self.name)
+end
+
+--- Returns the absolute line number the cursor is on in the miniconsole.
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getLineNumber
+function Geyser.MiniConsole:getLineNumber()
+  return getLineNumber(self.name)
+end
+
+--- Returns the number of lines in the miniconsole
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getLineCount
+function Geyser.MiniConsole:getLineCount()
+  return getLineCount(self.name)
+end
+
+--- Returns the absolute column number the virtual cursor is on
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getColumnNumber
+function Geyser.MiniConsole:getColumnNumber()
+  return getColumnNumber(self.name)
+end
+
+--- Returns the latest line's number in the miniconsole
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getLastLineNumber
+function Geyser.MiniConsole:getLastLineNumber()
+  return getLastLineNumber(self.name)
+end
+
+--- returns a section of the content of the miniconsole text buffer. Returns a Lua table with the content of the lines on a per line basis. The form value is result = {relative_linenumber = line}.
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getLines
+-- @param fromLine the absolute line number to start getting lines at
+-- @param toLine the absolute line number to stop getting lines at
+function Geyser.MiniConsole:getLines(fromLine, toLine)
+  return getLines(self.name, fromLine, toLine)
+end
+
+--- returns the content of the current line under the virtual cursor
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getCurrentLine
+function Geyser.MiniConsole:getCurrentLine()
+  return getCurrentLine(self.name)
+end
+
+--- select the text within the miniconsole's command line
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#selectCmdLineText
+function Geyser.MiniConsole:selectCmdLinetext()
+  return selectCmdLineText(self.name)
+end
+
+--- Select the current line the cursor is on in the miniconsole
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#selectCurrentLine
+function Geyser.MiniConsole:selectCurrentLine()
+  return selectCurrentLine(self.name)
+end
+
+--- Selects the specified parts of the line starting from the left and extending to the right for however how long. The line starts from 0.
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#selectSection
+-- @param fromPosition the column to start selecting from
+-- @param length the number of columns to select
+function Geyser.MiniConsole:selectSection(fromPosition, length)
+  return selectSection(self.name, fromPosition, length)
+end
+
+--- Selects a substring from the line where the user cursor is currently positioned - allowing you to edit selected text (apply colour, make it be a link, copy to other windows or other things).
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#selectString
+function Geyser.MiniConsole:selectString(text, number_of_match)
+  return selectString(self.name, text, number_of_match)
+end
+
+--- Returns the text currently selected by the virtual cursor using :selectString, :selectSection, etc (not selected by the mouse)
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getSelection
+function Geyser.MiniConsole:getSelection()
+  return getSelection(self.name)
+end
+
+--- Gets the current text format of the currently selected text.
+-- see https://wiki.mudlet.org/w/Manual:UI_Functions#getTextFormat
+function Geyser.MiniConsole:getTextFormat()
+  return getTextFormat(self.name)
+end
+
+--- Gets the number of columns the window is configured to wrap at
+function Geyser.MiniConsole:getWindowWrap()
+  return getWindowWrap(self.name)
+end
+
 -- Save a reference to our parent constructor
 Geyser.MiniConsole.parent = Geyser.Window
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Someone asked how to get the first line in a miniconsole in Lua, and I realized as I was answering this was a place that Geyser was missing functionality it should have. This PR adds the functions for moving and selecting text with the virtual cursor, and getting the information under the selection.

It also adds in a couple of get* functions which were missing, but I can see the argument for pulling them into their own PR. I ran across them while searching for the cursor related functions but they aren't strictly related.

#### Motivation for adding to Mudlet

API consistency and completeness.

Should not have to drop out of the OO paradigm of Geyser and use the base Mudlet functions the objects wrap for manipulating the cursor/selecting text. Ideally, we wrap anything that needs to have geyserObject.name passed into it to return the result specific to that item.

#### Other info (issues closed, discussion etc)

This will catch UserWindows as well, as they inherit from Geyser.MiniConsole

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
