### PR TITLE
Infrastructure: revert "don't error in PTB workflow if nothing happened last day"

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -68,14 +68,14 @@ jobs:
         bold=$(tput bold)
         normal=$(tput sgr0)
         EXIT_CODE_LINUX=0
-        LINUX_OUTPUT=$(mktemp)
         EXIT_CODE_MACOS=0
-        MACOS_OUTPUT=$(mktemp)
 
         echo "Linking ${bold}Linux PTB${normal} ${PTB_VERSION}..."
-        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" 1>$LINUX_OUTPUT || EXIT_CODE_LINUX=$?
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach linux:x86_64 "${LINUX_PTB_URL}" || EXIT_CODE_LINUX=$?
         echo "Linking ${bold}macOS PTB${normal} ${PTB_VERSION}..."
-        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" 1>$MACOS_OUTPUT || EXIT_CODE_MACOS=$?
+        dblsqd push -a mudlet -c public-test-build -r "${PTB_VERSION}" -s mudlet --type "standalone" --attach mac:x86_64 "${MACOS_PTB_URL}" || EXIT_CODE_MACOS=$?
 
-        [ -z "$EXIT_CODE_LINUX" ] || [ "$LINUX_OUTPUT" != *"This combination of os:arch and type exists already for this release."* ] && exit 1
-        [ -z "$EXIT_CODE_MACOS" ] || [ "$MACOS_OUTPUT" != *"This combination of os:arch and type exists already for this release."* ] && exit 1
+        if [ "${EXIT_CODE_LINUX}" != 0 ] && [ "${EXIT_CODE_MACOS}" != 0 ]; then
+          exit 1
+        fi
+


### PR DESCRIPTION
Reverts Mudlet/Mudlet#5835

Despite being eyeballed by many people, all this did was break the status reporting even more - now it reports errors on [every single PTB](https://github.com/Mudlet/Mudlet/actions/workflows/link-ptbs-to-dblsqd.yml).

Bash just might be too complicated to be the right tool for this if so many people get it all wrong.