### PR TITLE
Add: allow transparent text labels through right click map menu

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2487,8 +2487,8 @@ void T2DMap::createLabel(QRectF labelRectangle)
             text = tr("no text", "Default text if a label is created in mapper with no text");
         }
         label.text = text;
-        label.bgColor = QColorDialog::getColor(QColor(50, 50, 150, 100), nullptr, tr("Background color", "2D Mapper create label color dialog title"));
-        label.fgColor = QColorDialog::getColor(QColor(255, 255, 50, 255), nullptr, tr("Foreground color", "2D Mapper create label color dialog title"));
+        label.bgColor = QColorDialog::getColor(QColor(50, 50, 150, 100), nullptr, tr("Background color", "2D Mapper create label color dialog title"), QColorDialog::ShowAlphaChannel);
+        label.fgColor = QColorDialog::getColor(QColor(255, 255, 50, 255), nullptr, tr("Foreground color", "2D Mapper create label color dialog title"), QColorDialog::ShowAlphaChannel);
     } else if (textOrImageDialog.clickedButton() == imageButton) {
         label.bgColor = QColor(50, 50, 150, 100);
         label.text.clear();
@@ -2514,9 +2514,9 @@ void T2DMap::createLabel(QRectF labelRectangle)
 
     label.showOnTop = showOnTop;
     QPixmap pixmap(fabs(labelRectangle.width()), fabs(labelRectangle.height()));
+    pixmap.fill(Qt::transparent);
     QRect drawRectangle = labelRectangle.normalized().toRect();
     drawRectangle.moveTo(0, 0);
-    //pixmap.fill(QColor(0, 255, 0, 0));
     QPainter labelPainter(&pixmap);
     QPen labelPen;
     labelPainter.setFont(font);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

There was no way to create text label with transparent background through right click menu in map.

#### Motivation for adding to Mudlet

Getting label creation more consistent with Lua API.

#### Other info (issues closed, discussion etc)

This is first PR to address some issues with labels. I have some plans to improve that particular area. Hopefully I find some time and energy to do it :)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
