### PR TITLE
Fix:  make logging have a per profile persistent control method

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -344,7 +344,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mRoomBorderColor(Qt::lightGray)
 #endif
 , mMapStrongHighlight(false)
-, mLogStatus(false)
 , mEnableSpellCheck(true)
 , mDiscordDisableServerSide(true)
 , mDiscordAccessFlags(DiscordLuaAccessEnabled | DiscordSetSubMask)
@@ -406,7 +405,11 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 {
     TDebug::addHost(this);
 
-    // mLogStatus = mudlet::self()->mAutolog;
+    // The "autolog" sentinel file controls whether logging the game's text as
+    // plain text or HTML is immediately resumed on profile loading. Do not
+    // confuse it with the "autologin" item, which controls whether the profile
+    // is automatically started when the Mudlet application is run!
+    mLogStatus = QFile::exists(mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("autolog")));
     mLuaInterface.reset(new LuaInterface(this->getLuaInterpreter()->getLuaGlobalState()));
 
     // Copy across the details needed for the "color_table":

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2021 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *                                                                         *

--- a/src/Host.h
+++ b/src/Host.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2020, 2022 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *                                                                         *

--- a/src/Host.h
+++ b/src/Host.h
@@ -577,7 +577,7 @@ public:
     QColor mRoomBorderColor;
     bool mMapStrongHighlight;
     QStringList mGMCP_merge_table_keys;
-    bool mLogStatus;
+    bool mLogStatus = false;
     bool mEnableSpellCheck;
     QStringList mInstalledPackages;
     // module name = location on disk, sync to other profiles?, priority

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -162,9 +162,7 @@ std::pair<bool, QString> TMainConsole::setCmdLineStyleSheet(const QString& name,
 
 void TMainConsole::toggleLogging(bool isMessageEnabled)
 {
-    // CHECKME: This path seems suspicious, it is shared amongst ALL profiles
-    // but the action is "Per Profile"...!
-    QFile file(mudlet::getMudletPath(mudlet::mainDataItemPath, qsl("autolog")));
+    QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("autolog")));
     QDateTime logDateTime = QDateTime::currentDateTime();
     if (!mLogToLogFile) {
         file.open(QIODevice::WriteOnly | QIODevice::Text);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2017-2021 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -401,9 +401,6 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mEnableMSP") = pHost->mEnableMSP ? "yes" : "no";
     host.append_attribute("mEnableMSDP") = pHost->mEnableMSDP ? "yes" : "no";
     host.append_attribute("mMapStrongHighlight") = pHost->mMapStrongHighlight ? "yes" : "no";
-    // It does not make sense to store this detail in the game save as it now
-    // handled outside of the profile game saves:
-    // host.append_attribute("mLogStatus") = pHost->mLogStatus ? "yes" : "no";
     host.append_attribute("mEnableSpellCheck") = pHost->mEnableSpellCheck ? "yes" : "no";
     bool enableUserDictionary;
     bool useSharedDictionary;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -401,7 +401,9 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mEnableMSP") = pHost->mEnableMSP ? "yes" : "no";
     host.append_attribute("mEnableMSDP") = pHost->mEnableMSDP ? "yes" : "no";
     host.append_attribute("mMapStrongHighlight") = pHost->mMapStrongHighlight ? "yes" : "no";
-    host.append_attribute("mLogStatus") = pHost->mLogStatus ? "yes" : "no";
+    // It does not make sense to store this detail in the game save as it now
+    // handled outside of the profile game saves:
+    // host.append_attribute("mLogStatus") = pHost->mLogStatus ? "yes" : "no";
     host.append_attribute("mEnableSpellCheck") = pHost->mEnableSpellCheck ? "yes" : "no";
     bool enableUserDictionary;
     bool useSharedDictionary;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -815,7 +815,9 @@ void XMLimport::readHostPackage(Host* pHost)
     pHost->mEnableMSSP = attributes().value(qsl("mEnableMSSP")) == YES;
     pHost->mEnableMSP = attributes().value(qsl("mEnableMSP")) == YES;
     pHost->mMapStrongHighlight = attributes().value(qsl("mMapStrongHighlight")) == YES;
-    pHost->mLogStatus = attributes().value(qsl("mLogStatus")) == YES;
+    // It does not make sense to store this detail in the game save as it now
+    // handled outside of the profile game saves:
+    // pHost->mLogStatus = attributes().value(qsl("mLogStatus")) == YES;
     pHost->mEnableSpellCheck = attributes().value(qsl("mEnableSpellCheck")) == YES;
     bool enableUserDictionary = attributes().value(qsl("mEnableUserDictionary")) == YES;
     bool useSharedDictionary = attributes().value(qsl("mUseSharedDictionary")) == YES;

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2021 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -815,9 +815,6 @@ void XMLimport::readHostPackage(Host* pHost)
     pHost->mEnableMSSP = attributes().value(qsl("mEnableMSSP")) == YES;
     pHost->mEnableMSP = attributes().value(qsl("mEnableMSP")) == YES;
     pHost->mMapStrongHighlight = attributes().value(qsl("mMapStrongHighlight")) == YES;
-    // It does not make sense to store this detail in the game save as it now
-    // handled outside of the profile game saves:
-    // pHost->mLogStatus = attributes().value(qsl("mLogStatus")) == YES;
     pHost->mEnableSpellCheck = attributes().value(qsl("mEnableSpellCheck")) == YES;
     bool enableUserDictionary = attributes().value(qsl("mEnableUserDictionary")) == YES;
     bool useSharedDictionary = attributes().value(qsl("mUseSharedDictionary")) == YES;

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -184,7 +184,6 @@ mudlet::mudlet()
 , mpMainToolBar(nullptr)
 , version(qsl("Mudlet " APP_VERSION APP_BUILD))
 , mpCurrentActiveHost(nullptr)
-, mAutolog(false)
 , mpTabBar(nullptr)
 , mIsLoadingLayout(false)
 , mHasSavedLayout(false)
@@ -345,13 +344,6 @@ mudlet::mudlet()
     mpSplitter_profileContainer->setChildrenCollapsible(false);
 
     mpHBoxLayout_profileContainer->addWidget(mpSplitter_profileContainer);
-
-    QFile file_autolog(getMudletPath(mainDataItemPath, qsl("autolog")));
-    if (file_autolog.exists()) {
-        mAutolog = true;
-    } else {
-        mAutolog = false;
-    }
 
     mpButtonConnect = new QToolButton(this);
     mpButtonConnect->setText(tr("Connect"));
@@ -1540,7 +1532,6 @@ void mudlet::addConsoleForNewHost(Host* pH)
     if (pH->mpConsole) {
         return;
     }
-    pH->mLogStatus = mAutolog;
     auto pConsole = new TMainConsole(pH);
     if (!pConsole) {
         return;
@@ -1577,6 +1568,9 @@ void mudlet::addConsoleForNewHost(Host* pH)
     mpCurrentActiveHost = pH;
 
     if (pH->mLogStatus) {
+        // The above flag is set/reset at the start of the TMainConsole
+        // constructor - and if it is set we now need to "click" the button
+        // to immediately start logging the game output as text/HTML:
         pConsole->logButton->click();
     }
 

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2013-2021 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2013-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Chris Leacy - cleacy1972@gmail.com              *
  *   Copyright (C) 2016-2018 by Ian Adkins - ieadkins@gmail.com            *

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -366,7 +366,6 @@ public:
     QToolBar* mpMainToolBar;
     QString version;
     QPointer<Host> mpCurrentActiveHost;
-    bool mAutolog;
     QList<QMediaPlayer*> mMusicBoxList;
     TTabBar* mpTabBar;
     QStringList packagesToInstallList;


### PR DESCRIPTION
As an long outstanding issue whether a profile was logged or not on startup was down to a centralised mechanism that worked on every profile loaded - when it should have been a per profile one...

This will close #5872 and close #5114.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix: control over a profile's logging to text/HTML from one session to the next has been improved so that each profile is independent of any other; previously there was a common/shared setting that was saved between Mudlet application runs that meant the last profile used setting was applied to any profile started in the next run.