### PR TITLE
Fix: MXP Sound/Music Tags not functioning with U Attribute

### DIFF
--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -58,12 +58,8 @@ public:
         if (mediaVolume == TMediaData::MediaVolumePreload) {
             // Support preloading
             mMediaVolume = TMediaData::MediaVolumePreload;
-        } else if (mediaVolume > TMediaData::MediaVolumeMax) {
-            mMediaVolume = TMediaData::MediaVolumeMax;
-        } else if (mediaVolume < TMediaData::MediaVolumeMin) {
-            mMediaVolume = TMediaData::MediaVolumeMin;
         } else {
-            mMediaVolume = mediaVolume;
+            mMediaVolume =  qBound(TMediaData::MediaVolumeMin, mMediaVolume, TMediaData::MediaVolumeMax);
         }
     }
     int getMediaLoops() const { return mMediaLoops; }

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -59,7 +59,7 @@ public:
             // Support preloading
             mMediaVolume = TMediaData::MediaVolumePreload;
         } else {
-            mMediaVolume =  qBound(TMediaData::MediaVolumeMin, mMediaVolume, TMediaData::MediaVolumeMax);
+            mMediaVolume =  qBound(TMediaData::MediaVolumeMin, mediaVolume, TMediaData::MediaVolumeMax);
         }
     }
     int getMediaLoops() const { return mMediaLoops; }

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -59,7 +59,7 @@ public:
             // Support preloading
             mMediaVolume = TMediaData::MediaVolumePreload;
         } else {
-            mMediaVolume =  qBound(TMediaData::MediaVolumeMin, mediaVolume, TMediaData::MediaVolumeMax);
+            mMediaVolume =  qBound(static_cast<int>(TMediaData::MediaVolumeMin), mediaVolume, static_cast<int>(TMediaData::MediaVolumeMax));
         }
     }
     int getMediaLoops() const { return mMediaLoops; }

--- a/src/TMediaData.h
+++ b/src/TMediaData.h
@@ -54,7 +54,18 @@ public:
     QString getMediaFileName() const { return mMediaFileName; }
     void setMediaFileName(QString mediaFileName) { mMediaFileName = mediaFileName; }
     int getMediaVolume() const { return mMediaVolume; }
-    void setMediaVolume(int mediaVolume) { mMediaVolume = mediaVolume; }
+    void setMediaVolume(int mediaVolume) {
+        if (mediaVolume == TMediaData::MediaVolumePreload) {
+            // Support preloading
+            mMediaVolume = TMediaData::MediaVolumePreload;
+        } else if (mediaVolume > TMediaData::MediaVolumeMax) {
+            mMediaVolume = TMediaData::MediaVolumeMax;
+        } else if (mediaVolume < TMediaData::MediaVolumeMin) {
+            mMediaVolume = TMediaData::MediaVolumeMin;
+        } else {
+            mMediaVolume = mediaVolume;
+        }
+    }
     int getMediaLoops() const { return mMediaLoops; }
     void setMediaLoops(int mediaLoops) { mMediaLoops = mediaLoops; }
     int getMediaPriority() const { return mMediaPriority; }

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -88,66 +88,30 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 
 QString TMxpMusicTagHandler::extractFileName(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("fname"))) {
-        return tag->getAttributeValue(qsl("fname"));
-    } else if (tag->getAttributesCount() > 0) {
-        return tag->getAttrName(0);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("fname"), 0);
 }
 
 QString TMxpMusicTagHandler::extractVolume(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("v"))) {
-        return tag->getAttributeValue(qsl("v"));
-    } else if (tag->getAttributesCount() > 1 && tag->getAttributeValue(1).isEmpty()) {
-        return tag->getAttrName(1);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("v"), 1);
 }
 
 QString TMxpMusicTagHandler::extractLoops(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("l"))) {
-        return tag->getAttributeValue(qsl("l"));
-    } else if (tag->getAttributesCount() > 2) {
-        return tag->getAttrName(2);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("l"), 2);
 }
 
 QString TMxpMusicTagHandler::extractMusicContinue(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("c"))) {
-        return tag->getAttributeValue(qsl("c"));
-    } else if (tag->getAttributesCount() > 3) {
-        return tag->getAttrName(3);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("c"), 3);
 }
 
 QString TMxpMusicTagHandler::extractType(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("t"))) {
-        return tag->getAttributeValue(qsl("t"));
-    } else if (tag->getAttributesCount() > 4) {
-        return tag->getAttrName(4);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("t"), 4);
 }
 
 QString TMxpMusicTagHandler::extractUrl(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("u"))) {
-        return tag->getAttributeValue(qsl("u"));
-    } else if (tag->getAttributesCount() > 5) {
-        return tag->getAttrName(5);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("u"), 5);
 }

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -44,14 +44,6 @@ TMxpTagHandlerResult TMxpMusicTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 
         if (!volume.isEmpty()) {
             mediaData.setMediaVolume(volume.toInt());
-
-            if (mediaData.getMediaVolume() == TMediaData::MediaVolumePreload) {
-                // Support preloading
-            } else if (mediaData.getMediaVolume() > TMediaData::MediaVolumeMax) {
-                mediaData.setMediaVolume(TMediaData::MediaVolumeMax);
-            } else if (mediaData.getMediaVolume() < TMediaData::MediaVolumeMin) {
-                mediaData.setMediaVolume(TMediaData::MediaVolumeMin);
-            }
         } else {
             mediaData.setMediaVolume(TMediaData::MediaVolumeMax); // MSP the Max is the Default
         }

--- a/src/TMxpMusicTagHandler.cpp
+++ b/src/TMxpMusicTagHandler.cpp
@@ -109,7 +109,7 @@ QString TMxpMusicTagHandler::extractVolume(MxpStartTag* tag)
 {
     if (tag->hasAttribute(qsl("v"))) {
         return tag->getAttributeValue(qsl("v"));
-    } else if (tag->getAttributesCount() > 1) {
+    } else if (tag->getAttributesCount() > 1 && tag->getAttributeValue(1).isEmpty()) {
         return tag->getAttrName(1);
     }
 

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -185,7 +185,7 @@ bool TMxpNodeBuilder::acceptSequence(char ch, std::string& buffer)
         if (QChar(ch).isSpace()) {
             mHasSequence = true;
             return false;
-        } else if (ch == '/') {
+        } else if (ch == '/' && mCurrentTagAttrs.empty() && mCurrentAttrValue.empty()) {
             // Special case for end tags in the format <a given prefix/tag_name> used in MateriaMagica
             mCurrentTagName.clear();
             resetCurrentAttribute();

--- a/src/TMxpNodeBuilder.cpp
+++ b/src/TMxpNodeBuilder.cpp
@@ -185,7 +185,8 @@ bool TMxpNodeBuilder::acceptSequence(char ch, std::string& buffer)
         if (QChar(ch).isSpace()) {
             mHasSequence = true;
             return false;
-        } else if (ch == '/' && mCurrentTagAttrs.empty() && mCurrentAttrValue.empty()) {
+        }
+        if (ch == '/' && mCurrentTagAttrs.empty() && mCurrentAttrValue.empty()) {
             // Special case for end tags in the format <a given prefix/tag_name> used in MateriaMagica
             mCurrentTagName.clear();
             resetCurrentAttribute();

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -44,14 +44,6 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 
         if (!volume.isEmpty()) {
             mediaData.setMediaVolume(volume.toInt());
-
-            if (mediaData.getMediaVolume() == TMediaData::MediaVolumePreload) {
-                // Support preloading
-            } else if (mediaData.getMediaVolume() > TMediaData::MediaVolumeMax) {
-                mediaData.setMediaVolume(TMediaData::MediaVolumeMax);
-            } else if (mediaData.getMediaVolume() < TMediaData::MediaVolumeMin) {
-                mediaData.setMediaVolume(TMediaData::MediaVolumeMin);
-            }
         } else {
             mediaData.setMediaVolume(TMediaData::MediaVolumeMax); // MSP the Max is the Default
         }

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -111,7 +111,7 @@ QString TMxpSoundTagHandler::extractVolume(MxpStartTag* tag)
 {
     if (tag->hasAttribute(qsl("v"))) {
         return tag->getAttributeValue(qsl("v"));
-    } else if (tag->getAttributesCount() > 1) {
+    } else if (tag->getAttributesCount() > 1 && tag->getAttributeValue(1).isEmpty()) {
         return tag->getAttrName(1);
     }
 

--- a/src/TMxpSoundTagHandler.cpp
+++ b/src/TMxpSoundTagHandler.cpp
@@ -90,66 +90,31 @@ TMxpTagHandlerResult TMxpSoundTagHandler::handleStartTag(TMxpContext& ctx, TMxpC
 
 QString TMxpSoundTagHandler::extractFileName(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("fname"))) {
-        return tag->getAttributeValue(qsl("fname"));
-    } else if (tag->getAttributesCount() > 0) {
-        return tag->getAttrName(0);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("fname"), 0);
 }
 
 QString TMxpSoundTagHandler::extractVolume(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("v"))) {
-        return tag->getAttributeValue(qsl("v"));
-    } else if (tag->getAttributesCount() > 1 && tag->getAttributeValue(1).isEmpty()) {
-        return tag->getAttrName(1);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("v"), 1);
 }
 
 QString TMxpSoundTagHandler::extractLoops(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("l"))) {
-        return tag->getAttributeValue(qsl("l"));
-    } else if (tag->getAttributesCount() > 2) {
-        return tag->getAttrName(2);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("l"), 2);
 }
 
 QString TMxpSoundTagHandler::extractPriority(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("p"))) {
-        return tag->getAttributeValue(qsl("p"));
-    } else if (tag->getAttributesCount() > 3) {
-        return tag->getAttrName(3);
-    }
 
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("p"), 3);
 }
 
 QString TMxpSoundTagHandler::extractType(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("t"))) {
-        return tag->getAttributeValue(qsl("t"));
-    } else if (tag->getAttributesCount() > 4) {
-        return tag->getAttrName(4);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("t"), 4);
 }
 
 QString TMxpSoundTagHandler::extractUrl(MxpStartTag* tag)
 {
-    if (tag->hasAttribute(qsl("u"))) {
-        return tag->getAttributeValue(qsl("u"));
-    } else if (tag->getAttributesCount() > 5) {
-        return tag->getAttrName(5);
-    }
-
-    return QString();
+    return tag->getAttributeByNameOrIndex(qsl("u"), 5);
 }

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2189,14 +2189,6 @@ void cTelnet::setMSPVariables(const QByteArray& msg)
 
                 if (mspVAR == "V") {
                     mediaData.setMediaVolume(mspVAL.toInt());
-
-                    if (mediaData.getMediaVolume() == TMediaData::MediaVolumePreload) {
-                        continue; // Support preloading
-                    } else if (mediaData.getMediaVolume() > TMediaData::MediaVolumeMax) {
-                        mediaData.setMediaVolume(TMediaData::MediaVolumeMax);
-                    } else if (mediaData.getMediaVolume() < TMediaData::MediaVolumeMin) {
-                        mediaData.setMediaVolume(TMediaData::MediaVolumeMin);
-                    }
                 } else if (mspVAR == "L") {
                     mediaData.setMediaLoops(mspVAL.toInt());
 

--- a/test/TMxpTagParserTest.cpp
+++ b/test/TMxpTagParserTest.cpp
@@ -367,6 +367,32 @@ private slots:
         QCOMPARE(tag->asStartTag()->getAttribute("back").getValue(), "blue");
     }
 
+    void testUnquotedUrl() {
+        auto node = parseNode("<sound FName=\"cow.wav\" U=https://raw.githubusercontent.com/StickMUD/StickMUDSounds/master/sounds/>");
+
+        QVERIFY(node);
+        QVERIFY(node->isStartTag());
+
+        MxpStartTag* tag = node->asStartTag();
+        QCOMPARE(tag->getName(), "sound");
+        QCOMPARE(tag->getAttributeValue("FName"), "cow.wav");
+        QCOMPARE(tag->getAttributeValue("U"), "https://raw.githubusercontent.com/StickMUD/StickMUDSounds/master/sounds/");
+
+    }
+
+    void testEmptyTagWithSlash() {
+        auto node = parseNode("<send url=http://www.gogle.com/ />");
+
+        QVERIFY(node);
+        QVERIFY(node->isStartTag());
+
+        MxpStartTag* tag = node->asStartTag();
+        QVERIFY(tag->isEmpty());
+        QCOMPARE(tag->getName(), "send");
+        QCOMPARE(tag->getAttributeValue("url"), "http://www.gogle.com/");
+    }
+
+
     void cleanupTestCase() {}
 };
 


### PR DESCRIPTION
Fixes issue #5876

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->

#### Brief overview of PR changes/additions
- MXP tag parsing: Adds extra conditions for identifying closing tags with prefix, allowing parsing to continue when slashes are found inside an unquoted attribute value;  Test case for the example in the issue
- SOUND and MUSIC tag processing: extra check for detecting unnamed volume attribute
- Refactorings to remove duplicated code

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
