### PR TITLE
Add additional 2string functions for stripping formatting codes from c/d/hecho formatted text

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1982,7 +1982,32 @@ do
 end
 
 
+-- function for converting a color formatted string to 'plaintext' string
+local function x2string(text, style)
+  local ttbl = _Echos.Process(text, style)
+  local result = ""
+  for _, val in ipairs(ttbl) do
+    if type(val) == "string" and not val:starts("\27") then
+      result = result .. val
+    end
+  end
+  return result
+end
 
+-- function to convert a cecho formatted string to a nonformatted string
+function cecho2string(text)
+  return x2string(text, "Color")
+end
+
+-- function to convert a decho formatted string to a nonformatted string
+function decho2string(text)
+  return x2string(text, "Decimal")
+end
+
+-- function to convert a hecho formatted string to a nonformatted string
+function hecho2string(text)
+  return x2string(text, "Hex")
+end
 
 local ansiPattern = rex.new("\\e\\[([0-9:;]+?)m")
 

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -536,6 +536,96 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
     end)
   end)
 
+  describe("Tests the functionality of cecho2string", function()
+    it("Should be able to handle stripping colors", function()
+      local testCases = {
+        {"<red>This is<blue> a simple test", "This is a simple test"},
+        {"<purple>This<reset> is a <more> complicated test", "This is a <more> complicated test"},
+        {"This <ansiBlack>should also be easy", "This should also be easy"}
+      }
+      for _, case in ipairs(testCases) do
+        local expected = case[2]
+        local actual = cecho2string(case[1])
+        assert.equals(expected, actual)
+      end
+    end)
+
+    it("Should be able to strip formatting codes as well", function()
+      local testCases = {
+        {"<b>Bold</b>", "Bold"},
+        {"<u>Underline</u>", "Underline"},
+        {"<i>Italics</i>", "Italics"},
+        {"<s>Strikethrough</s>", "Strikethrough"},
+        {"<o>Overline</o>", "Overline"}
+      }
+      for _, case in ipairs(testCases) do
+        local expected = case[2]
+        local actual = cecho2string(case[1])
+        assert.equals(expected, actual)
+      end
+    end)
+  end)
+
+  describe("Tests the functionality of decho2string", function()
+    it("Should be able to handle stripping colors", function()
+      local testCases = {
+        {"<255,0,0>This is<0,255,0> a simple test", "This is a simple test"},
+        {"<128,128,0>This<r> is a <more> complicated test", "This is a <more> complicated test"},
+        {"This <0,0,0>should also be easy", "This should also be easy"}
+      }
+      for _, case in ipairs(testCases) do
+        local expected = case[2]
+        local actual = decho2string(case[1])
+        assert.equals(expected, actual)
+      end
+    end)
+
+    it("Should be able to strip formatting codes as well", function()
+      local testCases = {
+        {"<b>Bold</b>", "Bold"},
+        {"<u>Underline</u>", "Underline"},
+        {"<i>Italics</i>", "Italics"},
+        {"<s>Strikethrough</s>", "Strikethrough"},
+        {"<o>Overline</o>", "Overline"}
+      }
+      for _, case in ipairs(testCases) do
+        local expected = case[2]
+        local actual = decho2string(case[1])
+        assert.equals(expected, actual)
+      end
+    end)
+  end)
+
+  describe("Tests the functionality of hecho2string", function()
+    it("Should be able to handle stripping colors", function()
+      local testCases = {
+        {"#ff0000This is#00ff00 a simple test", "This is a simple test"},
+        {"#777700This#r is a #more complicated test", "This is a #more complicated test"},
+        {"This |c000000should also be easy", "This should also be easy"}
+      }
+      for _, case in ipairs(testCases) do
+        local expected = case[2]
+        local actual = hecho2string(case[1])
+        assert.equals(expected, actual)
+      end
+    end)
+
+    it("Should be able to strip formatting codes as well", function()
+      local testCases = {
+        {"#bBold#/b", "Bold"},
+        {"#uUnderline#/u", "Underline"},
+        {"#iItalics#/i", "Italics"},
+        {"#sStrikethrough#/s", "Strikethrough"},
+        {"#oOverline#/o", "Overline"}
+      }
+      for _, case in ipairs(testCases) do
+        local expected = case[2]
+        local actual = hecho2string(case[1])
+        assert.equals(expected, actual)
+      end
+    end)
+  end)
+
   describe("Tests the functionality of getHTMLformat", function()
     local fmt
     before_each(function()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
We have ansi2string to strip ansi from a string, but nothing to strip the formatting from a c/d/hecho formatted string.

This PR adds the functions, as well as tests for them.

#### Motivation for adding to Mudlet

Someone was asking how to do it for decho in discord, and providing these functions ourselves will be more user friendly than requiring them to use the lrexlib functions, especially since _Echos is undocumented so they wouldn't even know there were patterns already available.

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
