### PR TITLE
Fix: using control character mode without initialising it

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -806,7 +806,7 @@ private:
     //   EN: https://en.wikipedia.org/wiki/Code_page_437
     //   DE: https://de.wikipedia.org/wiki/Codepage_437
     //   RU: https://ru.wikipedia.org/wiki/CP437
-    TConsole::ControlCharacterMode mControlCharacterMode;
+    TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;
 
 };
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: using control character mode without initialising it
#### Motivation for adding to Mudlet
So wonky things don't happen.
#### Other info (issues closed, discussion etc)
Setting one simple variable should not be this long 😬 

```
TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;
```

Found thanks to https://github.com/Mudlet/Mudlet/pull/5848 using `UndefinedBehaviorSanitizer`: 

> ../src/Host.cpp:3940:9: runtime error: load of value 117205904, which is not a valid value for type 'TConsole::ControlCharacterMode'
