### PR TITLE
Fix: prevent bogus NAWS and window resize events on tab changes

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -553,6 +553,15 @@ void TConsole::resizeEvent(QResizeEvent* event)
     int x = event->size().width();
     int y = event->size().height();
 
+    if (mType == MainConsole && !x) {
+        // When multi-view is NOT active but more than one profile is loaded
+        // switching between tabs causes the deselected profile to resize its
+        // main console to a width of zero - but that is not useful from a NAWS
+        // or event handling system point of view - so abort doing anything
+        // with the event:
+        return;
+    }
+
     if (mType & (MainConsole|Buffer|SubConsole|UserWindow) && mpCommandLine && !mpCommandLine->isHidden()) {
         mpMainFrame->resize(x, y);
         mpBaseVFrame->resize(x, y);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13778,8 +13778,11 @@ void TLuaInterpreter::logError(std::string& e, const QString& name, const QStrin
 
     // Log error to Profile's Main TConsole:
     if (mpHost->mEchoLuaErrors) {
-        // ensure the Lua error is on a line of its own and is not prepended to the previous line
-        if (mpHost->mpConsole->buffer.size() > 0 && !mpHost->mpConsole->buffer.lineBuffer.at(mpHost->mpConsole->buffer.lineBuffer.size() - 1).isEmpty()) {
+        // ensure the Lua error is on a line of its own and is not prepended to
+        // the previous line, however there is a nasty gotcha in that during
+        // profile loading the (TMainConsole*) Host::mpConsole pointer is
+        // null - but then the buffer must itself be empty:
+        if (mpHost->mpConsole && mpHost->mpConsole->buffer.size() > 0 && !mpHost->mpConsole->buffer.lineBuffer.at(mpHost->mpConsole->buffer.lineBuffer.size() - 1).isEmpty()) {
             mpHost->postMessage(qsl("\n"));
         }
 


### PR DESCRIPTION
This should prevent NAWS messages and `sysWindowResizeEvents` with a width of 0 being raised when the user is multi-playing but not using multi-view and changes to a different tab. As this also stops that width of zero size being stored it also means a second resize event/message when the user switches back to the profile concerned is also not produced.

It is possible that these bogus messages of zero width might have been used to detect when the particular profile lost the focus when multi-playing but not using multiview - as such there might be a desireable for a new event to report when a profile loses/gains the state of being the "active" profile...

This should close #5814.

During testing a further **serious** bug was discovered that meant that Mudlet events raised early in the profile loading stage, before the main profile console was fully initialised, could cause the accessing of a null pointer with "Application Fatal" results...!
 
Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix - a bug introduced by #5160 which meant that tabbing away from the current profile when multi-playing but *not* using the multi-view mode would generate a bogus NAWS message to the Game Server and resize a `sysWindowResizeEvent` for the main console with a width of `0` (and thus another one with *normal* values, probably unchanged from the previous case when the profile was active and thus visible)..