### PR TITLE
Fix regression in Geyser.Label.echo due to #5751 (c/d/hecho in Labels)

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -26,7 +26,7 @@ Geyser.Label.scrollH = {}
 function Geyser.Label:echo(message, color, format)
   message = message or self.message
   self.message = message
-  message = message:gsub("\n", "<br>")
+  message = utf8.gsub(message, "\n", "<br>")
   color = color or self.fgColor
   self.fgColor = color
   if format then self:processFormatString(format) end


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
When I added https://github.com/Mudlet/Mudlet/pull/5751 I used the object form of string.gsub, which does not work with numbers, and may not work properly with utf8 encoded text either. This changes it to use utf8.gsub specifically, which happily takes a number for its first parameter and makes it a string.

#### Motivation for adding to Mudlet
Fix regression

#### Other info (issues closed, discussion etc)
fixes https://github.com/Mudlet/Mudlet/issues/5888

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
