### PR TITLE
add: allow to resize animated gif to label size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cmake-build-debug
 #Docker
 docker/docker-compose.override.yml
 docker/.env
+*.lua

--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -170,6 +170,12 @@ void TLabel::enterEvent(QEvent* event)
     }
 }
 
+void TLabel::resizeEvent(QResizeEvent* event)
+{
+    emit resized();
+    QWidget::resizeEvent(event);
+}
+
 
 // This function deferences previous functions in the Lua registry.
 // This allows the functions to be safely overwritten.

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -60,6 +60,7 @@ public:
     void mouseMoveEvent(QMouseEvent*) override;
     void leaveEvent(QEvent*) override;
     void enterEvent(QEvent*) override;
+    void resizeEvent(QResizeEvent* event) override;
     void setClickThrough(bool clickthrough);
 
     QPointer<Host> mpHost;
@@ -74,6 +75,9 @@ public:
 
 private:
     void releaseFunc(const int existingFunction, const int newFunction);
+
+signals:
+    void resized();
 };
 
 #endif // MUDLET_TLABEL_H

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4339,8 +4339,18 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
     } else if (funcName == qsl("setMovieSpeed")) {
         int speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
         movie->setSpeed(speed);
-    } else if (funcName == qsl("setMovieScale")) {
+    } else if (funcName == qsl("scaleMovie")) {
+        bool autoScale{true};
+        int n = lua_gettop(L);
+        if (n > 1) {
+            autoScale = getVerifiedBool(L, funcName.toUtf8().constData(), 2, "activate/deactivate scaling movie", true);
+        }
         movie->setScaledSize(pN->size());
+        if (autoScale) {
+            connect(pN, &TLabel::resized, [=] {movie->setScaledSize(pN->size());} );
+        } else {
+            pN->disconnect(SIGNAL(resized()));
+        }
     } else {
         return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
@@ -4374,9 +4384,9 @@ int TLuaInterpreter::setMovieSpeed(lua_State* L)
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovieSpeed
-int TLuaInterpreter::setMovieScale(lua_State* L)
+int TLuaInterpreter::scaleMovie(lua_State* L)
 {
-    return movieFunc(L, qsl("setMovieScale"));
+    return movieFunc(L, qsl("scaleMovie"));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setTextFormat
@@ -14859,7 +14869,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setMovie", TLuaInterpreter::setMovie);
     lua_register(pGlobalLua, "setMovieStart", TLuaInterpreter::setMovieStart);
     lua_register(pGlobalLua, "setMovieSpeed", TLuaInterpreter::setMovieSpeed);
-    lua_register(pGlobalLua, "setMovieScale", TLuaInterpreter::setMovieScale);
+    lua_register(pGlobalLua, "scaleMovie", TLuaInterpreter::scaleMovie);
     lua_register(pGlobalLua, "setMovieFrame", TLuaInterpreter::setMovieFrame);
     lua_register(pGlobalLua, "setMoviePaused", TLuaInterpreter::setMoviePaused);
     lua_register(pGlobalLua, "getImageSize", TLuaInterpreter::getImageSize);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4339,6 +4339,8 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
     } else if (funcName == qsl("setMovieSpeed")) {
         int speed = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie playback speed in %");
         movie->setSpeed(speed);
+    } else if (funcName == qsl("setMovieScale")) {
+        movie->setScaledSize(pN->size());
     } else {
         return warnArgumentValue(L, __func__, qsl("'%1' is not a known function name - bug in Mudlet, please report it").arg(funcName));
     }
@@ -4369,6 +4371,12 @@ int TLuaInterpreter::setMovieFrame(lua_State* L)
 int TLuaInterpreter::setMovieSpeed(lua_State* L)
 {
     return movieFunc(L, qsl("setMovieSpeed"));
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setMovieSpeed
+int TLuaInterpreter::setMovieScale(lua_State* L)
+{
+    return movieFunc(L, qsl("setMovieScale"));
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setTextFormat
@@ -14851,6 +14859,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setMovie", TLuaInterpreter::setMovie);
     lua_register(pGlobalLua, "setMovieStart", TLuaInterpreter::setMovieStart);
     lua_register(pGlobalLua, "setMovieSpeed", TLuaInterpreter::setMovieSpeed);
+    lua_register(pGlobalLua, "setMovieScale", TLuaInterpreter::setMovieScale);
     lua_register(pGlobalLua, "setMovieFrame", TLuaInterpreter::setMovieFrame);
     lua_register(pGlobalLua, "setMoviePaused", TLuaInterpreter::setMoviePaused);
     lua_register(pGlobalLua, "getImageSize", TLuaInterpreter::getImageSize);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -395,7 +395,7 @@ public:
     static int setMovie(lua_State*);
     static int setMovieStart(lua_State*);
     static int setMovieSpeed(lua_State*);
-    static int setMovieScale(lua_State*);
+    static int scaleMovie(lua_State*);
     static int setMovieFrame(lua_State*);
     static int setMoviePaused(lua_State*);
     static int setCmdLineAction(lua_State*);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -395,6 +395,7 @@ public:
     static int setMovie(lua_State*);
     static int setMovieStart(lua_State*);
     static int setMovieSpeed(lua_State*);
+    static int setMovieScale(lua_State*);
     static int setMovieFrame(lua_State*);
     static int setMoviePaused(lua_State*);
     static int setCmdLineAction(lua_State*);

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -222,6 +222,11 @@ function Geyser.Label:setMovieFrame(frameNr)
   return setMovieFrame(self.name, frameNr)
 end
 
+---setMovieScale resizes the movie to the label size
+function Geyser.Label:setMovieScale()
+  return setMovieScale(self.name)
+end
+
 
 --- Set whether or not the text in the label should be bold
 -- @param bool True for bold

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -222,9 +222,13 @@ function Geyser.Label:setMovieFrame(frameNr)
   return setMovieFrame(self.name, frameNr)
 end
 
----setMovieScale resizes the movie to the label size
-function Geyser.Label:setMovieScale()
-  return setMovieScale(self.name)
+---scaleMovie resizes the movie to the label size
+--@param autoScale optional parameter to stop scaling movie if false
+function Geyser.Label:scaleMovie(autoScale)
+  if autoScale ~= false then
+    autoScale = true
+  end
+  return scaleMovie(self.name, autoScale)
 end
 
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This adds the function scaleMovie(labelname, [autoScale]) which resizes the animated gif to the label size.
The autoScale parameter is optional and autoscaling (scale the gif to the label size if the label resizes) is on if not set.
Geyser.Label:scaleMovie([autoScale]) is also added
#### Motivation for adding to Mudlet
Discussion on Discord
#### Other info (issues closed, discussion etc)
If someone has suggestions for a better function name I'm open to it :wink: 
#### Release post highlight

