### PR TITLE
Improve: setMoviePaused should only ever pause, not unpause as well

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -4331,7 +4331,7 @@ int TLuaInterpreter::movieFunc(lua_State* L, const QString& funcName)
     if (funcName == qsl("setMovieStart")) {
         movie->start();
     } else if (funcName == qsl("setMoviePaused")) {
-        movie->setPaused(movie->state() != QMovie::Paused);
+        movie->setPaused(true);
     } else if (funcName == qsl("setMovieFrame")) {
         int frame = getVerifiedInt(L, funcName.toUtf8().constData(), 2, "movie frame number");
         lua_pushboolean(L, movie->jumpToFrame(frame));

--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -179,13 +179,13 @@ function Geyser.Label:enableAutoAdjustSize(width, height)
     self.autoWidth = false
   end
 
-  if height == false then 
+  if height == false then
     self.autoHeight = false
   end
   return true
 end
 
---- Disable autoAdjustSize 
+--- Disable autoAdjustSize
 function Geyser.Label:disableAutoAdjustSize()
   self.autoHeight = false
   self.autoWidth = false
@@ -200,12 +200,12 @@ function Geyser.Label:setMovie(fileName)
   return result, error
 end
 
----startMovie starts animation on label
+---startMovie starts animation on a label
 function Geyser.Label:startMovie()
   return setMovieStart(self.name)
 end
 
----pauseMovie pauses or resumes animation on label
+---pauseMovie pauses animation on a label
 function Geyser.Label:pauseMovie()
   return setMoviePaused(self.name)
 end
@@ -655,13 +655,13 @@ function Geyser.Label:displayNest()
     local width = v.get_width()
     local height = v.get_height()
     local number = #nestedLabels["V"]
-    
+
     if v.flyDir == "L" then
       v.x = parX + flyMap[v.flyDir][1] * width
     else
       v.x = parX + flyMap[v.flyDir][1] * parW
     end
-    
+
     -- T and B use their own offset values
     if v.flyDir == "T" then
       v.y = parY + flyMap[v.flyDir][2] * height * (number - flyIndex[v.flyDir]) + yOffsetT
@@ -670,17 +670,17 @@ function Geyser.Label:displayNest()
         v.y = 0
       end
     else
-      
+
       local edge = parY + parH + (number * height)
       if edge > maxDim["V"]  and v.flyDir == "B" then
         yOffsetT = edge - maxDim["V"]
       else
         yOffsetT = yOffset
       end
-      
+
       v.y = parY + flyMap[v.flyDir][2] * parH - yOffsetT + height * flyIndex[v.flyDir]
     end
-    
+
     v:show()
     v:raise()
     moveWindow(v.name, v.x, v.y)
@@ -709,13 +709,13 @@ function Geyser.Label:displayNest()
       end
       v.x = parX + flyMap[v.flyDir][1] * parW - xOffsetL + width * flyIndex[v.flyDir]
     end
-    
+
     if v.flyDir == "T" then
       v.y = parY + flyMap[v.flyDir][2] * height
     else
       v.y = parY + flyMap[v.flyDir][2] * parH
     end
-    
+
     v:show()
     v:raise()
     moveWindow(v.name, v.x, v.y)
@@ -767,7 +767,7 @@ function doNestEnter(label)
   if Geyser.Label.closeAllTimer then
     killTimer(Geyser.Label.closeAllTimer)
   end
-  
+
   if not label.nestParent then
     closeAllLevels(label)
   else
@@ -1093,7 +1093,7 @@ end
 
 -- internal function to create the right click Menu Labels
 function Geyser.Label:createMenuItems(restyle, MenuItems, configLabel, myMenu, depth)
-  
+
   depth = depth or 1
   MenuItems = MenuItems or self.MenuItems
   self.MenuItems = MenuItems
@@ -1101,7 +1101,7 @@ function Geyser.Label:createMenuItems(restyle, MenuItems, configLabel, myMenu, d
   configLabel = configLabel or myMenu
   myMenu.MenuLabels = myMenu.MenuLabels or {}
   local index = 1
-  
+
   for i = 1, #MenuItems do
     if type(MenuItems[i]) == "string" and not MenuItems[i].ignore then
       addElement(self, MenuItems[i], configLabel, myMenu, depth, index, restyle)
@@ -1203,8 +1203,8 @@ function Geyser.Label:hideMenuLabel(name)
   local nestTable = menuElement.nestParent.nestedLabels
   local index = table.index_of(menuElement.nestParent.nestedLabels, menuElement)
   -- If it's already hidden do nothing
-  if menuElement.ignore then 
-    return 
+  if menuElement.ignore then
+    return
   end
   menuElement.MenuIndex = index
   menuElement.MenuNestTable = nestTable
@@ -1222,8 +1222,8 @@ function Geyser.Label:showMenuLabel(name)
     error ("showMenuLabel: Couldn't find menu element "..name)
   end
   -- If it's already shown do nothing
-  if not menuElement.ignore then 
-    return 
+  if not menuElement.ignore then
+    return
   end
   menuElement.ignore = false
   table.insert(menuElement.MenuNestTable, menuElement.MenuIndex, menuElement)
@@ -1236,28 +1236,28 @@ end
 -- @param index of the new menu item (optional)
 function Geyser.Label:addMenuLabel(name, parent, index)
   local menuElement, menuParent = self:findMenuElement(parent, self.rightClickMenu, true)
-  
+
   if parent and not menuParent then
     error ("showMenuLabel: Couldn't find menu parent "..parent)
   end
-  
+
   menuElement = menuElement or self.rightClickMenu
   menuParent = menuParent or self.rightClickMenu.MenuItems
-  
+
   if parent then
     parent = parent.."."
   else
     parent = ""
   end
-  
+
   if not menuElement.MenuLabels[name] then
     menuParent[#menuParent + 1] = name
   elseif menuElement.MenuLabels[name].ignore then
     self:showMenuLabel(parent..name)
   end
-  
+
   self:createMenuItems()
-  
+
   if index then
     self:changeMenuIndex(parent..name, index)
   end
@@ -1268,14 +1268,14 @@ end
 -- @param index the new index
 function Geyser.Label:changeMenuIndex(name, index)
   local menuElement, menuTable = self:findMenuElement(name, self.rightClickMenu)
-  
+
   if not menuElement then
     error ("changeMenuIndex: Couldn't find menu element "..name)
   end
-  
+
   local nestTable = menuElement.nestParent.nestedLabels
   local newindex = nestTable[index].tblIndex
-  
+
   -- table index is not the same as index
   -- if element is parent behave differently
   if nestTable[index].isParent then
@@ -1286,9 +1286,9 @@ function Geyser.Label:changeMenuIndex(name, index)
   --nestTable
   table.remove(nestTable, menuElement.index)
   table.insert(nestTable, index, menuElement)
-  
+
   menuElement.index = index
-  
+
   -- MenuItems Table
   -- parents need to bring also their children to their index
   if menuElement.isParent then
@@ -1314,7 +1314,7 @@ end
 --@param[opt="c10"] cons.MenuFormat default font/echo format of your right click menu. different levels can use different formatting. usage MenuFormat1 MenuFormat2
 --@param[opt="light"] cons.Style default styling mode of your right click menu. 2 possible modes "light" and "dark". different levels can also have different styling modes
 --@param cons.MenuStyle default style of your menu. if this is given cons.Style will be ignored. different levels can also have different MenuStyles
---@param cons.MenuItems list of right click menu items/elements. usage example: MenuItems = {"First", "Second", {"First"},"Third"} 
+--@param cons.MenuItems list of right click menu items/elements. usage example: MenuItems = {"First", "Second", {"First"},"Third"}
 function Geyser.Label:createRightClickMenu(cons)
   cons.width = "0"
   cons.height = "0"
@@ -1326,13 +1326,13 @@ function Geyser.Label:createRightClickMenu(cons)
   cons.MenuStyleMode = {}
   cons.MenuStyleMode["light"] = [[QLabel::hover{ background-color: rgba(0,150,255,100%); color: white;} QLabel::!hover{color: black; background-color: rgba(240,240,240,100%);} ]]
   cons.MenuStyleMode["dark"] = [[QLabel::hover{ background-color: #282828;  color: #808080;} QLabel::!hover{color: #707070; background-color:#181818;}]]
-  
+
   cons.Style = cons.Style or "light"
-  
+
   if not(self.rightClickMenu) then
     self:setClickCallback(self.onRightClick, self)
   end
-  
+
   -- create a label with a nestable=true property as base menu
   self.rightClickMenu = Geyser.Label:new(cons, self)
   self:createMenuItems(nil, cons.MenuItems)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
setMoviePaused should only ever pause, not unpause as well
#### Motivation for adding to Mudlet
It can be really difficult to work with a function that toggles stuff for you in scripts, because if you make a mistake and double-call it by accident, it won't do anything. Better to always pause instead and if you'd like to unpause, use setMovieStart/startMovie instead
#### Other info (issues closed, discussion etc)
Missed this in the initial review