### PR TITLE
Fix: correctly save fore/background color and transparency of labels in JSON map files

### DIFF
--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -771,9 +771,11 @@ void TArea::writeJsonLabel(QJsonArray& array, const int id, const TMapLabel* pLa
     if (!(pLabel->fgColor.red() == defaultLabelForeground.red()
           && pLabel->fgColor.green() == defaultLabelForeground.green()
           && pLabel->fgColor.blue() == defaultLabelForeground.blue()
+          && pLabel->fgColor.alpha() == defaultLabelForeground.alpha()
           && pLabel->bgColor.red() == defaultLabelBackground.red()
-          && pLabel->bgColor.red() == defaultLabelBackground.green()
-          && pLabel->bgColor.red() == defaultLabelBackground.blue())) {
+          && pLabel->bgColor.green() == defaultLabelBackground.green()
+          && pLabel->bgColor.blue() == defaultLabelBackground.blue()
+          && pLabel->bgColor.alpha() == defaultLabelBackground.alpha())) {
 
         // For an image the colors are not used and tend to be set to black, if
         // so skip them. Unfortunately because of the way QColour s are


### PR DESCRIPTION
This error was introduced in the original "load/save Maps as JSON" PR, #4546 ...!

Also include a check for transparency - as a recent PR #5873 (*Edited: not 5783!*) added the option for that to both the fore and background colours of map labels.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix - prevent a corner case not saving the fore/background colour details for map labels correctly in JSON map files.