### PR TITLE
fix: get tempComplexRegexTrigger multiline to work

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7575,7 +7575,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
 
     QString soundFile;
     bool playSound;
-    if (lua_isstring(L, 11)) {
+    if (lua_type(L, 11) == LUA_TSTRING) {
         playSound = true;
         soundFile = lua_tostring(L, 11);
     } else {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7599,16 +7599,15 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     QStringList patterns;
     QList<int> propertyList;
     TTrigger* pP = host.getTriggerUnit()->findTrigger(triggerName);
-    if (!pP) {
-        patterns << pattern;
-        if (colorTrigger) {
-            propertyList << REGEX_COLOR_PATTERN;
-        } else {
-            propertyList << REGEX_PERL;
-        }
-    } else {
+    if (pP) {
         patterns = pP->getPatternsList();
         propertyList = pP->getRegexCodePropertyList();
+    }
+    patterns << pattern;
+    if (colorTrigger) {
+        propertyList << REGEX_COLOR_PATTERN;
+    } else {
+        propertyList << REGEX_PERL;
     }
 
     auto pT = new TTrigger("a", patterns, propertyList, multiLine, &host);
@@ -7616,7 +7615,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
     pT->setIsActive(true);
     pT->setTemporary(true);
     pT->registerTrigger();
-    pT->setName(pattern);
+    pT->setName(triggerName);
     pT->mPerlSlashGOption = matchAll; //match all
     pT->mFilterTrigger = filter;
     pT->setConditionLineDelta(lineDelta); //line delta
@@ -7643,7 +7642,7 @@ int TLuaInterpreter::tempComplexRegexTrigger(lua_State* L)
         lua_settable(L, LUA_REGISTRYINDEX);
     }
 
-    lua_pushstring(L, pattern.toUtf8().constData());
+    lua_pushnumber(L, pT->getID());
     return 1;
 }
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Should solve the issue at https://app.bountysource.com/issues/105127054-tempcomplexregextrigger-multiline-not-working

#### Motivation for adding to Mudlet
fix #5854

#### Other info (issues closed, discussion etc)
There are still a lot of issues with tempComplexRegexTrigger as mentioned at #5749

Should solve the issue.
The code in the example wont work as there is no linedelta set.
this should work:
```lua
t1 = tempComplexRegexTrigger("newname3", "^xxx", [[]], 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, nil)
t2 = tempComplexRegexTrigger("newname3", "^yyy", [[echo("<--Line 2")]], 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, nil)
```
#### Release post highlight
fix: tempComplexRegexTrigger multiline should work again
