### PR TITLE
Fix: guard against breaking c/d/hecho to the main console when someone makes a label named "main"

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -1314,7 +1314,7 @@ if rex then
       _G[func](...)
     end
 
-    if windowType(win) == "label" then
+    if windowType(win) == "label" and win ~= "main" then
       str = str:gsub("\n", "<br>")
       local t = _Echos.Process(str, style)
       if func ~= "echo" then


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Right now if you create a label named 'main' it will respond to windowType as "label" but xEcho will actually go to the main console. This was causing c/d/hecho("main", "text") to include a bunch of unrendered html, thinking it was going to a label.

This causes xEcho to assume it's a miniconsole and not a label if it's named "main", which will prevent the one instance we know the name of for sure. The best fix will ultimately be resolving https://github.com/Mudlet/Mudlet/issues/5947 and not allowing you to make display items with the same name but different types.

#### Motivation for adding to Mudlet
right now creating a label named "main" results in bad behaviour for c/d/hecho

#### Other info (issues closed, discussion etc)

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
