### PR TITLE
Fix: Stop painting half of an exit line

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2141,12 +2141,8 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
             if (!areaExit) {
                 // Non-area exit:
                 if (!oneWayExits.contains(rID)) {
-                    // Two way exit - but only draw the half of the line from
-                    // the room towards the exit - so that it does not overpaint
-                    // any door drawn on the other half from the other
-                    // direction:
+                    // Two way exit
                     QLineF l0 = QLineF(p2.toPointF(), p1.toPointF());
-                    l0.setLength(l0.length() / 2.0);
                     painter.save();
                     QPen exitPen = painter.pen();
                     // We need the line not to extend past the actual end point:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Draw a whole line even if one room at its end is not currently shown

#### Motivation for adding to Mudlet
Lines half vanished suddenly while scrolling the map. Lines stop in the middle of nowhere.
[Original bug report](https://discord.com/channels/283581582550237184/283582439002210305/938328813052522527) in Mudlet discord  on 2022/02/03

#### Other info (issues closed, discussion etc)
Discussion starts here: https://discord.com/channels/283581582550237184/283582439002210305/938888418186903664

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
