### PR TITLE
Fix: Remove the conversion of newlines to br tags, as it is causing more harm than good

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserLabel.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserLabel.lua
@@ -26,7 +26,6 @@ Geyser.Label.scrollH = {}
 function Geyser.Label:echo(message, color, format)
   message = message or self.message
   self.message = message
-  message = utf8.gsub(message, "\n", "<br>")
   color = color or self.fgColor
   self.fgColor = color
   if format then self:processFormatString(format) end


### PR DESCRIPTION
#### Brief overview of PR changes/additions
The conversion of newlines to `<br>` in Geyser.Label:echo is catching out more people in a negative way than we realized and is more of a harm than a help. This reverts that change.

#### Motivation for adding to Mudlet
It's causing our users headaches and problems, and that's never the intent.

#### Other info (issues closed, discussion etc)

#### Release post highlight

