### PR TITLE
Fix: always return "main" for windowType("main")

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3945,12 +3945,12 @@ void Host::setControlCharacterMode(const TConsole::ControlCharacterMode mode)
 
 std::optional<QString> Host::windowType(const QString& name) const
 {
-    if (mpConsole->mLabelMap.contains(name)) {
-        return {qsl("label")};
+    if (Q_UNLIKELY(name == QLatin1String("main"))) {
+        return {QLatin1String("main")};
     }
 
-    if (name == QLatin1String("main")) {
-        return {QLatin1String("main")};
+    if (mpConsole->mLabelMap.contains(name)) {
+        return {qsl("label")};
     }
 
     auto pWindow = mpConsole->mSubConsoleMap.value(name);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Always return "main" for windowType("main")
#### Motivation for adding to Mudlet
`createLabel("main"` is unfortunately possible at the moment, and that breaks the current logic of `windowType()`.