### PR TITLE
Fix: ensure that map sub-directory exists when writing JSON map file there

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2897,6 +2897,11 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     QString destination{dest};
 
     if (destination.isEmpty()) {
+        QString destFolder = mudlet::getMudletPath(mudlet::profileMapsPath, mProfileName);
+        QDir destDir(destFolder);
+        if (!destDir.exists()) {
+            destDir.mkdir(destFolder);
+        }
         destination = mudlet::getMudletPath(mudlet::profileDateTimeStampedJsonMapPathFileName, mProfileName, QDateTime::currentDateTime().toString(qsl("yyyy-MM-dd#HH-mm-ss")));
     }
 
@@ -2945,7 +2950,7 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
         mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose, true);
         mpProgressDialog->close();
         mpProgressDialog = nullptr;
-        return {false, qsl("could not open save file \"%1\"").arg(destination)};
+        return {false, qsl("could not open save file \"%1\", reason: %2").arg(destination, file.errorString())};
     }
 
     QJsonObject mapObj;


### PR DESCRIPTION
This should close #5938.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix: saving a JSON format map file in a new profile should now created the needed default destination directory.