### PR TITLE
Infrastructure: update en_US plural translations workflow

### DIFF
--- a/.github/workflows/update-en-us-plural.yml
+++ b/.github/workflows/update-en-us-plural.yml
@@ -1,0 +1,50 @@
+name: Update plural american english translations
+
+on:
+  schedule:
+    - cron: 0 0 * * FRI
+
+  workflow_dispatch:
+
+jobs:
+  update_and_commit_plural_english:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Mudlet' }}
+    env:
+      PLURAL_TRANSLATIONS_FILE: ./translations/translated/mudlet_en_US.ts
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: development
+        submodules: true
+
+    - name: update plural american english file
+      uses: Mudlet/lupdate-action@master
+      with:
+        args: -locations absolute -pluralonly ./src ./3rdparty/dblsqd/dblsqd ./3rdparty/edbee-lib/edbee-lib -ts ${{ env.PLURAL_TRANSLATIONS_FILE }}
+
+    - name: count the number of unfinished translations
+      id: count_unfinished
+      uses: Mudlet/xmlstarlet-action@v1.2
+      with:
+        args: sel -t -v count(.//translation[@type='unfinished']) ${{ env.PLURAL_TRANSLATIONS_FILE }}
+
+    - name: commit and create draft pull request
+      if: steps.count_unfinished.outputs.xmlstarlet_result > 0
+      uses: peter-evans/create-pull-request@v3.12.1
+      with:
+        token: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
+        add-paths: ${{ env.PLURAL_TRANSLATIONS_FILE }}
+        branch: update-en-us-plural
+        commit-message: (autocommit) Updated american english file to add plural forms
+        title: "Infrastructure: update plural american english translations"
+        body: |
+          #### Brief overview of PR changes/additions
+          :crown: An automated PR to add plural american english forms (based on ${{ github.ref }} - ${{ github.sha }}).
+          This PR is first marked as a draft because someone needs to add the plural forms using Qt Linguist on the `translations/translated/mudlet_en_US.ts` file and commit the changes to that branch.
+          #### Motivation for adding to Mudlet
+          So developers can pluralize the added american english text before the upcoming release.
+        author: mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>
+        committer: mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>
+        assignees: SlySven
+        draft: true


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add new workflow to automatically update the file containing american english plural sentences (still requires someone to do the pluralization job).

#### Motivation for adding to Mudlet
This PR should facilitate the associated step of the release process by gradually doing the job and automating the [three first sub steps](https://wiki.mudlet.org/w/Translating_Mudlet#Plural_forms_in_.28American.29_English).

#### Other info (issues closed, discussion etc)
Related to #5858.

I found out that dealing with all the edge cases to fully automate the process with automatic translations would be too complicated so I chose to create a draft PR so that contributors can add their commit with plural forms to it. Tell me if that's fine. Also tell me if the cron frequency is ok or if I should change it.

Two questions:
- Should I create an issue referencing the draft PR to tell contributors that there are sentences to pluralize ?
- Sometimes there is no new sentence to pluralize but there are still changes in the generated `translations/translated/mudlet_en_US.ts` file (to indicate that the location of the sentence in the source file changed). Should I also create a PR in that case (not a draft one) ?

#### Release post highlight
<!--
Use this space if you wish to write a short statement or example for inclusion
in the release post for the next release. 
-->
