### PR TITLE
Fix: allow the large 2D map area exit arrows to be reverted

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3982,3 +3982,14 @@ std::optional<QString> Host::windowType(const QString& name) const
 
     return {};
 }
+
+void Host::setLargeAreaExitArrows(const bool state)
+{
+    if (mLargeAreaExitArrows != state) {
+        mLargeAreaExitArrows = state;
+        if (mpMap && mpMap->mpMapper && mpMap->mpMapper->mp2dMap) {
+            mpMap->mpMapper->mp2dMap->mLargeAreaExitArrows = state;
+            mpMap->mpMapper->mp2dMap->update();
+        }
+    }
+}

--- a/src/Host.h
+++ b/src/Host.h
@@ -203,6 +203,8 @@ public:
                         useShared = mUseSharedDictionary; }
     void            setControlCharacterMode(const TConsole::ControlCharacterMode mode);
     TConsole::ControlCharacterMode  getControlCharacterMode() const { return mControlCharacterMode; }
+    bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
+    void            setLargeAreaExitArrows(const bool);
 
     void closingDown();
     bool isClosingDown();
@@ -808,6 +810,7 @@ private:
     //   RU: https://ru.wikipedia.org/wiki/CP437
     TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;
 
+    bool mLargeAreaExitArrows = true;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/Host.h
+++ b/src/Host.h
@@ -810,7 +810,7 @@ private:
     //   RU: https://ru.wikipedia.org/wiki/CP437
     TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;
 
-    bool mLargeAreaExitArrows = true;
+    bool mLargeAreaExitArrows = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -181,6 +181,7 @@ void T2DMap::init()
         slot_toggleMapViewOnly();
     }
     flushSymbolPixmapCache();
+    mLargeAreaExitArrows = mpHost->getLargeAreaExitArrows();
 }
 
 void T2DMap::slot_shiftDown()
@@ -1427,7 +1428,7 @@ void T2DMap::paintEvent(QPaintEvent* e)
     }
 
     if (!pArea->gridMode) {
-        paintAreaExits(painter, pen, exitList, oneWayExits, pArea, zLevel, exitWidth, areaExitsMap);
+        paintRoomExits(painter, pen, exitList, oneWayExits, pArea, zLevel, exitWidth, areaExitsMap);
     }
 
     // Draw label sizing or group selection box
@@ -1700,7 +1701,7 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
     painter.restore();
 }
 
-void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth, QMap<int, QPointF>& areaExitsMap)
+void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth, QMap<int, QPointF>& areaExitsMap)
 {
     const float widgetWidth = width();
     const float widgetHeight = height();
@@ -2206,35 +2207,35 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 pen.setColor(mpMap->getColor(k));
                 painter.setPen(pen);
                 if (room->getSouth() == rID) {
-                    line = QLineF(p2.x(), p2.y() + 2.0 * mRoomHeight,
+                    line = QLineF(p2.x(), p2.y() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x(), p2.y() + mRoomHeight);
                 } else if (room->getNorth() == rID) {
-                    line = QLineF(p2.x(), p2.y() - 2.0 * mRoomHeight,
+                    line = QLineF(p2.x(), p2.y() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x(), p2.y() - mRoomHeight);
                 } else if (room->getWest() == rID) {
-                    line = QLineF(p2.x() - 2.0 * mRoomWidth, p2.y(),
+                    line = QLineF(p2.x() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y(),
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y());
                 } else if (room->getEast() == rID) {
-                    line = QLineF(p2.x() + 2.0 * mRoomWidth, p2.y(),
+                    line = QLineF(p2.x() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y(),
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y());
                 } else if (room->getNorthwest() == rID) {
-                    line = QLineF(p2.x() - 2.0 * mRoomWidth, p2.y() - 2.0 * mRoomHeight,
+                    line = QLineF(p2.x() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y() - mRoomHeight);
                 } else if (room->getNortheast() == rID) {
-                    line = QLineF(p2.x() + 2.0 * mRoomWidth, p2.y() - 2.0 * mRoomHeight,
+                    line = QLineF(p2.x() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y() - mRoomHeight);
                 } else if (room->getSoutheast() == rID) {
-                    line = QLineF(p2.x() + 2.0 * mRoomWidth, p2.y() + 2.0 * mRoomHeight,
+                    line = QLineF(p2.x() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y() + mRoomHeight);
                 } else if (room->getSouthwest() == rID) {
-                    line = QLineF(p2.x() - 2.0 * mRoomWidth, p2.y() + 2.0 * mRoomHeight,
+                    line = QLineF(p2.x() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y() + mRoomHeight);
                 }
@@ -2243,22 +2244,30 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 // in the appropriate direction
                 painter.drawLine(line);
                 QLineF l0 = QLineF(line);
-                l0.setLength((mRoomWidth + mRoomHeight) * 0.4);
-                QPointF _p1 = l0.p1();
-                QPointF _p2 = l0.p2();
+                if (mLargeAreaExitArrows) {
+                    l0.setLength((mRoomWidth + mRoomHeight) * 0.4);
+                } else {
+                    l0.setLength(exitWidth * 5.0);
+                }
+                QPointF p1 = l0.p1();
+                QPointF p2 = l0.p2();
                 QLineF l1 = QLineF(l0);
                 qreal w1 = l1.angle() - 90.0;
                 QLineF l2;
-                l2.setP1(_p2);
+                l2.setP1(p2);
                 l2.setAngle(w1);
-                l2.setLength((mRoomWidth + mRoomHeight) * 0.15);
-                QPointF _p3 = l2.p2();
+                if (mLargeAreaExitArrows) {
+                    l2.setLength((mRoomWidth + mRoomHeight) * 0.15);
+                } else {
+                    l2.setLength(exitWidth * 2.0);
+                }
+                QPointF p3 = l2.p2();
                 l2.setAngle(l2.angle() + 180.0);
-                QPointF _p4 = l2.p2();
-                QPolygonF _poly;
-                _poly.append(_p1);
-                _poly.append(_p3);
-                _poly.append(_p4);
+                QPointF p4 = l2.p2();
+                QPolygonF polygon;
+                polygon.append(p1);
+                polygon.append(p3);
+                polygon.append(p4);
                 QBrush brush = painter.brush();
                 brush.setColor(mpMap->getColor(k));
                 brush.setStyle(Qt::SolidPattern);
@@ -2268,7 +2277,7 @@ void T2DMap::paintAreaExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 arrowPen.setCosmetic(mMapperUseAntiAlias);
                 painter.setPen(arrowPen);
                 painter.setBrush(brush);
-                painter.drawPolygon(_poly);
+                painter.drawPolygon(polygon);
                 painter.restore();
             }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -1703,6 +1703,7 @@ void T2DMap::drawDoor(QPainter& painter, const TRoom& room, const QString& dirKe
 
 void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, QList<int>& oneWayExits, const TArea* pArea, int zLevel, float exitWidth, QMap<int, QPointF>& areaExitsMap)
 {
+    const float exitArrowScale = (mLargeAreaExitArrows ? 2.0f : 1.0f);
     const float widgetWidth = width();
     const float widgetHeight = height();
 
@@ -2207,35 +2208,35 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
                 pen.setColor(mpMap->getColor(k));
                 painter.setPen(pen);
                 if (room->getSouth() == rID) {
-                    line = QLineF(p2.x(), p2.y() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
+                    line = QLineF(p2.x(), p2.y() + exitArrowScale * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x(), p2.y() + mRoomHeight);
                 } else if (room->getNorth() == rID) {
-                    line = QLineF(p2.x(), p2.y() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
+                    line = QLineF(p2.x(), p2.y() - exitArrowScale * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x(), p2.y() - mRoomHeight);
                 } else if (room->getWest() == rID) {
-                    line = QLineF(p2.x() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y(),
+                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y(),
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y());
                 } else if (room->getEast() == rID) {
-                    line = QLineF(p2.x() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y(),
+                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y(),
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y());
                 } else if (room->getNorthwest() == rID) {
-                    line = QLineF(p2.x() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
+                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y() - exitArrowScale * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y() - mRoomHeight);
                 } else if (room->getNortheast() == rID) {
-                    line = QLineF(p2.x() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
+                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y() - exitArrowScale * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y() - mRoomHeight);
                 } else if (room->getSoutheast() == rID) {
-                    line = QLineF(p2.x() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
+                    line = QLineF(p2.x() + exitArrowScale * mRoomWidth, p2.y() + exitArrowScale * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() + mRoomWidth, p2.y() + mRoomHeight);
                 } else if (room->getSouthwest() == rID) {
-                    line = QLineF(p2.x() - (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomWidth, p2.y() + (mLargeAreaExitArrows ? 2.0 : 1.0) * mRoomHeight,
+                    line = QLineF(p2.x() - exitArrowScale * mRoomWidth, p2.y() + exitArrowScale * mRoomHeight,
                                   p2.x(), p2.y());
                     clickPoint = QPointF(p2.x() - mRoomWidth, p2.y() + mRoomHeight);
                 }

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -175,7 +175,7 @@ public:
     // Introduced as a side effect of #4608 the larger area exit arrows don't
     // always work well on existing maps - so allow for them to be reverted
     // almost back to how they were before that PR:
-    bool mLargeAreaExitArrows = true;
+    bool mLargeAreaExitArrows = false;
 
 public slots:
     void slot_roomSelectionChanged();

--- a/src/T2DMap.h
+++ b/src/T2DMap.h
@@ -172,6 +172,10 @@ public:
     QColor mOpenDoorColor = QColor(10, 155, 10);
     QColor mClosedDoorColor = QColor(155, 155, 10);
     QColor mLockedDoorColor = QColor(155, 10, 10);
+    // Introduced as a side effect of #4608 the larger area exit arrows don't
+    // always work well on existing maps - so allow for them to be reverted
+    // almost back to how they were before that PR:
+    bool mLargeAreaExitArrows = true;
 
 public slots:
     void slot_roomSelectionChanged();
@@ -233,7 +237,7 @@ private:
     void drawRoom(QPainter&, QFont&, QFont&, QPen&, TRoom*, const bool isGridMode, const bool areRoomIdsLegible, const bool showRoomNames, const int, const float, const float, const QMap<int, QPointF>&);
     void paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor);
     int paintMapInfoContributor(QPainter&, int xOffset, int yOffset, const MapInfoProperties& properties);
-    void paintAreaExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
+    void paintRoomExits(QPainter&, QPen&, QList<int>& exitList, QList<int>& oneWayExits, const TArea*, int, float, QMap<int, QPointF>&);
     void initiateSpeedWalk(const int speedWalkStartRoomId, const int speedWalkTargetRoomId);
     inline void drawDoor(QPainter&, const TRoom&, const QString&, const QLineF&);
 

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -475,6 +475,10 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_attribute("ControlCharacterHandling") = QString::number(mode).toLatin1().constData();
     }
 
+    if (pHost->getLargeAreaExitArrows()) {
+        host.append_attribute("Large2DMapAreaExitArrows") = "yes";
+    }
+
     { // Blocked so that indentation reflects that of the XML file
         host.append_child("name").text().set(pHost->mHostName.toUtf8().constData());
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -961,6 +961,12 @@ void XMLimport::readHostPackage(Host* pHost)
         pHost->setControlCharacterMode(TConsole::NoControlCharacterReplacement);
     }
 
+    if (attributes().hasAttribute(qsl("Large2DMapAreaExitArrows"))) {
+        pHost->setLargeAreaExitArrows(attributes().value(qsl("Large2DMapAreaExitArrows")) == YES);
+    } else {
+        pHost->setLargeAreaExitArrows(true);
+    }
+
     while (!atEnd()) {
         readNext();
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -964,7 +964,8 @@ void XMLimport::readHostPackage(Host* pHost)
     if (attributes().hasAttribute(qsl("Large2DMapAreaExitArrows"))) {
         pHost->setLargeAreaExitArrows(attributes().value(qsl("Large2DMapAreaExitArrows")) == YES);
     } else {
-        pHost->setLargeAreaExitArrows(true);
+        // The default (and for map/profile files from before 4.15.0):
+        pHost->setLargeAreaExitArrows(false);
     }
 
     while (!atEnd()) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1097,6 +1097,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_expectCSpaceIdInColonLessMColorCode->setChecked(pHost->getHaveColorSpaceId());
     checkBox_allowServerToRedefineColors->setChecked(pHost->getMayRedefineColors());
     doubleSpinBox_networkPacketTimeout->setValue(pHost->mTelnet.getPostingTimeout() / 1000.0);
+    checkBox_largeAreaExitArrows->setChecked(pHost->getLargeAreaExitArrows());
 
     // Enable the controls that would be disabled if there wasn't a Host instance
     // on tab_general:
@@ -1179,6 +1180,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(comboBox_logFileNameFormat, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_logFileNameFormatChange);
     connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
     connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
+    connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mShortcutsManager->iterator();
@@ -1299,6 +1301,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(pushButton_playerRoomSecondaryColor, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
+    disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
 }
 
 void dlgProfilePreferences::clearHostDetails()
@@ -4195,4 +4198,14 @@ void dlgProfilePreferences::slot_deleteMap()
     qApp->processEvents(); // Allow the above message to show up when erasing big maps
 
     QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+}
+
+void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+
+    pHost->setLargeAreaExitArrows(state);
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -164,6 +164,7 @@ private slots:
     void slot_enableDarkEditor(const QString&);
     void slot_toggleMapDeleteButton(const bool);
     void slot_deleteMap();
+    void slot_changeLargeAreaExitArrows(const bool);
 
 signals:
     void signal_themeUpdateCompleted();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2139,14 +2139,11 @@ you can use it but there could be issues with aligning columns of text</string>
           </item>
           <item row="1" column="1">
            <widget class="QCheckBox" name="checkBox_largeAreaExitArrows">
-            <property name="toolTip">
-             <string>&lt;p&gt;In &lt;B&gt;Mudlet 4.15.0&lt;/b&gt; the arrows used to show an &lt;i&gt;area&lt;/i&gt; exit were made larger so that they are easier to see; however this does not always work well on existing maps that were not laid out to accommodate them. Clearing this checkbox will revert them to be more like they were before this change.&lt;/p&gt;</string>
-            </property>
             <property name="text">
              <string>Use large area exit arrows in 2D view</string>
             </property>
             <property name="checked">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2140,7 +2140,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="1" column="1">
            <widget class="QCheckBox" name="checkBox_largeAreaExitArrows">
             <property name="toolTip">
-             <string>&lt;p&gt;In &lt;B&gt;Mudlet 4.15.0&lt;/b&gt; the arrows used to show an &lt;i&gt;area&lt;/i&gt; exit were made larger so that they are easier to see; however this does not always work well on existing maps that were not laid out to accomodate them. Clearing this checkbox will revert them to be more like they were before this change.&lt;/p&gt;</string>
+             <string>&lt;p&gt;In &lt;B&gt;Mudlet 4.15.0&lt;/b&gt; the arrows used to show an &lt;i&gt;area&lt;/i&gt; exit were made larger so that they are easier to see; however this does not always work well on existing maps that were not laid out to accommodate them. Clearing this checkbox will revert them to be more like they were before this change.&lt;/p&gt;</string>
             </property>
             <property name="text">
              <string>Use large area exit arrows in 2D view</string>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2137,6 +2137,19 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBox_largeAreaExitArrows">
+            <property name="toolTip">
+             <string>&lt;p&gt;In &lt;B&gt;Mudlet 4.15.0&lt;/b&gt; the arrows used to show an &lt;i&gt;area&lt;/i&gt; exit were made larger so that they are easier to see; however this does not always work well on existing maps that were not laid out to accomodate them. Clearing this checkbox will revert them to be more like they were before this change.&lt;/p&gt;</string>
+            </property>
+            <property name="text">
+             <string>Use large area exit arrows in 2D view</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="0" alignment="Qt::AlignRight">
            <widget class="QLabel" name="label_mapSymbolsFont">
             <property name="text">
@@ -3909,6 +3922,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_isOnlyMapSymbolFontToBeUsed</tabstop>
   <tabstop>comboBox_playerRoomStyle</tabstop>
   <tabstop>checkBox_showDefaultArea</tabstop>
+  <tabstop>checkBox_largeAreaExitArrows</tabstop>
   <tabstop>fontComboBox_mapSymbols</tabstop>
   <tabstop>pushButton_showGlyphUsage</tabstop>
   <tabstop>pushButton_playerRoomPrimaryColor</tabstop>


### PR DESCRIPTION
This is to allow existing map files that were not laid out to accommodate them to still use the previous smaller ones.

The large arrows came about as a side effect of my adding door markings to more exits (and stubs) in #4608.

This should close #5945. Whilst hunting down this issue I found that the method `void T2DMap::paintAreaExits(...)` actually draws ALL the room exits - so I took the liberty of renaming it to: `void T2DMap::paintRoomExits(...)`. That method also contained some local variables that had names beginning with the `_` character - this is not recommended - even if it is not followed by the ***reserved*** cases of another one or an UPPER-case letter - I've also fixed those.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

#### Release post highlight
Fix: allow for larger area exit arrows introduced as part of Mudlet **4.15.0** to be changed back to something like they were before then - so that existing maps that were not laid out to accommodate them can continue to be usable.