### PR TITLE
Infrastructure: remove 'release post highlight' from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,3 @@
 #### Motivation for adding to Mudlet
 
 #### Other info (issues closed, discussion etc)
-
-#### Release post highlight
-<!--
-Use this space if you wish to write a short statement or example for inclusion
-in the release post for the next release. 
--->


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove 'release post highlight' from pull request template
#### Motivation for adding to Mudlet
This section is not used for release posts, it's too much work to aggregate.