### PR TITLE
Fix: ensure editor show BIDI control characters setting persists properly

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3982,3 +3982,13 @@ std::optional<QString> Host::windowType(const QString& name) const
 
     return {};
 }
+
+void Host::setEditorShowBidi(const bool state)
+{
+    if (mEditorShowBidi != state) {
+        mEditorShowBidi = state;
+        if (mpEditorDialog) {
+            mpEditorDialog->setEditorShowBidi(state);
+        }
+    }
+}

--- a/src/Host.h
+++ b/src/Host.h
@@ -391,6 +391,8 @@ public:
     bool commitLayoutUpdates(bool flush = false);
     void setScreenDimensions(const int width, const int height) { mScreenWidth = width; mScreenHeight = height; }
     std::optional<QString> windowType(const QString& name) const;
+    bool getEditorShowBidi() const { return mEditorShowBidi; }
+    void setEditorShowBidi(const bool);
 
     cTelnet mTelnet;
     QPointer<TMainConsole> mpConsole;
@@ -514,7 +516,6 @@ public:
     int mWrapIndentCount;
 
     bool mEditorAutoComplete;
-    bool mEditorShowBidi = true;
 
     // code editor theme (human-friendly name)
     QString mEditorTheme;
@@ -808,6 +809,7 @@ private:
     //   RU: https://ru.wikipedia.org/wiki/CP437
     TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;
 
+    bool mEditorShowBidi = true;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -425,7 +425,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("mShowPanel") = pHost->mShowPanel ? "yes" : "no";
     host.append_attribute("mHaveMapperScript") = pHost->mHaveMapperScript ? "yes" : "no";
     host.append_attribute("mEditorAutoComplete") = pHost->mEditorAutoComplete ? "yes" : "no";
-    host.append_attribute("mEditorShowBidi") = pHost->mEditorShowBidi ? "yes" : "no";
+    host.append_attribute("mEditorShowBidi") = pHost->getEditorShowBidi() ? "yes" : "no";
     host.append_attribute("mEditorTheme") = pHost->mEditorTheme.toUtf8().constData();
     host.append_attribute("mEditorThemeFile") = pHost->mEditorThemeFile.toUtf8().constData();
     host.append_attribute("mThemePreviewItemID") = QString::number(pHost->mThemePreviewItemID).toUtf8().constData();

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -824,8 +824,10 @@ void XMLimport::readHostPackage(Host* pHost)
     pHost->mMapperUseAntiAlias = attributes().value(qsl("mMapperUseAntiAlias")) == YES;
     pHost->mMapperShowRoomBorders = readDefaultTrueBool(qsl("mMapperShowRoomBorders"));
     pHost->mEditorAutoComplete = (attributes().value(qsl("mEditorAutoComplete")) == YES);
-    if (!attributes().hasAttribute("mEditorShowBidi") || (attributes().value(qsl("mEditorShowBidi")) == YES)) {
-        pHost->mEditorShowBidi = true;
+    if (attributes().hasAttribute("mEditorShowBidi")) {
+        pHost->setEditorShowBidi(attributes().value(qsl("mEditorShowBidi")) == YES);
+    } else {
+        pHost->setEditorShowBidi(true);
     }
     pHost->mEditorTheme = attributes().value(QLatin1String("mEditorTheme")).toString();
     pHost->mEditorThemeFile = attributes().value(QLatin1String("mEditorThemeFile")).toString();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1438,7 +1438,7 @@ void dlgProfilePreferences::loadEditorTab()
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->setFont(pHost->getDisplayFont());
     config->setAutocompleteAutoShow(pHost->mEditorAutoComplete);
-    config->setRenderBidiContolCharacters(pHost->mEditorShowBidi);
+    config->setRenderBidiContolCharacters(pHost->getEditorShowBidi());
     config->setAutocompleteMinimalCharacters(3);
     config->endChanges();
     edbeePreviewWidget->textDocument()->setLanguageGrammar(edbee::Edbee::instance()->grammarManager()->detectGrammarWithFilename(qsl("Buck.lua")));
@@ -1471,7 +1471,7 @@ void dlgProfilePreferences::loadEditorTab()
     theme_download_label->hide();
 
     checkBox_autocompleteLuaCode->setChecked(pHost->mEditorAutoComplete);
-    checkBox_showBidi->setChecked(pHost->mEditorShowBidi);
+    checkBox_showBidi->setChecked(pHost->getEditorShowBidi());
 
     // changes the theme being previewed
     connect(code_editor_theme_selection_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_theme_selected);
@@ -2766,7 +2766,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->mEditorTheme = code_editor_theme_selection_combobox->currentText();
         pHost->mEditorThemeFile = code_editor_theme_selection_combobox->currentData().toString();
         pHost->mEditorAutoComplete = checkBox_autocompleteLuaCode->isChecked();
-        pHost->mEditorShowBidi = checkBox_showBidi->isChecked();
+        pHost->setEditorShowBidi(checkBox_showBidi->isChecked());
         if (pHost->mpEditorDialog) {
             pHost->mpEditorDialog->setThemeAndOtherSettings(pHost->mEditorTheme);
         }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -633,7 +633,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
                                   : edbee::TextEditorConfig::HideWhitespaces);
     config->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     config->setAutocompleteAutoShow(mpHost->mEditorAutoComplete);
-    config->setRenderBidiContolCharacters(mpHost->mEditorShowBidi);
+    config->setRenderBidiContolCharacters(mpHost->getEditorShowBidi());
     config->setAutocompleteMinimalCharacters(3);
     config->endChanges();
 
@@ -8685,14 +8685,12 @@ void dlgTriggerEditor::slot_changeEditorTextOptions(QTextOption::Flags state)
     config->endChanges();
 }
 
-//
 // clearDocument( edbee::TextEditorWidget* ew)
 //
 // A temporary measure for dealing with the undo spanning over multiple documents bug,
 // in place until we create a proper multi-document solution. This gets called whenever
 // the editor needs to be "cleared", usually when a different alias/trigger/etc is
 // made or selected.
-
 void dlgTriggerEditor::clearDocument(edbee::TextEditorWidget* ew, const QString& initialText)
 {
     mpSourceEditorFindArea->hide();
@@ -8716,7 +8714,7 @@ void dlgTriggerEditor::clearDocument(edbee::TextEditorWidget* ew, const QString&
     config->setIndentSize(2);
     config->setCaretWidth(1);
     config->setAutocompleteAutoShow(mpHost->mEditorAutoComplete);
-    config->setRenderBidiContolCharacters(mpHost->mEditorShowBidi);
+    config->setRenderBidiContolCharacters(mpHost->getEditorShowBidi());
     config->setAutocompleteMinimalCharacters(3);
     config->endChanges();
 
@@ -8742,7 +8740,7 @@ void dlgTriggerEditor::setThemeAndOtherSettings(const QString& theme)
                                                : edbee::TextEditorConfig::HideWhitespaces);
     localConfig->setUseLineSeparator(mudlet::self()->mEditorTextOptions & QTextOption::ShowLineAndParagraphSeparators);
     localConfig->setAutocompleteAutoShow(mpHost->mEditorAutoComplete);
-    localConfig->setRenderBidiContolCharacters(mpHost->mEditorShowBidi);
+    localConfig->setRenderBidiContolCharacters(mpHost->getEditorShowBidi());
     localConfig->setAutocompleteMinimalCharacters(3);
     localConfig->endChanges();
 }
@@ -9203,4 +9201,13 @@ void dlgTriggerEditor::clearVarForm()
     mpVarsMainArea->hide();
     mpSourceEditorArea->hide();
     showInfo(msgInfoAddVar);
+}
+
+void dlgTriggerEditor::setEditorShowBidi(const bool state)
+{
+    auto config = mpSourceEditorEdbee->config();
+    config->beginChanges();
+    config->setRenderBidiContolCharacters(state);
+    config->endChanges();
+    mpSourceEditorEdbee->controller()->update();
 }

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -217,6 +217,7 @@ public:
     void delete_trigger();
     void delete_variable();
     void setSearchOptions(const SearchOptions);
+    void setEditorShowBidi(const bool);
 
 public slots:
     void slot_toggleHiddenVariables(bool);


### PR DESCRIPTION
This should close #5957.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>