### PR TITLE
Fix: getAreaExits does not return special exits

### DIFF
--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -568,10 +568,10 @@ const QMultiMap<int, QPair<QString, int>> TArea::getAreaExitRoomData() const
                 itSpecialExit.next();
                 QPair<QString, int> exitData;
                 exitData.first = itSpecialExit.key();
+                exitData.second = itSpecialExit.value();
                 TRoom* pToRoom = mpRoomDB->getRoom(exitData.second);
                 if (pToRoom && mpRoomDB->getArea(pToRoom->getArea()) != this) {
                     // Note that pToRoom->getArea() is misnamed, should be getAreaId() !
-                    exitData.second = itSpecialExit.value();
                     if (!exitData.first.isEmpty()) {
                         results.insert(fromRoomId, exitData);
                     }


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The lua interface function `getAreaExits(<area-id>, true)` did not return area exits through special exits, which it used to do in earlier versions and is documented in the wiki.

#### Motivation for adding to Mudlet
Fix a lost feature, even though it went unnoticed for a longer time.

#### Other info (issues closed, discussion etc)
Discussion on the IRE-Mudlet-Mapping discord with the user Nunya.