### PR TITLE
Fix: Openssl archive url

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -235,8 +235,8 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1d-win32.zip" "openssl-win32.zip"
-  ExtractZip "openssl-win32.zip" "openssl"
+  DownloadFile "https://www.openssl.org/source/openssl-1.1.1m.tar.gz" "openssl-win32.tar.gz"
+  ExtractTar "openssl-win32.tar.gz" "openssl"
   Step "installing"
   exec "XCOPY" @("/S", "/I", "/Q", "openssl", "$Env:MINGW_BASE_DIR\bin")
 }


### PR DESCRIPTION
http://wiki.overbyte.eu/arch/openssl-1.1.1d-win32.zip returning 404, changed to https://www.openssl.org/source/openssl-1.1.1m.tar.gz

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update openssl url

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
