### PR TITLE
Infrastructure: fix openssl and yajl downloads for all platforms 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-
 image: Visual Studio 2019
 environment:
   signing_password:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 image: Visual Studio 2019
 environment:
@@ -35,6 +34,7 @@ on_failure:
 - cd C:\src
 - powershell "Push-AppveyorArtifact ./verbose_output.log"
 - echo "Build failed - see verbose_output.log artifact upload for more information."
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 cache:
   - '%MINGW_BASE_DIR% -> CI\appveyor.install.ps1, CI\appveyor.functions.ps1'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,8 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 image: Visual Studio 2019
 environment:
   signing_password:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,6 @@ on_failure:
 - cd C:\src
 - powershell "Push-AppveyorArtifact ./verbose_output.log"
 - echo "Build failed - see verbose_output.log artifact upload for more information."
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 cache:
   - '%MINGW_BASE_DIR% -> CI\appveyor.install.ps1, CI\appveyor.functions.ps1'

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -235,7 +235,7 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1d-win32.zip" "openssl-win32.zip"
+  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1l-win32.zip" "openssl-win32.zip"
   ExtractZip "openssl-win32.zip" "openssl"
   Step "installing"
   exec "XCOPY" @("/S", "/I", "/Q", "openssl", "$Env:MINGW_BASE_DIR\bin")

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -255,7 +255,7 @@ function InstallHunspell() {
 
 function InstallYajl() {
   $Env:Path = $NoShPath
-  DownloadFile "https://github.com/lloyd/yajl/tarball/2.1.0" "yajl-2.1.0.tar.gz"
+  DownloadFile "https://github.com/lloyd/yajl/archive/refs/tags/2.1.0.tar.gz" "yajl-2.1.0.tar.gz"
   ExtractTar "yajl-2.1.0.tar.gz" "yajl-2.1.0"
   Set-Location "yajl-2.1.0\lloyd-yajl-66cb08c"
   Step "changing CMakeLists.txt"

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -257,7 +257,7 @@ function InstallYajl() {
   $Env:Path = $NoShPath
   DownloadFile "https://github.com/lloyd/yajl/archive/refs/tags/2.1.0.tar.gz" "yajl-2.1.0.tar.gz"
   ExtractTar "yajl-2.1.0.tar.gz" "yajl-2.1.0"
-  Set-Location "yajl-2.1.0\lloyd-yajl-66cb08c"
+  Set-Location "yajl-2.1.0"
   Step "changing CMakeLists.txt"
   (Get-Content CMakeLists.txt -Raw) -replace '\/W4' -replace '(?<=SET\(linkFlags)[^\)]+' -replace '\/wd4996 \/wd4255 \/wd4130 \/wd4100 \/wd4711' -replace '(?<=SET\(CMAKE_C_FLAGS_DEBUG .)\/D \DEBUG \/Od \/Z7', '-g' -replace '(?<=SET\(CMAKE_C_FLAGS_RELEASE .)\/D NDEBUG \/O2', '-O2' | Out-File -encoding ASCII CMakeLists.txt >> "$logFile" 2>&1
   if (!(Test-Path -Path "build" -PathType Container)) {

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -235,8 +235,8 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
-  DownloadFile "https://www.openssl.org/source/openssl-1.1.1m.tar.gz" "openssl-win32.tar.gz"
-  ExtractTar "openssl-win32.tar.gz" "openssl"
+  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1d-win32.zip" "openssl-win32.zip"
+  ExtractZip "openssl-win32.zip" "openssl"
   Step "installing"
   exec "XCOPY" @("/S", "/I", "/Q", "openssl", "$Env:MINGW_BASE_DIR\bin")
 }

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -235,6 +235,7 @@ function InstallPython() {
 }
 
 function InstallOpenssl() {
+  # needs to be from http://wiki.overbyte.eu/wiki/index.php/ICS_Download as it includes extra binaries not available on openssl.org
   DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1l-win32.zip" "openssl-win32.zip"
   ExtractZip "openssl-win32.zip" "openssl"
   Step "installing"

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -257,7 +257,7 @@ function InstallYajl() {
   $Env:Path = $NoShPath
   DownloadFile "https://github.com/lloyd/yajl/archive/refs/tags/2.1.0.tar.gz" "yajl-2.1.0.tar.gz"
   ExtractTar "yajl-2.1.0.tar.gz" "yajl-2.1.0"
-  Set-Location "yajl-2.1.0"
+  Set-Location "yajl-2.1.0\yajl-2.1.0"
   Step "changing CMakeLists.txt"
   (Get-Content CMakeLists.txt -Raw) -replace '\/W4' -replace '(?<=SET\(linkFlags)[^\)]+' -replace '\/wd4996 \/wd4255 \/wd4130 \/wd4100 \/wd4711' -replace '(?<=SET\(CMAKE_C_FLAGS_DEBUG .)\/D \DEBUG \/Od \/Z7', '-g' -replace '(?<=SET\(CMAKE_C_FLAGS_RELEASE .)\/D NDEBUG \/O2', '-O2' | Out-File -encoding ASCII CMakeLists.txt >> "$logFile" 2>&1
   if (!(Test-Path -Path "build" -PathType Container)) {


### PR DESCRIPTION
Reverts Mudlet/Mudlet#5965

The fix didn't actually work, appveyor gets stuck installing it indefinitely. Instead updated the URL to another one from the original website.