### PR TITLE
Infrastrucure: Add visual studio files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ cmake-build-debug
 #Docker
 docker/docker-compose.override.yml
 docker/.env
+
+#Visual Studio
+.vs
+out
+CMakeSettings.json


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Visual Studio 2022 comes with community edition, so potentially is another easily available IDE.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
