### PR TITLE
Add: map info bg can be customized through mapper colors preferences

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -302,7 +302,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mFgColor_2(QColorConstants::LightGray)
 , mBgColor_2(QColorConstants::Black)
 , mRoomBorderColor(QColorConstants::LightGray)
-, mMapInfoBg(QColor(150, 150, 150, 120))
 #else
 , mBlack(Qt::black)
 , mLightBlack(Qt::darkGray)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -302,6 +302,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mFgColor_2(QColorConstants::LightGray)
 , mBgColor_2(QColorConstants::Black)
 , mRoomBorderColor(QColorConstants::LightGray)
+, mMapInfoBg(QColor(150, 150, 150, 120))
 #else
 , mBlack(Qt::black)
 , mLightBlack(Qt::darkGray)

--- a/src/Host.h
+++ b/src/Host.h
@@ -579,6 +579,7 @@ public:
     QColor mFgColor_2;
     QColor mBgColor_2;
     QColor mRoomBorderColor;
+    QColor mMapInfoBg;
     bool mMapStrongHighlight;
     QStringList mGMCP_merge_table_keys;
     bool mLogStatus = false;

--- a/src/Host.h
+++ b/src/Host.h
@@ -579,7 +579,7 @@ public:
     QColor mFgColor_2;
     QColor mBgColor_2;
     QColor mRoomBorderColor;
-    QColor mMapInfoBg;
+    QColor mMapInfoBg = QColor(150, 150, 150, 120);
     bool mMapStrongHighlight;
     QStringList mGMCP_merge_table_keys;
     bool mLogStatus = false;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2390,7 +2390,7 @@ void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, c
         xOffset += mMultiSelectionListWidget.x() + mMultiSelectionListWidget.rect().width();
     }
 
-    painter.fillRect(xOffset, 10, width() - 10 - xOffset, 10, QColor(150, 150, 150, 120));
+    painter.fillRect(xOffset, 10, width() - 10 - xOffset, 10, mpHost->mMapInfoBg);
 
     for (const auto& key : mpMap->mMapInfoContributorManager->getContributorKeys()) {
         if (mpHost->mMapInfoContributors.contains(key)) {
@@ -2443,7 +2443,7 @@ int T2DMap::paintMapInfoContributor(QPainter& painter, int xOffset, int yOffset,
     mMapInfoRect.setHeight(testRect.height() + 10);
 
     // Restore Grey translucent background, was useful for debugging!
-    painter.fillRect(mMapInfoRect, QColor(150, 150, 150, 120));
+    painter.fillRect(mMapInfoRect, mpHost->mMapInfoBg);
     painter.setPen(properties.color);
     painter.setFont(font);
     painter.drawText(mMapInfoRect.left() + 10, mMapInfoRect.top(), mMapInfoRect.width() - 20, mMapInfoRect.height() - 10, Qt::TextWordWrap | Qt::AlignLeft | Qt::AlignTop, infoText);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -552,6 +552,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         host.append_child("mFgColor2").text().set(pHost->mFgColor_2.name().toUtf8().constData());
         host.append_child("mBgColor2").text().set(pHost->mBgColor_2.name().toUtf8().constData());
         host.append_child("mRoomBorderColor").text().set(pHost->mRoomBorderColor.name().toUtf8().constData());
+        host.append_child("mMapInfoBg").text().set(pHost->mMapInfoBg.name().toUtf8().constData());
         host.append_child("mBlack2").text().set(pHost->mBlack_2.name().toUtf8().constData());
         host.append_child("mLightBlack2").text().set(pHost->mLightBlack_2.name().toUtf8().constData());
         host.append_child("mRed2").text().set(pHost->mRed_2.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1086,6 +1086,8 @@ void XMLimport::readHostPackage(Host* pHost)
                 pHost->mBgColor_2.setNamedColor(readElementText());
             } else if (name() == "mRoomBorderColor") {
                 pHost->mRoomBorderColor.setNamedColor(readElementText());
+            } else if (name() == "mMapInfoBg") {
+                pHost->mMapInfoBg.setNamedColor(readElementText());
             } else if (name() == "mBlack2") {
                 pHost->mBlack_2.setNamedColor(readElementText());
             } else if (name() == "mLightBlack2") {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1675,17 +1675,17 @@ void dlgProfilePreferences::resetColors2()
     setColors2();
 }
 
-void dlgProfilePreferences::setColor(QPushButton* b, QColor& c, bool allowAlpha = false)
+void dlgProfilePreferences::setColor(QPushButton* button, QColor& presentColor, bool allowAlpha)
 {
     Host* pHost = mpHost;
     if (!pHost) {
         return;
     }
 
-    auto color = QColorDialog::getColor(c, this, tr("Pick color", "Generic pick color dialog title"),
+    auto color = QColorDialog::getColor(presentColor, this, tr("Pick color", "Generic pick color dialog title"),
                                         allowAlpha ? QColorDialog::ShowAlphaChannel : QColorDialog::ColorDialogOptions());
     if (color.isValid()) {
-        c = color;
+        presentColor = color;
 
         auto console = pHost->mpConsole;
         if (console) {
@@ -1700,14 +1700,14 @@ void dlgProfilePreferences::setColor(QPushButton* b, QColor& c, bool allowAlpha 
             }
         }
 
-        if (b == pushButton_black || b == pushButton_lBlack
-                || b == pushButton_red || b == pushButton_lRed
-                || b == pushButton_green || b == pushButton_lGreen
-                || b == pushButton_yellow || b == pushButton_lYellow
-                || b == pushButton_blue || b == pushButton_lBlue
-                || b == pushButton_magenta || b == pushButton_lMagenta
-                || b == pushButton_cyan || b == pushButton_lCyan
-                || b == pushButton_white || b == pushButton_lWhite) {
+        if (button == pushButton_black || button == pushButton_lBlack
+            || button == pushButton_red || button == pushButton_lRed
+            || button == pushButton_green || button == pushButton_lGreen
+            || button == pushButton_yellow || button == pushButton_lYellow
+            || button == pushButton_blue || button == pushButton_lBlue
+            || button == pushButton_magenta || button == pushButton_lMagenta
+            || button == pushButton_cyan || button == pushButton_lCyan
+            || button == pushButton_white || button == pushButton_lWhite) {
 
             pHost->updateAnsi16ColorsInTable();
         }
@@ -1715,7 +1715,7 @@ void dlgProfilePreferences::setColor(QPushButton* b, QColor& c, bool allowAlpha 
         // Also set a contrasting foreground color so text will always be
         // visible - if the button is disabled the colors will be somewhat
         // "greyed-out":
-        setButtonColor(b, color);
+        setButtonColor(button, color);
     }
 }
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1160,6 +1160,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(pushButton_foreground_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setFgColor2);
     connect(pushButton_background_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setBgColor2);
     connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::setRoomBorderColor);
+    connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::setMapInfoBackground);
 
     connect(mEnableGMCP, &QAbstractButton::clicked, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMSDP, &QAbstractButton::clicked, need_reconnect_for_data_protocol, &QWidget::show);
@@ -1275,6 +1276,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(pushButton_foreground_color_2, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(pushButton_background_color_2, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(pushButton_roomBorderColor, &QAbstractButton::clicked, nullptr, nullptr);
+    disconnect(pushButton_mapInfoBg, &QAbstractButton::clicked, nullptr, nullptr);
 
     disconnect(mEnableGMCP, &QAbstractButton::clicked, nullptr, nullptr);
     disconnect(mEnableMSSP, &QAbstractButton::clicked, nullptr, nullptr);
@@ -1564,6 +1566,7 @@ void dlgProfilePreferences::setColors2()
         pushButton_foreground_color_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mFgColor_2.name()));
         pushButton_background_color_2->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mBgColor_2.name()));
         pushButton_roomBorderColor->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mRoomBorderColor.name()));
+        pushButton_mapInfoBg->setStyleSheet(mudlet::self()->mBG_ONLY_STYLESHEET.arg(pHost->mMapInfoBg.name()));
     } else {
         pushButton_black_2->setStyleSheet(QString());
         pushButton_Lblack_2->setStyleSheet(QString());
@@ -1585,6 +1588,7 @@ void dlgProfilePreferences::setColors2()
         pushButton_foreground_color_2->setStyleSheet(QString());
         pushButton_background_color_2->setStyleSheet(QString());
         pushButton_roomBorderColor->setStyleSheet(QString());
+        pushButton_mapInfoBg->setStyleSheet(QString());
     }
 }
 
@@ -1666,18 +1670,20 @@ void dlgProfilePreferences::resetColors2()
     pHost->mLightMagenta_2 = Qt::magenta;
     pHost->mWhite_2 = Qt::lightGray;
     pHost->mLightWhite_2 = Qt::white;
+    pHost->mMapInfoBg = QColor(150, 150, 150, 120);
 
     setColors2();
 }
 
-void dlgProfilePreferences::setColor(QPushButton* b, QColor& c)
+void dlgProfilePreferences::setColor(QPushButton* b, QColor& c, bool allowAlpha = false)
 {
     Host* pHost = mpHost;
     if (!pHost) {
         return;
     }
 
-    auto color = QColorDialog::getColor(c, this);
+    auto color = QColorDialog::getColor(c, this, tr("Pick color", "Generic pick color dialog title"),
+                                        allowAlpha ? QColorDialog::ShowAlphaChannel : QColorDialog::ColorDialogOptions());
     if (color.isValid()) {
         c = color;
 
@@ -1981,6 +1987,14 @@ void dlgProfilePreferences::setRoomBorderColor()
     Host* pHost = mpHost;
     if (pHost) {
         setColor(pushButton_roomBorderColor, pHost->mRoomBorderColor);
+    }
+}
+
+void dlgProfilePreferences::setMapInfoBackground()
+{
+    Host* pHost = mpHost;
+    if (pHost) {
+        setColor(pushButton_mapInfoBg, pHost->mMapInfoBg, true);
     }
 }
 

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -104,6 +104,7 @@ public slots:
     void setFgColor2();
     void setBgColor2();
     void setRoomBorderColor();
+    void setMapInfoBackground();
     void resetColors2();
 
     // Map.
@@ -174,7 +175,7 @@ signals:
 private:
     void setColors();
     void setColors2();
-    void setColor(QPushButton*, QColor&);
+    void setColor(QPushButton*, QColor&, bool allowAlpha);
     void setPlayerRoomColor(QPushButton*, QColor&);
     void setButtonColor(QPushButton*, const QColor&);
     void loadEditorTab();

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -175,7 +175,7 @@ signals:
 private:
     void setColors();
     void setColors2();
-    void setColor(QPushButton*, QColor&, bool allowAlpha);
+    void setColor(QPushButton*, QColor&, bool allowAlpha = false);
     void setPlayerRoomColor(QPushButton*, QColor&);
     void setButtonColor(QPushButton*, const QColor&);
     void loadEditorTab();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2330,6 +2330,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Link color</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_foreground_color_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -2350,6 +2353,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Background color:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_background_color_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="3">
@@ -2367,6 +2373,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Room border color:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_roomBorderColor</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -2374,6 +2383,23 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="autoFillBackground">
              <bool>true</bool>
             </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_mapInfoBg">
+            <property name="text">
+             <string>Map info background:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_mapInfoBg</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="pushButton_mapInfoBg">
             <property name="text">
              <string/>
             </property>
@@ -2390,6 +2416,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_17">
             <property name="text">
              <string>Black:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_black_2</cstring>
             </property>
            </widget>
           </item>
@@ -2408,6 +2437,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light black:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lblack_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="3" column="3">
@@ -2424,6 +2456,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_42">
             <property name="text">
              <string>Red:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_red_2</cstring>
             </property>
            </widget>
           </item>
@@ -2442,6 +2477,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light red:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lred_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="4" column="3">
@@ -2458,6 +2496,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_43">
             <property name="text">
              <string>Green:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_green_2</cstring>
             </property>
            </widget>
           </item>
@@ -2476,6 +2517,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light green:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lgreen_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="5" column="3">
@@ -2492,6 +2536,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_48">
             <property name="text">
              <string>Yellow:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_yellow_2</cstring>
             </property>
            </widget>
           </item>
@@ -2510,6 +2557,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light yellow:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lyellow_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="6" column="3">
@@ -2526,6 +2576,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_44">
             <property name="text">
              <string>Blue:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_blue_2</cstring>
             </property>
            </widget>
           </item>
@@ -2544,6 +2597,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light blue:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lblue_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="7" column="3">
@@ -2560,6 +2616,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_45">
             <property name="text">
              <string>Magenta:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_magenta_2</cstring>
             </property>
            </widget>
           </item>
@@ -2578,6 +2637,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light magenta:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lmagenta_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="8" column="3">
@@ -2594,6 +2656,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_46">
             <property name="text">
              <string>Cyan:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_cyan_2</cstring>
             </property>
            </widget>
           </item>
@@ -2612,6 +2677,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light cyan:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lcyan_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="9" column="3">
@@ -2628,6 +2696,9 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QLabel" name="label_47">
             <property name="text">
              <string>White:</string>
+            </property>
+            <property name="buddy">
+             <cstring>pushButton_white_2</cstring>
             </property>
            </widget>
           </item>
@@ -2646,6 +2717,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Light white:</string>
             </property>
+            <property name="buddy">
+             <cstring>pushButton_Lwhite_2</cstring>
+            </property>
            </widget>
           </item>
           <item row="10" column="3">
@@ -2662,20 +2736,6 @@ you can use it but there could be issues with aligning columns of text</string>
            <widget class="QPushButton" name="reset_colors_button_2">
             <property name="text">
              <string>Reset all colors to default</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Map info background:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QPushButton" name="pushButton_mapInfoBg">
-            <property name="text">
-             <string/>
             </property>
            </widget>
           </item>
@@ -3943,6 +4003,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>pushButton_foreground_color_2</tabstop>
   <tabstop>pushButton_roomBorderColor</tabstop>
   <tabstop>pushButton_background_color_2</tabstop>
+  <tabstop>pushButton_mapInfoBg</tabstop>
   <tabstop>pushButton_black_2</tabstop>
   <tabstop>pushButton_red_2</tabstop>
   <tabstop>pushButton_green_2</tabstop>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -2665,6 +2665,20 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Map info background:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QPushButton" name="pushButton_mapInfoBg">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

I'll put a picture instead of description :)
![image](https://user-images.githubusercontent.com/3740628/155886643-e6c5b45f-fd2e-45dc-b208-83e6eb7fcec9.png)


#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
