### PR TITLE
Fix: switch to `5.1-syntax_5.1` branch for lcf submodule

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -141,10 +141,10 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: update submodule to latest in 5.1 branch
+      - name: update submodule to latest in 5.1-syntax_5.1 (i.e. only valid for Lua 5.1 scripts) branch
         run: |
           cd 3rdparty/lcf/
-          git checkout 5.1
+          git checkout 5.1-syntax_5.1
           git pull
 
       # strictly speaking this step isn't necessary since the PR action can filter as well, but it's easier
@@ -162,17 +162,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
-          title: "Infrastructure: Update Lua code formatter to latest upstream 5.1 branch"
+          title: "Infrastructure: Update Lua code formatter to latest upstream 5.1-syntax_5.1 branch"
           body: |
             #### Brief overview of PR changes/additions
-            :crown: An automated PR to update the built-in Lua code formatter to its latest version in upstream `5.1` branch.
+            :crown: An automated PR to update the built-in Lua code formatter to its latest version in upstream `5.1-syntax_5.1` branch.
             #### Motivation for adding to Mudlet
             Get new features, bugfixes, improvements! Stay modern.
             #### Other info (issues closed, discussion etc)
             _update triggered by ${{ github.ref }} ${{ github.sha }}_
           branch: update-lcf-${{ github.sha }}
           path: 3rdparty/lcf
-          commit-message: (autocommit) Updated lcf submodule to latest upstream 5.1 branch
+          commit-message: (autocommit) Updated lcf submodule to latest upstream 5.1-syntax_5.1 branch
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
   update-widecharwidth-source:

--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -141,7 +141,7 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: update submodule to latest in 5.1-syntax_5.1 (i.e. only valid for Lua 5.1 scripts) branch
+      - name: update submodule to latest in branch
         run: |
           cd 3rdparty/lcf/
           git checkout 5.1-syntax_5.1
@@ -162,17 +162,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}
         with:
-          title: "Infrastructure: Update Lua code formatter to latest upstream 5.1-syntax_5.1 branch"
+          title: "Infrastructure: Update Lua code formatter to latest upstream branch"
           body: |
             #### Brief overview of PR changes/additions
-            :crown: An automated PR to update the built-in Lua code formatter to its latest version in upstream `5.1-syntax_5.1` branch.
+            :crown: An automated PR to update the built-in Lua code formatter to its latest version in upstream `5.1-syntax_5.1` (parses code only as Lua version 5.1) branch.
             #### Motivation for adding to Mudlet
             Get new features, bugfixes, improvements! Stay modern.
             #### Other info (issues closed, discussion etc)
             _update triggered by ${{ github.ref }} ${{ github.sha }}_
           branch: update-lcf-${{ github.sha }}
           path: 3rdparty/lcf
-          commit-message: (autocommit) Updated lcf submodule to latest upstream 5.1-syntax_5.1 branch
+          commit-message: (autocommit) Updated lcf submodule to latest upstream branch
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
   update-widecharwidth-source:

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1602,11 +1602,7 @@ INSTALLS += \
 # leaves those empty sub-directories behind and that prevents their parents
 # from being deleted as well
 
-# This is the files that are needed to perform a `make dist` given a makefile
-# I.e. it is used to "Create a distribution tar file for this program. The tar
-# file should be set up so that the file names in the tar file start with a
-# subdirectory name which is the name of the package it is a distribution for.
-# This name can include the version number. "
+# This is the extra files that are needed to do a `make dist` given a makefile
 DISTFILES += \
     ../docker/Dockerfile \
     ../docker/docker-compose.override.linux.yml \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1579,6 +1579,19 @@ unix:!macx {
 
 
 DISTFILES += \
+    ../.github/CODEOWNERS \
+    ../.github/codeql/codeql-config.yml \
+    ../.github/codespell-wordlist.txt \
+    ../.github/dependabot.yml \
+    ../.github/repo-metadata.yml \
+    ../.github/workflows/clangtidy-diff-analysis.yml \
+    ../.github/workflows/codeql-analysis.yml \
+    ../.github/workflows/codespell-analysis.yml \
+    ../.github/workflows/dangerjs.yml \
+    ../.github/workflows/link-ptbs-to-dblsqd.yml \
+    ../.github/workflows/tag-pull-requests.yml \
+    ../.github/workflows/update-en-us-plural.yml \
+    ../.github/workflows/update-geyser-docs.yml \
     ../docker/Dockerfile \
     ../docker/docker-compose.override.linux.yml \
     ../docker/docker-compose.yml \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1490,13 +1490,38 @@ win32 {
     }
 }
 
-# Pull the docs and lua files into the project so they show up in the Qt Creator project files list
+# This is a list of files that we want to show up in the Qt Creator IDE that are
+# not otherwise used by the project:
 OTHER_FILES += \
     $${LUA.files} \
     $${LUA_GEYSER.files} \
     $${LUA_TRANSLATIONS.files} \
     $${LUA_TESTS.files} \
-    $${DISTFILES} \
+    ../.github/CODE_OF_CONDUCT.md \
+    ../.github/CODEOWNERS \
+    ../.github/codeql/codeql-config.yml \
+    ../.github/codespell-wordlist.txt \
+    ../.github/CONTRIBUTING.md \
+    ../.github/dependabot.yml \
+    ../.github/FUNDING.yml \
+    ../.github/ISSUE_TEMPLATE.md \
+    ../.github/pr-labeler.yml \
+    ../.github/PULL_REQUEST_TEMPLATE.md \
+    ../.github/repo-metadata.yml \
+    ../.github/SUPPORT.md \
+    ../.github/workflows/build-mudlet.yml \
+    ../.github/workflows/clangtidy-diff-analysis.yml \
+    ../.github/workflows/codeql-analysis.yml \
+    ../.github/workflows/codespell-analysis.yml \
+    ../.github/workflows/dangerjs.yml \
+    ../.github/workflows/link-ptbs-to-dblsqd.yml \
+    ../.github/workflows/tag-pull-requests.yml \
+    ../.github/workflows/update-3rdparty.yml \
+    ../.github/workflows/update-autocompletion.yml \
+    ../.github/workflows/update-en-us-plural.yml \
+    ../.github/workflows/update-geyser-docs.yml \
+    ../.github/workflows/update-translations.yml \
+    ../.github/workflows/whitespace-linter.yml \
     ../README \
     ../COMPILE \
     ../COPYING \
@@ -1509,7 +1534,7 @@ OTHER_FILES += \
 # to provide a graphic password requestor needed to install software
 unix:!macx {
 # say what we want to get installed by "make install" (executed by 'deployment' step):
-    INSTALLS += \
+INSTALLS += \
         target \
         LUA \
         LUA_GEYSER \
@@ -1577,40 +1602,18 @@ unix:!macx {
 # leaves those empty sub-directories behind and that prevents their parents
 # from being deleted as well
 
-
+# This is the files that are needed to perform a `make dist` given a makefile
+# I.e. it is used to "Create a distribution tar file for this program. The tar
+# file should be set up so that the file names in the tar file start with a
+# subdirectory name which is the name of the package it is a distribution for.
+# This name can include the version number. "
 DISTFILES += \
-    ../.github/CODEOWNERS \
-    ../.github/codeql/codeql-config.yml \
-    ../.github/codespell-wordlist.txt \
-    ../.github/dependabot.yml \
-    ../.github/repo-metadata.yml \
-    ../.github/workflows/clangtidy-diff-analysis.yml \
-    ../.github/workflows/codeql-analysis.yml \
-    ../.github/workflows/codespell-analysis.yml \
-    ../.github/workflows/dangerjs.yml \
-    ../.github/workflows/link-ptbs-to-dblsqd.yml \
-    ../.github/workflows/tag-pull-requests.yml \
-    ../.github/workflows/update-en-us-plural.yml \
-    ../.github/workflows/update-geyser-docs.yml \
     ../docker/Dockerfile \
     ../docker/docker-compose.override.linux.yml \
     ../docker/docker-compose.yml \
     CF-loader.xml \
     CMakeLists.txt \
     .clang-format \
-    ../.github/pr-labeler.yml \
-    ../.github/CODEOWNERS.md \
-    ../.github/CODE_OF_CONDUCT.md \
-    ../.github/CONTRIBUTING.md \
-    ../.github/FUNDING.yml \
-    ../.github/ISSUE_TEMPLATE.md \
-    ../.github/PULL_REQUEST_TEMPLATE.md \
-    ../.github/SUPPORT.md \
-    ../.github/workflows/build-mudlet.yml \
-    ../.github/workflows/update-3rdparty.yml \
-    ../.github/workflows/update-autocompletion.yml \
-    ../.github/workflows/update-translations.yml \
-    ../.github/workflows/whitespace-linter.yml \
     ../CMakeLists.txt \
     ../cmake/FindHUNSPELL.cmake \
     ../cmake/FindPCRE.cmake \


### PR DESCRIPTION
For the last few years we have been using the wrong branch as the one we were on did not permit the use of `goto` as an identifier and "labels" as targets for such `goto`s as version of Lua after 5.1 forbade that as it became a command to uncontrollably jump around Lua scripts as it does in the C (or BASIC) programming languages!

This change will pull in changes that @keneanung did to the lfc submodule as:
* https://github.com/martin-eden/lua_code_formatter/pull/15
* https://github.com/martin-eden/lua_code_formatter/pull/16
but we had forgotten to use.

This will close #5997.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>