### PR TITLE
Infrastucture: update changelog generator to handle releases as well

### DIFF
--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -177,7 +177,7 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
     Invoke-WebRequest "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86" -OutFile $Script:DownloadedFeed
     Write-Output "=== Generating a changelog ==="
     Push-Location "$Env:APPVEYOR_BUILD_FOLDER\CI\"
-    $Script:Changelog = lua "$Env:APPVEYOR_BUILD_FOLDER\CI\generate-ptb-changelog.lua" --releasefile $Script:DownloadedFeed
+    $Script:Changelog = lua "$Env:APPVEYOR_BUILD_FOLDER\CI\generate-ptb-changelog.lua" --mode ptb --releasefile $Script:DownloadedFeed
     Pop-Location
     Write-Output $Script:Changelog
     Write-Output "=== Creating release in Dblsqd ==="

--- a/CI/appveyor.after_success.ps1
+++ b/CI/appveyor.after_success.ps1
@@ -177,7 +177,7 @@ if ("$Env:APPVEYOR_REPO_TAG" -eq "false" -and -Not $Script:PublicTestBuild) {
     Invoke-WebRequest "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/win/x86" -OutFile $Script:DownloadedFeed
     Write-Output "=== Generating a changelog ==="
     Push-Location "$Env:APPVEYOR_BUILD_FOLDER\CI\"
-    $Script:Changelog = lua "$Env:APPVEYOR_BUILD_FOLDER\CI\generate-ptb-changelog.lua" --mode ptb --releasefile $Script:DownloadedFeed
+    $Script:Changelog = lua "$Env:APPVEYOR_BUILD_FOLDER\CI\generate-changelog.lua" --mode ptb --releasefile $Script:DownloadedFeed
     Pop-Location
     Write-Output $Script:Changelog
     Write-Output "=== Creating release in Dblsqd ==="

--- a/CI/generate-changelog.lua
+++ b/CI/generate-changelog.lua
@@ -21,7 +21,7 @@ else
   loadfile("../src/mudlet-lua/lua/TableUtils.lua")()
 end
 
-local parser = argparse("generate-ptb-changelog.lua", "Generate a changelog from the HEAD until the most recent published commit.")
+local parser = argparse("generate-changelog.lua", "Generate a changelog from the HEAD until the most recent published commit.")
 -- see https://argparse.readthedocs.io/en/stable/index.html
 parser:option("-m --mode", 'mode to run in'):choices({"ptb", "release"}):count("1")
 parser:option("-r --releasefile", "downloaded DBLSQD release feed file")

--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -24,7 +24,7 @@ end
 local parser = argparse("generate-ptb-changelog.lua", "Generate a changelog from the HEAD until the most recent published commit.")
 -- see https://argparse.readthedocs.io/en/stable/index.html
 parser:option("-r --releasefile", "downloaded DBLSQD release feed file")
-parser:option("-m --mode", 'mode to run in'):choices {"ptb", "release"}:count "1"
+parser:option("-m --mode", 'mode to run in'):choices({"ptb", "release"}):count("1")
 local args = parser:parse()
 
 local MAX_COMMITS_PER_CHANGELOG = 100

--- a/CI/generate-ptb-changelog.lua
+++ b/CI/generate-ptb-changelog.lua
@@ -37,7 +37,7 @@ end
 
 local MAX_COMMITS_PER_CHANGELOG = 100
 
--- Basic algorithm is as follows:
+-- Basic algorithm for the PTB mode is as follows:
 --   retrieve last MAX_COMMITS_PER_CHANGELOG commit hashes from current branch
 --   retrieve list of PTB releases and the hashes at the end of them (ie 4.14.1-ptb-2022-01-29-e8084)
 --   go through the list of commits, collecting hashes not present in releases

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -129,7 +129,7 @@ if { [ "${DEPLOY}" = "deploy" ]; } ||
       wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64" --output-document="$downloadedfeed"
       echo "=== Generating a changelog ==="
       cd "${SOURCE_DIR}" || exit
-      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
+      changelog=$(lua "${SOURCE_DIR}/CI/generate-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
 
       echo "=== Creating release in Dblsqd ==="
       dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true

--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -129,7 +129,7 @@ if { [ "${DEPLOY}" = "deploy" ]; } ||
       wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/linux/x86_64" --output-document="$downloadedfeed"
       echo "=== Generating a changelog ==="
       cd "${SOURCE_DIR}" || exit
-      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --releasefile "${downloadedfeed}")
+      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
 
       echo "=== Creating release in Dblsqd ==="
       dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -148,7 +148,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
       wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/mac/x86_64" --output-document="$downloadedfeed"
       echo "=== Generating a changelog ==="
       cd "${SOURCE_DIR}" || exit
-      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --releasefile "${downloadedfeed}")
+      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
 
       echo "=== Creating release in Dblsqd ==="
       dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true

--- a/CI/travis.osx.after_success.sh
+++ b/CI/travis.osx.after_success.sh
@@ -148,7 +148,7 @@ if [ "${DEPLOY}" = "deploy" ]; then
       wget "https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/public-test-build/mac/x86_64" --output-document="$downloadedfeed"
       echo "=== Generating a changelog ==="
       cd "${SOURCE_DIR}" || exit
-      changelog=$(lua "${SOURCE_DIR}/CI/generate-ptb-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
+      changelog=$(lua "${SOURCE_DIR}/CI/generate-changelog.lua" --mode ptb --releasefile "${downloadedfeed}")
 
       echo "=== Creating release in Dblsqd ==="
       dblsqd release -a mudlet -c public-test-build -m "${changelog}" "${VERSION}${MUDLET_VERSION_BUILD}" || true

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -1,6 +1,6 @@
 ----------------------------------------------------------------------------------
 --- Mudlet String Utils
---- Used by both LuaGlobal.lua and generate-ptb-changelog.lua
+--- Used by both LuaGlobal.lua and generate-changelog.lua
 ----------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update changelog generation script to allow for changelogs between release builds. Previously it handled PTBs only.
#### Motivation for adding to Mudlet
Release automation 🔨 
#### Other info (issues closed, discussion etc)
Relates to https://github.com/Mudlet/Mudlet/issues/5857 but does not completely close it yet. The script needs to be manually run from a desktop right now which is not ideal - some automated or web-based way would be.

Example to generate a changelog covering from the latest release to latest development:
```lua
lua generate-ptb-changelog.lua -m release --start-commit Mudlet-4.15.1 --end-commit HEAD
```

Hotfix update:

```lua
lua generate-ptb-changelog.lua -m release --start-commit Mudlet-4.15.0 --end-commit Mudlet-4.15.1
```