### PR TITLE
Add: new function getCustomLines1(...) to fix ordering of custom line points in original getCustomLines(...)

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9237,7 +9237,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
         lua_pushstring(L, exits.at(i).toUtf8().constData());
         lua_newtable(L); //customLines[direction]
         lua_pushstring(L, "attributes");
-        lua_newtable(L); //customLines[attributes]
+        lua_newtable(L); //customLines[direction]["attributes"]
         lua_pushstring(L, "style");
         switch (pR->customLinesStyle.value(exits.at(i))) {
         case Qt::DotLine:
@@ -9257,10 +9257,10 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
         default:
             lua_pushstring(L, "solid line");
         }
-        lua_settable(L, -3);
+        lua_settable(L, -3); //customLines[direction]["attributes"]["style"]
         lua_pushstring(L, "arrow");
         lua_pushboolean(L, pR->customLinesArrow.value(exits.at(i)));
-        lua_settable(L, -3);
+        lua_settable(L, -3); //customLines[direction]["attributes"]["arrow"]
         lua_pushstring(L, "color");
         lua_newtable(L);
         lua_pushstring(L, "r");
@@ -9272,13 +9272,17 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
         lua_pushstring(L, "b");
         lua_pushinteger(L, pR->customLinesColor.value(exits.at(i)).blue());
         lua_settable(L, -3);
-        lua_settable(L, -3); //color
-        lua_settable(L, -3); //attributes
+        lua_settable(L, -3); //customLines[direction]["attributes"]["color"]
+        lua_settable(L, -3); //customLines[direction]["attributes"]
         lua_pushstring(L, "points");
-        lua_newtable(L); //customLines[points]
+        lua_newtable(L); //customLines[direction][points]
         QList<QPointF> pointL = pR->customLines.value(exits.at(i));
         for (int k = 0, kTotal = pointL.size(); k < kTotal; ++k) {
-            lua_pushnumber(L, k);
+            // To allow the output from here to be fed back into addCustomLine
+            // we need to start the numbering from the Lua standard of 1 and
+            // NOT the C/C++ standard of 0 - otherwise the end-user has to
+            // fiddle with the zero-th entry to keep the points in order:
+            lua_pushnumber(L, k + 1);
             lua_newtable(L);
             lua_pushstring(L, "x");
             lua_pushnumber(L, pointL.at(k).x());
@@ -9288,7 +9292,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
             lua_settable(L, -3);
             lua_settable(L, -3);
         }
-        lua_settable(L, -3); //customLines[direction][points]
+        lua_settable(L, -3); //customLines[direction]["points"]
         lua_settable(L, -3); //customLines[direction]
     }
     return 1;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -9278,11 +9278,7 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
         lua_newtable(L); //customLines[direction][points]
         QList<QPointF> pointL = pR->customLines.value(exits.at(i));
         for (int k = 0, kTotal = pointL.size(); k < kTotal; ++k) {
-            // To allow the output from here to be fed back into addCustomLine
-            // we need to start the numbering from the Lua standard of 1 and
-            // NOT the C/C++ standard of 0 - otherwise the end-user has to
-            // fiddle with the zero-th entry to keep the points in order:
-            lua_pushnumber(L, k + 1);
+            lua_pushnumber(L, k);
             lua_newtable(L);
             lua_pushstring(L, "x");
             lua_pushnumber(L, pointL.at(k).x());
@@ -9298,6 +9294,84 @@ int TLuaInterpreter::getCustomLines(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getCustomLines1
+int TLuaInterpreter::getCustomLines1(lua_State* L)
+{
+    int roomID = getVerifiedInt(L, __func__, 1, "room id");
+    Host& host = getHostFromLua(L);
+    TRoom* pR = host.mpMap->mpRoomDB->getRoom(roomID);
+    if (!pR) { //if the room doesn't exist return nil
+        return warnArgumentValue(L, __func__, qsl("room %1 doesn't exist").arg(roomID));
+    }
+    lua_newtable(L); //return table customLines[]
+    QStringList exits = pR->customLines.keys();
+    for (int i = 0, iTotal = exits.size(); i < iTotal; ++i) {
+        lua_pushstring(L, exits.at(i).toUtf8().constData());
+        lua_newtable(L); //customLines[direction]
+        lua_pushstring(L, "attributes");
+        lua_newtable(L); //customLines[direction]["attributes"]
+        lua_pushstring(L, "style");
+        switch (pR->customLinesStyle.value(exits.at(i))) {
+        case Qt::DotLine:
+            lua_pushstring(L, "dot line");
+            break;
+        case Qt::DashLine:
+            lua_pushstring(L, "dash line");
+            break;
+        case Qt::DashDotLine:
+            lua_pushstring(L, "dash dot line");
+            break;
+        case Qt::DashDotDotLine:
+            lua_pushstring(L, "dash dot dot line");
+            break;
+        case Qt::SolidLine:
+            [[fallthrough]];
+        default:
+            lua_pushstring(L, "solid line");
+        }
+        lua_settable(L, -3); //customLines[direction]["attributes"]["style"]
+        lua_pushstring(L, "arrow");
+        lua_pushboolean(L, pR->customLinesArrow.value(exits.at(i)));
+        lua_settable(L, -3); //customLines[direction]["attributes"]["arrow"]
+        lua_pushstring(L, "color");
+        lua_newtable(L);
+        lua_pushinteger(L, 1);
+        lua_pushinteger(L, pR->customLinesColor.value(exits.at(i)).red());
+        lua_settable(L, -3);
+        lua_pushinteger(L, 2);
+        lua_pushinteger(L, pR->customLinesColor.value(exits.at(i)).green());
+        lua_settable(L, -3);
+        lua_pushinteger(L, 3);
+        lua_pushinteger(L, pR->customLinesColor.value(exits.at(i)).blue());
+        lua_settable(L, -3);
+        lua_settable(L, -3); //customLines[direction]["attributes"]["color"]
+        lua_settable(L, -3); //customLines[direction]["attributes"]
+        lua_pushstring(L, "points");
+        lua_newtable(L); //customLines[direction]["points"]
+        QList<QPointF> pointL = pR->customLines.value(exits.at(i));
+        for (int k = 0, kTotal = pointL.size(); k < kTotal; ++k) {
+            // To allow the output from here to be fed back into addCustomLine
+            // we need to start the numbering from the Lua standard of 1 and
+            // NOT the C/C++ standard of 0 - otherwise the end-user has to
+            // fiddle with the zero-th entry to keep the points in order:
+            lua_pushinteger(L, k+1);
+            lua_newtable(L); //customLines[direction]["points"][3 x coordinates]
+            lua_pushinteger(L, 1);
+            lua_pushnumber(L, pointL.at(k).x());
+            lua_settable(L, -3);
+            lua_pushinteger(L, 2);
+            lua_pushnumber(L, pointL.at(k).y());
+            lua_settable(L, -3);
+            lua_pushinteger(L, 3);
+            lua_pushnumber(L, pR->z);
+            lua_settable(L, -3);
+            lua_settable(L, -3); //customLines[direction]["points"][3 x coordinates]
+        }
+        lua_settable(L, -3); //customLines[direction]["points"]
+        lua_settable(L, -3); //customLines[direction]
+    }
+    return 1;
+}
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getExitWeights
 int TLuaInterpreter::getExitWeights(lua_State* L)
 {
@@ -15120,6 +15194,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "addCustomLine", TLuaInterpreter::addCustomLine);
     lua_register(pGlobalLua, "removeCustomLine", TLuaInterpreter::removeCustomLine);
     lua_register(pGlobalLua, "getCustomLines", TLuaInterpreter::getCustomLines);
+    lua_register(pGlobalLua, "getCustomLines1", TLuaInterpreter::getCustomLines1);
     lua_register(pGlobalLua, "getMudletVersion", TLuaInterpreter::getMudletVersion);
     lua_register(pGlobalLua, "openWebPage", TLuaInterpreter::openWebPage);
     lua_register(pGlobalLua, "getAllRoomEntrances", TLuaInterpreter::getAllRoomEntrances);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -158,6 +158,7 @@ public:
     std::pair<int, QString> startPermKey(QString&, QString&, int&, int&, QString&);
 
     static int getCustomLines(lua_State*);
+    static int getCustomLines1(lua_State*);
     static int addCustomLine(lua_State*);
     static int removeCustomLine(lua_State*);
     static int noop(lua_State*);


### PR DESCRIPTION
In this new function we make the first point be at an index of `1` (which is standard for Lua) instead of `0` (C/C++ array standard) so that the table of points return can be passed back to **[`addCustomLine(...)`](https://wiki.mudlet.org/w/Manual:Lua_Functions#addCustomLine)** without having to fiddle with a zero-th element which would be out of order otherwise. To aide in that it also changes the `"x"` and `"y"` used as the keys for coordinates in each point to `1` and `2`, and adds a `3` value which is the z-coordinate of the room. This means that the `"points"` table can be put straight into the second argument to `addCustomLine(...)`. Additionally the color details are also rekeyed to use `1`, `2` and `3` instead of `"r"`, `"g"` and `"b"` so that table can also be reused directly.

The need for this was discovered recently whilst I was looking at code to move rooms AND their associated custom exit lines using the Lua API. As it is, up to now a fix was needed to move the last listed point to be first, which can be achieved by a function that @demonic came up with:
```lua
function fix0index(tbl)
  local result = {}
  if #tbl ~= table.size(tbl) - 1 then
    debugc("This is not a list table, cannot fix the 0 index")
  end
  if not tbl[0] then
    return tbl
  end
  for i = 0, #tbl do
    result[i+1] = tbl[i]
  end
  return result
end
```

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>