### PR TITLE
Infrastructure: fix macOS codesigning to work again

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -135,6 +135,13 @@ jobs:
         HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
         HOMEBREW_NO_INSTALL_CLEANUP: "ON"
       run: |
+        # workaround for https://github.com/mitchellh/gon/issues/56
+        pushd .
+        cd /usr/local/Homebrew
+        git fetch --tags
+        git checkout 3.3.9
+        popd
+
         # these aren't available or don't work well in vcpkg
         brew install pkg-config libzzip libzip ccache luarocks expect mitchellh/gon/gon
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Downgrade Homebrew to verison compatible with gon
#### Motivation for adding to Mudlet
Fix macOS codesigning builds to work again
#### Other info (issues closed, discussion etc)
Tried to mount & run the gon .dmg file directly, but it seems like quite a hassle to do it from the command line.

Fixes https://github.com/Mudlet/Mudlet/issues/6008.