### PR TITLE
Infrastructure: shorten some lengthy variables

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3929,11 +3929,11 @@ void Host::setupIreDriverBugfix()
     }
 }
 
-void Host::setControlCharacterMode(const TConsole::ControlCharacterMode mode)
+void Host::setControlCharacterMode(const ControlCharacterMode mode)
 {
-    if (Q_UNLIKELY(!(mode == TConsole::AsIs
-                     || mode == TConsole::Picture
-                     || mode == TConsole::OEM))) {
+    if (Q_UNLIKELY(!(mode == ControlCharacterMode::AsIs
+                     || mode == ControlCharacterMode::Picture
+                     || mode == ControlCharacterMode::OEM))) {
         return;
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3929,11 +3929,11 @@ void Host::setupIreDriverBugfix()
     }
 }
 
-void Host::setControlCharacterMode(const TConsole::ControlCharacter mode)
+void Host::setControlCharacterMode(const TConsole::ControlCharacterMode mode)
 {
-    if (Q_UNLIKELY(!(mode == TConsole::NoReplacement
+    if (Q_UNLIKELY(!(mode == TConsole::AsIs
                      || mode == TConsole::Picture
-                     || mode == TConsole::OEMFont))) {
+                     || mode == TConsole::OEM))) {
         return;
     }
 

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3929,16 +3929,16 @@ void Host::setupIreDriverBugfix()
     }
 }
 
-void Host::setControlCharacterMode(const TConsole::ControlCharacterMode mode)
+void Host::setControlCharacterMode(const TConsole::ControlCharacter mode)
 {
-    if (Q_UNLIKELY(!(mode == TConsole::NoControlCharacterReplacement
-                     || mode == TConsole::PictureControlCharacterReplacement
-                     || mode == TConsole::OEMFontControlCharacterReplacement))) {
+    if (Q_UNLIKELY(!(mode == TConsole::NoReplacement
+                     || mode == TConsole::Picture
+                     || mode == TConsole::OEMFont))) {
         return;
     }
 
-    if (mControlCharacterMode != mode) {
-        mControlCharacterMode = mode;
+    if (mControlCharacter != mode) {
+        mControlCharacter = mode;
         emit signal_controlCharacterHandlingChanged(mode);
     }
 }

--- a/src/Host.h
+++ b/src/Host.h
@@ -201,8 +201,8 @@ public:
     void            getUserDictionaryOptions(bool& useDictionary, bool& useShared) {
                         useDictionary = mEnableUserDictionary;
                         useShared = mUseSharedDictionary; }
-    void            setControlCharacterMode(const TConsole::ControlCharacterMode mode);
-    TConsole::ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
+    void            setControlCharacterMode(const ControlCharacterMode mode);
+    ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
 
@@ -656,7 +656,7 @@ signals:
     void signal_changeDebugShowAllProblemCodepoints(const bool);
     // Tells all consoles associated with this Host (but NOT the Central Debug
     // one) to change the way they show  control characters:
-    void signal_controlCharacterHandlingChanged(const TConsole::ControlCharacterMode);
+    void signal_controlCharacterHandlingChanged(const ControlCharacterMode);
 
 private slots:
     void slot_purgeTemps();
@@ -801,16 +801,16 @@ private:
     QTimer purgeTimer;
 
     // How to display (most) incoming control characters in TConsoles:
-    // TConsole::AsIs (0x0) = as is, no replacement
-    // TConsole::Picture (0x1) = as Unicode "Control
+    // ControlCharacterMode::AsIs (0x0) = as is, no replacement
+    // ControlCharacterMode::Picture (0x1) = as Unicode "Control
     //   Pictures" - use Unicode codepoints in range U+2400 to U+2421
-    // TConsole::OEM (0x2) = as "OEM Font"
+    // ControlCharacterMode::OEM (0x2) = as "OEM Font"
     //   characters (most often seen as a part of CP437
     //   encoding), see the corresponding Wikipedia page, e.g.
     //   EN: https://en.wikipedia.org/wiki/Code_page_437
     //   DE: https://de.wikipedia.org/wiki/Codepage_437
     //   RU: https://ru.wikipedia.org/wiki/CP437
-    TConsole::ControlCharacterMode mControlCharacter = TConsole::ControlCharacterMode::AsIs;
+    ControlCharacterMode mControlCharacter = AsIs;
 
     bool mLargeAreaExitArrows = false;
     bool mEditorShowBidi = true;

--- a/src/Host.h
+++ b/src/Host.h
@@ -201,8 +201,8 @@ public:
     void            getUserDictionaryOptions(bool& useDictionary, bool& useShared) {
                         useDictionary = mEnableUserDictionary;
                         useShared = mUseSharedDictionary; }
-    void            setControlCharacterMode(const TConsole::ControlCharacterMode mode);
-    TConsole::ControlCharacterMode  getControlCharacterMode() const { return mControlCharacterMode; }
+    void            setControlCharacterMode(const TConsole::ControlCharacter mode);
+    TConsole::ControlCharacter  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
 
@@ -656,7 +656,7 @@ signals:
     void signal_changeDebugShowAllProblemCodepoints(const bool);
     // Tells all consoles associated with this Host (but NOT the Central Debug
     // one) to change the way they show  control characters:
-    void signal_controlCharacterHandlingChanged(const TConsole::ControlCharacterMode);
+    void signal_controlCharacterHandlingChanged(const TConsole::ControlCharacter);
 
 private slots:
     void slot_purgeTemps();
@@ -801,16 +801,16 @@ private:
     QTimer purgeTimer;
 
     // How to display (most) incoming control characters in TConsoles:
-    // TConsole::NoControlCharacterReplacement (0x0) = as is, no replacement
-    // TConsole::PictureControlCharacterReplacement (0x1) = as Unicode "Control
+    // TConsole::NoReplacement (0x0) = as is, no replacement
+    // TConsole::Picture (0x1) = as Unicode "Control
     //   Pictures" - use Unicode codepoints in range U+2400 to U+2421
-    // TConsole::PictureControlCharacterReplacement (0x2) = as "OEM Font"
+    // TConsole::OEMFont (0x2) = as "OEM Font"
     //   characters (most often seen as a part of CP437
     //   encoding), see the corresponding Wikipedia page, e.g.
     //   EN: https://en.wikipedia.org/wiki/Code_page_437
     //   DE: https://de.wikipedia.org/wiki/Codepage_437
     //   RU: https://ru.wikipedia.org/wiki/CP437
-    TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;
+    TConsole::ControlCharacter mControlCharacter = TConsole::ControlCharacter::NoReplacement;
 
     bool mLargeAreaExitArrows = false;
     bool mEditorShowBidi = true;

--- a/src/Host.h
+++ b/src/Host.h
@@ -201,8 +201,8 @@ public:
     void            getUserDictionaryOptions(bool& useDictionary, bool& useShared) {
                         useDictionary = mEnableUserDictionary;
                         useShared = mUseSharedDictionary; }
-    void            setControlCharacterMode(const TConsole::ControlCharacter mode);
-    TConsole::ControlCharacter  getControlCharacterMode() const { return mControlCharacter; }
+    void            setControlCharacterMode(const TConsole::ControlCharacterMode mode);
+    TConsole::ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
 
@@ -656,7 +656,7 @@ signals:
     void signal_changeDebugShowAllProblemCodepoints(const bool);
     // Tells all consoles associated with this Host (but NOT the Central Debug
     // one) to change the way they show  control characters:
-    void signal_controlCharacterHandlingChanged(const TConsole::ControlCharacter);
+    void signal_controlCharacterHandlingChanged(const TConsole::ControlCharacterMode);
 
 private slots:
     void slot_purgeTemps();
@@ -801,16 +801,16 @@ private:
     QTimer purgeTimer;
 
     // How to display (most) incoming control characters in TConsoles:
-    // TConsole::NoReplacement (0x0) = as is, no replacement
+    // TConsole::AsIs (0x0) = as is, no replacement
     // TConsole::Picture (0x1) = as Unicode "Control
     //   Pictures" - use Unicode codepoints in range U+2400 to U+2421
-    // TConsole::OEMFont (0x2) = as "OEM Font"
+    // TConsole::OEM (0x2) = as "OEM Font"
     //   characters (most often seen as a part of CP437
     //   encoding), see the corresponding Wikipedia page, e.g.
     //   EN: https://en.wikipedia.org/wiki/Code_page_437
     //   DE: https://de.wikipedia.org/wiki/Codepage_437
     //   RU: https://ru.wikipedia.org/wiki/CP437
-    TConsole::ControlCharacter mControlCharacter = TConsole::ControlCharacter::NoReplacement;
+    TConsole::ControlCharacterMode mControlCharacter = TConsole::ControlCharacterMode::AsIs;
 
     bool mLargeAreaExitArrows = false;
     bool mEditorShowBidi = true;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -71,7 +71,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 , mpBufferSearchBox(new QLineEdit)
 , mpBufferSearchUp(new QToolButton)
 , mpBufferSearchDown(new QToolButton)
-, mControlCharacterMode(pH->getControlCharacterMode())
+, mControlCharacter(pH->getControlCharacterMode())
 , mType(type)
 {
     auto ps = new QShortcut(this);
@@ -500,7 +500,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         mDisplayFontSize = mDisplayFont.pointSize();
 
         // They always use "Control Pictures" to show control characters:
-        mControlCharacterMode = PictureControlCharacterReplacement;
+        mControlCharacter = Picture;
         refreshView();
     } else if (mpHost) {
         connect(mpHost, &Host::signal_controlCharacterHandlingChanged, this, &TConsole::slot_changeControlCharacterHandling);
@@ -1986,10 +1986,10 @@ void TConsole::mouseReleaseEvent(QMouseEvent* event)
     raiseMudletMousePressOrReleaseEvent(event, false);
 }
 
-void TConsole::TConsole::slot_changeControlCharacterHandling(const ControlCharacterMode mode)
+void TConsole::TConsole::slot_changeControlCharacterHandling(const ControlCharacter mode)
 {
-    if (mControlCharacterMode != mode) {
-        mControlCharacterMode = mode;
+    if (mControlCharacter != mode) {
+        mControlCharacter = mode;
         refreshView();
     }
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1986,7 +1986,7 @@ void TConsole::mouseReleaseEvent(QMouseEvent* event)
     raiseMudletMousePressOrReleaseEvent(event, false);
 }
 
-void TConsole::TConsole::slot_changeControlCharacterHandling(const ControlCharacter mode)
+void TConsole::TConsole::slot_changeControlCharacterHandling(const ControlCharacterMode mode)
 {
     if (mControlCharacter != mode) {
         mControlCharacter = mode;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -46,6 +46,16 @@
 #include <list>
 #include <map>
 
+
+enum ControlCharacterMode {
+    AsIs = 0x0,
+    Picture = 0x1,
+    OEM = 0x2
+};
+
+// Needed so it can be handled as a QVariant
+Q_DECLARE_METATYPE(ControlCharacterMode)
+
 class QCloseEvent;
 class QLineEdit;
 class QScrollBar;
@@ -77,13 +87,6 @@ public:
         Buffer = 0x20 // Non-visible store for data that can be copied to/from other per profile TConsoles, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
     };
     Q_DECLARE_FLAGS(ConsoleType, ConsoleTypeFlag)
-
-    enum ControlCharacterMode {
-        AsIs = 0x0,
-        Picture = 0x1,
-        OEM = 0x2
-    };
-    Q_ENUM(ControlCharacterMode)
 
     Q_DISABLE_COPY(TConsole)
     explicit TConsole(Host*, ConsoleType type = UnknownType, QWidget* parent = nullptr);
@@ -292,7 +295,7 @@ public slots:
     void slot_toggleReplayRecording();
     void slot_stop_all_triggers(bool);
     void slot_toggleLogging();
-    void slot_changeControlCharacterHandling(const TConsole::ControlCharacterMode);
+    void slot_changeControlCharacterHandling(const ControlCharacterMode);
 
 
 protected:

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -78,12 +78,12 @@ public:
     };
     Q_DECLARE_FLAGS(ConsoleType, ConsoleTypeFlag)
 
-    enum ControlCharacterMode {
-        NoControlCharacterReplacement = 0x0,
-        PictureControlCharacterReplacement = 0x1,
-        OEMFontControlCharacterReplacement = 0x2
+    enum ControlCharacter {
+        NoReplacement = 0x0,
+        Picture = 0x1,
+        OEMFont = 0x2
     };
-    Q_ENUM(ControlCharacterMode)
+    Q_ENUM(ControlCharacter)
 
     Q_DISABLE_COPY(TConsole)
     explicit TConsole(Host*, ConsoleType type = UnknownType, QWidget* parent = nullptr);
@@ -283,7 +283,7 @@ public:
     int mBgImageMode = 0;
     QString mBgImagePath;
     bool mHScrollBarEnabled = false;
-    ControlCharacterMode mControlCharacterMode = NoControlCharacterReplacement;
+    ControlCharacter mControlCharacter = NoReplacement;
 
 
 public slots:
@@ -292,7 +292,7 @@ public slots:
     void slot_toggleReplayRecording();
     void slot_stop_all_triggers(bool);
     void slot_toggleLogging();
-    void slot_changeControlCharacterHandling(const TConsole::ControlCharacterMode);
+    void slot_changeControlCharacterHandling(const TConsole::ControlCharacter);
 
 
 protected:

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -78,12 +78,12 @@ public:
     };
     Q_DECLARE_FLAGS(ConsoleType, ConsoleTypeFlag)
 
-    enum ControlCharacter {
-        NoReplacement = 0x0,
+    enum ControlCharacterMode {
+        AsIs = 0x0,
         Picture = 0x1,
-        OEMFont = 0x2
+        OEM = 0x2
     };
-    Q_ENUM(ControlCharacter)
+    Q_ENUM(ControlCharacterMode)
 
     Q_DISABLE_COPY(TConsole)
     explicit TConsole(Host*, ConsoleType type = UnknownType, QWidget* parent = nullptr);
@@ -283,7 +283,7 @@ public:
     int mBgImageMode = 0;
     QString mBgImagePath;
     bool mHScrollBarEnabled = false;
-    ControlCharacter mControlCharacter = NoReplacement;
+    ControlCharacterMode mControlCharacter = AsIs;
 
 
 public slots:
@@ -292,7 +292,7 @@ public slots:
     void slot_toggleReplayRecording();
     void slot_stop_all_triggers(bool);
     void slot_toggleLogging();
-    void slot_changeControlCharacterHandling(const TConsole::ControlCharacter);
+    void slot_changeControlCharacterHandling(const TConsole::ControlCharacterMode);
 
 
 protected:

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2021 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2016, 2018-2022 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
@@ -586,10 +586,10 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
             graphemes.append((charWidth < 1) ? QChar() : grapheme);
         }
         break;
-    case TConsole::Picture:
+    case ControlCharacterMode::Picture:
         replaceControlCharacterWith_Picture(unicode, grapheme, column, graphemes, charWidth);
         break;
-    case TConsole::OEM:
+    case ControlCharacterMode::OEM:
         replaceControlCharacterWith_OEMFont(unicode, grapheme, column, graphemes, charWidth);
         break;
     } // End of switch

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -565,7 +565,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     uint unicode = getGraphemeBaseCharacter(grapheme);
     int charWidth = 0;
 
-    switch (mpConsole->mControlCharacterMode) {
+    switch (mpConsole->mControlCharacter) {
     default:
         // No special handling, except for these:
         if (Q_UNLIKELY(unicode == '\a' || unicode == '\t')) {
@@ -586,10 +586,10 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
             graphemes.append((charWidth < 1) ? QChar() : grapheme);
         }
         break;
-    case TConsole::PictureControlCharacterReplacement:
+    case TConsole::Picture:
         replaceControlCharacterWith_Picture(unicode, grapheme, column, graphemes, charWidth);
         break;
-    case TConsole::OEMFontControlCharacterReplacement:
+    case TConsole::OEMFont:
         replaceControlCharacterWith_OEMFont(unicode, grapheme, column, graphemes, charWidth);
         break;
     } // End of switch

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -589,7 +589,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     case TConsole::Picture:
         replaceControlCharacterWith_Picture(unicode, grapheme, column, graphemes, charWidth);
         break;
-    case TConsole::OEMFont:
+    case TConsole::OEM:
         replaceControlCharacterWith_OEMFont(unicode, grapheme, column, graphemes, charWidth);
         break;
     } // End of switch

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -947,20 +947,20 @@ void XMLimport::readHostPackage(Host* pHost)
     if (attributes().hasAttribute(QLatin1String("ControlCharacterHandling"))) {
         switch (attributes().value(QLatin1String("ControlCharacterHandling")).toInt()) {
         case 1:
-            pHost->setControlCharacterMode(TConsole::Picture);
+            pHost->setControlCharacterMode(ControlCharacterMode::Picture);
             break;
         case 2:
-            pHost->setControlCharacterMode(TConsole::OEM);
+            pHost->setControlCharacterMode(ControlCharacterMode::OEM);
             break;
         case 0:
             [[fallthrough]];
         default:
-            pHost->setControlCharacterMode(TConsole::AsIs);
+            pHost->setControlCharacterMode(ControlCharacterMode::AsIs);
         }
 
     } else {
         // The default value, also used up to Mudlet 4.14.1:
-        pHost->setControlCharacterMode(TConsole::AsIs);
+        pHost->setControlCharacterMode(ControlCharacterMode::AsIs);
     }
 
     if (attributes().hasAttribute(qsl("Large2DMapAreaExitArrows"))) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -950,17 +950,17 @@ void XMLimport::readHostPackage(Host* pHost)
             pHost->setControlCharacterMode(TConsole::Picture);
             break;
         case 2:
-            pHost->setControlCharacterMode(TConsole::OEMFont);
+            pHost->setControlCharacterMode(TConsole::OEM);
             break;
         case 0:
             [[fallthrough]];
         default:
-            pHost->setControlCharacterMode(TConsole::NoReplacement);
+            pHost->setControlCharacterMode(TConsole::AsIs);
         }
 
     } else {
         // The default value, also used up to Mudlet 4.14.1:
-        pHost->setControlCharacterMode(TConsole::NoReplacement);
+        pHost->setControlCharacterMode(TConsole::AsIs);
     }
 
     if (attributes().hasAttribute(qsl("Large2DMapAreaExitArrows"))) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -947,20 +947,20 @@ void XMLimport::readHostPackage(Host* pHost)
     if (attributes().hasAttribute(QLatin1String("ControlCharacterHandling"))) {
         switch (attributes().value(QLatin1String("ControlCharacterHandling")).toInt()) {
         case 1:
-            pHost->setControlCharacterMode(TConsole::PictureControlCharacterReplacement);
+            pHost->setControlCharacterMode(TConsole::Picture);
             break;
         case 2:
-            pHost->setControlCharacterMode(TConsole::OEMFontControlCharacterReplacement);
+            pHost->setControlCharacterMode(TConsole::OEMFont);
             break;
         case 0:
             [[fallthrough]];
         default:
-            pHost->setControlCharacterMode(TConsole::NoControlCharacterReplacement);
+            pHost->setControlCharacterMode(TConsole::NoReplacement);
         }
 
     } else {
         // The default value, also used up to Mudlet 4.14.1:
-        pHost->setControlCharacterMode(TConsole::NoControlCharacterReplacement);
+        pHost->setControlCharacterMode(TConsole::NoReplacement);
     }
 
     if (attributes().hasAttribute(qsl("Large2DMapAreaExitArrows"))) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1003,9 +1003,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
 
-    comboBox_controlCharacterHandling->setItemData(0, TConsole::NoControlCharacterReplacement);
-    comboBox_controlCharacterHandling->setItemData(1, TConsole::PictureControlCharacterReplacement);
-    comboBox_controlCharacterHandling->setItemData(2, TConsole::OEMFontControlCharacterReplacement);
+    comboBox_controlCharacterHandling->setItemData(0, TConsole::NoReplacement);
+    comboBox_controlCharacterHandling->setItemData(1, TConsole::Picture);
+    comboBox_controlCharacterHandling->setItemData(2, TConsole::OEMFont);
     auto cch_index = comboBox_controlCharacterHandling->findData(pHost->getControlCharacterMode());
     comboBox_controlCharacterHandling->setCurrentIndex((cch_index > 0) ? cch_index : 0);
     connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling);
@@ -4139,7 +4139,7 @@ void dlgProfilePreferences::slot_changeControlCharacterHandling()
         return;
     }
 
-    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<TConsole::ControlCharacterMode>());
+    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<TConsole::ControlCharacter>());
 }
 
 void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1003,9 +1003,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
 
-    comboBox_controlCharacterHandling->setItemData(0, TConsole::NoReplacement);
+    comboBox_controlCharacterHandling->setItemData(0, TConsole::AsIs);
     comboBox_controlCharacterHandling->setItemData(1, TConsole::Picture);
-    comboBox_controlCharacterHandling->setItemData(2, TConsole::OEMFont);
+    comboBox_controlCharacterHandling->setItemData(2, TConsole::OEM);
     auto cch_index = comboBox_controlCharacterHandling->findData(pHost->getControlCharacterMode());
     comboBox_controlCharacterHandling->setCurrentIndex((cch_index > 0) ? cch_index : 0);
     connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling);
@@ -4139,7 +4139,7 @@ void dlgProfilePreferences::slot_changeControlCharacterHandling()
         return;
     }
 
-    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<TConsole::ControlCharacter>());
+    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<TConsole::ControlCharacterMode>());
 }
 
 void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1003,9 +1003,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
 
-    comboBox_controlCharacterHandling->setItemData(0, TConsole::AsIs);
-    comboBox_controlCharacterHandling->setItemData(1, TConsole::Picture);
-    comboBox_controlCharacterHandling->setItemData(2, TConsole::OEM);
+    comboBox_controlCharacterHandling->setItemData(0, ControlCharacterMode::AsIs);
+    comboBox_controlCharacterHandling->setItemData(1, ControlCharacterMode::Picture);
+    comboBox_controlCharacterHandling->setItemData(2, ControlCharacterMode::OEM);
     auto cch_index = comboBox_controlCharacterHandling->findData(pHost->getControlCharacterMode());
     comboBox_controlCharacterHandling->setCurrentIndex((cch_index > 0) ? cch_index : 0);
     connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling);
@@ -4139,7 +4139,7 @@ void dlgProfilePreferences::slot_changeControlCharacterHandling()
         return;
     }
 
-    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<TConsole::ControlCharacterMode>());
+    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<ControlCharacterMode>());
 }
 
 void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Make this nicer to work with:

TConsole::ControlCharacterMode mControlCharacterMode = TConsole::ControlCharacterMode::NoControlCharacterReplacement;

(it's so long, it wraps in the github view)
#### Motivation for adding to Mudlet
Better [DevEx](https://humanitec.com/blog/developer-experience)
