### PR TITLE
Infrastructure: add workflow to pull latest development

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_REBASE_DEVELOPMENT }}


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Typing a `/rebase` comment in a PR will pull latest `development` changes in.
#### Motivation for adding to Mudlet
It's necessary to do this sometimes, and being able to do it from the web without messing with git is nice.
#### Other info (issues closed, discussion etc)
Built with https://github.com/marketplace/actions/automatic-rebase