### PR TITLE
Infrastructure: Update Windows CI zlib to 1.2.12

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -311,9 +311,9 @@ function InstallSqlite() {
 }
 
 function InstallZlib() {
-  DownloadFile "http://zlib.net/zlib-1.2.11.tar.gz" "zlib-1.2.11.tar.gz"
-  ExtractTar "$workingBaseDir\zlib-1.2.11.tar.gz" "$workingBaseDir\zlib"
-  Set-Location "$workingBaseDir\zlib\zlib-1.2.11"
+  DownloadFile "http://zlib.net/zlib-1.2.12.tar.gz" "zlib-1.2.12.tar.gz"
+  ExtractTar "$workingBaseDir\zlib-1.2.12.tar.gz" "$workingBaseDir\zlib"
+  Set-Location "$workingBaseDir\zlib\zlib-1.2.12"
   RunMake "win32/Makefile.gcc"
   $Env:INCLUDE_PATH = "$Env:MINGW_BASE_DIR\include"
   $Env:LIBRARY_PATH = "$Env:MINGW_BASE_DIR\lib"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update Windows CI zlib to 1.2.12
#### Motivation for adding to Mudlet
So Windows CI builds work
#### Other info (issues closed, discussion etc)
zlib takes down old releases which is a somewhat hostile move -

![image](https://user-images.githubusercontent.com/110988/161380875-4de0bf78-1099-45f3-88c2-68d957b734c2.png)
