### PR TITLE
Infrastructure: fix Luarocks on Windows

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -355,9 +355,9 @@ function InstallZziplib() {
 }
 
 function InstallLuarocks() {
-  DownloadFile "http://luarocks.github.io/luarocks/releases/luarocks-3.1.2-win32.zip" "luarocks.zip"
+  DownloadFile "http://luarocks.github.io/luarocks/releases/luarocks-3.8.0-win32.zip" "luarocks.zip"
   ExtractZip "luarocks.zip" "luarocks"
-  Set-Location luarocks\luarocks-3.1.2-win32
+  Set-Location luarocks\luarocks-3.8.0-win32
   Step "installing luarocks"
   exec ".\install.bat" @("/P", "C:\LuaRocks", "/MW", "/Q")
   Set-Location \LuaRocks\lua\luarocks\core


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Install Luarocks 3.8.0 to compile with Github's security policy.
#### Motivation for adding to Mudlet
CI builds on Windows work again.
#### Other info (issues closed, discussion etc)
https://github.com/Mudlet/Mudlet/pull/6013 fixed it for Ubuntu builds, this fixes it for Windows builds.

Requires https://github.com/Mudlet/Mudlet/pull/6027 to be merged first in order to work.