### PR TITLE
Infrastructure: Revert update to Boost 1.77.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
+
 image: Visual Studio 2019
 environment:
   signing_password:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-
 image: Visual Studio 2019
 environment:
   signing_password:

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -48,7 +48,7 @@ jobs:
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
-      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.bz2/download
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 
     steps:

--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
-      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.bz2/download
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
     steps:
     - name: Checkout Mudlet source code

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
-      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.bz2/download
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
 
 
     steps:

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -210,14 +210,14 @@ function InstallMsys() {
 }
 
 function InstallBoost([string] $outputLocation = "C:\Libraries\") {
-  DownloadFile "https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.gz/download" "boost.tar.gz" $true
+  DownloadFile "https://sourceforge.net/projects/boost/files/boost/1.71.0.beta1/boost_1_71_0_b1.tar.gz/download" "boost.tar.gz" $true
   if (!(Test-Path -Path "C:\Libraries\" -PathType Container)) {
     Step "Creating Boost path"
     New-Item -Path "C:\Libraries\" -ItemType "directory" >> "$logFile" 2>&1
   }
   ExtractTar "$workingBaseDir\boost.tar.gz" "$workingBaseDir"
   Step "Copying folder"
-  Move-Item "$workingBaseDir\boost_1_77_0" "$outputLocation" >> "$logFile" 2>&1
+  Move-Item "$workingBaseDir\boost_1_71_0" "$outputLocation" >> "$logFile" 2>&1
 }
 
 function InstallQt() {
@@ -463,7 +463,7 @@ function CheckAndInstallMsys(){
 }
 
 function CheckAndInstallBoost(){
-    CheckAndInstall "Boost" "C:\Libraries\boost_1_77_0\bootstrap.bat" { InstallBoost }
+    CheckAndInstall "Boost" "C:\Libraries\boost_1_71_0\bootstrap.bat" { InstallBoost }
 }
 
 function CheckAndInstallQt(){

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It’s a modern breed of a client on the gaming scene – with an intuitive user
 
 <details>
   <summary>Explain?</summary>
-
+  
 ### Easy to use client
 
 We’re big on usability, and as such, creating an easy to use client and interface is one of the defining goals of the project. This applies to both the power users and usual gamers – everyone will feel at home with Mudlet, without having to waste too much time figuring out how to do something.
@@ -119,7 +119,7 @@ This software wouldnt've been possible without these open source packages:
 - [edbee](http://www.edbee.net/)
 - [DBLSQD](https://www.dblsqd.com/)
 - [argparse](https://github.com/luarocks/argparse)
-- [Boost Graph Library](https://www.boost.org/doc/libs/1_77_0/libs/graph/doc/)
+- [Boost Graph Library](https://www.boost.org/doc/libs/1_75_0/libs/graph/doc/)
 - [Busted](http://olivinelabs.com/busted/)
 - [Ccache](https://ccache.dev/)
 - [Communi](https://communi.github.io/)


### PR DESCRIPTION
Reverts Mudlet/Mudlet#5916

While it finds Boost correctly, using Boost later down the road fails:

```
TAstar.h:30:10: fatal error: boost/graph/adjacency_list.hpp: No such file or directory
 #include <boost/graph/adjacency_list.hpp>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Should have waited for CI to pass before merging, that was a bit premature!