### PR TITLE
Infrastructure: fix Windows CI builds (use previous VS 2019 to get Qt 5.14.2 back)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ branches:
 init:
 - cmd: mkdir C:\src\
 
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 environment:
   signing_password:
     secure: JJDxNdreMgNn/IOcY+UVmlaqgDT4a7vcxsY3nfcgWY4=


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix Windows CI builds - use previous VS 2019 to get Qt 5.14.2 back.
#### Motivation for adding to Mudlet
So Windows CI builds work agian.
#### Other info (issues closed, discussion etc)
