### PR TITLE
Infrastructure: move ControlCharacterMode enum out of TConsole class

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3929,11 +3929,11 @@ void Host::setupIreDriverBugfix()
     }
 }
 
-void Host::setControlCharacterMode(const TConsole::ControlCharacterMode mode)
+void Host::setControlCharacterMode(const ControlCharacterMode mode)
 {
-    if (Q_UNLIKELY(!(mode == TConsole::AsIs
-                     || mode == TConsole::Picture
-                     || mode == TConsole::OEM))) {
+    if (Q_UNLIKELY(!(mode == ControlCharacterMode::AsIs
+                     || mode == ControlCharacterMode::Picture
+                     || mode == ControlCharacterMode::OEM))) {
         return;
     }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -201,8 +201,8 @@ public:
     void            getUserDictionaryOptions(bool& useDictionary, bool& useShared) {
                         useDictionary = mEnableUserDictionary;
                         useShared = mUseSharedDictionary; }
-    void            setControlCharacterMode(const TConsole::ControlCharacterMode mode);
-    TConsole::ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
+    void            setControlCharacterMode(const ControlCharacterMode mode);
+    ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
 
@@ -656,7 +656,7 @@ signals:
     void signal_changeDebugShowAllProblemCodepoints(const bool);
     // Tells all consoles associated with this Host (but NOT the Central Debug
     // one) to change the way they show  control characters:
-    void signal_controlCharacterHandlingChanged(const TConsole::ControlCharacterMode);
+    void signal_controlCharacterHandlingChanged(const ControlCharacterMode);
 
 private slots:
     void slot_purgeTemps();
@@ -801,16 +801,16 @@ private:
     QTimer purgeTimer;
 
     // How to display (most) incoming control characters in TConsoles:
-    // TConsole::AsIs (0x0) = as is, no replacement
-    // TConsole::Picture (0x1) = as Unicode "Control
+    // ControlCharacterMode::AsIs (0x0) = as is, no replacement
+    // ControlCharacterMode::Picture (0x1) = as Unicode "Control
     //   Pictures" - use Unicode codepoints in range U+2400 to U+2421
-    // TConsole::OEM (0x2) = as "OEM Font"
+    // ControlCharacterMode::OEM (0x2) = as "OEM Font"
     //   characters (most often seen as a part of CP437
     //   encoding), see the corresponding Wikipedia page, e.g.
     //   EN: https://en.wikipedia.org/wiki/Code_page_437
     //   DE: https://de.wikipedia.org/wiki/Codepage_437
     //   RU: https://ru.wikipedia.org/wiki/CP437
-    TConsole::ControlCharacterMode mControlCharacter = TConsole::ControlCharacterMode::AsIs;
+    ControlCharacterMode mControlCharacter = AsIs;
 
     bool mLargeAreaExitArrows = false;
     bool mEditorShowBidi = true;

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -46,6 +46,16 @@
 #include <list>
 #include <map>
 
+
+enum ControlCharacterMode {
+    AsIs = 0x0,
+    Picture = 0x1,
+    OEM = 0x2
+};
+
+// Needed so it can be handled as a QVariant
+Q_DECLARE_METATYPE(ControlCharacterMode)
+
 class QCloseEvent;
 class QLineEdit;
 class QScrollBar;
@@ -77,13 +87,6 @@ public:
         Buffer = 0x20 // Non-visible store for data that can be copied to/from other per profile TConsoles, should be uniquely named in pool of SubConsole/UserWindow/Buffers AND Labels
     };
     Q_DECLARE_FLAGS(ConsoleType, ConsoleTypeFlag)
-
-    enum ControlCharacterMode {
-        AsIs = 0x0,
-        Picture = 0x1,
-        OEM = 0x2
-    };
-    Q_ENUM(ControlCharacterMode)
 
     Q_DISABLE_COPY(TConsole)
     explicit TConsole(Host*, ConsoleType type = UnknownType, QWidget* parent = nullptr);
@@ -292,7 +295,7 @@ public slots:
     void slot_toggleReplayRecording();
     void slot_stop_all_triggers(bool);
     void slot_toggleLogging();
-    void slot_changeControlCharacterHandling(const TConsole::ControlCharacterMode);
+    void slot_changeControlCharacterHandling(const ControlCharacterMode);
 
 
 protected:

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2016, 2018-2021 by Stephen Lyons                   *
+ *   Copyright (C) 2014-2016, 2018-2022 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *   Copyright (C) 2017 by Chris Reid - WackyWormer@hotmail.com            *
@@ -586,10 +586,10 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
             graphemes.append((charWidth < 1) ? QChar() : grapheme);
         }
         break;
-    case TConsole::Picture:
+    case ControlCharacterMode::Picture:
         replaceControlCharacterWith_Picture(unicode, grapheme, column, graphemes, charWidth);
         break;
-    case TConsole::OEM:
+    case ControlCharacterMode::OEM:
         replaceControlCharacterWith_OEMFont(unicode, grapheme, column, graphemes, charWidth);
         break;
     } // End of switch

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -947,20 +947,20 @@ void XMLimport::readHostPackage(Host* pHost)
     if (attributes().hasAttribute(QLatin1String("ControlCharacterHandling"))) {
         switch (attributes().value(QLatin1String("ControlCharacterHandling")).toInt()) {
         case 1:
-            pHost->setControlCharacterMode(TConsole::Picture);
+            pHost->setControlCharacterMode(ControlCharacterMode::Picture);
             break;
         case 2:
-            pHost->setControlCharacterMode(TConsole::OEM);
+            pHost->setControlCharacterMode(ControlCharacterMode::OEM);
             break;
         case 0:
             [[fallthrough]];
         default:
-            pHost->setControlCharacterMode(TConsole::AsIs);
+            pHost->setControlCharacterMode(ControlCharacterMode::AsIs);
         }
 
     } else {
         // The default value, also used up to Mudlet 4.14.1:
-        pHost->setControlCharacterMode(TConsole::AsIs);
+        pHost->setControlCharacterMode(ControlCharacterMode::AsIs);
     }
 
     if (attributes().hasAttribute(qsl("Large2DMapAreaExitArrows"))) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1003,9 +1003,9 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
 
-    comboBox_controlCharacterHandling->setItemData(0, TConsole::AsIs);
-    comboBox_controlCharacterHandling->setItemData(1, TConsole::Picture);
-    comboBox_controlCharacterHandling->setItemData(2, TConsole::OEM);
+    comboBox_controlCharacterHandling->setItemData(0, ControlCharacterMode::AsIs);
+    comboBox_controlCharacterHandling->setItemData(1, ControlCharacterMode::Picture);
+    comboBox_controlCharacterHandling->setItemData(2, ControlCharacterMode::OEM);
     auto cch_index = comboBox_controlCharacterHandling->findData(pHost->getControlCharacterMode());
     comboBox_controlCharacterHandling->setCurrentIndex((cch_index > 0) ? cch_index : 0);
     connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling);
@@ -4139,7 +4139,7 @@ void dlgProfilePreferences::slot_changeControlCharacterHandling()
         return;
     }
 
-    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<TConsole::ControlCharacterMode>());
+    pHost->setControlCharacterMode(comboBox_controlCharacterHandling->currentData().value<ControlCharacterMode>());
 }
 
 void dlgProfilePreferences::slot_enableDarkEditor(const QString& link)


### PR DESCRIPTION
This is so that the TConsole scope is not required to use it.

Note that this is a PR against an existing PR here and NOT the `development` branch itself. That will be amended when the existing PR is merged - ideally with this PR included in it.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>