### PR TITLE
Infrastructure: fixup files in QMake OTHER_FILES and DISTFILES variables

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1499,6 +1499,9 @@ win32 {
 OTHER_FILES += \
     ../.appveyor.yml \
     ../.crowdin.yml \
+    ../.devcontainer/Dockerfile \
+    ../.devcontainer/devcontainer.json \
+    ../.devcontainer/library-scripts/desktop-lite-debian.sh \
     ../.github/CODE_OF_CONDUCT.md \
     ../.github/CODEOWNERS \
     ../.github/codeql/codeql-config.yml \
@@ -1516,6 +1519,7 @@ OTHER_FILES += \
     ../.github/workflows/codeql-analysis.yml \
     ../.github/workflows/codespell-analysis.yml \
     ../.github/workflows/dangerjs.yml \
+    ../.github/workflows/generate-changelog.yml \
     ../.github/workflows/link-ptbs-to-dblsqd.yml \
     ../.github/workflows/tag-pull-requests.yml \
     ../.github/workflows/update-3rdparty.yml \
@@ -1523,15 +1527,15 @@ OTHER_FILES += \
     ../.github/workflows/update-en-us-plural.yml \
     ../.github/workflows/update-geyser-docs.yml \
     ../.github/workflows/update-translations.yml \
-    ../.github/workflows/whitespace-linter.yml \
     ../.gitignore \
-    ../.travis.yml \
     ../CI/appveyor.after_success.ps1 \
     ../CI/appveyor.build.ps1 \
     ../CI/appveyor.functions.ps1 \
     ../CI/appveyor.install.ps1 \
     ../CI/appveyor.set-build-info.ps1 \
+    ../CI/appveyor.validate_deployment.ps1 \
     ../CI/copy-non-qt-win-dependencies.ps1 \
+    ../CI/generate-changelog.lua \
     ../CI/mudlet-deploy-key.enc \
     ../CI/mudlet-deploy-key-windows.ppk \
     ../CI/qt-silent-install.qs \
@@ -1546,10 +1550,13 @@ OTHER_FILES += \
     ../CI/travis.osx.before_install.sh \
     ../CI/travis.osx.install.sh \
     ../CI/travis.set-build-info.sh \
+    ../CI/travis.validate_deployment.sh \
+    ../CI/update-autocompletion.lua \
+    ../dangerfile.js \
+    ../docker/.env.template \
     ../docker/docker-compose.override.linux.yml \
     ../docker/docker-compose.yml \
     ../docker/Dockerfile \
-    ../README \
     mac-deploy.sh \
     mudlet-lua/genDoc.sh \
     mudlet-lua/lua/ldoc.css
@@ -1634,12 +1641,18 @@ DISTFILES += \
     $${LUA_GEYSER.files} \
     $${LUA_TESTS.files} \
     $${LUA_TRANSLATIONS.files} \
+    ../.clang-tidy \
     ../.gitmodules \
     ../cmake/FindHUNSPELL.cmake \
+    ../cmake/FindLua51.cmake \
     ../cmake/FindPCRE.cmake \
     ../cmake/FindPUGIXML.cmake \
+    ../cmake/FindSparkle.cmake \
     ../cmake/FindYAJL.cmake \
     ../cmake/FindZIP.cmake \
+    ../cmake/FindZZIPLIB.cmake \
+    ../cmake/IncludeOptionalModule.cmake \
+    ../cmake/InitGitSubmodule.cmake \
     ../CMakeLists.txt \
     ../COMMITMENT \
     ../COMPILE \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1497,10 +1497,8 @@ win32 {
 # This is a list of files that we want to show up in the Qt Creator IDE that are
 # not otherwise used by the project:
 OTHER_FILES += \
-    $${LUA.files} \
-    $${LUA_GEYSER.files} \
-    $${LUA_TESTS.files} \
-    $${LUA_TRANSLATIONS.files} \
+    ../.appveyor.yml \
+    ../.crowdin.yml \
     ../.github/CODE_OF_CONDUCT.md \
     ../.github/CODEOWNERS \
     ../.github/codeql/codeql-config.yml \
@@ -1526,11 +1524,35 @@ OTHER_FILES += \
     ../.github/workflows/update-geyser-docs.yml \
     ../.github/workflows/update-translations.yml \
     ../.github/workflows/whitespace-linter.yml \
-    ../COMPILE \
-    ../COPYING \
-    ../INSTALL \
+    ../.gitignore \
+    ../.travis.yml \
+    ../CI/appveyor.after_success.ps1 \
+    ../CI/appveyor.build.ps1 \
+    ../CI/appveyor.functions.ps1 \
+    ../CI/appveyor.install.ps1 \
+    ../CI/appveyor.set-build-info.ps1 \
+    ../CI/copy-non-qt-win-dependencies.ps1 \
+    ../CI/mudlet-deploy-key.enc \
+    ../CI/mudlet-deploy-key-windows.ppk \
+    ../CI/qt-silent-install.qs \
+    ../CI/travis.after_success.sh \
+    ../CI/travis.before_install.sh \
+    ../CI/travis.compile.sh \
+    ../CI/travis.install.sh \
+    ../CI/travis.linux.after_success.sh \
+    ../CI/travis.linux.before_install.sh \
+    ../CI/travis.linux.install.sh \
+    ../CI/travis.osx.after_success.sh \
+    ../CI/travis.osx.before_install.sh \
+    ../CI/travis.osx.install.sh \
+    ../CI/travis.set-build-info.sh \
+    ../docker/docker-compose.override.linux.yml \
+    ../docker/docker-compose.yml \
+    ../docker/Dockerfile \
     ../README \
-    mac-deploy.sh
+    mac-deploy.sh \
+    mudlet-lua/genDoc.sh \
+    mudlet-lua/lua/ldoc.css
 
 # Unix Makefile installer:
 # lua file installation, needs install, sudo, and a setting in /etc/sudo.conf
@@ -1608,31 +1630,11 @@ INSTALLS += \
 
 # This is the extra files that are needed to do a `make dist` given a makefile
 DISTFILES += \
-    ../.appveyor.yml \
-    ../.crowdin.yml \
-    ../.gitignore \
+    $${LUA.files} \
+    $${LUA_GEYSER.files} \
+    $${LUA_TESTS.files} \
+    $${LUA_TRANSLATIONS.files} \
     ../.gitmodules \
-    ../.travis.yml \
-    ../CI/appveyor.after_success.ps1 \
-    ../CI/appveyor.build.ps1 \
-    ../CI/appveyor.functions.ps1 \
-    ../CI/appveyor.install.ps1 \
-    ../CI/appveyor.set-build-info.ps1 \
-    ../CI/copy-non-qt-win-dependencies.ps1 \
-    ../CI/mudlet-deploy-key.enc \
-    ../CI/mudlet-deploy-key-windows.ppk \
-    ../CI/qt-silent-install.qs \
-    ../CI/travis.after_success.sh \
-    ../CI/travis.before_install.sh \
-    ../CI/travis.compile.sh \
-    ../CI/travis.install.sh \
-    ../CI/travis.linux.after_success.sh \
-    ../CI/travis.linux.before_install.sh \
-    ../CI/travis.linux.install.sh \
-    ../CI/travis.osx.after_success.sh \
-    ../CI/travis.osx.before_install.sh \
-    ../CI/travis.osx.install.sh \
-    ../CI/travis.set-build-info.sh \
     ../cmake/FindHUNSPELL.cmake \
     ../cmake/FindPCRE.cmake \
     ../cmake/FindPUGIXML.cmake \
@@ -1640,9 +1642,9 @@ DISTFILES += \
     ../cmake/FindZIP.cmake \
     ../CMakeLists.txt \
     ../COMMITMENT \
-    ../docker/docker-compose.override.linux.yml \
-    ../docker/docker-compose.yml \
-    ../docker/Dockerfile \
+    ../COMPILE \
+    ../COPYING \
+    ../INSTALL \
     ../mudlet.desktop \
     ../mudlet.png \
     ../mudlet.svg \
@@ -1653,10 +1655,8 @@ DISTFILES += \
     .clang-format \
     CF-loader.xml \
     CMakeLists.txt \
-    mudlet-lua/genDoc.sh \
     mudlet-lua/lua/generic-mapper/generic_mapper.xml \
     mudlet-lua/lua/generic-mapper/versions.lua \
-    mudlet-lua/lua/ldoc.css \
     mudlet-lua/tests/DB.lua \
     mudlet-lua/tests/GUIUtils.lua \
     mudlet-lua/tests/Other.lua \

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1499,8 +1499,8 @@ win32 {
 OTHER_FILES += \
     $${LUA.files} \
     $${LUA_GEYSER.files} \
-    $${LUA_TRANSLATIONS.files} \
     $${LUA_TESTS.files} \
+    $${LUA_TRANSLATIONS.files} \
     ../.github/CODE_OF_CONDUCT.md \
     ../.github/CODEOWNERS \
     ../.github/codeql/codeql-config.yml \
@@ -1526,10 +1526,10 @@ OTHER_FILES += \
     ../.github/workflows/update-geyser-docs.yml \
     ../.github/workflows/update-translations.yml \
     ../.github/workflows/whitespace-linter.yml \
-    ../README \
     ../COMPILE \
     ../COPYING \
     ../INSTALL \
+    ../README \
     mac-deploy.sh
 
 # Unix Makefile installer:
@@ -1608,56 +1608,56 @@ INSTALLS += \
 
 # This is the extra files that are needed to do a `make dist` given a makefile
 DISTFILES += \
-    ../docker/Dockerfile \
-    ../docker/docker-compose.override.linux.yml \
-    ../docker/docker-compose.yml \
-    CF-loader.xml \
-    CMakeLists.txt \
-    .clang-format \
-    ../CMakeLists.txt \
-    ../cmake/FindHUNSPELL.cmake \
-    ../cmake/FindPCRE.cmake \
-    ../cmake/FindYAJL.cmake \
-    ../cmake/FindZIP.cmake \
-    ../cmake/FindPUGIXML.cmake \
+    ../.appveyor.yml \
+    ../.crowdin.yml \
+    ../.gitignore \
+    ../.gitmodules \
     ../.travis.yml \
+    ../CI/appveyor.after_success.ps1 \
+    ../CI/appveyor.build.ps1 \
+    ../CI/appveyor.functions.ps1 \
+    ../CI/appveyor.install.ps1 \
+    ../CI/appveyor.set-build-info.ps1 \
+    ../CI/copy-non-qt-win-dependencies.ps1 \
+    ../CI/mudlet-deploy-key.enc \
+    ../CI/mudlet-deploy-key-windows.ppk \
+    ../CI/qt-silent-install.qs \
+    ../CI/travis.after_success.sh \
     ../CI/travis.before_install.sh \
+    ../CI/travis.compile.sh \
     ../CI/travis.install.sh \
+    ../CI/travis.linux.after_success.sh \
     ../CI/travis.linux.before_install.sh \
     ../CI/travis.linux.install.sh \
+    ../CI/travis.osx.after_success.sh \
     ../CI/travis.osx.before_install.sh \
     ../CI/travis.osx.install.sh \
     ../CI/travis.set-build-info.sh \
-    ../CI/travis.after_success.sh \
-    ../CI/travis.linux.after_success.sh \
-    ../CI/travis.osx.after_success.sh \
-    ../.appveyor.yml \
-    ../CI/appveyor.after_success.ps1 \
-    ../CI/appveyor.install.ps1 \
-    ../CI/appveyor.set-build-info.ps1 \
-    ../CI/appveyor.functions.ps1 \
-    ../CI/appveyor.build.ps1 \
-    mudlet-lua/lua/generic-mapper/generic_mapper.xml \
-    mudlet-lua/lua/generic-mapper/versions.lua \
-    mudlet-lua/lua/ldoc.css \
-    mudlet-lua/genDoc.sh \
-    mudlet-lua/tests/README.md \
-    mudlet-lua/tests/DB.lua \
-    mudlet-lua/tests/GUIUtils.lua \
-    mudlet-lua/tests/Other.lua \
+    ../cmake/FindHUNSPELL.cmake \
+    ../cmake/FindPCRE.cmake \
+    ../cmake/FindPUGIXML.cmake \
+    ../cmake/FindYAJL.cmake \
+    ../cmake/FindZIP.cmake \
+    ../CMakeLists.txt \
+    ../COMMITMENT \
+    ../docker/docker-compose.override.linux.yml \
+    ../docker/docker-compose.yml \
+    ../docker/Dockerfile \
     ../mudlet.desktop \
     ../mudlet.png \
     ../mudlet.svg \
     ../README.md \
     ../translations/translated/CMakeLists.txt \
     ../translations/translated/generate-translation-stats.lua \
-    ../COMMITMENT \
-    ../.crowdin.yml \
-    ../.gitignore \
-    ../.gitmodules \
     ../translations/translated/updateqm.pri \
-    ../CI/mudlet-deploy-key.enc \
-    ../CI/copy-non-qt-win-dependencies.ps1 \
-    ../CI/mudlet-deploy-key-windows.ppk \
-    ../CI/qt-silent-install.qs \
-    ../CI/travis.compile.sh
+    .clang-format \
+    CF-loader.xml \
+    CMakeLists.txt \
+    mudlet-lua/genDoc.sh \
+    mudlet-lua/lua/generic-mapper/generic_mapper.xml \
+    mudlet-lua/lua/generic-mapper/versions.lua \
+    mudlet-lua/lua/ldoc.css \
+    mudlet-lua/tests/DB.lua \
+    mudlet-lua/tests/GUIUtils.lua \
+    mudlet-lua/tests/Other.lua \
+    mudlet-lua/tests/README.md


### PR DESCRIPTION
This PR has three commits:
1. The first commit just sorts in a case insensitive manner the files in the `OTHER_FILES` and `DISTFILES` QMake variables. This is a precursor to making changes to them.
2. Swaps some files between QMake `OTHER_FILES` and `DISTFILES` variables. Technically the latter are for files that are needed to go into a source tarball that the traditional GNU `make dist` operation would produce. As such it does not seem reasonable to include CI/CB control files in it. Conversely the run-time LUA files that Mudlet needs definitely should be included and so this commit moves them from the `OTHER_FILES` variable, whose contents are merely files that we want to show up in the Qt Creator IDE so they can be seen, searched and edited from there.
3. Change contents of QMake `OTHER_FILES` and `DISTFILES` variables as there are files now in Mudlet that seem to have been forgotten from being added to these variables so they can be seen in Qt Creator, they are:
  * `OTHER_FILES`:
    * `./.devcontainer/Dockerfile` (added by #4087)
    * `./.devcontainer/devcontainer.json` (added by #4087)
    * `./.devcontainer/library-scripts/desktop-lite-debian.sh` (added by #4088)
    * `./.github/workflows/generate-changelog.yml` (added by #6006)
    * `./CI/appveyor.validate_deployment.ps1` (added by #3493)
    * `./CI/generate-changelog.lua` (renamed from `./CI/generate-ptb-changelog.lua` by #6002, that file created by #3517)
    * `./CI/travis.validate_deployment.sh` (added by #3493)
    * `./CI/update-autocompletion.lua` (added by #3452)
    * `./dangerfile.js` (added by #5489)
    * `./docker/.env.template` (added by #5047)
 * `DISTFILES`:
    * `./.clang-tidy` (added by #4858)
    * `./cmake/FindLua51.cmake` (added by #3167)
    * `./cmake/FindSparkle.cmake` (added #3477)
    * `./cmake/FindZZIPLIB.cmake` (added by #3630)
    * `./cmake/IncludeOptionalModule.cmake` (added by #3174)
    * `./cmake/InitGitSubmodule.cmake` (added by #3171)
  
Also, the following files have gone away:
  * `OTHER_FILES`:
    * `./.github/workflows/whitespace-linter.yml` (removed by #4152)
    * `./.travis.yml` (removed by #5611)
    * `./README` (renamed to ./dev_README by #439, removed by #1169)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>