### PR TITLE
Infrastructure: add website release post automation

### DIFF
--- a/.github/workflows/create-release-posts.yml
+++ b/.github/workflows/create-release-posts.yml
@@ -1,4 +1,4 @@
-name: Create release posts
+name: Create release posts in Wordpress
 on:
   release:
     types: [published]
@@ -7,7 +7,7 @@ jobs:
   release-post:
     runs-on: ubuntu-latest
     steps:
-    - name: Call release Webhook
+    - name: Notify mudlet.org of new release
       uses: fjogeleit/http-request-action@v1
       with:
         url: ${{ secrets.RELEASE_POST_WEBHOOK }}

--- a/.github/workflows/create-release-posts.yml
+++ b/.github/workflows/create-release-posts.yml
@@ -1,0 +1,14 @@
+name: Create release posts
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-post:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Call release Webhook
+      uses: fjogeleit/http-request-action@v1
+      with:
+        url: ${{ secrets.RELEASE_POST_WEBHOOK }}
+        method: 'GET'


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

One step for release automation.

As agreed with @vadi2 - Github release will be source for page posts.

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
fixes #5867