### PR TITLE
Infrastructure: automate author attribution

### DIFF
--- a/.github/workflows/generate-coder-attribution.yml
+++ b/.github/workflows/generate-coder-attribution.yml
@@ -59,11 +59,21 @@ jobs:
 
     - name: Generate changelog
       run: |
-        authors=$(git log Mudlet-4.1.0..HEAD --format="%aN <%aE>" --reverse | sort -u  | grep -oE ".+ <" | tr -d ' <' | sort -u)
-   
-    # - name: Upload changelog as html
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: changelog.html
-    #     path: changelog.html
+        # get list of authors
+        authors=$(git log $FROM_RELEASE..$TO_RELEASE --format="%aN" --reverse | sort -u)
+        # trim known bots
+        authors=$(echo "$authors" | grep -v "bot" | grep -v "mudlet-machine-account" | grep -v "ImgBotApp" | grep -v "mudlet-machine-account")
+        # beautify list
+        authors=$(echo "$authors" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
+        authors=$(echo "$authors" | sed 's/\(.*\), \(.*\)/\1, and \2/')
+
+        echo "$authors" > authors.txt
+        echo "[INFO] Authors from $FROM_RELEASE to $TO_RELEASE are:"
+        echo $authors
+
+    - name: Upload authors as txt
+      uses: actions/upload-artifact@v3
+      with:
+        name: authors.txt
+        path: authors.txt
 

--- a/.github/workflows/generate-coder-attribution.yml
+++ b/.github/workflows/generate-coder-attribution.yml
@@ -62,7 +62,8 @@ jobs:
         # get list of authors
         authors=$(git log $FROM_RELEASE..$TO_RELEASE --format="%aN" --reverse | sort -u)
         # trim known bots
-        authors=$(echo "$authors" | grep -v "bot" | grep -v "mudlet-machine-account" | grep -v "ImgBotApp" | grep -v "mudlet-machine-account")
+        authors=$(echo "$authors" | grep -v "bot" | grep -v "mudlet-machine-account" | grep -v "ImgBotApp" \
+          | grep -v "mudlet-machine-account" | grep -v "root")
         # beautify list
         authors=$(echo "$authors" | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g')
         authors=$(echo "$authors" | sed 's/\(.*\), \(.*\)/\1, and \2/')

--- a/.github/workflows/generate-coder-attribution.yml
+++ b/.github/workflows/generate-coder-attribution.yml
@@ -1,4 +1,4 @@
-name: Generate a changelog
+name: Generate coder attribution
 
 on:
   schedule:
@@ -59,7 +59,7 @@ jobs:
 
     - name: Generate changelog
       run: |
-        authors=$(git log $FROM_RELEASE..$TO_RELEASE --format="%aN <%aE>" --reverse | perl -e 'my %dedupe; while (<STDIN>) { print unless $dedupe{$_}++}')
+        authors=$(git log Mudlet-4.1.0..HEAD --format="%aN <%aE>" --reverse | sort -u  | grep -oE ".+ <" | tr -d ' <' | sort -u)
    
     # - name: Upload changelog as html
     #   uses: actions/upload-artifact@v3

--- a/.github/workflows/generate-list-of-authors.yml
+++ b/.github/workflows/generate-list-of-authors.yml
@@ -1,0 +1,69 @@
+name: Generate a changelog
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      from:
+        description: 'Generate from this release/commit (defaults to the latest release)'
+        required: false
+        # default is calculated dynamically
+      to:
+        description: 'Generate until this release/commit (defaults to latest development)'
+        required: false
+        default: 'HEAD'
+
+jobs:
+  generate-changelog:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Mudlet' }}
+
+    steps:
+    - name: Checkout Mudlet repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install Lua 5.1.5
+      uses: leafo/gh-actions-lua@v8
+      with:
+        luaVersion: "5.1.5"
+
+    - name: Install Luarocks
+      uses: leafo/gh-actions-luarocks@v4
+
+    - name: Install Lua dependencies
+      run: |
+        luarocks install argparse
+        luarocks install lunajson
+
+    - name: Calculate from and to releases
+      run: |
+        if [[ -z "${{ github.event.inputs.from }}" ]] ; then
+            FROM_RELEASE=$(git tag --sort=committerdate | tail -1)
+        else
+            FROM_RELEASE=${{ github.event.inputs.from }}
+        fi
+
+        if [[ -z "${{ github.event.inputs.to }}" ]] ; then
+            TO_RELEASE="HEAD"
+        else
+            TO_RELEASE=${{ github.event.inputs.to }}
+        fi
+
+        echo "Generating a changelog from $FROM_RELEASE until $TO_RELEASE"
+
+        echo "FROM_RELEASE=$FROM_RELEASE" >> $GITHUB_ENV
+        echo "TO_RELEASE=$TO_RELEASE" >> $GITHUB_ENV
+
+    - name: Generate changelog
+      run: |
+        authors=$(git log $FROM_RELEASE..$TO_RELEASE --format="%aN <%aE>" --reverse | perl -e 'my %dedupe; while (<STDIN>) { print unless $dedupe{$_}++}')
+   
+    # - name: Upload changelog as html
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: changelog.html
+    #     path: changelog.html
+


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add a workflow to automatically generate the list of authors who contributed to a release
#### Motivation for adding to Mudlet
Close https://github.com/Mudlet/Mudlet/issues/5918
#### Other info (issues closed, discussion etc)
Ideally this would be plugged into the last draft release post automatically - an improvement for the future.

If an author changes their name, that is not supported - it hasn't been a problem previously to list either name.