### PR TITLE
Infrastructure: switch to current vs 2019 appveyor image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ branches:
 init:
 - cmd: mkdir C:\src\
 
-image: Previous Visual Studio 2019
+image: Visual Studio 2019
 environment:
   signing_password:
     secure: JJDxNdreMgNn/IOcY+UVmlaqgDT4a7vcxsY3nfcgWY4=


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Switch to current vs 2019 appveyor image to stay on the latest.
#### Motivation for adding to Mudlet
With https://github.com/Mudlet/Mudlet/pull/6030 in place, we're no longer dependant upon appveyor for providing a particular Qt version.
#### Other info (issues closed, discussion etc)
