### PR TITLE
Infrastructure: cache Qt installation for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ branches:
 init:
 - cmd: mkdir C:\src\
 
-image: Previous Visual Studio 2019
+image: Visual Studio 2019
 environment:
   signing_password:
     secure: JJDxNdreMgNn/IOcY+UVmlaqgDT4a7vcxsY3nfcgWY4=
@@ -37,6 +37,7 @@ on_failure:
 
 cache:
   - '%MINGW_BASE_DIR% -> CI\appveyor.install.ps1, CI\appveyor.functions.ps1'
+  - '%QT_BASE_DIR% -> CI\appveyor.install.ps1, CI\appveyor.functions.ps1'
 
 notifications:
 - provider: Webhook


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Cache Qt installation for Windows
#### Motivation for adding to Mudlet
Keep our Windows builds fast
#### Other info (issues closed, discussion etc)
We didn't need to cache it previously since Qt was provided by Appveyor itself. Now that it's no longer the case (https://github.com/Mudlet/Mudlet/pull/6030), there's a need to manage caching ourselves.