### PR TITLE
Improve: add NULL handling in DB.lua

### DIFF
--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -358,10 +358,12 @@ function db:_sql_values(values)
       s = "NULL"
     elseif t == "table" and v._timestamp ~= nil then
       if not v._timestamp then
-        return "NULL"
+        s = "NULL"
       else
         s = "datetime('" .. v._timestamp .. "', 'unixepoch')"
       end
+		elseif t == "table" and v._isNull then
+			s = "NULL"
     else
       s = tostring(v)
     end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -434,7 +434,7 @@ end
 ---   )
 ---   </pre>
 ---   Note that you have to use double {{ }} if you have composite index/unique constrain.
-function db:create(db_name, sheets)
+function db:create(db_name, sheets, force)
   if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
   end
@@ -468,7 +468,7 @@ function db:create(db_name, sheets)
       for k, v in pairs(sht) do
         if string.starts(k, "_") then
           options[k] = v
-          sht[v] = nil
+          sht[k] = nil
         end
       end
     end
@@ -478,7 +478,7 @@ function db:create(db_name, sheets)
     end
 
     db.__schema[db_name][s_name] = { columns = sht, options = options }
-    db:_migrate(db_name, s_name)
+    db:_migrate(db_name, s_name, force)
   end
   return db:get_database(db_name)
 end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -217,6 +217,8 @@ function db:_sql_type(value)
     return "NULL"
   elseif t == "table" and value._timestamp ~= nil then
     return "INTEGER"
+  elseif t == "table" and value._isNull ~= nil then
+    return "NULL"
   else
     return "TEXT"
   end
@@ -433,13 +435,13 @@ end
 ---   </pre>
 ---   Note that you have to use double {{ }} if you have composite index/unique constrain.
 function db:create(db_name, sheets)
-  if not db.__env or (db.__env and db.__env == 'SQLite3 environment (closed)') then
+  if not db.__env or db.__env == 'SQLite3 environment (closed)' then
     db.__env = luasql.sqlite3()
   end
 
   db_name = db:safe_name(db_name)
 
-  if not db.__conn[db_name] or (db.__conn[db_name] and db.__conn[db_name] == 'SQLite3 connection (closed)') or (not io.exists(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")) then
+  if not db.__conn[db_name] or db.__conn[db_name] == 'SQLite3 connection (closed)' or (not io.exists(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")) then
     db.__conn[db_name] = db.__env:connect(getMudletHomeDir() .. "/Database_" .. db_name .. ".db")
     db.__conn[db_name]:setautocommit(false)
     db.__autocommit[db_name] = true
@@ -453,7 +455,7 @@ function db:create(db_name, sheets)
   -- field. The db package reserves any key that begins with an underscore to be special and syntax
   -- for its own use.
   for s_name, sht in pairs(sheets) do
-    options = {}
+    local options = {}
 
     if sht[1] ~= nil then
       -- in case the sheet was provided in the sheet = {"column1", "column2"} format:
@@ -463,15 +465,11 @@ function db:create(db_name, sheets)
       end
       sht = t
     else -- sheet provided in the sheet = {"column1" = default} format
-      local opts = {}
       for k, v in pairs(sht) do
         if string.starts(k, "_") then
           options[k] = v
-          opts[#opts + 1] = k
+          sht[v] = nil
         end
-      end
-      for _, v in ipairs(opts) do
-        sht[v] = nil
       end
     end
 
@@ -492,7 +490,7 @@ end
 -- and correct set of sheets and fields, along with their indexes. It should be safe to run
 -- at any time, and must not cause any data loss. It simply adds to what is there: in perticular
 -- it is not capable of removing indexes, columns, or sheets after they have been defined.
-function db:_migrate(db_name, s_name)
+function db:_migrate(db_name, s_name, force)
   local conn = db.__conn[db_name]
   local schema = db.__schema[db_name][s_name]
 
@@ -514,57 +512,13 @@ function db:_migrate(db_name, s_name)
       ---------------  GETS ALL COLUMNS FROM SHEET IF IT EXISTS
       db:echo_sql("SELECT * FROM " .. s_name)
       local get_sheet_cur = conn:execute("SELECT * FROM " .. s_name)  -- select the sheet
-
       if get_sheet_cur and get_sheet_cur ~= 0 then
-        local row = get_sheet_cur:fetch({}, "a") -- grab the first row, if any
-        if not row then
-          -- if no first row then
-          local tried_cols, contains, found_something, col = {}, table.contains, false
+        local colnames = get_sheet_cur:getcolnames()
 
-          while not found_something do
-            -- guarded by the error below from infinite looping
-            col = false
-            for k, v in pairs(schema.columns) do
-              -- look through sheet schema to find the first column that is text
-              if type(k) == "number" then
-                if string.sub(v, 1, 1) ~= "_" and not contains(tried_cols, v) then
-                  col = v break
-                end
-              else
-                if string.sub(k, 1, 1) ~= "_" and type(v) == "string" and not contains(tried_cols, k) then
-                  col = k break
-                end
-              end
-            end
-
-            if not col then
-              error("db:_migrate: cannot find a suitable column for testing a new row with.")
-            end
-
-            -- add row with found column set as "test"
-            db:add({ _db_name = db_name, _sht_name = s_name }, { [col] = "test" })
-
-            db:echo_sql("SELECT * FROM " .. s_name)
-            local get_row_cur = conn:execute("SELECT * FROM " .. s_name) -- select the sheet
-            row = get_row_cur:fetch({}, "a") -- grab the newly created row
-            get_row_cur:close()
-
-            -- delete the newly created row. If we picked a row that doesn't exist yet and we're
-            -- trying to add, the delete will fail - remember this, and try another row
-            local worked, msg = pcall(db.delete, db, { _db_name = db_name, _sht_name = s_name }, db:eq({ database = db_name, sheet = s_name, name = col, type = "string" }, "test"))
-
-            if not worked then
-              tried_cols[#tried_cols + 1] = col
-            else
-              found_something = true
-            end
-          end
-        end
-
-        if row then
+        if colnames then
           -- add each column from row to current_columns table
-          for k, v in pairs(row) do
-            current_columns[k] = ""
+          for _, v in ipairs(colnames) do
+            current_columns[v] = ""
           end
         end
         get_sheet_cur:close()
@@ -624,6 +578,32 @@ function db:_migrate(db_name, s_name)
     -- if we add all missing columns and we have more columns than we want
     -- then there are currently some columns we don't want anymore.
     then
+      --find the redundant columns
+      local redundant_columns = {}
+      for k, _ in pairs(current_columns) do
+        if k ~= "_row_id" and not schema.columns[k] then
+          table.insert(redundant_columns, k)
+        end
+      end
+      
+      --check if any of the redundant columns are non-empty
+      local max_redundant = {}
+      for i, v in ipairs(redundant_columns) do
+        max_redundant[i] = string.format([[max(%s) AS %s]], v, v)
+      end
+      local sql_check_blank = [[SELECT %s from %s;]]
+      local sql = sql_check_blank:format(table.concat(max_redundant, ", "), s_name)
+      local blank_cur = conn:execute(sql)
+      local blank_results = blank_cur:fetch({}, "a")
+      blank_cur:close()
+      local not_blank = {}
+      for k, _ in pairs(blank_results) do
+        table.insert(not_blank, k)
+      end
+      
+      -- if non-empty columns are supposed to be dropped and not force, raise an error
+      assert(not not_blank[1] or force, "db:_migrate halted due to data present in undefined columns: "..table.concat(not_blank, ","))
+      
       local get_create = "SELECT sql FROM sqlite_master " ..
       "WHERE type = 'table' AND " ..
       "name = '" .. s_name .. "'"
@@ -1276,7 +1256,9 @@ end
 -- type of the specified field. Strings will be single-quoted (and single-quotes
 -- within will be properly escaped), numbers will be rendered properly, and such.
 function db:_coerce(field, value)
-  if field.type == "number" then
+  if type(value) == "table" and value._isNull then
+    return "NULL"
+  elseif field.type == "number" then
     return tonumber(value) or "'" .. value .. "'"
   elseif field.type == "datetime" then
     if value._timestamp == false then
@@ -1625,6 +1607,9 @@ function db:Timestamp(ts, fmt)
   return setmetatable(dt, db.__TimestampMT)
 end
 
+function db:Null()
+  return {_isNull = true}
+end
 
 
 db.Field = {}

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -362,8 +362,8 @@ function db:_sql_values(values)
       else
         s = "datetime('" .. v._timestamp .. "', 'unixepoch')"
       end
-		elseif t == "table" and v._isNull then
-			s = "NULL"
+    elseif t == "table" and v._isNull then
+      s = "NULL"
     else
       s = tostring(v)
     end

--- a/src/mudlet-lua/lua/DB.lua
+++ b/src/mudlet-lua/lua/DB.lua
@@ -603,7 +603,7 @@ function db:_migrate(db_name, s_name, force)
         table.insert(not_blank, k)
       end
       
-      -- if non-empty columns are supposed to be dropped and not force, raise an error
+      -- don't drop non-empty columns unless force flag is provided
       assert(not not_blank[1] or force, "db:_migrate halted due to data present in undefined columns: "..table.concat(not_blank, ","))
       
       local get_create = "SELECT sql FROM sqlite_master " ..

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -375,7 +375,7 @@ describe("Tests DB.lua functions", function()
     function()
       local test = { name = "foo", id = 500, blubb = "bar" }
       db:add(mydb.sheet, test)
-      mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }})
+      mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}, true)
       local res = db:fetch(mydb.sheet)
       test.blubb = nil -- we expect the blubb gets deleted
       assert.are.equal(1, #res)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -105,7 +105,7 @@ describe("Tests DB.lua functions", function()
         local results = db:fetch(mydb.enemies)
         assert.is_true(#results == 1)
       end)
-			
+      
       it("Should replace a db entry if add_unique is used and the unique index matches", function()
         db:add(mydb.enemies, {name="Bob", city="Sacramento"})
         db:add(mydb.enemies, {name="Bob", city="San Francisco"})
@@ -382,17 +382,17 @@ describe("Tests DB.lua functions", function()
       res[1]._row_id = nil --we get the row id back, which we don't need
       assert.are.same(test, res[1])
     end)
-		
-		it("should fail to delete columns in a non empty table if force argument is not provided.",
+    
+    it("should fail to delete columns in a non empty table if force argument is not provided.",
     function()
-			local test = { name = "foo", id = 500, blubb = "bar" }
+      local test = { name = "foo", id = 500, blubb = "bar" }
       db:add(mydb.sheet, test)
       assert.has_error(function() db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}) end)
     end)
-		
-		it("should successfully delete empty columns in a non empty table",
-		function()
-			local test = { name = "foo", id = 500, blubb = db:Null() }
+    
+    it("should successfully delete empty columns in a non empty table",
+    function()
+      local test = { name = "foo", id = 500, blubb = db:Null() }
       db:add(mydb.sheet, test)
       mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}, true)
       local res = db:fetch(mydb.sheet)
@@ -400,7 +400,7 @@ describe("Tests DB.lua functions", function()
       assert.are.equal(1, #res)
       res[1]._row_id = nil --we get the row id back, which we don't need
       assert.are.same(test, res[1])
-		end)
+    end)
   end)
 
 
@@ -907,130 +907,130 @@ describe("Tests DB.lua functions", function()
       assert.is.same(exp_count, count)
     end)
   end)
-	
-	describe("Tests, if NULL handling works as intended",
-	function()
-		before_each(function()
-			mydb = db:create("mydbt_nulltesting",
-				{
-					sheet = {
-						name = "",
-						level = 0,
-						motto = "",
-						_unique = { "name" },
-					}
-				})
-		end)
-		
-		after_each(function()
-			db:close()
-			local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
+  
+  describe("Tests, if NULL handling works as intended",
+  function()
+    before_each(function()
+      mydb = db:create("mydbt_nulltesting",
+        {
+          sheet = {
+            name = "",
+            level = 0,
+            motto = "",
+            _unique = { "name" },
+          }
+        })
+    end)
+    
+    after_each(function()
+      db:close()
+      local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
       os.remove(filename)
       mydb = nil
-		end)
-		
-		it("should be able to insert NULL values",
-		function()
-			local test = {name = "Bellman", level = db:Null(), motto = ""}
-			db:add(mydb.sheet, test)
-			test.level = nil
-			local results = db:fetch(mydb.sheet)
-			assert.is_true(#results == 1)
-			results[1]._row_id = nil
-			assert.are.same(results[1], test)
-		end)
-		
-		it("should be able to fetch by NULL conditions",
-		function()
-			local test1 = {name = "Boots", level = 1, motto = ""}
-			local test2 = {name = "Bellman", level = db:Null(), motto = ""}
-			db:add(mydb.sheet, test1, test2)
-			test2.level = nil
-			local results_null = db:fetch(mydb.sheet, db:is_nil(mydb.sheet.level))
-			assert.is_true(#results_null == 1)
-			results_null[1]._row_id = nil
-			assert.are.same(results_null[1], test2)
-			local results_not_null = db:fetch(mydb.sheet, db:is_not_nil(mydb.sheet.level))
-			assert.is_true(#results_not_null == 1)
-			results_not_null[1]._row_id = nil
-			assert.are.same(results_not_null[1], test1)
-		end)
-		
-		it("should be able to set an existing field to NULL",
-		function()
-			local test = {name = "Bellman", level = 1, motto = "Four weeks to the month you may mark"}
-			db:add(mydb.sheet, test)
-			db:set(mydb.sheet.motto, db:Null(), db:eq(mydb.sheet.name, "Bellman"))
-			test.motto = nil
-			local results = db:fetch(mydb.sheet)
-			assert.is_true(#results == 1)
-			results[1]._row_id = nil
-			assert.are.same(results[1], test)
-		end)
-	end)
-	
-	describe("Tests, if default NULL works as intended",
-	function()
-		after_each(function()
-			db:close()
-			local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
-			os.remove(filename)
-			mydb = nil
-		end)
-			
-		it("should be able to create a table with default NULL",
-		function()
-			mydb = db:create("mydbt_nulltesting",
-			{
-				sheet = {
-					name = "",
-					house = db:Null(),
-					_unique = { "name" },
-				}
-			})
-			local test1 = {name = "Hermione", house = "Griffindor"}
-			local test2 = {name = "Viktor"}
-			db:add(mydb.sheet, test1, test2)
-			test2.house = nil
-			results1 = db:fetch(mydb.sheet, db:is_not_nil(mydb.sheet.house))
-			results2 = db:fetch(mydb.sheet, db:is_nil(mydb.sheet.house))
-			assert.is_true(#results1 == 1)
-			results1[1]._row_id = nil
-			assert.are.same(results1[1], test1)
-			assert.is_true(#results2 == 1)
-			results2[1]._row_id = nil
-			assert.are.same(results2[1], test2)
-		end)
-		
-		it("should be able to add a column with default NULL to a table",
-		function()
-			mydb = db:create("mydbt_nulltesting",
-			{
-				sheet = {
-					name = "",
-					level = 1,
-					_unique = { "name" },
-				}
-			})
-			
-			mydb = db:create("mydbt_nulltesting",
-			{
-				sheet = {
-					name = "",
-					level = 1,
-					house = db:Null(),
-					_unique = { "name" },
-				}
-			})
-			local test =  { {name = "Laergon", level = 1, house = "Kharon"}, {name = "Mymla", level = 5} }
-			db:add(mydb.sheet, test[1], test[2])
-			local results = db:fetch(mydb.sheet)
-			assert.is_true(#results == 2)
-			results[1]._row_id = nil
-			results[2]._row_id = nil
-			assert.is_true(table.size(results[1]) == 3)
-			assert.is_true(table.size(results[2]) == 2)
-			assert.are.same(results, test)
-		end)
-	end)
+    end)
+    
+    it("should be able to insert NULL values",
+    function()
+      local test = {name = "Bellman", level = db:Null(), motto = ""}
+      db:add(mydb.sheet, test)
+      test.level = nil
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+      results[1]._row_id = nil
+      assert.are.same(results[1], test)
+    end)
+    
+    it("should be able to fetch by NULL conditions",
+    function()
+      local test1 = {name = "Boots", level = 1, motto = ""}
+      local test2 = {name = "Bellman", level = db:Null(), motto = ""}
+      db:add(mydb.sheet, test1, test2)
+      test2.level = nil
+      local results_null = db:fetch(mydb.sheet, db:is_nil(mydb.sheet.level))
+      assert.is_true(#results_null == 1)
+      results_null[1]._row_id = nil
+      assert.are.same(results_null[1], test2)
+      local results_not_null = db:fetch(mydb.sheet, db:is_not_nil(mydb.sheet.level))
+      assert.is_true(#results_not_null == 1)
+      results_not_null[1]._row_id = nil
+      assert.are.same(results_not_null[1], test1)
+    end)
+    
+    it("should be able to set an existing field to NULL",
+    function()
+      local test = {name = "Bellman", level = 1, motto = "Four weeks to the month you may mark"}
+      db:add(mydb.sheet, test)
+      db:set(mydb.sheet.motto, db:Null(), db:eq(mydb.sheet.name, "Bellman"))
+      test.motto = nil
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 1)
+      results[1]._row_id = nil
+      assert.are.same(results[1], test)
+    end)
+  end)
+  
+  describe("Tests, if default NULL works as intended",
+  function()
+    after_each(function()
+      db:close()
+      local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
+      os.remove(filename)
+      mydb = nil
+    end)
+      
+    it("should be able to create a table with default NULL",
+    function()
+      mydb = db:create("mydbt_nulltesting",
+      {
+        sheet = {
+          name = "",
+          house = db:Null(),
+          _unique = { "name" },
+        }
+      })
+      local test1 = {name = "Hermione", house = "Griffindor"}
+      local test2 = {name = "Viktor"}
+      db:add(mydb.sheet, test1, test2)
+      test2.house = nil
+      results1 = db:fetch(mydb.sheet, db:is_not_nil(mydb.sheet.house))
+      results2 = db:fetch(mydb.sheet, db:is_nil(mydb.sheet.house))
+      assert.is_true(#results1 == 1)
+      results1[1]._row_id = nil
+      assert.are.same(results1[1], test1)
+      assert.is_true(#results2 == 1)
+      results2[1]._row_id = nil
+      assert.are.same(results2[1], test2)
+    end)
+    
+    it("should be able to add a column with default NULL to a table",
+    function()
+      mydb = db:create("mydbt_nulltesting",
+      {
+        sheet = {
+          name = "",
+          level = 1,
+          _unique = { "name" },
+        }
+      })
+      
+      mydb = db:create("mydbt_nulltesting",
+      {
+        sheet = {
+          name = "",
+          level = 1,
+          house = db:Null(),
+          _unique = { "name" },
+        }
+      })
+      local test =  { {name = "Laergon", level = 1, house = "Kharon"}, {name = "Mymla", level = 5} }
+      db:add(mydb.sheet, test[1], test[2])
+      local results = db:fetch(mydb.sheet)
+      assert.is_true(#results == 2)
+      results[1]._row_id = nil
+      results[2]._row_id = nil
+      assert.is_true(table.size(results[1]) == 3)
+      assert.is_true(table.size(results[2]) == 2)
+      assert.are.same(results, test)
+    end)
+  end)
 end)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -105,7 +105,7 @@ describe("Tests DB.lua functions", function()
         local results = db:fetch(mydb.enemies)
         assert.is_true(#results == 1)
       end)
-
+			
       it("Should replace a db entry if add_unique is used and the unique index matches", function()
         db:add(mydb.enemies, {name="Bob", city="Sacramento"})
         db:add(mydb.enemies, {name="Bob", city="San Francisco"})
@@ -907,5 +907,130 @@ describe("Tests DB.lua functions", function()
       assert.is.same(exp_count, count)
     end)
   end)
-
+	
+	describe("Tests, if NULL handling works as intended",
+	function()
+		before_each(function()
+			mydb = db:create("mydbt_nulltesting",
+				{
+					sheet = {
+						name = "",
+						level = 0,
+						motto = "",
+						_unique = { "name" },
+					}
+				})
+		end)
+		
+		after_each(function()
+			db:close()
+			local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
+      os.remove(filename)
+      mydb = nil
+		end)
+		
+		it("should be able to insert NULL values",
+		function()
+			local test = {name = "Bellman", level = db:Null(), motto = ""}
+			db:add(mydb.sheet, test)
+			test.level = nil
+			local results = db:fetch(mydb.sheet)
+			assert.is_true(#results == 1)
+			results[1]._row_id = nil
+			assert.are.same(results[1], test)
+		end)
+		
+		it("should be able to fetch by NULL conditions",
+		function()
+			local test1 = {name = "Boots", level = 1, motto = ""}
+			local test2 = {name = "Bellman", level = db:Null(), motto = ""}
+			db:add(mydb.sheet, test1, test2)
+			test2.level = nil
+			local results_null = db:fetch(mydb.sheet, db:is_nil(mydb.sheet.level))
+			assert.is_true(#results_null == 1)
+			results_null[1]._row_id = nil
+			assert.are.same(results_null[1], test2)
+			local results_not_null = db:fetch(mydb.sheet, db:is_not_nil(mydb.sheet.level))
+			assert.is_true(#results_not_null == 1)
+			results_not_null[1]._row_id = nil
+			assert.are.same(results_not_null[1], test1)
+		end)
+		
+		it("should be able to set an existing field to NULL",
+		function()
+			local test = {name = "Bellman", level = 1, motto = "Four weeks to the month you may mark"}
+			db:add(mydb.sheet, test)
+			db:set(mydb.sheet.motto, db:Null(), db:eq(mydb.sheet.name, "Bellman"))
+			test.motto = nil
+			local results = db:fetch(mydb.sheet)
+			assert.is_true(#results == 1)
+			results[1]._row_id = nil
+			assert.are.same(results[1], test)
+		end)
+	end)
+	
+	describe("Tests, if default NULL works as intended",
+	function()
+		after_each(function()
+			db:close()
+			local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
+			os.remove(filename)
+			mydb = nil
+		end)
+			
+		it("should be able to create a table with default NULL",
+		function()
+			mydb = db:create("mydbt_nulltesting",
+			{
+				sheet = {
+					name = "",
+					house = db:Null(),
+					_unique = { "name" },
+				}
+			})
+			local test1 = {name = "Hermione", house = "Griffindor"}
+			local test2 = {name = "Viktor"}
+			db:add(mydb.sheet, test1, test2)
+			test2.house = nil
+			results1 = db:fetch(mydb.sheet, db:is_not_nil(mydb.sheet.house))
+			results2 = db:fetch(mydb.sheet, db:is_nil(mydb.sheet.house))
+			assert.is_true(#results1 == 1)
+			results1[1]._row_id = nil
+			assert.are.same(results1[1], test1)
+			assert.is_true(#results2 == 1)
+			results2[1]._row_id = nil
+			assert.are.same(results2[1], test2)
+		end)
+		
+		it("should be able to add a column with default NULL to a table",
+		function()
+			mydb = db:create("mydbt_nulltesting",
+			{
+				sheet = {
+					name = "",
+					level = 1,
+					_unique = { "name" },
+				}
+			})
+			
+			mydb = db:create("mydbt_nulltesting",
+			{
+				sheet = {
+					name = "",
+					level = 1,
+					house = db:Null(),
+					_unique = { "name" },
+				}
+			})
+			local test =  { {name = "Laergon", level = 1, house = "Kharon"}, {name = "Mymla", level = 5} }
+			db:add(mydb.sheet, test[1], test[2])
+			local results = db:fetch(mydb.sheet)
+			assert.is_true(#results == 2)
+			results[1]._row_id = nil
+			results[2]._row_id = nil
+			assert.is_true(table.size(results[1]) == 3)
+			assert.is_true(table.size(results[2]) == 2)
+			assert.are.same(results, test)
+		end)
+	end)
 end)

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -371,7 +371,7 @@ describe("Tests DB.lua functions", function()
       assert.are.same(test, res[1])
     end)
 
-    it("should successfully delete columns in a non empty table.",
+    it("should successfully delete columns in a non empty table if force argument is provided.",
     function()
       local test = { name = "foo", id = 500, blubb = "bar" }
       db:add(mydb.sheet, test)
@@ -382,7 +382,25 @@ describe("Tests DB.lua functions", function()
       res[1]._row_id = nil --we get the row id back, which we don't need
       assert.are.same(test, res[1])
     end)
-
+		
+		it("should fail to delete columns in a non empty table if force argument is not provided.",
+    function()
+			local test = { name = "foo", id = 500, blubb = "bar" }
+      db:add(mydb.sheet, test)
+      assert.has_error(function() db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}) end)
+    end)
+		
+		it("should successfully delete empty columns in a non empty table",
+		function()
+			local test = { name = "foo", id = 500, blubb = db:Null() }
+      db:add(mydb.sheet, test)
+      mydb = db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}, true)
+      local res = db:fetch(mydb.sheet)
+      test.blubb = nil -- we expect the blubb gets deleted
+      assert.are.equal(1, #res)
+      res[1]._row_id = nil --we get the row id back, which we don't need
+      assert.are.same(test, res[1])
+		end)
   end)
 
 

--- a/src/mudlet-lua/tests/DB_spec.lua
+++ b/src/mudlet-lua/tests/DB_spec.lua
@@ -105,7 +105,7 @@ describe("Tests DB.lua functions", function()
         local results = db:fetch(mydb.enemies)
         assert.is_true(#results == 1)
       end)
-      
+
       it("Should replace a db entry if add_unique is used and the unique index matches", function()
         db:add(mydb.enemies, {name="Bob", city="Sacramento"})
         db:add(mydb.enemies, {name="Bob", city="San Francisco"})
@@ -382,14 +382,14 @@ describe("Tests DB.lua functions", function()
       res[1]._row_id = nil --we get the row id back, which we don't need
       assert.are.same(test, res[1])
     end)
-    
+
     it("should fail to delete columns in a non empty table if force argument is not provided.",
     function()
       local test = { name = "foo", id = 500, blubb = "bar" }
       db:add(mydb.sheet, test)
       assert.has_error(function() db:create("mydbt_testingonly", { sheet = { name = "", id = 0 }}) end)
     end)
-    
+
     it("should successfully delete empty columns in a non empty table",
     function()
       local test = { name = "foo", id = 500, blubb = db:Null() }
@@ -907,7 +907,7 @@ describe("Tests DB.lua functions", function()
       assert.is.same(exp_count, count)
     end)
   end)
-  
+
   describe("Tests, if NULL handling works as intended",
   function()
     before_each(function()
@@ -921,14 +921,14 @@ describe("Tests DB.lua functions", function()
           }
         })
     end)
-    
+
     after_each(function()
       db:close()
       local filename = getMudletHomeDir() .. "/Database_mydbtnulltesting.db"
       os.remove(filename)
       mydb = nil
     end)
-    
+
     it("should be able to insert NULL values",
     function()
       local test = {name = "Bellman", level = db:Null(), motto = ""}
@@ -939,7 +939,7 @@ describe("Tests DB.lua functions", function()
       results[1]._row_id = nil
       assert.are.same(results[1], test)
     end)
-    
+
     it("should be able to fetch by NULL conditions",
     function()
       local test1 = {name = "Boots", level = 1, motto = ""}
@@ -955,7 +955,7 @@ describe("Tests DB.lua functions", function()
       results_not_null[1]._row_id = nil
       assert.are.same(results_not_null[1], test1)
     end)
-    
+
     it("should be able to set an existing field to NULL",
     function()
       local test = {name = "Bellman", level = 1, motto = "Four weeks to the month you may mark"}
@@ -968,7 +968,7 @@ describe("Tests DB.lua functions", function()
       assert.are.same(results[1], test)
     end)
   end)
-  
+
   describe("Tests, if default NULL works as intended",
   function()
     after_each(function()
@@ -977,7 +977,7 @@ describe("Tests DB.lua functions", function()
       os.remove(filename)
       mydb = nil
     end)
-      
+
     it("should be able to create a table with default NULL",
     function()
       mydb = db:create("mydbt_nulltesting",
@@ -1001,7 +1001,7 @@ describe("Tests DB.lua functions", function()
       results2[1]._row_id = nil
       assert.are.same(results2[1], test2)
     end)
-    
+
     it("should be able to add a column with default NULL to a table",
     function()
       mydb = db:create("mydbt_nulltesting",
@@ -1012,7 +1012,7 @@ describe("Tests DB.lua functions", function()
           _unique = { "name" },
         }
       })
-      
+
       mydb = db:create("mydbt_nulltesting",
       {
         sheet = {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- allows assigning `NULL` values through `db` methods
- added checking for non-`NULL` values in columns that would be dropped by `db:create` and `db:_migrate` methods, in accordance with existing comments in DB.lua
- added tests to DB_spec.lua to validate the changes

#### Motivation for adding to Mudlet
- `NULL` is already partially supported through `db:is_nil` and `db:is_not_nil` methods. This expands on those capabilities
- where a blank value such as `""` is itself a possibility for a field, it is useful to indicate "unknown" with `NULL`
- dropping columns without checking for presence of non-`NULL` values could cause unexpected loss of data