### PR TITLE
Improve: Busted installation instructions on Windows

### DIFF
--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -24,9 +24,9 @@ On **Windows**
 	  - Setting `Path` and `PATHEXT` is fine
 2. Install Busted
 	- Open a command prompt and enter `luarocks install busted`
-	- If you get a command not recognized message
+	- If you get a `'luarocks' is not recognized...` message:
 	  - You may need to add the LuaRocks directory to your `Path` system environment variable and restart
-		- Alternatively, navigate the command prompt to the LuaRocks directory to run LuaRocks commands
+	  - Alternatively, navigate the command prompt to the LuaRocks directory to run LuaRocks commands
 
 You're now ready to run the tests.
 

--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -12,8 +12,8 @@ On **macOS**:
 	
 On **Windows**
 
-1. Install LuaRocks (Windows all-in-one executable (32-bit) is the version you need)
-	- Unzip the installer
+1. Download and unzip [LuaRocks](https://luarocks.org/releases/luarocks-3.8.0-windows-32.zip)
+
   - Open the x86 Native Tools Command Prompt that comes with Visual Studio in administrator mode (regular command prompt may work but is untested; the x64 Native Tools Command Prompt will *not* work)
 	- Navigate to the folder containing the unzipped files
 	- `install /P <install_path> /SELFCONTAINED /L` (omit angular brackets)

--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -9,6 +9,23 @@ On **macOS**:
 
 	brew install luarocks
 	luarocks install busted
+	
+On **Windows**
+
+1. Install LuaRocks (Windows all-in-one executable (32-bit) is the version you need)
+	- Unzip the installer
+  - Open the x86 Native Tools Command Prompt that comes with Visual Studio in administrator mode (regular command prompt may work but is untested; the x64 Native Tools Command Prompt will *not* work)
+	- Navigate to the folder containing the unzipped files
+	- `install /P <install_path> /SELFCONTAINED /L` (omit angular brackets)
+	  - You may need to include the `/F` option if you have previously installed LuaRocks
+	- Write down the recommend `LUA_PATH` and `LUA_CPATH` somewhere. You will need them in the running tests section
+	  - Do *not* set `LUA_PATH` or `LUA_CPATH` system environment variables as suggested by the installer output. It will interfere with Mudlet's package loader
+	  - Setting `Path` and `PATHEXT` is fine
+2. Install Busted
+	- Open a command prompt and enter `luarocks install busted`
+	- If you get a command not recognized message
+	  - You may need to add the LuaRocks directory to your `Path` system environment variable and restart
+		- Alternatively, navigate the command prompt to the LuaRocks directory to run LuaRocks commands
 
 You're now ready to run the tests.
 
@@ -16,6 +33,9 @@ You're now ready to run the tests.
 
 1. Open the `Mudlet self-test` profile by typing the name in the connection dialog ([example](https://wiki.mudlet.org/images/4/4d/Opening_Mudlet_self-test_profile.webm
 )).
+  - If you are following the instruction on Windows, add a script that appends the LuaRocks `LUA_PATH` and `LUA_CPATH` to `package.path` and `package.cpath`, respectively
+	  - This should be placed above the "test scripts" script
+	  - Example: `package.cpath = package.cpath .. [[;%APPDATA%\LuaRocks\lib\lua\5.1\?.dll;d:\l\luarocks\systree\lib\lua\5.1\?.dll]]`
 2. Use the `runTests` either with the location of the folder with all tests, or a specific test:
 ```
 -- run all tests in the folder:

--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -14,6 +14,7 @@ On **Windows**
 
 1. Download and unzip [LuaRocks](https://luarocks.org/releases/luarocks-3.8.0-windows-32.zip)
 
+  - Install Visual Studio (the [free community edition](https://visualstudio.microsoft.com/vs/community/) works)
   - Open the x86 Native Tools Command Prompt that comes with Visual Studio in administrator mode (regular command prompt may work but is untested; the x64 Native Tools Command Prompt will *not* work)
 	- Navigate to the folder containing the unzipped files
 	- `install /P <install_path> /SELFCONTAINED /L` (omit angular brackets)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- added instructions to install LuaRocks and Busted to be compatible with Mudlet
- added instructions to work around the package pathing problem
#### Motivation for adding to Mudlet
- getting Busted to work with Mudlet on Windows is non-trivial
- suggested by Vadi
