### PR TITLE
Infrastructure: update OpenSSL used for Windows

### DIFF
--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -242,7 +242,7 @@ function InstallPython() {
 
 function InstallOpenssl() {
   # needs to be from http://wiki.overbyte.eu/wiki/index.php/ICS_Download as it includes extra binaries not available on openssl.org
-  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1l-win32.zip" "openssl-win32.zip"
+  DownloadFile "http://wiki.overbyte.eu/arch/openssl-1.1.1n-win32.zip" "openssl-win32.zip"
   ExtractZip "openssl-win32.zip" "openssl"
   Step "installing"
   exec "XCOPY" @("/S", "/I", "/Q", "openssl", "$Env:MINGW_BASE_DIR\bin")


### PR DESCRIPTION
From `1.1.1l` (that last character is lower case 'L') to `1.1.1n`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>