### PR TITLE
Infrastructure: repair Windows CI build failures

### DIFF
--- a/.github/workflows/dangerjs.yml
+++ b/.github/workflows/dangerjs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: "12.x"
+        node-version: "14.x"
     - name: Install yarn dependencies
       run: |
         yarn add danger --dev

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -234,8 +234,10 @@ function InstallQt() {
   cd ..
   Step "Installing Qt"
   exec "aqt" @("install-qt", "windows", "desktop", "5.14.2", "win32_mingw73")
-  Step "Installing the mingw toolset we want: qt.tools.win32_mingw730"
-  exec "aqt" @("install-tool", "windows", "desktop", "qt.tools.win32_mingw730")
+  Step "Checking the mingw toolsets available:"
+  exec "aqt" @("list-tool", "windows", "desktop")
+  Step "Trying to install the mingw toolset we think we want: qt.tools.win32_mingw73"
+  exec "aqt" @("install-tool", "windows", "desktop", "qt.tools.win32_mingw73")
 }
 
 function InstallPython() {

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -299,7 +299,7 @@ function InstallPcre() {
   DownloadFile "https://deac-fra.dl.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.zip" "pcre.zip"
   ExtractZip "pcre.zip" "pcre"
   Set-Location pcre\pcre-8.45
-  RunConfigure "--enable-utf --enable-unicode-properties --prefix=$Env:MINGW_BASE_DIR_BASH"
+  RunConfigure "--disable-dependency-tracking --enable-utf --enable-unicode-properties --prefix=$Env:MINGW_BASE_DIR_BASH"
   RunMake
   RunMakeInstall
 }

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -340,7 +340,7 @@ function InstallLibzip() {
   }
   Set-Location build
   Step "running cmake"
-  exec "cmake" @("-G", "`"MinGW Makefiles`"", "-DCMAKE_INSTALL_PREFIX=`"$Env:MINGW_BASE_DIR`"", "-DENABLE_OPENSSL=OFF", "..")
+  exec "cmake" @("-G", "`"MinGW Makefiles`"", "-DCMAKE_INSTALL_PREFIX=`"$Env:MINGW_BASE_DIR`"", "-DENABLE_OPENSSL=OFF", "-DBUILD_REGRESS=OFF", "-DBUILD_EXAMPLES=OFF", "-DBUILD_DOC=OFF", "..")
   RunMake
   RunMakeInstall
   $Env:Path = $ShPath

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -234,10 +234,12 @@ function InstallQt() {
   cd ..
   Step "Installing Qt"
   exec "aqt" @("install-qt", "windows", "desktop", "5.14.2", "win32_mingw73")
-  Step "Checking the mingw toolsets available:"
+  Step "Checking the tools available:"
   exec "aqt" @("list-tool", "windows", "desktop")
-  Step "Trying to install the mingw toolset we think we want: qt.tools.win32_mingw73"
-  exec "aqt" @("install-tool", "windows", "desktop", "qt.tools.win32_mingw73")
+  Step "Checking the mingw toolsets available:"
+  exec "aqt" @("list-tool", "windows", "desktop", "tools_mingw")
+  Step "Trying to install a mingw toolset we want to use: qt.tools.win32_mingw730"
+  exec "aqt" @("install-tool", "windows", "desktop", "qt.tools.win32_mingw730")
 }
 
 function InstallPython() {

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -144,7 +144,7 @@ function RunMake([string] $makefile = "Makefile", [bool] $singleJob = $false){
     Step "Running make"
     try{
       if ($singleJob) {
-        exec "mingw32-make" @("-f", "$makefile"))
+        exec "mingw32-make" @("-f", "$makefile")
       }else{
         exec "mingw32-make" @("-f", "$makefile", "-j", $(Get-WmiObject win32_processor | Select -ExpandProperty "NumberOfLogicalProcessors"))
       }

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -239,7 +239,7 @@ function InstallQt() {
   Step "Checking the mingw toolsets available:"
   exec "aqt" @("list-tool", "windows", "desktop", "tools_mingw")
   Step "Trying to install a mingw toolset we want to use: qt.tools.win32_mingw730"
-  exec "aqt" @("install-tool", "windows", "desktop", "qt.tools.win32_mingw730")
+  exec "aqt" @("install-tool", "windows", "desktop", "tools_mingw", "qt.tools.win32_mingw730")
 }
 
 function InstallPython() {

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -234,6 +234,8 @@ function InstallQt() {
   cd ..
   Step "Installing Qt"
   exec "aqt" @("install-qt", "windows", "desktop", "5.14.2", "win32_mingw73")
+  Step "Installing the mingw toolset we want: qt.tools.win32_mingw730"
+  exec "aqt" @("install-tool", "windows", "desktop", "qt.tools.win32_mingw730")
 }
 
 function InstallPython() {


### PR DESCRIPTION
During running of the CI builds on AppVeyor for Windows we now are getting errors during the `.configure` stage for the build of PCRE - and we get the advices to try using the additional `--disable-dependency-tracking` to fix it. This PR tried to do that to see if it fixed things, but it didn't.

Further investigation by @keneanung and myself eventually revealed that although #6030 installed Qt it was not installing the expected Mingw GCC compiler (32-bit 7.3.0) - further digging revealed that an addition step was needed to do that.

During the investigation I spotted that when building `libzip` we were also building the regression tests, the documentation and the examples - none of which are used or needed by our Windows CI builds. So disabling them should reduce the build time slightly and there was no point to undoing the change that disabled their being built.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>