### PR TITLE
Fix: add handling of new features element in IRE Muds XML map format

### DIFF
--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -502,7 +502,7 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
             // If there is a "hidden" exit mark it as a locked door, otherwise
             // if there is a "door" mark it as an open/closed/locked door
             // depending on the value (I.R.E. MUD maps always uses "1" for "door"
-            // and/or "hidden" - though the latter does not alway appear with
+            // and/or "hidden" - though the latter does not always appear with
             // former):
             int door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
                     ? 3

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -474,7 +474,7 @@ void XMLimport::readRoomFeatures(TRoom* pR)
 void XMLimport::readRoomFeature(TRoom* pR)
 {
     if (Q_LIKELY(attributes().hasAttribute(qsl("type")))) {
-        pR->userData.insert(qsl("feature_%1").arg(attributes().value(qsl("type"))), qsl("true"));
+        pR->userData.insert(qsl("feature-%1").arg(attributes().value(qsl("type"))), qsl("true"));
     }
 }
 

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -28,6 +28,7 @@
 #include "TConsole.h"
 #include "TMap.h"
 #include "TRoomDB.h"
+#include "TRoom.h"
 #include "VarUnit.h"
 #include "mudlet.h"
 
@@ -447,9 +448,33 @@ void XMLimport::readRooms(QMultiHash<int, int>& areaRoomsHash)
             } else {
                 readUnknownMapElement();
             }
-        } else if (isEndElement()) {
+        } else if (isEndElement() && name() == qsl("rooms")) {
             break;
         }
+    }
+}
+
+void XMLimport::readRoomFeatures(TRoom* pR)
+{
+    while (!atEnd()) {
+        readNext();
+
+        if (Q_LIKELY(isStartElement())) {
+            if (name() == qsl("features")) {
+                continue;
+            } else if (Q_LIKELY(name() == qsl("feature"))) {
+                readRoomFeature(pR);
+            }
+        } else if (isEndElement() && name() == qsl("features")) {
+            break;
+        }
+    }
+}
+
+void XMLimport::readRoomFeature(TRoom* pR)
+{
+    if (Q_LIKELY(attributes().hasAttribute(qsl("type")))) {
+        pR->userData.insert(qsl("feature_%1").arg(attributes().value(qsl("type"))), qsl("true"));
     }
 }
 
@@ -474,32 +499,62 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
         } else if (Q_LIKELY(name() == qsl("exit"))) {
             QString dir = attributes().value(qsl("direction")).toString();
             int e = attributes().value(qsl("target")).toString().toInt();
+            // If there is a "hidden" exit mark it as a locked door, otherwise
+            // if there is a "door" mark it as an open/closed/locked door
+            // depending on the value (I.R.E. MUD maps always uses "1" for "door"
+            // and/or "hidden" - though the latter does not alway appear with
+            // former):
+            int door = (attributes().hasAttribute(qsl("hidden")) && attributes().value(qsl("hidden")).toString().toInt() == 1)
+                    ? 3
+                    : (attributes().hasAttribute(qsl("door")) && attributes().value(qsl("door")).toString().toInt() >= 0 && attributes().value(qsl("door")).toString().toInt() <= 3)
+                      ? attributes().value(qsl("door")).toString().toInt()
+                      : 0;
             if (dir.isEmpty()) {
-                continue;
+                if (attributes().value(qsl("special")).toString().toInt() == 1 && !attributes().value(qsl("command")).toString().isEmpty()) {
+                    // This is how IRE XML maps mark special exits, rather than
+                    // by just using a different string for the direction!
+                    dir = attributes().value(qsl("command")).toString();
+                    pT->setSpecialExit(e, dir);
+                    pT->setDoor(dir, door);
+                } else {
+                    continue;
+                }
             } else if (dir == qsl("north")) {
                 pT->north = e;
+                pT->setDoor(qsl("n"), door);
             } else if (dir == qsl("east")) {
                 pT->east = e;
+                pT->setDoor(qsl("e"), door);
             } else if (dir == qsl("south")) {
                 pT->south = e;
+                pT->setDoor(qsl("s"), door);
             } else if (dir == qsl("west")) {
                 pT->west = e;
+                pT->setDoor(qsl("w"), door);
             } else if (dir == qsl("up")) {
                 pT->up = e;
+                pT->setDoor(qsl("up"), door);
             } else if (dir == qsl("down")) {
                 pT->down = e;
+                pT->setDoor(qsl("down"), door);
             } else if (dir == qsl("northeast")) {
                 pT->northeast = e;
+                pT->setDoor(qsl("ne"), door);
             } else if (dir == qsl("southwest")) {
                 pT->southwest = e;
+                pT->setDoor(qsl("sw"), door);
             } else if (dir == qsl("southeast")) {
                 pT->southeast = e;
+                pT->setDoor(qsl("se"), door);
             } else if (dir == qsl("northwest")) {
                 pT->northwest = e;
+                pT->setDoor(qsl("nw"), door);
             } else if (dir == qsl("in")) {
                 pT->in = e;
+                pT->setDoor(qsl("in"), door);
             } else if (dir == qsl("out")) {
                 pT->out = e;
+                pT->setDoor(qsl("out"), door);
             } else {
                 // TODO: Handle Special Exits
             }
@@ -512,11 +567,13 @@ void XMLimport::readRoom(QMultiHash<int, int>& areamRoomMultiHash, unsigned int*
             pT->y = attributes().value(qsl("y")).toString().toInt();
             pT->z = attributes().value(qsl("z")).toString().toInt();
             continue;
+        } else if (name() == qsl("features")) {
+            readRoomFeatures(pT);
         } else if (Q_UNLIKELY(name().isEmpty())) {
             continue;
         }
 
-        if (isEndElement()) {
+        if (isEndElement() && name() == qsl("room")) {
             break;
         }
     }

--- a/src/XMLimport.h
+++ b/src/XMLimport.h
@@ -45,7 +45,7 @@ class TScript;
 class TTimer;
 class TTrigger;
 class TVar;
-
+class TRoom;
 
 class XMLimport : public QXmlStreamReader
 {
@@ -75,6 +75,8 @@ private:
     void readMap();
     void readRoom(QMultiHash<int, int>&, unsigned int*);
     void readRooms(QMultiHash<int, int>&);
+    void readRoomFeature(TRoom*);
+    void readRoomFeatures(TRoom*);
     void readEnvColor();
     void readEnvColors();
     void readArea();


### PR DESCRIPTION
These were making their maps unloadable by Mudlet as the new `<features>` element, containing one or more `<feature type="????">` were breaking the reader code.

Whilst examining the new files I also spotted that they are including some new exits of the form `<exit special="1", command="Abcde", target="12345">` whilst those are new the current reader will just silently ignore them. However it is easy to parse them as well.

Furthermore "exits" can also have `door="1"` and or `hidden="1"` *attributes* I thought I had put in code to parse those (to convert `door="1"` into an "open" door marking unless there was a `hidden="1"` to turn it into a "locked" door marking) years ago but it seems that detail never made it into the published/used code-base. 🤷‍♂️ 

This should close #6073.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>