### PR TITLE
Infrastructure: don't print danger message if everything was kosher

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -10,12 +10,7 @@ const pr_title = danger.github.pr.title
 // Checks the title to make sure it matches expectations
 const title_type = pr_title.match(TITLE_REGEX)
 if (title_type) {
-  const type_to_readable = {
-    add: "Addition",
-    fix: "Fix",
-    improve: "Improvement",
-    infra: "Infrastructure"
-  }
+  // no-op
 } else if(pr_title.match(/^\[?WIP\]?/i)) {
   fail("PR is still a WIP, do not merge")
 } else {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -16,7 +16,6 @@ if (title_type) {
     improve: "Improvement",
     infra: "Infrastructure"
   }
-  message(`PR type: \`${type_to_readable[title_type[0].toLowerCase()]}\``, {icon: ":heavy_check_mark:", line: 1})
 } else if(pr_title.match(/^\[?WIP\]?/i)) {
   fail("PR is still a WIP, do not merge")
 } else {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't print danger message if everything was kosher
#### Motivation for adding to Mudlet
Less noise when you create a PR
#### Other info (issues closed, discussion etc)
Danger doesn't require printing anything by default: https://github.com/danger/danger-js/discussions/1268#discussioncomment-2543449

We'll have to merge this in order to see if it worked. 

