### PR TITLE
Fix: return empty table if no stub-exits for getExitStubs functions

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2689,9 +2689,6 @@ int TLuaInterpreter::getExitStubs(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid room id").arg(roomId));
     }
     QList<int> stubs = pR->exitStubs;
-    if (stubs.empty()) {
-        return warnArgumentValue(L, __func__, qsl("no stubs in this room with id %1").arg(roomId));
-    }
     lua_newtable(L);
     for (int i = 0, total = stubs.size(); i < total; ++i) {
         lua_pushnumber(L, i);
@@ -2717,9 +2714,6 @@ int TLuaInterpreter::getExitStubs1(lua_State* L)
         return warnArgumentValue(L, __func__, qsl("number %1 is not a valid room id").arg(roomId));
     }
     QList<int> stubs = pR->exitStubs;
-    if (stubs.empty()) {
-        return warnArgumentValue(L, __func__, qsl("no stubs in this room with id %1").arg(roomId));
-    }
     lua_newtable(L);
     for (int i = 0, total = stubs.size(); i < total; ++i) {
         lua_pushnumber(L, i + 1);

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1164,3 +1164,39 @@ if not ttsSpeak then --check if ttsSpeak is defined, if not then Mudlet lacks TT
     _G[fn] = function() debugc(string.format("%s: Mudlet was compiled without TTS capabilities", fn)) end
   end
 end
+
+--[[
+Fixes up getExitStubs() and getExitStubs1() so they do not produce warning
+if there are no stub-exits in the room, instead return just an empty table.
+
+Disabled by default so it does not break existing scripts, but can be enabled by
+setting global noWarningForNoStubExits variable to true.
+--]]
+local oldGetExitStubs = getExitStubs
+local oldGetExitStubs1 = getExitStubs1
+noWarningForNoStubExits = noWarningForNoStubExits or false
+function getExitStubs(...)
+  if noWarningForNoStubExits then
+    local result, errMessage = oldGetExitStubs(...)
+    if result == nil and string.find(errMessage, "no stubs in this room with id") then
+      return {}
+    else
+      return result, errMessage
+    end
+  else
+    return oldGetExitStubs(...)
+  end
+end
+
+function getExitStubs1(...)
+  if noWarningForNoStubExits then
+    local result, errMessage = oldGetExitStubs1(...)
+    if result == nil and string.find(errMessage, "no stubs in this room with id") then
+      return {}
+    else
+      return result, errMessage
+    end
+  else
+    return oldGetExitStubs1(...)
+  end
+end

--- a/src/mudlet-lua/lua/Other.lua
+++ b/src/mudlet-lua/lua/Other.lua
@@ -1178,39 +1178,3 @@ function setConfig(...)
     oldsetConfig(k, v)
   end
 end
-
---[[
-Fixes up getExitStubs() and getExitStubs1() so they do not produce warning
-if there are no stub-exits in the room, instead return just an empty table.
-
-Disabled by default so it does not break existing scripts, but can be enabled by
-setting global noWarningForNoStubExits variable to true.
---]]
-local oldGetExitStubs = getExitStubs
-local oldGetExitStubs1 = getExitStubs1
-noWarningForNoStubExits = noWarningForNoStubExits or false
-function getExitStubs(...)
-  if noWarningForNoStubExits then
-    local result, errMessage = oldGetExitStubs(...)
-    if result == nil and string.find(errMessage, "no stubs in this room with id") then
-      return {}
-    else
-      return result, errMessage
-    end
-  else
-    return oldGetExitStubs(...)
-  end
-end
-
-function getExitStubs1(...)
-  if noWarningForNoStubExits then
-    local result, errMessage = oldGetExitStubs1(...)
-    if result == nil and string.find(errMessage, "no stubs in this room with id") then
-      return {}
-    else
-      return result, errMessage
-    end
-  else
-    return oldGetExitStubs1(...)
-  end
-end


### PR DESCRIPTION
The existing code produces a nil+warning message if there are no exit stubs for a room when `getExitStubs(...)` OR `getExitStubs1(...)` are called on it. This is unfortunate because the only way to find out whether a room has any exit stubs in a script is by using those functions.

Unlike the draft #6069 this does not produce a `nil` *without* a message in just this "problem" case, instead it returns an empty table, so the table can be stored locally and examined in both the case where there are and are not exit stubs. I feel this is a cleaner solution because there are other run-time problem situations that also will produce a `nil` and a message - which that draft doesn't really resolve IMHO.

~~To enable this fix (and thus to change the behaviour away from how a previous script/package might be working to examine the precise error message and thus not be entirely backward compatible) it is necessary to set the global boolean variable `noWarningForNoStubExits` to `true` - this has the nice side-effect that a script/package could test for the existence of this variable to test whether the fix is available!~~

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

*Edited 2022/06/18 to reflect revisions of [cb4e0e4](https://github.com/Mudlet/Mudlet/pull/6081/commits/cb4e0e4e01dadd947708058b41ff69e9f111865e)*