### PR TITLE
Add: indicate locked rooms in exits dialogue

### DIFF
--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -148,7 +148,7 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
             } else {
                 // Something else that isn't a positive number:
                 mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
-                roomIdToolTipText = utils::richText(tr("A positive roomID of the room that this special exit leads to is expected here. "
+                roomIdToolTipText = utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
                                                        "If left like this, this exit will be deleted when <tt>save</tt> is clicked."));
             }
         }
@@ -228,7 +228,7 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
     } else {
         // Something else that isn't a positive number:
         mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
-        roomIdToolTipText = utils::richText(tr("A positive roomID of the room that this special exit leads to is expected here. "
+        roomIdToolTipText = utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
                                                "If left like this, this exit will be deleted when <tt>save</tt> is clicked."));
     }
     mpEditor->setToolTip(roomIdToolTipText);
@@ -968,7 +968,7 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
         // This is the toolTip text for the roomID number column (and the
         // status icons)
         const QString roomIdToolTipText{generateToolTip(pExitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitToRoom->getWeight())};
-        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus, utils::richText(tr("A positive roomID of the room that this special exit leads to is expected here. "
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus, utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
                                                                                           "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
 
         pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, !showIconOnExitStatus
@@ -993,7 +993,7 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     } else {
         // Something else that isn't a positive number:
         pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, showIconOnExitStatus ? mIcon_invalidExit : QIcon());
-        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, utils::richText(tr("A positive roomID of the room that this special exit leads to is expected here. "
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, utils::richText(tr("The roomID of the room that this special exit leads to is expected here. "
                                                                                           "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
     }
 

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -125,12 +125,17 @@ QWidget* RoomIdLineEditDelegate::createEditor(QWidget* parent, const QStyleOptio
                 // Valid exit roomID in place:
                 int exitAreaID = exitToRoom->getArea();
                 bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
-                mpDlgRoomExits->setActionOnExit(mpEditor, outOfAreaExit ? mpDlgRoomExits->mpAction_otherAreaExit : mpDlgRoomExits->mpAction_inAreaExit);
+                bool exitRoomLocked = exitToRoom->isLocked;
+                mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
+                                                ? mpDlgRoomExits->mpAction_exitRoomLocked
+                                                : outOfAreaExit
+                                                  ? mpDlgRoomExits->mpAction_otherAreaExit
+                                                  : mpDlgRoomExits->mpAction_inAreaExit);
                 QString exitAreaName;
                 if (outOfAreaExit) {
                     exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
                 }
-                roomIdToolTipText = mpDlgRoomExits->generateToolTip(exitToRoom->name, exitAreaName, outOfAreaExit, exitToRoom->getWeight());
+                roomIdToolTipText = mpDlgRoomExits->generateToolTip(exitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, exitToRoom->getWeight());
             } else if (text.toInt() > 0) {
                 // A number but not valid:
                 mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
@@ -199,13 +204,18 @@ void RoomIdLineEditDelegate::slot_specialRoomExitIdEdited(const QString& text) c
         // A valid exit roomID number:
         int exitAreaID = pExitToRoom->getArea();
         bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
         }
 
-        mpDlgRoomExits->setActionOnExit(mpEditor, outOfAreaExit ? mpDlgRoomExits->mpAction_otherAreaExit : mpDlgRoomExits->mpAction_inAreaExit);
-        roomIdToolTipText = mpDlgRoomExits->generateToolTip(pExitToRoom->name, exitAreaName, outOfAreaExit, pExitToRoom->getWeight());
+        mpDlgRoomExits->setActionOnExit(mpEditor, exitRoomLocked
+                                        ? mpDlgRoomExits->mpAction_exitRoomLocked
+                                        : outOfAreaExit
+                                          ? mpDlgRoomExits->mpAction_otherAreaExit
+                                          : mpDlgRoomExits->mpAction_inAreaExit);
+        roomIdToolTipText = mpDlgRoomExits->generateToolTip(pExitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitToRoom->getWeight());
     } else if (text.toInt() > 0) {
         // A number but not valid
         mpDlgRoomExits->setActionOnExit(mpEditor, mpDlgRoomExits->mpAction_invalidExit);
@@ -236,6 +246,7 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
     mIcon_invalidExit.addFile(qsl(":/icons/dialog-error.png"), QSize(24, 24));
     mIcon_inAreaExit.addFile(qsl(":/icons/dialog-ok-apply.png"), QSize(24, 24));
     mIcon_otherAreaExit.addFile(qsl(":/icons/arrow-right_cyan.png"), QSize(24, 24));
+    mIcon_exitRoomLocked.addFile(qsl(":/icons/document-encrypt.png"), QSize(24, 24));
 
     mpAction_noExit = new QAction(this);
     mpAction_noExit->setText(QString());
@@ -255,9 +266,14 @@ dlgRoomExits::dlgRoomExits(Host* pH, const int roomNumber, QWidget* pW)
     mpAction_otherAreaExit->setToolTip(QString());
     mpAction_otherAreaExit->setIcon(mIcon_otherAreaExit);
 
+    mpAction_exitRoomLocked = new QAction(this);
+    mpAction_exitRoomLocked->setText(QString());
+    mpAction_exitRoomLocked->setToolTip(QString());
+    mpAction_exitRoomLocked->setIcon(mIcon_exitRoomLocked);
+
     mSpecialExitRoomIdPlaceholder = tr("(roomID)", "Placeholder, if no roomID is set for an exit.");
     mSpecialExitCommandPlaceholder = tr("(command or Lua script)", "Placeholder, if a special exit has no name/script set.");
-    mAllExitActionsSet << mpAction_noExit << mpAction_invalidExit << mpAction_inAreaExit << mpAction_otherAreaExit;
+    mAllExitActionsSet << mpAction_noExit << mpAction_invalidExit << mpAction_inAreaExit << mpAction_otherAreaExit << mpAction_exitRoomLocked;
 
     init();
 
@@ -421,28 +437,6 @@ void dlgRoomExits::slot_editSpecialExit(QTreeWidgetItem* pI, int column)
 void dlgRoomExits::slot_addSpecialExit()
 {
     auto pI = new QTreeWidgetItem(specialExits);
-// MINDE
-//    pI->setText(0, tr("(room ID)", "Placeholder, if no room ID is set for an exit, yet. This string is used in 2 places, ensure they match!")); //Exit RoomID
-//    pI->setForeground(0, QColor(Qt::red));
-//    pI->setToolTip(0, singleParagraph.arg(tr("Set the number of the room that this special exit leads to, will turn blue for a valid number; if left like "
-//                                             "this, this exit will be deleted when &lt;i&gt;save&lt;/i&gt; is clicked.")));
-//    pI->setTextAlignment(0, Qt::AlignRight);
-//    pI->setToolTip(1, singleParagraph.arg(tr("Prevent a route being created via this exit, equivalent to an infinite exit weight.")));
-//    pI->setCheckState(1, Qt::Unchecked); //Locked
-//    pI->setText(2, qsl("0")); //Exit Weight
-//    pI->setTextAlignment(2, Qt::AlignRight);
-//    pI->setToolTip(2, singleParagraph.arg(tr("Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.")));
-//    pI->setCheckState(3, Qt::Checked); //Doortype: none
-//    pI->setToolTip(3, singleParagraph.arg(tr("No door symbol is drawn on a custom exit line for this exit on 2D Map.")));
-//    pI->setCheckState(4, Qt::Unchecked); //Doortype: open
-//    pI->setToolTip(4, singleParagraph.arg(tr("Green (Open) door symbol is drawn on a custom exit line for this exit on 2D Map.")));
-//    pI->setCheckState(5, Qt::Unchecked); //Doortype: closed
-//    pI->setToolTip(5, singleParagraph.arg(tr("Orange (Closed) door symbol is drawn on a custom exit line for this exit on 2D Map.")));
-//    pI->setCheckState(6, Qt::Unchecked); //Doortype: locked
-//    pI->setToolTip(6, singleParagraph.arg(tr("Red (Locked) door symbol is drawn on a custom exit line for this exit on 2D Map.")));
-//    pI->setText(7, tr("(command or Lua script)", "Placeholder, if a special exit has no code given, yet. This string is also used programmatically - ensure all five instances are the same")); //Exit command
-//    pI->setTextAlignment(7, Qt::AlignLeft);
-//=======
     pI->setText(ExitsTreeWidget::colIndex_exitRoomId, mSpecialExitRoomIdPlaceholder); //Exit RoomID
     pI->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, utils::richText(tr("Set the number of the room that this special exit goes to.")));
     pI->setTextAlignment(ExitsTreeWidget::colIndex_exitRoomId, Qt::AlignRight);
@@ -965,15 +959,25 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
         // A valid exit roomID number:
         int exitAreaID = pExitToRoom->getArea();
         bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool exitRoomLocked = pExitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
         }
 
         // This is the toolTip text for the roomID number column (and the
-        // status icon)
-        const QString roomIdToolTipText{generateToolTip(pExitToRoom->name, exitAreaName, outOfAreaExit, pExitToRoom->getWeight())};
-        pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, showIconOnExitStatus ? (outOfAreaExit ? mIcon_otherAreaExit : mIcon_inAreaExit) : QIcon());
+        // status icons)
+        const QString roomIdToolTipText{generateToolTip(pExitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitToRoom->getWeight())};
+        pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus, utils::richText(tr("A positive roomID of the room that this special exit leads to is expected here. "
+                                                                                          "If left like this, this exit will be deleted when <tt>save</tt> is clicked.")));
+
+        pSpecialExit->setIcon(ExitsTreeWidget::colIndex_exitStatus, !showIconOnExitStatus
+                              ? QIcon()
+                              : exitRoomLocked
+                                ? mIcon_exitRoomLocked
+                                : outOfAreaExit
+                                  ? mIcon_otherAreaExit
+                                  : mIcon_inAreaExit);
         pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitRoomId, roomIdToolTipText);
         pSpecialExit->setToolTip(ExitsTreeWidget::colIndex_exitStatus, roomIdToolTipText);
 
@@ -1000,17 +1004,14 @@ void dlgRoomExits::setIconAndToolTipsOnSpecialExit(QTreeWidgetItem* pSpecialExit
     }
 }
 
-
 void dlgRoomExits::setActionOnExit(QLineEdit* pExitLineEdit, QAction* pWantedAction) const
 {
     auto pActions = pExitLineEdit->actions();
-    // In fact there should only be one action but this code is flexible enough
-    // to deal with there being other unrealated ones also present:
     bool found = false;
     for (int index = 0, total = pActions.count(); index < total; ++index) {
         auto pAction = pActions[index];
         if (pAction && mAllExitActionsSet.contains(pAction)) {
-            // This is one of the four we are looking for.
+            // This is one of the set we are looking for.
             if (pAction != pWantedAction) {
                 // but it isn't the one we want - so remove it from the QLineEdit
                 pExitLineEdit->removeAction(pAction);
@@ -1022,7 +1023,6 @@ void dlgRoomExits::setActionOnExit(QLineEdit* pExitLineEdit, QAction* pWantedAct
     }
     if (!found) {
         // It wasn't there so add it - so that the position is similar for the
-// FIXME: PENDING TO BE ADDED IN A SEPARATE PR - DELETE THIS COMMENT LINE WHEN THAT GOES IN...
         // special exit form put it to the right of the QLineEdit text:
         pExitLineEdit->addAction(pWantedAction, QLineEdit::TrailingPosition);
     }
@@ -1044,9 +1044,24 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
     return nullptr;
 }
 
-/* static */ QString dlgRoomExits::generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight)
+/* static */ QString dlgRoomExits::generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool exitRoomLocked, const bool outOfAreaExit, const int exitRoomWeight)
 {
     if (exitRoomName.trimmed().length()) {
+        if (exitRoomLocked) {
+            if (outOfAreaExit) {
+                return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
+                                               .arg(exitRoomName, exitAreaName),
+                                           tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
+                                              // Intentional comment to separate arguments
+                                              "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
+            }
+            return doubleParagraph.arg(tr("Exit to \"%1\".")
+                                           .arg(exitRoomName),
+                                       tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
+                                          // Intentional comment to separate arguments
+                                          "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
+
+        }
         if (outOfAreaExit) {
             return doubleParagraph.arg(tr("Exit to \"%1\" in area: \"%2\".")
                                            .arg(exitRoomName, exitAreaName),
@@ -1061,6 +1076,21 @@ QAction* dlgRoomExits::getActionOnExit(QLineEdit* pExitLineEdit) const
                                       // Intentional comment to separate arguments
                                       "Bold HTML tags are used to emphasis that the value is destination room's weight whether overridden by a non-zero exit weight here or not.")
                                        .arg(exitRoomWeight));
+    }
+
+    if (exitRoomLocked) {
+        if (outOfAreaExit) {
+            return doubleParagraph.arg(tr("Exit to unnamed room in area: \"%1\", is valid.")
+                                           .arg(exitAreaName),
+                                       tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
+                                          // Intentional comment to separate arguments
+                                          "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
+        }
+
+        return doubleParagraph.arg(tr("Exit to unnamed room is valid."),
+                                   tr("<b>Room is locked</b>, it will not be used for speed-walks for any exit that leads to it.",
+                                      // Intentional comment to separate arguments
+                                      "Bold HTML tags are used to emphasis that destination room locked status overrides any weight or lock (\"No route\") setting of any exit that goes to it."));
     }
 
     if (outOfAreaExit) {
@@ -1085,6 +1115,7 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
     if (exitToRoom) {
         int exitAreaID = exitToRoom->getArea();
         bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool exitRoomLocked = exitToRoom->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
@@ -1098,8 +1129,12 @@ void dlgRoomExits::normalExitEdited(const QString& roomExitIdText, QLineEdit* pE
         pDoorType_open->setEnabled(true);
         pDoorType_closed->setEnabled(true);
         pDoorType_locked->setEnabled(true);
-        setActionOnExit(pExit, outOfAreaExit ? mpAction_otherAreaExit : mpAction_inAreaExit);
-        pExit->setToolTip(generateToolTip(exitToRoom->name, exitAreaName, outOfAreaExit, exitToRoom->getWeight()));
+        setActionOnExit(pExit, exitRoomLocked
+                        ? mpAction_exitRoomLocked
+                        : outOfAreaExit
+                          ? mpAction_otherAreaExit
+                          : mpAction_inAreaExit);
+        pExit->setToolTip(generateToolTip(exitToRoom->name, exitAreaName, exitRoomLocked, outOfAreaExit, exitToRoom->getWeight()));
     } else {
         if (!roomExitIdText.isEmpty()) {
             // Something is entered but it does not yield a valid exit roomID:
@@ -1428,12 +1463,17 @@ void dlgRoomExits::initExit(int direction,
         exitLineEdit->setEnabled(true);                 //Enable it for editing
         int exitAreaID = pExitR->getArea();
         bool outOfAreaExit = (exitAreaID && exitAreaID != mAreaID);
+        bool exitRoomLocked = pExitR->isLocked;
         QString exitAreaName;
         if (outOfAreaExit) {
             exitAreaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(exitAreaID);
         }
-        setActionOnExit(exitLineEdit, outOfAreaExit ? mpAction_otherAreaExit : mpAction_inAreaExit);
-        exitLineEdit->setToolTip(generateToolTip(pExitR->name, exitAreaName, outOfAreaExit, pExitR->getWeight()));
+        setActionOnExit(exitLineEdit, exitRoomLocked
+                        ? mpAction_exitRoomLocked
+                        : outOfAreaExit
+                          ? mpAction_otherAreaExit
+                          : mpAction_inAreaExit);
+        exitLineEdit->setToolTip(generateToolTip(pExitR->name, exitAreaName, exitRoomLocked, outOfAreaExit, pExitR->getWeight()));
         noRoute->setEnabled(true); //Enable speedwalk lock control
         none->setEnabled(true);    //Enable door type controls...
         open->setEnabled(true);
@@ -1481,6 +1521,15 @@ void dlgRoomExits::init()
     }
 
     roomID->setText(QString::number(mRoomID));
+    if (pR->isLocked) {
+        // Add the padlock icon to the room number display to show the locked
+        // status of the room:
+        roomID->addAction(mpAction_exitRoomLocked, QLineEdit::TrailingPosition);
+        // Also revise the tool tip:
+        roomID->setToolTip(utils::richText(tr("This is the Room ID number for this room; this <b>room is locked</b> so it will not be used for speed-walks at all. Neither of these details can be changed here!",
+                                              // Intentional comment to separate arguments
+                                              "This text is a revision to the default tooltip text set for this widget in the 'room_exits.ui' file. Bold HTML tags are used to emphasis that this room's locked status overrides any weight or lock (\"No route\") setting of any exit that comes to it.")));
+    }
     mAreaID = pR->getArea();
     roomWeight->setText(QString::number(pR->getWeight()));
     QString titleText;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1522,13 +1522,14 @@ void dlgRoomExits::init()
 
     roomID->setText(QString::number(mRoomID));
     if (pR->isLocked) {
-        // Add the padlock icon to the room number display to show the locked
-        // status of the room:
-        roomID->addAction(mpAction_exitRoomLocked, QLineEdit::TrailingPosition);
-        // Also revise the tool tip:
+        // Revise the tool tip:
         roomID->setToolTip(utils::richText(tr("This is the Room ID number for this room; this <b>room is locked</b> so it will not be used for speed-walks at all. Neither of these details can be changed here!",
                                               // Intentional comment to separate arguments
                                               "This text is a revision to the default tooltip text set for this widget in the 'room_exits.ui' file. Bold HTML tags are used to emphasis that this room's locked status overrides any weight or lock (\"No route\") setting of any exit that comes to it.")));
+    } else {
+        // Hide the padlock icon to the right of the room number display to
+        // show the unlocked status of the room:
+        label_roomLocked->hide();
     }
     mAreaID = pR->getArea();
     roomWeight->setText(QString::number(pR->getWeight()));

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -1523,7 +1523,7 @@ void dlgRoomExits::init()
     roomID->setText(QString::number(mRoomID));
     if (pR->isLocked) {
         // Revise the tool tip:
-        roomID->setToolTip(utils::richText(tr("This is the Room ID number for this room; this <b>room is locked</b> so it will not be used for speed-walks at all. Neither of these details can be changed here!",
+        roomID->setToolTip(utils::richText(tr("This is the Room ID number for this room; this <b>room is locked</b> so it will not be used for speed-walks at all.",
                                               // Intentional comment to separate arguments
                                               "This text is a revision to the default tooltip text set for this widget in the 'room_exits.ui' file. Bold HTML tags are used to emphasis that this room's locked status overrides any weight or lock (\"No route\") setting of any exit that comes to it.")));
     } else {

--- a/src/dlgRoomExits.h
+++ b/src/dlgRoomExits.h
@@ -134,10 +134,12 @@ public:
     QIcon mIcon_invalidExit;
     QIcon mIcon_inAreaExit;
     QIcon mIcon_otherAreaExit;
+    QIcon mIcon_exitRoomLocked;
     QAction* mpAction_noExit = nullptr;
     QAction* mpAction_invalidExit = nullptr;
     QAction* mpAction_inAreaExit = nullptr;
     QAction* mpAction_otherAreaExit = nullptr;
+    QAction* mpAction_exitRoomLocked = nullptr;
 
 public slots:
     void save();
@@ -173,7 +175,7 @@ private slots:
     void slot_checkModified();
 
 private:
-    static QString generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool outOfAreaExit, const int exitRoomWeight);
+    static QString generateToolTip(const QString& exitRoomName, const QString& exitAreaName, const bool exitRoomLocked, const bool outOfAreaExit, const int exitRoomWeight);
     void init();
     void initExit(int direction, int exitId, QLineEdit* exitLineEdit,
                   QCheckBox* noRoute, QCheckBox* stub,

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -757,16 +757,62 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QLineEdit" name="roomID">
-           <property name="cursor">
-            <cursorShape>ForbiddenCursor</cursorShape>
+          <widget class="QFrame" name="frame_roomID">
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
            </property>
-           <property name="toolTip">
-            <string>&lt;p&gt;This is the Room ID Number for this room - it cannot be changed here!</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_roomID">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="roomID">
+              <property name="cursor">
+               <cursorShape>ForbiddenCursor</cursorShape>
+              </property>
+              <property name="toolTip">
+               <string>&lt;p&gt;This is the Room ID Number for this room - it cannot be changed here!</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::NoFrame</enum>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_roomLocked">
+              <property name="maximumSize">
+               <size>
+                <width>16</width>
+                <height>16</height>
+               </size>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="pixmap">
+               <pixmap resource="../mudlet.qrc">:/icons/document-encrypt.png</pixmap>
+              </property>
+              <property name="scaledContents">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item row="1" column="0">
@@ -780,15 +826,21 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLineEdit" name="roomWeight">
+          <widget class="QLabel" name="roomWeight">
            <property name="cursor">
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
             <string>&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set - this value cannot be changed here.&lt;/p&gt;</string>
            </property>
-           <property name="readOnly">
-            <bool>true</bool>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Plain</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -1938,7 +1990,7 @@
          <bool>true</bool>
         </property>
         <property name="columnCount">
-         <number>8</number>
+         <number>9</number>
         </property>
         <attribute name="headerDefaultSectionSize">
          <number>80</number>

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -783,7 +783,7 @@
                <cursorShape>ForbiddenCursor</cursorShape>
               </property>
               <property name="toolTip">
-               <string>&lt;p&gt;This is the Room ID Number for this room - it cannot be changed here!</string>
+               <string>&lt;p&gt;This is the Room ID Number for this room.</string>
               </property>
               <property name="frameShape">
                <enum>QFrame::NoFrame</enum>
@@ -831,7 +831,7 @@
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
-            <string>&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set - this value cannot be changed here.&lt;/p&gt;</string>
+            <string>&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set.&lt;/p&gt;</string>
            </property>
            <property name="frameShape">
             <enum>QFrame::StyledPanel</enum>


### PR DESCRIPTION
This PR was prompted by a discussion in Discord about the locked status of rooms not being shown in the "Room exits dialogue" despite it having a fundamental effect on the usability of exits in route-finding/speed-walking:

See Kaylee#0064's comment in the "#help" channel on 2022/05/05: https://www.discord.com/channels/283581582550237184/283582068334526464/971547534994591794 and the subsequent couple of comments from @vadi2 and then me on it.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>