### PR TITLE
Fix: convert QFrames in roomExits dialogue to titled QGroupBoxes

### DIFF
--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -49,7 +49,7 @@
          <bool>false</bool>
         </property>
         <property name="title">
-         <string>North-west</string>
+         <string>Northwest</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_nw">
          <item row="0" column="0">
@@ -317,7 +317,7 @@
          </sizepolicy>
         </property>
         <property name="title">
-         <string>North-east</string>
+         <string>Northeast</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_ne">
          <item row="0" column="0">
@@ -1051,7 +1051,7 @@
          </sizepolicy>
         </property>
         <property name="title">
-         <string>South-west</string>
+         <string>Southwest</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_sw">
          <item row="0" column="0">
@@ -1337,7 +1337,7 @@
          </sizepolicy>
         </property>
         <property name="title">
-         <string>South-east</string>
+         <string>Southeast</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_se">
          <item row="0" column="0">

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -38,7 +38,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_normalExits" rowstretch="1,1,1,1" columnstretch="1,1,1,1">
       <item row="0" column="0">
-       <widget class="QFrame" name="frame_nw">
+       <widget class="QGroupBox" name="groupBox_nw">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -48,11 +48,8 @@
         <property name="autoFillBackground">
          <bool>false</bool>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>North-west</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_nw">
          <item row="0" column="0">
@@ -178,18 +175,15 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QFrame" name="frame_n">
+       <widget class="QGroupBox" name="groupBox_n">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>North</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_n">
          <item row="0" column="0">
@@ -315,18 +309,15 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <widget class="QFrame" name="frame_ne">
+       <widget class="QGroupBox" name="groupBox_ne">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>North-east</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_ne">
          <item row="0" column="0">
@@ -452,18 +443,15 @@
        </widget>
       </item>
       <item row="0" column="3">
-       <widget class="QFrame" name="frame_up">
+       <widget class="QGroupBox" name="groupBox_up">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>Up</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_up">
          <item row="0" column="0">
@@ -589,18 +577,15 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QFrame" name="frame_w">
+       <widget class="QGroupBox" name="groupBox_w">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>West</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_w">
          <item row="0" column="0">
@@ -729,7 +714,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QFrame" name="frame_id">
+       <widget class="QGroupBox" name="groupBox_id">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -739,11 +724,8 @@
         <property name="cursor">
          <cursorShape>ForbiddenCursor</cursorShape>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
+        <property name="title">
+         <string>This room</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_id" columnstretch="4,5" columnminimumwidth="0,0">
          <item row="0" column="0">
@@ -796,18 +778,15 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QFrame" name="frame_e">
+       <widget class="QGroupBox" name="groupBox_e">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>East</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_e">
          <item row="0" column="0">
@@ -851,11 +830,11 @@
          </item>
          <item row="1" column="0" colspan="2">
           <widget class="QSpinBox" name="weight_e">
-           <property name="maximum">
-            <number>9999</number>
-           </property>
            <property name="toolTip">
             <string>&lt;p&gt;Set to a positive value to override the default (Room) Weight for using this Exit route, zero value assigns the default.&lt;/p&gt;</string>
+           </property>
+           <property name="maximum">
+            <number>9999</number>
            </property>
           </widget>
          </item>
@@ -930,18 +909,15 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QFrame" name="frame_down">
+       <widget class="QGroupBox" name="groupBox_down">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>Down</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_down">
          <item row="0" column="0">
@@ -1067,18 +1043,15 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QFrame" name="frame_sw">
+       <widget class="QGroupBox" name="groupBox_sw">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>South-west</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_sw">
          <item row="0" column="0">
@@ -1222,18 +1195,15 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QFrame" name="frame_s">
+       <widget class="QGroupBox" name="groupBox_s">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>South</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_s">
          <item row="0" column="0">
@@ -1359,18 +1329,15 @@
        </widget>
       </item>
       <item row="2" column="2">
-       <widget class="QFrame" name="frame_se">
+       <widget class="QGroupBox" name="groupBox_se">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>South-east</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_se">
          <item row="0" column="0">
@@ -1496,18 +1463,15 @@
        </widget>
       </item>
       <item row="2" column="3">
-       <widget class="QFrame" name="frame_in">
+       <widget class="QGroupBox" name="groupBox_in">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>In</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_in">
          <item row="0" column="0">
@@ -1633,7 +1597,7 @@
        </widget>
       </item>
       <item row="3" column="0" colspan="3">
-       <widget class="QFrame" name="frame_key">
+       <widget class="QGroupBox" name="groupBox_key">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -1646,18 +1610,11 @@
         <property name="cursor">
          <cursorShape>WhatsThisCursor</cursorShape>
         </property>
+        <property name="title">
+         <string>Key</string>
+        </property>
         <layout class="QGridLayout" name="gridLayout_key">
          <item row="0" column="0">
-          <widget class="QLabel" name="label_key">
-           <property name="text">
-            <string>Key:</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
           <widget class="QCheckBox" name="noroute_key">
            <property name="font">
             <font>
@@ -1675,7 +1632,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="0" column="1">
           <widget class="QCheckBox" name="stub_key">
            <property name="font">
             <font>
@@ -1687,7 +1644,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2" colspan="4">
+         <item row="0" column="2" colspan="4">
           <widget class="QLineEdit" name="key">
            <property name="font">
             <font>
@@ -1699,7 +1656,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0" colspan="2">
+         <item row="1" column="0" colspan="2">
           <widget class="QSpinBox" name="weight_key">
            <property name="font">
             <font>
@@ -1714,7 +1671,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
+         <item row="1" column="2">
           <widget class="QRadioButton" name="doortype_none_key">
            <property name="font">
             <font>
@@ -1729,7 +1686,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="3">
+         <item row="1" column="3">
           <widget class="QRadioButton" name="doortype_open_key">
            <property name="font">
             <font>
@@ -1741,7 +1698,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="4">
+         <item row="1" column="4">
           <widget class="QRadioButton" name="doortype_closed_key">
            <property name="font">
             <font>
@@ -1753,7 +1710,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="5">
+         <item row="1" column="5">
           <widget class="QRadioButton" name="doortype_locked_key">
            <property name="font">
             <font>
@@ -1769,18 +1726,15 @@
        </widget>
       </item>
       <item row="3" column="3">
-       <widget class="QFrame" name="frame_out">
+       <widget class="QGroupBox" name="groupBox_out">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+        <property name="title">
+         <string>Out</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_out">
          <item row="0" column="0">
@@ -1938,7 +1892,7 @@
          <bool>true</bool>
         </property>
         <property name="columnCount">
-         <number>8</number>
+         <number>9</number>
         </property>
         <attribute name="headerDefaultSectionSize">
          <number>80</number>


### PR DESCRIPTION
Using `QGroupBox`es (without the `QCheckBox`) is so they can display a title, mostly of the exit direction that the box is for - which makes things easier for new users to find their way around the dialogue.

This was prompted by a discussion between @vadi2 and I in #6102 where I found it was going to be tricky to include the exit direction in tool-tips...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>