### PR TITLE
Fix: locked & closed door QRadioButtons being swapped in room exit dialogue

### DIFF
--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -1562,7 +1562,7 @@
           </widget>
          </item>
          <item row="1" column="4">
-          <widget class="QRadioButton" name="doortype_locked_in">
+          <widget class="QRadioButton" name="doortype_closed_in">
            <property name="cursor">
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
@@ -1578,7 +1578,7 @@
           </widget>
          </item>
          <item row="1" column="5">
-          <widget class="QRadioButton" name="doortype_closed_in">
+          <widget class="QRadioButton" name="doortype_locked_in">
            <property name="cursor">
             <cursorShape>PointingHandCursor</cursorShape>
            </property>


### PR DESCRIPTION
This has been the case since 2014 when I extended the room exits dialogue considerably but has only just been reported.

This will close #6095.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>