### PR TITLE
fix default auto-join IRC channel

### DIFF
--- a/src/dlgIRC.h
+++ b/src/dlgIRC.h
@@ -64,7 +64,7 @@ public:
     inline static int DefaultHostPort = 6667;
     inline static bool DefaultHostSecure = false;
     inline static QString DefaultNickName = qsl("Mudlet");
-    inline static QStringList DefaultChannels = QStringList() << qsl("Mudlet");
+    inline static QStringList DefaultChannels = QStringList() << qsl("#mudlet");
     inline static int DefaultMessageBufferLimit = 5000;
 
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
IRC default auto-join channel list got changed from `#mudlet` to invalid channel name `Mudlet`, changing it back.
#### Motivation for adding to Mudlet
To win praises from the multitudes who use this feature and also care about the default
#### Other info (issues closed, discussion etc)
`static QStringList DefaultChannels;` and
`QStringList dlgIRC::DefaultChannels = QStringList() << qsl("#mudlet");`
got changed to
`inline static QStringList DefaultChannels = QStringList() << qsl("Mudlet");`
in https://github.com/Mudlet/Mudlet/commit/12eb35eceb91aaf17823eabb6014079437d2bb21