### PR TITLE
Infrastructure: Consider uncaught errors when running tests to be a failure

### DIFF
--- a/src/run-tests.xml
+++ b/src/run-tests.xml
@@ -473,6 +473,14 @@ function autoRunTests()
     end
   )
 
+  busted.subscribe(
+    {'error'},
+    function(element, parent, message)
+      logTestError()
+      return nil, true
+    end
+  )
+
   bustedState.setup({testLocation})
   bustedState.runTests()
   raiseEvent("testsComplete")


### PR DESCRIPTION
#### Brief overview of PR changes/additions
While making a gha to run busted tests for Mudlet packages inside Mudlet, I realized that if the tests hit legit errors during test runs it doesn't write out the failure file. This resolves that.
#### Motivation for adding to Mudlet
More accurate test results
#### Other info (issues closed, discussion etc)
