### PR TITLE
Infrastructure: remove hidden 'Website:' label from connection dialog

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -971,6 +971,9 @@ void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
         if (it != mudlet::scmDefaultGames.end()) {
             val = it.value().websiteInfo;
         }
+        website_entry->setVisible(!val.isEmpty());
+    } else {
+        website_entry->show();
     }
     website_entry->setText(val);
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -457,50 +457,50 @@ public:
     // games are to be added here in alphabetical order
     inline static const OrderedMap<QString, GameDetails> scmDefaultGames = {
         {"Avalon.de", {"avalon.mud.de", 23, false,
-                        "<center><a href='http://avalon.mud.de'>http://avalon.mud.de</a></center>",
+                        "<a href='http://avalon.mud.de'>http://avalon.mud.de</a>",
                         ":/icons/avalon.png"}},
-        {"Achaea", {"achaea.com", 23, false, "<center><a href='http://www.achaea.com/'>http://www.achaea.com</a></center>", ":/icons/achaea_120_30.png"}},
-        {"3Kingdoms", {"3k.org", 3200, false, "<center><a href='http://www.3k.org/'>http://www.3k.org</a></center>", ":/icons/3klogo.png"}},
+        {"Achaea", {"achaea.com", 23, false, "<a href='http://www.achaea.com/'>http://www.achaea.com</a>", ":/icons/achaea_120_30.png"}},
+        {"3Kingdoms", {"3k.org", 3200, false, "<a href='http://www.3k.org/'>http://www.3k.org</a>", ":/icons/3klogo.png"}},
         {"3Scapes", {
             "3k.org",   // address to connect to
             3200,       // port to connect on
             false,      // secure connection possible?
             // game's website
-            "<center><a href='http://www.3scapes.org/'>http://www.3scapes.org</a></center>",
+            "<a href='http://www.3scapes.org/'>http://www.3scapes.org</a>",
             // path to the profile icon
             ":/icons/3slogo.png"
         }},
-        {"Lusternia", {"lusternia.com", 23, false, "<center><a href='http://www.lusternia.com/'>http://www.lusternia.com</a></center>", ":/icons/lusternia_120_30.png"}},
-        {"BatMUD", {"batmud.bat.org", 23, false, "<center><a href='http://www.bat.org'>http://www.bat.org</a></center>", ":/icons/batmud_mud.png"}},
+        {"Lusternia", {"lusternia.com", 23, false, "<a href='http://www.lusternia.com/'>http://www.lusternia.com</a>", ":/icons/lusternia_120_30.png"}},
+        {"BatMUD", {"batmud.bat.org", 23, false, "<a href='http://www.bat.org'>http://www.bat.org</a>", ":/icons/batmud_mud.png"}},
 
         {"God Wars II", {"godwars2.org", 3000, false,
-                        "<center><a href='http://www.godwars2.org'>http://www.godwars2.org</a></center>",
+                        "<a href='http://www.godwars2.org'>http://www.godwars2.org</a>",
                         ":/icons/gw2.png"}},
-        {"Slothmud", {"slothmud.org", 6101, false, "<center><a href='http://www.slothmud.org/'>http://www.slothmud.org/</a></center>", ":/icons/Slothmud.png"}},
-        {"Aardwolf", {"aardmud.org", 4000, false, "<center><a href='http://www.aardwolf.com/'>http://www.aardwolf.com</a></center>", ":/icons/aardwolf_mud.png"}},
+        {"Slothmud", {"slothmud.org", 6101, false, "<a href='http://www.slothmud.org/'>http://www.slothmud.org/</a>", ":/icons/Slothmud.png"}},
+        {"Aardwolf", {"aardmud.org", 4000, false, "<a href='http://www.aardwolf.com/'>http://www.aardwolf.com</a>", ":/icons/aardwolf_mud.png"}},
         {"Materia Magica", {"materiamagica.com", 23, false,
-                        "<center><a href='http://www.materiamagica.com'>http://www.materiamagica.com</a></center>",
+                        "<a href='http://www.materiamagica.com'>http://www.materiamagica.com</a>",
                         ":/materiaMagicaIcon"}},
-        {"Realms of Despair", {"realmsofdespair.com", 4000, false, "<center><a href='http://www.realmsofdespair.com/'>http://www.realmsofdespair.com</a></center>", ":/icons/120x30RoDLogo.png"}},
-        {"ZombieMUD", {"zombiemud.org", 3000, false, "<center><a href='http://www.zombiemud.org/'>http://www.zombiemud.org</a></center>", ":/icons/zombiemud.png"}},
-        {"Aetolia", {"aetolia.com", 23, false, "<center><a href='http://www.aetolia.com/'>http://www.aetolia.com</a></center>", ":/icons/aetolia_120_30.png"}},
-        {"Imperian", {"imperian.com", 23, false, "<center><a href='http://www.imperian.com/'>http://www.imperian.com</a></center>", ":/icons/imperian_120_30.png"}},
-        {"WoTMUD", {"game.wotmud.org", 2224, false, "<center><a href='http://www.wotmud.org/'>Main website</a></center>\n"
-                                 "<center><a href='http://www.wotmod.org/'>Forums</a></center>", ":/icons/wotmudicon.png"}},
-        {"Midnight Sun 2", {"midnightsun2.org", 3000, false, "<center><a href='http://midnightsun2.org/'>http://midnightsun2.org/</a></center>", ":/icons/midnightsun2.png"}},
-        {"Luminari", {"luminarimud.com", 4100, false, "<center><a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a></center>", ":/icons/luminari_icon.png"}},
-        {"StickMUD", {"stickmud.com", 7680, false, "<center><a href='http://www.stickmud.com/'>stickmud.com</a></center>", ":/icons/stickmud_icon.jpg"}},
-        {"Clessidra", {"mud.clessidra.it", 4000, false, "<center><a href='http://www.clessidra.it/'>http://www.clessidra.it</a></center>", ":/icons/clessidra.jpg"}},
-        {"Reinos de Leyenda", {"reinosdeleyenda.es", 23, false, "<center><a href='https://www.reinosdeleyenda.es/'>Main website</a></center>\n"
-                                 "<center><a href='https://www.reinosdeleyenda.es/foro/'>Forums</a></center>\n"
-                                 "<center><a href='https://wiki.reinosdeleyenda.es/'>Wiki</a></center>\n", ":/icons/reinosdeleyenda_mud.png"}},
-        {"Fierymud", {"fierymud.org", 4000, false, "<center><a href='https://www.fierymud.org/'>https://www.fierymud.org</a></center>", ":/icons/fiery_mud.png"}},
+        {"Realms of Despair", {"realmsofdespair.com", 4000, false, "<a href='http://www.realmsofdespair.com/'>http://www.realmsofdespair.com</a>", ":/icons/120x30RoDLogo.png"}},
+        {"ZombieMUD", {"zombiemud.org", 3000, false, "<a href='http://www.zombiemud.org/'>http://www.zombiemud.org</a>", ":/icons/zombiemud.png"}},
+        {"Aetolia", {"aetolia.com", 23, false, "<a href='http://www.aetolia.com/'>http://www.aetolia.com</a>", ":/icons/aetolia_120_30.png"}},
+        {"Imperian", {"imperian.com", 23, false, "<a href='http://www.imperian.com/'>http://www.imperian.com</a>", ":/icons/imperian_120_30.png"}},
+        {"WoTMUD", {"game.wotmud.org", 2224, false, "<a href='http://www.wotmud.org/'>Main website</a><br>"
+                                 "<a href='http://www.wotmod.org/'>Forums</a>", ":/icons/wotmudicon.png"}},
+        {"Midnight Sun 2", {"midnightsun2.org", 3000, false, "<a href='http://midnightsun2.org/'>http://midnightsun2.org/</a>", ":/icons/midnightsun2.png"}},
+        {"Luminari", {"luminarimud.com", 4100, false, "<a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a>", ":/icons/luminari_icon.png"}},
+        {"StickMUD", {"stickmud.com", 7680, false, "<a href='http://www.stickmud.com/'>stickmud.com</a>", ":/icons/stickmud_icon.jpg"}},
+        {"Clessidra", {"mud.clessidra.it", 4000, false, "<a href='http://www.clessidra.it/'>http://www.clessidra.it</a>", ":/icons/clessidra.jpg"}},
+        {"Reinos de Leyenda", {"reinosdeleyenda.es", 23, false, "<a href='https://www.reinosdeleyenda.es/'>Main website</a>\n"
+                                 "<a href='https://www.reinosdeleyenda.es/foro/'>Forums</a>\n"
+                                 "<a href='https://wiki.reinosdeleyenda.es/'>Wiki</a>\n", ":/icons/reinosdeleyenda_mud.png"}},
+        {"Fierymud", {"fierymud.org", 4000, false, "<a href='https://www.fierymud.org/'>https://www.fierymud.org</a>", ":/icons/fiery_mud.png"}},
         {"Mudlet self-test", {"mudlet.org", 23, false, "", ""}},
-        {"Carrion Fields", {"carrionfields.net", 4449, false, "<center><a href='http://www.carrionfields.net'>www.carrionfields.net</a></center>", ":/icons/carrionfields.png"}},
-        {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<center><a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a></center>", ":/icons/cleftofdimensions.png"}},
-        {"Legends of the Jedi", {"legendsofthejedi.com", 5656, false, "<center><a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a></center>", ":/icons/legendsofthejedi_120x30.png"}},
-        {"CoreMUD", {"coremud.org", 4020, true, "<center><a href='https://coremud.org/'>coremud.org</a></center>", ":/icons/coremud_icon.jpg"}},
-        {"Multi-Users in Middle-earth", {"mume.org", 4242, true, "<center><a href='https://mume.org/'>mume.org</a></center>", ":/icons/mume.png"}},
+        {"Carrion Fields", {"carrionfields.net", 4449, false, "<a href='http://www.carrionfields.net'>www.carrionfields.net</a>", ":/icons/carrionfields.png"}},
+        {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a>", ":/icons/cleftofdimensions.png"}},
+        {"Legends of the Jedi", {"legendsofthejedi.com", 5656, false, "<a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a>", ":/icons/legendsofthejedi_120x30.png"}},
+        {"CoreMUD", {"coremud.org", 4020, true, "<a href='https://coremud.org/'>coremud.org</a>", ":/icons/coremud_icon.jpg"}},
+        {"Multi-Users in Middle-earth", {"mume.org", 4242, true, "<a href='https://mume.org/'>mume.org</a>", ":/icons/mume.png"}},
     };
     // clang-format on
 

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -825,8 +825,8 @@
             <property name="horizontalSpacing">
              <number>0</number>
             </property>
-            <item row="0" column="0" rowspan="2">
-             <widget class="QLabel" name="label_7">
+            <item row="0" column="0" alignment="Qt::AlignLeft">
+             <widget class="QLabel" name="label_website">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -835,6 +835,9 @@
               </property>
               <property name="text">
                <string>Website:</string>
+              </property>
+              <property name="indent">
+               <number>9</number>
               </property>
              </widget>
             </item>
@@ -857,6 +860,9 @@
               </property>
               <property name="scaledContents">
                <bool>true</bool>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>

--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -809,7 +809,7 @@
            <property name="title">
             <string>Informational</string>
            </property>
-           <layout class="QGridLayout" name="gridLayout_4">
+           <layout class="QVBoxLayout" name="vBoxLayout_4">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -822,26 +822,7 @@
             <property name="bottomMargin">
              <number>0</number>
             </property>
-            <property name="horizontalSpacing">
-             <number>0</number>
-            </property>
-            <item row="0" column="0" alignment="Qt::AlignLeft">
-             <widget class="QLabel" name="label_website">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Website:</string>
-              </property>
-              <property name="indent">
-               <number>9</number>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
+            <item>
              <widget class="QLabel" name="website_entry">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -869,7 +850,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0" colspan="3">
+            <item>
              <widget class="QPlainTextEdit" name="mud_description_textedit">
               <property name="minimumSize">
                <size>

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -739,18 +739,15 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QLabel" name="roomID">
+          <widget class="QLineEdit" name="roomID">
            <property name="cursor">
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
             <string>&lt;p&gt;This is the Room ID Number for this room - it cannot be changed here!</string>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -765,21 +762,15 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLabel" name="roomWeight">
+          <widget class="QLineEdit" name="roomWeight">
            <property name="cursor">
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
             <string>&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set - this value cannot be changed here.&lt;/p&gt;</string>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Plain</enum>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/ui/room_exits.ui
+++ b/src/ui/room_exits.ui
@@ -739,15 +739,18 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QLineEdit" name="roomID">
+          <widget class="QLabel" name="roomID">
            <property name="cursor">
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
             <string>&lt;p&gt;This is the Room ID Number for this room - it cannot be changed here!</string>
            </property>
-           <property name="readOnly">
-            <bool>true</bool>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -762,15 +765,21 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QLineEdit" name="roomWeight">
+          <widget class="QLabel" name="roomWeight">
            <property name="cursor">
             <cursorShape>ForbiddenCursor</cursorShape>
            </property>
            <property name="toolTip">
             <string>&lt;p&gt;This is the default weight for this room, which will be used for any exit &lt;i&gt;that leads to &lt;u&gt;this room&lt;/u&gt;&lt;/i&gt; which does not have its own value set - this value cannot be changed here.&lt;/p&gt;</string>
            </property>
-           <property name="readOnly">
-            <bool>true</bool>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Plain</enum>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This will close #6087 and address one task in #6039. ~~The latter also involved renaming the widget for the website label from `label_7` to `label_website`.~~

~~It turns out that there is no margin/space set around the elements of the informational area, so it was necessary to add an "indent" to the "Website" label to push it away from the left side. Also, by changing the alignment of the details that are shown for the website for the selected MUD to be centered in both horizontal AND vertical direction it removed the need for each entry in the: `(OrderedMap<QString, GameDetails>) mudlet::scmDefaultGames` that populates that field to include the HTML-like `<center>`...`</center>` tags to produce the same (horizontal centring) effect.~~

*It turns out that we don't really want it anyhow. With it's removal there is no need to retain the remaining two widgets in a `QGridLayout` anyhow, and they can be placed in an easier to maintain `QVBoxLayout` instead!*

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

*Edited 2022/05/27 to reflect revisions to PR*