### PR TITLE
Infrastructure: remove hidden 'Website:' label from connection dialog

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -825,19 +825,6 @@
             <property name="horizontalSpacing">
              <number>0</number>
             </property>
-            <item row="0" column="0" rowspan="2">
-             <widget class="QLabel" name="label_7">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Website:</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="1">
              <widget class="QLabel" name="website_entry">
               <property name="sizePolicy">


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove hidden 'Website:' label from connection dialog
#### Motivation for adding to Mudlet
While it was hidden by accident, it turns out that we don't want it anyway in order to reduce clutter