### PR TITLE
Infrastructure: correctly #include winsock2.h for Windows builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -415,6 +415,14 @@ if(USE_OWN_QT5KEYCHAIN)
     target_compile_definitions(mudlet PRIVATE INCLUDE_OWN_QT5_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
 endif()
 
+# Used to force an include of winsock2.h BEFORE Qt tries to include winsock.h
+# from windows.h - only needed on Windows builds but we cannot use Q_OS_WIN32
+# for an #ifdef because we need a symbol that is defined BEFORE we include
+# any Qt header file!
+if(WIN32)
+    target_compile_definitions(mudlet PRIVATE INCLUDE_WINSOCK2)
+endif()
+
 # One of IRC_STATIC or IRC_SHARED must be defined for the communi IRC library
 target_compile_definitions(communi PUBLIC IRC_STATIC)
 

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -25,6 +25,12 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+// (1 of 2) This must be included before any Qt library tries to include
+// windows.h which pulls in winsock.h to avoid (multiple):
+// "#warning Please include winsock2.h before windows.h [-Wcpp]" warnings
+#if defined(INCLUDE_WINSOCK2)
+#include <winsock2.h>
+#endif
 
 #include "pre_guard.h"
 #include <QElapsedTimer>

--- a/src/glwidget.h
+++ b/src/glwidget.h
@@ -23,8 +23,15 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <QOpenGLWidget>
+// (2 of 2) This must be included before any Qt library tries to include
+// windows.h which pulls in winsock.h to avoid (multiple):
+// "#warning Please include winsock2.h before windows.h [-Wcpp]" warnings
+#if defined(INCLUDE_WINSOCK2)
+#include <winsock2.h>
+#endif
+
 #include "pre_guard.h"
+#include <QOpenGLWidget>
 #include <QPointer>
 #include "post_guard.h"
 

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -75,6 +75,14 @@ msvc:QMAKE_CXXFLAGS += -MP
 # Mac specific flags.
 macx:QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.13
 
+# Used to force an include of winsock2.h BEFORE Qt tries to include winsock.h
+# from windows.h - only needed on Windows builds but we cannot use Q_OS_WIN32
+# for an #ifdef because we need a symbol that is defined BEFORE we include
+# any Qt header file!
+win32 {
+    DEFINES += INCLUDE_WINSOCK2
+}
+
 QT += network uitools multimedia gui concurrent
 qtHaveModule(gamepad) {
     QT += gamepad


### PR DESCRIPTION
One or more Qt libraries happens to cause the `windows.h` header file to be `#include`d; unfortunately this will also pull in the original `winsock.h` header file which is contains some definitions that clash with those from the (preferred) `winsock2.h` header file. The best way to prevent getting warnings of: "#warning Please include winsock2.h before windows.h [-Wcpp]" is to include the latter file where it is needed, *before* a Qt library can pull in the older (and obsolete) header.

As `Q_OS_WIN32` is actually defined in a Qt header file it is not suitable to use **that** being defined as the test for the inclusion and instead I have arranged for `INCLUDE_WINSOCK2` to be defined by the (QMake and CMake) build systems' project file to trigger the required `#include`s for **Windows** builds.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

*Note to self - correct spellings in commit message when PR is being merged!*