### PR TITLE
Infrastructure: remove some unused variable warnings with no 3D mapper

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -2345,6 +2345,11 @@ void TMap::set3DViewCenter(const int areaId, const int xPos, const int yPos, con
     if (mpM) {
         mpM->setViewCenter(areaId, xPos, yPos, zPos);
     }
+#else
+    Q_UNUSED(areaId)
+    Q_UNUSED(xPos)
+    Q_UNUSED(yPos)
+    Q_UNUSED(zPos)
 #endif
 }
 

--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -299,6 +299,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
     }
 
 #else
+    Q_UNUSED(is3DMode)
     mp2dMap->setVisible(true);
     widget_3DControls->setVisible(false);
     widget_2DControls->setVisible(true);


### PR DESCRIPTION
When the environmental variable `WITH_3DMAPPER` is set to `"NO"` for builds on Raspberry Pis or other hardware which Mudlet cannot work a 3D mapper for there are some arguments for some functions that are unused and which provoke warnings. This PR silences those warnings for that case.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>