### PR TITLE
Infrastructure: scope ControlCharacterMode enum

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -813,7 +813,7 @@ private:
     //   EN: https://en.wikipedia.org/wiki/Code_page_437
     //   DE: https://de.wikipedia.org/wiki/Codepage_437
     //   RU: https://ru.wikipedia.org/wiki/CP437
-    ControlCharacterMode mControlCharacter = AsIs;
+    ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
 
     bool mLargeAreaExitArrows = false;
     bool mEditorShowBidi = true;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -500,7 +500,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         mDisplayFontSize = mDisplayFont.pointSize();
 
         // They always use "Control Pictures" to show control characters:
-        mControlCharacter = Picture;
+        mControlCharacter = ControlCharacterMode::Picture;
         refreshView();
     } else if (mpHost) {
         connect(mpHost, &Host::signal_controlCharacterHandlingChanged, this, &TConsole::slot_changeControlCharacterHandling);

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -47,7 +47,7 @@
 #include <map>
 
 
-enum ControlCharacterMode {
+enum class ControlCharacterMode {
     AsIs = 0x0,
     Picture = 0x1,
     OEM = 0x2
@@ -286,7 +286,7 @@ public:
     int mBgImageMode = 0;
     QString mBgImagePath;
     bool mHScrollBarEnabled = false;
-    ControlCharacterMode mControlCharacter = AsIs;
+    ControlCharacterMode mControlCharacter = ControlCharacterMode::AsIs;
 
 
 public slots:

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -468,7 +468,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("EditorSearchOptions") = QString::number(pHost->mSearchOptions).toUtf8().constData();
     host.append_attribute("DebugShowAllProblemCodepoints") = pHost->debugShowAllProblemCodepoints() ? "yes" : "no";
     host.append_attribute("NetworkPacketTimeout") = pHost->mTelnet.getPostingTimeout();
-    if (int mode = pHost->getControlCharacterMode(); mode) {
+    if (int mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
         // Don't bother to include the attribute if it is the default (zero)
         // value - and as it is an ASCII digit it only needs
         // QString::toLatin1() encoding:

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -1003,10 +1003,10 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         }
     }
 
-    comboBox_controlCharacterHandling->setItemData(0, ControlCharacterMode::AsIs);
-    comboBox_controlCharacterHandling->setItemData(1, ControlCharacterMode::Picture);
-    comboBox_controlCharacterHandling->setItemData(2, ControlCharacterMode::OEM);
-    auto cch_index = comboBox_controlCharacterHandling->findData(pHost->getControlCharacterMode());
+    comboBox_controlCharacterHandling->setItemData(0, QVariant::fromValue(ControlCharacterMode::AsIs));
+    comboBox_controlCharacterHandling->setItemData(1, QVariant::fromValue(ControlCharacterMode::Picture));
+    comboBox_controlCharacterHandling->setItemData(2, QVariant::fromValue(ControlCharacterMode::OEM));
+    auto cch_index = comboBox_controlCharacterHandling->findData(static_cast<int>(pHost->getControlCharacterMode()));
     comboBox_controlCharacterHandling->setCurrentIndex((cch_index > 0) ? cch_index : 0);
     connect(comboBox_controlCharacterHandling, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeControlCharacterHandling);
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
ControlCharacterMode was declared globally, meaning `AsIs`, `Picture`, and `OEM` were declared as globals in the context which is not very clean. In addition to this, some libraries declare `Picture` globally themselves as well, which is a future problem.
#### Motivation for adding to Mudlet
Fixing a future problem and making code a bit cleaner.
#### Other info (issues closed, discussion etc)
