### PR TITLE
Infrastructure: increase minimum Qt to 5.14

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -230,11 +230,14 @@ jobs:
         CheckAndInstallZlib
         CheckAndInstallLibzip
 
-    - name: (Linux Clang) change compiler
+    - name: (Linux Clang) change compiler & disable optional components
       if: runner.os == 'Linux' && matrix.compiler == 'clang_64'
       run: |
          echo "CXX=clang++" >> $GITHUB_ENV
          echo "CC=clang" >> $GITHUB_ENV
+         echo "WITH_UPDATER=no" >> $GITHUB_ENV
+         echo "WITH_3DMAPPER=no" >> $GITHUB_ENV
+         echo "WITH_FONTS=no" >> $GITHUB_ENV
 
     - name: (Linux/macOS) restore ccache
       uses: pat-s/always-upload-cache@v3.0.1

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -29,11 +29,6 @@ jobs:
             triplet: x64-linux
             compiler: clang_64
             qt: '5.14.2'
-          - os: ubuntu-latest
-            buildname: 'ubuntu / qt 5.11'
-            triplet: x64-linux
-            compiler: gcc_64
-            qt: '5.11.0'
           - os: macos-10.15
             buildname: 'macos / c++ tests'
             triplet: x64-osx
@@ -240,13 +235,6 @@ jobs:
       run: |
          echo "CXX=clang++" >> $GITHUB_ENV
          echo "CC=clang" >> $GITHUB_ENV
-
-    - name: (Qt 5.11) disable optional components
-      if: matrix.qt == '5.11.0'
-      run: |
-        echo "WITH_UPDATER=no" >> $GITHUB_ENV
-        echo "WITH_3DMAPPER=no" >> $GITHUB_ENV
-        echo "WITH_FONTS=no" >> $GITHUB_ENV
 
     - name: (Linux/macOS) restore ccache
       uses: pat-s/always-upload-cache@v3.0.1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -338,7 +338,7 @@ endif()
 include(../3rdparty/cmake-scripts/sanitizers.cmake)
 
 find_package(
-  Qt5 5.11 REQUIRED
+  Qt5 5.14 REQUIRED
   COMPONENTS Core
              Multimedia
              Network
@@ -349,9 +349,9 @@ find_package(
 find_package(Qt5 COMPONENTS Gamepad QUIET)
 find_package(Qt5 COMPONENTS TextToSpeech QUIET)
 
-if(Qt5Core_VERSION VERSION_LESS 5.11)
+if(Qt5Core_VERSION VERSION_LESS 5.14)
   message(
-    FATAL_ERROR "Mudlet requires Qt 5.11 or later, yours is ${Qt5Core_VERSION}")
+    FATAL_ERROR "Mudlet requires Qt 5.14 or later, yours is ${Qt5Core_VERSION}")
 else()
   # Qt Speech (or at least the TTS part) was officially release in 5.10
   message(STATUS "Qt version: ${Qt5Core_VERSION}")

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -263,7 +263,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mEditorThemeFile(QLatin1String("Mudlet.tmTheme"))
 , mThemePreviewItemID(-1)
 , mThemePreviewType(QString())
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
 , mBlack(QColorConstants::Black)
 , mLightBlack(QColorConstants::DarkGray)
 , mRed(QColorConstants::DarkRed)
@@ -303,47 +302,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mFgColor_2(QColorConstants::LightGray)
 , mBgColor_2(QColorConstants::Black)
 , mRoomBorderColor(QColorConstants::LightGray)
-#else
-, mBlack(Qt::black)
-, mLightBlack(Qt::darkGray)
-, mRed(Qt::darkRed)
-, mLightRed(Qt::red)
-, mLightGreen(Qt::green)
-, mGreen(Qt::darkGreen)
-, mLightBlue(Qt::blue)
-, mBlue(Qt::darkBlue)
-, mLightYellow(Qt::yellow)
-, mYellow(Qt::darkYellow)
-, mLightCyan(Qt::cyan)
-, mCyan(Qt::darkCyan)
-, mLightMagenta(Qt::magenta)
-, mMagenta(Qt::darkMagenta)
-, mLightWhite(Qt::white)
-, mWhite(Qt::lightGray)
-, mFgColor(Qt::lightGray)
-, mBgColor(Qt::black)
-, mCommandBgColor(Qt::black)
-, mCommandFgColor(QColor(113, 113, 0))
-, mBlack_2(Qt::black)
-, mLightBlack_2(Qt::darkGray)
-, mRed_2(Qt::darkRed)
-, mLightRed_2(Qt::red)
-, mLightGreen_2(Qt::green)
-, mGreen_2(Qt::darkGreen)
-, mLightBlue_2(Qt::blue)
-, mBlue_2(Qt::darkBlue)
-, mLightYellow_2(Qt::yellow)
-, mYellow_2(Qt::darkYellow)
-, mLightCyan_2(Qt::cyan)
-, mCyan_2(Qt::darkCyan)
-, mLightMagenta_2(Qt::magenta)
-, mMagenta_2(Qt::darkMagenta)
-, mLightWhite_2(Qt::white)
-, mWhite_2(Qt::lightGray)
-, mFgColor_2(Qt::lightGray)
-, mBgColor_2(Qt::black)
-, mRoomBorderColor(Qt::lightGray)
-#endif
 , mMapStrongHighlight(false)
 , mEnableSpellCheck(true)
 , mDiscordDisableServerSide(true)
@@ -1159,11 +1117,7 @@ void Host::send(QString cmd, bool wantPrint, bool dontExpandAliases)
     }
     QStringList commandList;
     if (!mCommandSeparator.isEmpty()) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
         commandList = cmd.split(QString(mCommandSeparator), Qt::SkipEmptyParts);
-#else
-        commandList = cmd.split(QString(mCommandSeparator), QString::SkipEmptyParts);
-#endif
     } else if (!cmd.isEmpty()) {
         // don't split command if the command separator is blank
         commandList << cmd;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -922,19 +922,11 @@ inline void T2DMap::drawRoom(QPainter& painter,
     const float innerStubDoorPenThicknessFactor = 0.0125f;
 
     QColor lc;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     if (roomColor.lightness() > 127) {
         lc = QColorConstants::Black;
     } else {
         lc = QColorConstants::White;
     }
-#else
-    if (roomColor.lightness() > 127) {
-        lc = QColor(Qt::black);
-    } else {
-        lc = QColor(Qt::white);
-    }
-#endif
     pen = painter.pen();
     pen.setColor(lc);
     pen.setCosmetic(mMapperUseAntiAlias);
@@ -2361,12 +2353,8 @@ void T2DMap::paintRoomExits(QPainter& painter, QPen& pen, QList<int>& exitList, 
 // Work out text for information box, need to offset if room selection widget is present
 void T2DMap::paintMapInfo(const QElapsedTimer& renderTimer, QPainter& painter, const int displayAreaId, QColor& infoColor)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QList<QString> contributorList = mpMap->mMapInfoContributorManager->getContributorKeys();
     QSet<QString> contributorKeys{contributorList.begin(), contributorList.end()};
-#else
-    QSet<QString> contributorKeys = mpMap->mMapInfoContributorManager->getContributorKeys().toSet();
-#endif
     if (!contributorKeys.intersects(mpHost->mMapInfoContributors)) {
         return;
     }
@@ -2705,11 +2693,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                                 tl2.setAngle(normal.angle());
                                 tl2.setLength(-0.1);
                                 QPointF pi;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                                 if ((line.intersects(tl, &pi) == QLineF::BoundedIntersection) || (line.intersects(tl2, &pi) == QLineF::BoundedIntersection)) {
-#else
-                                if ((line.intersect(tl, &pi) == QLineF::BoundedIntersection) || (line.intersect(tl2, &pi) == QLineF::BoundedIntersection)) {
-#endif
                                     // Choose THIS line to edit as we have
                                     // clicked close enough to it...
                                     mCustomLineSelectedRoom = room->getId();
@@ -4174,11 +4158,7 @@ void T2DMap::slot_setRoomWeight()
                 weightCountsSet.insert(itWeightsUsed.value());
             }
             // Obtains a list of those weights sorted in ascending count of used
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             QList<uint> weightCountsList{weightCountsSet.begin(), weightCountsSet.end()};
-#else
-            QList<uint> weightCountsList{weightCountsSet.toList()};
-#endif
             if (weightCountsList.size() > 1) {
                 std::sort(weightCountsList.begin(), weightCountsList.end());
             }
@@ -4353,12 +4333,8 @@ void T2DMap::slot_setArea()
             if (!(mpMap->setRoomArea(currentRoomId, newAreaId, false))) {
                 // Failed on the last of multiple room area move so do the missed
                 // out recalculations for the dirtied areas
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 QSet<TArea*> areaPtrsSet{mpMap->mpRoomDB->getAreaPtrList().begin(), mpMap->mpRoomDB->getAreaPtrList().end()};
                 QSetIterator<TArea*> itpArea{areaPtrsSet};
-#else
-                QSetIterator<TArea*> itpArea{mpMap->mpRoomDB->getAreaPtrList().toSet()};
-#endif
                 while (itpArea.hasNext()) {
                     TArea* pArea = itpArea.next();
                     if (pArea->mIsDirty) {
@@ -4503,11 +4479,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 mMultiSelectionHighlightRoomId = 0;
                 break;
             case 1:
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
-#else
-                mMultiSelectionHighlightRoomId = mMultiSelectionSet.toList().first();
-#endif
                 break;
             default:
                 getCenterSelection(); // Sets mMultiSelectionHighlightRoomId to (a) central room
@@ -4681,11 +4653,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
     // to use "globalPos()" instead and see how it lies in relation to the child
     // widget:
     QRect selectionListWidgetGlobalRect = QRect(mapToGlobal(mMultiSelectionListWidget.frameRect().topLeft()), mapToGlobal(mMultiSelectionListWidget.frameRect().bottomRight()));
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
     if (mMultiSelectionListWidget.isVisible() && selectionListWidgetGlobalRect.contains(e->globalPosition().toPoint())) {
-#else
-    if (mMultiSelectionListWidget.isVisible() && selectionListWidgetGlobalRect.contains(e->globalPos())) {
-#endif
         e->accept();
         return;
     }
@@ -4719,11 +4687,7 @@ void T2DMap::wheelEvent(QWheelEvent* e)
             }
 
             // mouse pos within the widget
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             const QPointF pos = e->position();
-#else
-            const QPoint pos = mapFromGlobal(e->globalPos());
-#endif
 
             // Position of the mouse within the map, scaled -1 .. +1
             // i.e. if the mouse is in the center, nothing changes

--- a/src/TArea.cpp
+++ b/src/TArea.cpp
@@ -607,11 +607,7 @@ void TArea::writeJsonArea(QJsonArray& array) const
 
     writeJsonUserData(areaObj);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QList<int> roomList{rooms.begin(), rooms.end()};
-#else
-    QList<int> roomList = rooms.toList();
-#endif
     int roomCount = roomList.count();
     if (roomCount > 1) {
         std::sort(roomList.begin(), roomList.end());

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -940,11 +940,7 @@ void TCommandLine::handleTabCompletion(bool direction)
     buffer.replace(QChar(0x21af), QChar::LineFeed);
     buffer.replace(QChar::LineFeed, QChar::Space);
 
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
     QStringList wordList = buffer.split(QRegularExpression(qsl(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), Qt::SkipEmptyParts);
-#else
-    QStringList wordList = buffer.split(QRegularExpression(qsl(R"(\b)"), QRegularExpression::UseUnicodePropertiesOption), QString::SkipEmptyParts);
-#endif
 
     wordList.append(commandLineSuggestions.values());
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -209,17 +209,10 @@ public:
     QWidget* layerCommandLine = nullptr;
     QHBoxLayout* layoutLayer2 = nullptr;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QColor mBgColor = QColorConstants::Black;
     QColor mFgColor = QColorConstants::LightGray;
     QColor mSystemMessageFgColor = QColorConstants::Red;
     QColor mCommandBgColor = QColorConstants::Black;
-#else
-    QColor mBgColor = Qt::black;
-    QColor mFgColor = Qt::lightGray;
-    QColor mSystemMessageFgColor = Qt::red;
-    QColor mCommandBgColor = Qt::black;
-#endif
     QColor mSystemMessageBgColor = mBgColor;
     QColor mCommandFgColor = QColor(213, 195, 0);
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -327,11 +327,7 @@ int TLuaInterpreter::warnArgumentValue(lua_State* L, const char* functionName, c
     lua_pushstring(L, message.toUtf8().constData());
     if (mudlet::debugMode) {
         auto& host = getHostFromLua(L);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         TDebug(Qt::white, QColorConstants::Svg::orange) << "Lua: " << functionName << ": " << message << "\n" >> &host;
-#else
-        TDebug(Qt::white, QColor("orange")) << "Lua: " << functionName << ": " << message << "\n" >> &host;
-#endif
     }
     return 2;
 }
@@ -346,11 +342,7 @@ int TLuaInterpreter::warnArgumentValue(lua_State* L, const char* functionName, c
     lua_pushstring(L, message);
     if (mudlet::debugMode) {
         auto& host = getHostFromLua(L);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         TDebug(Qt::white, QColorConstants::Svg::orange) << "Lua: " << functionName << ": " << message << "\n" >> &host;
-#else
-        TDebug(Qt::white, QColor("orange")) << "Lua: " << functionName << ": " << message << "\n" >> &host;
-#endif
     }
     return 2;
 }
@@ -5024,23 +5016,15 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
         QSet<QString> keysSet;
         while (itRoom.hasNext()) {
             itRoom.next();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             // In the brave new world of range based initializers one must use
             // a pair of iterators that point to the SAME thing that lasts
             // long enough - using the output of a Qt method that returns a
             // QList twice is not good enough and causes seg. faults...
             QList<QString> roomDataKeysList{itRoom.value()->userData.keys()};
             keysSet.unite(QSet<QString>{roomDataKeysList.begin(), roomDataKeysList.end()});
-#else
-            keysSet.unite(itRoom.value()->userData.keys().toSet());
-#endif
         }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList keys{keysSet.begin(), keysSet.end()};
-#else
-        QStringList keys{keysSet.toList()};
-#endif
         if (keys.size() > 1) {
             std::sort(keys.begin(), keys.end());
         }
@@ -5062,11 +5046,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
             }
         }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList values{valuesSet.begin(), valuesSet.end()};
-#else
-        QStringList values{valuesSet.toList()};
-#endif
         if (values.size() > 1) {
             std::sort(values.begin(), values.end());
         }
@@ -5087,11 +5067,7 @@ int TLuaInterpreter::searchRoomUserData(lua_State* L)
             }
         }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QList<int> roomIds{roomIdsSet.begin(), roomIdsSet.end()};
-#else
-        QList<int> roomIds{roomIdsSet.toList()};
-#endif
         if (roomIds.size() > 1) {
             std::sort(roomIds.begin(), roomIds.end());
         }
@@ -5136,19 +5112,11 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
         QSet<QString> keysSet;
         while (itArea.hasNext()) {
             itArea.next();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             QList<QString> areaDataKeysList{itArea.value()->mUserData.keys()};
             keysSet.unite(QSet<QString>{areaDataKeysList.begin(), areaDataKeysList.end()});
-#else
-            keysSet.unite(itArea.value()->mUserData.keys().toSet());
-#endif
         }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList keys{keysSet.begin(), keysSet.end()};
-#else
-        QStringList keys{keysSet.toList()};
-#endif
         if (keys.size() > 1) {
             std::sort(keys.begin(), keys.end());
         }
@@ -5170,11 +5138,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
             }
         }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList values{valuesSet.begin(), valuesSet.end()};
-#else
-        QStringList values{valuesSet.toList()};
-#endif
         if (values.size() > 1) {
             std::sort(values.begin(), values.end());
         }
@@ -5195,11 +5159,7 @@ int TLuaInterpreter::searchAreaUserData(lua_State* L)
             }
         }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QList<int> areaIds{areaIdsSet.begin(), areaIdsSet.end()};
-#else
-        QList<int> areaIds{areaIdsSet.toList()};
-#endif
         if (areaIds.size() > 1) {
             std::sort(areaIds.begin(), areaIds.end());
         }
@@ -14206,13 +14166,7 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
             }
             lua_setfield(L, -2, qsl("buttons").toUtf8().constData());
 
-// The Qt documentation is unclear when, precisely QWheelEvent::globalPos()
-// became obsolete, 5.14.0 is a guess
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             auto globalPosition = qME->globalPosition();
-#else
-            auto globalPosition = qME->globalPos();
-#endif
             // Push globalX()
             lua_pushnumber(L, globalPosition.x());
             lua_setfield(L, -2, qsl("globalX").toUtf8().constData());
@@ -14221,24 +14175,14 @@ bool TLuaInterpreter::callLabelCallbackEvent(const int func, const QEvent* qE)
             lua_pushnumber(L, globalPosition.y());
             lua_setfield(L, -2, qsl("globalY").toUtf8().constData());
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             auto position = qME->position();
-#endif
 
             // Push x()
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             lua_pushnumber(L, position.x());
-#else
-            lua_pushnumber(L, qME->x());
-#endif
             lua_setfield(L, -2, qsl("x").toUtf8().constData());
 
             // Push y()
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             lua_pushnumber(L, position.y());
-#else
-            lua_pushnumber(L, qME->y());
-#endif
             lua_setfield(L, -2, qsl("y").toUtf8().constData());
 
             // Push angleDelta()
@@ -16344,12 +16288,8 @@ int TLuaInterpreter::getMapSelection(lua_State* L)
     }
 
     lua_newtable(L);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QList<int> selectionRoomsList{pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.begin(),
                                   pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.end()};
-#else
-    QList<int> selectionRoomsList{pHost->mpMap->mpMapper->mp2dMap->mMultiSelectionSet.toList()};
-#endif
     if (!selectionRoomsList.isEmpty()) {
         if (selectionRoomsList.count() > 1) {
             std::sort(selectionRoomsList.begin(), selectionRoomsList.end());
@@ -16532,16 +16472,12 @@ int TLuaInterpreter::getDictionaryWordList(lua_State* L)
 
     // This may stall if this is accessing the shared user dictionary and that
     // is being updated by another profile, but it should eventually return...
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     // We must keep a local reference/copy of the value returned because the
     // returned item is a deep-copy in the case of a shared dictionary and two
     // calls to TConsole::getWordSet() can return two different instances which
     // is fatally dangerous if used in a range based initialiser:
     QSet<QString> wordSet{host.mpConsole->getWordSet()};
     QStringList wordList{wordSet.begin(), wordSet.end()};
-#else
-    QStringList wordList{host.mpConsole->getWordSet().toList()};
-#endif
     int wordCount = wordList.size();
     if (wordCount > 1) {
         QCollator sorter;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -430,11 +430,7 @@ QString TMap::connectExitStubByToId(const int fromRoomId, const int toRoomId)
         return qsl("toID (%1) does not have any stub exits").arg(toRoomId);
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QSet<int> fromRoomStubs{pFromR->exitStubs.cbegin(), pFromR->exitStubs.cend()};
-#else
-    QSet<int> fromRoomStubs{pFromR->exitStubs.toSet()};
-#endif
     QListIterator<int> itToRoomStubs{pToR->exitStubs};
     QSet<int> toReverseStubDirections;
     while (itToRoomStubs.hasNext()) {
@@ -1787,11 +1783,7 @@ bool TMap::restore(QString location, bool downloadIfNotFound)
                 } else {
                     QList<int> oldRoomsList;
                     ifs >> oldRoomsList;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                     pA->rooms = QSet<int>{oldRoomsList.begin(), oldRoomsList.end()};
-#else
-                    pA->rooms = oldRoomsList.toSet();
-#endif
                 }
                 // Can be useful when analysing suspect map files!
                 //                qDebug() << "TMap::restore(...)" << "Area:" << areaID;
@@ -2978,15 +2970,9 @@ std::pair<bool, QString> TMap::writeJsonMapFile(const QString& dest)
     QList<int> areaRawIdsList{mpRoomDB->getAreaMap().keys()};
     QList<int> areaNameRawIdsList{mpRoomDB->getAreaNamesMap().keys()};
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QSet<int> areaIdsSet{areaRawIdsList.begin(), areaRawIdsList.end()};
     areaIdsSet.unite(QSet<int>{areaNameRawIdsList.begin(), areaNameRawIdsList.end()});
     QList<int> areaIdsList{areaIdsSet.begin(), areaIdsSet.end()};
-#else
-    QSet<int> areaIdsSet = areaRawIdsList.toSet();
-    areaIdsSet.unite(areaNameRawIdsList.toSet());
-    QList<int> areaIdsList = areaIdsSet.toList();
-#endif
     if (areaIdsList.count() > 1) {
         std::sort(areaIdsList.begin(), areaIdsList.end());
     }

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -703,13 +703,8 @@ TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
         if (state == QMediaPlayer::StoppedState) {
             TEvent mediaFinished{};
             mediaFinished.mArgumentList.append("sysMediaFinished");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().request().url().fileName());
             mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().request().url().path());
-#else
-            mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().canonicalUrl().fileName());
-            mediaFinished.mArgumentList.append(pPlayer.getMediaPlayer()->media().canonicalUrl().path());
-#endif
             mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             mediaFinished.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
@@ -762,11 +757,7 @@ TMediaPlayer TMedia::matchMediaPlayer(TMediaData& mediaData, const QString& abso
         TMediaPlayer pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
             if (pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)) { // Is the same sound or music playing?
-#else
-            if (pTestPlayer.getMediaPlayer()->media().canonicalUrl().toString().endsWith(absolutePathFileName)) {  // Is the same sound or music playing?
-#endif
                 pPlayer = pTestPlayer;
                 pPlayer.setMediaData(mediaData);
                 pPlayer.getMediaPlayer()->setVolume(mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.getMediaVolume());
@@ -796,11 +787,7 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
         TMediaPlayer pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
             if (!pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
-#else
-            if (!pTestPlayer.getMediaPlayer()->media().canonicalUrl().toString().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
-#endif
                 if (pTestPlayer.getMediaData().getMediaPriority() != TMediaData::MediaPriorityNotSet && pTestPlayer.getMediaData().getMediaPriority() > maxMediaPriority) {
                     maxMediaPriority = pTestPlayer.getMediaData().getMediaPriority();
                 }
@@ -833,11 +820,7 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (!mediaData.getMediaKey().isEmpty() && !pTestPlayer.getMediaData().getMediaKey().isEmpty()
                 && mediaData.getMediaKey() == pTestPlayer.getMediaData().getMediaKey()) { // Does it have the same key?
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
                 if (!pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)
-#else
-                if (!pTestPlayer.getMediaPlayer()->media().canonicalUrl().toString().endsWith(absolutePathFileName)
-#endif
                     || (!mediaData.getMediaUrl().isEmpty() && !pTestPlayer.getMediaData().getMediaUrl().isEmpty()
                         && mediaData.getMediaUrl() != pTestPlayer.getMediaData().getMediaUrl())) { // Is it a different sound or music than specified?
                     TMediaData stopMediaData = pTestPlayer.getMediaData();

--- a/src/TMxpElementDefinitionHandler.cpp
+++ b/src/TMxpElementDefinitionHandler.cpp
@@ -46,11 +46,7 @@ TMxpTagHandlerResult TMxpElementDefinitionHandler::handleStartTag(TMxpContext& c
     }
 
     if (tag->hasAttribute("ATT")) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
         el.attrs = tag->getAttributeValue("ATT").toLower().split(' ', Qt::SkipEmptyParts);
-#else
-        el.attrs = tag->getAttributeValue("ATT").toLower().split(' ', QString::SkipEmptyParts);
-#endif
     }
 
     if (tag->hasAttribute("TAG")) {

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -872,7 +872,6 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
             // operation we want to perform (obtain the directions of all custom
             // exit lines and remove those which are already included in the
             // colours) is much easier to perform on a QSet rather than a QList:
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             auto customLineKeys = customLines.keys();
             QSet<QString> missingKeys{customLineKeys.begin(), customLineKeys.end()};
             if (!customLinesColor.isEmpty()) {
@@ -880,9 +879,6 @@ void TRoom::restore(QDataStream& ifs, int roomID, int version)
                 QSet<QString> customLinesColorKeysSet{customLinesColorKeys.begin(), customLinesColorKeys.end()};
                 missingKeys.subtract(customLinesColorKeysSet);
             }
-#else
-            QSet<QString> missingKeys{customLines.keys().toSet().subtract(customLinesColor.keys().toSet())};
-#endif
             QSetIterator<QString> itMissingCustomLineColourKey(missingKeys);
             while (itMissingCustomLineColourKey.hasNext()) {
                 customLinesColor.insert(itMissingCustomLineColourKey.next(), QColor(Qt::red));
@@ -949,13 +945,8 @@ void TRoom::auditExits(const QHash<int, int> roomRemapping)
     // members from to identify any rogue members before removing them:
 
     QMap<QString, int> exitWeightsCopy = exitWeights;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QSet<int> exitStubsCopy{exitStubs.begin(), exitStubs.end()};
     QSet<int> exitLocksCopy{exitLocks.begin(), exitLocks.end()};
-#else
-    QSet<int> exitStubsCopy{exitStubs.toSet()};
-    QSet<int> exitLocksCopy{exitLocks.toSet()};
-#endif
     QMap<QString, int> doorsCopy = doors;
     QMap<QString, QList<QPointF>> customLinesCopy = customLines;
     QMap<QString, QColor> customLinesColorCopy = customLinesColor;

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -653,7 +653,6 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         }
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     // Check for existence of all areas needed by rooms
     QList<int> areaIdsFromRoomsList{areaRoomMultiHash.uniqueKeys()};
     QSet<int> areaIdSet{areaIdsFromRoomsList.begin(), areaIdsFromRoomsList.end()};
@@ -665,14 +664,6 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
         QSet<int> areaIdsFromAreaNamesSet{areaIdsFromAreaNamesList.begin(), areaIdsFromAreaNamesList.end()};
         areaIdSet.unite(areaIdsFromAreaNamesSet);
     }
-#else
-    // Check for existence of all areas needed by rooms
-    QSet<int> areaIdSet = areaRoomMultiHash.keys().toSet();
-
-    // START OF TASK 3
-    // Throw in the area Ids from the areaNamesMap:
-    areaIdSet.unite(areaNamesMap.keys().toSet());
-#endif
 
     // Check the set of area Ids against the ones we actually have:
     QSetIterator<int> itUsedArea(areaIdSet);
@@ -933,14 +924,10 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Purges any duplicates that a QList structure DOES permit, but a QSet does NOT:
             // Exit stubs:
             int _listCount = pR->exitStubs.count();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             // These next few construction of a QSet from a QList or vice versa
             // are probably safe as both iterators refer to the SAME instance
             // that is persistent:
             QSet<int> _set{pR->exitStubs.begin(), pR->exitStubs.end()};
-#else
-            QSet<int> _set{pR->exitStubs.toSet()};
-#endif
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     QString infoMsg = tr("[ INFO ]  - Duplicate exit stub identifiers found in room id: %1, this is an\n"
@@ -950,19 +937,11 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(), tr("[ INFO ]  - Duplicate exit stub identifiers found in room, this is an anomaly but has been cleaned up easily."), false);
             }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             pR->exitStubs = QList<int>{_set.begin(), _set.end()};
-#else
-            pR->exitStubs = _set.toList();
-#endif
 
             // Exit locks:
             _listCount = pR->exitLocks.count();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             _set = QSet<int>{pR->exitLocks.begin(), pR->exitLocks.end()};
-#else
-            _set = pR->exitLocks.toSet();
-#endif
             if (_set.count() < _listCount) {
                 if (mudlet::self()->showMapAuditErrors()) {
                     QString infoMsg = tr("[ INFO ]  - Duplicate exit lock identifiers found in room id: %1, this is an\n"
@@ -972,11 +951,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
                 }
                 mpMap->appendRoomErrorMsg(itRoom.key(), tr("[ INFO ]  - Duplicate exit lock identifiers found in room, this is an anomaly but has been cleaned up easily."), false);
             }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             pR->exitLocks = QList<int>{_set.begin(), _set.end()};
-#else
-            pR->exitLocks = _set.toList();
-#endif
 
             // TASK 9 IS DONE INSIDE THIS METHOD:
             pR->audit(roomRemapping, areaRemapping);
@@ -1009,14 +984,8 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             }
 
             // Now compare pA->rooms to areaRoomMultiHash.values(itArea.key())
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-            // Have to create a local copy of the list of rooms to safely make
-            // a QSet of them:
             QList<int> roomIdsInAreaList{areaRoomMultiHash.values(itArea.key())};
             QSet<int> foundRooms{roomIdsInAreaList.begin(), roomIdsInAreaList.end()};
-#else
-            QSet<int> foundRooms{areaRoomMultiHash.values(itArea.key()).toSet()};
-#endif
 
             QSetIterator<int> itFoundRoom(foundRooms);
             // Original form of code which was slower because the two sets of rooms were
@@ -1043,11 +1012,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
             // Report differences:
             if (!missingRooms.isEmpty()) {
                 QStringList roomList;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 QList<int> missingRoomsList{missingRooms.begin(), missingRooms.end()};
-#else
-                QList<int> missingRoomsList{missingRooms.toList()};
-#endif
                 if (missingRoomsList.size() > 1) {
                     // The on-screen listing are clearer if we sort the rooms
                     std::sort(missingRoomsList.begin(), missingRoomsList.end());
@@ -1083,11 +1048,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
             if (!extraRooms.isEmpty()) {
                 QStringList roomList;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                 QList<int> extraRoomsList{extraRooms.begin(), extraRooms.end()};
-#else
-                QList<int> extraRoomsList{extraRooms.toList()};
-#endif
                 if (extraRoomsList.size() > 1) {
                     std::sort(extraRoomsList.begin(), extraRoomsList.end());
                 }

--- a/src/TScrollBox.h
+++ b/src/TScrollBox.h
@@ -47,9 +47,7 @@ class TScrollBoxWidget : public QWidget
 
 public:
     Q_DISABLE_COPY(TScrollBoxWidget)
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 13, 0))
     Q_DISABLE_MOVE(TScrollBoxWidget)
-#endif
     explicit TScrollBoxWidget(QWidget* pW = nullptr);
     ~TScrollBoxWidget();
     void childEvent(QChildEvent* event) override;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -67,7 +67,6 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
 , mScreenOffset(0)
 , mMaxHRange(0)
 , mWideAmbigousWidthGlyphs(pH->wideAmbiguousEAsianGlyphs())
-, mUseOldUnicode8(false)
 , mTabStopwidth(8)
 // Should be the same as the size of the timeStampFormat constant in the TBuffer
 // class:
@@ -116,10 +115,6 @@ TTextEdit::TTextEdit(TConsole* pC, QWidget* pW, TBuffer* pB, Host* pH, bool isLo
     setMouseTracking(true); // test fix for MAC
     setEnabled(true);       //test fix for MAC
 
-    QVersionNumber runTimeVersion = QVersionNumber::fromString(QLatin1String(qVersion()));
-    if (runTimeVersion.majorVersion() == 5 && runTimeVersion.minorVersion() < 11) {
-        mUseOldUnicode8 = true;
-    }
     connect(mpHost, &Host::signal_changeIsAmbigousWidthGlyphsToBeWide, this, &TTextEdit::slot_changeIsAmbigousWidthGlyphsToBeWide, Qt::UniqueConnection);
 }
 
@@ -751,11 +746,7 @@ int TTextEdit::getGraphemeWidth(uint unicode) const
         }
         return 1;
     case widechar_widened_in_9: // -6 = Width is 1 in Unicode 8, 2 in Unicode 9+.
-        if (mUseOldUnicode8) {
-            return 1;
-        } else {
-            return 2;
-        }
+        return 2;
     default:
         return 1; // Got an uncoded return value from widechar_wcwidth(...)
     }

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -181,9 +181,6 @@ private:
     QPointer<QAction> mpContextMenuAnalyser;
     bool mWideAmbigousWidthGlyphs;
     std::chrono::high_resolution_clock::time_point mCopyImageStartTime;
-    // Set in constructor for run-time Qt versions less than 5.11 which only
-    // supports up to Unicode 8.0:
-    bool mUseOldUnicode8;
     // How many "normal" width "characters" are each tab stop apart, while
     // there is no current mechanism to adjust this, sensible values will
     // probably be 1 (so that a tab is just treated as a space), 2, 4 and 8,

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -458,18 +458,10 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
                     // otherwise highlight complete expression match
                     if (i % numberOfCaptureGroups != 1) {
                         pC->selectSection(begin, length);
-    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                         if (mBgColor != QColorConstants::Transparent) {
-    #else
-                        if (mBgColor != QColor("transparent")) {
-    #endif
                             pC->setBgColor(r1, g1, b1, 255);
                         }
-    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                         if (mFgColor != QColorConstants::Transparent) {
-    #else
-                        if (mFgColor != QColor("transparent")) {
-    #endif
                             pC->setFgColor(r2, g2, b2);
                         }
                     }
@@ -551,18 +543,10 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
             std::string& s = *its;
             int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mBgColor != QColorConstants::Transparent) {
-#else
-            if (mBgColor != QColor("transparent")) {
-#endif
                 pC->setBgColor(r1, g1, b1, 255);
             }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mFgColor != QColorConstants::Transparent) {
-#else
-            if (mFgColor != QColor("transparent")) {
-#endif
                 pC->setFgColor(r2, g2, b2);
             }
         }
@@ -695,18 +679,10 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
             std::string& s = *its;
             int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mBgColor != QColorConstants::Transparent) {
-#else
-            if (mBgColor != QColor("transparent")) {
-#endif
                 pC->setBgColor(r1, g1, b1, 255);
             }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mFgColor != QColorConstants::Transparent) {
-#else
-            if (mFgColor != QColor("transparent")) {
-#endif
                 pC->setFgColor(r2, g2, b2);
             }
         }
@@ -823,18 +799,10 @@ void TTrigger::processColorPattern(int patternNumber, std::list<std::string>& ca
             std::string& s = *its;
             int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mBgColor != QColorConstants::Transparent) {
-#else
-            if (mBgColor != QColor("transparent")) {
-#endif
                 pC->setBgColor(r1, g1, b1, 255);
             }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mFgColor != QColorConstants::Transparent) {
-#else
-            if (mFgColor != QColor("transparent")) {
-#endif
                 pC->setFgColor(r2, g2, b2);
             }
         }
@@ -974,18 +942,10 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
             std::string& s = *its;
             int length = QString::fromStdString(s).size();
             pC->selectSection(begin, length);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mBgColor != QColorConstants::Transparent) {
-#else
-            if (mBgColor != QColor("transparent")) {
-#endif
                 pC->setBgColor(r1, g1, b1, 255);
             }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             if (mFgColor != QColorConstants::Transparent) {
-#else
-            if (mFgColor != QColor("transparent")) {
-#endif
                 pC->setFgColor(r2, g2, b2);
             }
         }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -866,13 +866,8 @@ void XMLexport::writeTrigger(TTrigger* pT, pugi::xml_node xmlParent)
             trigger.append_child("mStayOpen").text().set(QString::number(pT->mStayOpen).toUtf8().constData());
             trigger.append_child("mCommand").text().set(pT->mCommand.toUtf8().constData());
             trigger.append_child("packageName").text().set(pT->mPackageName.toUtf8().constData());
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             trigger.append_child("mFgColor").text().set(pT->mFgColor == QColorConstants::Transparent ? "transparent": pT->mFgColor.name().toUtf8().constData());
             trigger.append_child("mBgColor").text().set(pT->mBgColor == QColorConstants::Transparent ? "transparent": pT->mBgColor.name().toUtf8().constData());
-#else
-            trigger.append_child("mFgColor").text().set(pT->mFgColor == QColor("transparent") ? "transparent": pT->mFgColor.name().toUtf8().constData());
-            trigger.append_child("mBgColor").text().set(pT->mBgColor == QColor("transparent") ? "transparent": pT->mBgColor.name().toUtf8().constData());
-#endif
             trigger.append_child("mSoundFile").text().set(pT->mSoundFile.toUtf8().constData());
             trigger.append_child("colorTriggerFgColor").text().set(pT->mColorTriggerFgColor.name().toUtf8().constData());
             trigger.append_child("colorTriggerBgColor").text().set(pT->mColorTriggerBgColor.name().toUtf8().constData());

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -374,12 +374,8 @@ void XMLimport::readMap()
     QListIterator<int> itAreaWithRooms(tempAreaRoomsHash.uniqueKeys());
     while (itAreaWithRooms.hasNext()) {
         int areaId = itAreaWithRooms.next();
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         auto values = tempAreaRoomsHash.values(areaId);
         QSet<int> areaRoomsSet{values.begin(), values.end()};
-#else
-        QSet<int> areaRoomsSet{tempAreaRoomsHash.values(areaId).toSet()};
-#endif
 
         if (!mpHost->mpMap->mpRoomDB->areas.contains(areaId)) {
             // It is known for map files to have rooms with area Ids that are

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -479,11 +479,7 @@ void dlgIRC::slot_onTextEntered()
         lineEdit->clear();
     } else if (input.length() > 1) {
         QString error;
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
         QString command = lineEdit->text().mid(1).split(" ", Qt::SkipEmptyParts).value(0).toUpper();
-#else
-        QString command = lineEdit->text().mid(1).split(" ", QString::SkipEmptyParts).value(0).toUpper();
-#endif
         if (commandParser->commands().contains(command)) {
             error = tr("[ERROR] Syntax: %1").arg(commandParser->syntax(command).replace(qsl("<"), qsl("&lt;")).replace(qsl(">"), qsl("&gt;")));
         } else {
@@ -805,11 +801,7 @@ QStringList dlgIRC::readIrcChannels(Host* pH)
     if (channelstr.isEmpty()) {
         channels << dlgIRC::DefaultChannels;
     } else {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
         channels = channelstr.split(qsl(" "), Qt::SkipEmptyParts);
-#else
-        channels = channelstr.split(qsl(" "), QString::SkipEmptyParts);
-#endif
     }
     return channels;
 }

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -289,9 +289,7 @@ void dlgPackageExporter::slot_packageChanged(int index)
     mPlainDescription = packageInfo.value(qsl("description"));
     QString description{mPlainDescription};
     description.replace(QLatin1String("$packagePath"), qsl("%1/%2").arg(packagePath, packageName));
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
     ui->textEdit_description->setMarkdown(description);
-#endif
     QString version = packageInfo.value(qsl("version"));
     ui->lineEdit_version->setText(version);
     QStringList dependencies = packageInfo.value(qsl("dependencies")).split(QLatin1Char(','));
@@ -380,7 +378,6 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
 
         if (evt->type() == QEvent::FocusOut) {
             mPlainDescription = ui->textEdit_description->toPlainText();
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
             //$packagePath allows to put images in a package which will then be displayed in the description
             //during package creation it uses the profile folder. But once the package is created it will use
             //profile folder/packagename
@@ -400,7 +397,6 @@ bool dlgPackageExporter::eventFilter(QObject* obj, QEvent* evt)
                 plainText.replace(qsl("$%1").arg(info.fileName()), fname);
             }
             ui->textEdit_description->setMarkdown(plainText);
-#endif
             return false;
         }
     }
@@ -1553,9 +1549,7 @@ void dlgPackageExporterDescription::insertFromMimeData(const QMimeData* source)
                 fname = QUrl::toPercentEncoding(fname).constData();
                 plainText.replace(qsl("$%1").arg(info.fileName()), fname);
             }
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
             setMarkdown(plainText);
-#endif
         }
     } else {
         QTextEdit::insertFromMimeData(source);

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -167,9 +167,7 @@ class dlgPackageExporterDescription : public QTextEdit
 
 public:
     Q_DISABLE_COPY(dlgPackageExporterDescription)
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 13, 0))
     Q_DISABLE_MOVE(dlgPackageExporterDescription)
-#endif
     explicit dlgPackageExporterDescription(QWidget* pW = nullptr);
     ~dlgPackageExporterDescription();
     bool canInsertFromMimeData(const QMimeData* source) const override;

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -165,11 +165,7 @@ void dlgPackageManager::slot_item_clicked(QTableWidgetItem* pItem)
         mDescription->show();
         QString packageDir = mudlet::self()->getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), packageName);
         description.replace(QLatin1String("$packagePath"), packageDir);
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
         mDescription->setMarkdown(description);
-#else
-        mDescription->setText(description);
-#endif
     }
 
     QStringList labelText, details;

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -2715,11 +2715,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         }
 
         if (!newIrcChannels.isEmpty()) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
             QStringList tL = newIrcChannels.split(" ", Qt::SkipEmptyParts);
-#else
-            QStringList tL = newIrcChannels.split(" ", QString::SkipEmptyParts);
-#endif
             for (QString s : tL) {
                 if (s.startsWith("#") || s.startsWith("&") || s.startsWith("+")) {
                     newChanList << s;

--- a/src/dlgRoomExits.cpp
+++ b/src/dlgRoomExits.cpp
@@ -476,12 +476,8 @@ void dlgRoomExits::save()
         return;
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QList<QString> originalExitCmdsList{pR->getSpecialExits().keys()};
     QSet<QString> originalExitCmds{originalExitCmdsList.begin(), originalExitCmdsList.end()};
-#else
-    QSet<QString> originalExitCmds = pR->getSpecialExits().keys().toSet();
-#endif
 
     for (int i = 0; i < specialExits->topLevelItemCount(); ++i) {
         QTreeWidgetItem* pI = specialExits->topLevelItem(i);

--- a/src/dlgRoomSymbol.cpp
+++ b/src/dlgRoomSymbol.cpp
@@ -117,11 +117,7 @@ QStringList dlgRoomSymbol::getComboBoxItems()
         itSymbolUsed.next();
         symbolCountsSet.insert(itSymbolUsed.value());
     }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QList<int> symbolCountsList{symbolCountsSet.begin(), symbolCountsSet.end()};
-#else
-    QList<int> symbolCountsList{symbolCountsSet.toList()};
-#endif
     if (symbolCountsList.size() > 1) {
         std::sort(symbolCountsList.begin(), symbolCountsList.end());
     }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4043,13 +4043,8 @@ void dlgTriggerEditor::saveTrigger()
         pT->mSoundTrigger = mpTriggersMainArea->groupBox_soundTrigger->isChecked();
         pT->setSound(mpTriggersMainArea->lineEdit_soundFile->text());
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QColor fgColor(QColorConstants::Transparent);
         QColor bgColor(QColorConstants::Transparent);
-#else
-        QColor fgColor("transparent");
-        QColor bgColor("transparent");
-#endif
         if (!mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString().isEmpty()) {
             fgColor = QColor(mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString());
         }
@@ -5156,13 +5151,8 @@ void dlgTriggerEditor::slot_trigger_selected(QTreeWidgetItem* pItem)
 
         QColor fgColor(pT->getFgColor());
         QColor bgColor(pT->getBgColor());
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         bool transparentFg = fgColor == QColorConstants::Transparent;
         bool transparentBg = bgColor == QColorConstants::Transparent;
-#else
-        bool transparentFg = fgColor == QColor("transparent");
-        bool transparentBg = bgColor == QColor("transparent");
-#endif
         mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(fgColor, pT->isColorizerTrigger()));
         mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, transparentFg ? qsl("transparent") : fgColor.name());
         mpTriggersMainArea->pushButtonFgColor->setText(transparentFg ? tr("keep",
@@ -8450,13 +8440,8 @@ void dlgTriggerEditor::slot_colorizeTriggerSetFgColor()
     auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonFgColor->property(cButtonBaseColor).toString()),
                                         this,
                                         tr("Select foreground color to apply to matches"));
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     color = color.isValid() ? color : QColorConstants::Transparent;
     bool keepColor = color == QColorConstants::Transparent;
-#else
-    color = color.isValid() ? color : QColor("transparent");
-    bool keepColor = color == QColor("transparent");
-#endif
     mpTriggersMainArea->pushButtonFgColor->setStyleSheet(generateButtonStyleSheet(color));
     mpTriggersMainArea->pushButtonFgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
     mpTriggersMainArea->pushButtonFgColor->setProperty(cButtonBaseColor, keepColor ? qsl("transparent") : color.name());
@@ -8476,13 +8461,8 @@ void dlgTriggerEditor::slot_colorizeTriggerSetBgColor()
     auto color = QColorDialog::getColor(QColor(mpTriggersMainArea->pushButtonBgColor->property(cButtonBaseColor).toString()),
                                         this,
                                         tr("Select background color to apply to matches"));
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     color = color.isValid() ? color : QColorConstants::Transparent;
     bool keepColor = color == QColorConstants::Transparent;
-#else
-    color = color.isValid() ? color : QColor("transparent");
-    bool keepColor = color == QColor("transparent");
-#endif
     mpTriggersMainArea->pushButtonBgColor->setStyleSheet(generateButtonStyleSheet(color));
     mpTriggersMainArea->pushButtonBgColor->setText(keepColor ? tr("keep", "Keep the existing colour on matches to highlight. Use shortest word possible so it fits on the button") : QString());
     mpTriggersMainArea->pushButtonBgColor->setProperty(cButtonBaseColor, keepColor ? qsl("transparent") : color.name());
@@ -8859,11 +8839,7 @@ void dlgTriggerEditor::slot_editorContextMenu()
 
 QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bool isEnabled)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     if (color != QColorConstants::Transparent && color.isValid()) {
-#else
-    if (color != QColor("transparent") && color.isValid()) {
-#endif
         if (isEnabled) {
             return mudlet::self()->mTEXT_ON_BG_STYLESHEET
                     .arg(color.lightness() > 127 ? QLatin1String("black") : QLatin1String("white"),

--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -223,11 +223,7 @@ void GLWidget::slot_setCameraPositionZ(int angle)
 
 void GLWidget::initializeGL()
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QColor color(QColorConstants::Black);
-#else
-    QColor color(Qt::black);
-#endif
     glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
     xRot = 1;
     yRot = 5;
@@ -274,11 +270,7 @@ void GLWidget::paintGL()
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
             QPainter painter(this);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
             painter.setPen(QColorConstants::White);
-#else
-            painter.setPen(Qt::white);
-#endif
             painter.setFont(QFont("Bitstream Vera Sans Mono", 30));
             painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing);
 

--- a/src/ircmessageformatter.cpp
+++ b/src/ircmessageformatter.cpp
@@ -223,11 +223,7 @@ QString IrcMessageFormatter::formatNickMessage(IrcNickMessage* message, bool isF
 QString IrcMessageFormatter::formatNoticeMessage(IrcNoticeMessage* message, bool isForLua)
 {
     if (message->isReply()) {
-#if (QT_VERSION) >= (QT_VERSION_CHECK(5, 14, 0))
         const QStringList params = message->content().split(" ", Qt::SkipEmptyParts);
-#else
-        const QStringList params = message->content().split(" ", QString::SkipEmptyParts);
-#endif
         const QString cmd = params.value(0);
         if (cmd.toUpper() == "PING") {
             const QString secs = formatSeconds(params.value(1).toInt());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,9 @@ int main(int argc, char* argv[])
 #endif // _MSC_VER && _DEBUG
     spDebugConsole = nullptr;
 
+#if defined (Q_OS_UNIX)
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 
 #if defined(Q_OS_MACOS)
     // Workaround for horrible mac rendering issues once the mapper widget

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,11 +150,7 @@ int main(int argc, char* argv[])
 #endif // _MSC_VER && _DEBUG
     spDebugConsole = nullptr;
 
-    // due to a Qt bug, this only safely works for both non- and HiDPI displays on 5.12+
-    // 5.6 - 5.11 make the application blow up in size on non-HiDPI displays
-#if defined (Q_OS_UNIX) && (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
 
 #if defined(Q_OS_MACOS)
     // Workaround for horrible mac rendering issues once the mapper widget

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -4289,11 +4289,7 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
     // to allow for persistent editing of it as it is not possible to obtain it
     // from the Hunspell library:
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     wordSet = QSet<QString>(wordList.begin(), wordList.end());
-#else
-    wordSet = wordList.toSet();
-#endif
 
 #if defined(Q_OS_WIN32)
     mudlet::self()->sanitizeUtf8Path(affixPathFileName, qsl("profile.dic"));
@@ -4344,11 +4340,7 @@ Hunhandle* mudlet::prepareSharedDictionary()
         return nullptr;
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     mWordSet_shared = QSet<QString>(wordList.begin(), wordList.end());
-#else
-    mWordSet_shared = wordList.toSet();
-#endif
 
 #if defined(Q_OS_WIN32)
     mudlet::self()->sanitizeUtf8Path(affixPathFileName, qsl("profile.dic"));
@@ -4376,11 +4368,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
         return false;
     }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QStringList wordList{wordSet.begin(), wordSet.end()};
-#else
-    QStringList wordList{wordSet.toList()};
-#endif
 
     // This also sorts wordList as a wanted side-effect:
     int wordCount = scanWordList(wordList, graphemeCounts);

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -35,8 +35,8 @@
 #                                                                          #
 ############################################################################
 
-lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_VERSION, 11)) {
-    error("Mudlet requires Qt 5.11 or later")
+lessThan(QT_MAJOR_VERSION, 5)|if(lessThan(QT_MAJOR_VERSION,6):lessThan(QT_MINOR_VERSION, 14)) {
+    error("Mudlet requires Qt 5.14 or later")
 }
 
 # Including IRC Library


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Increase minimum Qt version from 5.11 to 5.14.
#### Motivation for adding to Mudlet
We stuck with Qt 5.11 as a minimum because that is what Debian stable supported. Debian stable now [uses 5.15](https://packages.debian.org/search?keywords=qt5&searchon=names&suite=stable&section=all), so it is safe for us to upgrade to the latest version we use - which is 5.14.
#### Other info (issues closed, discussion etc)
A lot of #ifdefs got removed as well, making the code a lot cleaner!