### PR TITLE
Infrastructure: fix a couple of member initialisation order warnings

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -328,6 +328,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mSearchOptions(dlgTriggerEditor::SearchOption::SearchOptionNone)
 , mpDlgIRC(nullptr)
 , mpDlgProfilePreferences(nullptr)
+, mTutorialForCompactLineAlreadyShown(false)
 , mDisplayFont(QFont(qsl("Bitstream Vera Sans Mono"), 14, QFont::Normal))
 , mLuaInterface(nullptr)
 , mTriggerUnit(this)
@@ -360,7 +361,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mPlayerRoomInnerDiameterPercentage(70)
 , mDebugShowAllProblemCodepoints(false)
 , mCompactInputLine(false)
-, mTutorialForCompactLineAlreadyShown(false)
 {
     TDebug::addHost(this);
 

--- a/src/dlgMapLabel.h
+++ b/src/dlgMapLabel.h
@@ -57,8 +57,8 @@ private:
     QColorDialog* fgColorDialog = nullptr;
     QString imagePath;
     QString text;
-    QColor bgColor;
     QColor fgColor;
+    QColor bgColor;
     QFont font;
 
 private slots:

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -727,7 +727,7 @@ HEADERS += \
     TMxpTagHandler.h \
     TMxpTagParser.h \
     TMxpTagProcessor.h \
-    TMxpSupportTagHandler.cpp \
+    TMxpSupportTagHandler.h \
     TMxpVarTagHandler.h \
     TMxpVersionTagHandler.h \
     Tree.h \


### PR DESCRIPTION
Also correct a typo in the QMake project file that listed a `.cpp` file in the `HEADERS` qmake variable when it should have been the corresponding `.h` one.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>