### PR TITLE
Improve: remove extraneous setPalette calls

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -398,7 +398,6 @@ bool TCommandLine::event(QEvent* event)
                 mUserKeptOnTyping = false;
                 mTabCompletionCount = -1;
                 mAutoCompletionCount = -1;
-                setPalette(mRegularPalette);
                 mHistoryBuffer = 0;
                 ke->accept();
                 return true;
@@ -894,7 +893,6 @@ void TCommandLine::enterCommand(QKeyEvent* event)
         } else {
             mHistoryBuffer = 1;
         }
-        setPalette(mRegularPalette);
 
         mHistoryList.removeAll(toPlainText());
         if (!mHistoryList.isEmpty()) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove extraneous calls to set the command line's black palette any time a command is entered or the Escape key is pressed. This code has been in there since 2009 and as far as I can tell, doesn't add value.
#### Motivation for adding to Mudlet
Maybe it'll fix the flickering issue I've seen on Linux sometimes?
#### Other info (issues closed, discussion etc)
