### PR TITLE
Improve: don't set default volume, rate, or pitch for TTS

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -12303,9 +12303,6 @@ void TLuaInterpreter::ttsBuild()
     bSpeechQueueing = false;
 
     connect(speechUnit, &QTextToSpeech::stateChanged, &TLuaInterpreter::ttsStateChanged);
-    speechUnit->setVolume(1.0);
-    speechUnit->setRate(0.0);
-    speechUnit->setPitch(0.0);
     return;
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't set default TTS settings because these values differ from system defaults - meaning Mudlet's TTS doesn't sound like you'd expect it to out of the box.
#### Motivation for adding to Mudlet
Better out of the box TTS experience.
#### Other info (issues closed, discussion etc)
On macOS, default pitch is actually -.23727678571429 and rate is -.125. Let's not mess with the values and let Qt do its thing.

Thanks to @tspivey for working through the solution.