### PR TITLE
Fix: use native language for desciptions of a couple of predefined MUDS

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -1021,7 +1021,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
  *                   "The dust is like a tide, and only a few people in the rivers and lakes."
  *                   "\n\n"
  *                   "Chinese open source martial arts MUD Yan Huang Qunxia biography, the game includes 25 masters and 5 major families. Laughing, grudge."
- *\
+ */
                    "皇图霸业谈笑中，不胜人生一场醉。\n"
                    "提剑跨骑挥鬼雨，白骨如山鸟惊飞。\n"
                    "尘事如潮人如水，只叹江湖几人回。"

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -716,166 +716,311 @@ QPair<bool, QString> dlgConnectionProfiles::writeProfileData(const QString& prof
 QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quint16 port, const QString& profile_name) const
 {
     if (hostUrl == QLatin1String("realmsofdespair.com")) {
-        return QLatin1String(
-                "The Realms of Despair is the original SMAUG MUD and is FREE to play. We have an active Roleplaying community, an active player-killing (deadly) community, and a very active "
-                "peaceful community. Players can choose from 13 classes (including a deadly-only class) and 13 races. Character appearances are customizable on creation and we have a vast "
-                "collection of equipment that is level, gender, class, race and alignment specific. We boast well over 150 original, exclusive areas, with a total of over 20,000 rooms. Mob killing, "
-                "or 'running' is one of our most popular activities, with monster difficulties varying from easy one-player kills to difficult group kills. We have four deadly-only Clans, twelve "
-                "peaceful-only Guilds, eight Orders, and fourteen Role-playing Nations that players can join to interact more closely with other players. We have two mortal councils that actively "
-                "work toward helping players: The Symposium hears ideas for changes, and the Newbie Council assists new players. Our team of Immortals are always willing to answer questions and to "
-                "help out however necessary. Best of all, playing the Realms of Despair is totally FREE!");
-    } else if (hostUrl == QLatin1String("zombiemud.org")) {
-        return QLatin1String(
-                "Since 1994, ZombieMUD has been on-line and bringing orc-butchering fun to the masses from our home base in Oulu, Finland. We're a pretty friendly bunch, with players logging in "
-                "from all over the globe to test their skill in our medieval role-playing environment. With 15 separate guilds and 41 races to choose from, as a player the only limitation to your "
-                "achievements on the game is your own imagination and will to succeed.");
-    } else if (hostUrl == QLatin1String("carrionfields.net")) {
-        return QLatin1String("Carrion Fields is a unique blend of high-caliber roleplay and complex, hardcore player-versus-player combat that has been running continuously, and 100% free, for over "
-                             "25 years.\n\nChoose from among 21 races, 17 highly customizable classes, and several cabals and religions to suit your playstyle and the story you want to tell. Our "
-                             "massive, original world is full of secrets and envied limited objects that take skill to acquire and great care to keep.\n\nWe like to think of ourselves as the Dark "
-                             "Souls of MUDs, with a community that is supportive of new players - unforgiving though our world may be. Join us for a real challenge and real rewards: "
-                             "adrenalin-pumping battles, memorable quests run by our volunteer immortal staff, and stories that will stick with you for a lifetime.");
-    } else if (hostUrl == QLatin1String("cleftofdimensions.net")) {
-        return QLatin1String("Do you have a soft spot for an old SNES RPG? Are you a fan of retro gaming? The Cleft of Dimensions is an adventure-driven MUD with content inspired by a variety of "
-                             "classic video games. Do you want to jump on goombas? Maybe you'd rather immolate them with lava or bombard them with meteors. Then again, why fight when enslavement's "
-                             "an option? If that doesn't work out, you've got this motorcycle you could crash into them. The Cleft has 16 character classes, each with a distinctive "
-                             "playstyle.\n\nGameplay in the Cleft features exploration, puzzles, quests, and combat. At time of writing, the world contains 98 areas. Quests range from deciphering "
-                             "treasure maps and committing industrial espionage to seeking the blessings of the mana spirits or just going fishing. A remort system facilitates repeat playthroughs to "
-                             "find content you missed the first time around.\n\nThe Cleft opened in July 2000 and has been in active development ever since. We're always innovating. Recent features "
-                             "include Discord integration (https://discord.gg/cSqkpbu) and areas written with artificial intelligence. Check us out!");
-    } else if (hostUrl == QLatin1String("godwars2.org")) {
-        return QLatin1String(
-                "God Wars II is a fast and furious combat mud, designed to test player skill in terms of pre-battle preparation and on-the-spot reflexes, as well as the ability to adapt quickly to "
-                "new situations. Take on the role of a godlike supernatural being in a fight for supremacy.\n\nRoomless world. Manual combat. Endless possibilities.");
-    } else if (hostUrl == QLatin1String("3k.org")) {
-        if (port == 3200) {
-            return QLatin1String(
-                    "3Scapes is an alternative dimension to 3Kingdoms, similar in many respects, but unique and twisted in so many ways.  3Scapes offers a faster pace of play, along with "
-                    "an assortment "
-                    "of new guilds, features, and areas.");
-        } else { // port==3000
-            return QLatin1String(
-                    "Simple enough to learn, yet complex enough to challenge you for years, 3Kingdoms is a colossal adventure through which many years of active and continued development by its "
-                    "dedicated coding staff.  Based around the mighty town of Pinnacle, three main realms beckon the player to explore. These kingdoms are known as: Fantasy, a vast medieval realm "
-                    "full "
-                    "of orcs, elves, dragons, and a myriad of other creatures; Science, a post-apocalyptic, war-torn world set in the not-so-distant future; and Chaos, a transient realm where the "
-                    "enormous realities of Fantasy and Science collide to produce creatures so bizarre that they have yet to be categorized.  During their exploration of the realms, players have the "
-                    "opportunity to join any of well over a dozen different guilds, which grant special, unique powers to the player, furthering their abilities as they explore the vast expanses of "
-                    "each realm. Add in the comprehensive skill system that 3K offers and you are able to extensively customize your characters.");
-        }
-    } else if (hostUrl == QLatin1String("slothmud.org")) {
-        return QLatin1String(
-                "SlothMUD... the ultimate in DIKUMUD! The most active, intricate, exciting FREE MUD of its kind. This text based multiplayer free online rpg game and is enjoyed continuously by "
-                "players worldwide. With over 27,500 uniquely described rooms, 9,300 distinct creatures, 14,200 characters, and 87,100 pieces of equipment, charms, trinkets and other items, our "
-                "online rpg world is absolutely enormous and ready to explore.");
-    } else if (hostUrl == QLatin1String("game.wotmud.org")) {
-        return QLatin1String(
-                "WoTMUD is the most popular on-line game based on the late Robert Jordan's epic Wheel of Time fantasy novels.\n"
-                "Not only totally FREE to play since it started in 1993 it was officially sanctioned by the Author himself.\n"
-                "Explore a World very like that of Rand al'Thor's; from the Blight in the North down to the Isle of Madmen far, far south.\n"
-                "Wander around in any of the towns from the books such as Caemlyn, Tar Valon or Tear, or start your adventure in the Two Rivers area, not YET the home of the Dragon Reborn.\n"
-                "Will you join one of the Clans working for the triumph of the Light over the creatures and minions of the Dark One; or will you be one of the returning invaders in the South West, "
-                "descendants of Artur Hawkwing's long-thought lost Armies; or just maybe you are skilled enough to be a hideous Trolloc, creature of the Dark, who like Humans - but only as a source "
-                "of sustenance.\n"
-                "Very definitely a Player Verses Player (PvP) world but with strong Role Playing (RP) too; nowhere is totally safe but some parts are much more dangerous than others - once you "
-                "enter you may never leave...");
-    } else if (hostUrl == qsl("midnightsun2.org")) {
-        return QLatin1String(
-                "Midnight Sun is a medieval fantasy LPmud that has been around since 1991. We are a non-PK, hack-and-slash game, cooperative rather than competitive in nature, and with a strong "
-                "sense of community.");
-    } else if (hostUrl == qsl("mudlet.org")) {
-        return QLatin1String(
-                "This isn't a game profile, but a special one for testing Mudlet itself using Busted. You can also use it as a starting point to create automated tests for your own profiles!");
-    } else if (hostUrl == qsl("luminarimud.com")) {
-        return QLatin1String("Luminari is a deep, engaging game set in the world of the Luminari - A place where magic is entwined with the fabric of reality and the forces of evil and destruction "
-                             "are rising from a long slumber to again wreak havoc on the realm.  The gameplay of Luminari will be familiar to anyone who has played Dungeons and Dragons, Pathfinder "
-                             "or any of the many RPG systems based on the d20 ruleset.");
-    } else if (hostUrl == qsl("stickmud.com")) {
-        return qsl("StickMUD is a free, medieval fantasy game with a graphical user interface and a depth of features. You are welcomed into the game world with maps and dashboards to "
-                              "complement your imagination. Newbies escape quickly into game play with minimal study time. Awaken under the wondrous Mallorn Tree in the center of Newbie Park and "
-                              "learn by playing. Challenge non-player characters to gain experience, advance level and maximize your stats. Between battles, sit on the enchanted bench under the Tree "
-                              "to rapidly heal and reduce wait time. Signs in the park present game features such as races, clans and guilds. Read up on teasers about the adventures on the path "
-                              "ahead like dragons, castles and sailing. Join a guild and learn the ways of a Bard, Fighter, Mage, Necromancer, Ninja, Thief, Healer or Priest. Train skills in both "
-                              "craft and combat aligned with your guild. Participate in frequent game-wide events to earn points exchanged for gold, experience or skill training. Heroes and villains "
-                              "alike are invited! Role play is optional and player vs. player combat is allowed in much of the game. StickMUD was born in Finland in June 1991 and is now hosted in "
-                              "Canada. Our diverse community of players and active game engineers are ready to welcome new players like you to one of the best text-based multi-player games ever!");
-    } else if (hostUrl == qsl("reinosdeleyenda.es")) {
-        return qsl(
-                "The oldest Spanish free mud with more than 20 years of running history.\n\n"
-                "Reinos de Leyenda takes place in the ever changing world of Eirea, ravaged by the mischiefs of the gods after "
-                "more than a thousand years of contempt and hideous war amongst their zealous mortal pawns.\n\n"
-                "History is written on a day per day basis, taking into consideration the players' choices "
-                "to decide the irreversible aftermath of this everlasting struggle.\n\n"
-                "This is a PvP MUD which allows the player to set how high are the stakes: the more you risk losing upon death, the more glory to be earned by your heroism. RP, while "
-                "not enforced, is rewarded with non-PvP oriented perks and unique treasure.\n\n"
-                "A powerful character customization system allows you to choose your deity –or fully disregard the gods– and join one of the player-run realms that govern the land "
-                "to explore a breathing world, delve into the secrets of the oceans, shape your legacy, craft forgotten marvels for you –or your allies– and fight for faith, glory or coin.");
-        /**
-                 * Translation to the following text to Spanish as per request from SlyVen on PR #1505.
-                 * -- begin translation --
-                 * El mud Español gratis con más de 20 años de historia.
-                 *
-                 * Reinos de Leyenda toma lugar en el siempre cambiante mundo de Eirea, devastado por las intrigas de los dioses tras más de un millar de años de desprecio y cruenta guerra entre sus fanáticos peones mortales.
-                 *
-                 * La historia se escribe día a día, tomando en consideración las elecciones de los jugadores para decidir las consecuencias irreversibles de este conflicto imperecedero.
-                 *
-                 * Éste es un MUD con PvP que permite al jugador establecer cuánto quiere arriesgar al morir: a más riesgo, más gloria ganará por sus heroicidades. La interpretación (Rol) no está obligada, pero si recompensada
-                 * con habilidades especiales -no orientadas al combate- y tesoros únicos.
-                 *
-                 * El detallado creador del juego te permitirá elegir tu deidad -o renegar completamente de los dioses- y unirte a uno de los reinos que los jugadores se encargan de gobernar para explorar un mundo viviente, sumergirte en los misterios del océano,
-                 * dar forma a tu legado, forjar maravillas olvidadas para ti -o tus aliados- y luchar por fe, gloria o dinero.
-                 * -- end translation --
-                 */
-    } else if (hostUrl == qsl("mud.clessidra.it")) {
-        return qsl("Clessidra is the first all italian MUD ever created! On Clessidra you may find only original Areas, all in italian! Many features make Clessidra one of the best, or "
-                              "the best, MUD in Italy : Advanced travel mode, fight one to one versus your friend, or enemy, The Arena and its fight, the Mortal Challenge, the intelligent MOBs and "
-                              "their Quest and fighting style, a random automatic mission assignament and for you and your friends you must try the advanced Clan system that allows wars and "
-                              "conquest. A mercenary system to help playing when few players are online, a crafting system to create special object and a graphical user interface to help newbie and "
-                              "expert players have a better experince. A MUD that evolves with new challenge, new rules, new skills!");
-        /**
-                 * Original Italian
-                 * -- begin translation --
-                 * Clessidra e' il primo MUD completamente in italiano mai creato. Su Clessidra potrete trovare solo aree originali ed in italiano. Molte caratteristiche rendono Clessidra uno dei migliori, se non il migliore, MUD in Italia : Avanzati sistemi di spostamento, sfide uno-contro-uno contro gli amici, o i nemici, L'arena e i combattimenti, Le sfide all'ultimo sangue e i MOB intelligenti con le loro Quest e tecniche di combattimento, un sistema di assegnazione di missioni casuali e un avanzatissimo sistema di Clan che permettera' guerre e conquiste. Disponibilità di mercenari in caso di poca utenza, sistema di produzione/mercato per ottenere esclusivi oggetti, un interfaccia grafica per aiutarti a giocare, sia per i novizi che gli esperti. Un MUD che si evolve di continuo.
-                 * -- end translation --
-                 */
-    } else if (hostUrl == qsl("fierymud.org")) {
-        return qsl("The original vision of FieryMUD was to create a challanging MUD for advanced players. This new reborne Fiery is a hope to bring back the goals of the past by "
-                              "inflicting certain death on unsuspecting players. FieryMUD will continue to grow and change through the coming years and those players who seek challenge and possess "
-                              "imagination will come in search of what the 3D world fails to offer them.");
-
-    } else if (hostUrl == qsl("coremud.org")) {
-        return qsl(
-                "Welcome to Core Mud, an interactive text MUD set on the planet formal star-charts refer to as Hermes 571-G, but that everyone in the know refers to simply as \"Core\".\n\nCore is "
-                "one of the most distant settlements known to mankind, most famous for its lucrative yet oppressive mines, but more than mankind can be found here...\n\nCore is a diverse group of 9 "
-                "races in total, all vying for recognition or profits, or both, working for The Company, the megalithic entity running the colony itself.\n\nTo The Company, everything is secondary "
-                "to profits.\n\nIt is up to you to determine how best to survive in this environment, whether that be through combat training, superior mining skills, or technical prowess.\n\nCore "
-                "MUD is always free to play and features a fun and supportive atmosphere. Roleplaying is encouraged but not mandatory.\n\nMining is your primary source of income, but there are "
-                "multiple ways to scrape together a few credits... or a few million.\n\nCore Mud also features an economy which is player-driven.  Players own merchandise shops featuring energy "
-                "weaponry or useful tools, pubs featuring assorted alcoholic (of course) and non-alcoholic beverages, and clinics for healing, to name a few.\n\nCome join us today!");
-
-    } else if (hostUrl == qsl("legendsofthejedi.com")) {
-        return qsl("Legends of the Jedi is a text-based roleplaying experience that immerses players in a multiplayer world where they can rewrite classic Star Wars stories with their own "
-                              "heroes, villains, battles, and endings. Over the course of each two-year timeline, the game explores all the key eras of the Star Wars Expanded Universe.\n\nTake and "
-                              "hold planets as an Imperial Stormtrooper, command the Rebel navy and liberate the galaxy, pursue targets as a bounty hunter, or shape things on a larger scale as a "
-                              "member of the Galactic Senate. Maybe you'll even be one of the few born with force sensitivity, destined to be trained by Jedi or Sith.\n\nThe game offers an extensive "
-                              "crafting system for engineers to supply weapons, armor, and ships to the galaxy. Develop new, cutting-edge armaments to give your side an edge, or open a shop in a "
-                              "bustling commercial district and become wealthy as part of a powerful engineering conglomerate.\n\nLOTJ offers full PVP in both ground and space combat, governed by a "
-                              "set of rules to minimize griefing and ensure that all kills have sufficient in-character cause.\n\nWhat role will you play? The legend awaits!");
-
-    } else if (hostUrl == qsl("mume.org")) {
-        return qsl("Multi-Users in Middle-earth (MUME) is a highly competitive world PvP DikuMUD, set in J. R. R. Tolkien’s fictional world of Middle-earth, as described in The Hobbit and "
-                "The Lord of the Rings, where players may choose to join the epic war between the forces of Sauron and the armies of the Free peoples. In MUME players can explore, "
-                "role-play, acquire achievements, and complete quests across many challenging locations across Middle-earth such as Lothlórien, the Shire, Bree, Rivendell, Goblin-town,"
-                " Mirkwood, Dol Guldur, and the Mines of Moria. The game is completely at no cost to play and has been continually enhanced since its inception in the fall of 1991.");
-    } else if (hostUrl == qsl("mud.ren")) {
-        return qsl("天下风云出我辈，一入江湖岁月催。\n"
-                "皇图霸业谈笑中，不胜人生一场醉。\n"
-                "提剑跨骑挥鬼雨，白骨如山鸟惊飞。\n"
-                "尘事如潮人如水，只叹江湖几人回。\n\n"
-                "中文开源武侠MUD炎黄群侠传，游戏包括25大门派和5大世家，正邪只在一念间；近千门武学等你学习，上百种任务随你体验；让自己成为一代宗师，江湖笑，恩怨了。");
-    } else {
-        return readProfileData(profile_name, qsl("description"));
+        // clang-format off
+        // wrap before the last word on a line is here so that the source text
+        // is no more than 80 characters excluding the indent for readbility in
+        // an editor. Note that the text is autowrapped in the widget used to
+        // show it so ensure lines end in a space (for locales that use spaces)
+        // and use two '\n' to get a blank line between paragraphs.                          ------>|
+        // clang-format on
+        return qsl("The Realms of Despair is the original SMAUG MUD and is FREE to play. We have an "
+                   "active Roleplaying community, an active player-killing (deadly) community, and "
+                   "a very active peaceful community. Players can choose from 13 classes (including "
+                   "a deadly-only class) and 13 races. Character appearances are customizable on "
+                   "creation and we have a vast collection of equipment that is level, gender, "
+                   "class, race and alignment specific. We boast well over 150 original, exclusive "
+                   "areas, with a total of over 20,000 rooms. Mob killing, or 'running' is one of "
+                   "our most popular activities, with monster difficulties varying from easy one-"
+                   "player kills to difficult group kills. We have four deadly-only Clans, twelve "
+                   "peaceful-only Guilds, eight Orders, and fourteen Role-playing Nations that "
+                   "players can join to interact more closely with other players. We have two mortal "
+                   "councils that actively work toward helping players: The Symposium hears ideas "
+                   "for changes, and the Newbie Council assists new players. Our team of Immortals "
+                   "are always willing to answer questions and to help out however necessary. Best "
+                   "of all, playing the Realms of Despair is totally FREE!");
     }
+    if (hostUrl == QLatin1String("zombiemud.org")) {
+        return qsl("Since 1994, ZombieMUD has been on-line and bringing orc-butchering fun to the "
+                   "masses from our home base in Oulu, Finland. We're a pretty friendly bunch, with "
+                   "players logging in from all over the globe to test their skill in our medieval "
+                   "role-playing environment. With 15 separate guilds and 41 races to choose from, "
+                   "as a player the only limitation to your achievements on the game is your own "
+                   "imagination and will to succeed.");
+    }
+    if (hostUrl == QLatin1String("carrionfields.net")) {
+        return qsl("Carrion Fields is a unique blend of high-caliber roleplay and complex, hardcore "
+                   "player-versus-player combat that has been running continuously, and 100% free, "
+                   "for over 25 years."
+                   "\n\n"
+                   "Choose from among 21 races, 17 highly customizable classes, and several cabals "
+                   "and religions to suit your playstyle and the story you want to tell. Our "
+                   "massive, original world is full of secrets and envied limited objects that take "
+                   "skill to acquire and great care to keep."
+                   "\n\n"
+                   "We like to think of ourselves as the Dark Souls of MUDs, with a community that "
+                   "is supportive of new players - unforgiving though our world may be. Join us for a "
+                   "real challenge and real rewards: adrenalin-pumping battles, memorable quests run "
+                   "by our volunteer immortal staff, and stories that will stick with you for a "
+                   "lifetime.");
+    }
+    if (hostUrl == QLatin1String("cleftofdimensions.net")) {
+        return qsl("Do you have a soft spot for an old SNES RPG? Are you a fan of retro gaming? The "
+                   "Cleft of Dimensions is an adventure-driven MUD with content inspired by a variety "
+                   "of classic video games. Do you want to jump on goombas? Maybe you'd rather "
+                   "immolate them with lava or bombard them with meteors. Then again, why fight when "
+                   "enslavement's an option? If that doesn't work out, you've got this motorcycle you "
+                   "could crash into them. The Cleft has 16 character classes, each with a "
+                   "distinctive playstyle."
+                   "\n\n"
+                   "Gameplay in the Cleft features exploration, puzzles, quests, and combat. At time "
+                   "of writing, the world contains 98 areas. Quests range from deciphering treasure "
+                   "maps and committing industrial espionage to seeking the blessings of the mana "
+                   "spirits or just going fishing. A remort system facilitates repeat playthroughs to "
+                   "find content you missed the first time around."
+                   "\n\n"
+                   "The Cleft opened in July 2000 and has been in active development ever since. We're "
+                   "always innovating. Recent features include Discord integration "
+                   "(https://discord.gg/cSqkpbu) and areas written with artificial intelligence. Check "
+                   "us out!");
+    }
+    if (hostUrl == QLatin1String("godwars2.org")) {
+        return qsl("God Wars II is a fast and furious combat mud, designed to test player skill in "
+                   "terms of pre-battle preparation and on-the-spot reflexes, as well as the ability "
+                   "to adapt quickly to new situations. Take on the role of a godlike supernatural "
+                   "being in a fight for supremacy.\n\nRoomless world. Manual combat. Endless "
+                   "possibilities.");
+    }
+    if (hostUrl == QLatin1String("3k.org")) {
+        if (port == 3200) {
+            return qsl("3Scapes is an alternative dimension to 3Kingdoms, similar in many respects, but "
+                       "unique and twisted in so many ways.  3Scapes offers a faster pace of play, along "
+                       "with an assortment of new guilds, features, and areas.");
+        }
+        // else port==3000
+        return qsl("Simple enough to learn, yet complex enough to challenge you for years, 3Kingdoms "
+                   "is a colossal adventure through which many years of active and continued "
+                   "development by its dedicated coding staff.  Based around the mighty town of "
+                   "Pinnacle, three main realms beckon the player to explore. These kingdoms are known "
+                   "as: Fantasy, a vast medieval realm full of orcs, elves, dragons, and a myriad of "
+                   "other creatures; Science, a post-apocalyptic, war-torn world set in the not-so-"
+                   "distant future; and Chaos, a transient realm where the enormous realities of "
+                   "Fantasy and Science collide to produce creatures so bizarre that they have yet to "
+                   "be categorized.  During their exploration of the realms, players have the "
+                   "opportunity to join any of well over a dozen different guilds, which grant "
+                   "special, unique powers to the player, furthering their abilities as they explore "
+                   "the vast expanses of each realm. Add in the comprehensive skill system that 3K "
+                   "offers and you are able to extensively customize your characters.");
+    }
+    if (hostUrl == QLatin1String("slothmud.org")) {
+        return qsl("SlothMUD... the ultimate in DIKUMUD! The most active, intricate, exciting FREE MUD "
+                   "of its kind. This text based multiplayer free online rpg game and is enjoyed "
+                   "continuously by players worldwide. With over 27,500 uniquely described rooms, "
+                   "9,300 distinct creatures, 14,200 characters, and 87,100 pieces of equipment, "
+                   "charms, trinkets and other items, our online rpg world is absolutely enormous and "
+                   "ready to explore.");
+    }
+    if (hostUrl == QLatin1String("game.wotmud.org")) {
+        return qsl("WoTMUD is the most popular on-line game based on the late Robert Jordan's epic "
+                   "Wheel of Time fantasy novels."
+                   "\n\n"
+                   "Not only totally FREE to play since it started in 1993 it was officially "
+                   "sanctioned by the Author himself."
+                   "\n\n"
+                   "Explore a World very like that of Rand al'Thor's; from the Blight in the North "
+                   "down to the Isle of Madmen far, far south."
+                   "\n\n"
+                   "Wander around in any of the towns from the books such as Caemlyn, Tar Valon or "
+                   "Tear, or start your adventure in the Two Rivers area, not YET the home of the "
+                   "Dragon Reborn."
+                   "\n\n"
+                   "Will you join one of the Clans working for the triumph of the Light over the "
+                   "creatures and minions of the Dark One; or will you be one of the returning "
+                   "invaders in the South West, descendants of Artur Hawkwing's long-thought lost "
+                   "Armies; or just maybe you are skilled enough to be a hideous Trolloc, creature of "
+                   "the Dark, who like Humans - but only as a source of sustenance."
+                   "\n\n"
+                   "Very definitely a Player Verses Player (PvP) world but with strong Role Playing "
+                   "(RP) too; nowhere is totally safe but some parts are much more dangerous than "
+                   "others - once you enter you may never leave...");
+    }
+    if (hostUrl == QLatin1String("midnightsun2.org")) {
+        return qsl("Midnight Sun is a medieval fantasy LPmud that has been around since 1991. We are a "
+                   "non-PK, hack-and-slash game, cooperative rather than competitive in nature, and "
+                   "with a strong sense of community.");
+    }
+    if (hostUrl == QLatin1String("mudlet.org")) {
+        return qsl("This isn't a game profile, but a special one for testing Mudlet itself using "
+                   "Busted. You can also use it as a starting point to create automated tests for your "
+                   "own profiles!");
+    }
+    if (hostUrl == QLatin1String("luminarimud.com")) {
+        return qsl("Luminari is a deep, engaging game set in the world of the Luminari - A place where "
+                   "magic is entwined with the fabric of reality and the forces of evil and "
+                   "destruction are rising from a long slumber to again wreak havoc on the realm.  "
+                   "The gameplay of Luminari will be familiar to anyone who has played Dungeons and "
+                   "Dragons, Pathfinder or any of the many RPG systems based on the d20 ruleset.");
+    }
+    if (hostUrl == QLatin1String("stickmud.com")) {
+        return qsl("StickMUD is a free, medieval fantasy game with a graphical user interface and a "
+                   "depth of features. You are welcomed into the game world with maps and dashboards "
+                   "to complement your imagination. Newbies escape quickly into game play with minimal "
+                   "study time. Awaken under the wondrous Mallorn Tree in the center of Newbie Park "
+                   "and learn by playing. Challenge non-player characters to gain experience, advance "
+                   "level and maximize your stats. Between battles, sit on the enchanted bench under "
+                   "the Tree to rapidly heal and reduce wait time. Signs in the park present game "
+                   "features such as races, clans and guilds. Read up on teasers about the adventures "
+                   "on the path ahead like dragons, castles and sailing. Join a guild and learn the "
+                   "ways of a Bard, Fighter, Mage, Necromancer, Ninja, Thief, Healer or Priest. Train "
+                   "skills in both craft and combat aligned with your guild. Participate in frequent "
+                   "game-wide events to earn points exchanged for gold, experience or skill training. "
+                   "Heroes and villains alike are invited! Role play is optional and player vs. player "
+                   "combat is allowed in much of the game. StickMUD was born in Finland in June 1991 "
+                   "and is now hosted in Canada. Our diverse community of players and active game "
+                   "engineers are ready to welcome new players like you to one of the best text-based "
+                   "multi-player games ever!");
+    }
+    if (hostUrl == QLatin1String("reinosdeleyenda.es")) {
+// English translation (was used prior to switch to native Spanish of the MUD)
+//        return qsl("The oldest Spanish free mud with more than 20 years of running history."
+//                   "\n\n"
+//                   "Reinos de Leyenda takes place in the ever changing world of Eirea, ravaged by the "
+//                   "mischiefs of the gods after more than a thousand years of contempt and hideous war "
+//                   "amongst their zealous mortal pawns."
+//                   "\n\n"
+//                   "History is written on a day per day basis, taking into consideration the players' "
+//                   "choices to decide the irreversible aftermath of this everlasting struggle."
+//                   "\n\n"
+//                   "This is a PvP MUD which allows the player to set how high are the stakes: the more "
+//                   "you risk losing upon death, the more glory to be earned by your heroism. RP, while "
+//                   "not enforced, is rewarded with non-PvP oriented perks and unique treasure."
+//                   "\n\n"
+//                   "A powerful character customization system allows you to choose your deity –or "
+//                   "fully disregard the gods– and join one of the player-run realms that govern the "
+//                   "land to explore a breathing world, delve into the secrets of the oceans, shape "
+//                   "your legacy, craft forgotten marvels for you –or your allies– and fight for faith, "
+//                   "glory or coin.");
+        return qsl("El mud Español gratis con más de 20 años de historia."
+                   "\n\n"
+                   "Reinos de Leyenda toma lugar en el siempre cambiante mundo de Eirea, devastado por "
+                   "las intrigas de los dioses tras más de un millar de años de desprecio y cruenta "
+                   "guerra entre sus fanáticos peones mortales."
+                   "\n\n"
+                   "La historia se escribe día a día, tomando en consideración las elecciones de los "
+                   "jugadores para decidir las consecuencias irreversibles de este conflicto "
+                   "imperecedero."
+                   "\n\n"
+                   "Éste es un MUD con PvP que permite al jugador establecer cuánto quiere arriesgar "
+                   "al morir: a más riesgo, más gloria ganará por sus heroicidades. La interpretación "
+                   "(Rol) no está obligada, pero si recompensada con habilidades especiales -no "
+                   "orientadas al combate- y tesoros únicos."
+                   "\n\n"
+                   "El detallado creador del juego te permitirá elegir tu deidad -o renegar "
+                   "completamente de los dioses- y unirte a uno de los reinos que los jugadores se "
+                   "encargan de gobernar para explorar un mundo viviente, sumergirte en los misterios "
+                   "del océano, dar forma a tu legado, forjar maravillas olvidadas para ti -o tus "
+                   "aliados- y luchar por fe, gloria o dinero.");
+    }
+    if (hostUrl == QLatin1String("mud.clessidra.it")) {
+// English translation (was used prior to switch to native Italian of the MUD)
+//        return qsl("Clessidra is the first all italian MUD ever created! On Clessidra you may find "
+//                   "only original Areas, all in italian! Many features make Clessidra one of the best, "
+//                   "or the best MUD in Italy: Advanced travel mode, fight one to one versus your "
+//                   "friend, or enemy, The Arena and its fight, the Mortal Challenge, the intelligent "
+//                   "MOBs and their Quest and fighting style, a random automatic mission assignament "
+//                   "and for you and your friends you must try the advanced Clan system that allows "
+//                   "wars and conquest. A mercenary system to help playing when few players are online, "
+//                   "a crafting system to create special object and a graphical user interface to help "
+//                   "newbie and expert players have a better experience. A MUD that evolves with new "
+//                   "challenge, new rules, new skills!");
+        return qsl("Clessidra e' il primo MUD completamente in italiano mai creato. Su Clessidra "
+                   "potrete trovare solo aree originali ed in italiano. Molte caratteristiche rendono "
+                   "Clessidra uno dei migliori, se non il migliore, MUD in Italia : Avanzati sistemi "
+                   "di spostamento, sfide uno-contro-uno contro gli amici, o i nemici, L'arena e i "
+                   "combattimenti, Le sfide all'ultimo sangue e i MOB intelligenti con le loro Quest e "
+                   "tecniche di combattimento, un sistema di assegnazione di missioni casuali e un "
+                   "avanzatissimo sistema di Clan che permettera' guerre e conquiste. Disponibilità di "
+                   "mercenari in caso di poca utenza, sistema di produzione/mercato per ottenere "
+                   "esclusivi oggetti, un interfaccia grafica per aiutarti a giocare, sia per i novizi "
+                   "che gli esperti. Un MUD che si evolve di continuo.");
+    }
+    if (hostUrl == QLatin1String("fierymud.org")) {
+        return qsl("The original vision of FieryMUD was to create a challanging MUD for advanced "
+                   "players. This new reborne Fiery is a hope to bring back the goals of the past by "
+                   "inflicting certain death on unsuspecting players. FieryMUD will continue to grow "
+                   "and change through the coming years and those players who seek challenge and "
+                   "possess imagination will come in search of what the 3D world fails to offer them.");
+    }
+    if (hostUrl == QLatin1String("coremud.org")) {
+        return qsl("Welcome to Core Mud, an interactive text MUD set on the planet formal star-charts "
+                   "refer to as Hermes 571-G, but that everyone in the know refers to simply as \"Core\"."
+                   "\n\n"
+                   "Core is one of the most distant settlements known to mankind, most famous for its "
+                   "lucrative yet oppressive mines, but more than mankind can be found here..."
+                   "\n\n"
+                   "Core is a diverse group of 9 races in total, all vying for recognition or profits, "
+                   "or both, working for The Company, the megalithic entity running the colony itself."
+                   "\n\n"
+                   "To The Company, everything is secondary to profits."
+                   "\n\n"
+                   "It is up to you to determine how best to survive in this environment, whether that "
+                   "be through combat training, superior mining skills, or technical prowess."
+                   "\n\n"
+                   "Core MUD is always free to play and features a fun and supportive atmosphere. "
+                   "Roleplaying is encouraged but not mandatory."
+                   "\n\n"
+                   "Mining is your primary source of income, but there are multiple ways to scrape "
+                   "together a few credits... or a few million."
+                   "\n\n"
+                   "Core Mud also features an economy which is player-driven.  Players own "
+                   "merchandise shops featuring energy weaponry or useful tools, pubs featuring "
+                   "assorted alcoholic (of course) and non-alcoholic beverages, and clinics for "
+                   "healing, to name a few."
+                   "\n\n"
+                   "Come join us today!");
+    }
+    if (hostUrl == QLatin1String("legendsofthejedi.com")) {
+        return qsl("Legends of the Jedi is a text-based roleplaying experience that immerses players "
+                   "in a multiplayer world where they can rewrite classic Star Wars stories with their "
+                   "own heroes, villains, battles, and endings. Over the course of each two-year "
+                   "timeline, the game explores all the key eras of the Star Wars Expanded Universe."
+                   "\n\n"
+                   "Take and hold planets as an Imperial Stormtrooper, command the Rebel navy and "
+                   "liberate the galaxy, pursue targets as a bounty hunter, or shape things on a "
+                   "larger scale as a member of the Galactic Senate. Maybe you'll even be one of the "
+                   "few born with force sensitivity, destined to be trained by Jedi or Sith."
+                   "\n\n"
+                   "The game offers an extensive crafting system for engineers to supply weapons, "
+                   "armor, and ships to the galaxy. Develop new, cutting-edge armaments to give your "
+                   "side an edge, or open a shop in a bustling commercial district and become wealthy "
+                   "as part of a powerful engineering conglomerate."
+                   "\n\nL"
+                   "OTJ offers full PVP in both ground and space combat, governed by a set of rules to "
+                   "minimize griefing and ensure that all kills have sufficient in-character cause."
+                   "\n\n"
+                   "What role will you play? The legend awaits!");
+    }
+    if (hostUrl == QLatin1String("mume.org")) {
+        return qsl("Multi-Users in Middle-earth (MUME) is a highly competitive world PvP DikuMUD, set "
+                   "in J. R. R. Tolkien’s fictional world of Middle-earth, as described in The Hobbit "
+                   "and The Lord of the Rings, where players may choose to join the epic war between "
+                   "the forces of Sauron and the armies of the Free peoples. In MUME players can "
+                   "explore, role-play, acquire achievements, and complete quests across many "
+                   "challenging locations across Middle-earth such as Lothlórien, the Shire, Bree, "
+                   "Rivendell, Goblin-town, Mirkwood, Dol Guldur, and the Mines of Moria. The game is "
+                   "completely at no cost to play and has been continually enhanced since its "
+                   "inception in the fall of 1991.");
+    }
+    if (hostUrl == QLatin1String("mud.ren")) {
+        return qsl("天下风云出我辈，一入江湖岁月催。\n"
+                   "皇图霸业谈笑中，不胜人生一场醉。\n"
+                   "提剑跨骑挥鬼雨，白骨如山鸟惊飞。\n"
+                   "尘事如潮人如水，只叹江湖几人回。"
+                   "\n\n"
+                   "中文开源武侠MUD炎黄群侠传，游戏包括25大门派和5大世家，正邪只在一念间；近千门武学等你学习，上百种任务随你体验；让自己成为一代宗师，江湖笑，恩怨了。");
+    }
+    // Else, if there isn't a predefined text, return whatever the user might
+    // have stored:
+    return readProfileData(profile_name, qsl("description"));
 }
 
 void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -880,25 +880,26 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
                    "multi-player games ever!");
     }
     if (hostUrl == QLatin1String("reinosdeleyenda.es")) {
-// English translation (was used prior to switch to native Spanish of the MUD)
-//        return qsl("The oldest Spanish free mud with more than 20 years of running history."
-//                   "\n\n"
-//                   "Reinos de Leyenda takes place in the ever changing world of Eirea, ravaged by the "
-//                   "mischiefs of the gods after more than a thousand years of contempt and hideous war "
-//                   "amongst their zealous mortal pawns."
-//                   "\n\n"
-//                   "History is written on a day per day basis, taking into consideration the players' "
-//                   "choices to decide the irreversible aftermath of this everlasting struggle."
-//                   "\n\n"
-//                   "This is a PvP MUD which allows the player to set how high are the stakes: the more "
-//                   "you risk losing upon death, the more glory to be earned by your heroism. RP, while "
-//                   "not enforced, is rewarded with non-PvP oriented perks and unique treasure."
-//                   "\n\n"
-//                   "A powerful character customization system allows you to choose your deity –or "
-//                   "fully disregard the gods– and join one of the player-run realms that govern the "
-//                   "land to explore a breathing world, delve into the secrets of the oceans, shape "
-//                   "your legacy, craft forgotten marvels for you –or your allies– and fight for faith, "
-//                   "glory or coin.");
+/* English translation, provided by Game:
+ *                   "The oldest Spanish free mud with more than 20 years of running history."
+ *                   "\n\n"
+ *                   "Reinos de Leyenda takes place in the ever changing world of Eirea, ravaged by the "
+ *                   "mischiefs of the gods after more than a thousand years of contempt and hideous war "
+ *                   "amongst their zealous mortal pawns."
+ *                   "\n\n"
+ *                   "History is written on a day per day basis, taking into consideration the players' "
+ *                   "choices to decide the irreversible aftermath of this everlasting struggle."
+ *                   "\n\n"
+ *                   "This is a PvP MUD which allows the player to set how high are the stakes: the more "
+ *                   "you risk losing upon death, the more glory to be earned by your heroism. RP, while "
+ *                   "not enforced, is rewarded with non-PvP oriented perks and unique treasure."
+ *                   "\n\n"
+ *                   "A powerful character customization system allows you to choose your deity –or "
+ *                   "fully disregard the gods– and join one of the player-run realms that govern the "
+ *                   "land to explore a breathing world, delve into the secrets of the oceans, shape "
+ *                   "your legacy, craft forgotten marvels for you –or your allies– and fight for faith, "
+ *                   "glory or coin.");
+ */
         return qsl("El mud Español gratis con más de 20 años de historia."
                    "\n\n"
                    "Reinos de Leyenda toma lugar en el siempre cambiante mundo de Eirea, devastado por "
@@ -921,17 +922,18 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
                    "aliados- y luchar por fe, gloria o dinero.");
     }
     if (hostUrl == QLatin1String("mud.clessidra.it")) {
-// English translation (was used prior to switch to native Italian of the MUD)
-//        return qsl("Clessidra is the first all italian MUD ever created! On Clessidra you may find "
-//                   "only original Areas, all in italian! Many features make Clessidra one of the best, "
-//                   "or the best MUD in Italy: Advanced travel mode, fight one to one versus your "
-//                   "friend, or enemy, The Arena and its fight, the Mortal Challenge, the intelligent "
-//                   "MOBs and their Quest and fighting style, a random automatic mission assignament "
-//                   "and for you and your friends you must try the advanced Clan system that allows "
-//                   "wars and conquest. A mercenary system to help playing when few players are online, "
-//                   "a crafting system to create special object and a graphical user interface to help "
-//                   "newbie and expert players have a better experience. A MUD that evolves with new "
-//                   "challenge, new rules, new skills!");
+/* English translation, provided by Game:
+ *                   "Clessidra is the first all italian MUD ever created! On Clessidra you may find "
+ *                   "only original Areas, all in italian! Many features make Clessidra one of the best, "
+ *                   "or the best MUD in Italy: Advanced travel mode, fight one to one versus your "
+ *                   "friend, or enemy, The Arena and its fight, the Mortal Challenge, the intelligent "
+ *                   "MOBs and their Quest and fighting style, a random automatic mission assignament "
+ *                   "and for you and your friends you must try the advanced Clan system that allows "
+ *                   "wars and conquest. A mercenary system to help playing when few players are online, "
+ *                   "a crafting system to create special object and a graphical user interface to help "
+ *                   "newbie and expert players have a better experience. A MUD that evolves with new "
+ *                   "challenge, new rules, new skills!");
+ */
         return qsl("Clessidra e' il primo MUD completamente in italiano mai creato. Su Clessidra "
                    "potrete trovare solo aree originali ed in italiano. Molte caratteristiche rendono "
                    "Clessidra uno dei migliori, se non il migliore, MUD in Italia : Avanzati sistemi "
@@ -1012,6 +1014,14 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
     }
     if (hostUrl == QLatin1String("mud.ren")) {
         return qsl("天下风云出我辈，一入江湖岁月催。\n"
+/* English translation (courtesy of Google NOT the originator):
+ *                   "The world is out of my generation."
+ *                   "Emperor Tu Baye talked about laughter, it was drunk in life."
+ *                   "The sword rides on the ride, and the white bone is like a mountain bird to fly."
+ *                   "The dust is like a tide, and only a few people in the rivers and lakes."
+ *                   "\n\n"
+ *                   "Chinese open source martial arts MUD Yan Huang Qunxia biography, the game includes 25 masters and 5 major families. Laughing, grudge."
+ *\
                    "皇图霸业谈笑中，不胜人生一场醉。\n"
                    "提剑跨骑挥鬼雨，白骨如山鸟惊飞。\n"
                    "尘事如潮人如水，只叹江湖几人回。"

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -718,7 +718,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
     if (hostUrl == QLatin1String("realmsofdespair.com")) {
         // clang-format off
         // wrap before the last word on a line is here so that the source text
-        // is no more than 80 characters excluding the indent for readbility in
+        // is no more than 80 characters (excluding the indent) for readbility in
         // an editor. Note that the text is autowrapped in the widget used to
         // show it so ensure lines end in a space (for locales that use spaces)
         // and use two '\n' to get a blank line between paragraphs.                          ------>|

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -492,9 +492,9 @@ public:
         {"Luminari", {"luminarimud.com", 4100, false, "<a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a>", ":/icons/luminari_icon.png"}},
         {"StickMUD", {"stickmud.com", 7680, false, "<a href='http://www.stickmud.com/'>stickmud.com</a>", ":/icons/stickmud_icon.jpg"}},
         {"Clessidra", {"mud.clessidra.it", 4000, false, "<a href='http://www.clessidra.it/'>http://www.clessidra.it</a>", ":/icons/clessidra.jpg"}},
-        {"Reinos de Leyenda", {"reinosdeleyenda.es", 23, false, "<a href='https://www.reinosdeleyenda.es/'>Main website</a>\n"
-                                 "<a href='https://www.reinosdeleyenda.es/foro/'>Forums</a>\n"
-                                 "<a href='https://wiki.reinosdeleyenda.es/'>Wiki</a>\n", ":/icons/reinosdeleyenda_mud.png"}},
+        {"Reinos de Leyenda", {"reinosdeleyenda.es", 23, false, "<a href='https://www.reinosdeleyenda.es/'>Sitio web principal</a><br>"
+                                 "<a href='https://www.reinosdeleyenda.es/foro/'>Foros</a><br>"
+                                 "<a href='https://wiki.reinosdeleyenda.es/'>Wiki</a>", ":/icons/reinosdeleyenda_mud.png"}},
         {"Fierymud", {"fierymud.org", 4000, false, "<a href='https://www.fierymud.org/'>https://www.fierymud.org</a>", ":/icons/fiery_mud.png"}},
         {"Mudlet self-test", {"mudlet.org", 23, false, "", ""}},
         {"Carrion Fields", {"carrionfields.net", 4449, false, "<a href='http://www.carrionfields.net'>www.carrionfields.net</a>", ":/icons/carrionfields.png"}},


### PR DESCRIPTION
Following the inclusion of "Mud.ren" with its Chinese description text (in https://github.com/Mudlet/Mudlet/pull/6140), I felt it was appropriate to put in the native language texts for a Spanish and an Italian MUD who have already provided us with the text to use but which we hadn't so far. This will address points which I made about this in: https://github.com/Mudlet/Mudlet/pull/1505 and https://github.com/Mudlet/Mudlet/pull/2502#discussion_r273176458 respectively...

I have cleaned up the texts involved for all the descriptions so that they are all wrapped in our `qsl(`...`)` wrapper and the
host URLs that are used to identify which one to use are all wrapped in `QLatin1String(`...`)` as they should all be ASCII (as they are all OS compatible file names as well) and there is a `QLatin1String::operator==()` method for them.

In passing I have also "fixed" the "website" entries for the Spanish MUD as it is appropriate for them to be in Spanish rather than English as they are not URLs but HTTP-like `<a href="xxxx">`...`</a>` entries.

I propose to follow this PR with another one to move the description data to the same place as all the other data about the predefined MUDs (the container defined in the `./src/mudlet.h` file: `(inline static const OrderedMap<QString, GameDetails>) mudlet::scmDefaultGames`)

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>