### PR TITLE
Improve tab order in the connection screen - again

### DIFF
--- a/src/ui/connection_profiles.ui
+++ b/src/ui/connection_profiles.ui
@@ -942,6 +942,17 @@
  <tabstops>
   <tabstop>profiles_tree_widget</tabstop>
   <tabstop>welcome_message</tabstop>
+  <tabstop>profile_name_entry</tabstop>
+  <tabstop>host_name_entry</tabstop>
+  <tabstop>port_entry</tabstop>
+  <tabstop>port_ssl_tsl</tabstop>
+  <tabstop>tabWidget_connectionInfo</tabstop>
+  <tabstop>login_entry</tabstop>
+  <tabstop>character_password_entry</tabstop>
+  <tabstop>profile_history</tabstop>
+  <tabstop>discord_optin_checkBox</tabstop>
+  <tabstop>autologin_checkBox</tabstop>
+  <tabstop>auto_reconnect</tabstop>
   <tabstop>mud_description_textedit</tabstop>
   <tabstop>remove_profile_button</tabstop>
   <tabstop>copy_profile_toolbutton</tabstop>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
Pressing `Tab` before navigated in this order:

![image](https://user-images.githubusercontent.com/117238/178599639-bff95dba-8e66-49e9-948d-141045956ea6.png)

![image](https://user-images.githubusercontent.com/117238/178600422-5662802f-99b3-4e3e-9187-57fde41204f6.png)


Now it will be this:

![image](https://user-images.githubusercontent.com/117238/178609855-58d159a5-1f7b-46c2-acc2-2f1daf355c9f.png)

![image](https://user-images.githubusercontent.com/117238/178609875-e58247e7-cd1e-49bc-ae8b-59d3288ce50e.png)

(Colors of numbers are irrelevant)
(Objects 8 - 12 will only be reached if 7 was pushed, i.e. the "Optional" tab contents are shown)

#### Motivation for adding to Mudlet
Better a11t.
Fix #6146

#### Other info (issues closed, discussion etc)
Not sure if this is a lot better, I have not actually tried it with a screenreader yet.