### PR TITLE
fix autologin and autoreconnect conflict

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2824,6 +2824,13 @@ void mudlet::doAutoLogin(const QString& profile_name)
 
     pHost->setLogin(readProfileData(profile_name, qsl("login")));
     pHost->setPass(readProfileData(profile_name, qsl("password")));
+    
+    QString val = readProfileData(profile_name, qsl("autoreconnect"));
+    if (!val.isEmpty() && val.toInt() == Qt:Checked) {
+        pHost->setAutoReconnect(true);
+    } else {
+        pHost->setAutoReconnect(false);
+    }
 
     // This settings also need to be configured, note that the only time not to
     // save the setting is on profile loading:

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2826,7 +2826,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     pHost->setPass(readProfileData(profile_name, qsl("password")));
     
     QString val = readProfileData(profile_name, qsl("autoreconnect"));
-    if (!val.isEmpty() && val.toInt() == Qt:Checked) {
+    if (!val.isEmpty() && val.toInt() == Qt::Checked) {
         pHost->setAutoReconnect(true);
     } else {
         pHost->setAutoReconnect(false);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
make doAutoLogin check for autoreconnect and set the variable so that it works properly without connection window loading
#### Motivation for adding to Mudlet
There was a sunk cost thing after I figured out what was causing it, so might as well fix it too.
#### Other info (issues closed, discussion etc)
fixed #6153 