### PR TITLE
Infrastructure: trim translations-related debug output

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1108,7 +1108,7 @@ void mudlet::migrateDebugConsole(Host* currentHost)
 void mudlet::scanForMudletTranslations(const QString& path)
 {
     mMudletTranslationsPathName = path;
-    qDebug().nospace().noquote() << "mudlet::scanForMudletTranslations(\"" << path << "\") INFO - Seeking Mudlet translation files:";
+    // qDebug().nospace().noquote() << "mudlet::scanForMudletTranslations(\"" << path << "\") INFO - Seeking Mudlet translation files:";
     mTranslationsMap.clear();
 
     QDir translationDir(path);
@@ -1136,7 +1136,7 @@ void mudlet::scanForMudletTranslations(const QString& path)
 
         std::unique_ptr<QTranslator> pMudletTranslator = std::make_unique<QTranslator>();
         if (Q_LIKELY(pMudletTranslator->load(translationFileName, path))) {
-            qDebug().noquote().nospace() << "    found a Mudlet translation for locale code: \"" << languageCode << "\".";
+            // qDebug().noquote().nospace() << "    found a Mudlet translation for locale code: \"" << languageCode << "\".";
             if (!translationStats.isEmpty()) {
                 // For this to not be empty then we are reading the translations
                 // from the expected resource file and the translation
@@ -1206,7 +1206,7 @@ void mudlet::scanForMudletTranslations(const QString& path)
 void mudlet::scanForQtTranslations(const QString& path)
 {
     mQtTranslationsPathName = path;
-    qDebug().nospace().noquote() << "mudlet::scanForQtTranslations(\"" << path << "\") INFO - Seeking Qt translation files:";
+    // qDebug().nospace().noquote() << "mudlet::scanForQtTranslations(\"" << path << "\") INFO - Seeking Qt translation files:";
     QMutableMapIterator<QString, translation> itTranslation(mTranslationsMap);
     while (itTranslation.hasNext()) {
         itTranslation.next();
@@ -1214,7 +1214,7 @@ void mudlet::scanForQtTranslations(const QString& path)
         std::unique_ptr<QTranslator> pQtTranslator = std::make_unique<QTranslator>();
         QString translationFileName(qsl("qt_%1.qm").arg(languageCode));
         if (pQtTranslator->load(translationFileName, path)) {
-            qDebug().noquote().nospace() << "    found a Qt translation for locale code: \"" << languageCode << "\"";
+            // qDebug().noquote().nospace() << "    found a Qt translation for locale code: \"" << languageCode << "\"";
             /*
              * Unfortunately, success in this operation does not mean that
              * a qt_xx_YY.qm translation file has been located, as the
@@ -1230,7 +1230,7 @@ void mudlet::scanForQtTranslations(const QString& path)
             current.mQtTranslationFileName = translationFileName;
             itTranslation.setValue(current);
         } else {
-            qDebug().noquote().nospace() << "    no Qt translation found for locale code: \"" << languageCode << "\"";
+            // qDebug().noquote().nospace() << "    no Qt translation found for locale code: \"" << languageCode << "\"";
         }
     }
 }
@@ -1238,7 +1238,7 @@ void mudlet::scanForQtTranslations(const QString& path)
 void mudlet::loadTranslators(const QString& languageCode)
 {
     if (!mTranslatorsLoadedList.isEmpty()) {
-        qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - uninstalling existing translation previously loaded...";
+        // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - uninstalling existing translation previously loaded...";
         QMutableListIterator<QPointer<QTranslator>> itTranslator(mTranslatorsLoadedList);
         itTranslator.toBack();
         while (itTranslator.hasPrevious()) {
@@ -1261,7 +1261,7 @@ void mudlet::loadTranslators(const QString& languageCode)
         // up the process of locating the file:
         pQtTranslator->load(qtTranslatorFileName, mQtTranslationsPathName);
         if (!pQtTranslator->isEmpty()) {
-            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mQtTranslationsPathName << "/"<< qtTranslatorFileName << "\"...";
+            // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mQtTranslationsPathName << "/"<< qtTranslatorFileName << "\"...";
             qApp->installTranslator(pQtTranslator);
             mTranslatorsLoadedList.append(pQtTranslator);
         }
@@ -1272,8 +1272,8 @@ void mudlet::loadTranslators(const QString& languageCode)
     if (!mudletTranslatorFileName.isEmpty()) {
         pMudletTranslator->load(mudletTranslatorFileName, mMudletTranslationsPathName);
         if (!pMudletTranslator->isEmpty()) {
-            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mMudletTranslationsPathName << "/"
-                                         << mudletTranslatorFileName << "\"...";
+//            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mMudletTranslationsPathName << "/"
+//                                         << mudletTranslatorFileName << "\"...";
             qApp->installTranslator(pMudletTranslator);
             mTranslatorsLoadedList.append(pMudletTranslator);
         }
@@ -1959,9 +1959,10 @@ void mudlet::readEarlySettings(const QSettings& settings)
     mUserLocale = QLocale(mInterfaceLanguage);
     if (mUserLocale == QLocale::c()) {
         qWarning().nospace().noquote() << "mudlet::readEarlySettings(...) WARNING - Unable to convert language code \"" << mInterfaceLanguage << "\" to a recognised locale, reverting to the POSIX 'C' one.";
-    } else {
-        qDebug().nospace().noquote() << "mudlet::readEarlySettings(...) INFO - Using language code \"" << mInterfaceLanguage << "\" to switch to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::countryToString(mUserLocale.country()) << ")\" locale.";
+        return;
     }
+
+//    qDebug().nospace().noquote() << "mudlet::readEarlySettings(...) INFO - Using language code \"" << mInterfaceLanguage << "\" to switch to \"" << QLocale::languageToString(mUserLocale.language()) << " (" << QLocale::countryToString(mUserLocale.country()) << ")\" locale.";
 }
 
 void mudlet::readLateSettings(const QSettings& settings)


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
It's been a few years that translations have been added to Mudlet now, and things are working without issues. Maybe now is a good time to reduce some of the spammy text developers are faced with?

Before:

```
Could not find Discord library - searched in:
     "/media/vadi/SSDer/Programs/Qt/5.15.2/gcc_64/plugins"
     "/media/vadi/SSDer/Programs/Mudlet/cmake-build-debug/src"
mudlet::readEarlySettings(...) INFO - Using language code "en_US" to switch to "English (United States)" locale.
mudlet::scanForMudletTranslations(":/lang") INFO - Seeking Mudlet translation files:
    found a Mudlet translation for locale code: "ar_SA".
    found a Mudlet translation for locale code: "de_DE".
    found a Mudlet translation for locale code: "el_GR".
    found a Mudlet translation for locale code: "en_GB".
    found a Mudlet translation for locale code: "en_US".
    found a Mudlet translation for locale code: "es_ES".
    found a Mudlet translation for locale code: "fi_FI".
    found a Mudlet translation for locale code: "fr_FR".
    found a Mudlet translation for locale code: "it_IT".
    found a Mudlet translation for locale code: "nl_NL".
    found a Mudlet translation for locale code: "pl_PL".
    found a Mudlet translation for locale code: "pt_BR".
    found a Mudlet translation for locale code: "pt_PT".
    found a Mudlet translation for locale code: "ru_RU".
    found a Mudlet translation for locale code: "tr_TR".
    found a Mudlet translation for locale code: "zh_CN".
    found a Mudlet translation for locale code: "zh_TW".
mudlet::scanForQtTranslations("/media/vadi/SSDer/Programs/Qt/5.15.2/gcc_64/translations") INFO - Seeking Qt translation files:
    found a Qt translation for locale code: "ar_SA"
    found a Qt translation for locale code: "de_DE"
    no Qt translation found for locale code: "el_GR"
    found a Qt translation for locale code: "en_GB"
    found a Qt translation for locale code: "en_US"
    found a Qt translation for locale code: "es_ES"
    found a Qt translation for locale code: "fi_FI"
    found a Qt translation for locale code: "fr_FR"
    found a Qt translation for locale code: "it_IT"
    no Qt translation found for locale code: "nl_NL"
    found a Qt translation for locale code: "pl_PL"
    found a Qt translation for locale code: "pt_BR"
    found a Qt translation for locale code: "pt_PT"
    found a Qt translation for locale code: "ru_RU"
    found a Qt translation for locale code: "tr_TR"
    found a Qt translation for locale code: "zh_CN"
    found a Qt translation for locale code: "zh_TW"
mudlet::loadTranslators("en_US") INFO - installing Mudlet translation from: ":/lang/mudlet_en_US.qm"...
mudlet::mudlet() INFO - 'fusion' has been detected as the style factory in use - no styling fixes applied.
Device discovery cannot open device "/dev/input/event0"
Device discovery cannot open device "/dev/input/event1"
Device discovery cannot open device "/dev/input/event10"
Device discovery cannot open device "/dev/input/event11"
Device discovery cannot open device "/dev/input/event12"
Device discovery cannot open device "/dev/input/event13"
Device discovery cannot open device "/dev/input/event14"
Device discovery cannot open device "/dev/input/event15"
Device discovery cannot open device "/dev/input/event16"
Device discovery cannot open device "/dev/input/event17"
Device discovery cannot open device "/dev/input/event18"
Device discovery cannot open device "/dev/input/event19"
Device discovery cannot open device "/dev/input/event2"
Device discovery cannot open device "/dev/input/event20"
Device discovery cannot open device "/dev/input/event21"
Device discovery cannot open device "/dev/input/event22"
Device discovery cannot open device "/dev/input/event23"
Device discovery cannot open device "/dev/input/event24"
Device discovery cannot open device "/dev/input/event3"
Device discovery cannot open device "/dev/input/event4"
Device discovery cannot open device "/dev/input/event5"
Device discovery cannot open device "/dev/input/event6"
Device discovery cannot open device "/dev/input/event7"
Device discovery cannot open device "/dev/input/event8"
Device discovery cannot open device "/dev/input/event9"
Device discovery cannot open device "/dev/input/mice"
Device discovery cannot open device "/dev/input/mouse0"
cTelnet::encodingChanged("UTF-8") INFO - Installing a codec for OOB protocols that can handle: ()
[LOADING PROFILE]: "/home/vadi/.config/mudlet/profiles/game.tempestseason.com/current//2022-07-25#08-26-47.xml"
TMainConsole::setSystemSpellDictionary("en_US") INFO - System Hunspell dictionary loaded for profile, it uses a "UTF-8" encoding...
TMainConsole::setProfileSpellDictionary() INFO - Preparing profile's own Hunspell dictionary...
Loaded custom dictionary "/home/vadi/.config/mudlet/profiles/game.tempestseason.com/profile.dic" with 0 words.
  No change in the number of words in dictionary.
Host::Host() - restore map case 4 {QTimer::singleShot(0)} lambda.
TMap::restore("") INFO: restoring map of Profile: "game.tempestseason.com" URL: game.tempestseason.com
```

After:

```
Could not find Discord library - searched in:
     "/media/vadi/SSDer/Programs/Qt/5.15.2/gcc_64/plugins"
     "/media/vadi/SSDer/Programs/Mudlet/cmake-build-debug/src"
mudlet::mudlet() INFO - 'fusion' has been detected as the style factory in use - no styling fixes applied.
Device discovery cannot open device "/dev/input/event0"
Device discovery cannot open device "/dev/input/event1"
Device discovery cannot open device "/dev/input/event10"
Device discovery cannot open device "/dev/input/event11"
Device discovery cannot open device "/dev/input/event12"
Device discovery cannot open device "/dev/input/event13"
Device discovery cannot open device "/dev/input/event14"
Device discovery cannot open device "/dev/input/event15"
Device discovery cannot open device "/dev/input/event16"
Device discovery cannot open device "/dev/input/event17"
Device discovery cannot open device "/dev/input/event18"
Device discovery cannot open device "/dev/input/event19"
Device discovery cannot open device "/dev/input/event2"
Device discovery cannot open device "/dev/input/event20"
Device discovery cannot open device "/dev/input/event21"
Device discovery cannot open device "/dev/input/event22"
Device discovery cannot open device "/dev/input/event23"
Device discovery cannot open device "/dev/input/event24"
Device discovery cannot open device "/dev/input/event3"
Device discovery cannot open device "/dev/input/event4"
Device discovery cannot open device "/dev/input/event5"
Device discovery cannot open device "/dev/input/event6"
Device discovery cannot open device "/dev/input/event7"
Device discovery cannot open device "/dev/input/event8"
Device discovery cannot open device "/dev/input/event9"
Device discovery cannot open device "/dev/input/mice"
Device discovery cannot open device "/dev/input/mouse0"
cTelnet::encodingChanged("UTF-8") INFO - Installing a codec for OOB protocols that can handle: ()
[LOADING PROFILE]: "/home/vadi/.config/mudlet/profiles/game.tempestseason.com/current//2022-07-25#08-26-47.xml"
TMainConsole::setSystemSpellDictionary("en_US") INFO - System Hunspell dictionary loaded for profile, it uses a "UTF-8" encoding...
TMainConsole::setProfileSpellDictionary() INFO - Preparing profile's own Hunspell dictionary...
Loaded custom dictionary "/home/vadi/.config/mudlet/profiles/game.tempestseason.com/profile.dic" with 0 words.
  No change in the number of words in dictionary.
Host::Host() - restore map case 4 {QTimer::singleShot(0)} lambda.
TMap::restore("") INFO: restoring map of Profile: "game.tempestseason.com" URL: game.tempestseason.com
```
#### Motivation for adding to Mudlet
Better developer experience!