### PR TITLE
Fix: do not allow map context menu "Set Exits" when multiple rooms selected

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2891,7 +2891,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
                     popup->addAction(moveRoom);
                 }
 
-                if (selectionSize > 0) {
+                if (selectionSize == 1) {
                     auto roomExits = new QAction(tr("Set exits...", "2D Mapper context menu (room) item"), this);
                     connect(roomExits, &QAction::triggered, this, &T2DMap::slot_setExits);
                     popup->addAction(roomExits);


### PR DESCRIPTION
Whilst it will successfully operates on the "centre" room indicated in the "Full" map info this is not obvious for most users and has been flagged as causing "User confusion".

This will close #6181.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>