### PR TITLE
Infrastructure: fix ordered-map submodule location and pointer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/microsoft/vcpkg
 [submodule "3rdparty/qt-ordered-map"]
 	path = 3rdparty/qt-ordered-map
-	url = https://github.com/mandeepsandhu/qt-ordered-map
+	url = https://github.com/Mudlet/qt-ordered-map


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix ordered-map submodule to point to Mudlets fork of the repository with additional improvements to fix build errors.
#### Motivation for adding to Mudlet
Better DevEx.
#### Other info (issues closed, discussion etc)
I accidentally changed the submodule pointer in [d65b097](https://github.com/Mudlet/Mudlet/commit/d65b0971b05d0decc428871d44d5014e69872e4d#diff-d13e7b1742a8ce835c698a943b78960068904988815320d62bb8a724ff877d99). Fixing it, noticed that the pointer in `.gitmodules` was never updated either, which explains why new checkouts still had the spammy build messages.