### PR TITLE
Add: customisable shortcut for toggling between input line and main window

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3982,3 +3982,12 @@ void Host::setEditorShowBidi(const bool state)
         }
     }
 }
+
+bool Host::caretEnabled() const {
+    return mCaretEnabled;
+}
+
+void Host::setCaretEnabled(bool enabled) {
+    mCaretEnabled = enabled;
+    mpConsole->setCaretMode(enabled);
+}

--- a/src/Host.h
+++ b/src/Host.h
@@ -395,6 +395,8 @@ public:
     std::optional<QString> windowType(const QString& name) const;
     bool getEditorShowBidi() const { return mEditorShowBidi; }
     void setEditorShowBidi(const bool);
+    bool caretEnabled() const;
+    void setCaretEnabled(bool enabled);
 
     cTelnet mTelnet;
     QPointer<TMainConsole> mpConsole;
@@ -646,6 +648,17 @@ public:
 
     bool mAnnounceIncomingText = true;
 
+    // shortcuts options visually impaired players have to switch between the input line and the main window
+    enum class CaretShortcut {
+        None,
+        Tab,
+        CtrlTab,
+        F6
+    };
+    Q_ENUM(CaretShortcut)
+    // shortcut to switch between the input line and the main window
+    CaretShortcut mCaretShortcut = CaretShortcut::None;
+
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous
     // width characters:
@@ -819,6 +832,8 @@ private:
 
     bool mLargeAreaExitArrows = false;
     bool mEditorShowBidi = true;
+    // should focus should be on the main window with the caret enabled?
+    bool mCaretEnabled = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Host::DiscordOptionFlags)

--- a/src/TAccessibleTextEdit.cpp
+++ b/src/TAccessibleTextEdit.cpp
@@ -393,7 +393,7 @@ QString TAccessibleTextEdit::attributes(int offset, int *startOffset, int *endOf
     const bool isStrikeOut = attributes & TChar::StrikeOut;
     const bool isUnderline = attributes & TChar::Underline;
     const bool isReverse = attributes & TChar::Reverse;
-    const bool caretIsHere = mudlet::self()->isCaretModeEnabled() && textEdit()->mCaretLine == line &&
+    const bool caretIsHere = textEdit()->mpHost->caretEnabled() && textEdit()->mCaretLine == line &&
         textEdit()->mCaretColumn == column;
 
     // Different weight values are not handled.

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -178,8 +178,8 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Tab:
-            // check if tab is the caret shortcut key
-            if (mpHost->mCaretShortcut == Host::CaretShortcut::Tab) {
+            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(ke->modifiers() & Qt::ControlModifier)) ||
+                (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (ke->modifiers() & Qt::ControlModifier))) {
                 mpHost->setCaretEnabled(true);
                 ke->accept();
                 return true;
@@ -208,6 +208,14 @@ bool TCommandLine::event(QEvent* event)
             // other than just the Ctrl one
             // CHECKME: What about system foreground application switching?
             if (keybindingMatched(ke)) {
+                return true;
+            }
+            break;
+
+        case Qt::Key_F6:
+            if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
+                mpHost->setCaretEnabled(true);
+                ke->accept();
                 return true;
             }
             break;

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -178,6 +178,13 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Tab:
+            // check if tab is the caret shortcut key
+            if (mpHost->mCaretShortcut == Host::CaretShortcut::Tab) {
+                mpHost->setCaretEnabled(true);
+                ke->accept();
+                return true;
+            }
+
             if ((ke->modifiers() & allModifiers) == Qt::ControlModifier) {
                 // Switch to NEXT profile tab
                 int currentIndex = mudlet::self()->mpTabBar->currentIndex();
@@ -189,14 +196,12 @@ bool TCommandLine::event(QEvent* event)
                 }
                 ke->accept();
                 return true;
-
             }
 
             if ((ke->modifiers() & allModifiers) == Qt::NoModifier) {
                 handleTabCompletion(true);
                 ke->accept();
                 return true;
-
             }
 
             // Process as a possible key binding if there are ANY modifiers

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -17246,6 +17246,26 @@ int TLuaInterpreter::setConfig(lua_State * L)
             host.mBlankLineBehaviour = Host::BlankLineBehaviour::ReplaceWithSpace;
         }
     }
+    if (key == qsl("caretShortcut")) {
+        static const QStringList keys{"none", "tab", "ctrltab", "f6"};
+        const auto key = getVerifiedString(L, __func__, 2, "value");
+
+        if (!keys.contains(key)) {
+            lua_pushfstring(L, "%s: bad argument #%d type (key should be one of %s, got %s!)",
+                __func__, 2, keys.join(qsl(", ")).toUtf8().constData(), key.toUtf8().constData());
+            return lua_error(L);
+        }
+
+        if (key == qsl("none")) {
+            host.mCaretShortcut = Host::CaretShortcut::None;
+        } else if (key == qsl("tab")) {
+            host.mCaretShortcut = Host::CaretShortcut::Tab;
+        } else if (key == qsl("ctrltab")) {
+            host.mCaretShortcut = Host::CaretShortcut::CtrlTab;
+        } else if (key == qsl("f6")) {
+            host.mCaretShortcut = Host::CaretShortcut::F6;
+        }
+    }
 
     return warnArgumentValue(L, __func__, qsl("'%1' isn't a valid configuration option").arg(key));
 }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2918,6 +2918,15 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         case Qt::Key_PageDown:
             newCaretLine = std::min(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
             break;
+        case Qt::Key_C:
+            if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+                if (!QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier)) {
+                    slot_copySelectionToClipboard();
+                } else {
+                    slot_copySelectionToClipboardHTML();
+                }
+            }
+            break;
         case Qt::Key_Tab: {
             if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier))
                 || (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2733,7 +2733,6 @@ void TTextEdit::updateCaret()
 // you act upon the key.
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
-    qDebug() << "TTextEdit::keyPressEvent()" << event;
     if (!mpHost->caretEnabled()) {
         QWidget::keyPressEvent(event);
         return;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2708,6 +2708,7 @@ void TTextEdit::updateCaret()
 // you act upon the key.
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
+    qDebug() << "TTextEdit::keyPressEvent()" << event->key();
     if (!mpHost->caretEnabled()) {
         QWidget::keyPressEvent(event);
         return;
@@ -2805,6 +2806,12 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
     case Qt::Key_PageDown:
         newCaretLine = std::min(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
         break;
+    case Qt::Key_Tab: {
+            if (mpHost->mCaretShortcut == Host::CaretShortcut::Tab) {
+                mpHost->setCaretEnabled(false);
+                break;
+            }
+        }
     }
 
     // Did the key press change the caret position?

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2736,7 +2736,6 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
     qDebug() << "TTextEdit::keyPressEvent()" << event;
     if (!mpHost->caretEnabled()) {
         QWidget::keyPressEvent(event);
-        qDebug() << "no caret - quitting";
         return;
     }
 
@@ -2921,7 +2920,6 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             newCaretLine = std::min(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
             break;
         case Qt::Key_Tab: {
-            qDebug() << "TTextEdit::keyPressEvent() - tab";
             if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier))
                 || (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))) {
                 mpHost->setCaretEnabled(false);
@@ -2930,7 +2928,6 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         }
 
         case Qt::Key_F6: {
-            qDebug() << "TTextEdit::keyPressEvent() - F6";
             if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
                 mpHost->setCaretEnabled(false);
                 break;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -510,7 +510,7 @@ void TTextEdit::drawLine(QPainter& painter, int lineNumber, int lineOfScreen, in
     }
 
     // If caret mode is enabled and the line is empty, still draw the caret.
-    if (mudlet::self()->isCaretModeEnabled() && mCaretLine == lineNumber && lineText.isEmpty()) {
+    if (mpHost->caretEnabled() && mCaretLine == lineNumber && lineText.isEmpty()) {
         auto textRect = QRect(0, mFontHeight * lineOfScreen, mFontWidth, mFontHeight);
         painter.fillRect(textRect, mFgColor);
     }
@@ -650,7 +650,7 @@ int TTextEdit::drawGraphemeBackground(QPainter& painter, QVector<QColor>& fgColo
     }
     textRects.append(textRect);
     QColor bgColor;
-    bool caretIsHere = mudlet::self()->isCaretModeEnabled() && mCaretLine == line && mCaretColumn == column;
+    bool caretIsHere = mpHost->caretEnabled() && mCaretLine == line && mCaretColumn == column;
     if (Q_UNLIKELY(static_cast<bool>(attributes & TChar::Reverse) != (charStyle.isSelected() != caretIsHere))) {
         fgColors.append(charStyle.background());
         bgColor = charStyle.foreground();
@@ -2650,7 +2650,7 @@ void TTextEdit::setCaretPosition(int line, int column)
     mCaretLine = line;
     mCaretColumn = column;
 
-    if (!mudlet::self()->isCaretModeEnabled()) {
+    if (!mpHost->caretEnabled()) {
         return;
     }
 
@@ -2708,7 +2708,7 @@ void TTextEdit::updateCaret()
 // you act upon the key.
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
-    if (!mudlet::self()->isCaretModeEnabled()) {
+    if (!mpHost->caretEnabled()) {
         QWidget::keyPressEvent(event);
         return;
     }

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -164,6 +164,15 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
     QWidget::focusInEvent(event);
 }
 
+void TTextEdit::focusOutEvent(QFocusEvent *event)
+{
+    if (mpHost->caretEnabled()) {
+        mpHost->setCaretEnabled(false);
+    }
+
+    QWidget::focusOutEvent(event);
+}
+// debug using gammaray to see which events are raised
 
 void TTextEdit::slot_toggleTimeStamps(const bool state)
 {
@@ -2708,9 +2717,10 @@ void TTextEdit::updateCaret()
 // you act upon the key.
 void TTextEdit::keyPressEvent(QKeyEvent* event)
 {
-    qDebug() << "TTextEdit::keyPressEvent()" << event->key();
+    qDebug() << "TTextEdit::keyPressEvent()" << event;
     if (!mpHost->caretEnabled()) {
         QWidget::keyPressEvent(event);
+        qDebug() << "no caret - quitting";
         return;
     }
 
@@ -2807,12 +2817,23 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
         newCaretLine = std::min(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
         break;
     case Qt::Key_Tab: {
-            if (mpHost->mCaretShortcut == Host::CaretShortcut::Tab) {
+            qDebug() << "TTextEdit::keyPressEvent() - tab";
+            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier)) ||
+                (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))){
+                mpHost->setCaretEnabled(false);
+                break;
+            }
+        }
+
+    case Qt::Key_F6: {
+            qDebug() << "TTextEdit::keyPressEvent() - F6";
+            if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
                 mpHost->setCaretEnabled(false);
                 break;
             }
         }
     }
+
 
     // Did the key press change the caret position?
     if (newCaretLine == -1 && newCaretColumn == -1) {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2905,40 +2905,31 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
                 newCaretColumn = 0;
             }
             newCaretColumn = 0;
-        break;
-    case Qt::Key_Home:
-        if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-            newCaretLine = 0;
-            newCaretColumn = 0;
-        } else {
-            newCaretColumn = 0;
-        }
-        newCaretColumn = 0;
-        break;
-    case Qt::Key_End:
-        if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
-            newCaretLine = mpBuffer->lineBuffer.length() - 1;
-            newCaretColumn = mpBuffer->lineBuffer[mCaretLine].length() - 1;
-        } else {
-            newCaretColumn = mpBuffer->lineBuffer.at(mCaretLine).length() - 1;
-        }
-        break;
-    case Qt::Key_PageUp:
-        newCaretLine = std::max(mCaretLine - mScreenHeight, 0);
-        break;
-    case Qt::Key_PageDown:
-        newCaretLine = std::min(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
-        break;
-    case Qt::Key_Tab: {
+            break;
+        case Qt::Key_End:
+            if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+                newCaretLine = mpBuffer->lineBuffer.length() - 1;
+                newCaretColumn = mpBuffer->lineBuffer[mCaretLine].length() - 1;
+            } else {
+                newCaretColumn = mpBuffer->lineBuffer.at(mCaretLine).length() - 1;
+            }
+            break;
+        case Qt::Key_PageUp:
+            newCaretLine = std::max(mCaretLine - mScreenHeight, 0);
+            break;
+        case Qt::Key_PageDown:
+            newCaretLine = std::min(mCaretLine + mScreenHeight, mpBuffer->lineBuffer.length() - 2);
+            break;
+        case Qt::Key_Tab: {
             qDebug() << "TTextEdit::keyPressEvent() - tab";
-            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier)) ||
-                (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))){
+            if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(event->modifiers() & Qt::ControlModifier))
+                || (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (event->modifiers() & Qt::ControlModifier))) {
                 mpHost->setCaretEnabled(false);
                 break;
             }
         }
 
-    case Qt::Key_F6: {
+        case Qt::Key_F6: {
             qDebug() << "TTextEdit::keyPressEvent() - F6";
             if (mpHost->mCaretShortcut == Host::CaretShortcut::F6) {
                 mpHost->setCaretEnabled(false);
@@ -2946,7 +2937,6 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
             }
         }
     }
-
 
     // Did the key press change the caret position?
     if (newCaretLine == -1 && newCaretColumn == -1) {

--- a/src/TTextEdit.h
+++ b/src/TTextEdit.h
@@ -144,6 +144,7 @@ public slots:
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
 
 private slots:
     void slot_copySelectionToClipboardImage();

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -468,6 +468,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("EditorSearchOptions") = QString::number(pHost->mSearchOptions).toUtf8().constData();
     host.append_attribute("DebugShowAllProblemCodepoints") = pHost->debugShowAllProblemCodepoints() ? "yes" : "no";
     host.append_attribute("announceIncomingText") = pHost->mAnnounceIncomingText ? "yes" : "no";
+    host.append_attribute("caretShortcut") = QMetaEnum::fromType<Host::CaretShortcut>().valueToKey(
+            static_cast<int>(pHost->mCaretShortcut));
     host.append_attribute("NetworkPacketTimeout") = pHost->mTelnet.getPostingTimeout();
     if (int mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
         // Don't bother to include the attribute if it is the default (zero)

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -897,8 +897,8 @@ void XMLimport::readHostPackage(Host* pHost)
             pHost->mCaretShortcut = Host::CaretShortcut::CtrlTab;
         } else if (caretShortcut == qsl("F6")) {
             pHost->mCaretShortcut = Host::CaretShortcut::F6;
-		}
-	}
+        }
+    }
     if (attributes().hasAttribute("blankLineBehaviour")) {
         const QStringRef blankLineBehaviour(attributes().value(qsl("blankLineBehaviour")));
         if (blankLineBehaviour == qsl("Hide")) {

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -887,6 +887,18 @@ void XMLimport::readHostPackage(Host* pHost)
     } else {
         pHost->mAnnounceIncomingText = true;
     }
+    if (attributes().hasAttribute("caretShortcut")) {
+        const QStringRef caretShortcut(attributes().value(qsl("caretShortcut")));
+        if (caretShortcut == qsl("None")) {
+            pHost->mCaretShortcut = Host::CaretShortcut::None;
+        } else if (caretShortcut == qsl("Tab")) {
+            pHost->mCaretShortcut = Host::CaretShortcut::Tab;
+        } else if (caretShortcut == qsl("CtrlTab")) {
+            pHost->mCaretShortcut = Host::CaretShortcut::CtrlTab;
+        } else if (caretShortcut == qsl("F6")) {
+            pHost->mCaretShortcut = Host::CaretShortcut::F6;
+        }
+    }
     pHost->mEditorTheme = attributes().value(QLatin1String("mEditorTheme")).toString();
     pHost->mEditorThemeFile = attributes().value(QLatin1String("mEditorThemeFile")).toString();
     pHost->mThemePreviewItemID = attributes().value(QLatin1String("mThemePreviewItemID")).toInt();

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -503,6 +503,7 @@ void dlgProfilePreferences::disableHostDetails()
     widget_timerDebugOutputMinimumInterval->setEnabled(false);
     label_networkPacketTimeout->setEnabled(false);
     doubleSpinBox_networkPacketTimeout->setEnabled(false);
+    comboBox_caretModeKey->setEnabled(false);
 }
 
 void dlgProfilePreferences::enableHostDetails()
@@ -599,6 +600,7 @@ void dlgProfilePreferences::enableHostDetails()
     checkBox_debugShowAllCodepointProblems->setEnabled(true);
     label_networkPacketTimeout->setEnabled(true);
     doubleSpinBox_networkPacketTimeout->setEnabled(true);
+    comboBox_caretModeKey->setEnabled(true);
 }
 
 void dlgProfilePreferences::initWithHost(Host* pHost)
@@ -1101,6 +1103,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     checkBox_expectCSpaceIdInColonLessMColorCode->setChecked(pHost->getHaveColorSpaceId());
     checkBox_allowServerToRedefineColors->setChecked(pHost->getMayRedefineColors());
     doubleSpinBox_networkPacketTimeout->setValue(pHost->mTelnet.getPostingTimeout() / 1000.0);
+    comboBox_caretModeKey->setCurrentIndex(static_cast<int>(pHost->mCaretShortcut));
     checkBox_largeAreaExitArrows->setChecked(pHost->getLargeAreaExitArrows());
 
     // Enable the controls that would be disabled if there wasn't a Host instance
@@ -2845,6 +2848,7 @@ void dlgProfilePreferences::slot_save_and_exit()
         pHost->setHaveColorSpaceId(checkBox_expectCSpaceIdInColonLessMColorCode->isChecked());
         pHost->setMayRedefineColors(checkBox_allowServerToRedefineColors->isChecked());
         pHost->setDebugShowAllProblemCodepoints(checkBox_debugShowAllCodepointProblems->isChecked());
+        pHost->mCaretShortcut = static_cast<Host::CaretShortcut>(comboBox_caretModeKey->currentIndex());
 
         if (widget_playerRoomStyle->isVisible()) {
             // Although the controls have been interactively modifying the

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -633,7 +633,6 @@ mudlet::mudlet()
     connect(dactionPackageExporter, &QAction::triggered, this, &mudlet::slot_package_exporter);
     connect(dactionModuleManager, &QAction::triggered, this, &mudlet::slot_module_manager);
     connect(dactionMultiView, &QAction::triggered, this, &mudlet::slot_multi_view);
-    connect(dactionCaretMode, &QAction::triggered, this, &mudlet::slot_caret_mode);
     connect(dactionInputLine, &QAction::triggered, this, &mudlet::slot_compact_input_line);
     connect(mpActionTriggers.data(), &QAction::triggered, this, &mudlet::show_trigger_dialog);
     connect(dactionScriptEditor, &QAction::triggered, this, &mudlet::show_editor_dialog);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2985,12 +2985,11 @@ void mudlet::slot_multi_view(const bool state)
 
 void mudlet::slot_caret_mode(bool state) const
 {
-    // FIXME: Support multiple hosts.
     if (!mpCurrentActiveHost) {
         return;
     }
 
-    mpCurrentActiveHost->mpConsole->setCaretMode(state);
+    mpCurrentActiveHost->setCaretEnabled(state);
 }
 
 // Called by the short-cut to the menu item that doesn't pass the checked state

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2982,15 +2982,6 @@ void mudlet::slot_multi_view(const bool state)
     }
 }
 
-void mudlet::slot_caret_mode(bool state) const
-{
-    if (!mpCurrentActiveHost) {
-        return;
-    }
-
-    mpCurrentActiveHost->setCaretEnabled(state);
-}
-
 // Called by the short-cut to the menu item that doesn't pass the checked state
 // of the menu-item that it provides a short-cut to:
 void mudlet::slot_toggle_compact_input_line()

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -509,8 +509,6 @@ public:
     };
     // clang-format on
 
-    bool isCaretModeEnabled() { return dactionCaretMode->isChecked(); }
-
 public slots:
     void processEventLoopHack_timerRun();
     void slot_mapper();

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -522,7 +522,6 @@ public slots:
     void slot_show_help_dialog_irc();
     void slot_open_mappingscripts_page();
     void slot_multi_view(const bool);
-    void slot_caret_mode(bool) const;
     void slot_toggle_multi_view();
     void slot_connection_dlg_finished(const QString& profile, bool connectOnLoad);
     void slot_timer_fires();

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -111,7 +111,6 @@
     </property>
     <addaction name="dactionOptions"/>
     <addaction name="dactionMultiView"/>
-    <addaction name="dactionCaretMode"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -362,23 +361,6 @@
   <action name="dactionCloseProfile">
    <property name="text">
     <string>Close profile</string>
-   </property>
-  </action>
-  <action name="dactionCaretMode">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Caret Mode</string>
-   </property>
-   <property name="toolTip">
-    <string>Move through the MUD text with the keyboard.</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Tab</string>
-   </property>
-   <property name="shortcutContext">
-    <enum>Qt::WindowShortcut</enum>
    </property>
   </action>
  </widget>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3876,7 +3876,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="2" column="0">
            <widget class="QLabel" name="label_caretModeKey">
             <property name="text">
-             <string>smaller text here</string>
+             <string>Switch between input line and main window using:</string>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3844,16 +3844,6 @@ you can use it but there could be issues with aligning columns of text</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_blankLinesBehaviour">
-            <property name="text">
-             <string>When the game sends blank lines:</string>
-            </property>
-            <property name="buddy">
-             <cstring>comboBox_blankLinesBehaviour</cstring>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="comboBox_blankLinesBehaviour">
             <item>
@@ -3869,6 +3859,47 @@ you can use it but there could be issues with aligning columns of text</string>
             <item>
              <property name="text">
               <string>replace with a space</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_blankLinesBehaviour">
+            <property name="text">
+             <string>When the game sends blank lines:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_blankLinesBehaviour</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_caretModeKey">
+            <property name="text">
+             <string>Switch between input line and main window using:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="comboBox_caretModeKey">
+            <item>
+             <property name="text">
+              <string>no key</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tab</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ctrl+Tab</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>F6</string>
              </property>
             </item>
            </widget>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3876,7 +3876,7 @@ you can use it but there could be issues with aligning columns of text</string>
           <item row="2" column="0">
            <widget class="QLabel" name="label_caretModeKey">
             <property name="text">
-             <string>Switch between input line and main window using:</string>
+             <string>smaller text here</string>
             </property>
            </widget>
           </item>

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -42,7 +42,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>10</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <property name="sizePolicy">

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -3878,6 +3878,9 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Switch between input line and main window using:</string>
             </property>
+            <property name="buddy">
+             <cstring>comboBox_caretModeKey</cstring>
+            </property>
            </widget>
           </item>
           <item row="2" column="1">

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -42,7 +42,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>10</number>
      </property>
      <widget class="QWidget" name="tab_general">
       <property name="sizePolicy">
@@ -3833,8 +3833,8 @@ you can use it but there could be issues with aligning columns of text</string>
          <property name="title">
           <string>Accessibility</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
            <widget class="QCheckBox" name="checkBox_announceIncomingText">
             <property name="toolTip">
              <string>On some platforms, like macOS, the screen reader tool has issues announcing incoming text fully, without skipping. You can opt into disabling announcing new text from the game with this option to use a custom TTS instead which avoids such issues</string>
@@ -3842,6 +3842,40 @@ you can use it but there could be issues with aligning columns of text</string>
             <property name="text">
              <string>Announce incoming text in screen reader</string>
             </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_caretModeKey">
+            <property name="text">
+             <string>Switch between input line and main window using:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_caretModeKey</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="comboBox_caretModeKey">
+            <item>
+             <property name="text">
+              <string>no key</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tab</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ctrl+Tab</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>F6</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Customisable shortcuts for toggling between input line and main window: can either be set to `Tab`, `Ctrl+Tab`, or `F6`.
#### Motivation for adding to Mudlet
A lot of freedom for visually impaired users to use a shortcut that works for them.
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/6174.


https://user-images.githubusercontent.com/110988/181607778-575c0650-36db-43f0-af28-744d7616153d.mp4


