### PR TITLE
Infrastructure: update build agent to macOS 11

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -29,7 +29,7 @@ jobs:
             triplet: x64-linux
             compiler: clang_64
             qt: '5.14.2'
-          - os: macos-10.15
+          - os: macos-11
             buildname: 'macos / c++ tests'
             triplet: x64-osx
             compiler: clang_64


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update build agent to macOS 11
#### Motivation for adding to Mudlet
macOS 10.15 is being removed by Github.
#### Other info (issues closed, discussion etc)
