### PR TITLE
Fix: Read map UserData from JSON map files

### DIFF
--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3096,7 +3096,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
 
     mDefaultAreaName = mapObj[QLatin1String("defaultAreaName")].toString();
     mUnnamedAreaName = mapObj[QLatin1String("anonymousAreaName")].toString();
-    if (mapObj.contains(QLatin1String("userData"))){
+    if (mapObj.contains(QLatin1String("userData"))) {
         readJsonUserData(mapObj[QLatin1String("userData")].toObject());
     }
     QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3096,7 +3096,7 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
 
     mDefaultAreaName = mapObj[QLatin1String("defaultAreaName")].toString();
     mUnnamedAreaName = mapObj[QLatin1String("anonymousAreaName")].toString();
-    if(mapObj.contains(QLatin1String("userData"))){
+    if (mapObj.contains(QLatin1String("userData"))){
         readJsonUserData(mapObj[QLatin1String("userData")].toObject());
     }
     QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -3096,6 +3096,9 @@ std::pair<bool, QString> TMap::readJsonMapFile(const QString& source, const bool
 
     mDefaultAreaName = mapObj[QLatin1String("defaultAreaName")].toString();
     mUnnamedAreaName = mapObj[QLatin1String("anonymousAreaName")].toString();
+    if(mapObj.contains(QLatin1String("userData"))){
+        readJsonUserData(mapObj[QLatin1String("userData")].toObject());
+    }
     QString mapSymbolFontText = mapObj[QLatin1String("mapSymbolFontDetails")].toString();
     float mapSymbolFontFudgeFactor = (qRound(mapObj[QLatin1String("mapSymbolFontFudgeFactor")].toDouble() * 1000.0)) / 1000;
     bool isOnlyMapSymbolFontToBeUsed = mapObj[QLatin1String("onlyMapSymbolFontToBeUsed")].toBool();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This enables Mudlet to read map USerData from map files.

#### Motivation for adding to Mudlet
Feature parity between binary and JSON map imports. I assume this was an oversight.

#### Other info (issues closed, discussion etc)
