### PR TITLE
Improve: disable caret mode when Ctrl+C is pressed

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2925,6 +2925,7 @@ void TTextEdit::keyPressEvent(QKeyEvent* event)
                 } else {
                     slot_copySelectionToClipboardHTML();
                 }
+                mpHost->setCaretEnabled(false);
             }
             break;
         case Qt::Key_Tab: {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable caret mode when Ctrl+C is pressed
#### Motivation for adding to Mudlet
Saves VI players from using ctrl/whatever to go back to the input line after pressing Ctrl+C
#### Other info (issues closed, discussion etc)
