### PR TITLE
Infrastructure: use cmake 3.23.3 that's available in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 image: Visual Studio 2019
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 image: Visual Studio 2019
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 image: Visual Studio 2019
 environment:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,7 @@ branches:
   - /^Mudlet-.+/   # build release tags (yes, the option also applies to tags)
 init:
 - cmd: mkdir C:\src\
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 image: Visual Studio 2019
 environment:

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -14,7 +14,8 @@ if (-not $(Test-Path "$workingBaseDir")) {
 }
 
 $64Bit = (Get-WmiObject Win32_OperatingSystem).OSArchitecture -eq "64-bit"
-# Appveyor installs its CMake in C:\Program Files\CMake despite being a 64bit system
+# Appveyor's CMake is in C:\Program Files\CMake
+
 if($64Bit -and ($Env:APPVEYOR -ne "True")){
   $CMakePath = "C:\Program Files (x86)\CMake\bin"
 } else {

--- a/CI/appveyor.functions.ps1
+++ b/CI/appveyor.functions.ps1
@@ -14,7 +14,8 @@ if (-not $(Test-Path "$workingBaseDir")) {
 }
 
 $64Bit = (Get-WmiObject Win32_OperatingSystem).OSArchitecture -eq "64-bit"
-if($64Bit){
+# Appveyor installs its CMake in C:\Program Files\CMake despite being a 64bit system
+if($64Bit -and ($Env:APPVEYOR -ne "True")){
   $CMakePath = "C:\Program Files (x86)\CMake\bin"
 } else {
   $CMakePath = "C:\Program Files\CMake\bin"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use cmake 3.23.3 that's available in AppVeyor
#### Motivation for adding to Mudlet
Cut down Windows CI build times by 2min
#### Other info (issues closed, discussion etc)
Close https://github.com/Mudlet/Mudlet/issues/5908