### PR TITLE
Infrastructure: improve build caching on Linux & macOS

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -44,7 +44,6 @@ jobs:
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.bz2/download
-      CCACHE_DIR: ${{runner.workspace}}/ccache
       # APP_BUILD embeds the git sha which changes on every commit, throwing the cache off - ignore it
       CCACHE_IGNOREOPTIONS: "-DAPP_BUILD=*"
 
@@ -135,6 +134,7 @@ jobs:
         brew install pkg-config libzzip libzip ccache luarocks expect mitchellh/gon/gon
 
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
+        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics
         export PATH="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/tools/lua:$PATH"
@@ -185,6 +185,8 @@ jobs:
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
         sudo update-alternatives --set gcc /usr/bin/gcc-7
         sudo update-alternatives --set g++ /usr/bin/g++-7
+        
+        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics
         export PATH="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/tools/lua:$PATH"

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -185,7 +185,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
         sudo update-alternatives --set gcc /usr/bin/gcc-7
         sudo update-alternatives --set g++ /usr/bin/g++-7
-        
+
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -44,7 +44,9 @@ jobs:
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.77.0/boost_1_77_0.tar.bz2/download
-
+      CCACHE_DIR: ${{runner.workspace}}/ccache
+      # APP_BUILD embeds the git sha which changes on every commit, throwing the cache off - ignore it
+      CCACHE_IGNOREOPTIONS: "-DAPP_BUILD=*"
 
     steps:
     - name: Checkout Mudlet source code
@@ -133,7 +135,6 @@ jobs:
         brew install pkg-config libzzip libzip ccache luarocks expect mitchellh/gon/gon
 
         echo "/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics
         export PATH="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/tools/lua:$PATH"
@@ -184,8 +185,6 @@ jobs:
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
         sudo update-alternatives --set gcc /usr/bin/gcc-7
         sudo update-alternatives --set g++ /usr/bin/g++-7
-
-        echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 
         # Install lua-yajl early to generate translation statistics
         export PATH="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/tools/lua:$PATH"
@@ -248,7 +247,7 @@ jobs:
 
     - name: (Linux/macOS) check ccache stats prior to build
       if: runner.os == 'Linux' || runner.os == 'macOS'
-      run: ccache --show-stats
+      run: ccache --zero-stats --show-stats
 
     - name: Build Mudlet
       uses: lukka/run-cmake@v3


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Ignore APP_BUILD variable for caching purposes, because it changes with every commit and confuses caching
#### Motivation for adding to Mudlet
Faster Linux and macOS builds
#### Other info (issues closed, discussion etc)
Discovered issue while working on https://github.com/Mudlet/Mudlet/pull/6193

Also zero stats out before a build, so we can see the stats for a particular build only.