### PR TITLE
Infrastructure: update clang-tidy review to 0.9.0

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -114,7 +114,7 @@ jobs:
           --target autogen
 
     - name: Check C++ changes against style guide
-      uses: ZedThree/clang-tidy-review@v0.8.4
+      uses: ZedThree/clang-tidy-review@v0.9.0
       id: static_analysis
       with:
         build_dir: 'b/ninja' # path is relative to checkout directory


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Update clang-tidy review to 0.9.0
#### Motivation for adding to Mudlet
Perhaps it will stop crashing on relative paths now - https://github.com/ZedThree/clang-tidy-review/releases/tag/v0.9.0 mentions this issue is fixed
#### Other info (issues closed, discussion etc)
If it works, the bot is an additional source of analysis for better code