### PR TITLE
Infrastructure: setup-windows-sdk.ps1 to not close immediately on error

### DIFF
--- a/setup-windows-sdk.ps1
+++ b/setup-windows-sdk.ps1
@@ -27,12 +27,14 @@ Write-Output "Running qmake"
 $Env:PATH="C:\Program Files (x86)\CMake\bin;C:\Program Files\7-Zip;$Env:QT_BASE_DIR\bin;$Env:MINGW_BASE_DIR\bin;" + (($Env:PATH.Split(';') | Where-Object { $_ -ne 'C:\Program Files\Git\usr\bin' }) -join ';')
 qmake CONFIG+=debug ../src/mudlet.pro
 if("$LastExitCode" -ne "0"){
+  Read-Host
   exit 1
 }
 
 Write-Output "Running make"
 mingw32-make -j $(Get-WmiObject win32_processor | Select -ExpandProperty "NumberOfLogicalProcessors")
 if("$LastExitCode" -ne "0"){
+  Read-Host
   exit 1
 }
 


### PR DESCRIPTION
Added "Read-Host" to the Windows build PS script, this prevents the console from closing automatically and thus allow you to view debug log after you close the test build

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Added a "Read-Host" command before the powershell build script exits.

#### Motivation for adding to Mudlet
The way setup-windows-sdk.ps1 was written, it would automatically close the console windows if it detects any error, which leaves you scratching your head as far as what actually went wrong.  

#### Other info (issues closed, discussion etc)
