### PR TITLE
Infrastructure: fix clang-tidy static analyser build

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -77,6 +77,15 @@ jobs:
     - name: Use CMake 3.20.1
       uses: lukka/get-cmake@v3.20.1
 
+    - name: (Linux) Install non-vcpkg dependencies
+      if: runner.os == 'Linux'
+      run: |
+        # Install from vcpkg everything we can for cross-platform consistency
+        # If not available, use other methods
+        sudo apt-get install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev gettext -y
+
+        echo "Skipping generation of translation stats, so not installing lua-yajl."
+
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
       uses: lukka/run-vcpkg@v7
@@ -86,15 +95,6 @@ jobs:
         vcpkgArguments: '@${{env.vcpkgResponseFile}}'
         vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
         appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-cachekey
-
-    - name: (Linux) Install non-vcpkg dependencies
-      if: runner.os == 'Linux'
-      run: |
-        # Install from vcpkg everything we can for cross-platform consistency
-        # If not available, use other methods
-        sudo apt-get install pkg-config libzip-dev libglu1-mesa-dev libpulse-dev -y
-
-        echo "Skipping generation of translation stats, so not installing lua-yajl."
 
     - name: Generate compile_commands.json
       uses: lukka/run-cmake@v3


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Install gettext for vcpkg like we do in the main `build-mudlet.yml` workflow, otherwise it fails without it: 
https://github.com/Mudlet/Mudlet/runs/7637079471?check_suite_focus=true#step:9:236
#### Motivation for adding to Mudlet
So clang-tidy static analysis can work
#### Other info (issues closed, discussion etc)
Moved installation of dependencies above the vcpkg step - hopefully that is not an issue