### PR TITLE
Fix: amend identifier that's a macro (and breaks compilation) on MSYS2/MINGW-W64

### DIFF
--- a/src/TAccessibleConsole.h
+++ b/src/TAccessibleConsole.h
@@ -40,13 +40,16 @@ public:
 
     static QAccessibleInterface* consoleFactory(const QString &classname, QObject *object)
     {
-        QAccessibleInterface *interface = nullptr;
+        // The original identifier "interface" was no good as it is an existing
+        // macro (on MSYS2/Mingw-w64) and breaks compilation on that platform in
+        // an obsecure way:
+        QAccessibleInterface* pInterface = nullptr;
 
         if (classname == QLatin1String("TConsole") && object && object->isWidgetType()) {
-            interface = new TAccessibleConsole(static_cast<QWidget *>(object));
+            pInterface = new TAccessibleConsole(static_cast<QWidget *>(object));
         }
 
-        return interface;
+        return pInterface;
     }
 };
 

--- a/src/TAccessibleTextEdit.h
+++ b/src/TAccessibleTextEdit.h
@@ -41,13 +41,16 @@ public:
 
     static QAccessibleInterface* textEditFactory(const QString &classname, QObject *object)
     {
-        QAccessibleInterface *interface = nullptr;
+        // The original identifier "interface" was no good as it is an existing
+        // macro (on MSYS2/Mingw-w64) and breaks compilation on that platform in
+        // an obsecure way:
+        QAccessibleInterface* pInterface = nullptr;
 
         if (classname == QLatin1String("TTextEdit") && object && object->isWidgetType()) {
-            interface = new TAccessibleTextEdit(static_cast<QWidget *>(object));
+            pInterface = new TAccessibleTextEdit(static_cast<QWidget *>(object));
         }
 
-        return interface;
+        return pInterface;
     }
 
     void* interface_cast(QAccessible::InterfaceType t) override


### PR DESCRIPTION
The error messages that this was producing were somewhat obscure but only appeared in my MSYS2/Mingw-w64 based Windows setup (where I have the environmental variable `WITH_MAIN_BUILD_SYSTEM` defined to `"NO"`)! The result of it however was that any build based on code since #6090 went in was failing...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>