### PR TITLE
Improve: Smooth fadein and fadeout for MCMP

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -973,6 +973,11 @@ void TMedia::play(TMediaData& mediaData)
     // Set volume, start and play media
     pPlayer.getMediaPlayer()->setVolume(mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.getMediaVolume());
     pPlayer.getMediaPlayer()->setPosition(mediaData.getMediaStart());
+
+    if (mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet || mediaData.getMediaFadeOut() != TMediaData::MediaFadeNotSet) {
+        pPlayer.getMediaPlayer()->setNotifyInterval(50); // Smoother volume changes with the tighter interval (default = 1000).
+    }
+
     pPlayer.getMediaPlayer()->play();
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Mud Client Media Protocol (MCMP) Enhancement

To reduce the choppiness of sounds and music where fadein and fadeout are used, tighten up the notifyInterval such that the linear volume increase for fadein and linear volume decrease for fadeout will update more than the current interval of once a second.  The notifyInterval is only updated where fadein and fadeout are used.

#### Motivation for adding to Mudlet
Improves user experience

#### Other info (issues closed, discussion etc)
Closes issue #6192

To test, turn up volume and listen to the difference between the following on the command line in the PR vs. Mudlet 4.16:

`lua playMusicFile({url = "https://www.iamtalon.me/", name = "spacemusic.mp3", fadein = 5000, fadeout = 5000})` 