### PR TITLE
Fix: ensure liboleaut32 library is used for both QMake Windows Setups

### DIFF
--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -294,8 +294,7 @@ unix:!macx {
         LIBS +=  \
             -L"$${MINGW_BASE_DIR_TEST}\\bin" \
             -llua51 \
-            -lhunspell-1.6 \
-            -loleaut32
+            -lhunspell-1.6
 
         INCLUDEPATH += \
              "C:\\Libraries\\boost_1_77_0" \
@@ -327,7 +326,8 @@ unix:!macx {
         -lzip \                 # for dlgPackageExporter
         -lz \                   # for ctelnet.cpp
         -lpugixml \
-        -lWs2_32
+        -lws2_32 \
+        -loleaut32
 
     # Leave this unset - we do not need it on Windows:
     # LUA_DEFAULT_DIR =


### PR DESCRIPTION
#6090 added the library to the QMake LIBS variable for the main build system but it is in fact needed also for the MSYS2/Mingw-w64 setup (that I use) as well so needs to be put in a different location in the main QMake project file.

Whilst checking to see if the CMake alternative worked in my setup I noticed that there is a typo in the adjacent line for the "ws2_32" library. The documentation at, say: https://docs.microsoft.com/en-us/windows/win32/winsock/initialization-2 calls it `Ws2_32`, however the files in a Windows filesystem (and the corresponding line in the CMake build file):
```
if(WIN32)
  target_link_libraries(mudlet ws2_32)
...
endif()
```
specifies an all-lower case (library file) name - this is possibly okay because of the way that Windows handles file names but it is probably better to use the same thing all around.

I note that though we list both `libws2_32` and `liboleut32` in the QMake project files it seems that only the former needs (?) to be mentioned in the CMake case - limited experimentation I've done on my setup suggests that the latter is linked in automagically without being explicitly stated!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>