### PR TITLE
Infrastructure: fix auto-updates for ktoolbox and cmake-scripts

### DIFF
--- a/.github/workflows/update-3rdparty.yml
+++ b/.github/workflows/update-3rdparty.yml
@@ -251,7 +251,7 @@ jobs:
             #### Other info (issues closed, discussion etc)
             _update triggered by ${{ github.ref }} ${{ github.sha }}_
           branch: update-singleshot-connect-${{ github.sha }}
-          path: src/
+          path: 3rdparty/kdtoolbox
           commit-message: (autocommit) Update singleshot_connect.h to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"
 
@@ -291,6 +291,6 @@ jobs:
             #### Other info (issues closed, discussion etc)
             _update triggered by ${{ github.ref }} ${{ github.sha }}_
           branch: update-cmake-scripts-${{ github.sha }}
-          path: src/
+          path: 3rdparty/cmake-scripts
           commit-message: (autocommit) Update sanitizers.cmake to latest upstream
           author: "mudlet-machine-account <mudlet-machine-account@users.noreply.github.com>"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Enable automatic updates for https://github.com/Mudlet/Mudlet/tree/development/3rdparty/kdtoolbox/singleshot_connect and https://github.com/Mudlet/Mudlet/tree/development/3rdparty/cmake-scripts
#### Motivation for adding to Mudlet
So we're on the latest version of the 3rd party tools
#### Other info (issues closed, discussion etc)
The path filter was broken and pointed to `src/` instead of `3rdparty/