### PR TITLE
Infrastructure: fix clang-tidy review workflow to build

### DIFF
--- a/.github/workflows/clangtidy-diff-analysis.yml
+++ b/.github/workflows/clangtidy-diff-analysis.yml
@@ -77,6 +77,12 @@ jobs:
     - name: Use CMake 3.20.1
       uses: lukka/get-cmake@v3.20.1
 
+    - name: (Linux) Install non-vcpkg dependencies (1/2)
+      if: runner.os == 'Linux'
+      run: |
+        # gettext is needed for vcpkg
+        sudo apt-get install gettext -y
+
     # Restore from cache the previously built ports. If "cache miss", then provision vcpkg, install desired ports, finally cache everything for the next run.
     - name: Restore from cache and run vcpkg
       uses: lukka/run-vcpkg@v7
@@ -87,7 +93,7 @@ jobs:
         vcpkgDirectory: '${{github.workspace}}/3rdparty/vcpkg'
         appendedCacheKey: ${{hashFiles(env.vcpkgResponseFile)}}-cachekey
 
-    - name: (Linux) Install non-vcpkg dependencies
+    - name: (Linux) Install non-vcpkg dependencies (2/2)
       if: runner.os == 'Linux'
       run: |
         # Install from vcpkg everything we can for cross-platform consistency

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -206,6 +206,9 @@ void TBuffer::updateColors()
     mForeGroundColor = pH->mFgColor;
     mForeGroundColorLight = pH->mFgColor;
     mBackGroundColor = pH->mBgColor;
+
+    // test change
+    int a;
 }
 
 QPoint TBuffer::getEndPos()

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -206,9 +206,6 @@ void TBuffer::updateColors()
     mForeGroundColor = pH->mFgColor;
     mForeGroundColorLight = pH->mFgColor;
     mBackGroundColor = pH->mBgColor;
-
-    // test change
-    int a;
 }
 
 QPoint TBuffer::getEndPos()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Install gettext dependencies needed for vcpkg
#### Motivation for adding to Mudlet
So the clang-tidy review workflow can run again
#### Other info (issues closed, discussion etc)
It wasn't kept up to date with `build-mudlet.yml` where the fix was already applied. 