### PR TITLE
Infrastructure: add links to naming antipatterns in Lua API

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15277,6 +15277,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getLabelSizeHint", TLuaInterpreter::getLabelSizeHint);
     lua_register(pGlobalLua, "announce", TLuaInterpreter::announce);
     // PLACEMARKER: End of main Lua interpreter functions registration
+    // check new functions against https://www.linguistic-antipatterns.com when creating them
 
     QStringList additionalLuaPaths;
     QStringList additionalCPaths;

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -641,6 +641,7 @@ public:
     static int getLabelSizeHint(lua_State*);
     static int announce(lua_State*);
     // PLACEMARKER: End of Lua functions declarations
+    // check new functions against https://www.linguistic-antipatterns.com when creating them
 
     void freeLuaRegistryIndex(int index);
     void freeAllInLuaRegistry(TEvent);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add links to naming antipatterns in Lua API, so we remember to check them when adding new functions. 

The naming antipatterns can apply to Mudlet-internal functions too.
#### Motivation for adding to Mudlet
Better API quality
#### Other info (issues closed, discussion etc)
Intentionally duplicated so we don't miss it.