### PR TITLE
Infrastructure: remove unneeded Host::connectToServer()

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1628,11 +1628,6 @@ bool Host::killTrigger(const QString& name)
     return mTriggerUnit.killTrigger(name);
 }
 
-void Host::connectToServer()
-{
-    mTelnet.connectIt(mUrl, mPort);
-}
-
 void Host::closingDown()
 {
     mIsClosingDown = true;

--- a/src/Host.h
+++ b/src/Host.h
@@ -219,7 +219,6 @@ public:
     KeyUnit*     getKeyUnit()     { return &mKeyUnit; }
     ScriptUnit*  getScriptUnit()  { return &mScriptUnit; }
 
-    void connectToServer();
     void send(QString cmd, bool wantPrint = true, bool dontExpandAliases = false);
 
     int getHostID()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2926,7 +2926,7 @@ void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
     //      the worst that can happen is that they have to login manually.
 
     if (connect) {
-        pHost->connectToServer();
+        pHost->mTelnet.connectIt(pHost->getUrl(), pHost->getPort());
     } else {
         QString infoMsg = tr("[  OK  ]  - Profile \"%1\" loaded in offline mode.").arg(profile);
         pHost->postMessage(infoMsg);


### PR DESCRIPTION
It can be replaced by another, more detailed, function call (using `ctelnet::connectIt(...)`) that is used elsewhere both within the `mudlet` and other classes.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>