### PR TITLE
Infrastructure: tidy up naming of SLOT methods and their usage - Part 2

### DIFF
--- a/src/TForkedProcess.cpp
+++ b/src/TForkedProcess.cpp
@@ -60,7 +60,7 @@ TForkedProcess::TForkedProcess(TLuaInterpreter* pInterpreter, lua_State* L)
 
     // QProcess::finished is overloaded so we have to say which form we are
     // connecting here
-    connect(this, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), mpInterpreter, &TLuaInterpreter::slotDeleteSender);
+    connect(this, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), mpInterpreter, &TLuaInterpreter::slot_deleteSender);
     connect(this, qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this, &TForkedProcess::slot_finished);
     connect(this, &QProcess::readyReadStandardOutput, this, &TForkedProcess::slot_receivedData);
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -191,7 +191,7 @@ TLuaInterpreter::TLuaInterpreter(Host* pH, const QString& hostName, int id)
 , mpFileDownloader(new QNetworkAccessManager(this))
 , mpFileSystemWatcher(new QFileSystemWatcher(this))
 {
-    connect(&purgeTimer, &QTimer::timeout, this, &TLuaInterpreter::slotPurge);
+    connect(&purgeTimer, &QTimer::timeout, this, &TLuaInterpreter::slot_purge);
     connect(mpFileDownloader, &QNetworkAccessManager::finished, this, &TLuaInterpreter::slot_httpRequestFinished);
     connect(mpFileSystemWatcher, &QFileSystemWatcher::fileChanged, this, &TLuaInterpreter::slot_pathChanged);
     connect(mpFileSystemWatcher, &QFileSystemWatcher::directoryChanged, this, &TLuaInterpreter::slot_pathChanged);
@@ -597,7 +597,7 @@ void TLuaInterpreter::slot_pathChanged(const QString& path)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::slotDeleteSender(int exitCode, QProcess::ExitStatus exitStatus)
+void TLuaInterpreter::slot_deleteSender(int exitCode, QProcess::ExitStatus exitStatus)
 {
     Q_UNUSED(exitCode);
     Q_UNUSED(exitStatus);
@@ -606,7 +606,7 @@ void TLuaInterpreter::slotDeleteSender(int exitCode, QProcess::ExitStatus exitSt
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::slotPurge()
+void TLuaInterpreter::slot_purge()
 {
     while (!objectsToDelete.isEmpty()) {
         delete objectsToDelete.takeFirst();

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -678,8 +678,8 @@ public:
 public slots:
     void slot_httpRequestFinished(QNetworkReply*);
     void slot_pathChanged(const QString& path);
-    void slotPurge();
-    void slotDeleteSender(int, QProcess::ExitStatus);
+    void slot_purge();
+    void slot_deleteSender(int, QProcess::ExitStatus);
 
 private:
     bool callReference(lua_State*, QString name, int parameters);

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -213,14 +213,17 @@ public:
 
 
 public slots:
-    void setDownloadProgress(qint64, qint64);
+    void slot_setDownloadProgress(qint64, qint64);
     void slot_replyFinished(QNetworkReply*);
     void slot_processReplayChunk();
-    void handle_socket_signal_hostFound(QHostInfo);
-    void handle_socket_signal_connected();
-    void handle_socket_signal_disconnected();
-    void handle_socket_signal_readyRead();
-    void handle_socket_signal_error();
+    void slot_socketHostFound(QHostInfo);
+    void slot_socketConnected();
+    void slot_socketDisconnected();
+    void slot_socketReadyToBeRead();
+// Not used    void slot_socketError();
+#if !defined(QT_NO_SSL)
+    void slot_socketSslError(const QList<QSslError>&);
+#endif
     void slot_timerPosting();
     void slot_send_login();
     void slot_send_pass();
@@ -348,12 +351,6 @@ private:
     // we can send NAWS data when it changes:
     int mNaws_x = 0;
     int mNaws_y = 0;
-
-private slots:
-#if !defined(QT_NO_SSL)
-    void handle_socket_signal_sslError(const QList<QSslError> &errors);
-#endif
-
 };
 
 #endif // MUDLET_CTELNET_H

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -32,18 +32,18 @@ dlgComposer::dlgComposer(Host* pH) : mpHost(pH)
     setupUi(this);
     QFont f = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);
     edit->setFont(f);
-    connect(saveButton, &QAbstractButton::clicked, this, &dlgComposer::save);
-    connect(cancelButton, &QAbstractButton::clicked, this, &dlgComposer::cancel);
+    connect(saveButton, &QAbstractButton::clicked, this, &dlgComposer::slot_save);
+    connect(cancelButton, &QAbstractButton::clicked, this, &dlgComposer::slot_cancel);
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
-void dlgComposer::cancel()
+void dlgComposer::slot_cancel()
 {
     mpHost->mTelnet.atcpComposerCancel();
     this->hide();
 }
 
-void dlgComposer::save()
+void dlgComposer::slot_save()
 {
     mpHost->mTelnet.atcpComposerSave(edit->toPlainText());
     this->hide();

--- a/src/dlgComposer.h
+++ b/src/dlgComposer.h
@@ -42,8 +42,8 @@ public:
     void init(const QString &title, const QString &newText);
 
 public slots:
-    void save();
-    void cancel();
+    void slot_save();
+    void slot_cancel();
 
 private:
     QPointer<Host> mpHost;

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -212,23 +212,23 @@ dlgConnectionProfiles::dlgConnectionProfiles(QWidget* parent)
     connect(mpCopyProfile, &QAction::triggered, this, &dlgConnectionProfiles::slot_copy_profile);
     connect(copyProfileSettings, &QAction::triggered, this, &dlgConnectionProfiles::slot_copy_profilesettings_only);
     connect(remove_profile_button, &QAbstractButton::clicked, this, &dlgConnectionProfiles::slot_deleteProfile);
-    connect(profile_name_entry, &QLineEdit::textEdited, this, &dlgConnectionProfiles::slot_update_name);
-    connect(profile_name_entry, &QLineEdit::editingFinished, this, &dlgConnectionProfiles::slot_save_name);
-    connect(host_name_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_update_url);
-    connect(port_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_update_port);
-    connect(port_ssl_tsl, &QCheckBox::stateChanged, this, &dlgConnectionProfiles::slot_update_SSL_TSL_port);
+    connect(profile_name_entry, &QLineEdit::textEdited, this, &dlgConnectionProfiles::slot_updateName);
+    connect(profile_name_entry, &QLineEdit::editingFinished, this, &dlgConnectionProfiles::slot_saveName);
+    connect(host_name_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_updateUrl);
+    connect(port_entry, &QLineEdit::textChanged, this, &dlgConnectionProfiles::slot_updatePort);
+    connect(port_ssl_tsl, &QCheckBox::stateChanged, this, &dlgConnectionProfiles::slot_updateSslTslPort);
     connect(autologin_checkBox, &QCheckBox::stateChanged, this, &dlgConnectionProfiles::slot_update_autologin);
     connect(auto_reconnect, &QCheckBox::stateChanged, this, &dlgConnectionProfiles::slot_update_autoreconnect);
-    connect(login_entry, &QLineEdit::textEdited, this, &dlgConnectionProfiles::slot_update_login);
-    connect(character_password_entry, &QLineEdit::textEdited, this, &dlgConnectionProfiles::slot_update_pass);
+    connect(login_entry, &QLineEdit::textEdited, this, &dlgConnectionProfiles::slot_updateLogin);
+    connect(character_password_entry, &QLineEdit::textEdited, this, &dlgConnectionProfiles::slot_updatePassword);
     connect(mud_description_textedit, &QPlainTextEdit::textChanged, this, &dlgConnectionProfiles::slot_update_description);
-    connect(profiles_tree_widget, &QListWidget::currentItemChanged, this, &dlgConnectionProfiles::slot_item_clicked);
+    connect(profiles_tree_widget, &QListWidget::currentItemChanged, this, &dlgConnectionProfiles::slot_itemClicked);
     connect(profiles_tree_widget, &QListWidget::itemDoubleClicked, this, &dlgConnectionProfiles::accept);
 
     connect(discord_optin_checkBox, &QCheckBox::stateChanged, this, &dlgConnectionProfiles::slot_update_discord_optin);
 
     // website_entry atm is only a label
-    //connect(website_entry, SIGNAL(textEdited(const QString)), this, SLOT(slot_update_website(const QString)));
+    //connect(website_entry, SIGNAL(textEdited(const QString)), this, SLOT(slot_updateWebsite(const QString)));
 
     clearNotificationArea();
 
@@ -302,15 +302,16 @@ void dlgConnectionProfiles::slot_update_description()
     }
 }
 
-void dlgConnectionProfiles::slot_update_website(const QString& url)
-{
-    QListWidgetItem* pItem = profiles_tree_widget->currentItem();
-    if (pItem) {
-        writeProfileData(pItem->data(csmNameRole).toString(), qsl("website"), url);
-    }
-}
+// Not used:
+//void dlgConnectionProfiles::slot_updateWebsite(const QString& url)
+//{
+//    QListWidgetItem* pItem = profiles_tree_widget->currentItem();
+//    if (pItem) {
+//        writeProfileData(pItem->data(csmNameRole).toString(), qsl("website"), url);
+//    }
+//}
 
-void dlgConnectionProfiles::slot_update_pass(const QString& pass)
+void dlgConnectionProfiles::slot_updatePassword(const QString& pass)
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     if (!pItem) {
@@ -353,7 +354,7 @@ void dlgConnectionProfiles::deleteSecurePassword(const QString& profile) const
     job->start();
 }
 
-void dlgConnectionProfiles::slot_update_login(const QString& login)
+void dlgConnectionProfiles::slot_updateLogin(const QString& login)
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     if (pItem) {
@@ -361,7 +362,7 @@ void dlgConnectionProfiles::slot_update_login(const QString& login)
     }
 }
 
-void dlgConnectionProfiles::slot_update_url(const QString& url)
+void dlgConnectionProfiles::slot_updateUrl(const QString& url)
 {
     if (url.isEmpty()) {
         validUrl = false;
@@ -425,7 +426,7 @@ void dlgConnectionProfiles::slot_update_discord_optin(int state)
     }
 }
 
-void dlgConnectionProfiles::slot_update_port(const QString& ignoreBlank)
+void dlgConnectionProfiles::slot_updatePort(const QString& ignoreBlank)
 {
     QString port = port_entry->text().trimmed();
 
@@ -451,7 +452,7 @@ void dlgConnectionProfiles::slot_update_port(const QString& ignoreBlank)
     }
 }
 
-void dlgConnectionProfiles::slot_update_SSL_TSL_port(int state)
+void dlgConnectionProfiles::slot_updateSslTslPort(int state)
 {
     if (validateProfile()) {
         QListWidgetItem* pItem = profiles_tree_widget->currentItem();
@@ -462,13 +463,13 @@ void dlgConnectionProfiles::slot_update_SSL_TSL_port(int state)
     }
 }
 
-void dlgConnectionProfiles::slot_update_name(const QString& newName)
+void dlgConnectionProfiles::slot_updateName(const QString& newName)
 {
     Q_UNUSED(newName)
     validateProfile();
 }
 
-void dlgConnectionProfiles::slot_save_name()
+void dlgConnectionProfiles::slot_saveName()
 {
     QListWidgetItem* pItem = profiles_tree_widget->currentItem();
     QString newProfileName = profile_name_entry->text().trimmed();
@@ -530,13 +531,13 @@ void dlgConnectionProfiles::slot_save_name()
         fillout_form();
         // and re-select the profile since focus is lost
         auto pRestoredItems = findData(*profiles_tree_widget, newProfileName, csmNameRole);
-        Q_ASSERT_X(pRestoredItems.count() < 1, "dlgConnectionProfiles::slot_save_name", "no previously deleted Mud found with matching name when trying to restore one");
-        Q_ASSERT_X(pRestoredItems.count() > 1, "dlgConnectionProfiles::slot_save_name", "multiple deleted Muds found with matching name when trying to restore one");
+        Q_ASSERT_X(pRestoredItems.count() < 1, "dlgConnectionProfiles::slot_saveName", "no previously deleted Mud found with matching name when trying to restore one");
+        Q_ASSERT_X(pRestoredItems.count() > 1, "dlgConnectionProfiles::slot_saveName", "multiple deleted Muds found with matching name when trying to restore one");
 
         // As we are using QAbstractItemView::SingleSelection this will
         // automatically unselect the previous item:
         profiles_tree_widget->setCurrentItem(pRestoredItems.first());
-        slot_item_clicked(pRestoredItems.first());
+        slot_itemClicked(pRestoredItems.first());
     } else {
         setItemName(pItem, newProfileName);
         pItem->setIcon(customIcon(newProfileName, std::nullopt));
@@ -1033,7 +1034,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
     return readProfileData(profile_name, qsl("description"));
 }
 
-void dlgConnectionProfiles::slot_item_clicked(QListWidgetItem* pItem)
+void dlgConnectionProfiles::slot_itemClicked(QListWidgetItem* pItem)
 {
     if (!pItem) {
         return;
@@ -1591,7 +1592,7 @@ void dlgConnectionProfiles::slot_copy_profile()
     auto watcher = new QFutureWatcher<bool>;
     QObject::connect(watcher, &QFutureWatcher<bool>::finished, [=]() {
         mProfileList << profile_name;
-        slot_item_clicked(pItem);
+        slot_itemClicked(pItem);
         // Clear the Discord optin on the copied profile - just because the source
         // one may have had it enabled does not mean we can assume the new one would
         // want it set:
@@ -1636,7 +1637,7 @@ void dlgConnectionProfiles::slot_copy_profilesettings_only()
     copyProfileSettingsOnly(oldname, profile_name);
 
     mProfileList << profile_name;
-    slot_item_clicked(pItem);
+    slot_itemClicked(pItem);
     // Clear the Discord optin on the copied profile - just because the source
     // one may have had it enabled does not mean we can assume the new one would
     // want it set:
@@ -1824,13 +1825,13 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         if (host_name_entry->text().trimmed().size() > 0) {
             pHost->setUrl(host_name_entry->text().trimmed());
         } else {
-            slot_update_url(pHost->getUrl());
+            slot_updateUrl(pHost->getUrl());
         }
 
         if (port_entry->text().trimmed().size() > 0) {
             pHost->setPort(port_entry->text().trimmed().toInt());
         } else {
-            slot_update_port(QString::number(pHost->getPort()));
+            slot_updatePort(QString::number(pHost->getPort()));
         }
 
         pHost->mSslTsl = port_ssl_tsl->isChecked();
@@ -1838,13 +1839,13 @@ void dlgConnectionProfiles::loadProfile(bool alsoConnect)
         if (character_password_entry->text().trimmed().size() > 0) {
             pHost->setPass(character_password_entry->text().trimmed());
         } else {
-            slot_update_pass(pHost->getPass());
+            slot_updatePassword(pHost->getPass());
         }
 
         if (login_entry->text().trimmed().size() > 0) {
             pHost->setLogin(login_entry->text().trimmed());
         } else {
-            slot_update_login(pHost->getLogin());
+            slot_updateLogin(pHost->getLogin());
         }
 
         // This settings also need to be configured, note that the only time not to

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -65,18 +65,18 @@ signals:
     void signal_load_profile(QString profile_name, bool alsoConnect);
 
 public slots:
-    void slot_update_name(const QString&);
-    void slot_save_name();
-    void slot_update_url(const QString&);
-    void slot_update_port(const QString&);
-    void slot_update_SSL_TSL_port(int state);
-    void slot_update_login(const QString&);
-    void slot_update_pass(const QString&);
-    void slot_update_website(const QString&);
+    void slot_updateName(const QString&);
+    void slot_saveName();
+    void slot_updateUrl(const QString&);
+    void slot_updatePort(const QString&);
+    void slot_updateSslTslPort(int state);
+    void slot_updateLogin(const QString&);
+    void slot_updatePassword(const QString&);
+// Not used:    void slot_updateWebsite(const QString&);
     void slot_deleteprofile_check(const QString&);
     void slot_update_description();
 
-    void slot_item_clicked(QListWidgetItem*);
+    void slot_itemClicked(QListWidgetItem*);
     void slot_addProfile();
     void slot_deleteProfile();
     void slot_reallyDeleteProfile();

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -32,28 +32,28 @@ dlgMapLabel::dlgMapLabel(QWidget* pF) : QDialog(pF), fgColor(QColor(255, 255, 50
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Create label", "Create label dialog title"));
 
-    connect(comboBox_type, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgMapLabel::updateControlsVisibility);
+    connect(comboBox_type, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgMapLabel::slot_updateControlsVisibility);
     connect(comboBox_type, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgMapLabel::updated);
-    connect(toolButton_imagePick, &QToolButton::released, this, &dlgMapLabel::pickFile);
+    connect(toolButton_imagePick, &QToolButton::released, this, &dlgMapLabel::slot_pickFile);
     connect(checkBox_stretchImage, &QCheckBox::stateChanged, this, &dlgMapLabel::updated);
     connect(lineEdit_text, &QLineEdit::textChanged, this, [&](const QString& pText) {
         text = pText;
         emit updated();
     });
-    connect(pushButton_bgColor, &QPushButton::released, this, &dlgMapLabel::pickBgColor);
-    connect(pushButton_fgColor, &QPushButton::released, this, &dlgMapLabel::pickFgColor);
-    connect(toolButton_fontPick, &QToolButton::released, this, &dlgMapLabel::pickFont);
-    connect(pushButton_save, &QPushButton::released, this, &dlgMapLabel::save);
+    connect(pushButton_bgColor, &QPushButton::released, this, &dlgMapLabel::slot_pickBgColor);
+    connect(pushButton_fgColor, &QPushButton::released, this, &dlgMapLabel::slot_pickFgColor);
+    connect(toolButton_fontPick, &QToolButton::released, this, &dlgMapLabel::slot_pickFont);
+    connect(pushButton_save, &QPushButton::released, this, &dlgMapLabel::slot_save);
     connect(pushButton_cancel, &QPushButton::released, this, &dlgMapLabel::close);
     connect(comboBox_position, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [=]() { emit updated(); });
     connect(checkBox_scaling, &QCheckBox::stateChanged, this, [=]() { emit updated(); });
-    connect(this, &dlgMapLabel::updated, this, &dlgMapLabel::updateControls);
+    connect(this, &dlgMapLabel::updated, this, &dlgMapLabel::slot_updateControls);
 
     font = QApplication::font();
     font.setStyle(QFont::StyleNormal);
     text = lineEdit_text->placeholderText();
-    updateControls();
-    updateControlsVisibility();
+    slot_updateControls();
+    slot_updateControlsVisibility();
 }
 
 dlgMapLabel::~dlgMapLabel() {}
@@ -68,7 +68,7 @@ QString dlgMapLabel::getImagePath()
     return imagePath;
 }
 
-void dlgMapLabel::pickFgColor()
+void dlgMapLabel::slot_pickFgColor()
 {
     fgColorDialog = new QColorDialog(this);
     fgColorDialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -87,7 +87,7 @@ void dlgMapLabel::pickFgColor()
     fgColorDialog->raise();
 }
 
-void dlgMapLabel::pickBgColor()
+void dlgMapLabel::slot_pickBgColor()
 {
     auto originalColor = QColor(bgColor);
     bgColorDialog = new QColorDialog(this);
@@ -106,7 +106,7 @@ void dlgMapLabel::pickBgColor()
     bgColorDialog->raise();
 }
 
-void dlgMapLabel::pickFont()
+void dlgMapLabel::slot_pickFont()
 {
     auto originalFont = QFont(font);
     fontDialog = new QFontDialog(font, this);
@@ -126,13 +126,13 @@ void dlgMapLabel::pickFont()
     fontDialog->raise();
 }
 
-void dlgMapLabel::pickFile()
+void dlgMapLabel::slot_pickFile()
 {
     imagePath = QFileDialog::getOpenFileName(nullptr, tr("Select image", "2D Mapper create label file dialog title"));
     emit updated();
 }
 
-void dlgMapLabel::save()
+void dlgMapLabel::slot_save()
 {
     accept();
 }
@@ -172,7 +172,7 @@ bool dlgMapLabel::stretchImage()
     return checkBox_stretchImage->isChecked();
 }
 
-void dlgMapLabel::updateControls()
+void dlgMapLabel::slot_updateControls()
 {
     lineEdit_font->setText(QString("%1, %2pt %3").arg(font.family(), QString::number(font.pointSize()), font.styleName()));
     pushButton_fgColor->setStyleSheet(BUTTON_STYLESHEET.arg(QString::number(fgColor.red()), QString::number(fgColor.green()), QString::number(fgColor.blue()), QString::number(fgColor.alpha())));
@@ -180,7 +180,7 @@ void dlgMapLabel::updateControls()
     lineEdit_image->setText(imagePath);
 }
 
-void dlgMapLabel::updateControlsVisibility()
+void dlgMapLabel::slot_updateControlsVisibility()
 {
     bool isText = isTextLabel();
     label_image->setVisible(!isText);

--- a/src/dlgMapLabel.h
+++ b/src/dlgMapLabel.h
@@ -62,13 +62,13 @@ private:
     QFont font;
 
 private slots:
-    void save();
-    void pickFgColor();
-    void pickBgColor();
-    void pickFont();
-    void pickFile();
-    void updateControls();
-    void updateControlsVisibility();
+    void slot_save();
+    void slot_pickFgColor();
+    void slot_pickBgColor();
+    void slot_pickFont();
+    void slot_pickFile();
+    void slot_updateControls();
+    void slot_updateControlsVisibility();
 };
 
 #endif //MUDLET_DLGMAPLABEL_H


### PR DESCRIPTION
When Qt's slot/signal system is used to invoke a method there is some overhead - so it makes sense to ensure developers can spot all such methods (functions). We have tried to do this with a `slot_` prefix to the methods we create but it has not been applied uniformly. This PR (and one or more to follow) is intended to help with this by more rigorously doing so - the names changed herein should all follow a `slot_`*camelCaseMethodName* style. In addition some methods were detected that are not currently used or which are not actually used via the signal/slot system, these have been commented out or have had the prefix removed and the declaration in the relevant header file moved as appropriate.

For reference the changes made are:
* `TLuaInterpreter::slotDeleteSender(...)` ==> `TLuaInterpreter::slot_deleteSender(...)`
* `TLuaInterpreter::slotPurge()` ==> `TLuaInterpreter::slot_purge()`
* `cTelnet::handle_socket_signal_connected()` ==> `cTelnet::slot_socketConnected()`
* `cTelnet::handle_socket_signal_disconnected()` ==> `cTelnet::slot_socketDisconnected()`
* `cTelnet::handle_socket_signal_hostFound(...)` ==> `cTelnet::slot_socketHostFound(...)`
* `cTelnet::handle_socket_signal_readyRead()` ==> `cTelnet::slot_socketReadyToBeRead()`
* `cTelnet::handle_socket_signal_sslError(...)` ==> `cTelnet::slot_socketSslError(...)`
* `cTelnet::setDownloadProgress(...)` ==> `cTelnet::slot_setDownloadProgress(...)`
* `dlgComposer::cancel()` ==> `dlgComposer::slot_cancel()`
* `dlgComposer::save()` ==> `dlgComposer::slot_save()`
* `dlgConnectionProfiles::slot_item_clicked(...)` ==> `dlgConnectionProfiles::slot_itemClicked(...)`
* `dlgConnectionProfiles::slot_save_name()` ==> `dlgConnectionProfiles::slot_saveName()`
* `dlgConnectionProfiles::slot_update_login(...)` ==> `dlgConnectionProfiles::slot_updateLogin(...)`
* `dlgConnectionProfiles::slot_update_name(...)` ==> `dlgConnectionProfiles::slot_updateName(...)`
* `dlgConnectionProfiles::slot_update_pass(...)` ==> `dlgConnectionProfiles::slot_updatePassword(...)`
* `dlgConnectionProfiles::slot_update_port(...)` ==> `dlgConnectionProfiles::slot_updatePort(...)`
* `dlgConnectionProfiles::slot_update_SSL_TSL_port(...)` ==> `dlgConnectionProfiles::slot_updateSslTslPort(...)`
* `dlgConnectionProfiles::slot_update_url(...)` ==> `dlgConnectionProfiles::slot_updateUrl(...)`
* `dlgMapLabel::pickBgColor()` ==> `dlgMapLabel::slot_pickBgColor()`
* `dlgMapLabel::pickFgColor()` ==> `dlgMapLabel::slot_pickFgColor()`
* `dlgMapLabel::pickFile()` ==> `dlgMapLabel::slot_pickFile()`
* `dlgMapLabel::pickFont()` ==> `dlgMapLabel::slot_pickFont()`
* `dlgMapLabel::save()` ==> `dlgMapLabel::slot_save()`
* `dlgMapLabel::updateControls()` ==> `dlgMapLabel::slot_updateControls()`
* `dlgMapLabel::updateControlsVisibility()` ==> `dlgMapLabel::slot_updateControlsVisibility()`

Commented out as not being used:
* `cTelnet::handle_socket_signal_error()` ==> `cTelnet::slot_socketError()`
* `dlgConnectionProfiles::slot_update_website(...) ==> `dlgConnectionProfiles::slot_updateWebsite(const QString& url)`

I have my doubts about whether the `dlgMapLabel::save()`/`dlgMapLabel::slot_save()` method is needed at all, as it might be that the `QDialog::accept()` slot could have been inserted into the `QObject::connect(...)` call directly instead...?

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>