### PR TITLE
Infrastructure: tidy up naming of SLOT methods and their usage - Part 3

### DIFF
--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -40,11 +40,11 @@ dlgModuleManager::dlgModuleManager(QWidget* parent, Host* pHost)
     mModuleHelpButton = ui->helpButton;
 
     layoutModules();
-    connect(mModuleUninstallButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_uninstall_module);
-    connect(mModuleInstallButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_install_module);
-    connect(mModuleHelpButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_help_module);
-    connect(mModuleTable, &QTableWidget::itemClicked, this, &dlgModuleManager::slot_module_clicked);
-    connect(mModuleTable, &QTableWidget::itemChanged, this, &dlgModuleManager::slot_module_changed);
+    connect(mModuleUninstallButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_uninstallModule);
+    connect(mModuleInstallButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_installModule);
+    connect(mModuleHelpButton, &QAbstractButton::clicked, this, &dlgModuleManager::slot_helpModule);
+    connect(mModuleTable, &QTableWidget::itemClicked, this, &dlgModuleManager::slot_moduleClicked);
+    connect(mModuleTable, &QTableWidget::itemChanged, this, &dlgModuleManager::slot_moduleChanged);
     connect(mpHost->mpConsole, &QWidget::destroyed, this, &dlgModuleManager::close);
     setWindowTitle(tr("Module Manager - %1").arg(mpHost->getName()));
     setAttribute(Qt::WA_DeleteOnClose);
@@ -128,7 +128,7 @@ void dlgModuleManager::layoutModules()
     mModuleTable->resizeColumnsToContents();
 }
 
-void dlgModuleManager::slot_install_module()
+void dlgModuleManager::slot_installModule()
 {
     if (!mpHost) {
         return;
@@ -153,7 +153,7 @@ void dlgModuleManager::slot_install_module()
     layoutModules();
 }
 
-void dlgModuleManager::slot_uninstall_module()
+void dlgModuleManager::slot_uninstallModule()
 {
     if (!mpHost) {
         return;
@@ -170,7 +170,7 @@ void dlgModuleManager::slot_uninstall_module()
     layoutModules();
 }
 
-void dlgModuleManager::slot_module_clicked(QTableWidgetItem* pItem)
+void dlgModuleManager::slot_moduleClicked(QTableWidgetItem* pItem)
 {
     if (!mpHost) {
         return;
@@ -199,7 +199,7 @@ void dlgModuleManager::slot_module_clicked(QTableWidgetItem* pItem)
     }
 }
 
-void dlgModuleManager::slot_module_changed(QTableWidgetItem* pItem)
+void dlgModuleManager::slot_moduleChanged(QTableWidgetItem* pItem)
 {
     if (!mpHost) {
         return;
@@ -224,7 +224,7 @@ void dlgModuleManager::slot_module_changed(QTableWidgetItem* pItem)
     mpHost->mModulePriorities[entry->text()] = itemPriority->text().toInt();
 }
 
-void dlgModuleManager::slot_help_module()
+void dlgModuleManager::slot_helpModule()
 {
     if (!mpHost) {
         return;

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -47,11 +47,11 @@ public:
      QTableWidget* mModuleTable;
 
 private slots:
-    void slot_install_module();
-    void slot_uninstall_module();
-    void slot_help_module();
-    void slot_module_clicked(QTableWidgetItem*);
-    void slot_module_changed(QTableWidgetItem*);
+    void slot_installModule();
+    void slot_uninstallModule();
+    void slot_helpModule();
+    void slot_moduleClicked(QTableWidgetItem*);
+    void slot_moduleChanged(QTableWidgetItem*);
 
 private:
     Ui::module_manager* ui = nullptr;

--- a/src/dlgNotepad.cpp
+++ b/src/dlgNotepad.cpp
@@ -45,7 +45,7 @@ dlgNotepad::dlgNotepad(Host* pH)
         restore();
     }
 
-    connect(notesEdit, &QPlainTextEdit::textChanged, this, &dlgNotepad::slot_text_written);
+    connect(notesEdit, &QPlainTextEdit::textChanged, this, &dlgNotepad::slot_textWritten);
 
     startTimer(2min);
 }
@@ -111,7 +111,7 @@ void dlgNotepad::restore()
     restoreFile(fileName, false);
 }
 
-void dlgNotepad::slot_text_written()
+void dlgNotepad::slot_textWritten()
 {
     mNeedToSave = true;
 }

--- a/src/dlgNotepad.h
+++ b/src/dlgNotepad.h
@@ -44,7 +44,7 @@ public:
     void restore();
 
 private slots:
-    void slot_text_written();
+    void slot_textWritten();
 
 private:
     void timerEvent(QTimerEvent *event) override;

--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -93,14 +93,14 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     mPackagePathFileName.clear();
     mXmlPathFileName.clear();
     connect(ui->addFiles, &QAbstractButton::clicked, this, &dlgPackageExporter::slot_addFiles);
-    connect(mExportButton, &QAbstractButton::clicked, this, &dlgPackageExporter::slot_export_package);
+    connect(mExportButton, &QAbstractButton::clicked, this, &dlgPackageExporter::slot_exportPackage);
     connect(ui->pushButton_packageLocation, &QPushButton::clicked, this, &dlgPackageExporter::slot_openPackageLocation);
     connect(ui->lineEdit_packageName, &QLineEdit::textChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     connect(this, &dlgPackageExporter::signal_exportLocationChanged, this, &dlgPackageExporter::slot_updateLocationPlaceholder);
     slot_updateLocationPlaceholder();
     connect(ui->packageList, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgPackageExporter::slot_packageChanged);
     connect(ui->addDependency, &QPushButton::clicked, this, &dlgPackageExporter::slot_addDependency);
-    connect(ui->pushButton_addIcon, &QPushButton::clicked, this, &dlgPackageExporter::slot_import_icon);
+    connect(ui->pushButton_addIcon, &QPushButton::clicked, this, &dlgPackageExporter::slot_importIcon);
     connect(mCancelButton, &QPushButton::clicked, this, &dlgPackageExporter::slot_cancelExport);
 
     ui->listWidget_addedFiles->installEventFilter(this);
@@ -340,7 +340,7 @@ void dlgPackageExporter::checkToEnableExportButton()
     }
 }
 
-void dlgPackageExporter::slot_import_icon()
+void dlgPackageExporter::slot_importIcon()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Open Icon"), QDir::currentPath(), tr("Image Files (*.png *.jpg *.jpeg *.bmp *.tif *.ico *.icns)"));
     if (fileName.isEmpty()) {
@@ -455,7 +455,7 @@ void dlgPackageExporter::copy_directory(const QString& fromDir, const QString& t
     }
 }
 
-void dlgPackageExporter::slot_export_package()
+void dlgPackageExporter::slot_exportPackage()
 {
     // The native windows dialog does not support displaying files - and as this
     // code will clobber/overwrite an existing package with the same
@@ -916,12 +916,12 @@ std::pair<bool, QString> dlgPackageExporter::zipPackage(const QString& stagingDi
 
         QFileInfo stagingFileInfo(stagingFile.fileInfo());
         if (!stagingFileInfo.isReadable()) {
-            qWarning() << "dlgPackageExporter::slot_export_package() skipping file: " << stagingFile.fileName() << "it is NOT readable!";
+            qWarning() << "dlgPackageExporter::slot_exportPackage() skipping file: " << stagingFile.fileName() << "it is NOT readable!";
             continue;
         }
 
         if (stagingFileInfo.isSymLink()) {
-            qWarning() << "dlgPackageExporter::slot_export_package() skipping file: " << stagingFile.fileName() << "it is a Symlink - avoided to prevent file-system loops!";
+            qWarning() << "dlgPackageExporter::slot_exportPackage() skipping file: " << stagingFile.fileName() << "it is a Symlink - avoided to prevent file-system loops!";
             continue;
         }
 

--- a/src/dlgPackageExporter.h
+++ b/src/dlgPackageExporter.h
@@ -88,12 +88,12 @@ public:
 
 public slots:
     void slot_addFiles();
-    void slot_export_package();
+    void slot_exportPackage();
 
 private slots:
     void slot_addDependency();
     void slot_removeDependency();
-    void slot_import_icon();
+    void slot_importIcon();
     void slot_openPackageLocation();
     void slot_packageChanged(int);
     void slot_updateLocationPlaceholder();

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -41,12 +41,12 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     mDetailsTable = ui->additionalDetails;
     mDescription = ui->packageDescription;
     resetPackageTable();
-    connect(mPackageTable, &QTableWidget::itemClicked, this, &dlgPackageManager::slot_item_clicked);
-    connect(mInstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_install_package);
-    connect(mRemoveButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_remove_packages);
+    connect(mPackageTable, &QTableWidget::itemClicked, this, &dlgPackageManager::slot_itemClicked);
+    connect(mInstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_installPackage);
+    connect(mRemoveButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_removePackages);
     connect(mpHost->mpConsole, &QWidget::destroyed, this, &dlgPackageManager::close);
-    connect(mPackageTable, &QTableWidget::currentItemChanged, this, &dlgPackageManager::slot_item_clicked);
-    connect(mPackageTable, &QTableWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggle_remove_button);
+    connect(mPackageTable, &QTableWidget::currentItemChanged, this, &dlgPackageManager::slot_itemClicked);
+    connect(mPackageTable, &QTableWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggleRemoveButton);
 
     setWindowTitle(tr("Package Manager (experimental) - %1").arg(mpHost->getName()));
     mDetailsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -100,7 +100,7 @@ void dlgPackageManager::resetPackageTable()
     mPackageTable->resizeColumnsToContents();
 }
 
-void dlgPackageManager::slot_install_package()
+void dlgPackageManager::slot_installPackage()
 {
     QString fileName = QFileDialog::getOpenFileName(this, tr("Import Mudlet Package"), QDir::currentPath());
     if (fileName.isEmpty()) {
@@ -116,7 +116,7 @@ void dlgPackageManager::slot_install_package()
     mpHost->installPackage(fileName, 0);
 }
 
-void dlgPackageManager::slot_remove_packages()
+void dlgPackageManager::slot_removePackages()
 {
     QModelIndexList selection = mPackageTable->selectionModel()->selectedRows();
     QStringList removePackages;
@@ -135,7 +135,7 @@ void dlgPackageManager::slot_remove_packages()
     mDescription->hide();
 }
 
-void dlgPackageManager::slot_item_clicked(QTableWidgetItem* pItem)
+void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
 {
     if (!pItem) {
         return;
@@ -231,7 +231,7 @@ void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& pack
     }
 }
 
-void dlgPackageManager::slot_toggle_remove_button()
+void dlgPackageManager::slot_toggleRemoveButton()
 {
     QModelIndexList selection = mPackageTable->selectionModel()->selectedRows();
     int selectionCount = selection.count();

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -47,10 +47,10 @@ public:
     void resetPackageTable();
 
 private slots:
-    void slot_install_package();
-    void slot_remove_packages();
-    void slot_item_clicked(QTableWidgetItem*);
-    void slot_toggle_remove_button();
+    void slot_installPackage();
+    void slot_removePackages();
+    void slot_itemClicked(QTableWidgetItem*);
+    void slot_toggleRemoveButton();
 
 private:
     void fillAdditionalDetails(const QMap<QString, QString>&);


### PR DESCRIPTION
When Qt's slot/signal system is used to invoke a method there is some overhead - so it makes sense to ensure developers can spot all such methods (functions). We have tried to do this with a `slot_` prefix to the methods we create but it has not been applied uniformly. This PR (and one or more to follow) is intended to help with this by more rigorously doing so - the names changed herein should all follow a `slot_`*camelCaseMethodName* style. In addition some methods were detected that are not currently used or which are not actually used via the signal/slot system, these have been commented out or have had the prefix removed and the declaration in the relevant header file moved as appropriate.

For reference the changes made are:
* `dlgModuleManager::slot_help_module()` ==> `dlgModuleManager::slot_helpModule()`
* `dlgModuleManager::slot_install_module()` ==> `dlgModuleManager::slot_installModule()`
* `dlgModuleManager::slot_module_changed(...)` ==> `dlgModuleManager::slot_moduleChanged(...)`
* `dlgModuleManager::slot_module_clicked(...)` ==> `dlgModuleManager::slot_moduleClicked(...)`
* `dlgModuleManager::slot_uninstall_module()` ==> `dlgModuleManager::slot_uninstallModule()`
* `dlgNotepad::slot_text_written()` ==> `dlgNotepad::slot_textWritten()`
* `dlgPackageExporter::slot_import_icon()` ==> `dlgPackageExporter::slot_importIcon()`
* `dlgPackageExporter::slot_export_package()` ==> `dlgPackageExporter::slot_exportPackage()`
* `dlgPackageManager::slot_install_package()` ==> `dlgPackageManager::slot_installPackage()`
* `dlgPackageManager::slot_item_clicked(...)` ==> `dlgPackageManager::slot_itemClicked(...)`
* `dlgPackageManager::slot_toggle_remove_button()` ==> `dlgPackageManager::slot_toggleRemoveButton()`
* `dlgPackageManager::slot_remove_packages()` ==> `dlgPackageManager::slot_removePackages()`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>