### PR TITLE
Infrastructure: tidy up naming of SLOT methods and their usage - Part 4

### DIFF
--- a/src/dlgActionMainArea.cpp
+++ b/src/dlgActionMainArea.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,4 +27,16 @@ dlgActionMainArea::dlgActionMainArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog
     setupUi(this);
+
+    connect(lineEdit_action_name, &QLineEdit::editingFinished, this, &dlgActionMainArea::slot_editingNameFinished);
+}
+
+void dlgActionMainArea::trimName()
+{
+    lineEdit_action_name->setText(lineEdit_action_name->text().trimmed());
+}
+
+void dlgActionMainArea::slot_editingNameFinished()
+{
+    trimName();
 }

--- a/src/dlgActionMainArea.h
+++ b/src/dlgActionMainArea.h
@@ -35,6 +35,13 @@ class dlgActionMainArea : public QWidget, public Ui::actions_main_area
 public:
     Q_DISABLE_COPY(dlgActionMainArea)
     explicit dlgActionMainArea(QWidget*);
+
+    // public function allow to trim even when QLineEdit::editingFinished()
+    // is not raised. Example: When the user saves without leaving the LineEdit
+    void trimName();
+
+private slots:
+    void slot_editingNameFinished();
 };
 
 #endif // MUDLET_DLGACTIONMAINAREA_H

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -27,7 +27,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editing_name_finished);
+    connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editingNameFinished);
 
     if (mudlet::self()->firstLaunch) {
         lineEdit_alias_pattern->setPlaceholderText("for example, ^myalias$ to match 'myalias'");
@@ -39,7 +39,7 @@ void dlgAliasMainArea::trimName()
     lineEdit_alias_name->setText(lineEdit_alias_name->text().trimmed());
 }
 
-void dlgAliasMainArea::slot_editing_name_finished()
+void dlgAliasMainArea::slot_editingNameFinished()
 {
     trimName();
 }

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -30,6 +30,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
     connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editingNameFinished);
 
     if (mudlet::self()->firstLaunch) {
+        // TODO - make this text translatable: https://github.com/Mudlet/Mudlet/issues/6261
         lineEdit_alias_pattern->setPlaceholderText("for example, ^myalias$ to match 'myalias'");
     }
 }

--- a/src/dlgAliasMainArea.h
+++ b/src/dlgAliasMainArea.h
@@ -39,8 +39,9 @@ public:
     // public function allow to trim even when QLineEdit::editingFinished()
     // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
+
 private slots:
-    void slot_editing_name_finished();
+    void slot_editingNameFinished();
 };
 
 #endif // MUDLET_DLGALIASESMAINAREA_H

--- a/src/dlgKeysMainArea.cpp
+++ b/src/dlgKeysMainArea.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,4 +27,15 @@ dlgKeysMainArea::dlgKeysMainArea(QWidget* pF) : QWidget(pF)
 {
     // init generated dialog
     setupUi(this);
+    connect(lineEdit_key_name, &QLineEdit::editingFinished, this, &dlgKeysMainArea::slot_editingNameFinished);
+}
+
+void dlgKeysMainArea::trimName()
+{
+    lineEdit_key_name->setText(lineEdit_key_name->text().trimmed());
+}
+
+void dlgKeysMainArea::slot_editingNameFinished()
+{
+    trimName();
 }

--- a/src/dlgKeysMainArea.h
+++ b/src/dlgKeysMainArea.h
@@ -35,6 +35,13 @@ class dlgKeysMainArea : public QWidget, public Ui::keybindings_main_area
 public:
     Q_DISABLE_COPY(dlgKeysMainArea)
     explicit dlgKeysMainArea(QWidget*);
+
+    // public function allow to trim even when QLineEdit::editingFinished()
+    // is not raised. Example: When the user saves without leaving the LineEdit
+    void trimName();
+
+private slots:
+    void slot_editingNameFinished();
 };
 
 #endif // MUDLET_DLGKEYSMAINAREA_H

--- a/src/dlgScriptsMainArea.cpp
+++ b/src/dlgScriptsMainArea.cpp
@@ -27,7 +27,7 @@ dlgScriptsMainArea::dlgScriptsMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_script_name, &QLineEdit::editingFinished, this, &dlgScriptsMainArea::slot_editing_name_finished);
+    connect(lineEdit_script_name, &QLineEdit::editingFinished, this, &dlgScriptsMainArea::slot_editingNameFinished);
     connect(lineEdit_script_event_handler_entry, &QLineEdit::editingFinished, this, &dlgScriptsMainArea::slot_editing_event_name_finished);
 }
 
@@ -41,7 +41,7 @@ void dlgScriptsMainArea::trimEventHandlerName()
     lineEdit_script_event_handler_entry->setText(lineEdit_script_event_handler_entry->text().trimmed());
 }
 
-void dlgScriptsMainArea::slot_editing_name_finished()
+void dlgScriptsMainArea::slot_editingNameFinished()
 {
     trimName();
 }

--- a/src/dlgScriptsMainArea.cpp
+++ b/src/dlgScriptsMainArea.cpp
@@ -28,7 +28,7 @@ dlgScriptsMainArea::dlgScriptsMainArea(QWidget* pF) : QWidget(pF)
     setupUi(this);
 
     connect(lineEdit_script_name, &QLineEdit::editingFinished, this, &dlgScriptsMainArea::slot_editingNameFinished);
-    connect(lineEdit_script_event_handler_entry, &QLineEdit::editingFinished, this, &dlgScriptsMainArea::slot_editing_event_name_finished);
+    connect(lineEdit_script_event_handler_entry, &QLineEdit::editingFinished, this, &dlgScriptsMainArea::slot_editingEventNameFinished);
 }
 
 void dlgScriptsMainArea::trimName()
@@ -46,7 +46,7 @@ void dlgScriptsMainArea::slot_editingNameFinished()
     trimName();
 }
 
-void dlgScriptsMainArea::slot_editing_event_name_finished()
+void dlgScriptsMainArea::slot_editingEventNameFinished()
 {
     trimEventHandlerName();
 }

--- a/src/dlgScriptsMainArea.h
+++ b/src/dlgScriptsMainArea.h
@@ -39,8 +39,9 @@ public:
     // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
     void trimEventHandlerName();
+
 private slots:
-    void slot_editing_name_finished();
+    void slot_editingNameFinished();
     void slot_editing_event_name_finished();
 };
 

--- a/src/dlgScriptsMainArea.h
+++ b/src/dlgScriptsMainArea.h
@@ -42,7 +42,7 @@ public:
 
 private slots:
     void slot_editingNameFinished();
-    void slot_editing_event_name_finished();
+    void slot_editingEventNameFinished();
 };
 
 #endif // MUDLET_DLGSCRIPTSMAINAREA_H

--- a/src/dlgTimersMainArea.cpp
+++ b/src/dlgTimersMainArea.cpp
@@ -27,7 +27,7 @@ dlgTimersMainArea::dlgTimersMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_timer_name, &QLineEdit::editingFinished, this, &dlgTimersMainArea::slot_editing_name_finished);
+    connect(lineEdit_timer_name, &QLineEdit::editingFinished, this, &dlgTimersMainArea::slot_editingNameFinished);
 }
 
 void dlgTimersMainArea::trimName()
@@ -35,7 +35,7 @@ void dlgTimersMainArea::trimName()
     lineEdit_timer_name->setText(lineEdit_timer_name->text().trimmed());
 }
 
-void dlgTimersMainArea::slot_editing_name_finished()
+void dlgTimersMainArea::slot_editingNameFinished()
 {
     trimName();
 }

--- a/src/dlgTimersMainArea.h
+++ b/src/dlgTimersMainArea.h
@@ -39,8 +39,9 @@ public:
     // public function allow to trim even when QLineEdit::editingFinished()
     // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
+
 private slots:
-    void slot_editing_name_finished();
+    void slot_editingNameFinished();
 };
 
 #endif // MUDLET_DLGTIMERSMAINAREA_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -4324,6 +4324,7 @@ void dlgTriggerEditor::saveAction()
         return;
     }
 
+    mpActionsMainArea->trimName();
     QString name = mpActionsMainArea->lineEdit_action_name->text();
     QString icon = mpActionsMainArea->lineEdit_action_icon->text();
     QString commandDown = mpActionsMainArea->lineEdit_action_button_command_down->text();
@@ -4806,6 +4807,7 @@ void dlgTriggerEditor::saveKey()
         return;
     }
 
+    mpKeysMainArea->trimName();
     QString name = mpKeysMainArea->lineEdit_key_name->text();
     if (name.isEmpty() || name == tr("New key")) {
         name = mpKeysMainArea->lineEdit_key_binding->text();

--- a/src/dlgTriggersMainArea.cpp
+++ b/src/dlgTriggersMainArea.cpp
@@ -27,7 +27,7 @@ dlgTriggersMainArea::dlgTriggersMainArea(QWidget* pF) : QWidget(pF)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_trigger_name, &QLineEdit::editingFinished, this, &dlgTriggersMainArea::slot_editing_name_finished);
+    connect(lineEdit_trigger_name, &QLineEdit::editingFinished, this, &dlgTriggersMainArea::slot_editingNameFinished);
 }
 
 void dlgTriggersMainArea::trimName()
@@ -35,7 +35,7 @@ void dlgTriggersMainArea::trimName()
     lineEdit_trigger_name->setText(lineEdit_trigger_name->text().trimmed());
 }
 
-void dlgTriggersMainArea::slot_editing_name_finished()
+void dlgTriggersMainArea::slot_editingNameFinished()
 {
     trimName();
 }

--- a/src/dlgTriggersMainArea.h
+++ b/src/dlgTriggersMainArea.h
@@ -39,8 +39,9 @@ public:
     // public function allow to trim even when QLineEdit::editingFinished()
     // is not raised. Example: When the user saves without leaving the LineEdit
     void trimName();
+
 private slots:
-    void slot_editing_name_finished();
+    void slot_editingNameFinished();
 };
 
 #endif // MUDLET_DLGTRIGGERSMAINAREA_H


### PR DESCRIPTION
When Qt's slot/signal system is used to invoke a method there is some overhead - so it makes sense to ensure developers can spot all such methods (functions). We have tried to do this with a `slot_` prefix to the methods we create but it has not been applied uniformly. This PR (and one or more to follow) is intended to help with this by more rigorously doing so - the names changed herein should all follow a `slot_`*camelCaseMethodName* style. In addition some methods were detected that are not currently used or which are not actually used via the signal/slot system, these have been commented out or have had the prefix removed and the declaration in the relevant header file moved as appropriate.

For reference the changes made are:
* `dlgAliasMainArea::slot_editing_name_finished()` ==> `dlgAliasMainArea::slot_editingNameFinished()`
* `dlgScriptsMainArea::slot_editing_name_finished()` ==> `dlgScriptsMainArea::slot_editingNameFinished()`
* `dlgScriptsMainArea::slot_editing_event_name_finished()` ==> `dlgScriptsMainArea::slot_editingEventNameFinished()`, *added in a later commit.*
* `dlgTimersMainArea::slot_editing_name_finished()` ==> `dlgTimersMainArea::slot_editingNameFinished()`
* `dlgTriggersMainArea::slot_editing_name_finished()` ==> `dlgTriggersMainArea::slot_editingNameFinished()`

It ~~seems~~*was* odd that there ~~are~~*were* not corresponding `slot_`s to trim spaces off either end for the "Actions" (Buttons/Menus/Toolbars) and "Keybindings" Mudlet item types, *so they have been added as well.*

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>