### PR TITLE
Fix: Make first-launch alias placeholder pattern be translatable

### DIFF
--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -30,7 +30,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
     connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editing_name_finished);
 
     if (mudlet::self()->firstLaunch) {
-        lineEdit_alias_pattern->setPlaceholderText(tr("for example, ^myalias$ to match 'myalias'"));
+        lineEdit_alias_pattern->setPlaceholderText(tr("for example, ^myalias$ to match 'myalias'", "This text is shown as placeholder in the pattern box when no real pattern was entered, yet."));
     }
 }
 

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -30,7 +30,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pF) : QWidget(pF)
     connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editing_name_finished);
 
     if (mudlet::self()->firstLaunch) {
-        lineEdit_alias_pattern->setPlaceholderText("for example, ^myalias$ to match 'myalias'");
+        lineEdit_alias_pattern->setPlaceholderText(tr("for example, ^myalias$ to match 'myalias'"));
     }
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Make the placeholder text that appears in the alias pattern field - only on first Mudlet launch - be properly translatable
#### Motivation for adding to Mudlet
Fixing an oversight
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/6261