### PR TITLE
Fix: MCMP continue

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -5784,10 +5784,10 @@ int TLuaInterpreter::playMusicFileAsTableArgument(lua_State* L)
                 }
 
                 mediaData.setMediaLoops(value);
-            } else if (key == QLatin1String("continue")) {
-                bool value = getVerifiedBool(L, __func__, -1, "value for continue must be boolean");
-                mediaData.setMediaContinue(value);
             }
+        } else if (key == QLatin1String("continue")) {
+            bool value = getVerifiedBool(L, __func__, -1, "value for continue must be boolean");
+            mediaData.setMediaContinue(value);
         }
 
         // removes value, but keeps key for next iteration

--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -756,7 +756,7 @@ TMediaPlayer TMedia::matchMediaPlayer(TMediaData& mediaData, const QString& abso
         TMediaPlayer pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-            if (pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)) { // Is the same sound or music playing?
+            if (pTestPlayer.getMediaData().getMediaAbsolutePathFileName().endsWith(absolutePathFileName)) { // Is the same sound or music playing?
                 pPlayer = pTestPlayer;
                 pPlayer.setMediaData(mediaData);
                 pPlayer.getMediaPlayer()->setVolume(mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.getMediaVolume());
@@ -786,7 +786,7 @@ bool TMedia::doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& a
         TMediaPlayer pTestPlayer = itTMediaPlayer.next();
 
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
-            if (!pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
+            if (!pTestPlayer.getMediaData().getMediaAbsolutePathFileName().endsWith(absolutePathFileName)) { // Is it a different sound or music than specified?
                 if (pTestPlayer.getMediaData().getMediaPriority() != TMediaData::MediaPriorityNotSet && pTestPlayer.getMediaData().getMediaPriority() > maxMediaPriority) {
                     maxMediaPriority = pTestPlayer.getMediaData().getMediaPriority();
                 }
@@ -819,7 +819,7 @@ void TMedia::matchMediaKeyAndStopMediaVariants(TMediaData& mediaData, const QStr
         if (pTestPlayer.getMediaPlayer()->state() == QMediaPlayer::PlayingState && pTestPlayer.getMediaPlayer()->mediaStatus() != QMediaPlayer::LoadingMedia) {
             if (!mediaData.getMediaKey().isEmpty() && !pTestPlayer.getMediaData().getMediaKey().isEmpty()
                 && mediaData.getMediaKey() == pTestPlayer.getMediaData().getMediaKey()) { // Does it have the same key?
-                if (!pTestPlayer.getMediaPlayer()->media().request().url().toString().endsWith(absolutePathFileName)
+                if (!pTestPlayer.getMediaData().getMediaAbsolutePathFileName().endsWith(absolutePathFileName)
                     || (!mediaData.getMediaUrl().isEmpty() && !pTestPlayer.getMediaData().getMediaUrl().isEmpty()
                         && mediaData.getMediaUrl() != pTestPlayer.getMediaData().getMediaUrl())) { // Is it a different sound or music than specified?
                     TMediaData stopMediaData = pTestPlayer.getMediaData();
@@ -853,10 +853,10 @@ void TMedia::play(TMediaData& mediaData)
         pPlayer = TMedia::matchMediaPlayer(mediaData, fileNameList.at(0));
     }
 
-    if (pPlayer.isInitialized()) { // Same music is already playing
-        if (mediaData.getMediaContinue() == TMediaData::MediaContinueDefault && mediaData.getMediaLoops() == TMediaData::MediaLoopsDefault) {
-            return; // Continue playing it && Don't add more iterations of it
-        }
+    bool sameMusicIsPlaying = false;
+
+    if (pPlayer.isInitialized()) {
+        sameMusicIsPlaying = true; // Same music is playing; Reuse that MediaPlayer
     } else {
         pPlayer = TMedia::getMediaPlayer(mediaData);
     }
@@ -867,9 +867,28 @@ void TMedia::play(TMediaData& mediaData)
         return;
     }
 
+    auto playlist = !sameMusicIsPlaying ? new QMediaPlaylist : (pPlayer.getMediaPlayer()->playlist() != nullptr ? pPlayer.getMediaPlayer()->playlist() : new QMediaPlaylist);
     QString absolutePathFileName;
 
     if (mediaData.getMediaLoops() == TMediaData::MediaLoopsDefault) { // Play once
+        playlist->setPlaybackMode(QMediaPlaylist::Sequential);
+
+        if (sameMusicIsPlaying) {
+            if (mediaData.getMediaContinue() == TMediaData::MediaContinueRestart) {
+                mpHost->mpMedia->stopMedia(mediaData); // Stop the music; Restart it below.
+
+                if (!playlist->isEmpty()) {
+                    playlist->clear();
+                }
+            } else {
+                if (!playlist->isEmpty() && playlist->mediaCount() > 1) { // Purge media from the previous playlist
+                    playlist->removeMedia(playlist->nextIndex(), playlist->mediaCount());
+                }
+
+                return; // No action required. Continue playing the same music.
+            }
+        }
+
         if (fileNameList.size() > 1) {
             absolutePathFileName = fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()));
         } else {
@@ -886,9 +905,21 @@ void TMedia::play(TMediaData& mediaData)
 
         pPlayer.getMediaPlayer()->setMedia(QUrl::fromLocalFile(absolutePathFileName));
     } else {
-        auto playlist = new QMediaPlaylist;
-
         if (mediaData.getMediaLoops() == TMediaData::MediaLoopsRepeat) { // Repeat indefinitely
+            playlist->setPlaybackMode(QMediaPlaylist::Loop);
+
+            if (sameMusicIsPlaying) {
+                if (mediaData.getMediaContinue() == TMediaData::MediaContinueRestart) {
+                    mpHost->mpMedia->stopMedia(mediaData); // Stop the music; Restart it below.
+
+                    if (!playlist->isEmpty()) {
+                        playlist->clear();
+                    }
+                } else {
+                    return; // No action required. Continue playing the same music.
+                }
+            }
+
             if (fileNameList.size() > 1) {
                 absolutePathFileName = fileNameList.at(QRandomGenerator::global()->bounded(fileNameList.size()));
             } else {
@@ -904,10 +935,23 @@ void TMedia::play(TMediaData& mediaData)
             }
 
             playlist->addMedia(QUrl::fromLocalFile(absolutePathFileName));
-            playlist->setPlaybackMode(QMediaPlaylist::Loop);
         } else {
-            if (mediaData.getMediaType() == TMediaData::MediaTypeMusic && mediaData.getMediaContinue() == TMediaData::MediaContinueDefault) {
-                mediaData.setMediaLoops(mediaData.getMediaLoops() - 1); // Subtract the currently playing music from the total
+            playlist->setPlaybackMode(QMediaPlaylist::Sequential);
+
+            if (sameMusicIsPlaying) {
+                if (mediaData.getMediaContinue() == TMediaData::MediaContinueRestart) {
+                    mpHost->mpMedia->stopMedia(mediaData); // Stop the music; Restart it below.
+
+                    if (!playlist->isEmpty()) {
+                        playlist->clear();
+                    }
+                } else {
+                    if (!playlist->isEmpty() && playlist->mediaCount() > 1) { // Purge media from the previous playlist
+                        playlist->removeMedia(playlist->nextIndex(), playlist->mediaCount());
+                    }
+
+                    mediaData.setMediaLoops(mediaData.getMediaLoops() - 1); // Subtract the currently playing music from the total
+                }
             }
 
             for (int k = 0; k < mediaData.getMediaLoops(); k++) { // Repeat a finite number of times
@@ -929,6 +973,10 @@ void TMedia::play(TMediaData& mediaData)
 
                 playlist->addMedia(QUrl::fromLocalFile(absolutePathFileName));
             }
+        }
+
+        if (sameMusicIsPlaying && mediaData.getMediaContinue() == TMediaData::MediaContinueDefault) {
+            return;
         }
 
         playlist->setCurrentIndex(1);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed the `continue` parameter of [Mud Client Media Protocol](https://wiki.mudlet.org/w/Manual:Scripting#MUD_Client_Media_Protocol), the Mudlet Lua API's [playMusicFile](https://wiki.mudlet.org/w/Manual:Miscellaneous_Functions#playMusicFile), and Mud Sound Protocol (MSP). The `continue` parameter now operates in the same way as is described in the [MSP standard's](https://www.zuggsoft.com/zmud/msp.htm) _C parameter_. Also resolved 1) a bug in the Lua interpreter that was blocking `continue = false` from operating and 2) another bug that was harming the accuracy of matching playing music to requested music.

#### Motivation for adding to Mudlet
Reported by Talon on the Mudlet Discord.

#### Other info (issues closed, discussion etc)
Release notes: For media handling, the `continue` parameter was fixed to match its related specifications and standards for playing music.

Talon reported this command was not _continuing_ appropriately:
```lua
lua playMusicFile({url = "https://www.iamtalon.me/", name = "spacemusic.mp3", type = "music", tag = "test", key = "test", loops = "-1", continue = true})
```
Testing: Run the command above at least twice within a few seconds on the client command line in production Mudlet vs. the PR to hear the difference.  `continue = true` is intended to let the music keep playing continuously, while `continue = false` should restart it.

Note that in production Mudlet that `continue = false` will not work as expected either, due to another bug fix resolved with an error in brace `{}` placement found in the Mudlet Lua Interpreter.