### PR TITLE
Infrastructure: tidy up naming of SLOT methods and their usage - Part 5 (last)

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2023,7 +2023,7 @@ void TBuffer::resetColors()
     }
 
     // These should match the corresponding settings in
-    // dlgProfilePreferences::resetColors() :
+    // dlgProfilePreferences::slot_resetColors() :
     pHost->mBlack = Qt::black;
     pHost->mLightBlack = Qt::darkGray;
     pHost->mRed = Qt::darkRed;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -411,7 +411,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     emergencyStop->setFocusPolicy(Qt::NoFocus);
     emergencyStop->setCheckable(true);
     emergencyStop->setToolTip(utils::richText(tr("Emergency Stop. Stops all timers and triggers.")));
-    connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stop_all_triggers);
+    connect(emergencyStop, &QAbstractButton::clicked, this, &TConsole::slot_stopAllItems);
 
     mpBufferSearchBox->setMinimumSize(QSize(100, 30));
     mpBufferSearchBox->setMaximumSize(QSize(150, 30));
@@ -1791,7 +1791,7 @@ void TConsole::appendBuffer(const TBuffer& bufferSlice)
     mLowerPane->showNewLines();
 }
 
-void TConsole::slot_stop_all_triggers(bool b)
+void TConsole::slot_stopAllItems(bool b)
 {
     if (b) {
         mpHost->stopAllTriggers();

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -289,7 +289,7 @@ public slots:
     void slot_searchBufferUp();
     void slot_searchBufferDown();
     void slot_toggleReplayRecording();
-    void slot_stop_all_triggers(bool);
+    void slot_stopAllItems(bool);
     void slot_toggleLogging();
     void slot_changeControlCharacterHandling(const ControlCharacterMode);
 

--- a/src/TimerUnit.cpp
+++ b/src/TimerUnit.cpp
@@ -203,7 +203,7 @@ bool TimerUnit::registerTimer(TTimer* pT)
 
     // This has some side effects, including stopping the timer...
     pT->setTime(pT->getTime());
-    QTimer::connect(pT->getQTimer(), &QTimer::timeout, mudlet::self(), &mudlet::slot_timer_fires, Qt::UniqueConnection);
+    QTimer::connect(pT->getQTimer(), &QTimer::timeout, mudlet::self(), &mudlet::slot_timerFires, Qt::UniqueConnection);
     return true;
 }
 
@@ -215,7 +215,7 @@ void TimerUnit::unregisterTimer(TTimer* pT)
     // Stop the QTimer ASAP:
     pT->stop();
     pT->deactivate();
-    QTimer::disconnect(pT->getQTimer(), &QTimer::timeout, mudlet::self(), &mudlet::slot_timer_fires);
+    QTimer::disconnect(pT->getQTimer(), &QTimer::timeout, mudlet::self(), &mudlet::slot_timerFires);
     if (pT->getParent()) {
         _removeTimer(pT);
         return;

--- a/src/dlgConnectionProfiles.h
+++ b/src/dlgConnectionProfiles.h
@@ -73,21 +73,21 @@ public slots:
     void slot_updateLogin(const QString&);
     void slot_updatePassword(const QString&);
 // Not used:    void slot_updateWebsite(const QString&);
-    void slot_deleteprofile_check(const QString&);
-    void slot_update_description();
+    void slot_deleteProfileCheck(const QString&);
+    void slot_updateDescription();
 
     void slot_itemClicked(QListWidgetItem*);
     void slot_addProfile();
     void slot_deleteProfile();
     void slot_reallyDeleteProfile();
 
-    void slot_update_autologin(int state);
-    void slot_update_autoreconnect(int state);
-    void slot_update_discord_optin(int state);
+    void slot_updateAutoConnect(int state);
+    void slot_updateAutoReconnect(int state);
+    void slot_updateDiscordOptIn(int state);
     void slot_load();
     void slot_cancel();
-    void slot_copy_profile();
-    void slot_copy_profilesettings_only();
+    void slot_copyProfile();
+    void slot_copyOnlySettingsOfProfile();
 
 
 protected:
@@ -151,13 +151,13 @@ private:
 
 
 private slots:
-    void slot_profile_menu(QPoint pos);
-    void slot_set_custom_icon();
-    void slot_set_custom_color();
-    void slot_reset_custom_icon();
+    void slot_profileContextMenu(QPoint pos);
+    void slot_setCustomIcon();
+    void slot_setCustomColor();
+    void slot_resetCustomIcon();
     void slot_togglePasswordVisibility(const bool);
-    void slot_password_saved(QKeychain::Job* job);
-    void slot_password_deleted(QKeychain::Job* job);
+    void slot_passwordSaved(QKeychain::Job* job);
+    void slot_passwordDeleted(QKeychain::Job* job);
     void slot_reenableAllProfileItems();
 };
 

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -244,7 +244,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pF, Host* pHost)
 
     connect(checkBox_showSpacesAndTabs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowSpacesAndTabs);
     connect(checkBox_showLineFeedsAndParagraphs, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeShowLineFeedsAndParagraphs);
-    connect(closeButton, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_save_and_exit);
+    connect(closeButton, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_saveAndClose);
     connect(pMudlet, &mudlet::signal_hostCreated, this, &dlgProfilePreferences::slot_handleHostAddition);
     connect(pMudlet, &mudlet::signal_hostDestroyed, this, &dlgProfilePreferences::slot_handleHostDeletion);
     // Because QComboBox::currentIndexChanged has multiple (overloaded) forms we
@@ -374,7 +374,7 @@ void dlgProfilePreferences::setupPasswordsMigration()
         comboBox_store_passwords_in->setCurrentIndex(1);
     }
 
-    connect(comboBox_store_passwords_in, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_passwords_location_changed);
+    connect(comboBox_store_passwords_in, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_passwordStorageLocationChanged);
 }
 
 void dlgProfilePreferences::disableHostDetails()
@@ -725,7 +725,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     if (!pHost->getMmpMapLocation().isEmpty()) {
         groupBox_downloadMapOptions->setVisible(true);
-        connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::downloadMap);
+        connect(buttonDownloadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_downloadMap);
     } else {
         groupBox_downloadMapOptions->setVisible(false);
     }
@@ -1119,58 +1119,58 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // CHECKME: Have moved ALL the connects, where possible, to the end so that
     // none are triggered by the setup operations...
-    connect(pushButton_command_line_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setCommandLineFgColor);
-    connect(pushButton_command_line_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setCommandLineBgColor);
+    connect(pushButton_command_line_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandLineFgColor);
+    connect(pushButton_command_line_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandLineBgColor);
 
-    connect(pushButton_black, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorBlack);
-    connect(pushButton_lBlack, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightBlack);
-    connect(pushButton_red, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorRed);
-    connect(pushButton_lRed, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightRed);
-    connect(pushButton_green, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorGreen);
-    connect(pushButton_lGreen, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightGreen);
-    connect(pushButton_yellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorYellow);
-    connect(pushButton_lYellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightYellow);
-    connect(pushButton_blue, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorBlue);
-    connect(pushButton_lBlue, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightBlue);
-    connect(pushButton_magenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorMagenta);
-    connect(pushButton_lMagenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightMagenta);
-    connect(pushButton_cyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorCyan);
-    connect(pushButton_lCyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightCyan);
-    connect(pushButton_white, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorWhite);
-    connect(pushButton_lWhite, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightWhite);
+    connect(pushButton_black, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorBlack);
+    connect(pushButton_lBlack, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightBlack);
+    connect(pushButton_red, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorRed);
+    connect(pushButton_lRed, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightRed);
+    connect(pushButton_green, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorGreen);
+    connect(pushButton_lGreen, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightGreen);
+    connect(pushButton_yellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorYellow);
+    connect(pushButton_lYellow, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightYellow);
+    connect(pushButton_blue, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorBlue);
+    connect(pushButton_lBlue, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightBlue);
+    connect(pushButton_magenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorMagenta);
+    connect(pushButton_lMagenta, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightMagenta);
+    connect(pushButton_cyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorCyan);
+    connect(pushButton_lCyan, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightCyan);
+    connect(pushButton_white, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorWhite);
+    connect(pushButton_lWhite, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setColorLightWhite);
 
-    connect(pushButton_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setFgColor);
-    connect(pushButton_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setBgColor);
-    connect(pushButton_command_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setCommandFgColor);
-    connect(pushButton_command_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::setCommandBgColor);
+    connect(pushButton_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setFgColor);
+    connect(pushButton_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setBgColor);
+    connect(pushButton_command_foreground_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandFgColor);
+    connect(pushButton_command_background_color, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setCommandBgColor);
 
-    connect(pushButton_resetColors, &QAbstractButton::clicked, this, &dlgProfilePreferences::resetColors);
-    connect(reset_colors_button_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::resetColors2);
+    connect(pushButton_resetColors, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetColors);
+    connect(reset_colors_button_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_resetMapColors);
 
-    connect(fontComboBox, &QFontComboBox::currentFontChanged, this, &dlgProfilePreferences::setDisplayFont);
-    connect(fontSize, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::setFontSize);
+    connect(fontComboBox, &QFontComboBox::currentFontChanged, this, &dlgProfilePreferences::slot_setDisplayFont);
+    connect(fontSize, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_setFontSize);
 
-    connect(pushButton_black_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorBlack2);
-    connect(pushButton_Lblack_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightBlack2);
-    connect(pushButton_green_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorGreen2);
-    connect(pushButton_Lgreen_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightGreen2);
-    connect(pushButton_red_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorRed2);
-    connect(pushButton_Lred_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightRed2);
-    connect(pushButton_blue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorBlue2);
-    connect(pushButton_Lblue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightBlue2);
-    connect(pushButton_yellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorYellow2);
-    connect(pushButton_Lyellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightYellow2);
-    connect(pushButton_cyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorCyan2);
-    connect(pushButton_Lcyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightCyan2);
-    connect(pushButton_magenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorMagenta2);
-    connect(pushButton_Lmagenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightMagenta2);
-    connect(pushButton_white_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorWhite2);
-    connect(pushButton_Lwhite_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setColorLightWhite2);
+    connect(pushButton_black_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorBlack);
+    connect(pushButton_Lblack_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightBlack);
+    connect(pushButton_green_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorGreen);
+    connect(pushButton_Lgreen_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightGreen);
+    connect(pushButton_red_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorRed);
+    connect(pushButton_Lred_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightRed);
+    connect(pushButton_blue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorBlue);
+    connect(pushButton_Lblue_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightBlue);
+    connect(pushButton_yellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorYellow);
+    connect(pushButton_Lyellow_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightYellow);
+    connect(pushButton_cyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorCyan);
+    connect(pushButton_Lcyan_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightCyan);
+    connect(pushButton_magenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorMagenta);
+    connect(pushButton_Lmagenta_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightMagenta);
+    connect(pushButton_white_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorWhite);
+    connect(pushButton_Lwhite_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapColorLightWhite);
 
-    connect(pushButton_foreground_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setFgColor2);
-    connect(pushButton_background_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::setBgColor2);
-    connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::setRoomBorderColor);
-    connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::setMapInfoBackground);
+    connect(pushButton_foreground_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapExitsColor);
+    connect(pushButton_background_color_2, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapBgColor);
+    connect(pushButton_roomBorderColor, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapRoomBorderColor);
+    connect(pushButton_mapInfoBg, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setMapInfoBgColor);
 
     connect(mEnableGMCP, &QAbstractButton::clicked, need_reconnect_for_data_protocol, &QWidget::show);
     connect(mEnableMSDP, &QAbstractButton::clicked, need_reconnect_for_data_protocol, &QWidget::show);
@@ -1179,11 +1179,11 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     connect(mFORCE_MCCP_OFF, &QAbstractButton::clicked, need_reconnect_for_specialoption, &QWidget::show);
     connect(mFORCE_GA_OFF, &QAbstractButton::clicked, need_reconnect_for_specialoption, &QWidget::show);
-    connect(mpMenu.data(), &QMenu::triggered, this, &dlgProfilePreferences::slot_chooseProfilesChanged);
+    connect(mpMenu.data(), &QMenu::triggered, this, &dlgProfilePreferences::slot_chosenProfilesChanged);
 
-    connect(pushButton_copyMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::copyMap);
-    connect(pushButton_loadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::loadMap);
-    connect(pushButton_saveMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::saveMap);
+    connect(pushButton_copyMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_copyMap);
+    connect(pushButton_loadMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_loadMap);
+    connect(pushButton_saveMap, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_saveMap);
     connect(comboBox_encoding, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_setEncoding);
 
     connect(pushButton_whereToLog, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_setLogDir);
@@ -1439,7 +1439,7 @@ void dlgProfilePreferences::loadEditorTab()
         return;
     }
 
-    connect(tabWidget, &QTabWidget::currentChanged, this, &dlgProfilePreferences::slot_editor_tab_selected);
+    connect(tabWidget, &QTabWidget::currentChanged, this, &dlgProfilePreferences::slot_tabChanged);
 
     auto config = edbeePreviewWidget->config();
     config->beginChanges();
@@ -1470,7 +1470,7 @@ void dlgProfilePreferences::loadEditorTab()
     code_editor_theme_selection_combobox->lineEdit()->setPlaceholderText(qsl("Select theme"));
     auto themeIndex = code_editor_theme_selection_combobox->findText(pHost->mEditorTheme);
     code_editor_theme_selection_combobox->setCurrentIndex(themeIndex);
-    slot_theme_selected(themeIndex);
+    slot_themeSelected(themeIndex);
 
     code_editor_theme_selection_combobox->setInsertPolicy(QComboBox::NoInsert);
     code_editor_theme_selection_combobox->setMaxVisibleItems(20);
@@ -1479,7 +1479,7 @@ void dlgProfilePreferences::loadEditorTab()
     script_preview_combobox->lineEdit()->setPlaceholderText(qsl("Select script to preview"));
     auto scriptIndex = script_preview_combobox->findData(QVariant::fromValue(QPair<QString, int>(pHost->mThemePreviewType, pHost->mThemePreviewItemID)));
     script_preview_combobox->setCurrentIndex(scriptIndex == -1 ? 1 : scriptIndex);
-    slot_script_selected(scriptIndex == -1 ? 1 : scriptIndex);
+    slot_scriptSelected(scriptIndex == -1 ? 1 : scriptIndex);
 
     script_preview_combobox->setInsertPolicy(QComboBox::NoInsert);
     script_preview_combobox->setMaxVisibleItems(20);
@@ -1491,14 +1491,14 @@ void dlgProfilePreferences::loadEditorTab()
     checkBox_showBidi->setChecked(pHost->getEditorShowBidi());
 
     // changes the theme being previewed
-    connect(code_editor_theme_selection_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_theme_selected);
+    connect(code_editor_theme_selection_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_themeSelected);
 
     // allows people to select a script of theirs to preview
-    connect(script_preview_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_script_selected);
+    connect(script_preview_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_scriptSelected);
 
     // fire tab selection event manually should the dialog open on it by default
     if (tabWidget->currentIndex() == 3) {
-        slot_editor_tab_selected(3);
+        slot_tabChanged(3);
     }
 }
 
@@ -1615,7 +1615,7 @@ void dlgProfilePreferences::setTab(QString tab)
     tabWidget->setCurrentIndex(0);
 }
 
-void dlgProfilePreferences::resetColors()
+void dlgProfilePreferences::slot_resetColors()
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -1655,7 +1655,7 @@ void dlgProfilePreferences::resetColors()
     pHost->updateAnsi16ColorsInTable();
 }
 
-void dlgProfilePreferences::resetColors2()
+void dlgProfilePreferences::slot_resetMapColors()
 {
     Host* pHost = mpHost;
 
@@ -1687,7 +1687,7 @@ void dlgProfilePreferences::resetColors2()
     setColors2();
 }
 
-void dlgProfilePreferences::setColor(QPushButton* button, QColor& presentColor, bool allowAlpha)
+void dlgProfilePreferences::setButtonAndProfileColor(QPushButton* button, QColor& presentColor, bool allowAlpha)
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -1731,61 +1731,61 @@ void dlgProfilePreferences::setColor(QPushButton* button, QColor& presentColor, 
     }
 }
 
-void dlgProfilePreferences::setFgColor()
+void dlgProfilePreferences::slot_setFgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_foreground_color, pHost->mFgColor);
+        setButtonAndProfileColor(pushButton_foreground_color, pHost->mFgColor);
     }
 }
 
-void dlgProfilePreferences::setBgColor()
+void dlgProfilePreferences::slot_setBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_background_color, pHost->mBgColor);
+        setButtonAndProfileColor(pushButton_background_color, pHost->mBgColor);
     }
 }
 
-void dlgProfilePreferences::setCommandFgColor()
+void dlgProfilePreferences::slot_setCommandFgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_command_foreground_color, pHost->mCommandFgColor);
+        setButtonAndProfileColor(pushButton_command_foreground_color, pHost->mCommandFgColor);
     }
 }
 
-void dlgProfilePreferences::setCommandLineFgColor()
+void dlgProfilePreferences::slot_setCommandLineFgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_command_line_foreground_color, pHost->mCommandLineFgColor);
+        setButtonAndProfileColor(pushButton_command_line_foreground_color, pHost->mCommandLineFgColor);
     }
 }
 
-void dlgProfilePreferences::setCommandLineBgColor()
+void dlgProfilePreferences::slot_setCommandLineBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_command_line_background_color, pHost->mCommandLineBgColor);
+        setButtonAndProfileColor(pushButton_command_line_background_color, pHost->mCommandLineBgColor);
     }
 }
 
-void dlgProfilePreferences::setCommandBgColor()
+void dlgProfilePreferences::slot_setCommandBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_command_background_color, pHost->mCommandBgColor);
+        setButtonAndProfileColor(pushButton_command_background_color, pHost->mCommandBgColor);
     }
 }
 
-void dlgProfilePreferences::setFontSize()
+void dlgProfilePreferences::slot_setFontSize()
 {
     mFontSize = fontSize->currentIndex() + 1;
-    setDisplayFont();
+    slot_setDisplayFont();
 }
 
-void dlgProfilePreferences::setDisplayFont()
+void dlgProfilePreferences::slot_setDisplayFont()
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -1833,312 +1833,312 @@ void dlgProfilePreferences::setDisplayFont()
 }
 
 // Currently UNUSED!
-void dlgProfilePreferences::setCommandLineFont()
-{
-    Host* pHost = mpHost;
-    if (!pHost) {
-        return;
-    }
-    bool ok;
-    QFont font = QFontDialog::getFont(&ok, pHost->mCommandLineFont, this);
-    pHost->mCommandLineFont = font;
-    if (pHost->mpConsole) {
-        pHost->mpConsole->changeColors();
-    }
-}
+//void dlgProfilePreferences::slot_setCommandLineFont()
+//{
+//    Host* pHost = mpHost;
+//    if (!pHost) {
+//        return;
+//    }
+//    bool ok;
+//    QFont font = QFontDialog::getFont(&ok, pHost->mCommandLineFont, this);
+//    pHost->mCommandLineFont = font;
+//    if (pHost->mpConsole) {
+//        pHost->mpConsole->changeColors();
+//    }
+//}
 
-void dlgProfilePreferences::setColorBlack()
-{
-    Host* pHost = mpHost;
-    if (pHost) {
-        setColor(pushButton_black, pHost->mBlack);
-    }
-}
-
-void dlgProfilePreferences::setColorLightBlack()
+void dlgProfilePreferences::slot_setColorBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lBlack, pHost->mLightBlack);
+        setButtonAndProfileColor(pushButton_black, pHost->mBlack);
     }
 }
 
-void dlgProfilePreferences::setColorRed()
+void dlgProfilePreferences::slot_setColorLightBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_red, pHost->mRed);
+        setButtonAndProfileColor(pushButton_lBlack, pHost->mLightBlack);
     }
 }
 
-void dlgProfilePreferences::setColorLightRed()
+void dlgProfilePreferences::slot_setColorRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lRed, pHost->mLightRed);
+        setButtonAndProfileColor(pushButton_red, pHost->mRed);
     }
 }
 
-void dlgProfilePreferences::setColorGreen()
+void dlgProfilePreferences::slot_setColorLightRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_green, pHost->mGreen);
+        setButtonAndProfileColor(pushButton_lRed, pHost->mLightRed);
     }
 }
 
-void dlgProfilePreferences::setColorLightGreen()
+void dlgProfilePreferences::slot_setColorGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lGreen, pHost->mLightGreen);
+        setButtonAndProfileColor(pushButton_green, pHost->mGreen);
     }
 }
 
-void dlgProfilePreferences::setColorYellow()
-
+void dlgProfilePreferences::slot_setColorLightGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_yellow, pHost->mYellow);
+        setButtonAndProfileColor(pushButton_lGreen, pHost->mLightGreen);
     }
 }
 
-void dlgProfilePreferences::setColorLightYellow()
-{
-    Host* pHost = mpHost;
-    if (pHost) {
-        setColor(pushButton_lYellow, pHost->mLightYellow);
-    }
-}
-
-void dlgProfilePreferences::setColorBlue()
+void dlgProfilePreferences::slot_setColorYellow()
 
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_blue, pHost->mBlue);
+        setButtonAndProfileColor(pushButton_yellow, pHost->mYellow);
     }
 }
 
-void dlgProfilePreferences::setColorLightBlue()
+void dlgProfilePreferences::slot_setColorLightYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lBlue, pHost->mLightBlue);
+        setButtonAndProfileColor(pushButton_lYellow, pHost->mLightYellow);
     }
 }
 
-void dlgProfilePreferences::setColorMagenta()
+void dlgProfilePreferences::slot_setColorBlue()
 
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_magenta, pHost->mMagenta);
+        setButtonAndProfileColor(pushButton_blue, pHost->mBlue);
     }
 }
 
-void dlgProfilePreferences::setColorLightMagenta()
+void dlgProfilePreferences::slot_setColorLightBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lMagenta, pHost->mLightMagenta);
+        setButtonAndProfileColor(pushButton_lBlue, pHost->mLightBlue);
     }
 }
 
-void dlgProfilePreferences::setColorCyan()
+void dlgProfilePreferences::slot_setColorMagenta()
+
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_cyan, pHost->mCyan);
+        setButtonAndProfileColor(pushButton_magenta, pHost->mMagenta);
     }
 }
 
-void dlgProfilePreferences::setColorLightCyan()
+void dlgProfilePreferences::slot_setColorLightMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lCyan, pHost->mLightCyan);
+        setButtonAndProfileColor(pushButton_lMagenta, pHost->mLightMagenta);
     }
 }
 
-void dlgProfilePreferences::setColorWhite()
+void dlgProfilePreferences::slot_setColorCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_white, pHost->mWhite);
+        setButtonAndProfileColor(pushButton_cyan, pHost->mCyan);
     }
 }
 
-void dlgProfilePreferences::setColorLightWhite()
+void dlgProfilePreferences::slot_setColorLightCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_lWhite, pHost->mLightWhite);
+        setButtonAndProfileColor(pushButton_lCyan, pHost->mLightCyan);
     }
 }
 
-void dlgProfilePreferences::setFgColor2()
+void dlgProfilePreferences::slot_setColorWhite()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_foreground_color_2, pHost->mFgColor_2);
+        setButtonAndProfileColor(pushButton_white, pHost->mWhite);
     }
 }
 
-void dlgProfilePreferences::setBgColor2()
+void dlgProfilePreferences::slot_setColorLightWhite()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_background_color_2, pHost->mBgColor_2);
+        setButtonAndProfileColor(pushButton_lWhite, pHost->mLightWhite);
     }
 }
 
-void dlgProfilePreferences::setRoomBorderColor()
+void dlgProfilePreferences::slot_setMapExitsColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_roomBorderColor, pHost->mRoomBorderColor);
+        setButtonAndProfileColor(pushButton_foreground_color_2, pHost->mFgColor_2);
     }
 }
 
-void dlgProfilePreferences::setMapInfoBackground()
+void dlgProfilePreferences::slot_setMapBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_mapInfoBg, pHost->mMapInfoBg, true);
+        setButtonAndProfileColor(pushButton_background_color_2, pHost->mBgColor_2);
     }
 }
 
-void dlgProfilePreferences::setColorBlack2()
+void dlgProfilePreferences::slot_setMapRoomBorderColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_black_2, pHost->mBlack_2);
+        setButtonAndProfileColor(pushButton_roomBorderColor, pHost->mRoomBorderColor);
     }
 }
 
-void dlgProfilePreferences::setColorLightBlack2()
+void dlgProfilePreferences::slot_setMapInfoBgColor()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lblack_2, pHost->mLightBlack_2);
+        setButtonAndProfileColor(pushButton_mapInfoBg, pHost->mMapInfoBg, true);
     }
 }
 
-void dlgProfilePreferences::setColorRed2()
+void dlgProfilePreferences::slot_setMapColorBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_red_2, pHost->mRed_2);
+        setButtonAndProfileColor(pushButton_black_2, pHost->mBlack_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightRed2()
+void dlgProfilePreferences::slot_setMapColorLightBlack()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lred_2, pHost->mLightRed_2);
+        setButtonAndProfileColor(pushButton_Lblack_2, pHost->mLightBlack_2);
     }
 }
 
-void dlgProfilePreferences::setColorGreen2()
+void dlgProfilePreferences::slot_setMapColorRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_green_2, pHost->mGreen_2);
+        setButtonAndProfileColor(pushButton_red_2, pHost->mRed_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightGreen2()
+void dlgProfilePreferences::slot_setMapColorLightRed()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lgreen_2, pHost->mLightGreen_2);
+        setButtonAndProfileColor(pushButton_Lred_2, pHost->mLightRed_2);
     }
 }
 
-void dlgProfilePreferences::setColorBlue2()
+void dlgProfilePreferences::slot_setMapColorGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_blue_2, pHost->mBlue_2);
+        setButtonAndProfileColor(pushButton_green_2, pHost->mGreen_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightBlue2()
+void dlgProfilePreferences::slot_setMapColorLightGreen()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lblue_2, pHost->mLightBlue_2);
+        setButtonAndProfileColor(pushButton_Lgreen_2, pHost->mLightGreen_2);
     }
 }
 
-void dlgProfilePreferences::setColorYellow2()
+void dlgProfilePreferences::slot_setMapColorBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_yellow_2, pHost->mYellow_2);
+        setButtonAndProfileColor(pushButton_blue_2, pHost->mBlue_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightYellow2()
+void dlgProfilePreferences::slot_setMapColorLightBlue()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lyellow_2, pHost->mLightYellow_2);
+        setButtonAndProfileColor(pushButton_Lblue_2, pHost->mLightBlue_2);
     }
 }
 
-void dlgProfilePreferences::setColorCyan2()
+void dlgProfilePreferences::slot_setMapColorYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_cyan_2, pHost->mCyan_2);
+        setButtonAndProfileColor(pushButton_yellow_2, pHost->mYellow_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightCyan2()
+void dlgProfilePreferences::slot_setMapColorLightYellow()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lcyan_2, pHost->mLightCyan_2);
+        setButtonAndProfileColor(pushButton_Lyellow_2, pHost->mLightYellow_2);
     }
 }
 
-void dlgProfilePreferences::setColorMagenta2()
+void dlgProfilePreferences::slot_setMapColorCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_magenta_2, pHost->mMagenta_2);
+        setButtonAndProfileColor(pushButton_cyan_2, pHost->mCyan_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightMagenta2()
+void dlgProfilePreferences::slot_setMapColorLightCyan()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2);
+        setButtonAndProfileColor(pushButton_Lcyan_2, pHost->mLightCyan_2);
     }
 }
 
-void dlgProfilePreferences::setColorWhite2()
+void dlgProfilePreferences::slot_setMapColorMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_white_2, pHost->mWhite_2);
+        setButtonAndProfileColor(pushButton_magenta_2, pHost->mMagenta_2);
     }
 }
 
-void dlgProfilePreferences::setColorLightWhite2()
+void dlgProfilePreferences::slot_setMapColorLightMagenta()
 {
     Host* pHost = mpHost;
     if (pHost) {
-        setColor(pushButton_Lwhite_2, pHost->mLightWhite_2);
+        setButtonAndProfileColor(pushButton_Lmagenta_2, pHost->mLightMagenta_2);
     }
 }
 
-void dlgProfilePreferences::downloadMap()
+void dlgProfilePreferences::slot_setMapColorWhite()
+{
+    Host* pHost = mpHost;
+    if (pHost) {
+        setButtonAndProfileColor(pushButton_white_2, pHost->mWhite_2);
+    }
+}
+
+void dlgProfilePreferences::slot_setMapColorLightWhite()
+{
+    Host* pHost = mpHost;
+    if (pHost) {
+        setButtonAndProfileColor(pushButton_Lwhite_2, pHost->mLightWhite_2);
+    }
+}
+
+void dlgProfilePreferences::slot_downloadMap()
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -2152,7 +2152,7 @@ void dlgProfilePreferences::downloadMap()
     pHost->mpMap->downloadMap();
 }
 
-void dlgProfilePreferences::loadMap()
+void dlgProfilePreferences::slot_loadMap()
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -2202,7 +2202,7 @@ void dlgProfilePreferences::loadMap()
             label_mapFileActionResult->setText(tr("Could not load map from %1.").arg(fileName));
         }
 
-        QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+        QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
 
         // Restore setting immediately before we used it
         mudlet::self()->setShowMapAuditErrors(showAuditErrors);
@@ -2210,7 +2210,7 @@ void dlgProfilePreferences::loadMap()
     dialog->open();
 }
 
-void dlgProfilePreferences::saveMap()
+void dlgProfilePreferences::slot_saveMap()
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -2267,7 +2267,7 @@ void dlgProfilePreferences::saveMap()
         }
         mudlet::self()->setShowMapAuditErrors(showAuditErrors);
 
-        QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+        QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
     });
     dialog->open();
 }
@@ -2278,7 +2278,7 @@ QString dlgProfilePreferences::mapSaveLoadDirectory(Host* pHost) {
     return mapsDir.exists() ? mapsPath : mudlet::getMudletPath(mudlet::profileHomePath, pHost->getName());
 }
 
-void dlgProfilePreferences::hideActionLabel()
+void dlgProfilePreferences::slot_hideActionLabel()
 {
     label_mapFileActionResult->hide();
 }
@@ -2288,7 +2288,7 @@ void dlgProfilePreferences::hidePasswordMigrationLabel()
     label_password_migration_notification->hide();
 }
 
-void dlgProfilePreferences::slot_passwords_location_changed(int index)
+void dlgProfilePreferences::slot_passwordStorageLocationChanged(int index)
 {
     // index 0 = use secure storage, index 1 = use profile storage
     if (index == 0) {
@@ -2308,7 +2308,7 @@ void dlgProfilePreferences::slot_passwords_location_changed(int index)
     }
 }
 
-void dlgProfilePreferences::copyMap()
+void dlgProfilePreferences::slot_copyMap()
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -2376,7 +2376,7 @@ void dlgProfilePreferences::copyMap()
         if (itOtherProfile.value() > 0) {
             // Skip the ones where we have already got the player room from the
             // active profile
-            qDebug() << "dlgProfilePreference::copyMap() in other ACTIVE profile:" << itOtherProfile.key() << "\n    the player was located in:" << itOtherProfile.value();
+            qDebug() << "dlgProfilePreference::slot_copyMap() in other ACTIVE profile:" << itOtherProfile.key() << "\n    the player was located in:" << itOtherProfile.value();
             if (pHost->mpMap->mpRoomDB->getRoom(itOtherProfile.value())) {
                 // That room IS in the map we are copying across, so update the
                 // local record of it for the map for that profile:
@@ -2398,7 +2398,7 @@ void dlgProfilePreferences::copyMap()
                                                &otherProfileAreaCount,
                                                &otherProfileRoomCount)) {
 
-            qDebug() << "dlgProfilePreference::copyMap() in other INACTIVE profile:"
+            qDebug() << "dlgProfilePreference::slot_copyMap() in other INACTIVE profile:"
                      << itOtherProfile.key()
                      << "\n    the file examined was:"
                      << otherProfileFileUsed
@@ -2434,7 +2434,7 @@ void dlgProfilePreferences::copyMap()
 
     if (!pHost->mpConsole->saveMap(QString())) {
         label_mapFileActionResult->setText(tr("Could not backup the map - saving it failed."));
-        QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+        QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
         return;
     }
 
@@ -2459,7 +2459,7 @@ void dlgProfilePreferences::copyMap()
 
     if (thisProfileLatestMapFile.fileName().isEmpty()) {
         label_mapFileActionResult->setText(tr("Could not copy the map - failed to work out which map file we just saved the map as!"));
-        QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+        QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
         return;
     }
 
@@ -2477,7 +2477,7 @@ void dlgProfilePreferences::copyMap()
 
         if (!thisProfileLatestMapFile.copy(mudlet::getMudletPath(mudlet::profileMapPathFileName, otherHostName, thisProfileLatestMapPathFileName))) {
             label_mapFileActionResult->setText(tr("Could not copy the map to %1 - unable to copy the new map file over.").arg(otherHostName));
-            QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+            QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
             continue; // Try again with next profile
         } else {
             label_mapFileActionResult->setText(tr("Map copied successfully to other profile %1.").arg(otherHostName));
@@ -2493,7 +2493,7 @@ void dlgProfilePreferences::copyMap()
     // QStringList in many ways, the SLOT/SIGNAL system treats them as different
     // - I thinK - so use QList<QString> throughout the SIGNAL/SLOT links Slysven!
     label_mapFileActionResult->setText(tr("Map copied, now signalling other profiles to reload it."));
-    QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+    QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
 
     // CHECK: Race condition? We might be changing this while other profile
     // are accessing it...
@@ -2586,7 +2586,7 @@ void dlgProfilePreferences::slot_logFileNameFormatChange(const int index)
     label_logFileNameExtension->setVisible(isShown);
 }
 
-void dlgProfilePreferences::slot_save_and_exit()
+void dlgProfilePreferences::slot_saveAndClose()
 {
     if (mpDialogMapGlyphUsage) {
         mpDialogMapGlyphUsage->close();
@@ -2776,7 +2776,7 @@ void dlgProfilePreferences::slot_save_and_exit()
             pHost->mpDlgIRC->ircRestart();
         }
 
-        setDisplayFont();
+        slot_setDisplayFont();
 
         if (console) {
             int x = console->width();
@@ -2923,7 +2923,7 @@ void dlgProfilePreferences::slot_save_and_exit()
     close();
 }
 
-void dlgProfilePreferences::slot_chooseProfilesChanged(QAction* _action)
+void dlgProfilePreferences::slot_chosenProfilesChanged(QAction* _action)
 {
     Q_UNUSED(_action);
 
@@ -3125,7 +3125,7 @@ void dlgProfilePreferences::addActionsToPreview(TAction* pActionParent, std::vec
 }
 
 // updates latest edbee themes when the user opens up the editor tab
-void dlgProfilePreferences::slot_editor_tab_selected(int tabIndex)
+void dlgProfilePreferences::slot_tabChanged(int tabIndex)
 {
     // bail out if this is not the editor tab - or if the Host has gone away
     Host* pHost = mpHost;
@@ -3274,7 +3274,7 @@ void dlgProfilePreferences::populateThemesList()
 }
 
 // user has picked a different theme to preview, so apply it
-void dlgProfilePreferences::slot_theme_selected(int index)
+void dlgProfilePreferences::slot_themeSelected(int index)
 {
     auto themeFileName = code_editor_theme_selection_combobox->itemData(index).toString();
     auto themeName = code_editor_theme_selection_combobox->itemText(index);
@@ -3290,7 +3290,7 @@ void dlgProfilePreferences::slot_theme_selected(int index)
 }
 
 // user has picked a different script to preview, so show it
-void dlgProfilePreferences::slot_script_selected(int index)
+void dlgProfilePreferences::slot_scriptSelected(int index)
 {
     Host* pHost = mpHost;
     if (!pHost) {
@@ -4224,7 +4224,7 @@ void dlgProfilePreferences::slot_deleteMap()
     label_mapFileActionResult->setText(tr("Deleted map."));
     qApp->processEvents(); // Allow the above message to show up when erasing big maps
 
-    QTimer::singleShot(10s, this, &dlgProfilePreferences::hideActionLabel);
+    QTimer::singleShot(10s, this, &dlgProfilePreferences::slot_hideActionLabel);
 }
 
 void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -55,64 +55,64 @@ public:
 
 public slots:
     // Fonts.
-    void setFontSize();
-    void setDisplayFont();
-    void setCommandLineFont();
+    void slot_setFontSize();
+    void slot_setDisplayFont();
+// Not used: slot_setCommandLineFont();
 
     // Terminal colors.
-    void setColorBlack();
-    void setColorLightBlack();
-    void setColorRed();
-    void setColorLightRed();
-    void setColorBlue();
-    void setColorLightBlue();
-    void setColorGreen();
-    void setColorLightGreen();
-    void setColorYellow();
-    void setColorLightYellow();
-    void setColorCyan();
-    void setColorLightCyan();
-    void setColorMagenta();
-    void setColorLightMagenta();
-    void setColorWhite();
-    void setColorLightWhite();
-    void setFgColor();
-    void setBgColor();
-    void setCommandLineBgColor();
-    void setCommandLineFgColor();
-    void setCommandFgColor();
-    void setCommandBgColor();
-    void resetColors();
+    void slot_setColorBlack();
+    void slot_setColorLightBlack();
+    void slot_setColorRed();
+    void slot_setColorLightRed();
+    void slot_setColorBlue();
+    void slot_setColorLightBlue();
+    void slot_setColorGreen();
+    void slot_setColorLightGreen();
+    void slot_setColorYellow();
+    void slot_setColorLightYellow();
+    void slot_setColorCyan();
+    void slot_setColorLightCyan();
+    void slot_setColorMagenta();
+    void slot_setColorLightMagenta();
+    void slot_setColorWhite();
+    void slot_setColorLightWhite();
+    void slot_setFgColor();
+    void slot_setBgColor();
+    void slot_setCommandLineBgColor();
+    void slot_setCommandLineFgColor();
+    void slot_setCommandBgColor();
+    void slot_setCommandFgColor();
+    void slot_resetColors();
 
     // Mapper colors.
-    void setColorBlack2();
-    void setColorLightBlack2();
-    void setColorRed2();
-    void setColorLightRed2();
-    void setColorBlue2();
-    void setColorLightBlue2();
-    void setColorGreen2();
-    void setColorLightGreen2();
-    void setColorYellow2();
-    void setColorLightYellow2();
-    void setColorCyan2();
-    void setColorLightCyan2();
-    void setColorMagenta2();
-    void setColorLightMagenta2();
-    void setColorWhite2();
-    void setColorLightWhite2();
-    void setFgColor2();
-    void setBgColor2();
-    void setRoomBorderColor();
-    void setMapInfoBackground();
-    void resetColors2();
+    void slot_setMapColorBlack();
+    void slot_setMapColorLightBlack();
+    void slot_setMapColorRed();
+    void slot_setMapColorLightRed();
+    void slot_setMapColorBlue();
+    void slot_setMapColorLightBlue();
+    void slot_setMapColorGreen();
+    void slot_setMapColorLightGreen();
+    void slot_setMapColorYellow();
+    void slot_setMapColorLightYellow();
+    void slot_setMapColorCyan();
+    void slot_setMapColorLightCyan();
+    void slot_setMapColorMagenta();
+    void slot_setMapColorLightMagenta();
+    void slot_setMapColorWhite();
+    void slot_setMapColorLightWhite();
+    void slot_setMapExitsColor();
+    void slot_setMapBgColor();
+    void slot_setMapRoomBorderColor();
+    void slot_setMapInfoBgColor();
+    void slot_resetMapColors();
 
     // Map.
-    void downloadMap();
-    void loadMap();
-    void saveMap();
-    void copyMap();
-    void slot_chooseProfilesChanged(QAction*);
+    void slot_downloadMap();
+    void slot_loadMap();
+    void slot_saveMap();
+    void slot_copyMap();
+    void slot_chosenProfilesChanged(QAction*);
     void slot_showMapGlyphUsage();
 
 
@@ -123,9 +123,9 @@ public slots:
     void slot_changeLogFileAsHtml(bool isHtml);
 
     // Save.
-    void slot_save_and_exit();
+    void slot_saveAndClose();
 
-    void hideActionLabel();
+    void slot_hideActionLabel();
     void slot_setEncoding(const int);
 
     void slot_handleHostAddition(Host*, quint8);
@@ -136,9 +136,9 @@ public slots:
 private slots:
     void slot_changeShowSpacesAndTabs(bool);
     void slot_changeShowLineFeedsAndParagraphs(bool);
-    void slot_script_selected(int index);
-    void slot_editor_tab_selected(int tabIndex);
-    void slot_theme_selected(int index);
+    void slot_scriptSelected(int index);
+    void slot_tabChanged(int tabIndex);
+    void slot_themeSelected(int index);
     void slot_setMapSymbolFont(const QFont&);
     void slot_setMapSymbolFontStrategy(bool);
     void slot_changeShowMenuBar(int);
@@ -154,7 +154,7 @@ private slots:
     void slot_changeToolBarVisibility(const mudlet::controlsVisibility);
     void slot_changeShowIconsOnMenus(const Qt::CheckState);
     void slot_changeGuiLanguage(int);
-    void slot_passwords_location_changed(int);
+    void slot_passwordStorageLocationChanged(int);
     void slot_changePlayerRoomStyle(const int);
     void slot_setPlayerRoomPrimaryColor();
     void slot_setPlayerRoomSecondaryColor();
@@ -175,7 +175,7 @@ signals:
 private:
     void setColors();
     void setColors2();
-    void setColor(QPushButton*, QColor&, bool allowAlpha = false);
+    void setButtonAndProfileColor(QPushButton*, QColor&, bool allowAlpha = false);
     void setPlayerRoomColor(QPushButton*, QColor&);
     void setButtonColor(QPushButton*, const QColor&);
     void loadEditorTab();

--- a/src/dlgRoomSymbol.cpp
+++ b/src/dlgRoomSymbol.cpp
@@ -35,10 +35,10 @@ dlgRoomSymbol::dlgRoomSymbol(Host* pHost, QWidget* pParentWidget)
     // init generated dialog
     setupUi(this);
 
-    connect(lineEdit_roomSymbol, &QLineEdit::textChanged, this, &dlgRoomSymbol::updatePreview);
-    connect(pushButton_roomSymbolColor, &QAbstractButton::released, this, &dlgRoomSymbol::openColorSelector);
-    connect(pushButton_reset, &QAbstractButton::released, this, &dlgRoomSymbol::resetColor);
-    connect(comboBox_roomSymbol, &QComboBox::currentTextChanged, this, &dlgRoomSymbol::updatePreview);
+    connect(lineEdit_roomSymbol, &QLineEdit::textChanged, this, &dlgRoomSymbol::slot_updatePreview);
+    connect(pushButton_roomSymbolColor, &QAbstractButton::released, this, &dlgRoomSymbol::slot_openColorSelector);
+    connect(pushButton_reset, &QAbstractButton::released, this, &dlgRoomSymbol::slot_resetColors);
+    connect(comboBox_roomSymbol, &QComboBox::currentTextChanged, this, &dlgRoomSymbol::slot_updatePreview);
 
     setAttribute(Qt::WA_DeleteOnClose);
 }
@@ -64,7 +64,7 @@ void dlgRoomSymbol::init(QHash<QString, int>& pSymbols, QSet<TRoom*>& pRooms)
             roomColor = mpHost->mpMap->getColor(firstRoomId);
         }
     }
-    updatePreview();
+    slot_updatePreview();
 }
 
 void dlgRoomSymbol::initInstructionLabel()
@@ -162,7 +162,7 @@ QString dlgRoomSymbol::getNewSymbol()
     }
 }
 
-void dlgRoomSymbol::updatePreview()
+void dlgRoomSymbol::slot_updatePreview()
 {
     auto realColor = selectedColor != nullptr ? selectedColor : defaultColor();
     auto newSymbol = getNewSymbol();
@@ -194,39 +194,39 @@ QFont dlgRoomSymbol::getFontForPreview(QString text) {
     return font;
 }
 
-void dlgRoomSymbol::openColorSelector()
+void dlgRoomSymbol::slot_openColorSelector()
 {
     auto* dialog = selectedColor != nullptr ? new QColorDialog(selectedColor, this) : new QColorDialog(defaultColor(), this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(tr("Pick color"));
-    dialog->open(this, SLOT(colorSelected(const QColor&)));
-    connect(dialog, &QColorDialog::currentColorChanged, this, &dlgRoomSymbol::currentColorChanged);
-    connect(dialog, &QColorDialog::rejected, this, &dlgRoomSymbol::colorRejected);
+    dialog->open(this, SLOT(slot_colorSelected(const QColor&)));
+    connect(dialog, &QColorDialog::currentColorChanged, this, &dlgRoomSymbol::slot_currentColorChanged);
+    connect(dialog, &QColorDialog::rejected, this, &dlgRoomSymbol::slot_colorRejected);
 }
 
-void dlgRoomSymbol::currentColorChanged(const QColor& color)
+void dlgRoomSymbol::slot_currentColorChanged(const QColor& color)
 {
     previewColor = color;
-    updatePreview();
+    slot_updatePreview();
 }
 
-void dlgRoomSymbol::colorSelected(const QColor& color)
+void dlgRoomSymbol::slot_colorSelected(const QColor& color)
 {
     selectedColor = color;
-    updatePreview();
+    slot_updatePreview();
 }
 
-void dlgRoomSymbol::colorRejected()
+void dlgRoomSymbol::slot_colorRejected()
 {
     previewColor = selectedColor;
-    updatePreview();
+    slot_updatePreview();
 }
 
-void dlgRoomSymbol::resetColor()
+void dlgRoomSymbol::slot_resetColors()
 {
     selectedColor = QColor();
     previewColor = QColor();
-    updatePreview();
+    slot_updatePreview();
 }
 
 QColor dlgRoomSymbol::backgroundBasedColor(QColor background)

--- a/src/dlgRoomSymbol.h
+++ b/src/dlgRoomSymbol.h
@@ -57,12 +57,12 @@ private:
     QColor roomColor;
 
 private slots:
-    void openColorSelector();
-    void currentColorChanged(const QColor&);
-    void colorSelected(const QColor&);
-    void colorRejected();
-    void updatePreview();
-    void resetColor();
+    void slot_openColorSelector();
+    void slot_currentColorChanged(const QColor&);
+    void slot_colorSelected(const QColor&);
+    void slot_colorRejected();
+    void slot_updatePreview();
+    void slot_resetColors();
 };
 
 #endif // MUDLET_DLGROOMSYMBOL_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -319,7 +319,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_triggers->setHost(mpHost);
     treeWidget_triggers->header()->hide();
     treeWidget_triggers->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_triggers, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_triggers, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     treeWidget_aliases->hide();
     treeWidget_aliases->setHost(mpHost);
@@ -328,7 +328,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_aliases->header()->hide();
     treeWidget_aliases->setRootIsDecorated(false);
     treeWidget_aliases->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_aliases, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_aliases, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     treeWidget_actions->hide();
     treeWidget_actions->setHost(mpHost);
@@ -337,7 +337,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_actions->header()->hide();
     treeWidget_actions->setRootIsDecorated(false);
     treeWidget_actions->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_actions, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_actions, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     treeWidget_timers->hide();
     treeWidget_timers->setHost(mpHost);
@@ -346,7 +346,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_timers->header()->hide();
     treeWidget_timers->setRootIsDecorated(false);
     treeWidget_timers->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_timers, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_timers, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     treeWidget_variables->hide();
     treeWidget_variables->setHost(mpHost);
@@ -356,7 +356,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_variables->header()->hide();
     treeWidget_variables->setRootIsDecorated(false);
     treeWidget_variables->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_variables, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_variables, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     treeWidget_keys->hide();
     treeWidget_keys->setHost(mpHost);
@@ -365,7 +365,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_keys->header()->hide();
     treeWidget_keys->setRootIsDecorated(false);
     treeWidget_keys->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_keys, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_keys, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     treeWidget_scripts->hide();
     treeWidget_scripts->setHost(mpHost);
@@ -374,7 +374,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     treeWidget_scripts->header()->hide();
     treeWidget_scripts->setRootIsDecorated(false);
     treeWidget_scripts->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(treeWidget_scripts, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_item_selected_save);
+    connect(treeWidget_scripts, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_saveSelectedItem);
 
     QAction* viewTriggerAction = new QAction(QIcon(qsl(":/icons/tools-wizard.png")), tr("Triggers"), this);
     viewTriggerAction->setStatusTip(tr("Show Triggers"));
@@ -404,7 +404,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     QAction* viewVarsAction = new QAction(QIcon(qsl(":/icons/variables.png")), tr("Variables"), this);
     viewVarsAction->setStatusTip(tr("Show Variables"));
     viewVarsAction->setToolTip(qsl("%1 (%2)").arg(tr("Show Variables"), tr("Ctrl+6")));
-    connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_show_vars);
+    connect(viewVarsAction, &QAction::triggered, this, &dlgTriggerEditor::slot_showVariables);
 
     QAction* viewActionAction = new QAction(QIcon(qsl(":/icons/bookmarks.png")), tr("Buttons"), this);
     viewActionAction->setStatusTip(tr("Show Buttons"));
@@ -561,7 +561,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     connect(checkBox_displayAllVariables, &QAbstractButton::toggled, this, &dlgTriggerEditor::slot_toggleHiddenVariables);
 
-    connect(mpVarsMainArea->checkBox_variable_hidden, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_toggleHiddenVar);
+    connect(mpVarsMainArea->checkBox_variable_hidden, &QAbstractButton::clicked, this, &dlgTriggerEditor::slot_hideVariable);
 
     toolBar2->addAction(viewTriggerAction);
     toolBar2->addAction(viewAliasAction);
@@ -650,8 +650,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(treeWidget_aliases, &QTreeWidget::itemSelectionChanged, this, &dlgTriggerEditor::slot_treeSelectionChanged);
     connect(treeWidget_actions, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_actionSelected);
     connect(treeWidget_actions, &QTreeWidget::itemSelectionChanged, this, &dlgTriggerEditor::slot_treeSelectionChanged);
-    connect(treeWidget_variables, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_var_selected);
-    connect(treeWidget_variables, &QTreeWidget::itemChanged, this, &dlgTriggerEditor::slot_var_changed);
+    connect(treeWidget_variables, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_variableSelected);
+    connect(treeWidget_variables, &QTreeWidget::itemChanged, this, &dlgTriggerEditor::slot_variableChanged);
     connect(treeWidget_variables, &QTreeWidget::itemSelectionChanged, this, &dlgTriggerEditor::slot_treeSelectionChanged);
     connect(treeWidget_searchResults, &QTreeWidget::itemClicked, this, &dlgTriggerEditor::slot_itemSelectedInSearchResults);
 
@@ -837,7 +837,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     }
 }
 
-void dlgTriggerEditor::slot_toggleHiddenVar(bool status)
+void dlgTriggerEditor::slot_hideVariable(bool status)
 {
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
@@ -3529,7 +3529,7 @@ void dlgTriggerEditor::addVar(bool isFolder)
     mpCurrentVarItem = pNewItem;
     treeWidget_variables->setCurrentItem(pNewItem);
     showInfo(msgInfoAddVar);
-    slot_var_selected(treeWidget_variables->currentItem());
+    slot_variableSelected(treeWidget_variables->currentItem());
 }
 
 void dlgTriggerEditor::addKey(bool isFolder)
@@ -4629,7 +4629,7 @@ void dlgTriggerEditor::saveVar()
     QString newName = mpVarsMainArea->lineEdit_var_name->text();
     QString newValue = mpSourceEditorEdbeeDocument->text();
     if (newName.isEmpty()) {
-        slot_var_selected(pItem);
+        slot_variableSelected(pItem);
         return;
     }
     mChangingVar = true;
@@ -4797,7 +4797,7 @@ void dlgTriggerEditor::saveVar()
     }
     pItem->setIcon(0, icon);
     mChangingVar = false;
-    slot_var_selected(pItem);
+    slot_variableSelected(pItem);
 }
 
 void dlgTriggerEditor::saveKey()
@@ -5304,7 +5304,7 @@ void dlgTriggerEditor::recursiveSearchVariables(TVar* var, QList<TVar*>& list, b
     }
 }
 
-void dlgTriggerEditor::slot_var_changed(QTreeWidgetItem* pItem)
+void dlgTriggerEditor::slot_variableChanged(QTreeWidgetItem* pItem)
 {
     // This handles a small case where the radio button is clicked while the item is currently selected
     // which causes the variable to not save. In places where we populate the TreeWidgetItem, we have
@@ -5367,7 +5367,7 @@ void dlgTriggerEditor::slot_var_changed(QTreeWidgetItem* pItem)
     }
 }
 
-void dlgTriggerEditor::slot_var_selected(QTreeWidgetItem* pItem)
+void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
 {
     if (!pItem ||treeWidget_variables->indexOfTopLevelItem(pItem) == 0) {
         // Null item or it is for the first row of the tree
@@ -5704,7 +5704,7 @@ void dlgTriggerEditor::slot_treeSelectionChanged()
             } else if (sender == treeWidget_actions) {
                 slot_actionSelected(item);
             } else if (sender == treeWidget_variables) {
-                slot_var_selected(item);
+                slot_variableSelected(item);
             } else if (sender == treeWidget_triggers) {
                 slot_triggerSelected(item);
             }
@@ -6883,7 +6883,7 @@ void dlgTriggerEditor::slot_showKeys()
     }
 }
 
-void dlgTriggerEditor::slot_show_vars()
+void dlgTriggerEditor::slot_showVariables()
 {
     changeView(EditorViewType::cmVarsView);
     repopulateVars();
@@ -6900,7 +6900,7 @@ void dlgTriggerEditor::slot_show_vars()
     } else {
         mpVarsMainArea->show();
         mpSourceEditorArea->show();
-        slot_var_selected(treeWidget_variables->currentItem());
+        slot_variableSelected(treeWidget_variables->currentItem());
     }
     if (!mVarEditorSplitterState.isEmpty()) {
         splitter_right->restoreState(mVarEditorSplitterState);
@@ -6923,7 +6923,7 @@ void dlgTriggerEditor::show_vars()
     if (pI) {
         if (pI->childCount() > 0) {
             mpVarsMainArea->show();
-            slot_var_selected(treeWidget_variables->currentItem());
+            slot_variableSelected(treeWidget_variables->currentItem());
         } else {
             mpVarsMainArea->hide();
             showInfo(msgInfoAddVar);
@@ -7224,7 +7224,7 @@ void dlgTriggerEditor::slot_deleteItemOrGroup()
     }
 }
 
-void dlgTriggerEditor::slot_item_selected_save(QTreeWidgetItem* pItem)
+void dlgTriggerEditor::slot_saveSelectedItem(QTreeWidgetItem* pItem)
 {
     if (!pItem) {
         return;
@@ -7253,7 +7253,7 @@ void dlgTriggerEditor::slot_item_selected_save(QTreeWidgetItem* pItem)
         saveVar();
         break;
     case EditorViewType::cmUnknownView:
-        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_item_selected_save() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
+        qWarning().nospace().noquote() << "dlgTriggerEditor::slot_saveSelectedItem() WARNING - switch(EditorViewType) not expected to be called for \"EditorViewType::cmUnknownView!\"";
     }
 }
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -222,16 +222,16 @@ public:
 
 public slots:
     void slot_toggleHiddenVariables(bool);
-    void slot_toggleHiddenVar(bool);
-    void slot_var_selected(QTreeWidgetItem*);
-    void slot_var_changed(QTreeWidgetItem*);
-    void slot_show_vars();
+    void slot_hideVariable(bool);
+    void slot_variableSelected(QTreeWidgetItem*);
+    void slot_variableChanged(QTreeWidgetItem*);
+    void slot_showVariables();
     void slot_viewErrorsAction();
     void slot_setupPatternControls(const int);
     void slot_soundTrigger();
     void slot_colorizeTriggerSetBgColor();
     void slot_colorizeTriggerSetFgColor();
-    void slot_item_selected_save(QTreeWidgetItem* pItem);
+    void slot_saveSelectedItem(QTreeWidgetItem* pItem);
     void slot_export();
     void slot_import();
     void slot_viewStatsAction();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -321,7 +321,7 @@ mudlet::mudlet()
     mpTabBar->setFocusPolicy(Qt::NoFocus);
     mpTabBar->setTabsClosable(true);
     mpTabBar->setAutoHide(true);
-    connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_close_profile_requested);
+    connect(mpTabBar, &QTabBar::tabCloseRequested, this, &mudlet::slot_closeProfileRequested);
     mpTabBar->setMovable(true);
     connect(mpTabBar, &QTabBar::currentChanged, this, &mudlet::slot_tabChanged);
     connect(mpTabBar, &QTabBar::tabMoved, this, &mudlet::slot_tabMoved);
@@ -567,24 +567,24 @@ mudlet::mudlet()
     connect(mpActionButtons.data(), &QAction::triggered, this, &mudlet::slot_showActionDialog);
     connect(mpActionOptions.data(), &QAction::triggered, this, &mudlet::slot_showPreferencesDialog);
     connect(mpActionAbout.data(), &QAction::triggered, this, &mudlet::slot_showAboutDialog);
-    connect(mpActionMultiView.data(), &QAction::triggered, this, &mudlet::slot_multi_view);
+    connect(mpActionMultiView.data(), &QAction::triggered, this, &mudlet::slot_multiView);
     connect(mpActionReconnect.data(), &QAction::triggered, this, &mudlet::slot_reconnect);
     connect(mpActionDisconnect.data(), &QAction::triggered, this, &mudlet::slot_disconnect);
-    connect(mpActionCloseProfile.data(), &QAction::triggered, this, &mudlet::slot_close_current_profile);
+    connect(mpActionCloseProfile.data(), &QAction::triggered, this, &mudlet::slot_closeCurrentProfile);
     connect(mpActionReplay.data(), &QAction::triggered, this, &mudlet::slot_replay);
     connect(mpActionNotes.data(), &QAction::triggered, this, &mudlet::slot_notes);
     connect(mpActionMapper.data(), &QAction::triggered, this, &mudlet::slot_mapper);
     connect(mpActionIRC.data(), &QAction::triggered, this, &mudlet::slot_irc);
-    connect(mpActionDiscord.data(), &QAction::triggered, this, &mudlet::slot_discord);
-    connect(mpActionMudletDiscord.data(), &QAction::triggered, this, &mudlet::slot_mudlet_discord);
-    connect(mpActionPackageManager.data(), &QAction::triggered, this, &mudlet::slot_package_manager);
-    connect(mpActionModuleManager.data(), &QAction::triggered, this, &mudlet::slot_module_manager);
-    connect(mpActionPackageExporter.data(), &QAction::triggered, this, &mudlet::slot_package_exporter);
+    connect(mpActionDiscord.data(), &QAction::triggered, this, &mudlet::slot_profileDiscord);
+    connect(mpActionMudletDiscord.data(), &QAction::triggered, this, &mudlet::slot_mudletDiscord);
+    connect(mpActionPackageManager.data(), &QAction::triggered, this, &mudlet::slot_packageManager);
+    connect(mpActionModuleManager.data(), &QAction::triggered, this, &mudlet::slot_moduleManager);
+    connect(mpActionPackageExporter.data(), &QAction::triggered, this, &mudlet::slot_packageExporter);
 
     connect(dactionConnect, &QAction::triggered, this, &mudlet::slot_showConnectionDialog);
     connect(dactionReconnect, &QAction::triggered, this, &mudlet::slot_reconnect);
     connect(dactionDisconnect, &QAction::triggered, this, &mudlet::slot_disconnect);
-    connect(dactionCloseProfile, &QAction::triggered, this, &mudlet::slot_close_current_profile);
+    connect(dactionCloseProfile, &QAction::triggered, this, &mudlet::slot_closeCurrentProfile);
     connect(dactionNotepad, &QAction::triggered, this, &mudlet::slot_notes);
     connect(dactionReplay, &QAction::triggered, this, &mudlet::slot_replay);
 
@@ -592,8 +592,8 @@ mudlet::mudlet()
     connect(dactionVideo, &QAction::triggered, this, &mudlet::slot_showHelpDialogVideo);
     connect(dactionForum, &QAction::triggered, this, &mudlet::slot_showHelpDialogForum);
     connect(dactionIRC, &QAction::triggered, this, &mudlet::slot_irc);
-    connect(dactionDiscord, &QAction::triggered, this, &mudlet::slot_discord);
-    connect(dactionMudletDiscord, &QAction::triggered, this, &mudlet::slot_mudlet_discord);
+    connect(dactionDiscord, &QAction::triggered, this, &mudlet::slot_profileDiscord);
+    connect(dactionMudletDiscord, &QAction::triggered, this, &mudlet::slot_mudletDiscord);
     connect(dactionLiveHelpChat, &QAction::triggered, this, &mudlet::slot_irc);
     connect(dactionShowErrors, &QAction::triggered, [=]() {
         auto host = getActiveHost();
@@ -629,10 +629,10 @@ mudlet::mudlet()
     dactionUpdate->setVisible(false);
     dactionReportIssue->setVisible(false);
 #endif
-    connect(dactionPackageManager, &QAction::triggered, this, &mudlet::slot_package_manager);
-    connect(dactionPackageExporter, &QAction::triggered, this, &mudlet::slot_package_exporter);
-    connect(dactionModuleManager, &QAction::triggered, this, &mudlet::slot_module_manager);
-    connect(dactionMultiView, &QAction::triggered, this, &mudlet::slot_multi_view);
+    connect(dactionPackageManager, &QAction::triggered, this, &mudlet::slot_packageManager);
+    connect(dactionPackageExporter, &QAction::triggered, this, &mudlet::slot_packageExporter);
+    connect(dactionModuleManager, &QAction::triggered, this, &mudlet::slot_moduleManager);
+    connect(dactionMultiView, &QAction::triggered, this, &mudlet::slot_multiView);
     connect(dactionInputLine, &QAction::triggered, this, &mudlet::slot_compactInputLine);
     connect(mpActionTriggers.data(), &QAction::triggered, this, &mudlet::slot_showTriggerDialog);
     connect(dactionScriptEditor, &QAction::triggered, this, &mudlet::slot_showEditorDialog);
@@ -697,7 +697,7 @@ mudlet::mudlet()
 #if defined(INCLUDE_UPDATER)
     updater = new Updater(this, mpSettings);
     connect(updater, &Updater::signal_updateAvailable, this, &mudlet::slot_updateAvailable);
-    connect(dactionUpdate, &QAction::triggered, this, &mudlet::slot_check_manual_update);
+    connect(dactionUpdate, &QAction::triggered, this, &mudlet::slot_manualUpdateCheck);
 #if defined(Q_OS_MACOS)
     // ensure that 'Check for updates' is under the Applications menu per convention
     dactionUpdate->setMenuRole(QAction::ApplicationSpecificRole);
@@ -1279,7 +1279,7 @@ void mudlet::loadTranslators(const QString& languageCode)
     }
 }
 
-void mudlet::slot_module_manager()
+void mudlet::slot_moduleManager()
 {
     Host* pH = getActiveHost();
     if (!pH) {
@@ -1306,7 +1306,7 @@ bool mudlet::openWebPage(const QString& path)
     return QDesktopServices::openUrl(url);
 }
 
-void mudlet::slot_package_manager()
+void mudlet::slot_packageManager()
 {
     Host* pH = getActiveHost();
     if (!pH) {
@@ -1323,7 +1323,7 @@ void mudlet::slot_package_manager()
     packageManager->activateWindow();
 }
 
-void mudlet::slot_package_exporter()
+void mudlet::slot_packageExporter()
 {
     Host* pH = getActiveHost();
     if (!pH) {
@@ -1333,13 +1333,13 @@ void mudlet::slot_package_exporter()
     d->show();
 }
 
-void mudlet::slot_close_current_profile()
+void mudlet::slot_closeCurrentProfile()
 {
     Host* pH = getActiveHost();
     if (!pH) {
         return;
     }
-    slot_close_profile_requested(mpTabBar->currentIndex());
+    slot_closeProfileRequested(mpTabBar->currentIndex());
 
     if (!getActiveHost()) {
         disableToolbarButtons();
@@ -1347,7 +1347,7 @@ void mudlet::slot_close_current_profile()
     }
 }
 
-void mudlet::slot_close_profile_requested(int tab)
+void mudlet::slot_closeProfileRequested(int tab)
 {
     QString name = mpTabBar->tabData(tab).toString();
     closeHost(name);
@@ -1606,7 +1606,7 @@ void mudlet::addConsoleForNewHost(Host* pH)
 }
 
 
-void mudlet::slot_timer_fires()
+void mudlet::slot_timerFires()
 {
     QTimer* pQT = qobject_cast<QTimer*>(sender());
     if (Q_UNLIKELY(!pQT)) {
@@ -1616,16 +1616,16 @@ void mudlet::slot_timer_fires()
     // Pull the Host name and TTimer::id from the properties:
     QString hostName(pQT->property(TTimer::scmProperty_HostName).toString());
     if (Q_UNLIKELY(hostName.isEmpty())) {
-        qWarning().nospace().noquote() << "mudlet::slot_timer_fires() INFO - Host name is empty - so TTimer has probably been deleted.";
+        qWarning().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host name is empty - so TTimer has probably been deleted.";
         pQT->deleteLater();
         return;
     }
 
     Host* pHost = mHostManager.getHost(hostName);
-    Q_ASSERT_X(pHost, "mudlet::slot_timer_fires()", "Unable to deduce Host pointer from data in QTimer");
+    Q_ASSERT_X(pHost, "mudlet::slot_timerFires()", "Unable to deduce Host pointer from data in QTimer");
     int id = pQT->property(TTimer::scmProperty_TTimerId).toInt();
     if (Q_UNLIKELY(!id)) {
-        qWarning().nospace().noquote() << "mudlet::slot_timer_fires() INFO - TTimer ID is zero - so TTimer has probably been deleted.";
+        qWarning().nospace().noquote() << "mudlet::slot_timerFires() INFO - TTimer ID is zero - so TTimer has probably been deleted.";
         pQT->deleteLater();
         return;
     }
@@ -1633,7 +1633,7 @@ void mudlet::slot_timer_fires()
     if (Q_LIKELY(pTT)) {
 // commented out as it will be spammy in normal situations but saved as useful
 // during timer debugging... 8-)
-//        qDebug().nospace().noquote() << "mudlet::slot_timer_fires() INFO - Host: \"" << hostName << "\" QTimer firing for TTimer Id:" << id;
+//        qDebug().nospace().noquote() << "mudlet::slot_timerFires() INFO - Host: \"" << hostName << "\" QTimer firing for TTimer Id:" << id;
 //        qDebug().nospace().noquote() << "    (objectName:\"" << pQT->objectName() << "\")";
         pTT->execute();
         if (pTT->checkRestart()) {
@@ -1644,7 +1644,7 @@ void mudlet::slot_timer_fires()
         return;
     }
 
-    qWarning().nospace().noquote() << "mudlet::slot_timer_fires() ERROR - Timer not registered, it seems to have been called: \"" << pQT->objectName() << "\" - automatically deleting it!";
+    qWarning().nospace().noquote() << "mudlet::slot_timerFires() ERROR - Timer not registered, it seems to have been called: \"" << pQT->objectName() << "\" - automatically deleting it!";
     // Clean up any bogus ones:
     pQT->stop();
     pQT->deleteLater();
@@ -2136,7 +2136,7 @@ void mudlet::slot_showConnectionDialog()
         return;
     }
     mConnectionDialog = new dlgConnectionProfiles(this);
-    connect(mConnectionDialog, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connection_dlg_finished);
+    connect(mConnectionDialog, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connectionDialogueFinished);
     mConnectionDialog->fillout_form();
 
     connect(mConnectionDialog, &QDialog::accepted, this, [=]() { enableToolbarButtons(); });
@@ -2250,7 +2250,7 @@ void mudlet::slot_showVariableDialog()
     if (!pEditor) {
         return;
     }
-    pEditor->slot_show_vars();
+    pEditor->slot_showVariables();
     pEditor->raise();
     pEditor->showNormal();
     pEditor->activateWindow();
@@ -2392,17 +2392,17 @@ void mudlet::assignKeySequences()
 
         delete packagesShortcut.data();
         packagesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_package_manager);
+        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_packageManager);
         dactionPackageManager->setShortcut(QKeySequence());
 
         delete modulesShortcut.data();
         modulesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_module_manager);
+        connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_moduleManager);
         dactionModuleManager->setShortcut(QKeySequence());
 
         delete multiViewShortcut.data();
         multiViewShortcut = new QShortcut(multiViewKeySequence, this);
-        connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggle_multi_view);
+        connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggleMultiView);
         dactionMultiView->setShortcut(QKeySequence());
 
         delete connectShortcut.data();
@@ -2422,7 +2422,7 @@ void mudlet::assignKeySequences()
 
         delete closeProfileShortcut.data();
         closeProfileShortcut = new QShortcut(closeProfileKeySequence, this);
-        connect(closeProfileShortcut.data(), &QShortcut::activated, this, &mudlet::slot_close_current_profile);
+        connect(closeProfileShortcut.data(), &QShortcut::activated, this, &mudlet::slot_closeCurrentProfile);
         dactionCloseProfile->setShortcut(QKeySequence());
     } else {
         // The menu is shown so tie the QKeySequences to the menu items and it
@@ -2556,7 +2556,7 @@ void mudlet::slot_irc()
     pHost->mpDlgIRC->show();
 }
 
-void mudlet::slot_discord()
+void mudlet::slot_profileDiscord()
 {
     Host* pHost = getActiveHost();
     QString invite;
@@ -2566,7 +2566,7 @@ void mudlet::slot_discord()
     openWebPage(invite.isEmpty() ? mMudletDiscordInvite : invite);
 }
 
-void mudlet::slot_mudlet_discord()
+void mudlet::slot_mudletDiscord()
 {
     openWebPage(mMudletDiscordInvite);
 }
@@ -2849,7 +2849,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
     }
 
     emit signal_hostCreated(pHost, mHostManager.getHostCount());
-    slot_connection_dlg_finished(profile_name, true);
+    slot_connectionDialogueFinished(profile_name, true);
     enableToolbarButtons();
     updateMultiViewControls();
 }
@@ -2868,7 +2868,7 @@ void mudlet::slot_processEventLoopHackTimerRun()
     pH->mpConsole->refresh();
 }
 
-void mudlet::slot_connection_dlg_finished(const QString& profile, bool connect)
+void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connect)
 {
     Host* pHost = getHostManager().getHost(profile);
     if (!pHost) {
@@ -2948,15 +2948,15 @@ void mudlet::installModulesList(Host* pHost, QStringList modules)
 // Connected to and needed by the shortcut to trigger the menu or toolbar button
 // action because it does not provide the checked state of the item to which the
 // shortcut is associated:
-void mudlet::slot_toggle_multi_view()
+void mudlet::slot_toggleMultiView()
 {
     const bool newState = !mMultiView;
-    slot_multi_view(newState);
+    slot_multiView(newState);
 }
 
 // Connected to a menu and toolbar button (but not a short-cut to one of them)
 // as they provide their checked state directly:
-void mudlet::slot_multi_view(const bool state)
+void mudlet::slot_multiView(const bool state)
 {
     // Ensure the state of both controls is updated to reflect the state of the
     // option:
@@ -3633,7 +3633,7 @@ void mudlet::checkUpdatesOnStart()
     }
 }
 
-void mudlet::slot_check_manual_update()
+void mudlet::slot_manualUpdateCheck()
 {
     updater->manuallyCheckUpdates();
 }
@@ -3693,7 +3693,7 @@ void mudlet::slot_updateAvailable(const int updateCount)
                                                    // Intentional comment
                                                    "Review update(s) menu item, %n is the count of how many updates are available",
                                                    updateCount),
-                                                this, &mudlet::slot_check_manual_update);
+                                                this, &mudlet::slot_manualUpdateCheck);
     pActionReview->setToolTip(utils::richText(tr("Review the update(s) available...",
                                                  // Intentional comment
                                                  "Tool-tip for review update(s) menu item, given that the count of how many updates are available is already shown in the menu, the %n parameter that is that number need not be used here",
@@ -3879,7 +3879,7 @@ void mudlet::slot_passwordMigratedToSecureStorage(QKeychain::Job* job)
 {
     const auto profileName = job->property("profile").toString();
     if (job->error()) {
-        qWarning() << "mudlet::slot_password_saved ERROR: couldn't migrate for" << profileName << "; error was:" << job->errorString();
+        qWarning().nospace().noquote() << "mudlet::slot_passwordMigratedToSecureStorage(...) ERROR - could not migrate for \"" << profileName << "\"; error was: \"" << job->errorString() << "\".";
     } else {
         deleteProfileData(profileName, qsl("password"));
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -521,24 +521,24 @@ public slots:
     void slot_showHelpDialogForum();
 // Not used:    void slot_showHelpDialogIrc();
     void slot_openMappingScriptsPage();
-    void slot_multi_view(const bool);
-    void slot_toggle_multi_view();
-    void slot_connection_dlg_finished(const QString& profile, bool connectOnLoad);
-    void slot_timer_fires();
+    void slot_multiView(const bool);
+    void slot_toggleMultiView();
+    void slot_connectionDialogueFinished(const QString& profile, bool connectOnLoad);
+    void slot_timerFires();
     void slot_replay();
     void slot_disconnect();
     void slot_notes();
     void slot_reconnect();
-    void slot_close_current_profile();
-    void slot_close_profile_requested(int);
+    void slot_closeCurrentProfile();
+    void slot_closeProfileRequested(int);
     void slot_irc();
-    void slot_discord();
-    void slot_mudlet_discord();
-    void slot_package_manager();
-    void slot_package_exporter();
-    void slot_module_manager();
+    void slot_profileDiscord();
+    void slot_mudletDiscord();
+    void slot_packageManager();
+    void slot_packageExporter();
+    void slot_moduleManager();
 #if defined(INCLUDE_UPDATER)
-    void slot_check_manual_update();
+    void slot_manualUpdateCheck();
 #endif
     void slot_restoreMainMenu() { setMenuBarVisibility(visibleAlways); }
     void slot_restoreMainToolBar() { setToolBarVisibility(visibleAlways); }


### PR DESCRIPTION
When Qt's slot/signal system is used to invoke a method there is some overhead - so it makes sense to ensure developers can spot all such methods (functions). We have tried to do this with a `slot_` prefix to the methods we create but it has not been applied uniformly. This PR is intended to conclude helping with this by more rigorously doing so - the names changed herein should all follow a `slot_`*camelCaseMethodName* style. In addition some methods were detected that are not currently used or which are not actually used via the signal/slot system, these have been commented out or have had the prefix removed and the declaration in the relevant header file moved as appropriate.

There were two similar sets of (not prefixed with `slot_`) slots in the Profile preferences class that adjusted the colour settings separately for the main console and the mapper the latter had the same names but with a `2` suffix. To made it more clear I have changed them to include `Map` in their names instead.

Also, the NON-slot method: `(void) dlgProfilePreferences::setColor(QPushButton*, QColor&, bool)` 
has been renamed to: `(void) dlgProfilePreferences::setButtonAndProfileColor(QPushButton*, QColor&, bool)` so that it is clearly distinguishable from built in Qt methods that are also called `setColor` - though which do have different signatures!

For reference the changes made are:
* `TConsole::slot_stop_all_triggers(...)` ==> `TConsole::slot_stopAllItems(...)`
* `dlgConnectionProfiles::slot_copy_profile()` ==> `dlgConnectionProfiles::slot_copyProfile()`
* `dlgConnectionProfiles::slot_copy_profilesettings_only()` ==> `dlgConnectionProfiles::slot_copyOnlySettingsOfProfile()`
* `dlgConnectionProfiles::slot_deleteprofile_check(...)` ==> `dlgConnectionProfiles::slot_deleteProfileCheck(...)`
* `dlgConnectionProfiles::slot_password_deleted(...)` ==> `dlgConnectionProfiles::slot_passwordDeleted(...)`
* `dlgConnectionProfiles::slot_password_saved(...) ==> `dlgConnectionProfiles::slot_passwordSaved(...)`
* `dlgConnectionProfiles::slot_profile_menu(...)` ==> `dlgConnectionProfiles::slot_profileContextMenu(...)`
* `dlgConnectionProfiles::slot_reset_custom_icon()` ==> `dlgConnectionProfiles::slot_resetCustomIcon()`
* `dlgConnectionProfiles::slot_set_custom_icon()` ==> `dlgConnectionProfiles::slot_setCustomIcon()`
* `dlgConnectionProfiles::slot_set_custom_color()` ==> `dlgConnectionProfiles::slot_setCustomColor()`
* `dlgConnectionProfiles::slot_update_autologin(...)` ==> `dlgConnectionProfiles::slot_updateAutoConnect(...)`
* `dlgConnectionProfiles::slot_update_autoreconnect(...)` ==> `dlgConnectionProfiles::slot_updateAutoReconnect(...)`
* `dlgConnectionProfiles::slot_update_description()` ==> `dlgConnectionProfiles::slot_updateDescription()`
* `dlgConnectionProfiles::slot_update_discord_optin(...)` ==> `dlgConnectionProfiles::slot_updateDiscordOptIn(...)`
* `dlgProfilePreferences::copyMap()` ==> `dlgProfilePreferences::slot_copyMap()`
* `dlgProfilePreferences::downloadMap()` ==> `dlgProfilePreferences::slot_downloadMap()`
* `dlgProfilePreferences::hideActionLabel()` ==> `dlgProfilePreferences::slot_hideActionLabel()`
* `dlgProfilePreferences::loadMap()` ==> `dlgProfilePreferences::slot_loadMap()`
* `dlgProfilePreferences::resetColors()` ==> `dlgProfilePreferences::slot_resetColors()`
* `dlgProfilePreferences::resetColors2()` ==> `dlgProfilePreferences::slot_resetMapColors()`
* `dlgProfilePreferences::saveMap()` ==> `dlgProfilePreferences::slot_saveMap()`
* `dlgProfilePreferences::setBgColor()` ==> `dlgProfilePreferences::slot_setBgColor()`
* `dlgProfilePreferences::setBgColor2()` ==> `dlgProfilePreferences::slot_setMapBgColor()`
* `dlgProfilePreferences::setColorBlack()` ==> `dlgProfilePreferences::slot_setColorBlack()`
* `dlgProfilePreferences::setColorBlack2()` ==> `dlgProfilePreferences::slot_setMapColorBlack()`
* `dlgProfilePreferences::setColorBlue()` ==> `dlgProfilePreferences::slot_setColorBlue()`
* `dlgProfilePreferences::setColorCyan()` ==> `dlgProfilePreferences::slot_setColorCyan()`
* `dlgProfilePreferences::setColorBlue2()` ==> `dlgProfilePreferences::slot_setMapColorBlue()`
* `dlgProfilePreferences::setColorCyan2()` ==> `dlgProfilePreferences::slot_setMapColorCyan()`
* `dlgProfilePreferences::setColorGreen()` ==> `dlgProfilePreferences::slot_setColorGreen()`
* `dlgProfilePreferences::setColorGreen2()` ==> `dlgProfilePreferences::slot_setMapColorGreen()`
* `dlgProfilePreferences::setColorLightBlack()` ==> `dlgProfilePreferences::slot_setColorLightBlack()`
* `dlgProfilePreferences::setColorLightBlack2()` ==> `dlgProfilePreferences::slot_setMapColorLightBlack()`
* `dlgProfilePreferences::setColorLightBlue()` ==> `dlgProfilePreferences::slot_setColorLightBlue()`
* `dlgProfilePreferences::setColorLightBlue2()` ==> `dlgProfilePreferences::slot_setMapColorLightBlue()`
* `dlgProfilePreferences::setColorLightCyan()` ==> `dlgProfilePreferences::slot_setColorLightCyan()`
* `dlgProfilePreferences::setColorLightCyan2()` ==> `dlgProfilePreferences::slot_setMapColorLightCyan()`
* `dlgProfilePreferences::setColorLightGreen()` ==> `dlgProfilePreferences::slot_setColorLightGreen()`
* `dlgProfilePreferences::setColorLightGreen2()` ==> `dlgProfilePreferences::slot_setMapColorLightGreen()`
* `dlgProfilePreferences::setColorLightMagenta()` ==> `dlgProfilePreferences::slot_setColorLightMagenta()`
* `dlgProfilePreferences::setColorLightMagenta2()` ==> `dlgProfilePreferences::slot_setMapColorLightMagenta()`
* `dlgProfilePreferences::setColorLightRed()` ==> `dlgProfilePreferences::slot_setColorLightRed()`
* `dlgProfilePreferences::setColorLightRed2()` ==> `dlgProfilePreferences::slot_setMapColorLightRed()`
* `dlgProfilePreferences::setColorLightWhite()` ==> `dlgProfilePreferences::slot_setColorLightWhite()`
* `dlgProfilePreferences::setColorLightWhite2()` ==> `dlgProfilePreferences::slot_setMapColorLightWhite()`
* `dlgProfilePreferences::setColorLightYellow()` ==> `dlgProfilePreferences::slot_setColorLightYellow()`
* `dlgProfilePreferences::setColorLightYellow2()` ==> `dlgProfilePreferences::slot_setMapColorLightYellow()`
* `dlgProfilePreferences::setColorMagenta()` ==> `dlgProfilePreferences::slot_setColorMagenta()`
* `dlgProfilePreferences::setColorMagenta2()` ==> `dlgProfilePreferences::slot_setMapColorMagenta()`
* `dlgProfilePreferences::setColorRed2()` ==> `dlgProfilePreferences::slot_setMapColorRed()`
* `dlgProfilePreferences::setColorRed()` ==> `dlgProfilePreferences::slot_setColorRed()`
* `dlgProfilePreferences::setColorWhite()` ==> `dlgProfilePreferences::slot_setColorWhite()`
* `dlgProfilePreferences::setColorWhite2()` ==> `dlgProfilePreferences::slot_setMapColorWhite()`
* `dlgProfilePreferences::setColorYellow()` ==> `dlgProfilePreferences::slot_setColorYellow()`
* `dlgProfilePreferences::setColorYellow2()` ==> `dlgProfilePreferences::slot_setMapColorYellow()`
* `dlgProfilePreferences::setCommandBgColor()` ==> `dlgProfilePreferences::slot_setCommandBgColor()`
* `dlgProfilePreferences::setCommandFgColor()` ==> `dlgProfilePreferences::slot_setCommandFgColor()`
* `dlgProfilePreferences::setCommandLineBgColor()` ==> `dlgProfilePreferences::slot_setCommandLineBgColor()`
* `dlgProfilePreferences::setCommandLineFgColor()` ==> `dlgProfilePreferences::slot_setCommandLineFgColor()`
* `dlgProfilePreferences::setDisplayFont()` ==> `dlgProfilePreferences::slot_setDisplayFont()`
* `dlgProfilePreferences::setFgColor()` ==> `dlgProfilePreferences::slot_setFgColor()`
* `dlgProfilePreferences::setFgColor2()` ==> `dlgProfilePreferences::slot_setMapExitsColor()`
* `dlgProfilePreferences::setFontSize()` ==> `dlgProfilePreferences::slot_setFontSize()`
* `dlgProfilePreferences::setMapInfoBackground()` ==> `dlgProfilePreferences::slot_setMapInfoBgColor()`
* `dlgProfilePreferences::setRoomBorderColor()` ==> `dlgProfilePreferences::slot_setMapRoomBorderColor()`
* `dlgProfilePreferences::slot_script_selected(...)` ==> `dlgProfilePreferences::slot_scriptSelected(...)`
* `dlgProfilePreferences::slot_theme_selected(...)` ==> `dlgProfilePreferences::slot_themeSelected(...)`
* `dlgRoomSymbol::colorRejected()` ==> `dlgRoomSymbol::slot_colorRejected()`
* `dlgRoomSymbol::colorSelected(...)` ==> `dlgRoomSymbol::slot_colorSelected(...)`
* `dlgRoomSymbol::currentColorChanged(...)` ==> `dlgRoomSymbol::slot_currentColorChanged(...)`
* `dlgRoomSymbol::openColorSelector()` ==> `dlgRoomSymbol::slot_openColorSelector()`
* `dlgRoomSymbol::resetColor()` ==> `dlgRoomSymbol::slot_resetColors()`
* `dlgRoomSymbol::updatePreview()` ==> `dlgRoomSymbol::slot_updatePreview()`
* `dlgTriggerEditor::slot_show_vars()` ==> `dlgTriggerEditor::slot_showVariables()`
* `dlgTriggerEditor::slot_var_changed(...)` ==> `dlgTriggerEditor::slot_variableChanged(...)`
* `dlgTriggerEditor::slot_var_selected(...)` ==>  `dlgTriggerEditor::slot_variableSelected(...)`
* `mudlet::slot_check_manual_update()` ==> `mudlet::slot_manualUpdateCheck()`
* `mudlet::slot_close_current_profile()` ==> `mudlet::slot_closeCurrentProfile()`
* `mudlet::slot_close_profile_requested(...)` ==> `mudlet::slot_closeProfileRequested(...)`
* `mudlet::slot_connection_dlg_finished(...)` ==> `mudlet::slot_connectionDialogueFinished(...)`
* `mudlet::slot_module_manager()` ==> `mudlet::slot_moduleManager()`
* `mudlet::slot_mudlet_discord()` ==> `mudlet::slot_mudletDiscord()`
* `mudlet::slot_multi_view(...)` ==> `mudlet::slot_multiView(const bool state)`
* `mudlet::slot_package_manager()` ==> `mudlet::slot_packageManager()`
* `mudlet::slot_package_exporter()` ==> `mudlet::slot_packageExporter()`
* `mudlet::slot_timer_fires()` ==> `mudlet::slot_timerFires()`
* `mudlet::slot_toggle_multi_view()` ==> `mudlet::slot_toggleMultiView()`

Also the names for these in particular have been changed to make more sense:
* `dlgProfilePreferences::slot_chooseProfilesChanged()` ==> `dlgProfilePreferences::slot_chosenProfilesChanged()`
* `dlgProfilePreferences::slot_editor_tab_selected(...)` ==> `dlgProfilePreferences::slot_tabChanged(...)`
* `dlgProfilePreferences::slot_passwords_location_changed(...)` ==> `dlgProfilePreferences::slot_passwordStorageLocationChanged(...)`
* `dlgProfilePreferences::slot_save_and_exit()` ==> `dlgProfilePreferences::slot_saveAndClose()`
* `dlgTriggerEditor::slot_toggleHiddenVar(...)` ==> `dlgTriggerEditor::slot_hideVariable(...)` - changed to distinguish it from `slot_toggleHiddenVariables(...)`
* `dlgTriggerEditor::slot_item_selected_save(...)` ==> `dlgTriggerEditor::slot_saveSelectedItem(...)`
* `mudlet::slot_discord()` ==> `mudlet::slot_profileDiscord()` - changed to distinguish it from `slot_mudletDiscord()`

Not currently used and commented out:
* `dlgProfilePreferences::setCommandLineFont()` ==> `dlgProfilePreferences::slot_setCommandLineFont()`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>