### PR TITLE
Add utf8.cut function to match string.cut

### DIFF
--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -14,6 +14,13 @@ function string:cut(maxLen)
   end
 end
 
+function utf8.cut(str, maxLen)
+  if utf8.len(str) <= maxLen then
+    return str
+  end
+  return utf8.remove(str, maxLen)
+end
+
 
 
 --- Documentation: https://wiki.mudlet.org/w/Manual:String_Functions#string.enclose

--- a/src/mudlet-lua/lua/StringUtils.lua
+++ b/src/mudlet-lua/lua/StringUtils.lua
@@ -18,7 +18,7 @@ function utf8.cut(str, maxLen)
   if utf8.len(str) <= maxLen then
     return str
   end
-  return utf8.remove(str, maxLen)
+  return utf8.remove(str, maxLen + 1)
 end
 
 

--- a/src/mudlet-lua/tests/StringUtils_spec.lua
+++ b/src/mudlet-lua/tests/StringUtils_spec.lua
@@ -22,6 +22,27 @@ describe("Tests StringUtils.lua functions", function()
     end)
   end)
 
+  describe("Tests the functionality of utf8.cut", function()
+    it("should return the same string if it is <= maxLen", function()
+      local testString = "Haydée"
+      local expected = "Haydée"
+      local actual = utf8.cut(testString, 6)
+      assert.equals(expected, actual)
+      local actual = utf8.cut(testString, 10)
+      assert.equals(expected, actual)
+    end)
+
+    it("should return a string of length maxLen if it is given a string longer than that", function()
+      local testString = "This is a test of the Haydée utf8 string cutting system"
+      local expected = "This is a "
+      local expectedLength = 10
+      local actual = utf8.cut(testString, expectedLength)
+      local actualLength = utf8.len(actual)
+      assert.equals(expected, actual)
+      assert.equals(expectedLength, actualLength)
+    end)
+  end)
+
   describe("Tests the functionality of string.enclose", function()
     it("should return [[]] is empty string is given", function()
       assert.equals("[[]]", string.enclose(""))


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Adds utf8.cut to match our added string.cut function

#### Motivation for adding to Mudlet
someone asked after it on the forums, and while utf8.remove can be used to similar effect, I feel it's better to include also include a cut function with the same syntax.

#### Other info (issues closed, discussion etc)
https://forums.mudlet.org/viewtopic.php?p=46875#p46875