### PR TITLE
Improve: make text wrapping quicker

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2330,13 +2330,20 @@ void TBuffer::logRemainingOutput()
 }
 
 inline void
-TBuffer::binarySearchHorizontalAdvance(const int &lineIndex, const int &indentSize, const QString &lineIndent,
+TBuffer::binarySearchHorizontalAdvance(const int &lineIndex, const int &indentSize, const QString &lineIndent, const int &lineWidth,
                                        const int &screenWidth, const int &subStringStart, const int &lineCharTotal,
                                        const QFontMetrics &fontMetrics, int &lineCharIterator, const bool isBefore) {
     // Does an initial entire string check to ensure we are not searching for no reason
     QStringRef lineText = lineBuffer.at(lineIndex).midRef(subStringStart, lineCharTotal - subStringStart);
     int indentWidth = (indentSize > 0) ? fontMetrics.horizontalAdvance(lineIndent) : 0;
-    int calculatedWidth = fontMetrics.horizontalAdvance(lineText.toString()) + indentWidth;
+    int calculatedWidth;
+    // Skip horizontalAdvance for first run, since it was already calculated before binarySearch was called
+    if (subStringStart == 0) {
+        calculatedWidth = lineWidth;
+    } else {
+        calculatedWidth = fontMetrics.horizontalAdvance(lineText.toString()) + indentWidth;
+    }
+    
     if (calculatedWidth <= screenWidth) {
         lineCharIterator = lineCharTotal;
         return;
@@ -2450,7 +2457,7 @@ inline int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TCh
                 // First run gets lineWidth from outside
                 if (lineWidth > screenWidth) {
                     // This sets lineCharIterator to the position right before it breaches screenWidth
-                    binarySearchHorizontalAdvance(currentLine, indentSize, lineIndent, screenWidth, subStringStart, lineCharTotal, fontMetrics, lineCharIterator, true);
+                    binarySearchHorizontalAdvance(currentLine, indentSize, lineIndent, lineWidth, screenWidth, subStringStart, lineCharTotal, fontMetrics, lineCharIterator, true);
                     wordFinder.setPosition(lineCharIterator);
                     // If current position is not at a boundary, we move to the previous one
                     if (!wordFinder.isAtBoundary() || (wordFinder.boundaryReasons() & QTextBoundaryFinder::BreakOpportunity) == 0) {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -222,7 +222,7 @@ private:
     void decodeSGR48(const QStringList&, bool isColonSeparated = true);
     void decodeOSC(const QString&);
     void resetColors();
-    void binarySearchHorizontalAdvance(const int& lineIndex, const int& indentSize, const QString& lineIndent, const int& screenWidth, const int& subStringStart, const int& lineCharTotal, const QFontMetrics& qfm, int& lineCharIterator, const bool isBefore);
+    void binarySearchHorizontalAdvance(const int& lineIndex, const int& indentSize, const QString& lineIndent, const int& lineWidth, const int& screenWidth, const int& subStringStart, const int& lineCharTotal, const QFontMetrics& qfm, int& lineCharIterator, const bool isBefore);
 
     // First stage in decoding SGR/OCS sequences - set true when we see the
     // ASCII ESC character:


### PR DESCRIPTION
Avoided duplicate call to horizontalAdvance, basically skip the first call since it was called before the function is called

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
horizontalAdvance is an expensive call, current implementation in binarySearchHorizontalAdvance has a duplicate call that happen when the function is called for the first time for the line being wrapped.  This PR avoided that. 

#### Motivation for adding to Mudlet
This would have reduce the horizontalAdvance call for line that needs to be wrapped as follow:
Wrapped 1 time : 50%
Wrapped 2 times : 33.3%
Wrapped 3 times : 25%
Wrapped 4 times : 20%
Wrapped 5 times : 16.6%
Wrapped 6 times : 14.28%
Wrapped 7 times : 12.5%
Basically, 1/(wrapped times + 1).

#### Other info (issues closed, discussion etc)
