### PR TITLE
Fix: prevent crash when search-engine search used after selection is lost

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1882,6 +1882,10 @@ std::pair<bool, int> TTextEdit::drawTextForClipboard(QPainter& painter, QRect re
 
 void TTextEdit::searchSelectionOnline()
 {
+    if (!establishSelectedText()) {
+        return;
+    }
+
     QString selectedText = getSelectedText(QChar::Space);
     QString url = QUrl::toPercentEncoding(selectedText.trimmed());
     url.prepend(mpHost->getSearchEngine().second);


### PR DESCRIPTION
This will close #6275 - and it adopts the first solution approach that I suggested there:
> Mudlet would recognise that there is no longer a valid selection and thus not attempt to even try and activate a Web-based search.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>