### PR TITLE
Infrastructure: fix raspberry pi compile

### DIFF
--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: development
   workflow_dispatch:
-  pull_request:
 
 jobs:
   analyze:

--- a/.github/workflows/performance-analysis.yml
+++ b/.github/workflows/performance-analysis.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: development
   workflow_dispatch:
+  pull_request:
 
 jobs:
   analyze:

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2405,7 +2405,7 @@ TBuffer::binarySearchHorizontalAdvance(const int &lineIndex, const int &indentSi
 // format = What the indent character is (default to space)
 // onlyWrapOneLine = True would wrap only the startLine, while False would wraps text all the way from startLine until the end of the buffer (default: True)
 // containsNewLine = True to indicate the line can contain LineFeed, while false means it does not contain LineFeed (default: False)
-inline int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& format, bool onlyWrapOneLine, bool containsNewLine)
+int TBuffer::wrapLine(int startLine, int screenWidth, int indentSize, TChar& format, bool onlyWrapOneLine, bool containsNewLine)
 {
     const int bufferSize = static_cast<int>(buffer.size());
     if (bufferSize < startLine || startLine < 0) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove `inline` keyword which was breaking compilation
#### Motivation for adding to Mudlet
Fix raspberry pi compile
#### Other info (issues closed, discussion etc)
See https://stackoverflow.com/questions/5057021/why-are-c-inline-functions-in-the-header