### PR TITLE
Fix: caret mode not enabling properly in Linux

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3985,7 +3985,6 @@ bool Host::caretEnabled() const {
 void Host::setCaretEnabled(bool enabled) {
     mCaretEnabled = enabled;
     mpConsole->setCaretMode(enabled);
-    qDebug() << "caret mode" << enabled;
 }
 
 bool Host::autoWrap() const {

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3985,6 +3985,7 @@ bool Host::caretEnabled() const {
 void Host::setCaretEnabled(bool enabled) {
     mCaretEnabled = enabled;
     mpConsole->setCaretMode(enabled);
+    qDebug() << "caret mode" << enabled;
 }
 
 bool Host::autoWrap() const {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2044,23 +2044,23 @@ void TConsole::setCaretMode(bool enabled)
         mUpperPane->initializeCaret();
         mUpperPane->setFocusPolicy(Qt::StrongFocus);
         mUpperPane->setFocusProxy(nullptr);
-#if defined(Q_OS_WIN32)
+//#if defined(Q_OS_WIN32)
         // windows doesn't move keyboard focus to the main window without this
         mUpperPane->setFocus(Qt::MouseFocusReason);
         mUpperPane->grabKeyboard();
 
         QAccessibleEvent event(mUpperPane, QAccessible::Focus);
         QAccessible::updateAccessibility(&event);
-#endif
+//#endif
 
     } else {
         mUpperPane->setFocusPolicy(Qt::ClickFocus);
-#if defined(Q_OS_WIN32)
+//#if defined(Q_OS_WIN32)
         // NVDA breaks focus reset, so do it on a timer
         QTimer::singleShot(0, this, [this] () {
             mUpperPane->releaseKeyboard();
         });
-#endif
+//#endif
         if (mType == MainConsole) {
             mUpperPane->setFocusProxy(mpCommandLine);
             QAccessibleEvent event(mpCommandLine, QAccessible::Focus);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2044,23 +2044,23 @@ void TConsole::setCaretMode(bool enabled)
         mUpperPane->initializeCaret();
         mUpperPane->setFocusPolicy(Qt::StrongFocus);
         mUpperPane->setFocusProxy(nullptr);
-//#if defined(Q_OS_WIN32)
-        // windows doesn't move keyboard focus to the main window without this
+#if defined(Q_OS_WIN32) || defined(Q_OS_LINUX)
+        // windows & linux don't move keyboard focus to the main window without this
         mUpperPane->setFocus(Qt::MouseFocusReason);
         mUpperPane->grabKeyboard();
 
         QAccessibleEvent event(mUpperPane, QAccessible::Focus);
         QAccessible::updateAccessibility(&event);
-//#endif
+#endif
 
     } else {
         mUpperPane->setFocusPolicy(Qt::ClickFocus);
-//#if defined(Q_OS_WIN32)
+#if defined(Q_OS_WIN32) || defined(Q_OS_LINUX)
         // NVDA breaks focus reset, so do it on a timer
         QTimer::singleShot(0, this, [this] () {
             mUpperPane->releaseKeyboard();
         });
-//#endif
+#endif
         if (mType == MainConsole) {
             mUpperPane->setFocusProxy(mpCommandLine);
             QAccessibleEvent event(mpCommandLine, QAccessible::Focus);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix cursor mode to be properly toggled on/off in packaged Linux versions
#### Motivation for adding to Mudlet
So blind players can review the output window
#### Other info (issues closed, discussion etc)
Fixes https://github.com/Mudlet/Mudlet/issues/6198