### PR TITLE
Fix: Change Coremud DNS

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -504,7 +504,7 @@ public:
         {"Carrion Fields", {"carrionfields.net", 4449, false, "<a href='http://www.carrionfields.net'>www.carrionfields.net</a>", ":/icons/carrionfields.png"}},
         {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a>", ":/icons/cleftofdimensions.png"}},
         {"Legends of the Jedi", {"legendsofthejedi.com", 5656, false, "<a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a>", ":/icons/legendsofthejedi_120x30.png"}},
-        {"CoreMUD", {"coremud.org", 4020, true, "<a href='https://coremud.org/'>coremud.org</a>", ":/icons/coremud_icon.jpg"}},
+        {"CoreMUD", {"core.evilmog.io", 4020, true, "<a href='https://core.evilmog.io/'>core.evilmog.io</a>", ":/icons/coremud_icon.jpg"}},
         {"Multi-Users in Middle-earth", {"mume.org", 4242, true, "<a href='https://mume.org/'>mume.org</a>", ":/icons/mume.png"}},
     };
     // clang-format on


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Change coremud.org to core.evilmog.io while network solutions sorts out DNS
#### Motivation for adding to Mudlet
CoreMUD is down until DNS changes
#### Other info (issues closed, discussion etc)
