### PR TITLE
Infrastructure: Adjust test instructions in README

### DIFF
--- a/src/mudlet-lua/tests/README.md
+++ b/src/mudlet-lua/tests/README.md
@@ -1,44 +1,52 @@
 # Setting up for tests
 
-**Ubuntu**, have Mudlet and [Busted](https://lunarmodules.github.io/busted/) installed:
+## Ubuntu
 
+Have Mudlet and [Busted](https://lunarmodules.github.io/busted/) installed:
+
+```sh
   sudo apt-get install luarocks
   sudo luarocks install busted
+```
 
-On **macOS**:
+## macOS
 
+```sh
   brew install luarocks
   luarocks install busted
+```
 
-On **Windows**
+## Windows
 
-1. Download and unzip [LuaRocks](https://luarocks.org/releases/luarocks-3.8.0-windows-32.zip)
+### Download and unzip [LuaRocks](https://luarocks.org/releases/luarocks-3.8.0-windows-32.zip)
 
-  - Install Visual Studio (the [free community edition](https://visualstudio.microsoft.com/vs/community/) works)
-  - Open the x86 Native Tools Command Prompt that comes with Visual Studio in administrator mode (regular command prompt may work but is untested; the x64 Native Tools Command Prompt will *not* work)
+- Install Visual Studio (the [free community edition](https://visualstudio.microsoft.com/vs/community/) works)
+- Open the x86 Native Tools Command Prompt that comes with Visual Studio in administrator mode (regular command prompt may work but is untested; the x64 Native Tools Command Prompt will *not* work)
   - Navigate to the folder containing the unzipped files
   - `install /P <install_path> /SELFCONTAINED /L` (omit angular brackets)
     - You may need to include the `/F` option if you have previously installed LuaRocks
-  - Write down the recommend `LUA_PATH` and `LUA_CPATH` somewhere. You will need them in the running tests section
-    - Do *not* set `LUA_PATH` or `LUA_CPATH` system environment variables as suggested by the installer output. It will interfere with Mudlet's package loader
+  - Set the `LUA_PATH` or `LUA_CPATH` system environment variables as suggested by the installer output, ensuring that it ends in two `;;` characters. This causes Lua to insert additional paths needed by Mudlet and without them Mudlet won't be able to load its included lua libraries properly. For example:
+  - LUA_PATH for me is set to `C:\Qt\Tools\mingw730_32\lib\luarocks\rocks-5.1\?.lua;C:\Qt\Tools\mingw730_32\lib\luarocks\rocks-5.1\?\init.lua;C:\Qt\Tools\mingw730_32\share\lua\5.1\?.lua;C:\Qt\Tools\mingw730_32\share\lua\5.1\?\init.lua;;`
+  - LUA_CPATH for me is set to `C:\Qt\Tools\mingw730_32\lib\luarocks\rocks-5.1\?.dll;;`
     - Setting `Path` and `PATHEXT` is fine
-2. Install Busted
-  - Open a command prompt and enter `luarocks install busted`
-  - If you get a `'luarocks' is not recognized...` message:
-    - You may need to add the LuaRocks directory to your `Path` system environment variable and restart
-    - Alternatively, navigate the command prompt to the LuaRocks directory to run LuaRocks commands
+
+### Install Busted
+
+- Open a command prompt and enter `luarocks install busted`
+- If you get a `'luarocks' is not recognized...` message:
+  - You may need to add the LuaRocks directory to your `Path` system environment variable and restart
+  - Alternatively, navigate the command prompt to the LuaRocks directory to run LuaRocks commands
 
 You're now ready to run the tests.
 
-# Running tests
+## Running tests
 
 1. Open the `Mudlet self-test` profile by typing the name in the connection dialog ([example](https://wiki.mudlet.org/images/4/4d/Opening_Mudlet_self-test_profile.webm
 )).
-  - If you are following the instruction on Windows, add a script that appends the LuaRocks `LUA_PATH` and `LUA_CPATH` to `package.path` and `package.cpath`, respectively
-    - This should be placed above the "test scripts" script
-    - Example: `package.cpath = package.cpath .. [[;%APPDATA%\LuaRocks\lib\lua\5.1\?.dll;d:\l\luarocks\systree\lib\lua\5.1\?.dll]]`
+
 2. Use the `runTests` either with the location of the folder with all tests, or a specific test:
-```
+
+```txt
 -- run all tests in the folder:
 runTests <full path>/src/mudlet-lua/tests
 
@@ -46,11 +54,11 @@ runTests <full path>/src/mudlet-lua/tests
 runTests <full path>/src/mudlet-lua/tests/StringUtils_spec.lua
 ```
 
-# Creating tests
+## Creating tests
 
 See [Busted manual](https://lunarmodules.github.io/busted/) and currently existing tests for examples on how to write tests.
 
-## Test structure
+### Test structure
 
 Each file in `tests/` should mimic its companion in `lua/` - i.e., ``tests/DB.lua`` tests all the functionality that is present in ``lua/DB.lua``.
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Updates to the README.md for running the Busted tests for Mudlet. Fixes linting issues with the file layout, and adjusts the instructions for dealing with LUA_PATH and LUA_CPATH to account for the issues seen in https://github.com/Mudlet/Mudlet/issues/6058

You can view the changes rendered at https://github.com/demonnic/Mudlet/tree/update_windows_busted_instructions/src/mudlet-lua/tests

#### Motivation for adding to Mudlet

Keep someone from accidentally blowing up their Mudlet while trying to setup to run tests. 

#### Other info (issues closed, discussion etc)

closes https://github.com/Mudlet/Mudlet/issues/6058