### PR TITLE
fix ansi2decho so that it correctly handles ANSI texts with BOLD first

### DIFF
--- a/src/mudlet-lua/lua/GUIUtils.lua
+++ b/src/mudlet-lua/lua/GUIUtils.lua
@@ -2024,6 +2024,7 @@ end
 function ansi2decho(text, ansi_default_color)
   assert(type(text) == 'string', 'ansi2decho: bad argument #1 type (expected string, got '..type(text)..'!)')
   local lastColour = ansi_default_color
+  local coloursToUse = nil
 
   -- match each set of ansi tags, ie [0;36;40m and convert to decho equivalent.
   -- this works since both ansi colours and echo don't need closing tags and map to each other
@@ -2047,7 +2048,7 @@ function ansi2decho(text, ansi_default_color)
     for i = 0, 7 do
       lightColours[i] = convertindex(i+8)
     end
-    local coloursToUse = colours
+    coloursToUse = coloursToUse or colours
 
     -- since fg/bg can come in different order and we need them as fg:bg for decho, collect
     -- the data first, then assemble it in the order we need at the end

--- a/src/mudlet-lua/tests/GUIUtils_spec.lua
+++ b/src/mudlet-lua/tests/GUIUtils_spec.lua
@@ -100,6 +100,17 @@ describe("Tests the GUI utilities as far as possible without mudlet", function()
       assert.equals(expected, actual)
     end)
 
+    it("Should handle bold, before or after colours", function()
+      local sequences = {
+        {"\27[31m\27[1m", "<128,0,0><255,0,0>"},
+        {"\27[1m\27[31m", "<255,0,0>"},
+      }
+      for _, seq in ipairs(sequences) do
+          local actualResult = ansi2decho(seq[1])
+          assert.are.same(seq[2], actualResult)
+      end
+    end)
+
     it("Should leave normal text and other escape sequences alone", function()
       local sequences = {
         {"Hello World", "Hello World"},


### PR DESCRIPTION
#### Brief overview of PR changes/additions

See description on https://github.com/Mudlet/Mudlet/issues/6185

#### Motivation for adding to Mudlet

My mud uses texts with the _bold_ ANSI code prefixing the actual color codes and, without this, Mudlet doesn't display them properly.

#### Other info (issues closed, discussion etc)

Fixes https://github.com/Mudlet/Mudlet/issues/6185
