### PR TITLE
Fix: Show Coremud description also at new URL

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -953,7 +953,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
                    "and change through the coming years and those players who seek challenge and "
                    "possess imagination will come in search of what the 3D world fails to offer them.");
     }
-    if (hostUrl == QLatin1String("coremud.org") || hostURL == QLating1String("core.evilmog.io")) {
+    if (hostUrl == QLatin1String("coremud.org") || hostURL == QLatin1String("core.evilmog.io")) {
         return qsl("Welcome to Core Mud, an interactive text MUD set on the planet formal star-charts "
                    "refer to as Hermes 571-G, but that everyone in the know refers to simply as \"Core\"."
                    "\n\n"

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -953,7 +953,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
                    "and change through the coming years and those players who seek challenge and "
                    "possess imagination will come in search of what the 3D world fails to offer them.");
     }
-    if (hostUrl == QLatin1String("coremud.org")) {
+    if (hostUrl == QLatin1String("coremud.org") || hostURL == QLating1String("core.evilmog.io")) {
         return qsl("Welcome to Core Mud, an interactive text MUD set on the planet formal star-charts "
                    "refer to as Hermes 571-G, but that everyone in the know refers to simply as \"Core\"."
                    "\n\n"

--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -953,7 +953,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
                    "and change through the coming years and those players who seek challenge and "
                    "possess imagination will come in search of what the 3D world fails to offer them.");
     }
-    if (hostUrl == QLatin1String("coremud.org") || hostURL == QLatin1String("core.evilmog.io")) {
+    if (hostUrl == QLatin1String("coremud.org") || hostUrl == QLatin1String("core.evilmog.io")) {
         return qsl("Welcome to Core Mud, an interactive text MUD set on the planet formal star-charts "
                    "refer to as Hermes 571-G, but that everyone in the know refers to simply as \"Core\"."
                    "\n\n"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Game description text will now be shown again like before the URL change

#### Motivation for adding to Mudlet
Thanks @SlySven for bug report in original PR: https://github.com/Mudlet/Mudlet/pull/6289#issuecomment-1239433835

#### Other info (issues closed, discussion etc)
Confirmed description missing for new profiles:
![image](https://user-images.githubusercontent.com/117238/188978688-da986e72-3923-40b3-ada8-f17f67505e9e.png)
