### PR TITLE
Fix: tab order of variables editor

### DIFF
--- a/src/ui/vars_main_area.ui
+++ b/src/ui/vars_main_area.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
+    <width>515</width>
     <height>75</height>
    </rect>
   </property>

--- a/src/ui/vars_main_area.ui
+++ b/src/ui/vars_main_area.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>515</width>
+    <width>560</width>
     <height>75</height>
    </rect>
   </property>
@@ -86,6 +86,9 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
+        <property name="buddy">
+         <cstring>comboBox_variable_value_type</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">
@@ -110,6 +113,9 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buddy">
+            <cstring>lineEdit_var_name</cstring>
            </property>
           </widget>
          </item>
@@ -176,6 +182,9 @@ from GUI)</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>comboBox_variable_key_type</cstring>
         </property>
        </widget>
       </item>

--- a/src/ui/vars_main_area.ui
+++ b/src/ui/vars_main_area.ui
@@ -216,6 +216,12 @@ from GUI)</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>lineEdit_var_name</tabstop>
+  <tabstop>comboBox_variable_key_type</tabstop>
+  <tabstop>comboBox_variable_value_type</tabstop>
+  <tabstop>checkBox_variable_hidden</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix tab order of variables editor
#### Motivation for adding to Mudlet
Better a11y
#### Other info (issues closed, discussion etc)
All other areas of the script editor have a sane order, just need to use Ctrl+Tab in some places to jump around. Fixed with documentation @ https://wiki.mudlet.org/w/Screen_Readers#Trigger_navigation

Related: https://github.com/Mudlet/Mudlet/issues/1768