### PR TITLE
Fix: named groups will work correctly with multimatches

### DIFF
--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -578,7 +578,7 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         mConditionMap[pCondition] = pCondition;
         pCondition->multiCaptureList.push_back(captureList);
         pCondition->multiCapturePosList.push_back(posList);
-        if (nameMatches != nullptr) {
+        if (nameMatches) {
             pCondition->nameCaptures.push_back(*nameMatches);
         } else {
             pCondition->nameCaptures.push_back(QVector<QPair<QString, QString>>());

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -581,7 +581,7 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         if (nameMatches != nullptr) {
             pCondition->nameCaptures.push_back(*nameMatches);
         } else {
-            pCondition->nameCaptures.push_back(QVector<QPair<QString,QString>>());
+            pCondition->nameCaptures.push_back(QVector<QPair<QString, QString>>());
         }
         if (mudlet::debugMode) {
             TDebug(Qt::darkYellow, Qt::black) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -580,6 +580,8 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         pCondition->multiCapturePosList.push_back(posList);
         if (nameMatches != nullptr) {
             pCondition->nameCaptures.push_back(*nameMatches);
+        } else {
+            pCondition->nameCaptures.push_back(QVector<QPair<QString,QString>>());
         }
         if (mudlet::debugMode) {
             TDebug(Qt::darkYellow, Qt::black) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber

--- a/src/mudlet-lua/lua/DebugTools.lua
+++ b/src/mudlet-lua/lua/DebugTools.lua
@@ -22,7 +22,7 @@ function showMultimatches()
   for k, v in ipairs(multimatches) do
     echo("\nregex " .. k .. " captured: (multimatches[" .. k .. "][1-n])");
     for k2, v2 in pairs(v) do
-      echo("\n          key=" .. k2 .. " value=" .. v2);
+      echo("\n          key=" .. k2 .. " value=" .. v2 .. " ");
     end
   end
   echo("\n-------------------------------------------------------\n");


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Fix: named groups will work correctly with multimatches
Additional I noticed that showMultimatches() cuts last letter of value on dev branch

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
Fixes #6252
Fixes #6180