### PR TITLE
Improve: allow precise movement of map labels

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4322,8 +4322,8 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
         if (room) {
             if (room->customLines.contains(mCustomLineSelectedExit)) {
                 if (room->customLines[mCustomLineSelectedExit].size() > mCustomLineSelectedPoint) {
-                    float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                    float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                    qreal mx = static_cast<qreal>(event->pos().x()) / static_cast<qreal>(mRoomWidth) + mOx - static_cast<qreal>(xspan / 2.0f);
+                    qreal my = static_cast<qreal>(yspan / 2.0f) - static_cast<qreal>(event->pos().y()) / static_cast<qreal>(mRoomHeight) - mOy;
                     QPointF pc = QPointF(mx, my);
                     room->customLines[mCustomLineSelectedExit][mCustomLineSelectedPoint] = pc;
                     room->calcRoomDimensions();
@@ -4353,9 +4353,9 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 if (!mapLabel.highlight) {
                     continue;
                 }
-                int mx = qRound((event->pos().x() / mRoomWidth) + mOx -(xspan / 2.0));
-                int my = qRound((yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy);
-                mapLabel.pos = QVector3D(mx, my, mOz);
+                float mx = (static_cast<float>(event->pos().x()) / mRoomWidth) + static_cast<float>(mOx) -(xspan / 2.0f);
+                float my = (yspan / 2.0f) - (static_cast<float>(event->pos().y()) / mRoomHeight) - static_cast<float>(mOy);
+                mapLabel.pos = QVector3D(mx, my, static_cast<float>(mOz));
                 pA->mMapLabels[itMapLabel.key()] = mapLabel;
                 needUpdate = true;
             }
@@ -4386,11 +4386,10 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
             return;
         }
 
-        float fx = xspan / 2.0 * mRoomWidth - mRoomWidth * mOx;
-        float fy = yspan / 2.0 * mRoomHeight - mRoomHeight * mOy;
-
         if (!mSizeLabel) { // NOT sizing a label
             mMultiSelectionSet.clear();
+            float fx = xspan / 2.0f * mRoomWidth - mRoomWidth * static_cast<float>(mOx);
+            float fy = yspan / 2.0f * mRoomHeight - mRoomHeight * static_cast<float>(mOy);
             QSetIterator<int> itSelectedRoom(pArea->getAreaRooms());
             while (itSelectedRoom.hasNext()) {
                 int currentRoomId = itSelectedRoom.next();
@@ -4398,21 +4397,20 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                 if (!room) {
                     continue;
                 }
-                int rx = qRound(room->x      * mRoomWidth + fx);
-                int ry = qRound(room->y * -1 * mRoomHeight + fy);
-                int rz = room->z;
 
                 // copy rooms on all z-levels if the shift key is being pressed
                 // CHECK: Consider adding z-level to multi-selection Widget?
-                if (rz != mOz && !(event->modifiers().testFlag(Qt::ShiftModifier))) {
+                if ((room->z != mOz) && !(event->modifiers().testFlag(Qt::ShiftModifier))) {
                     continue;
                 }
 
+                float rx = static_cast<float>(room->x     ) * mRoomWidth  + fx;
+                float ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
                 QRectF dr;
                 if (pArea->gridMode) {
-                    dr = QRectF(rx - (mRoomWidth / 2.0), ry - (mRoomHeight / 2.0), mRoomWidth, mRoomHeight);
+                    dr = QRectF(static_cast<qreal>(rx - (mRoomWidth / 2.0f)), static_cast<qreal>(ry - (mRoomHeight / 2.0f)), static_cast<qreal>(mRoomWidth), static_cast<qreal>(mRoomHeight));
                 } else {
-                    dr = QRectF(rx - ((mRoomWidth * rSize) / 2.0), ry - ((mRoomHeight * rSize) / 2.0), mRoomWidth * rSize, mRoomHeight * rSize);
+                    dr = QRectF(static_cast<qreal>(rx - mRoomWidth * static_cast<float>(rSize / 2.0)), static_cast<qreal>(ry - mRoomHeight * static_cast<float>(rSize / 2.0)), static_cast<qreal>(mRoomWidth) * rSize, static_cast<qreal>(mRoomHeight) * rSize);
                 }
                 if (mMultiRect.contains(dr)) {
                     mMultiSelectionSet.insert(currentRoomId);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4404,7 +4404,7 @@ void T2DMap::mouseMoveEvent(QMouseEvent* event)
                     continue;
                 }
 
-                float rx = static_cast<float>(room->x     ) * mRoomWidth  + fx;
+                float rx = static_cast<float>(room->x) * mRoomWidth  + fx;
                 float ry = static_cast<float>(room->y * -1) * mRoomHeight + fy;
                 QRectF dr;
                 if (pArea->gridMode) {


### PR DESCRIPTION
We were rounding the coordinates which was forcing the movements to only be to integer values for the X and Y coordinates. It might be worth revisiting the code in this area in the future so as to provide a "snap-to- grid" capability (but with a smaller step size than the unit space of the room coordinates that this defect was causing!)

Also optimise some bits of code by only doing them if they are needed, i.e. by placing them inside/after some `if (...) {...}`s that might cause their results to be skipped/unused.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>