### PR TITLE
Fix crashing when a TToolBar (floating/dockable toolbar) is turned into a TEasyButtonBar (fixed around main console)

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -285,7 +285,7 @@ int ActionUnit::getNewID()
     return ++mMaxID;
 }
 
-void ActionUnit::regenerateToolBars()
+std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
 {
     for (auto& action : mActionRootNodeList) {
         if (action->mLocation != 4) {
@@ -345,9 +345,11 @@ void ActionUnit::regenerateToolBars()
         action->mpToolBar = pTB;
         pTB->setStyleSheet(pTB->mpTAction->css);
     }
+
+    return mToolBarList;
 }
 
-void ActionUnit::regenerateEasyButtonBars()
+std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
 {
     for (auto& rootAction : mActionRootNodeList) {
         if (rootAction->mLocation == 4) {
@@ -414,6 +416,8 @@ void ActionUnit::regenerateEasyButtonBars()
         rootAction->mpEasyButtonBar = pTB;
         pTB->setStyleSheet(pTB->mpTAction->css);
     }
+
+    return mEasyButtonBarList;
 }
 
 TAction* ActionUnit::getHeadAction(TToolBar* pT)
@@ -589,6 +593,6 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 
 void ActionUnit::updateToolbar()
 {
-    regenerateToolBars();
-    regenerateEasyButtonBars();
+        getToolBarList();
+        getEasyButtonBarList();
 }

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -536,10 +536,6 @@ TAction* ActionUnit::getHeadAction(TEasyButtonBar* pT)
 
 void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 {
-    if (!pA->isDataChanged()) {
-        return;
-    }
-
     pTB->clear();
     if (pA->mLocation == 4) {
         // Floating toolbars are handled differently from EasyButtonBars, and

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -302,14 +302,15 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
         }
         if (action->mPackageName.size() > 0) {
             for (auto& childAction : *action->mpMyChildrenList) {
+                bool found = false;
                 QPointer<TToolBar> pTB = nullptr;
                 for (auto& toolBar : mToolBarList) {
                     if (toolBar == childAction->mpToolBar) {
+                        found = true;
                         pTB = toolBar;
-                        break;
                     }
                 }
-                if (!pTB) {
+                if (!found) {
                     pTB = new TToolBar(childAction, childAction->getName(), mudlet::self());
                     mToolBarList.push_back(pTB);
                 }
@@ -324,15 +325,15 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
             }
             continue; //action package
         }
-
+        bool found = false;
         QPointer<TToolBar> pTB = nullptr;
         for (auto& toolBar : mToolBarList) {
             if (toolBar == action->mpToolBar) {
+                found = true;
                 pTB = toolBar;
-                break;
             }
         }
-        if (!pTB) {
+        if (!found) {
             pTB = new TToolBar(action, action->getName(), mudlet::self());
             mToolBarList.push_back(pTB);
         }
@@ -368,14 +369,15 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
             // It has a package name so it is actually the parent
             // module/package item rather than the actual ToolBar
             for (auto childActionIterator = rootAction->mpMyChildrenList->begin(); childActionIterator != rootAction->mpMyChildrenList->end(); childActionIterator++) {
+                bool found = false;
                 TEasyButtonBar* pTB = nullptr;
                 for (auto& easyButtonBar : mEasyButtonBarList) {
                     if (easyButtonBar == (*childActionIterator)->mpEasyButtonBar) {
+                        found = true;
                         pTB = easyButtonBar;
-                        break;
                     }
                 }
-                if (!pTB) {
+                if (!found) {
                     pTB = new TEasyButtonBar(rootAction, (*childActionIterator)->getName(), mpHost->mpConsole->mpTopToolBar);
                     mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
                     mEasyButtonBarList.emplace_back(pTB);
@@ -392,15 +394,15 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
             }
             continue; //rootAction package
         }
-
+        bool found = false;
         TEasyButtonBar* pTB = nullptr;
         for (auto& easyButtonBar : mEasyButtonBarList) {
             if (easyButtonBar == rootAction->mpEasyButtonBar) {
+                found = true;
                 pTB = easyButtonBar;
-                break;
             }
         }
-        if (!pTB) {
+        if (!found) {
             pTB = new TEasyButtonBar(rootAction, rootAction->getName(), mpHost->mpConsole->mpTopToolBar);
             mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
             mEasyButtonBarList.emplace_back(pTB);

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -167,11 +167,11 @@ void ActionUnit::reParentAction(int childID, int oldParentID, int newParentID, i
             if (pChild->mLocation == 3) {
                 mpHost->mpConsole->mpRightToolBar->layout()->removeWidget(pChild->mpEasyButtonBar);
             }
+        }
+        if (pChild->mpToolBar) {
             if (pChild->mLocation == 4) {
-                if (pChild->mpToolBar) {
-                    pChild->mpToolBar->setFloating(false);
-                    mudlet::self()->removeDockWidget(pChild->mpToolBar);
-                }
+                pChild->mpToolBar->setFloating(false);
+                mudlet::self()->removeDockWidget(pChild->mpToolBar);
             }
         }
     }
@@ -285,23 +285,31 @@ int ActionUnit::getNewID()
     return ++mMaxID;
 }
 
-std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
+void ActionUnit::regenerateToolBars()
 {
     for (auto& action : mActionRootNodeList) {
         if (action->mLocation != 4) {
+            // This TAction is not set to be a floating/dockable widget type toolbar
+            if (action->mpToolBar) {
+                // But it has a TToolBar type toolbar so we need to
+                // remove the ToolBar from the list of TToolBars:
+                mToolBarList.remove(action->mpToolBar);
+                // And destroy it:
+                action->mpToolBar->deleteLater();
+                action->mpToolBar = nullptr;
+            }
             continue; // skip over any root action node that is NOT going to be a TToolBar.
         }
-        if (action->mPackageName.size() > 0) {
+        if (!action->mPackageName.isEmpty()) {
             for (auto& childAction : *action->mpMyChildrenList) {
-                bool found = false;
                 QPointer<TToolBar> pTB = nullptr;
                 for (auto& toolBar : mToolBarList) {
                     if (toolBar == childAction->mpToolBar) {
-                        found = true;
                         pTB = toolBar;
+                        break;
                     }
                 }
-                if (!found) {
+                if (!pTB) {
                     pTB = new TToolBar(childAction, childAction->getName(), mudlet::self());
                     mToolBarList.push_back(pTB);
                 }
@@ -316,15 +324,15 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
             }
             continue; //action package
         }
-        bool found = false;
+
         QPointer<TToolBar> pTB = nullptr;
         for (auto& toolBar : mToolBarList) {
             if (toolBar == action->mpToolBar) {
-                found = true;
                 pTB = toolBar;
+                break;
             }
         }
-        if (!found) {
+        if (!pTB) {
             pTB = new TToolBar(action, action->getName(), mudlet::self());
             mToolBarList.push_back(pTB);
         }
@@ -337,27 +345,36 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
         action->mpToolBar = pTB;
         pTB->setStyleSheet(pTB->mpTAction->css);
     }
-
-    return mToolBarList;
 }
 
-std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
+void ActionUnit::regenerateEasyButtonBars()
 {
     for (auto& rootAction : mActionRootNodeList) {
         if (rootAction->mLocation == 4) {
+            // This TAction is set to be a floating/dockable widget
+            if (rootAction->mpEasyButtonBar) {
+                // But it has a TEasyButtonBar type toolbar so we need to
+                // remove the TEasyButtonBar from the list of TEasyButtonBars:
+                mEasyButtonBarList.remove(rootAction->mpEasyButtonBar);
+                // And destroy it:
+                rootAction->mpEasyButtonBar->deleteLater();
+                rootAction->mpEasyButtonBar = nullptr;
+            }
             continue; // skip over any root action node that IS going to be a TToolBar.
         }
-        if (rootAction->mPackageName.size() > 0) {
+
+        if (!rootAction->mPackageName.isEmpty()) {
+            // It has a package name so it is actually the parent
+            // module/package item rather than the actual ToolBar
             for (auto childActionIterator = rootAction->mpMyChildrenList->begin(); childActionIterator != rootAction->mpMyChildrenList->end(); childActionIterator++) {
-                bool found = false;
                 TEasyButtonBar* pTB = nullptr;
                 for (auto& easyButtonBar : mEasyButtonBarList) {
                     if (easyButtonBar == (*childActionIterator)->mpEasyButtonBar) {
-                        found = true;
                         pTB = easyButtonBar;
+                        break;
                     }
                 }
-                if (!found) {
+                if (!pTB) {
                     pTB = new TEasyButtonBar(rootAction, (*childActionIterator)->getName(), mpHost->mpConsole->mpTopToolBar);
                     mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
                     mEasyButtonBarList.emplace_back(pTB);
@@ -374,15 +391,15 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
             }
             continue; //rootAction package
         }
-        bool found = false;
+
         TEasyButtonBar* pTB = nullptr;
         for (auto& easyButtonBar : mEasyButtonBarList) {
             if (easyButtonBar == rootAction->mpEasyButtonBar) {
-                found = true;
                 pTB = easyButtonBar;
+                break;
             }
         }
-        if (!found) {
+        if (!pTB) {
             pTB = new TEasyButtonBar(rootAction, rootAction->getName(), mpHost->mpConsole->mpTopToolBar);
             mpHost->mpConsole->mpTopToolBar->layout()->addWidget(pTB);
             mEasyButtonBarList.emplace_back(pTB);
@@ -397,8 +414,6 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
         rootAction->mpEasyButtonBar = pTB;
         pTB->setStyleSheet(pTB->mpTAction->css);
     }
-
-    return mEasyButtonBarList;
 }
 
 TAction* ActionUnit::getHeadAction(TToolBar* pT)
@@ -443,7 +458,21 @@ void ActionUnit::constructToolbar(TAction* pA, TToolBar* pTB)
     }
 
     pTB->clear();
-    if ((pA->mLocation != 4) || (!pA->isActive())) {
+    if (pA->mLocation != 4) {
+        // EasyButtonBars are handled differently from ToolBars, and
+        // if we get here then the TAction has just been changed to be one of
+        // those; we might still have a TToolBar associated with the
+        // (owner) TAction and if so we need to dispose of it:
+        if (pA->mpToolBar) {
+            // We need to remove the TToolBar from the list of TToolBars
+            mToolBarList.remove(pA->mpToolBar);
+            // before we get rid of it:
+            pA->mpToolBar->deleteLater();
+            pA->mpToolBar = nullptr;
+        }
+    }
+
+    if (!pA->isActive()) {
         pTB->setFloating(false);
         mudlet::self()->removeDockWidget(pTB);
         return;
@@ -502,11 +531,30 @@ TAction* ActionUnit::getHeadAction(TEasyButtonBar* pT)
 
 void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 {
-    pTB->clear();
-    if (pA->mLocation == 4) {
-        //floating toolbars are handled differently
+    if (!pA->isDataChanged()) {
         return;
     }
+
+    pTB->clear();
+    if (pA->mLocation == 4) {
+        // Floating toolbars are handled differently from EasyButtonBars, and
+        // if we get here then the TAction has just been changed to be one of
+        // those; we might still have a TEasyButtonBar associated with the
+        // (owner) TAction and if so we need to dispose of it:
+        if (pA->mpEasyButtonBar) {
+            // We need to remove the TEasyButtonBar from the list of TEasyButtonBars
+            mEasyButtonBarList.remove(pA->mpEasyButtonBar);
+            // before we get rid of it:
+            pA->mpEasyButtonBar->deleteLater();
+            pA->mpEasyButtonBar = nullptr;
+        }
+        return;
+    }
+
+    // However, just because pA->mLocation != 4 does not mean that pA is for a
+    // TEasyButtonBar - it could be a menu or a button or a package/module
+    // (container)
+
     if (!pA->isActive()) {
         pTB->hide();
         return;
@@ -541,6 +589,6 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 
 void ActionUnit::updateToolbar()
 {
-        getToolBarList();
-        getEasyButtonBarList();
+    regenerateToolBars();
+    regenerateEasyButtonBars();
 }

--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -300,7 +300,7 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
             }
             continue; // skip over any root action node that is NOT going to be a TToolBar.
         }
-        if (!action->mPackageName.isEmpty()) {
+        if (action->mPackageName.size() > 0) {
             for (auto& childAction : *action->mpMyChildrenList) {
                 QPointer<TToolBar> pTB = nullptr;
                 for (auto& toolBar : mToolBarList) {
@@ -364,8 +364,7 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
             }
             continue; // skip over any root action node that IS going to be a TToolBar.
         }
-
-        if (!rootAction->mPackageName.isEmpty()) {
+        if (rootAction->mPackageName.size() > 0) {
             // It has a package name so it is actually the parent
             // module/package item rather than the actual ToolBar
             for (auto childActionIterator = rootAction->mpMyChildrenList->begin(); childActionIterator != rootAction->mpMyChildrenList->end(); childActionIterator++) {

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -69,11 +69,10 @@ public:
     void uninstall(const QString&);
     void _uninstall(TAction* pChild, const QString& packageName);
     void updateToolbar();
+    std::list<QPointer<TToolBar>> getToolBarList();
+    std::list<QPointer<TEasyButtonBar>> getEasyButtonBarList();
     TAction* getHeadAction(TToolBar*);
     TAction* getHeadAction(TEasyButtonBar*);
-    std::list<QPointer<TToolBar>> getToolBarList() { return mToolBarList; }
-    void regenerateToolBars();
-    void regenerateEasyButtonBars();
     void constructToolbar(TAction*, TToolBar* pTB);
     void constructToolbar(TAction*, TEasyButtonBar* pTB);
     void showToolBar(const QString&);

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -93,6 +93,8 @@ private:
     QMap<int, TAction*> mActionMap;
     std::list<TAction*> mActionRootNodeList;
     int mMaxID = 0;
+    QPointer<TToolBar> mpToolBar;
+    QPointer<TEasyButtonBar> mpEasyButtonBar;
     bool mModuleMember = false;
     std::list<QPointer<TToolBar>> mToolBarList;
     std::list<QPointer<TEasyButtonBar>> mEasyButtonBarList;

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -69,10 +69,11 @@ public:
     void uninstall(const QString&);
     void _uninstall(TAction* pChild, const QString& packageName);
     void updateToolbar();
-    std::list<QPointer<TToolBar>> getToolBarList();
-    std::list<QPointer<TEasyButtonBar>> getEasyButtonBarList();
     TAction* getHeadAction(TToolBar*);
     TAction* getHeadAction(TEasyButtonBar*);
+    std::list<QPointer<TToolBar>> getToolBarList() { return mToolBarList; }
+    void regenerateToolBars();
+    void regenerateEasyButtonBars();
     void constructToolbar(TAction*, TToolBar* pTB);
     void constructToolbar(TAction*, TEasyButtonBar* pTB);
     void showToolBar(const QString&);
@@ -92,8 +93,6 @@ private:
     QMap<int, TAction*> mActionMap;
     std::list<TAction*> mActionRootNodeList;
     int mMaxID = 0;
-    QPointer<TToolBar> mpToolBar;
-    QPointer<TEasyButtonBar> mpEasyButtonBar;
     bool mModuleMember = false;
     std::list<QPointer<TToolBar>> mToolBarList;
     std::list<QPointer<TEasyButtonBar>> mEasyButtonBarList;

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3862,7 +3862,7 @@ bool Host::commitLayoutUpdates(bool flush)
     if (mpConsole && !flush) {
         // commit changes (or rather clear the layout changed flags) for dockwidget
         // consoles (user windows)
-        for (auto dockedConsoleName : mDockLayoutChanges) {
+        for (auto dockedConsoleName : qAsConst(mDockLayoutChanges)) {
             auto pD = mpConsole->mDockWidgetMap.value(dockedConsoleName);
             if (Q_LIKELY(pD) && pD->property("layoutChanged").toBool()) {
                 pD->setProperty("layoutChanged", QVariant(false));
@@ -3875,10 +3875,11 @@ bool Host::commitLayoutUpdates(bool flush)
     // commit changes (or rather clear the layout changed flags) for
     // dockable/floating toolbars across all profiles:
     if (!flush) {
-        for (auto pToolBar : mToolbarLayoutChanges) {
-            // Under some circumstances there is NOT a
-            // pToolBar->property("layoutChanged") and examining that
-            // non-existent variant to see if it was true or false causes seg. faults!
+        for (auto pToolBar : qAsConst(mToolbarLayoutChanges)) {
+            if (!pToolBar || pToolBar.isNull()) {
+                // This can happen when a TToolBar is deleted
+                continue;
+            }
             if (Q_UNLIKELY(!pToolBar->property("layoutChanged").isValid())) {
                 qWarning().nospace().noquote() << "host::commitLayoutUpdates() WARNING - was about to check for \"layoutChanged\" meta-property on a toolbar without that property!";
             } else if (pToolBar->property("layoutChanged").toBool()) {

--- a/src/Host.h
+++ b/src/Host.h
@@ -640,7 +640,7 @@ public:
     QPointer<dlgIRC> mpDlgIRC;
     QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
     QList<QString> mDockLayoutChanges;
-    QList<TToolBar*> mToolbarLayoutChanges;
+    QList<QPointer<TToolBar>> mToolbarLayoutChanges;
 
     // string list: 0 - event name, 1 - display label, 2 - tooltip text
     QMap<QString, QStringList> mConsoleActions;


### PR DESCRIPTION
It seems that although we added new `TToolBar`s and `TEasyButtonBar`s to a pair of `std::list<QPointer<T>>` containers we were not removing them from those containers when they were (or should) have been deleted. We were also not removing them from their owner `TAction`s when changing from one to the other.

~~Also:~~
~~* change a couple of `QString::size() > 0` to `!QString::isEmpty()` as that better represents the spirit of the test~~
~~* remove some `(bool)` local variables as a pointer assigned a value in the same process that would be setting that boolean to `true` would also be setting the pointer to an equally testable non-`nullptr` value.~~
~~* rename a couple of methods called `getXxxxList()` that return a `std::list<QPointer<Xxxx>>` to `regenerateXxxxs()` that are `void` methods. This is because the return values are not used (and the data that would have been returned is actually stored in members of the `ActionUnit` class; furthermore this sort of miss-naming things is something that the additions of https://github.com/Mudlet/Mudlet/pull/6246 are trying to eliminate..~~

This should have closed https://github.com/Mudlet/Mudlet/issues/6293. However, now that we are properly deleting `TToolBar` instances their removals now causes crashes in the code that records where `QDockWidget` derived class instances are positioned. It probably also explains a comment I made in https://github.com/Mudlet/Mudlet/pull/4040!

To improve the situation I have converted `Host::mToolbarLayoutChanges` from a `QList<TToolBar*>` to a `QList<QPointer<TToolBar>>` which will help to identify if the pointed to items have been deleted.

There were also a couple of places in the modified method where I was seeing warnings about C++11 "Range loop detach"	potentially happening on non-`const` Qt containers in range-for loops - which can be fixed by wrapping the container in `qAsConst(`...`)`.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>