### PR TITLE
Infrastructure: remove some cruft from `ActionUnit` header

### DIFF
--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -92,8 +92,6 @@ private:
     QMap<int, TAction*> mActionMap;
     std::list<TAction*> mActionRootNodeList;
     int mMaxID = 0;
-    QPointer<TToolBar> mpToolBar;
-    QPointer<TEasyButtonBar> mpEasyButtonBar;
     bool mModuleMember = false;
     std::list<QPointer<TToolBar>> mToolBarList;
     std::list<QPointer<TEasyButtonBar>> mEasyButtonBarList;


### PR DESCRIPTION
Originally done in #6330 but not germane to the issue being addressed there, so factored out to a separate PR.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>