### PR TITLE
Infrastructure: change badly named ActionUnit::getXxxxBarList() methods

### DIFF
--- a/src/ActionUnit.cpp
+++ b/src/ActionUnit.cpp
@@ -285,7 +285,7 @@ int ActionUnit::getNewID()
     return ++mMaxID;
 }
 
-std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
+void ActionUnit::regenerateToolBars()
 {
     for (auto& action : mActionRootNodeList) {
         if (action->mLocation != 4) {
@@ -337,11 +337,9 @@ std::list<QPointer<TToolBar>> ActionUnit::getToolBarList()
         action->mpToolBar = pTB;
         pTB->setStyleSheet(pTB->mpTAction->css);
     }
-
-    return mToolBarList;
 }
 
-std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
+void ActionUnit::regenerateEasyButtonBars()
 {
     for (auto& rootAction : mActionRootNodeList) {
         if (rootAction->mLocation == 4) {
@@ -397,8 +395,6 @@ std::list<QPointer<TEasyButtonBar>> ActionUnit::getEasyButtonBarList()
         rootAction->mpEasyButtonBar = pTB;
         pTB->setStyleSheet(pTB->mpTAction->css);
     }
-
-    return mEasyButtonBarList;
 }
 
 TAction* ActionUnit::getHeadAction(TToolBar* pT)
@@ -541,6 +537,6 @@ void ActionUnit::constructToolbar(TAction* pA, TEasyButtonBar* pTB)
 
 void ActionUnit::updateToolbar()
 {
-        getToolBarList();
-        getEasyButtonBarList();
+    regenerateToolBars();
+    regenerateEasyButtonBars();
 }

--- a/src/ActionUnit.h
+++ b/src/ActionUnit.h
@@ -69,10 +69,11 @@ public:
     void uninstall(const QString&);
     void _uninstall(TAction* pChild, const QString& packageName);
     void updateToolbar();
-    std::list<QPointer<TToolBar>> getToolBarList();
-    std::list<QPointer<TEasyButtonBar>> getEasyButtonBarList();
+    std::list<QPointer<TToolBar>> getToolBarList() { return mToolBarList; }
     TAction* getHeadAction(TToolBar*);
     TAction* getHeadAction(TEasyButtonBar*);
+    void regenerateToolBars();
+    void regenerateEasyButtonBars();
     void constructToolbar(TAction*, TToolBar* pTB);
     void constructToolbar(TAction*, TEasyButtonBar* pTB);
     void showToolBar(const QString&);


### PR DESCRIPTION
There are a couple of methods called `getXxxxList()` that return a `std::list<QPointer<Xxxx>>` which are changed here to `regenerateXxxxs()` that are `void` methods. This is because the return values are not used (and the data that would have been returned is actually stored in members of the `ActionUnit` class; furthermore this sort of miss-naming things is something that the additions of #6246 are trying to eliminate.

Originally done in #6330 but not germane to the issue being addressed there, so factored out to a separate PR.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>