### PR TITLE
Infrastructure: use correct alias for installing Lua on macOS

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -4,7 +4,7 @@ set +e
 shopt -s expand_aliases
 #Removed boost as first item as a temporary workaround to prevent trying to
 #upgrade to boost version 1.68.0 which has not been bottled yet...
-BREWS="luarocks cmake hunspell libzip lua51 pcre pkg-config qt5 yajl ccache pugixml"
+BREWS="luarocks cmake hunspell libzip lua@5.1 pcre pkg-config qt5 yajl ccache pugixml"
 OUTDATED_BREWS=$(brew outdated)
 
 for i in $BREWS; do


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Use correct alias for installing Lua via homebrew on macOS
#### Motivation for adding to Mudlet
Fixes this:

```
Installing lua51
Warning: Use lua@5.1 instead of deprecated lua51
```
#### Other info (issues closed, discussion etc)
