### PR TITLE
Infrastructure: Remove possibly unneeded concurrent-ruby install

### DIFF
--- a/CI/travis.osx.install.sh
+++ b/CI/travis.osx.install.sh
@@ -54,7 +54,6 @@ for i in $BREWS; do
     fi
   done
 done
-gem install concurrent-ruby
 gem update cocoapods
 
 # create an alias to avoid the need to list the lua dir all the time


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Running `./CI/travis.osx.install.sh` on a macOS local system fails because concurrent-ruby requires admin rights to install. Before I dive into the hassle of making a password prompt, maybe this dependency is not needed anymore? It was introduced as a workaround for https://github.com/Mudlet/Mudlet/pull/3130 originally.
#### Motivation for adding to Mudlet
Less hassle for macOS developers.
#### Other info (issues closed, discussion etc)
