### PR TITLE
Infrastructure: fix CodeQL job permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,9 @@ jobs:
   analyze:
     name: ${{matrix.buildname}}
     runs-on: ubuntu-latest
+    
+    permissions:
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
   analyze:
     name: ${{matrix.buildname}}
     runs-on: ubuntu-latest
-    
+
     permissions:
       security-events: write
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix CodeQL job permissions
#### Motivation for adding to Mudlet
So the CodeQL job can properly report errors it finds, I suppose
#### Other info (issues closed, discussion etc)
See example at https://github.com/github/codeql-action#usage