### PR TITLE
Infra: Remove stray whitespace

### DIFF
--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -121,7 +121,10 @@ bool TAlias::match(const QString& toMatch)
 
     if (rc == 0) {
         if (mpHost->mpEditorDialog) {
-            mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Alias Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
+            mpHost->mpEditorDialog->mpErrorConsole->print(
+                qsl("%1\n").arg(tr("[Alias Error:] %1 capture group limit exceeded, capture less groups.").arg(MAX_CAPTURE_GROUPS)),
+                QColor(255, 128, 0),
+                QColor(Qt::black));
         }
         qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
     } else {
@@ -189,7 +192,10 @@ bool TAlias::match(const QString& toMatch)
             goto END;
         } else if (rc == 0) {
             if (mpHost->mpEditorDialog) {
-                mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Alias Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
+                mpHost->mpEditorDialog->mpErrorConsole->print(
+                    qsl("%1\n").arg(tr("[Alias Error:] %1 capture group limit exceeded, capture less groups.").arg(MAX_CAPTURE_GROUPS)),
+                    QColor(255, 128, 0),
+                    QColor(Qt::black));
             }
             qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
         }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -15558,7 +15558,7 @@ void TLuaInterpreter::initIndenterGlobals()
         if (lua_isstring(pIndenterState.get(), -1)) {
             e = tr("Lua error: %1.").arg(lua_tostring(pIndenterState.get(), -1));
         }
-        QString msg = tr("[ ERROR ] - Cannot load code formatter, indenting functionality won't be available.\n");
+        QString msg = qsl("%1\n").arg(tr("[ ERROR ] - Cannot load code formatter, indenting functionality won't be available."));
         msg.append(e);
         mpHost->postMessage(msg);
     }

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -216,7 +216,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         QTextCodec* pLogCodec = QTextCodec::codecForName("UTF-8");
         mLogStream.setCodec(pLogCodec);
         if (isMessageEnabled) {
-            QString message = tr("Logging has started. Log file is %1\n").arg(mLogFile.fileName());
+            QString message = qsl("%1\n").arg(tr("Logging has started. Log file is %1").arg(mLogFile.fileName()));
             printSystemMessage(message);
             // This puts text onto console that is IMMEDIATELY POSTED into log file so
             // must be done BEFORE logging starts - or actually mLogToLogFile gets set!
@@ -226,7 +226,7 @@ void TMainConsole::toggleLogging(bool isMessageEnabled)
         file.remove();
         mLogToLogFile = false;
         if (isMessageEnabled) {
-            QString message = tr("Logging has been stopped. Log file is %1\n").arg(mLogFile.fileName());
+            QString message = qsl("%1\n").arg(tr("Logging has been stopped. Log file is %1").arg(mLogFile.fileName()));
             printSystemMessage(message);
             // This puts text onto console that is IMMEDIATELY POSTED into log file so
             // must be done AFTER logging ends - or actually mLogToLogFile gets reset!
@@ -1442,10 +1442,11 @@ void TMainConsole::showStatistics()
         return;
     }
 
-    QString header = tr("+--------------------------------------------------------------+\n"
-                        "|                      system statistics                       |\n"
-                        "+--------------------------------------------------------------+\n",
-                        "Header for the system's statistics information displayed in the console, it is 64 'narrow' characters wide");
+    QString header = qsl("%1\n").arg(tr(
+        "+--------------------------------------------------------------+\n"
+        "|                      system statistics                       |\n"
+        "+--------------------------------------------------------------+",
+        "Header for the system's statistics information displayed in the console, it is 64 'narrow' characters wide"));
     print(header, QColor(150, 120, 0), Qt::black);
 
     QStringList subjects;

--- a/src/TMap.cpp
+++ b/src/TMap.cpp
@@ -109,7 +109,7 @@ void TMap::mapClear()
 void TMap::logError(QString& msg)
 {
     if (mpHost->mpEditorDialog) {
-        mpHost->mpEditorDialog->mpErrorConsole->print(tr("[MAP ERROR:]%1\n").arg(msg), QColor(255, 128, 0), QColor(Qt::black));
+        mpHost->mpEditorDialog->mpErrorConsole->print(qsl("%1\n").arg(tr("[MAP ERROR:]%1").arg(msg)), QColor(255, 128, 0), QColor(Qt::black));
     }
 }
 

--- a/src/TRoom.cpp
+++ b/src/TRoom.cpp
@@ -1632,11 +1632,12 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             QString auditKeyLocked = qsl("audit.invalid_exit.%1.isLocked").arg(dirCode);
             userData.insert(auditKeyLocked, qsl("true"));
             if (mudlet::self()->showMapAuditErrors()) {
-                infoMsg.append(tr("\nIt was locked, this is recorded as user data with key:\n"
-                                  "\"%1\".")
-                                       .arg(auditKeyLocked));
+                infoMsg.append(
+                    qsl("\n%1").arg(
+                        tr("It was locked, this is recorded as user data with key:\n\"%1\".")
+                        .arg(auditKeyLocked)));
             }
-            logMsg.append(tr(R"(  It was locked, this is recorded as user data with key: "%1".)").arg(auditKeyLocked));
+            logMsg.append(qsl("  %1").arg(tr(R"(It was locked, this is recorded as user data with key: "%1".)").arg(auditKeyLocked)));
             exitLocks.removeAll(dirCode);
         }
 
@@ -1644,11 +1645,12 @@ void TRoom::auditExit(int& exitRoomId,                     // Reference to where
             QString auditKeyWeight = qsl("audit.invalid_exit.%1.weight").arg(dirCode);
             userData.insert(auditKeyWeight, QString::number(exitWeights.value(exitKey)));
             if (mudlet::self()->showMapAuditErrors()) {
-                infoMsg.append(tr("\nIt had a weight, this is recorded as user data with key:\n"
-                                  "\"%1\".")
-                                       .arg(auditKeyWeight));
+                infoMsg.append(
+                    qsl("\n%1").arg(
+                        tr("It had a weight, this is recorded as user data with key:\n\"%1\".")
+                        .arg(auditKeyWeight)));
             }
-            logMsg.append(tr(R"(  It had a weight, this is recorded as user data with key: "%1".)").arg(auditKeyWeight));
+            logMsg.append(qsl("  %1").arg(tr(R"(It had a weight, this is recorded as user data with key: "%1".)").arg(auditKeyWeight)));
             exitWeights.remove(exitKey);
         }
         if (mudlet::self()->showMapAuditErrors()) {

--- a/src/TRoomDB.cpp
+++ b/src/TRoomDB.cpp
@@ -854,7 +854,7 @@ void TRoomDB::auditRooms(QHash<int, int>& roomRemapping, QHash<int, int>& areaRe
 
         QString infoMsg;
         if (mudlet::self()->showMapAuditErrors()) {
-            infoMsg = tr("[ INFO ]  - The renumbered rooms will be:\n");
+            infoMsg = qsl("%1\n").arg(tr("[ INFO ]  - The renumbered rooms will be:"));
         }
         QMutableHashIterator<int, int> itRenumberedRoomId(roomRemapping);
         while (itRenumberedRoomId.hasNext()) {
@@ -1174,8 +1174,8 @@ void TRoomDB::restoreAreaMap(QDataStream& ifs)
                     R"(It has been detected that "_###" form suffixes have already been used, for simplicity in the renaming algorithm these will have been removed and possibly changed as Mudlet sorts this matter out, if a number assigned in this way <b>is</b> important to you, you can change it back, provided you rename the area that has been allocated the suffix that was wanted first...!</p>)");
         }
         if (!renamedMap.empty()) {
-            detailText = tr("[  OK  ]  - The changes made are:\n"
-                            "(ID) \"old name\" ==> \"new name\"\n");
+            detailText = qsl("%1\n").arg(tr("[  OK  ]  - The changes made are:\n"
+                                            "(ID) \"old name\" ==> \"new name\""));
             QMapIterator<QString, QString> itRemappedNames = renamedMap;
             itRemappedNames.toBack();
             // Seems to look better if we iterate through backwards!

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1569,7 +1569,7 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
             QAction* clearErrorConsole = new QAction(tr("Clear console"), this);
             connect(clearErrorConsole, &QAction::triggered, this, [=]() {
                 mpConsole->buffer.clear();
-                mpConsole->print(tr("*** starting new session ***\n"));
+                mpConsole->print(qsl("%1\n").arg(tr("*** starting new session ***")));
             });
             popup->addAction(clearErrorConsole);
         }

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -322,7 +322,10 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
 {
     if (rc == 0) {
         if (mpHost->mpEditorDialog) {
-            mpHost->mpEditorDialog->mpErrorConsole->print(tr("[Trigger Error:] %1 capture group limit exceeded, capture less groups.\n").arg(MAX_CAPTURE_GROUPS), QColor(255, 128, 0), QColor(Qt::black));
+            mpHost->mpEditorDialog->mpErrorConsole->print(
+                qsl("%1\n").arg(tr("[Trigger Error:] %1 capture group limit exceeded, capture less groups.").arg(MAX_CAPTURE_GROUPS)),
+                QColor(255, 128, 0),
+                QColor(Qt::black));
         }
         qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
     }
@@ -1158,12 +1161,12 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
 
                 if (mudlet::debugMode) {
                     // FIXME: This message is translated - but most other TDebug ones are not!
-                    TDebug(Qt::yellow, Qt::darkMagenta) << tr("Trigger name=%1 expired.\n").arg(mName) >> mpHost;
+                    TDebug(Qt::yellow, Qt::darkMagenta) << qsl("%1\n").arg(tr("Trigger name=%1 expired.").arg(mName)) >> mpHost;
                 }
 
             } else if (mudlet::debugMode) {
                 // FIXME: This message is translated - but most other TDebug ones are not!
-                TDebug(Qt::yellow, Qt::darkMagenta) << tr("Trigger name=%1 will fire %n more time(s).\n", "", mExpiryCount).arg(mName) >> mpHost;
+                TDebug(Qt::yellow, Qt::darkMagenta) << qsl("%1\n").arg(tr("Trigger name=%1 will fire %n more time(s).", "", mExpiryCount).arg(mName)) >> mpHost;
             }
         }
 

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -563,18 +563,18 @@ void cTelnet::slot_socketHostFound(QHostInfo hostInfo)
 {
 #if !defined(QT_NO_SSL)
     if (mpHost->mSslTsl) {
-        postMessage(tr("[ INFO ]  - Trying secure connection to %1: %2 ...\n").arg(hostInfo.hostName(), QString::number(hostPort)));
+        postMessage(qsl("%1\n").arg(tr("[ INFO ]  - Trying secure connection to %1: %2 ...").arg(hostInfo.hostName(), QString::number(hostPort))));
         socket.connectToHostEncrypted(hostInfo.hostName(), hostPort, QIODevice::ReadWrite);
 
     } else {
 #endif
         if (!hostInfo.addresses().isEmpty()) {
             mHostAddress = hostInfo.addresses().constFirst();
-            postMessage(tr("[ INFO ]  - The IP address of %1 has been found. It is: %2\n").arg(hostName, mHostAddress.toString()));
+            postMessage(qsl("%1\n").arg(tr("[ INFO ]  - The IP address of %1 has been found. It is: %2").arg(hostName, mHostAddress.toString())));
             if (!mConnectViaProxy) {
-                postMessage(tr("[ INFO ]  - Trying to connect to %1:%2 ...\n").arg(mHostAddress.toString(), QString::number(hostPort)));
+                postMessage(qsl("%1\n").arg(tr("[ INFO ]  - Trying to connect to %1:%2 ...").arg(mHostAddress.toString(), QString::number(hostPort))));
             } else {
-                postMessage(tr("[ INFO ]  - Trying to connect to %1:%2 via proxy...\n").arg(mHostAddress.toString(), QString::number(hostPort)));
+                postMessage(qsl("%1\n").arg(tr("[ INFO ]  - Trying to connect to %1:%2 via proxy...").arg(mHostAddress.toString(), QString::number(hostPort))));
             }
             socket.connectToHost(mHostAddress, hostPort);
         } else {

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -208,7 +208,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     // Update the editor preferences
     connect(mudlet::self(), &mudlet::signal_editorTextOptionsChanged, this, &dlgTriggerEditor::slot_changeEditorTextOptions);
-    mpSourceEditorEdbeeDocument->setText(tr("-- Enter your lua code here\n"));
+    mpSourceEditorEdbeeDocument->setText(qsl("%1\n").arg(tr("-- Enter your lua code here")));
 
     mudlet::loadEdbeeTheme(mpHost->mEditorTheme, mpHost->mEditorThemeFile);
 
@@ -288,7 +288,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mpErrorConsole->setWrapAt(100);
     mpErrorConsole->mUpperPane->slot_toggleTimeStamps(true);
     mpErrorConsole->mLowerPane->slot_toggleTimeStamps(true);
-    mpErrorConsole->print(tr("*** starting new session ***\n"));
+    mpErrorConsole->print(qsl("%1\n").arg(tr("*** starting new session ***")));
     mpErrorConsole->setMinimumHeight(100);
     mpErrorConsole->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Minimum);
     splitter_right->addWidget(mpErrorConsole);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,14 +225,14 @@ int main(int argc, char* argv[])
     QStringList texts;
     if (parser.isSet(showHelp)) {
         // Do "help" action
-        texts << QCoreApplication::translate("main", "Usage: %1 [OPTION...]\n"
-                                                     "       -h, --help           displays this message.\n"
-                                                     "       -v, --version        displays version information.\n"
-                                                     "       -q, --quiet          no splash screen on startup.\n"
-                                                     "       --profile=<profile>  additional profile to open\n\n"
-                                                     "There are other inherited options that arise from the Qt Libraries which are\n"
-                                                     "less likely to be useful for normal use of this application:\n")
-                 .arg(QLatin1String(APP_TARGET));
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Usage: %1 [OPTION...]\n"
+                               "       -h, --help           displays this message.\n"
+                               "       -v, --version        displays version information.\n"
+                               "       -q, --quiet          no splash screen on startup.\n"
+                               "       --profile=<profile>  additional profile to open\n\n"
+                               "There are other inherited options that arise from the Qt Libraries which are\n"
+                               "less likely to be useful for normal use of this application:")
+                 .arg(QLatin1String(APP_TARGET)));
         // From documentation and from http://qt-project.org/doc/qt-5/qapplication.html:
         texts << qsl("       --dograb        ignore any implicit or explicit -nograb.\n"
                                 "                       --dograb wins over --nograb even when --nograb is last on\n"
@@ -273,8 +273,8 @@ int main(int argc, char* argv[])
                                 "                       specified port. The number is the port value and block is\n"
                                 "                       optional and will make the application wait until a\n"
                                 "                       debugger connects to it.\n\n");
-        texts << QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues\n");
-        texts << QCoreApplication::translate("main", "Project home page: http://www.mudlet.org/\n");
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues"));
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Project home page: http://www.mudlet.org/"));
         std::cout << texts.join(QString()).toStdString();
         return 0;
     }
@@ -282,19 +282,20 @@ int main(int argc, char* argv[])
     if (parser.isSet(showVersion)) {
         // Do "version" action - wording and format is quite tightly specified by the coding standards
 #if defined(QT_DEBUG)
-        texts << QCoreApplication::translate("main", "%1 %2%3 (with debug symbols, without optimisations)\n",
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "%1 %2%3 (with debug symbols, without optimisations)",
          "%1 is the name of the application like mudlet or Mudlet.exe, %2 is the version number like 3.20 and %3 is a build suffix like -dev")
-                 .arg(QLatin1String(APP_TARGET), QLatin1String(APP_VERSION), QLatin1String(APP_BUILD));
+                 .arg(QLatin1String(APP_TARGET), QLatin1String(APP_VERSION), QLatin1String(APP_BUILD)));
 #else // ! defined(QT_DEBUG)
         texts << QLatin1String(APP_TARGET " " APP_VERSION APP_BUILD " \n");
 #endif // ! defined(QT_DEBUG)
-        texts << QCoreApplication::translate("main", "Qt libraries %1 (compilation) %2 (runtime)\n",
-             "%1 and %2 are version numbers").arg(QLatin1String(QT_VERSION_STR), qVersion());
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Qt libraries %1 (compilation) %2 (runtime)",
+             "%1 and %2 are version numbers").arg(QLatin1String(QT_VERSION_STR), qVersion()));
         // PLACEMARKER: Date-stamp needing annual update
-        texts << QCoreApplication::translate("main", "Copyright © 2008-2022  Mudlet developers\n");
-        texts << QCoreApplication::translate("main", "Licence GPLv2+: GNU GPL version 2 or later - http://gnu.org/licenses/gpl.html\n");
-        texts << QCoreApplication::translate("main", "This is free software: you are free to change and redistribute it.\n"
-                                                     "There is NO WARRANTY, to the extent permitted by law.\n");
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Copyright © 2008-2022  Mudlet developers"));
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Licence GPLv2+: GNU GPL version 2 or later - http://gnu.org/licenses/gpl.html"));
+        texts << qsl("%1\n").arg(QCoreApplication::translate("main",
+            "This is free software: you are free to change and redistribute it.\n"
+            "There is NO WARRANTY, to the extent permitted by law."));
         std::cout << texts.join(QString()).toStdString();
         return 0;
     }

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -113,15 +113,16 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         TArea* area = mpHost->mpMap->mpRoomDB->getArea(areaId);
         QString areaName = mpHost->mpMap->mpRoomDB->getAreaNamesMap().value(areaId);
         if (area) {
-            infoText = tr("Area:%1%2 ID:%1%3 x:%1%4%1<‑>%1%5 y:%1%6%1<‑>%1%7 z:%1%8%1<‑>%1%9\n",
-                          // Intentional separator
-                          "This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle "
-                          "them literally in raw strings) and non-breaking hyphens which are used to "
-                          "prevent the line being split at some places it might otherwise be; when "
-                          "translating please consider at which points the text may be divided to fit onto "
-                          "more than one line. "
-                          "%2 is the (text) name of the area, %3 is the number for it, "
-                          "%4 to %9 are pairs (min <-> max) of extremes for each of x,y and z coordinates")
+            infoText = qsl("%1\n").arg(
+                           tr("Area:%1%2 ID:%1%3 x:%1%4%1<‑>%1%5 y:%1%6%1<‑>%1%7 z:%1%8%1<‑>%1%9",
+                           // Intentional separator
+                           "This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle "
+                           "them literally in raw strings) and non-breaking hyphens which are used to "
+                           "prevent the line being split at some places it might otherwise be; when "
+                           "translating please consider at which points the text may be divided to fit onto "
+                           "more than one line. "
+                           "%2 is the (text) name of the area, %3 is the number for it, "
+                           "%4 to %9 are pairs (min <-> max) of extremes for each of x,y and z coordinates")
                                .arg(QChar(160),
                                     areaName,
                                     QString::number(areaId),
@@ -130,14 +131,14 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                     QString::number(area->min_y),
                                     QString::number(area->max_y),
                                     QString::number(area->min_z),
-                                    QString::number(area->max_z));
+                                    QString::number(area->max_z)));
         } else {
             infoText = QChar::LineFeed;
         }
 
 
         if (!room->name.isEmpty()) {
-            infoText.append(tr("Room Name: %1\n").arg(room->name));
+            infoText.append(qsl("%1\n").arg(tr("Room Name: %1").arg(room->name)));
         }
 
         // Italicise the text if the current display area {mAreaID} is not the
@@ -150,7 +151,8 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         // If one or more rooms are selected - make the text slightly orange.
         switch (selectionSize) {
         case 0:
-            infoText.append(tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1current player location\n",
+            infoText.append(qsl("%1\n").arg(
+                               tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1current player location",
                                // Intentional comment to separate arguments
                                "This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle "
                                "them literally in raw strings) and a non-breaking hyphen which are used to "
@@ -159,7 +161,11 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                "more than one line. "
                                "This text is for when NO rooms are selected, %3 is the room number "
                                "of, and %4-%6 are the x,y and z coordinates for, the current player's room.")
-                                    .arg(QChar(160), QString::number(roomID), QString::number(room->x), QString::number(room->y), QString::number(room->z)));
+                                    .arg(QChar(160),
+                                        QString::number(roomID),
+                                        QString::number(room->x),
+                                        QString::number(room->y),
+                                        QString::number(room->z))));
             if (areaId != displayAreaId) {
                 isItalic = true;
             } else {
@@ -167,7 +173,8 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             }
             break;
         case 1:
-            infoText.append(tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1selected room\n",
+            infoText.append(qsl("%1\n").arg(
+                               tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1selected room",
                                // Intentional comment to separate arguments
                                "This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle "
                                "them literally in raw strings) and a non-breaking hyphen which are used to "
@@ -176,7 +183,11 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                "more than one line. "
                                "This text is for when ONE room is selected, %3 is the room number "
                                "of, and %4-%6 are the x,y and z coordinates for, the selected Room.")
-                                    .arg(QChar(160), QString::number(roomID), QString::number(room->x), QString::number(room->y), QString::number(room->z)));
+                                    .arg(QChar(160),
+                                        QString::number(roomID),
+                                        QString::number(room->x),
+                                        QString::number(room->y),
+                                        QString::number(room->z))));
             isBold = true;
             if (infoColor.lightness() > 127) {
                 color = QColor(255, 223, 191); // Slightly orange white
@@ -185,7 +196,8 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
             }
             break;
         default:
-            infoText.append(tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms\n",
+            infoText.append(qsl("%1\n").arg(
+                               tr("Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms",
                                // Intentional comment to separate arguments
                                "This text uses non-breaking spaces (as '%1's, as Qt Creator cannot handle "
                                "them literally in raw strings) and a non-breaking hyphen which are used to "
@@ -199,7 +211,11 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
                                "provided so that non-English translations can select required plural forms as "
                                "needed.",
                                selectionSize)
-                                    .arg(QChar(160), QString::number(roomID), QString::number(room->x), QString::number(room->y), QString::number(room->z)));
+                                    .arg(QChar(160),
+                                        QString::number(roomID),
+                                        QString::number(room->x),
+                                        QString::number(room->y),
+                                        QString::number(room->z))));
             isBold = true;
             if (infoColor.lightness() > 127) {
                 color = QColor(255, 223, 191); // Slightly orange white


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Refactored some code, removed whitespace from texts for translation.

#### Motivation for adding to Mudlet
Translators don't need to worry matching a number of empty lines at the edge of a translated text.

#### Other info (issues closed, discussion etc)
Fix #3466