### PR TITLE
Fix: Size MacOS alias fonts normally

### DIFF
--- a/src/ui/aliases_main_area.ui
+++ b/src/ui/aliases_main_area.ui
@@ -94,11 +94,6 @@
        <height>21</height>
       </size>
      </property>
-     <property name="font">
-      <font>
-       <pointsize>9</pointsize>
-      </font>
-     </property>
      <property name="toolTip">
       <string>enter a perl regex pattern for your alias; alias are triggers on your input</string>
      </property>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Grant same size to fonts used in alias editor on Mac OS

#### Motivation for adding to Mudlet
Before: 
![image](https://user-images.githubusercontent.com/117238/193480839-9d891b77-9fb7-42a1-a010-0ec3ec95e3e6.png)

After:
![image](https://user-images.githubusercontent.com/117238/193695570-ca0cb7e1-d011-4c5f-a860-e39025794306.png)

#### Other info (issues closed, discussion etc)
Fix #3685