### PR TITLE
Fix: "Don't call QList::begin()/end() on temporary" warning

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4277,7 +4277,8 @@ void T2DMap::slot_setArea()
             if (!(mpMap->setRoomArea(currentRoomId, newAreaId, false))) {
                 // Failed on the last of multiple room area move so do the missed
                 // out recalculations for the dirtied areas
-                QSet<TArea*> areaPtrsSet{mpMap->mpRoomDB->getAreaPtrList().begin(), mpMap->mpRoomDB->getAreaPtrList().end()};
+                auto areaPtrsList{mpMap->mpRoomDB->getAreaPtrList()};
+                QSet<TArea*> areaPtrsSet{areaPtrsList.begin(), areaPtrsList.end()};
                 QSetIterator<TArea*> itpArea{areaPtrsSet};
                 while (itpArea.hasNext()) {
                     TArea* pArea = itpArea.next();


### PR DESCRIPTION
This problem has an informational URL in Qt Creator: https://github.com/KDE/clazy/blob/1.11/docs/checks/README-temporary-iterator.md which carries a warning that it can cause a crash because the `end()` iterator gets returned from a different container that the `begin()` one.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>