### PR TITLE
Add: setCommandBackgroundColor, setCommandForegroundColor lua functions

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3755,6 +3755,34 @@ bool Host::resetBackgroundImage(const QString &name)
     return false;
 }
 
+bool Host::setCommandBackgroundColor(const QString& name, int r, int g, int b, int alpha)
+{
+    if (!mpConsole) {
+        return false;
+    }
+
+    auto pC = mpConsole->mSubConsoleMap.value(name);
+    if (pC) {
+        pC->setCommandBgColor(r, g, b, alpha);
+        return true;
+    }
+    return false;
+}
+
+bool Host::setCommandForegroundColor(const QString& name, int r, int g, int b, int alpha)
+{
+    if (!mpConsole) {
+        return false;
+    }
+
+    auto pC = mpConsole->mSubConsoleMap.value(name);
+    if (pC) {
+        pC->setCommandFgColor(r, g, b, alpha);
+        return true;
+    }
+    return false;
+}
+
 // Needed to extract into a separate method from mudlet::slot_mapper() so that
 // we can use it WITHOUT loading a file - at least for the
 // TConsole::importMap(...) case that may need to create a map widget before it

--- a/src/Host.h
+++ b/src/Host.h
@@ -379,6 +379,8 @@ public:
     bool setLabelOnLeave(const QString&, const int);
     std::pair<bool, QString> setMovie(const QString& labelName, const QString& moviePath);
     bool setBackgroundColor(const QString& name, int r, int g, int b, int alpha);
+    bool setCommandBackgroundColor(const QString& name, int r, int g, int b, int alpha);
+    bool setCommandForegroundColor(const QString& name, int r, int g, int b, int alpha);
     std::optional<QColor> getBackgroundColor(const QString& name) const;
     bool setBackgroundImage(const QString& name, QString& path, int mode);
     bool resetBackgroundImage(const QString& name);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1640,6 +1640,26 @@ void TConsole::setFgColor(const QColor& newColor)
     mLowerPane->forceUpdate();
 }
 
+void TConsole::setCommandBgColor(int r, int g, int b, int a)
+{
+    setCommandBgColor(QColor(r, g, b, a));
+}
+
+void TConsole::setCommandBgColor(const QColor& newColor)
+{
+    mCommandBgColor = newColor;
+}
+
+void TConsole::setCommandFgColor(int r, int g, int b, int a)
+{
+    setCommandFgColor(QColor(r, g, b, a));
+}
+
+void TConsole::setCommandFgColor(const QColor& newColor)
+{
+    mCommandFgColor = newColor;
+}
+
 void TConsole::setScrollBarVisible(bool isVisible)
 {
     if (mpScrollBar) {

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -145,6 +145,10 @@ public:
     void setFgColor(const QColor&);
     void setBgColor(int, int, int, int);
     void setBgColor(const QColor&);
+    void setCommandBgColor(const QColor&);
+    void setCommandBgColor(int, int, int, int);
+    void setCommandFgColor(const QColor&);
+    void setCommandFgColor(int, int, int, int);
     void setScrollBarVisible(bool);
     void setHorizontalScrollBar(bool);
     void setCmdVisible(bool);

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3950,6 +3950,120 @@ int TLuaInterpreter::getBackgroundColor(lua_State* L)
     return 4;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCommandBackgroundColor
+int TLuaInterpreter::setCommandBackgroundColor(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QString windowName;
+    int r, alpha;
+    int s = 1;
+
+    auto validRange = [](int number) {
+        return number >= 0 && number <= 255;
+    };
+
+    if (lua_type(L, s) == LUA_TSTRING) {
+        windowName = WINDOW_NAME(L, s++);
+        r = getVerifiedInt(L, __func__, s, "red value 0-255");
+        if (!validRange(r)) {
+            return warnArgumentValue(L, __func__, qsl("red value %1 needs to be between 0-255").arg(r));
+        }
+    } else if (lua_isnumber(L, s)) {
+        r = static_cast<int>(lua_tonumber(L, s));
+        if (!validRange(r)) {
+            return warnArgumentValue(L, __func__, qsl("red value %1 needs to be between 0-255").arg(r));
+        }
+    } else {
+        lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (window name as string, or red value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+
+    int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    if (!validRange(g)) {
+        return warnArgumentValue(L, __func__, qsl("green value %1 needs to be between 0-255").arg(g));
+    }
+
+    int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    if (!validRange(b)) {
+        return warnArgumentValue(L, __func__, qsl("blue value %1 needs to be between 0-255").arg(b));
+    }
+
+    // if we get nothing for the alpha value, assume it is 255. If we get a non-number value, complain.
+    alpha = 255;
+    if (lua_gettop(L) > s) {
+        alpha = getVerifiedInt(L, __func__, ++s, "alpha value 0-255", true);
+        if (!validRange(alpha)) {
+            return warnArgumentValue(L, __func__, qsl("alpha value %1 needs to be between 0-255").arg(alpha));
+        }
+    }
+
+    if (isMain(windowName)) {
+        host.mCommandBgColor.setRgb(r, g, b, alpha);
+        host.mpConsole->setCommandBgColor(r, g, b, alpha);
+    } else if (!host.setCommandBackgroundColor(windowName, r, g, b, alpha)) {
+        return warnArgumentValue(L, __func__, qsl("window/label '%1' not found").arg(windowName));
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setCommandForegroundColor
+int TLuaInterpreter::setCommandForegroundColor(lua_State* L)
+{
+    Host& host = getHostFromLua(L);
+    QString windowName;
+    int r, alpha;
+    int s = 1;
+
+    auto validRange = [](int number) {
+        return number >= 0 && number <= 255;
+    };
+
+    if (lua_type(L, s) == LUA_TSTRING) {
+        windowName = WINDOW_NAME(L, s++);
+        r = getVerifiedInt(L, __func__, s, "red value 0-255");
+        if (!validRange(r)) {
+            return warnArgumentValue(L, __func__, qsl("red value %1 needs to be between 0-255").arg(r));
+        }
+    } else if (lua_isnumber(L, s)) {
+        r = static_cast<int>(lua_tonumber(L, s));
+        if (!validRange(r)) {
+            return warnArgumentValue(L, __func__, qsl("red value %1 needs to be between 0-255").arg(r));
+        }
+    } else {
+        lua_pushfstring(L, "setBackgroundColor: bad argument #%d type (window name as string, or red value 0-255 as number expected, got %s!)", s, luaL_typename(L, s));
+        return lua_error(L);
+    }
+
+    int g = getVerifiedInt(L, __func__, ++s, "green value 0-255");
+    if (!validRange(g)) {
+        return warnArgumentValue(L, __func__, qsl("green value %1 needs to be between 0-255").arg(g));
+    }
+
+    int b = getVerifiedInt(L, __func__, ++s, "blue value 0-255");
+    if (!validRange(b)) {
+        return warnArgumentValue(L, __func__, qsl("blue value %1 needs to be between 0-255").arg(b));
+    }
+
+    // if we get nothing for the alpha value, assume it is 255. If we get a non-number value, complain.
+    alpha = 255;
+    if (lua_gettop(L) > s) {
+        alpha = getVerifiedInt(L, __func__, ++s, "alpha value 0-255", true);
+        if (!validRange(alpha)) {
+            return warnArgumentValue(L, __func__, qsl("alpha value %1 needs to be between 0-255").arg(alpha));
+        }
+    }
+
+    if (isMain(windowName)) {
+        host.mCommandFgColor.setRgb(r, g, b, alpha);
+        host.mpConsole->setCommandFgColor(r, g, b, alpha);
+    } else if (!host.setCommandForegroundColor(windowName, r, g, b, alpha)) {
+        return warnArgumentValue(L, __func__, qsl("window/label '%1' not found").arg(windowName));
+    }
+    lua_pushboolean(L, true);
+    return 1;
+}
+
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#calcFontSize
 int TLuaInterpreter::calcFontSize(lua_State* L)
 {
@@ -14888,6 +15002,8 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "setBackgroundImage", TLuaInterpreter::setBackgroundImage);
     lua_register(pGlobalLua, "resetBackgroundImage", TLuaInterpreter::resetBackgroundImage);
     lua_register(pGlobalLua, "setBackgroundColor", TLuaInterpreter::setBackgroundColor);
+    lua_register(pGlobalLua, "setCommandBackgroundColor", TLuaInterpreter::setCommandBackgroundColor);
+    lua_register(pGlobalLua, "setCommandForegroundColor", TLuaInterpreter::setCommandForegroundColor);
     lua_register(pGlobalLua, "setCmdLineAction", TLuaInterpreter::setCmdLineAction);
     lua_register(pGlobalLua, "resetCmdLineAction", TLuaInterpreter::resetCmdLineAction);
     lua_register(pGlobalLua, "setCmdLineStyleSheet", TLuaInterpreter::setCmdLineStyleSheet);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -391,6 +391,8 @@ public:
     static int setBackgroundImage(lua_State*);
     static int resetBackgroundImage(lua_State*);
     static int setBackgroundColor(lua_State*);
+    static int setCommandBackgroundColor(lua_State*);
+    static int setCommandForegroundColor(lua_State*);
     static int setLabelClickCallback(lua_State*);
     static int setMovie(lua_State*);
     static int startMovie(lua_State*);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Adds Lua functions to set colors for commands echo (same style as `setBackgroundColor`)
It set commands color for windows as well (although it is not used at the moment), but to keep signature of API identical as `setBackgroundColor` and allow some echo option in the future I've decided to keep optional window parameter (we can skip it in docs).

#### Motivation for adding to Mudlet

Feature request

#### Other info (issues closed, discussion etc)

closes #6211 
