### PR TITLE
Fix: addMouseEvent caused crash to desktop if display name differs from unique name

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1579,11 +1579,12 @@ void TTextEdit::mousePressEvent(QMouseEvent* event)
         while (it.hasNext()) {
             it.next();
             QStringList actionInfo = it.value();
+            const QString &uniqueName = it.key();
             const QString &actionName = actionInfo.at(1);
-            QAction * action = new QAction(actionName, this);
-            action->setToolTip(actionInfo.at(2));
-            popup->addAction(action);
-            connect(action, &QAction::triggered, this, [this, actionName] { slot_mouseAction(actionName); });
+            QAction * mouseAction = new QAction(actionName, this);
+            mouseAction->setToolTip(actionInfo.at(2));
+            popup->addAction(mouseAction);
+            connect(mouseAction, &QAction::triggered, this, [this, uniqueName] { slot_mouseAction(uniqueName); });
         }
         popup->popup(mapToGlobal(event->pos()), action);
         event->accept();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
While iterating overs mouse actions in lamba calling `slout_mouseAction` action label was used instead of unique name (key of map)

#### Motivation for adding to Mudlet
Bugfixing

#### Other info (issues closed, discussion etc)
fixes: #5534