### PR TITLE
Fix: Make table.matches/n_matches not error when presented with tables/functions/etc

### DIFF
--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -240,10 +240,7 @@ function table.matches(tbl, ...)
     for key,value in pairs(tbl) do
       local keyType = type(key)
       local valueType = type(value)
-      if (valueType == "string" or valueType == "number") and string.match(value, pattern) then
-        matches[key] = value
-      end
-      if (check_keys and ((keyType == "string" or keyType == "number") and string.match(key, pattern))) then
+      if ((valueType == "string" or valueType == "number") and string.match(value, pattern)) or (check_keys and ((keyType == "string" or keyType == "number") and string.match(key, pattern))) then
         matches[key] = value
       end
     end

--- a/src/mudlet-lua/lua/TableUtils.lua
+++ b/src/mudlet-lua/lua/TableUtils.lua
@@ -238,7 +238,12 @@ function table.matches(tbl, ...)
     local ptype = type(pattern)
     assert(ptype == "string", string.format("table.matches: bad argument #%d type (pattern to check as string expected, got %s)", index+1, ptype))
     for key,value in pairs(tbl) do
-      if string.match(value, pattern) or (check_keys and string.match(key, pattern)) then
+      local keyType = type(key)
+      local valueType = type(value)
+      if (valueType == "string" or valueType == "number") and string.match(value, pattern) then
+        matches[key] = value
+      end
+      if (check_keys and ((keyType == "string" or keyType == "number") and string.match(key, pattern))) then
         matches[key] = value
       end
     end
@@ -262,7 +267,8 @@ function table.n_matches(tbl, ...)
     local ptype = type(pattern)
     assert(ptype == "string", string.format("table.n_matches: bad argument #%d type (pattern to check as string expected, got %s)", index+1, ptype))
     for key,value in pairs(tbl) do
-      if string.match(value, pattern) and not table.contains(matches, value) then
+      local valueType = type(value)
+      if (valueType == "string" or valueType == "number") and string.match(value, pattern) and not table.index_of(matches, value) then
         table.insert(matches, value)
       end
     end

--- a/src/mudlet-lua/tests/TableUtils_spec.lua
+++ b/src/mudlet-lua/tests/TableUtils_spec.lua
@@ -339,6 +339,20 @@ describe("Tests TableUtils.lua functions", function()
       end
       assert.has_error(errfn, "table.matches: bad argument #3 type (pattern to check as string expected, got number)")
     end)
+
+    it("should not error when things which are not strings or numbers are passed in", function()
+      local tbl = {
+        this = "that",
+        test = "passed",
+        tbl = {},
+        func = function() end,
+      }
+      local expected = {
+        test = "passed"
+      }
+      local actual = table.matches(tbl, "pass.+")
+      assert.same(expected, actual)
+    end)
   end)
 
   describe("Tests the functionality of table.n_matches", function()
@@ -395,6 +409,18 @@ describe("Tests TableUtils.lua functions", function()
         table.n_matches(tbl, "a string", not_string)
       end
       assert.has_error(errfn, "table.n_matches: bad argument #3 type (pattern to check as string expected, got number)")
+    end)
+
+    it("should not error if it contains non-string, non-number values", function()
+      local tbl = {
+        this = "that",
+        test = "passed",
+        tbl = {},
+        func = function() end,
+      }
+      local expected = { "passed" }
+      local actual = table.n_matches(tbl, "pass.+")
+      assert.same(expected, actual)
     end)
   end)
 


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Mudlet shouldn't error just because your table has items it can't run string.match against properly. 
#### Motivation for adding to Mudlet
Smoother scripting experience
#### Other info (issues closed, discussion etc)
fix error presented in https://github.com/Mudlet/Mudlet/issues/6328 (but not the requested new feature)