### PR TITLE
add Ctrl+F shortcut to search main window, and rework Ctrl-C

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -118,8 +118,8 @@ bool TCommandLine::event(QEvent* event)
             return false;
         }
 
-        if(ke->matches(QKeySequence::Copy)){ // Copy is Ctrl+C and possibly Ctrl+Ins, F16
-            if(mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0)) {
+        if (ke->matches(QKeySequence::Copy)){ // Copy is Ctrl+C and possibly Ctrl+Ins, F16
+            if (mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0)) {
                 // Only process if there is a selection active in the TConsole
                 mpConsole->mUpperPane->slot_copySelectionToClipboard();
                 ke->accept();
@@ -127,8 +127,8 @@ bool TCommandLine::event(QEvent* event)
             }
         }
 
-        if(ke->matches(QKeySequence::Find)){ // Find is Ctrl+F
-            if(mudlet::self()->dactionInputLine->isChecked()){
+        if (ke->matches(QKeySequence::Find)){ // Find is Ctrl+F
+            if (mudlet::self()->dactionInputLine->isChecked()){
                 // If hidden then reveal as if pressed Alt-L
                 mudlet::self()->dactionInputLine->setChecked(false);
                 mudlet::self()->mpCurrentActiveHost->setCompactInputLine(false);

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -118,6 +118,26 @@ bool TCommandLine::event(QEvent* event)
             return false;
         }
 
+        if(ke->matches(QKeySequence::Copy)){ // Copy is Ctrl+C and possibly Ctrl+Ins, F16
+            if(mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0)) {
+                // Only process if there is a selection active in the TConsole
+                mpConsole->mUpperPane->slot_copySelectionToClipboard();
+                ke->accept();
+                return true;
+            }
+        }
+
+        if(ke->matches(QKeySequence::Find)){ // Find is Ctrl+F
+            if(mudlet::self()->dactionInputLine->isChecked()){
+                // If hidden then reveal as if pressed Alt-L
+                mudlet::self()->dactionInputLine->setChecked(false);
+                mudlet::self()->mpCurrentActiveHost->setCompactInputLine(false);
+            }
+            mpConsole->mpBufferSearchBox->setFocus();
+            ke->accept();
+            return true;
+        }
+
         // Shortcut for keypad keys
         if ((ke->modifiers() & Qt::KeypadModifier) && mpKeyUnit->processDataStream(static_cast<Qt::Key>(ke->key()), static_cast<Qt::KeyboardModifiers>(ke->modifiers()))) {
             ke->accept();
@@ -440,25 +460,6 @@ bool TCommandLine::event(QEvent* event)
                 return true;
             }
             break;
-
-        case Qt::Key_C:
-            if (((ke->modifiers() & allModifiers) == Qt::ControlModifier)
-                && (mpConsole->mUpperPane->mSelectedRegion != QRegion(0, 0, 0, 0))) {
-
-                // Only process as a Control-C if it is EXACTLY those two keys
-                // and no other AND there is a selection active in the TConsole
-                mpConsole->mUpperPane->slot_copySelectionToClipboard();
-                ke->accept();
-                return true;
-            }
-
-            if (keybindingMatched(ke)) {
-                // Process as a possible key binding if there are ANY modifiers
-                return true;
-            }
-
-            processNormalKey(event);
-            return false;
 
         case Qt::Key_1:
             if (handleCtrlTabChange(ke, 1)) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
`Ctrl+F` will now send cursor over to the search box, and potentially unhide it just as `Alt+L` would do.  It uses platform independent `QKeySequence::Find` instead of looking for literal `Ctrl`+`F`.

While I was at it, I changed `Ctrl+C` to use `QKeySequence::Copy` too because it was looking for literal `Ctrl`+`C`.  [Documentation](https://doc.qt.io/qt-5/qkeysequence.html#standard-shortcuts) says that `Ctrl+C` means copy everywhere, as probably everyone is aware, but also `Ctrl+Ins` means copy on some platforms.  So, after this change, you can also copy from game output via `Ctrl+Ins`.  
#### Motivation for adding to Mudlet
Find/Search is what people expect out of `Ctrl+F` in most software.

You already can copy from command input box with `Ctrl+Ins`, so that part will add some consistency as well.
#### Other info (issues closed, discussion etc)
closes #1427