### PR TITLE
improve Make timestamps persist between sessions

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -369,6 +369,8 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     // confuse it with the "autologin" item, which controls whether the profile
     // is automatically started when the Mudlet application is run!
     mLogStatus = QFile::exists(mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("autolog")));
+    // "autotimestamp" determines if profile loads with timestamps enabled
+    mTimeStampStatus = QFile::exists(mudlet::getMudletPath(mudlet::profileDataItemPath, mHostName, qsl("autotimestamp")));
     mLuaInterface.reset(new LuaInterface(this->getLuaInterpreter()->getLuaGlobalState()));
 
     // Copy across the details needed for the "color_table":

--- a/src/Host.h
+++ b/src/Host.h
@@ -588,6 +588,7 @@ public:
     bool mMapStrongHighlight;
     QStringList mGMCP_merge_table_keys;
     bool mLogStatus = false;
+    bool mTimeStampStatus = false;
     bool mEnableSpellCheck;
     QStringList mInstalledPackages;
     // module name = location on disk, sync to other profiles?, priority

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -341,7 +341,7 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
     layoutButtonMainLayer->addWidget(buttonLayerSpacer);
     layoutButtonMainLayer->addWidget(buttonLayer);
 
-    auto timeStampButton = new QToolButton;
+    timeStampButton = new QToolButton;
     timeStampButton->setCheckable(true);
     timeStampButton->setMinimumSize(QSize(30, 30));
     timeStampButton->setMaximumSize(QSize(30, 30));

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -273,6 +273,7 @@ public:
     TSplitter* splitter = nullptr;
     bool mIsPromptLine = false;
     QToolButton* logButton = nullptr;
+    QToolButton* timeStampButton = nullptr;
     bool mUserAgreedToCloseConsole = false;
     QLineEdit* mpBufferSearchBox = nullptr;
     QToolButton* mpBufferSearchUp = nullptr;

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -183,7 +183,7 @@ void TTextEdit::slot_toggleTimeStamps(const bool state)
         mShowTimeStamps = state;
         QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("autotimestamp")));
         if (state){
-            file.open(QUIDevice::WriteOnly | QIODevice::Text);
+            file.open(QIODevice::WriteOnly | QIODevice::Text);
             QTextStream out(&file);
             file.close();
         } else {

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -181,6 +181,14 @@ void TTextEdit::slot_toggleTimeStamps(const bool state)
 {
     if (mShowTimeStamps != state) {
         mShowTimeStamps = state;
+        QFile file(mudlet::getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), qsl("autotimestamp")));
+        if (state){
+            file.open(QUIDevice::WriteOnly | QIODevice::Text);
+            QTextStream out(&file);
+            file.close();
+        } else {
+            file.remove();
+        }
         forceUpdate();
         update();
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1580,6 +1580,11 @@ void mudlet::addConsoleForNewHost(Host* pH)
         pConsole->logButton->click();
     }
 
+    if (pH->mTimeStampStatus) {
+        // This is similar to logging above, but for timestamps
+        pConsole->timeStampButton->click();
+    }
+
     pConsole->show();
 
     auto pEditor = new dlgTriggerEditor(pH);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Logging stays on when you close and reopen, and now timestamps will do the same thing.  Pretty much just duplicated the code and had it do the other thing.
#### Motivation for adding to Mudlet
Consistency between sessions
#### Other info (issues closed, discussion etc)
closes #5681 