### PR TITLE
Infrastructure: update English (American) plurals-only translations

### DIFF
--- a/translations/translated/mudlet_en_US.ts
+++ b/translations/translated/mudlet_en_US.ts
@@ -29,9 +29,9 @@
         <location filename="../../src/mapInfoContributorManager.cpp" line="200"/>
         <source>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</source>
         <comment>This text uses non-breaking spaces (as &apos;%1&apos;s, as Qt Creator cannot handle them literally in raw strings) and a non-breaking hyphen which are used to prevent the line being split at some places it might otherwise be; when translating please consider at which points the text may be divided to fit onto more than one line. This text is for when TWO or MORE rooms are selected; %1 is the room number for which %2-%4 are the x,y and z coordinates of the room nearest the middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms selected and will ALWAYS be greater than 1 in this situation. It is provided so that non-English translations can select required plural forms as needed.</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>{Unused} Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</numerusform>
+            <numerusform>Room%1ID:%1%2 Position%1on%1Map: (%3,%4,%5) ‑%1center of %n selected rooms</numerusform>
         </translation>
     </message>
 </context>
@@ -107,9 +107,9 @@
     <message numerus="yes">
         <location filename="../../src/TTrigger.cpp" line="1169"/>
         <source>Trigger name=%1 will fire %n more time(s).</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Trigger name=%1 will fire 1 more time.</numerusform>
+            <numerusform>Trigger name=%1 will fire %n more times.</numerusform>
         </translation>
     </message>
 </context>


### PR DESCRIPTION
Needed as a result of #6342 which touched a couple of "engineering English" translatable `QString`s that have the `%n` quantity for plural texts in them.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>