### PR TITLE
Infrastructure: Word-wrap dynamically instead of fixed

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3584,12 +3584,11 @@ void T2DMap::slot_movePosition()
     pLEx->setText(QString::number(pR_start->x));
     pLEy->setText(QString::number(pR_start->y));
     pLEz->setText(QString::number(pR_start->z));
-    QLabel* pLa0 = new QLabel(tr("Move the selection, centered on\n"
-                                 "the highlighted room (%1) to:",
+    QLabel* pLa0 = new QLabel(tr("Move the selection, centered on the highlighted room (%1) to:",
                                  // Intentional comment to separate arguments
-                                 "Use linefeeds as necessary to format text into a reasonable rectangle of text, "
                                  "%1 is a room number")
                               .arg(mMultiSelectionHighlightRoomId));
+    pLa0->setWordWrap(true);
     // Record the starting coordinates - can be a help when working out how to move a block of rooms!
     QLabel* pLa1 = new QLabel(tr("x coordinate (was %1):").arg(pR_start->x));
     QLabel* pLa2 = new QLabel(tr("y coordinate (was %1):").arg(pR_start->y));

--- a/src/dlgRoomSymbol.cpp
+++ b/src/dlgRoomSymbol.cpp
@@ -77,23 +77,21 @@ void dlgRoomSymbol::initInstructionLabel()
     QString instructions;
     if (mpSymbols.size() == 1) {
         if (mpRooms.size() > 1) {
-            instructions = tr("The only used symbol is \"%1\" in one or\n"
-                              "more of the selected %n room(s), delete this to\n"
-                              "clear it from all selected rooms or replace\n"
+            instructions = tr("The only used symbol is \"%1\" in one or "
+                              "more of the selected %n room(s), delete this to "
+                              "clear it from all selected rooms or replace "
                               "with a new symbol to use for all the rooms:",
                               // Intentional comment to separate arguments!
                               "This is for when applying a new room symbol to one or more rooms "
                               "and some have the SAME symbol (others may have none) at present, "
-                              "%n is the total number of rooms involved and is at least two. "
-                              "Use line feeds to format text into a reasonable rectangle.",
+                              "%n is the total number of rooms involved and is at least two. ",
                               mpRooms.size()).arg(mpSymbols.keys().first());
         } else {
-            instructions = tr("The symbol is \"%1\" in the selected room,\n"
-                              "delete this to clear the symbol or replace\n"
+            instructions = tr("The symbol is \"%1\" in the selected room, "
+                              "delete this to clear the symbol or replace "
                               "it with a new symbol for this room:",
                               // Intentional comment to separate arguments!
-                              "This is for when applying a new room symbol to one room. "
-                              "Use line feeds to format text into a reasonable rectangle.")
+                              "This is for when applying a new room symbol to one room.")
                                    .arg(mpSymbols.keys().first());
         }
     } else {
@@ -103,10 +101,12 @@ void dlgRoomSymbol::initInstructionLabel()
                           " • enter a space to clear any existing symbols\n"
                           "for all of the %n selected room(s):",
                           // Intentional comment to separate arguments!
-                          "Use line feeds to format text into a reasonable rectangle if needed, "
+                          "This is for when applying a new room symbol to one or more rooms "
+                          "and some have different symbols (others may have none) at present, "
                           "%n is the number of rooms involved.", mpRooms.size());
     }
     label_instructions->setText(instructions);
+    label_instructions->setWordWrap(true);
 }
 
 QStringList dlgRoomSymbol::getComboBoxItems()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove label texts' hard line breaks, make them wrap dynamically instead.

#### Motivation for adding to Mudlet
Less confusion, easier i18n, more thorough use of screen real estate

#### Other info (issues closed, discussion etc)
Less hard fixed white space:

Before:
![image](https://user-images.githubusercontent.com/117238/196010527-247c99bc-0cbb-4574-9524-f7e9d9d584fd.png)

After:
![image](https://user-images.githubusercontent.com/117238/196011663-7293ab7f-f836-4be8-8598-4d1a32370f38.png)

---

Only half translators seems like they were understanding or following the recommendation:
> Use linefeeds as necessary to format text into a reasonable rectangle of text

Others just wrote the text in one line (as done in most other circumstances anyways) e.g.

![image](https://user-images.githubusercontent.com/117238/196010439-f47bb70c-84b7-4739-9f58-8700048791a7.png)

![image](https://user-images.githubusercontent.com/117238/196010441-12731e96-403c-4df0-a010-f03c34def398.png)
