### PR TITLE
fix CoreMUD got their domain back, undoing changes

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -953,7 +953,7 @@ QString dlgConnectionProfiles::getDescription(const QString& hostUrl, const quin
                    "and change through the coming years and those players who seek challenge and "
                    "possess imagination will come in search of what the 3D world fails to offer them.");
     }
-    if (hostUrl == QLatin1String("coremud.org") || hostUrl == QLatin1String("core.evilmog.io")) {
+    if (hostUrl == QLatin1String("coremud.org")) {
         return qsl("Welcome to Core Mud, an interactive text MUD set on the planet formal star-charts "
                    "refer to as Hermes 571-G, but that everyone in the know refers to simply as \"Core\"."
                    "\n\n"

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -504,7 +504,7 @@ public:
         {"Carrion Fields", {"carrionfields.net", 4449, false, "<a href='http://www.carrionfields.net'>www.carrionfields.net</a>", ":/icons/carrionfields.png"}},
         {"Cleft of Dimensions", {"cleftofdimensions.net", 4354, false, "<a href='https://www.cleftofdimensions.net/'>cleftofdimensions.net</a>", ":/icons/cleftofdimensions.png"}},
         {"Legends of the Jedi", {"legendsofthejedi.com", 5656, false, "<a href='https://www.legendsofthejedi.com/'>legendsofthejedi.com</a>", ":/icons/legendsofthejedi_120x30.png"}},
-        {"CoreMUD", {"core.evilmog.io", 4020, true, "<a href='https://core.evilmog.io/'>core.evilmog.io</a>", ":/icons/coremud_icon.jpg"}},
+        {"CoreMUD", {"coremud.org", 4020, true, "<a href='https://coremud.org/'>coremud.org</a>", ":/icons/coremud_icon.jpg"}},
         {"Multi-Users in Middle-earth", {"mume.org", 4242, true, "<a href='https://mume.org/'>mume.org</a>", ":/icons/mume.png"}},
     };
     // clang-format on


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
DNS settings for CoreMUD were changed in development and PTB but not in release versions.  DNS problems were resolved and now they're using the original DNS.  This reverts changes from #6289 and #6296

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
From [Discord](https://discord.com/channels/283581582550237184/283582439002210305/1031951839295455275):
> we can yeet the following PR's 6289 6296 6297 6298