### PR TITLE
fix off by 1 issue when scrolling up in caret mode

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -2711,7 +2711,7 @@ void TTextEdit::updateCaret()
 
     if (!mIsLowerPane) {
         if (mCaretLine < lineOffset) {
-            scrollTo(mCaretLine);
+            scrollTo(mCaretLine + 1);
         } else if (mCaretLine >= lineOffset + mScreenHeight) {
             int emptyLastLine = mpBuffer->lineBuffer.last().isEmpty();
             if (mCaretLine == mpBuffer->lineBuffer.length() - 1 - emptyLastLine) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Caret mode currently skips a line when you go up to the previous page.  You can end up with your cursor on a line between two pages.  With this change, each line will be visually there.
#### Motivation for adding to Mudlet
Makes scrolling work as expected
#### Other info (issues closed, discussion etc)

I neglected to make an issue for it.  Caret mode is not in the latest release, and is part of the new accessibility work that's in the PTB.  On the Special Options tab in settings, at the bottom set up a key to switch between input and output window.  Use that to move your cursor into the output window.  That's the caret mode I'm referring to.  It's for navigating to a word for screen readers to read, but is also visible.

While in that mode, use arrow up to go back a screen, it skips a line between pages, and initially your cursor will be just out of view, as it skips a line when paging up.  It still gets read by screen readers, but it just isn't visible.  So that's what this fixes.