### PR TITLE
Infrastructure: Fix the ldoc format for Geyser.Gauge:setStyleSheet

### DIFF
--- a/src/mudlet-lua/lua/geyser/GeyserGauge.lua
+++ b/src/mudlet-lua/lua/geyser/GeyserGauge.lua
@@ -155,7 +155,7 @@ function Geyser.Gauge:echo(message, color, format)
   self.formatTable = self.text.formatTable
 end
 
--- Sets the style sheet for the gauge
+--- Sets the style sheet for the gauge
 -- @param css Style sheet for the front label
 -- @param cssback Style sheet for the back label
 -- @param cssText Style sheet for the text label


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
The missing `-` was causing the function not to be included in the Geyser API docs. This should fix that.
#### Motivation for adding to Mudlet
Someone in Discord was asking about setting stylesheets on a TimerGauge, and it turned out it wasn't in the docs for Geyser.Gauge when they went looking.
#### Other info (issues closed, discussion etc)
