### PR TITLE
Add: sysBufferShrinkEvent for when a console's buffer is trimmed

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -24,6 +24,7 @@
 #include "TBuffer.h"
 
 #include "mudlet.h"
+#include "TEvent.h"
 #include "TStringUtils.h"
 
 #include "pre_guard.h"
@@ -104,8 +105,9 @@ const QString blankTimeStamp  = qsl("------------ ");
 
 // Store for text and attributes (such as character color) to be drawn on screen 
 // Contents are rendered by a TTextEdit
-TBuffer::TBuffer(Host* pH)
-: mBlack(pH->mBlack)
+TBuffer::TBuffer(Host* pH, TConsole* pConsole)
+: mpConsole(pConsole)
+, mBlack(pH->mBlack)
 , mLightBlack(pH->mLightBlack)
 , mRed(pH->mRed)
 , mLightRed(pH->mLightRed)
@@ -2724,7 +2726,19 @@ void TBuffer::shrinkBuffer()
         promptBuffer.pop_front();
         timeBuffer.pop_front();
         buffer.pop_front();
-        mCursorY--;
+        --mCursorY;
+    }
+
+    if (mpConsole->getType() & (TConsole::MainConsole|TConsole::UserWindow|TConsole::SubConsole|TConsole::Buffer)) {
+        // Signal to lua subsystem that indexes into the Console will need adjusting
+        TEvent bufferShrinkEvent{};
+        bufferShrinkEvent.mArgumentList.append(QLatin1String("sysBufferShrinkEvent"));
+        bufferShrinkEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        bufferShrinkEvent.mArgumentList.append(mpConsole->mConsoleName);
+        bufferShrinkEvent.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
+        bufferShrinkEvent.mArgumentList.append(QString::number(mBatchDeleteSize));
+        bufferShrinkEvent.mArgumentTypeList.append(ARGUMENT_TYPE_NUMBER);
+        mpHost->raiseEvent(bufferShrinkEvent);
     }
 }
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -2726,7 +2726,7 @@ void TBuffer::shrinkBuffer()
         promptBuffer.pop_front();
         timeBuffer.pop_front();
         buffer.pop_front();
-        --mCursorY;
+        mCursorY--;
     }
 
     if (mpConsole->getType() & (TConsole::MainConsole|TConsole::UserWindow|TConsole::SubConsole|TConsole::Buffer)) {

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -51,6 +51,7 @@
 
 class Host;
 class QTextCodec;
+class TConsole;
 
 class TChar
 {
@@ -143,7 +144,7 @@ class TBuffer
     inline static const int MAX_CHARACTERS_PER_ECHO = 1000000;
 
 public:
-    explicit TBuffer(Host* pH);
+    explicit TBuffer(Host* pH, TConsole* pConsole = nullptr);
     QPoint insert(QPoint&, const QString& text, int, int, int, int, int, int, bool bold, bool italics, bool underline, bool strikeout);
     bool insertInLine(QPoint& cursor, const QString& what, const TChar& format);
     void expandLine(int y, int count, TChar&);
@@ -224,6 +225,8 @@ private:
     void decodeOSC(const QString&);
     void resetColors();
     void binarySearchHorizontalAdvance(const int& lineIndex, const int& indentSize, const QString& lineIndent, const int& lineWidth, const int& screenWidth, const int& subStringStart, const int& lineCharTotal, const QFontMetrics& qfm, int& lineCharIterator, const bool isBefore);
+
+    QPointer<TConsole> mpConsole;
 
     // First stage in decoding SGR/OCS sequences - set true when we see the
     // ASCII ESC character:

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
- *   Copyright (C) 2014-2021 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2021 by Vadim Peretokin - vperetokin@gmail.com          *
@@ -60,7 +60,7 @@ const QString TConsole::cmLuaLineVariable("line");
 TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
 : QWidget(parent)
 , mpHost(pH)
-, buffer(pH)
+, buffer(pH, this)
 , emergencyStop(new QToolButton)
 , mpBaseVFrame(new QWidget(this))
 , mpTopToolBar(new QWidget(mpBaseVFrame))

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -2409,12 +2409,33 @@ int TLuaInterpreter::setConsoleBufferSize(lua_State* L)
         windowName = WINDOW_NAME(L, s++);
     }
 
-    int luaFrom = getVerifiedInt(L, __func__, s++, "linesLimit");
-    int luaTo = getVerifiedInt(L, __func__, s, "sizeOfBatchDeletion");
+    auto linesLimit = getVerifiedInt(L, __func__, s++, "linesLimit");
+    auto sizeOfBatchDeletion = getVerifiedInt(L, __func__, s, "sizeOfBatchDeletion");
 
+    // The macro will have returned with a nil + error message if the windowName
+    // was not found:
     auto console = CONSOLE(L, windowName);
-    console->buffer.setBufferSize(luaFrom, luaTo);
-    return 0;
+    console->buffer.setBufferSize(linesLimit, sizeOfBatchDeletion);
+    // Indicate success with a true return value:
+    lua_pushboolean(L, true);
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getConsoleBufferSize
+int TLuaInterpreter::getConsoleBufferSize(lua_State* L)
+{
+    QString windowName;
+    if (lua_gettop(L)) {
+        windowName = WINDOW_NAME(L, 1);
+    }
+
+    // The macro will have returned with a nil + error message if the windowName
+    // was not found:
+    auto console = CONSOLE(L, windowName);
+    // Indicate success with two numeric return values:
+    lua_pushnumber(L, console->buffer.mLinesLimit);
+    lua_pushnumber(L, console->buffer.mBatchDeleteSize);
+    return 2;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableScrollBar
@@ -15079,6 +15100,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "getBorderBottom", TLuaInterpreter::getBorderBottom);
     lua_register(pGlobalLua, "getBorderLeft", TLuaInterpreter::getBorderLeft);
     lua_register(pGlobalLua, "getBorderSizes", TLuaInterpreter::getBorderSizes);
+    lua_register(pGlobalLua, "getConsoleBufferSize", TLuaInterpreter::getConsoleBufferSize);
     lua_register(pGlobalLua, "setConsoleBufferSize", TLuaInterpreter::setConsoleBufferSize);
     lua_register(pGlobalLua, "enableScrollBar", TLuaInterpreter::enableScrollBar);
     lua_register(pGlobalLua, "disableScrollBar", TLuaInterpreter::disableScrollBar);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -460,6 +460,7 @@ public:
     static int getBorderLeft(lua_State*);
     static int getBorderRight(lua_State*);
     static int getBorderSizes(lua_State*);
+    static int getConsoleBufferSize(lua_State*);
     static int setConsoleBufferSize(lua_State*);
     static int enableScrollBar(lua_State*);
     static int disableScrollBar(lua_State*);


### PR DESCRIPTION
This ought to help if any line number indexes are being used to access the buffer underlying a console as then they can be revised downwards to match the number of lines removed from the buffer/console concerned.

This commit also improves the UI for the setConsoleBufferSize(...) Lua API function to bring it up to our current design style. It will now return true on success or nil + an error message otherwise.

This will close #6366...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>