### PR TITLE
Add: support for OpenBSD operating system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
-#    Copyright (C) 2015-2018, 2020 by Stephen Lyons                        #
+#    Copyright (C) 2015-2018, 2020, 2022 by Stephen Lyons                  #
 #                                                - slysven@virginmedia.com #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
@@ -21,14 +21,14 @@
 
 ############################################################################
 #                                                                          #
-#    NOTICE: FreeBSD and GNU/Hurd are not officially supported platforms   #
-#    as such; the work on getting them working has been done by myself,    #
-#    and other developers, unless they have explicitly said so, are not    #
-#    able to address issues relating specifically to these Operating       #
-#    Systems. Nevertheless users of either are equally welcome to          #
-#    contribute to the development of Mudlet - bugfixes and enhancements   #
-#    are welcome from all!                                                 #
-#                         Stephen Lyons, February 2018, updated March 2021 #
+#    NOTICE: FreeBSD, OpenBSD and GNU/Hurd are not officially supported    #
+#    platforms as such; the work on getting them working has been done by  #
+#    myself, and other developers, unless they have explicitly said so,    #
+#    are not able to address issues relating specifically to these         #
+#    Operating Systems. Nevertheless users of these operating systems are  #
+#    equally welcome to contribute to the development of Mudlet - bugfixes #
+#    and enhancements are welcome from all!                                #
+#        Stephen Lyons, February 2018, updated March 2021 & October 2022   #
 #                                                                          #
 ############################################################################
 

--- a/src/Announcer.h
+++ b/src/Announcer.h
@@ -1,7 +1,10 @@
+#ifndef ANNOUNCER_H
+#define ANNOUNCER_H
 /***************************************************************************
  *   Copyright 2019-2022 Leonard de Ruijter, James Teh - OSARA             *
  *   Copyright 2017 The Qt Company Ltd.                                    *
  *   Copyright (C) 2022 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,9 +23,6 @@
  ***************************************************************************/
 
 
-#ifndef ANNOUNCER_H
-#define ANNOUNCER_H
-
 #include <QAccessible>
 #include <QAccessibleInterface>
 #include <QAccessibleWidget>
@@ -32,7 +32,7 @@
 #include <QLibrary>
 #endif
 
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
   // implemented per recommendation from Orca dev: https://mail.gnome.org/archives/orca-list/2022-June/msg00027.html
 class InvisibleNotification : public QWidget {
   Q_OBJECT
@@ -82,7 +82,7 @@ public:
   explicit Announcer(QWidget *parent = nullptr);
   void announce(const QString& text, const QString& processing = QString());
 
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
   static QAccessibleInterface *accessibleFactory(const QString &classname,
                                                  QObject *object) {
 #undef interface // mingw compilation breaks without this
@@ -102,7 +102,7 @@ public:
 #endif
 
 private:
-#if defined(Q_OS_LINUX)
+#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
   InvisibleNotification *notification;
   InvisibleStatusbar *statusbar;
 #endif

--- a/src/AnnouncerUnix.cpp
+++ b/src/AnnouncerUnix.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
 *   Copyright (C) 2022 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+*   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
 *                                                                         *
 *   This program is free software; you can redistribute it and/or modify  *
 *   it under the terms of the GNU General Public License as published by  *
@@ -22,17 +23,21 @@
 #include <QDebug>
 #include <QAccessible>
 
-InvisibleNotification::InvisibleNotification(QWidget *parent) : QWidget(parent) {
+InvisibleNotification::InvisibleNotification(QWidget *parent)
+: QWidget(parent)
+{
     setObjectName("InvisibleNotification");
     setAccessibleName("InvisibleNotification");
     setAccessibleDescription("An invisible widget used as a workaround to announce text to the screen reader");
 }
 
-void InvisibleNotification::setText(const QString &text) {
+void InvisibleNotification::setText(const QString &text)
+{
     this->mText = text;
 }
 
-QString InvisibleNotification::text() {
+QString InvisibleNotification::text()
+{
     return mText;
 }
 
@@ -41,20 +46,25 @@ InvisibleNotification* InvisibleAccessibleNotification::notification() const
     return static_cast<InvisibleNotification*>(object());
 }
 
-QString InvisibleAccessibleNotification::text(QAccessible::Text t) const {
+QString InvisibleAccessibleNotification::text(QAccessible::Text t) const
+{
     Q_UNUSED(t)
 
     // return the notifications contents regardless of the request as part of the workaround
     return notification()->text();
 }
 
-InvisibleStatusbar::InvisibleStatusbar(QWidget *parent) : QWidget(parent) {
+InvisibleStatusbar::InvisibleStatusbar(QWidget *parent)
+: QWidget(parent)
+{
     setObjectName("InvisibleStatusbar");
     setAccessibleName("InvisibleStatusbar");
     setAccessibleDescription("An invisible widget used as part as a workaround to announce text to the screen reader");
 }
 
-Announcer::Announcer(QWidget *parent): QWidget{parent}, statusbar(new InvisibleStatusbar(this))
+Announcer::Announcer(QWidget *parent)
+: QWidget{parent}
+, statusbar(new InvisibleStatusbar(this))
 {
     notification = new InvisibleNotification(statusbar);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,7 +160,7 @@ set(mudlet_SRCS
 if(APPLE)
   list(APPEND mudlet_SRCS AnnouncerMac.mm)
 elseif(UNIX AND NOT APPLE)
-  list(APPEND mudlet_SRCS AnnouncerLinux.cpp)
+  list(APPEND mudlet_SRCS AnnouncerUnix.cpp)
 elseif(WIN32)
   list(APPEND mudlet_SRCS AnnouncerWindows.cpp)
   list(APPEND mudlet_SRCS uiawrapper.cpp)

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -350,7 +350,6 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mWideAmbigousWidthGlyphs(false)
 , mSGRCodeHasColSpaceId(false)
 , mServerMayRedefineColors(false)
-, mSpellDic(qsl("en_US"))
 // DISABLED: - Prevent "None" option for user dictionary - changed to true and not changed anywhere else
 , mEnableUserDictionary(true)
 , mUseSharedDictionary(false)
@@ -2532,6 +2531,20 @@ bool Host::discordUserIdMatch(const QString& userName, const QString& userDiscri
     } else {
         return true;
     }
+}
+
+QString  Host::getSpellDic()
+{
+    if (!mSpellDic.isEmpty()) {
+        return mSpellDic;
+    }
+#if defined(Q_OS_OPENBSD)
+    // OpenBSD does not ship a USA dictionary so we will have to use
+    // a different starting one to try and locate system ones
+    return (qsl("en-GB"));
+#else
+    return (qsl("en_US"));
+#endif
 }
 
 void Host::setSpellDic(const QString& newDict)

--- a/src/Host.h
+++ b/src/Host.h
@@ -196,7 +196,7 @@ public:
     void            setDiscordInviteURL(const QString& s);
     const QString&  getDiscordInviteURL() const { return mDiscordInviteURL; }
     void            setSpellDic(const QString&);
-    const QString&  getSpellDic() { return mSpellDic; }
+    QString         getSpellDic();
     void            setUserDictionaryOptions(const bool useDictionary, const bool useShared);
     void            getUserDictionaryOptions(bool& useDictionary, bool& useShared) {
                         useDictionary = mEnableUserDictionary;

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -3008,11 +3008,11 @@ void cTelnet::setKeepAlive(int socketHandle)
 
 #else // For OSes other than Windows:
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS) || defined(Q_OS_OPENBSD)
     setsockopt(socketHandle, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
 #else
     // FreeBSD always has the Keep-alive option enabled, so the above is not
-    // needed
+    // usable
     Q_UNUSED(on)
 #endif
 
@@ -3036,15 +3036,23 @@ void cTelnet::setKeepAlive(int socketHandle)
 #if defined(Q_OS_MACOS)
     // TCP_KEEPIDLE is TCP_KEEPALIVE on MacOs
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPALIVE, &timeout, sizeof(timeout));
+#elif defined(Q_OS_OPENBSD)
+    // There does not appear to be a per-socket option for TCP_KEEPALIVE on OpenBSD
+    // only a system wide one
 #else
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPIDLE, &timeout, sizeof(timeout));
 #endif
+
+#if !defined(Q_OS_OPENBSD)
+    // There does not appear to be a per-socket options for these on OpenBSD
+    // only system wide one:
 
     // Interval between keep-alives, in seconds:
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval));
     // Number of failed keep alives before forcing a close:
     setsockopt(socketHandle, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
-#endif // defined(Q_OS_WIN32)
+#endif // !defined(Q_OS_OPENBSD)
+#endif // !defined(Q_OS_WIN32)
 }
 
 // Used to convert a collection of Bytes in the current MUD Server encoding

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -657,6 +657,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
 
     // On the first run for a profile this will be the "English (American)"
     // dictionary "en_US".
+    // Unfortunately OpenBSD does not ship a dictionary for THAT language which
+    // prevents us using it to find any system ones
     const QString& currentDictionary = pHost->getSpellDic();
     // This will also set mudlet::mUsingMudletDictionaries as appropriate:
     QString path = mudlet::getMudletPath(mudlet::hunspellDictionaryPath, currentDictionary);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -84,8 +84,7 @@
 #include <QRandomGenerator>
 #include <zip.h>
 #include <QStyle>
-#ifdef Q_OS_LINUX
-#elif defined(Q_OS_WIN32)
+#if defined(Q_OS_WIN32)
 #include <QSettings>
 #endif
 
@@ -777,10 +776,15 @@ void mudlet::loadMaps()
     // More useful is the cross-referenced (Country <-> Languages):
     // https://www.unicode.org/cldr/charts/latest/supplemental/language_territory_information.html
     // Initially populated from the dictionaries provided within the Debian
-    // GNU/Linux distribution:
+    // GNU/Linux distribution, and supplimented by those provided with
+    // OpenBSD 7.1:
     //: In the translation source texts the language is the leading term, with, generally, the (primary) country(ies) in the brackets, with a trailing language disabiguation after a '-' Chinese is an exception!
     mDictionaryLanguageCodeMap = {{qsl("af"), tr("Afrikaans")},
                                   {qsl("af_za"), tr("Afrikaans (South Africa)")},
+                                  {qsl("ak"), tr("Akan")},
+                                  {qsl("ak_gh"), tr("Akan (Ghana)")},
+                                  {qsl("am"), tr("Amharic")},
+                                  {qsl("am_et"), tr("Amharic (Ethiopia)")},
                                   {qsl("an"), tr("Aragonese")},
                                   {qsl("an_es"), tr("Aragonese (Spain)")},
                                   {qsl("ar"), tr("Arabic")},
@@ -802,6 +806,8 @@ void mudlet::loadMaps()
                                   {qsl("ar_sy"), tr("Arabic (Syria)")},
                                   {qsl("ar_tn"), tr("Arabic (Tunisia)")},
                                   {qsl("ar_ye"), tr("Arabic (Yemen)")},
+                                  {qsl("az"), tr("Azerbaijani")},
+                                  {qsl("az_ir"), tr("Azerbaijani (Iran)")},
                                   {qsl("be"), tr("Belarusian")},
                                   {qsl("be_by"), tr("Belarusian (Belarus)")},
                                   {qsl("be_ru"), tr("Belarusian (Russia)")},
@@ -821,10 +827,14 @@ void mudlet::loadMaps()
                                   {qsl("ca"), tr("Catalan")},
                                   {qsl("ca_es"), tr("Catalan (Spain)")},
                                   {qsl("ca_es_valencia"), tr("Catalan (Spain - Valencian)")},
+                                  // OpenBSD - it uses a word not a code:
+                                  {qsl("cestina"), tr("Cestina {Czech}", "This is the native name of the language, as used by OpenBSD for one of it's supplied dictionaries")},
                                   {qsl("ckb"), tr("Central Kurdish")},
                                   {qsl("ckb_iq"), tr("Central Kurdish (Iraq)")},
                                   {qsl("cs"), tr("Czech")},
                                   {qsl("cs_cz"), tr("Czech (Czechia)")},
+                                  {qsl("cy"), tr("Welsh")},
+                                  {qsl("cy_gb"), tr("Welsh (United Kingdom {Wales})")},
                                   {qsl("da"), tr("Danish")},
                                   {qsl("da_dk"), tr("Danish (Denmark)")},
                                   {qsl("de"), tr("German")},
@@ -841,6 +851,12 @@ void mudlet::loadMaps()
                                   {qsl("dz_bt"), tr("Dzongkha (Bhutan)")},
                                   {qsl("el"), tr("Greek")},
                                   {qsl("el_gr"), tr("Greek (Greece)")},
+                                  {qsl("eo"), tr("Esperato")},
+                                  // Used by OpenBSD but this code is a bit
+                                  // bogus as, by definition, this 'Universal'
+                                  // constructed language should be the same in
+                                  // any country, so doesn't need a country code suffix.
+                                  {qsl("eo_eo"), tr("Esperato")},
                                   {qsl("en"), tr("English")},
                                   {qsl("en_ag"), tr("English (Antigua/Barbuda)")},
                                   {qsl("en_au"), tr("English (Australia)")},
@@ -896,15 +912,26 @@ void mudlet::loadMaps()
                                   {qsl("eu"), tr("Basque")},
                                   {qsl("eu_es"), tr("Basque (Spain)")},
                                   {qsl("eu_fr"), tr("Basque (France)")},
+                                  {qsl("fa"), tr("Persian")},
                                   {qsl("fi"), tr("Finnish")},
                                   {qsl("fi_fi"), tr("Finnish")},
+                                  {qsl("fo"), tr("Faroese")},
+                                  {qsl("fo_fo"), tr("Faroese (Faroe Islands)")},
                                   {qsl("fr"), tr("French")},
+                                  // On OpenBSD this seems to be the "usual spellings of French,
+                                  // with, in addition, some new spellings rectifying past
+                                  // inconsistencies":
+                                  {qsl("fr_xx_classique"), tr("French")},
                                   {qsl("fr_be"), tr("French (Belgium)")},
                                   {qsl("fr_ca"), tr("French (Catalan)")},
                                   {qsl("fr_ch"), tr("French (Switzerland)")},
                                   {qsl("fr_fr"), tr("French (France)")},
                                   {qsl("fr_lu"), tr("French (Luxemburg)")},
                                   {qsl("fr_mc"), tr("French (Monaco)")},
+                                  {qsl("fur"), tr("Friulian")},
+                                  {qsl("fur_it"), tr("Friulian (Italy)")},
+                                  {qsl("fy"), tr("Western Frisian")},
+                                  {qsl("ga"), tr("Irish")},
                                   {qsl("gd"), tr("Gaelic")},
                                   {qsl("gd_gb"), tr("Gaelic (United Kingdom {Scots})")},
                                   {qsl("gl"), tr("Galician")},
@@ -922,6 +949,7 @@ void mudlet::loadMaps()
                                   {qsl("hi_in"), tr("Hindi (India)")},
                                   {qsl("hr"), tr("Croatian")},
                                   {qsl("hr_hr"), tr("Croatian (Croatia)")},
+                                  {qsl("hsb"), tr("Upper Sorbian")},
                                   {qsl("hu"), tr("Hungarian")},
                                   {qsl("hu_hu"), tr("Hungarian (Hungary)")},
                                   {qsl("hy"), tr("Armenian")},
@@ -943,14 +971,26 @@ void mudlet::loadMaps()
                                   {qsl("ku"), tr("Kurdish")},
                                   {qsl("ku_sy"), tr("Kurdish (Syria)")},
                                   {qsl("ku_tr"), tr("Kurdish (Turkey)")},
+                                  {qsl("la"), tr("Latin")},
+                                  {qsl("lb"), tr("Luxembourgish")},
+                                  {qsl("lb_lu"), tr("Luxembourgish (Luxembourg)")},
                                   {qsl("lo"), tr("Lao")},
                                   {qsl("lo_la"), tr("Lao (Laos)")},
+                                  // OpenBSD - it uses a word not the code 'wen' for Sorbian:
+                                  {qsl("lower sorbian"), tr("Lower Sorbian")},
                                   {qsl("lt"), tr("Lithuanian")},
                                   {qsl("lt_lt"), tr("Lithuanian (Lithuania)")},
                                   {qsl("lv"), tr("Latvian")},
                                   {qsl("lv_lv"), tr("Latvian (Latvia)")},
+                                  {qsl("mg"), tr("Malagasy")},
+                                  {qsl("mg_mg"), tr("Malagasy (Madagascar)")},
+                                  {qsl("mi"), tr("Māori")},
+                                  // OpenBSD - "tai tokerau" is apparently "Northern" in Māori
+                                  {qsl("mi_x_tai tokerau"), tr("Māori {\"Northern Māori Dictionary\"}", "The term in {...} describes a project (now archived at the wayback machine) to compile a dictionary for the language.")},
                                   {qsl("ml"), tr("Malayalam")},
                                   {qsl("ml_in"), tr("Malayalam (India)")},
+                                  {qsl("mn"), tr("Mongolian")},
+                                  {qsl("mn_mn"), tr("Mongolian (Mongolia)")},
                                   {qsl("nb"), tr("Norwegian Bokmål")},
                                   {qsl("nb_no"), tr("Norwegian Bokmål (Norway)")},
                                   {qsl("ne"), tr("Nepali")},
@@ -963,8 +1003,18 @@ void mudlet::loadMaps()
                                   {qsl("nl_sr"), tr("Dutch (Suriname)")},
                                   {qsl("nn"), tr("Norwegian Nynorsk")},
                                   {qsl("nn_no"), tr("Norwegian Nynorsk (Norway)")},
+                                  {qsl("nr"), tr("South Ndebele")},
+                                  {qsl("nr_za"), tr("South Ndebele (South Africa)")},
+                                  {qsl("nso"), tr("Northern Sotho")},
+                                  {qsl("nso_za"), tr("Northern Sotho (South Africa)")},
+                                  {qsl("ny"), tr("Nyanja")},
+                                  {qsl("ny_mw"), tr("Nyanja (Malawi)")},
                                   {qsl("oc"), tr("Occitan")},
                                   {qsl("oc_fr"), tr("Occitan (France)")},
+                                  {qsl("or"), tr("Odia")},
+                                  {qsl("or_in"), tr("Odia (India)")},
+                                  {qsl("pa"), tr("Punjabi")},
+                                  {qsl("pa_in"), tr("Punjabi (India)")},
                                   {qsl("pl"), tr("Polish")},
                                   {qsl("pl_pl"), tr("Polish (Poland)")},
                                   {qsl("pt"), tr("Portuguese")},
@@ -972,6 +1022,17 @@ void mudlet::loadMaps()
                                   {qsl("pt_pt"), tr("Portuguese (Portugal)")},
                                   {qsl("ro"), tr("Romanian")},
                                   {qsl("ro_ro"), tr("Romanian (Romania)")},
+                                  {qsl("ro_ro_cedilla"), tr("Romanian (Romania {s and t with cedillas})")},
+                                  {qsl("ro_ro_classic"), tr("Romanian (Romania {s and t with commas})")},
+                                  {qsl("ro_ro_classiccedilla"), tr("Romanian (Romania {s and t with commas and cedillas})")},
+                                  // This is on OpenBSD and likely comes from:
+                                  // https://addons.thunderbird.net/en-US/thunderbird/addon/tb-langpack-roa-es-val/
+                                  // but it is probably wrong and should have been ca_VALENCIA or similar
+                                  // Some authorities consider Valencian to be the same as Catalan whilst
+                                  // others regard them as separate languages. roa may be a code
+                                  // for the large language "Romance" group which covers a large part of
+                                  // Western Europe:
+                                  {qsl("roa_es_val"), tr("Valencian (Spain)")},
                                   {qsl("ru"), tr("Russian")},
                                   {qsl("ru_ru"), tr("Russian (Russia)")},
                                   {qsl("se"), tr("Northern Sami")},
@@ -984,6 +1045,8 @@ void mudlet::loadMaps()
                                   {qsl("si_lk"), tr("Sinhala (Sri Lanka)")},
                                   {qsl("sk"), tr("Slovak")},
                                   {qsl("sk_sk"), tr("Slovak (Slovakia)")},
+                                  // Variant found on OpenBSD
+                                  {qsl("sk_sk_ascii"), tr("Slovak (Slovakia)")},
                                   {qsl("sl"), tr("Slovenian")},
                                   {qsl("sl_si"), tr("Slovenian (Slovenia)")},
                                   {qsl("so"), tr("Somali")},
@@ -994,16 +1057,23 @@ void mudlet::loadMaps()
                                   {qsl("sr_me"), tr("Serbian (Montenegro)")},
                                   {qsl("sr_rs"), tr("Serbian (Serbia)")},
                                   {qsl("sr_latn_rs"), tr("Serbian (Serbia - Latin-alphabet)")},
+                                  // OpenBSD - uses words not a code:
+                                  {qsl("srpski_latinica"), tr("Serbian (Serbia - Latin-alphabet)")},
                                   {qsl("sr_yu"), tr("Serbian (former state of Yugoslavia)")},
                                   {qsl("ss"), tr("Swati")},
                                   {qsl("ss_sz"), tr("Swati (Swaziland)")},
                                   {qsl("ss_za"), tr("Swati (South Africa)")},
                                   {qsl("sv"), tr("Swedish")},
+                                  {qsl("st"), tr("Southern Sotho")},
+                                  {qsl("st_za"), tr("Southern Sotho (South Africa)")},
                                   {qsl("sv_se"), tr("Swedish (Sweden)")},
                                   {qsl("sv_fi"), tr("Swedish (Finland)")},
                                   {qsl("sw"), tr("Swahili")},
                                   {qsl("sw_ke"), tr("Swahili (Kenya)")},
                                   {qsl("sw_tz"), tr("Swahili (Tanzania)")},
+                                  {qsl("ta"), tr("Tamil")},
+                                  // OpenBSD uses ta as a Country/Regional designation though that doesn't seem to exist in practice
+                                  {qsl("ta_ta"), tr("Tamil (India {Tamil Nadu})")},
                                   {qsl("te"), tr("Telugu")},
                                   {qsl("te_in"), tr("Telugu (India)")},
                                   {qsl("th"), tr("Thai")},
@@ -1022,20 +1092,28 @@ void mudlet::loadMaps()
                                   {qsl("ts_za"), tr("Tsonga (South Africa)")},
                                   {qsl("uk"), tr("Ukrainian")},
                                   {qsl("uk_ua"), tr("Ukrainian (Ukraine)")},
+                                  {qsl("ur"), tr("Urdu")},
                                   {qsl("uz"), tr("Uzbek")},
                                   {qsl("uz_uz"), tr("Uzbek (Uzbekistan)")},
                                   {qsl("ve"), tr("Venda")},
+                                  {qsl("ve_za"), tr("Venda (South Africa)")},
                                   {qsl("vi"), tr("Vietnamese")},
                                   {qsl("vi_vn"), tr("Vietnamese (Vietnam)")},
                                   {qsl("vi_daucu"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
                                   {qsl("vi_daumoi"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
+                                  // OpenBSD has the old names, see:
+                                  // https://github.com/1ec5/hunspell-vi/commit/fecdb355e7c114e1d5ca22fe5b301b2d54af84c9
+                                  {qsl("vi_x_old"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
+                                  {qsl("vi_x_new"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
                                   {qsl("wa"), tr("Walloon")},
                                   {qsl("xh"), tr("Xhosa")},
+                                  {qsl("xh_za"), tr("Xhosa (South Africa)")},
                                   {qsl("yi"), tr("Yiddish")},
                                   {qsl("zh"), tr("Chinese")},
                                   {qsl("zh_cn"), tr("Chinese (China - simplified)")},
                                   {qsl("zh_tw"), tr("Chinese (Taiwan - traditional)")},
-                                  {qsl("zu"), tr("Zulu")}};
+                                  {qsl("zu"), tr("Zulu")},
+                                  {qsl("zu_za"), tr("Zulu (South Africa)")}};
 
     mEncodingNameMap = {{"ASCII", tr("ASCII (Basic)", "Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)")},
                         {"UTF-8", tr("UTF-8 (Recommended)", "Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)")},
@@ -2732,8 +2810,21 @@ int64_t mudlet::getPhysicalMemoryTotal()
     int64_t memInfo{0};
     auto len = sizeof(memInfo);
 
-    if (sysctl(mib, 2, &memInfo, &len, nullptr, 0) == 0)
-    {
+    if (!sysctl(mib, 2, &memInfo, &len, nullptr, 0)) {
+        return memInfo;
+    }
+
+    return -1;
+#elif defined(Q_OS_OPENBSD)
+    // Very similar to MacOS but uses a different second level name
+    int mib[2];
+    mib[0] = CTL_HW;
+    mib[1] = HW_PHYSMEM64; // Or do we really want HW_USERMEM64?
+
+    int64_t memInfo{0};
+    auto len = sizeof(memInfo);
+
+    if (!sysctl(mib, 2, &memInfo, &len, nullptr, 0)) {
         return memInfo;
     }
 
@@ -3561,6 +3652,31 @@ QString mudlet::getMudletPath(const mudletPathType mode, const QString& extra1, 
         } else if (QFile::exists(qsl("/usr/share/hunspell/%1.aff").arg(extra1))) {
             mudlet::self()->mUsingMudletDictionaries = false;
             return QLatin1String("/usr/share/hunspell/");
+        } else if (QFile::exists(qsl("%1/../../src/%2.aff").arg(QCoreApplication::applicationDirPath(), extra1))) {
+            // From debug or release subdirectory of a shadow build directory alongside the ./src one:
+            mudlet::self()->mUsingMudletDictionaries = true;
+            return qsl("%1/../../src/").arg(QCoreApplication::applicationDirPath());
+        } else if (QFile::exists(qsl("%1/../src/%2.aff").arg(QCoreApplication::applicationDirPath(), extra1))) {
+            // From shadow build directory alongside the ./src one:
+            mudlet::self()->mUsingMudletDictionaries = true;
+            return qsl("%1/../src/").arg(QCoreApplication::applicationDirPath());
+        } else {
+            // From build within ./src
+            mudlet::self()->mUsingMudletDictionaries = true;
+            return qsl("%1/").arg(QCoreApplication::applicationDirPath());
+        }
+#elif defined(Q_OS_OPENBSD)
+        // OpenBSD uses dictionary files from Mozilla rather than direct from,
+        // Hunspell, but it does not ship a en_us one so we cannot use that on
+        // the first run to find the rest - instead try for the en_GB one
+        // - some of the entries for some of the locale/language/other parts of
+        // the filesnames seem to be a bit random:
+        if (QFile::exists(qsl("/usr/local/share/mozilla-dicts/%1.aff").arg(extra1))) {
+            mudlet::self()->mUsingMudletDictionaries = false;
+            return QLatin1String("/usr/local/share/mozilla-dicts/");
+        } else if (QFile::exists(qsl("/usr/share/mozilla-dicts/%1.aff").arg(extra1))) {
+            mudlet::self()->mUsingMudletDictionaries = false;
+            return QLatin1String("/usr/share/mozilla-dicts/");
         } else if (QFile::exists(qsl("%1/../../src/%2.aff").arg(QCoreApplication::applicationDirPath(), extra1))) {
             // From debug or release subdirectory of a shadow build directory alongside the ./src one:
             mudlet::self()->mUsingMudletDictionaries = true;
@@ -4673,7 +4789,7 @@ bool mudlet::desktopInDarkMode()
         coreMacOS::CFRelease(uiStyle);
     }
     return isDark;
-#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
     QProcess process;
     process.start(qsl("gsettings"), QStringList() << qsl("get") << qsl("org.gnome.desktop.interface") << qsl("gtk-theme"));
     process.waitForFinished();

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -776,15 +776,10 @@ void mudlet::loadMaps()
     // More useful is the cross-referenced (Country <-> Languages):
     // https://www.unicode.org/cldr/charts/latest/supplemental/language_territory_information.html
     // Initially populated from the dictionaries provided within the Debian
-    // GNU/Linux distribution, and supplimented by those provided with
-    // OpenBSD 7.1:
+    // GNU/Linux distribution:
     //: In the translation source texts the language is the leading term, with, generally, the (primary) country(ies) in the brackets, with a trailing language disabiguation after a '-' Chinese is an exception!
     mDictionaryLanguageCodeMap = {{qsl("af"), tr("Afrikaans")},
                                   {qsl("af_za"), tr("Afrikaans (South Africa)")},
-                                  {qsl("ak"), tr("Akan")},
-                                  {qsl("ak_gh"), tr("Akan (Ghana)")},
-                                  {qsl("am"), tr("Amharic")},
-                                  {qsl("am_et"), tr("Amharic (Ethiopia)")},
                                   {qsl("an"), tr("Aragonese")},
                                   {qsl("an_es"), tr("Aragonese (Spain)")},
                                   {qsl("ar"), tr("Arabic")},
@@ -806,8 +801,6 @@ void mudlet::loadMaps()
                                   {qsl("ar_sy"), tr("Arabic (Syria)")},
                                   {qsl("ar_tn"), tr("Arabic (Tunisia)")},
                                   {qsl("ar_ye"), tr("Arabic (Yemen)")},
-                                  {qsl("az"), tr("Azerbaijani")},
-                                  {qsl("az_ir"), tr("Azerbaijani (Iran)")},
                                   {qsl("be"), tr("Belarusian")},
                                   {qsl("be_by"), tr("Belarusian (Belarus)")},
                                   {qsl("be_ru"), tr("Belarusian (Russia)")},
@@ -827,8 +820,6 @@ void mudlet::loadMaps()
                                   {qsl("ca"), tr("Catalan")},
                                   {qsl("ca_es"), tr("Catalan (Spain)")},
                                   {qsl("ca_es_valencia"), tr("Catalan (Spain - Valencian)")},
-                                  // OpenBSD - it uses a word not a code:
-                                  {qsl("cestina"), tr("Cestina {Czech}", "This is the native name of the language, as used by OpenBSD for one of it's supplied dictionaries")},
                                   {qsl("ckb"), tr("Central Kurdish")},
                                   {qsl("ckb_iq"), tr("Central Kurdish (Iraq)")},
                                   {qsl("cs"), tr("Czech")},
@@ -851,12 +842,6 @@ void mudlet::loadMaps()
                                   {qsl("dz_bt"), tr("Dzongkha (Bhutan)")},
                                   {qsl("el"), tr("Greek")},
                                   {qsl("el_gr"), tr("Greek (Greece)")},
-                                  {qsl("eo"), tr("Esperato")},
-                                  // Used by OpenBSD but this code is a bit
-                                  // bogus as, by definition, this 'Universal'
-                                  // constructed language should be the same in
-                                  // any country, so doesn't need a country code suffix.
-                                  {qsl("eo_eo"), tr("Esperato")},
                                   {qsl("en"), tr("English")},
                                   {qsl("en_ag"), tr("English (Antigua/Barbuda)")},
                                   {qsl("en_au"), tr("English (Australia)")},
@@ -912,11 +897,8 @@ void mudlet::loadMaps()
                                   {qsl("eu"), tr("Basque")},
                                   {qsl("eu_es"), tr("Basque (Spain)")},
                                   {qsl("eu_fr"), tr("Basque (France)")},
-                                  {qsl("fa"), tr("Persian")},
                                   {qsl("fi"), tr("Finnish")},
                                   {qsl("fi_fi"), tr("Finnish")},
-                                  {qsl("fo"), tr("Faroese")},
-                                  {qsl("fo_fo"), tr("Faroese (Faroe Islands)")},
                                   {qsl("fr"), tr("French")},
                                   // On OpenBSD this seems to be the "usual spellings of French,
                                   // with, in addition, some new spellings rectifying past
@@ -928,9 +910,6 @@ void mudlet::loadMaps()
                                   {qsl("fr_fr"), tr("French (France)")},
                                   {qsl("fr_lu"), tr("French (Luxemburg)")},
                                   {qsl("fr_mc"), tr("French (Monaco)")},
-                                  {qsl("fur"), tr("Friulian")},
-                                  {qsl("fur_it"), tr("Friulian (Italy)")},
-                                  {qsl("fy"), tr("Western Frisian")},
                                   {qsl("ga"), tr("Irish")},
                                   {qsl("gd"), tr("Gaelic")},
                                   {qsl("gd_gb"), tr("Gaelic (United Kingdom {Scots})")},
@@ -949,7 +928,6 @@ void mudlet::loadMaps()
                                   {qsl("hi_in"), tr("Hindi (India)")},
                                   {qsl("hr"), tr("Croatian")},
                                   {qsl("hr_hr"), tr("Croatian (Croatia)")},
-                                  {qsl("hsb"), tr("Upper Sorbian")},
                                   {qsl("hu"), tr("Hungarian")},
                                   {qsl("hu_hu"), tr("Hungarian (Hungary)")},
                                   {qsl("hy"), tr("Armenian")},
@@ -976,21 +954,12 @@ void mudlet::loadMaps()
                                   {qsl("lb_lu"), tr("Luxembourgish (Luxembourg)")},
                                   {qsl("lo"), tr("Lao")},
                                   {qsl("lo_la"), tr("Lao (Laos)")},
-                                  // OpenBSD - it uses a word not the code 'wen' for Sorbian:
-                                  {qsl("lower sorbian"), tr("Lower Sorbian")},
                                   {qsl("lt"), tr("Lithuanian")},
                                   {qsl("lt_lt"), tr("Lithuanian (Lithuania)")},
                                   {qsl("lv"), tr("Latvian")},
                                   {qsl("lv_lv"), tr("Latvian (Latvia)")},
-                                  {qsl("mg"), tr("Malagasy")},
-                                  {qsl("mg_mg"), tr("Malagasy (Madagascar)")},
-                                  {qsl("mi"), tr("Māori")},
-                                  // OpenBSD - "tai tokerau" is apparently "Northern" in Māori
-                                  {qsl("mi_x_tai tokerau"), tr("Māori {\"Northern Māori Dictionary\"}", "The term in {...} describes a project (now archived at the wayback machine) to compile a dictionary for the language.")},
                                   {qsl("ml"), tr("Malayalam")},
                                   {qsl("ml_in"), tr("Malayalam (India)")},
-                                  {qsl("mn"), tr("Mongolian")},
-                                  {qsl("mn_mn"), tr("Mongolian (Mongolia)")},
                                   {qsl("nb"), tr("Norwegian Bokmål")},
                                   {qsl("nb_no"), tr("Norwegian Bokmål (Norway)")},
                                   {qsl("ne"), tr("Nepali")},
@@ -1003,18 +972,8 @@ void mudlet::loadMaps()
                                   {qsl("nl_sr"), tr("Dutch (Suriname)")},
                                   {qsl("nn"), tr("Norwegian Nynorsk")},
                                   {qsl("nn_no"), tr("Norwegian Nynorsk (Norway)")},
-                                  {qsl("nr"), tr("South Ndebele")},
-                                  {qsl("nr_za"), tr("South Ndebele (South Africa)")},
-                                  {qsl("nso"), tr("Northern Sotho")},
-                                  {qsl("nso_za"), tr("Northern Sotho (South Africa)")},
-                                  {qsl("ny"), tr("Nyanja")},
-                                  {qsl("ny_mw"), tr("Nyanja (Malawi)")},
                                   {qsl("oc"), tr("Occitan")},
                                   {qsl("oc_fr"), tr("Occitan (France)")},
-                                  {qsl("or"), tr("Odia")},
-                                  {qsl("or_in"), tr("Odia (India)")},
-                                  {qsl("pa"), tr("Punjabi")},
-                                  {qsl("pa_in"), tr("Punjabi (India)")},
                                   {qsl("pl"), tr("Polish")},
                                   {qsl("pl_pl"), tr("Polish (Poland)")},
                                   {qsl("pt"), tr("Portuguese")},
@@ -1022,17 +981,6 @@ void mudlet::loadMaps()
                                   {qsl("pt_pt"), tr("Portuguese (Portugal)")},
                                   {qsl("ro"), tr("Romanian")},
                                   {qsl("ro_ro"), tr("Romanian (Romania)")},
-                                  {qsl("ro_ro_cedilla"), tr("Romanian (Romania {s and t with cedillas})")},
-                                  {qsl("ro_ro_classic"), tr("Romanian (Romania {s and t with commas})")},
-                                  {qsl("ro_ro_classiccedilla"), tr("Romanian (Romania {s and t with commas and cedillas})")},
-                                  // This is on OpenBSD and likely comes from:
-                                  // https://addons.thunderbird.net/en-US/thunderbird/addon/tb-langpack-roa-es-val/
-                                  // but it is probably wrong and should have been ca_VALENCIA or similar
-                                  // Some authorities consider Valencian to be the same as Catalan whilst
-                                  // others regard them as separate languages. roa may be a code
-                                  // for the large language "Romance" group which covers a large part of
-                                  // Western Europe:
-                                  {qsl("roa_es_val"), tr("Valencian (Spain)")},
                                   {qsl("ru"), tr("Russian")},
                                   {qsl("ru_ru"), tr("Russian (Russia)")},
                                   {qsl("se"), tr("Northern Sami")},
@@ -1045,8 +993,6 @@ void mudlet::loadMaps()
                                   {qsl("si_lk"), tr("Sinhala (Sri Lanka)")},
                                   {qsl("sk"), tr("Slovak")},
                                   {qsl("sk_sk"), tr("Slovak (Slovakia)")},
-                                  // Variant found on OpenBSD
-                                  {qsl("sk_sk_ascii"), tr("Slovak (Slovakia)")},
                                   {qsl("sl"), tr("Slovenian")},
                                   {qsl("sl_si"), tr("Slovenian (Slovenia)")},
                                   {qsl("so"), tr("Somali")},
@@ -1057,23 +1003,16 @@ void mudlet::loadMaps()
                                   {qsl("sr_me"), tr("Serbian (Montenegro)")},
                                   {qsl("sr_rs"), tr("Serbian (Serbia)")},
                                   {qsl("sr_latn_rs"), tr("Serbian (Serbia - Latin-alphabet)")},
-                                  // OpenBSD - uses words not a code:
-                                  {qsl("srpski_latinica"), tr("Serbian (Serbia - Latin-alphabet)")},
                                   {qsl("sr_yu"), tr("Serbian (former state of Yugoslavia)")},
                                   {qsl("ss"), tr("Swati")},
                                   {qsl("ss_sz"), tr("Swati (Swaziland)")},
                                   {qsl("ss_za"), tr("Swati (South Africa)")},
                                   {qsl("sv"), tr("Swedish")},
-                                  {qsl("st"), tr("Southern Sotho")},
-                                  {qsl("st_za"), tr("Southern Sotho (South Africa)")},
                                   {qsl("sv_se"), tr("Swedish (Sweden)")},
                                   {qsl("sv_fi"), tr("Swedish (Finland)")},
                                   {qsl("sw"), tr("Swahili")},
                                   {qsl("sw_ke"), tr("Swahili (Kenya)")},
                                   {qsl("sw_tz"), tr("Swahili (Tanzania)")},
-                                  {qsl("ta"), tr("Tamil")},
-                                  // OpenBSD uses ta as a Country/Regional designation though that doesn't seem to exist in practice
-                                  {qsl("ta_ta"), tr("Tamil (India {Tamil Nadu})")},
                                   {qsl("te"), tr("Telugu")},
                                   {qsl("te_in"), tr("Telugu (India)")},
                                   {qsl("th"), tr("Thai")},
@@ -1092,11 +1031,9 @@ void mudlet::loadMaps()
                                   {qsl("ts_za"), tr("Tsonga (South Africa)")},
                                   {qsl("uk"), tr("Ukrainian")},
                                   {qsl("uk_ua"), tr("Ukrainian (Ukraine)")},
-                                  {qsl("ur"), tr("Urdu")},
                                   {qsl("uz"), tr("Uzbek")},
                                   {qsl("uz_uz"), tr("Uzbek (Uzbekistan)")},
                                   {qsl("ve"), tr("Venda")},
-                                  {qsl("ve_za"), tr("Venda (South Africa)")},
                                   {qsl("vi"), tr("Vietnamese")},
                                   {qsl("vi_vn"), tr("Vietnamese (Vietnam)")},
                                   {qsl("vi_daucu"), tr("Vietnamese (DauCu variant - old-style diacritics)")},
@@ -1107,13 +1044,11 @@ void mudlet::loadMaps()
                                   {qsl("vi_x_new"), tr("Vietnamese (DauMoi variant - new-style diacritics)")},
                                   {qsl("wa"), tr("Walloon")},
                                   {qsl("xh"), tr("Xhosa")},
-                                  {qsl("xh_za"), tr("Xhosa (South Africa)")},
                                   {qsl("yi"), tr("Yiddish")},
                                   {qsl("zh"), tr("Chinese")},
                                   {qsl("zh_cn"), tr("Chinese (China - simplified)")},
                                   {qsl("zh_tw"), tr("Chinese (Taiwan - traditional)")},
-                                  {qsl("zu"), tr("Zulu")},
-                                  {qsl("zu_za"), tr("Zulu (South Africa)")}};
+                                  {qsl("zu"), tr("Zulu")}};
 
     mEncodingNameMap = {{"ASCII", tr("ASCII (Basic)", "Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)")},
                         {"UTF-8", tr("UTF-8 (Recommended)", "Keep the English translation intact, so if a user accidentally changes to a language they don't understand, they can change back e.g. ISO 8859-2 (Центральная Европа/Central European)")},

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -85,6 +85,10 @@
 #elif defined(Q_OS_HURD)
 #include <errno.h>
 #include <unistd.h>
+#elif defined(Q_OS_OPENBSD)
+// OpenBSD doesn't have a sysinfo.h
+#include <sys/sysctl.h>
+#include <unistd.h>
 #elif defined(Q_OS_UNIX)
 // Including both GNU/Linux and FreeBSD
 #include <sys/resource.h>

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -25,14 +25,14 @@
 
 ############################################################################
 #                                                                          #
-#    NOTICE: FreeBSD and GNU/Hurd are not officially supported platforms   #
-#    as such; the work on getting them working has been done by myself,    #
-#    and other developers, unless they have explicitly said so, are not    #
-#    able to address issues relating specifically to these Operating       #
-#    Systems. Nevertheless users of either are equally welcome to          #
-#    contribute to the development of Mudlet - bugfixes and enhancements   #
-#    are welcome from all!                                                 #
-#                         Stephen Lyons, February 2018, updated March 2021 #
+#    NOTICE: FreeBSD, OpenBSD and GNU/Hurd are not officially supported    #
+#    platforms as such; the work on getting them working has been done by  #
+#    myself, and other developers, unless they have explicitly said so,    #
+#    are not able to address issues relating specifically to these         #
+#    Operating Systems. Nevertheless users of these operating systems are  #
+#    equally welcome to contribute to the development of Mudlet - bugfixes #
+#    and enhancements are welcome from all!                                #
+#        Stephen Lyons, February 2018, updated March 2021 & October 2022   #
 #                                                                          #
 ############################################################################
 
@@ -256,6 +256,15 @@ unix:!macx {
     isEmpty( BINDIR ) BINDIR = $${PREFIX}/bin
 # Again according to FHS /usr/local/share/games is the corresponding place for locally built games documentation:
     isEmpty( DOCDIR ) DOCDIR = $${DATAROOTDIR}/doc/mudlet
+    openbsd {
+        LIBS += \
+# Some OS platforms have a hyphen (I think Cygwin does as well):
+            -llua5.1 \
+            -lhunspell-1.7
+        INCLUDEPATH += \
+            /usr/local/include \
+            /usr/local/include/lua-5.1
+    }
     freebsd {
         LIBS += \
 # Some OS platforms have a hyphen (I think Cygwin does as well):
@@ -267,7 +276,8 @@ unix:!macx {
 # FreeBSD (at least) supports multiple Lua versions (and 5.1 is not the default anymore):
         INCLUDEPATH += \
             /usr/local/include/lua51
-    } else {
+    }
+    linux {
         LIBS += \
             -llua5.1 \
             -lhunspell
@@ -774,8 +784,9 @@ win32 {
     HEADERS += uiawrapper.h
 }
 
-linux {
-    SOURCES += AnnouncerLinux.cpp
+openbsd|linux {
+    SOURCES += \
+        AnnouncerUnix.cpp
 }
 
 # This is for compiled UI files, not those used at runtime through the resource file.

--- a/translations/translated/updateqm.pri
+++ b/translations/translated/updateqm.pri
@@ -48,7 +48,9 @@ win32 {
     CMD = "where"
     message("You can safely ignore one or two \"INFO: Could not find files for the given pattern(s).\" messages that may appear!")
 } else {
-    CMD = "which"
+    # OpenBSD reports the failure to find lua5.1 loudly enough to be seen;
+    # so explictly bin the stderr output:
+    CMD = "which 2>/dev/null"
 }
 
 LUA_SEARCH_OUT = $$system("$$CMD lua5.1")


### PR DESCRIPTION
Tweak the built-in Hunspell spelling support system to accomodate the dictionaries that OpenBSD provides (unfortunately American English is NOT one of them so we cannot use that one to locate the OS provided ones, so instead, for that OS, look for the British one instead)...

Adjust the search for the Lua executable in `./translations/translated/updateqm.pri` so that for the non-Windows case it is silent when a particular executable is NOT found (as otherwise OpenBSD at least will moan, to `stderr`, on the first tried filename - which is a little confusing - when the second tried one succeeds!)

Rename `./src/AnnouncerLinux.cpp` to `./src/AnnouncerUnix.cpp` on the basis that it can be used by more than just the GNU/Linux OS.

Add names for the OpenBSD specific Hunspell dictionaries so that the "Input line" Tab of the Mudlet preferences displays meaningful names for the found "system" (or in the OpenBSD case those packaged for the Mozilla email and web-browser) dictionaries.

At present the CMake project build system does not seem to work on OpenBSD, it seems that the Qt library finding stuff does not correctly find the required Qt5 modules for one or more of the third party components.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>
