### PR TITLE
Infrastructure: unify class constructor initialisers (Part 1 of 2)

### DIFF
--- a/src/AltFocusMenuBarDisable.cpp
+++ b/src/AltFocusMenuBarDisable.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,7 +25,9 @@ AltFocusMenuBarDisable::AltFocusMenuBarDisable()
     setObjectName(baseStyle()->objectName());
 }
 
-AltFocusMenuBarDisable::AltFocusMenuBarDisable(const QString &style) : QProxyStyle(QStyleFactory::create(style)) {}
+AltFocusMenuBarDisable::AltFocusMenuBarDisable(const QString &style)
+: QProxyStyle(QStyleFactory::create(style))
+{}
 
 int AltFocusMenuBarDisable::styleHint(StyleHint styleHint, const QStyleOption *opt, const QWidget *widget, QStyleHintReturn *returnData) const
 {

--- a/src/AnnouncerWindows.cpp
+++ b/src/AnnouncerWindows.cpp
@@ -44,7 +44,10 @@
 // https://github.com/jcsteh/osara/blob/master/src/uia.cpp
 class Announcer::UiaProvider : public IRawElementProviderSimple {
 public:
-  UiaProvider(_In_ HWND hwnd) : refCount(0), controlHWnd(hwnd) {}
+    UiaProvider(_In_ HWND hwnd)
+    : refCount(0)
+    , controlHWnd(hwnd)
+    {}
 
   ULONG STDMETHODCALLTYPE AddRef() { return InterlockedIncrement(&refCount); }
 
@@ -135,7 +138,11 @@ bool Announcer::initializeUia() {
   return true;
 }
 
-Announcer::Announcer(QWidget *parent) : QWidget{parent} { initializeUia(); }
+Announcer::Announcer(QWidget *parent)
+: QWidget{parent}
+{
+    initializeUia();
+}
 
 BSTR bStrFromQString(const QString &value) {
   return SysAllocString(reinterpret_cast<const wchar_t *>(value.utf16()));

--- a/src/DarkTheme.cpp
+++ b/src/DarkTheme.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,7 +22,9 @@
 #include "AltFocusMenuBarDisable.h"
 
 //DarkTheme only works with Fusion style
-DarkTheme::DarkTheme() : DarkTheme(new AltFocusMenuBarDisable(qsl("Fusion"))) {}
+DarkTheme::DarkTheme()
+: DarkTheme(new AltFocusMenuBarDisable(qsl("Fusion")))
+{}
 
 DarkTheme::DarkTheme(QStyle* style) : QProxyStyle(style) {}
 

--- a/src/EAction.cpp
+++ b/src/EAction.cpp
@@ -25,7 +25,9 @@
 #include "mudlet.h"
 
 
-EAction::EAction(QIcon& icon, QString& name) : QAction(icon, name, mudlet::self()), mID()
+EAction::EAction(QIcon& icon, QString& name)
+: QAction(icon, name, mudlet::self())
+, mID()
 {
     setText(name);
     setObjectName(name);

--- a/src/TAccessibleConsole.h
+++ b/src/TAccessibleConsole.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
- *   Copyright (C) 2014-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2020, 2022 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2022 by Thiago Jung Bauermann - bauermann@kolabnow.com  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -33,7 +34,8 @@
 class TAccessibleConsole : public QAccessibleWidget
 {
 public:
-    explicit TAccessibleConsole(QWidget* w) : QAccessibleWidget(w, QAccessible::Pane)
+    explicit TAccessibleConsole(QWidget* w)
+    : QAccessibleWidget(w, QAccessible::Pane)
     {
         Q_ASSERT(isValid());
     }

--- a/src/TAccessibleTextEdit.h
+++ b/src/TAccessibleTextEdit.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       *
- *   Copyright (C) 2014-2020 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2020, 2022 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2022 by Thiago Jung Bauermann - bauermann@kolabnow.com  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -34,7 +35,8 @@
 class TAccessibleTextEdit : public QAccessibleWidget, public QAccessibleTextInterface
 {
 public:
-    explicit TAccessibleTextEdit(QWidget* w) : QAccessibleWidget(w, QAccessible::EditableText)
+    explicit TAccessibleTextEdit(QWidget* w)
+    : QAccessibleWidget(w, QAccessible::EditableText)
     {
         Q_ASSERT(isValid());
     }

--- a/src/TAstar.h
+++ b/src/TAstar.h
@@ -68,7 +68,10 @@ class distance_heuristic : public boost::astar_heuristic<Graph, CostType>
 {
 public:
     typedef typename boost::graph_traits<Graph>::vertex_descriptor Vertex;
-    distance_heuristic(LocMap l, Vertex goal) : m_location(l), m_goal(goal) {}
+    distance_heuristic(LocMap l, Vertex goal)
+    : m_location(l)
+    , m_goal(goal)
+    {}
 
     CostType operator()(Vertex u)
     {
@@ -98,7 +101,9 @@ template <class Vertex>
 class astar_goal_visitor : public boost::default_astar_visitor
 {
 public:
-    explicit astar_goal_visitor(Vertex goal) : m_goal(goal) {}
+    explicit astar_goal_visitor(Vertex goal)
+    : m_goal(goal)
+    {}
 
     template <class Graph>
     void examine_vertex(Vertex u, Graph& g) {

--- a/src/TMxpBRTagHandler.h
+++ b/src/TMxpBRTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,7 +25,9 @@
 class TMxpBRTagHandler : public TMxpSingleTagHandler
 {
 public:
-    TMxpBRTagHandler() : TMxpSingleTagHandler("BR") {}
+    TMxpBRTagHandler()
+    : TMxpSingleTagHandler("BR")
+    {}
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
 };

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
- *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2020, 2022 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -34,7 +34,9 @@ protected:
     TMxpContext* mpContext;
 
 public:
-    TMxpClient() : mpContext(nullptr) {}
+    TMxpClient()
+    : mpContext(nullptr)
+    {}
 
     virtual void initialize(TMxpContext* context) { mpContext = context; }
 

--- a/src/TMxpFontTagHandler.h
+++ b/src/TMxpFontTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,7 +26,9 @@
 class TMxpFontTagHandler : public TMxpSingleTagHandler
 {
 public:
-    TMxpFontTagHandler() : TMxpSingleTagHandler("FONT") {}
+    TMxpFontTagHandler()
+    : TMxpSingleTagHandler("FONT")
+    {}
 
     TMxpTagHandlerResult handleStartTag(TMxpContext &context, TMxpClient& client, MxpStartTag* tag) override;
 

--- a/src/TMxpLinkTagHandler.h
+++ b/src/TMxpLinkTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -30,7 +31,11 @@ class TMxpLinkTagHandler : public TMxpSingleTagHandler
     QString getHref(const MxpStartTag* tag);
 
 public:
-    TMxpLinkTagHandler() : TMxpSingleTagHandler("A"), mIsHrefInContent(false), mLinkId(0) {}
+    TMxpLinkTagHandler()
+    : TMxpSingleTagHandler("A")
+    , mIsHrefInContent(false)
+    , mLinkId(0)
+    {}
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
     TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) override;

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -34,7 +34,8 @@
 #include <QDebug>
 #include "post_guard.h"
 
-dlgAboutDialog::dlgAboutDialog(QWidget* parent) : QDialog(parent)
+dlgAboutDialog::dlgAboutDialog(QWidget* parent)
+: QDialog(parent)
 {
     setupUi(this);
 

--- a/src/dlgComposer.cpp
+++ b/src/dlgComposer.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2010 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2016, 2022 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,8 +26,8 @@
 #include "Host.h"
 
 
-dlgComposer::dlgComposer(Host* pH) : mpHost(pH)
-
+dlgComposer::dlgComposer(Host* pH)
+: mpHost(pH)
 {
     setupUi(this);
     QFont f = QFont(qsl("Bitstream Vera Sans Mono"), 10, QFont::Normal);

--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -22,7 +22,9 @@
 #include "TRoomDB.h"
 #include "dlgMapper.h"
 
-MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH) : QObject(parent), mpHost(pH)
+MapInfoContributorManager::MapInfoContributorManager(QObject* parent, Host* pH)
+: QObject(parent)
+, mpHost(pH)
 {
     registerContributor(qsl("Short"), [=](int roomID, int selectionSize, int areaId, int displayAreaId, QColor& infoColor) {
         return shortInfo(roomID, selectionSize, areaId, displayAreaId, infoColor);


### PR DESCRIPTION
This is so they all have each member initialiser on a single line - so that changes can be more easily seen/comprehended in Git differences (as opposed to them all being on a long single line...!)

This is a response to the comment: https://github.com/Mudlet/Mudlet/pull/6379#issuecomment-1287238558

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>