### PR TITLE
Infrastructure: unify class constructor initialisers (Part 2 0f 2)

### DIFF
--- a/src/TMxpMusicTagHandler.h
+++ b/src/TMxpMusicTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Mike Conley - sousesider[at]gmail.com           *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,7 +27,9 @@
 class TMxpMusicTagHandler : public TMxpSingleTagHandler
 {
 public:
-    TMxpMusicTagHandler() : TMxpSingleTagHandler("MUSIC") {}
+    TMxpMusicTagHandler()
+    : TMxpSingleTagHandler("MUSIC")
+    {}
 
     static QString extractFileName(MxpStartTag* tag);
     static QString extractVolume(MxpStartTag* tag);

--- a/src/TMxpSoundTagHandler.h
+++ b/src/TMxpSoundTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Mike Conley - sousesider[at]gmail.com           *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -26,7 +27,9 @@
 class TMxpSoundTagHandler : public TMxpSingleTagHandler
 {
 public:
-    TMxpSoundTagHandler() : TMxpSingleTagHandler("SOUND") {}
+    TMxpSoundTagHandler()
+    : TMxpSingleTagHandler("SOUND")
+    {}
 
     static QString extractFileName(MxpStartTag* tag);
     static QString extractVolume(MxpStartTag* tag);

--- a/src/TMxpSupportTagHandler.h
+++ b/src/TMxpSupportTagHandler.h
@@ -29,7 +29,9 @@ class TMxpSupportTagHandler : public TMxpSingleTagHandler
 public:
     QString processSupportsRequest(TMxpContext& ctx, MxpStartTag* tag);
 
-    TMxpSupportTagHandler() : TMxpSingleTagHandler("SUPPORT") {}
+    TMxpSupportTagHandler()
+    : TMxpSingleTagHandler("SUPPORT")
+    {}
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
 };

--- a/src/TMxpTagHandler.h
+++ b/src/TMxpTagHandler.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
- *   Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2020, 2022 by Stephen Lyons - slysven@virginmedia.com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -104,7 +104,9 @@ public:
     }
 
 protected:
-    explicit TMxpSingleTagHandler(QString tagName) : tagName(std::move(tagName)) {}
+    explicit TMxpSingleTagHandler(QString tagName)
+    : tagName(std::move(tagName))
+    {}
 };
 
 #endif //MUDLET_TMXPTAGHANDLER_H

--- a/src/TMxpVarTagHandler.h
+++ b/src/TMxpVarTagHandler.h
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2014-2018 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2014-2018, 2022 by Stephen Lyons                        *
+ *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -30,7 +31,10 @@ class TMxpVarTagHandler : public TMxpTagHandler {
     MxpStartTag mCurrentStartTag;
     QString mCurrentVarContent;
 public:
-    TMxpVarTagHandler() : mCurrentStartTag(MxpStartTag("VAR")) {}
+    TMxpVarTagHandler()
+    : mCurrentStartTag(MxpStartTag("VAR"))
+    {}
+
     bool supports(TMxpContext& ctx, TMxpClient& client, MxpTag* tag) override;
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
     TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) override;

--- a/src/TMxpVersionTagHandler.h
+++ b/src/TMxpVersionTagHandler.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2020 by Gustavo Sousa - gustavocms@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,7 +25,10 @@
 class TMxpVersionTagHandler : public TMxpSingleTagHandler
 {
 public:
-    TMxpVersionTagHandler() : TMxpSingleTagHandler("VERSION") {}
+    TMxpVersionTagHandler()
+    : TMxpSingleTagHandler("VERSION")
+    {}
+
     inline static const QString scmVersionString = qsl("\n\x1b[1z<VERSION MXP=1.0 CLIENT=Mudlet VERSION=%1>\n");
 
     TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;

--- a/src/TSplitter.cpp
+++ b/src/TSplitter.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2009 by Heiko Koehn - KoehnHeiko@googlemail.com         *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,7 +26,9 @@
 #include "TSplitterHandle.h"
 
 
-TSplitter::TSplitter(Qt::Orientation o, QWidget* p) : QSplitter(o, p), mpSplitterHandle()
+TSplitter::TSplitter(Qt::Orientation o, QWidget* p)
+: QSplitter(o, p)
+, mpSplitterHandle()
 {
 }
 

--- a/src/TTabBar.h
+++ b/src/TTabBar.h
@@ -2,7 +2,7 @@
 #define TTABBAR_H
 
 /***************************************************************************
- *   Copyright (C) 2018, 2020-2021 by Stephen Lyons                        *
+ *   Copyright (C) 2018, 2020-2022 by Stephen Lyons                        *
  *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -36,7 +36,10 @@ class TTabBar : public QTabBar
     Q_OBJECT
 
 public:
-    explicit TTabBar(QWidget* parent) : QTabBar(parent) {}
+    explicit TTabBar(QWidget* parent)
+    : QTabBar(parent)
+    {}
+
     ~TTabBar() = default;
     TTabBar() = delete;
     QSize tabSizeHint(int index) const override;

--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2010 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -31,7 +32,9 @@
 #include <QHeaderView>
 #include "post_guard.h"
 
-TTreeWidget::TTreeWidget(QWidget* pW) : QTreeWidget(pW), mChildID()
+TTreeWidget::TTreeWidget(QWidget* pW)
+: QTreeWidget(pW)
+, mChildID()
 {
     setSelectionMode(QAbstractItemView::SingleSelection);
     setSelectionBehavior(QAbstractItemView::SelectRows);

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2013 by Chris Mitchell                                  *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2021 by Stephen Lyons - slysven@virginmedia..com        *
+ *   Copyright (C) 2021-2022 by Stephen Lyons - slysven@virginmedia..com   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,7 +29,8 @@
 #include "post_guard.h"
 
 
-VarUnit::VarUnit() : base()
+VarUnit::VarUnit()
+: base()
 {
 }
 


### PR DESCRIPTION
This is so they all have each member initialiser on a single line - so that changes can be more easily seen/comprehended in Git differences (as opposed to them all being on a long single line...!)

This is a response to the comment: https://github.com/Mudlet/Mudlet/pull/6379#issuecomment-1287238558

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>