### PR TITLE
Fix: Stop sound/music precisely for MCMP

### DIFF
--- a/src/TMedia.cpp
+++ b/src/TMedia.cpp
@@ -670,6 +670,81 @@ QList<TMediaPlayer> TMedia::getMediaPlayerList(TMediaData& mediaData)
     return mTMediaPlayerList;
 }
 
+void TMedia::updateMediaPlayerList(TMediaPlayer& player)
+{
+    int matchedMediaPlayerIndex = -1;
+    TMediaData mediaData = player.getMediaData();
+    QList<TMediaPlayer> mTMediaPlayerList = TMedia::getMediaPlayerList(mediaData);
+
+    for (int i = 0; i < mTMediaPlayerList.size(); ++i) {
+        TMediaPlayer pTestPlayer = mTMediaPlayerList.at(i);
+
+        if (pTestPlayer.getMediaPlayer() == player.getMediaPlayer()) {
+            matchedMediaPlayerIndex = i;
+            break;
+        }
+    }
+
+    switch (mediaData.getMediaProtocol()) {
+    case TMediaData::MediaProtocolMSP:
+        switch (mediaData.getMediaType()) {
+        case TMediaData::MediaTypeSound:
+            if (matchedMediaPlayerIndex == -1) {
+                mMSPSoundList.append(player);
+            } else {
+                mMSPSoundList.replace(matchedMediaPlayerIndex, player);
+            }
+            break;
+        case TMediaData::MediaTypeMusic:
+            if (matchedMediaPlayerIndex == -1) {
+                mMSPMusicList.append(player);
+            } else {
+                mMSPMusicList.replace(matchedMediaPlayerIndex, player);
+            }
+            break;
+        }
+        break;
+
+    case TMediaData::MediaProtocolGMCP:
+        switch (mediaData.getMediaType()) {
+        case TMediaData::MediaTypeSound:
+            if (matchedMediaPlayerIndex == -1) {
+                mGMCPSoundList.append(player);
+            } else {
+                mGMCPSoundList.replace(matchedMediaPlayerIndex, player);
+            }
+            break;
+        case TMediaData::MediaTypeMusic:
+            if (matchedMediaPlayerIndex == -1) {
+                mGMCPMusicList.append(player);
+            } else {
+                mGMCPMusicList.replace(matchedMediaPlayerIndex, player);
+            }
+            break;
+        }
+        break;
+
+    case TMediaData::MediaProtocolAPI:
+        switch (mediaData.getMediaType()) {
+        case TMediaData::MediaTypeSound:
+            if (matchedMediaPlayerIndex == -1) {
+                mAPISoundList.append(player);
+            } else {
+                mAPISoundList.replace(matchedMediaPlayerIndex, player);
+            }
+            break;
+        case TMediaData::MediaTypeMusic:
+            if (matchedMediaPlayerIndex == -1) {
+                mAPIMusicList.append(player);
+            } else {
+                mAPIMusicList.replace(matchedMediaPlayerIndex, player);
+            }
+            break;
+        }
+        break;
+    }
+}
+
 TMediaPlayer TMedia::getMediaPlayer(TMediaData& mediaData)
 {
     TMediaPlayer pPlayer{};
@@ -993,41 +1068,6 @@ void TMedia::play(TMediaData& mediaData)
         pPlayer.getMediaPlayer()->setPlaylist(playlist);
     }
 
-    switch (mediaData.getMediaProtocol()) {
-    case TMediaData::MediaProtocolMSP:
-        switch (mediaData.getMediaType()) {
-        case TMediaData::MediaTypeSound:
-            mMSPSoundList.append(pPlayer);
-            break;
-        case TMediaData::MediaTypeMusic:
-            mMSPMusicList.append(pPlayer);
-            break;
-        }
-        break;
-
-    case TMediaData::MediaProtocolGMCP:
-        switch (mediaData.getMediaType()) {
-        case TMediaData::MediaTypeSound:
-            mGMCPSoundList.append(pPlayer);
-            break;
-        case TMediaData::MediaTypeMusic:
-            mGMCPMusicList.append(pPlayer);
-            break;
-        }
-        break;
-
-    case TMediaData::MediaProtocolAPI:
-        switch (mediaData.getMediaType()) {
-        case TMediaData::MediaTypeSound:
-            mAPISoundList.append(pPlayer);
-            break;
-        case TMediaData::MediaTypeMusic:
-            mAPIMusicList.append(pPlayer);
-            break;
-        }
-        break;
-    }
-
     // Set volume, start and play media
     pPlayer.getMediaPlayer()->setVolume(mediaData.getMediaFadeIn() != TMediaData::MediaFadeNotSet ? 1 : mediaData.getMediaVolume());
     pPlayer.getMediaPlayer()->setPosition(mediaData.getMediaStart());
@@ -1037,6 +1077,8 @@ void TMedia::play(TMediaData& mediaData)
     }
 
     pPlayer.getMediaPlayer()->play();
+
+    updateMediaPlayerList(pPlayer);
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Scripting#type:_sound

--- a/src/TMedia.h
+++ b/src/TMedia.h
@@ -90,6 +90,7 @@ private:
     void downloadFile(TMediaData& mediaData);
     QString setupMediaAbsolutePathFileName(TMediaData& mediaData);
     QList<TMediaPlayer> getMediaPlayerList(TMediaData& mediaData);
+    void updateMediaPlayerList(TMediaPlayer& player);
     TMediaPlayer getMediaPlayer(TMediaData& mediaData);
     TMediaPlayer matchMediaPlayer(TMediaData& mediaData, const QString& absolutePathFileName);
     bool doesMediaHavePriorityToPlay(TMediaData& mediaData, const QString& absolutePathFileName);

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -494,7 +494,7 @@ public:
                                  "<a href='http://www.wotmod.org/'>Forums</a>", ":/icons/wotmudicon.png"}},
         {"Midnight Sun 2", {"midnightsun2.org", 3000, false, "<a href='http://midnightsun2.org/'>http://midnightsun2.org/</a>", ":/icons/midnightsun2.png"}},
         {"Luminari", {"luminarimud.com", 4100, false, "<a href='http://www.luminarimud.com/'>http://www.luminarimud.com/</a>", ":/icons/luminari_icon.png"}},
-        {"StickMUD", {"stickmud.com", 7680, false, "<a href='http://www.stickmud.com/'>stickmud.com</a>", ":/icons/stickmud_icon.jpg"}},
+        {"StickMUD", {"stickmud.com", 7670, true, "<a href='http://www.stickmud.com/'>stickmud.com</a>", ":/icons/stickmud_icon.jpg"}},
         {"Clessidra", {"mud.clessidra.it", 4000, false, "<a href='http://www.clessidra.it/'>http://www.clessidra.it</a>", ":/icons/clessidra.jpg"}},
         {"Reinos de Leyenda", {"reinosdeleyenda.es", 23, false, "<a href='https://www.reinosdeleyenda.es/'>Sitio web principal</a><br>"
                                  "<a href='https://www.reinosdeleyenda.es/foro/'>Foros</a><br>"


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
To correct a symptom where more media was stopping than was intended using the `key` parameter, an issue was fixed with the code that handles Mud Sound Protocol (MSP), Mud Client Media Protocol (MCMP), and the Sound/Music Lua API. Reproducing the issue identified that the TMediaData element of reused TMediaPlayer(s) were not getting updated as intended. Better handling of the QList(s) that cache the TMediaPlayer(s) corrected the problem. A side benefit of implementing this fix will be better reuse of the TMediaPlayer(s), generating more efficiency in Mudlet.

#### Motivation for adding to Mudlet
Mudlet Discord user Blizzard#7841 reported the issue on the #help channel.

<img width="1055" alt="Screen Shot 2022-10-23 at 5 06 20 PM" src="https://user-images.githubusercontent.com/3058178/197418309-790c5661-6e3f-4709-8119-5a6f133abe34.png">

#### Other info (issues closed, discussion etc)
Release Notes: Corrected a symptom where more media was stopping than was intended using the `key` parameter with Mud Client Media Protocol (MCMP) and the Sound/Music API for Mudlet.

**Testing**

This is an edge case, so the scenario here is a bit quirky to reproduce the issue.

In this scenario, we will play space music with a `key` of `space-music` and weirder things music with a `key` of `weirder-things`. The `weirder-things` music will stop the `space-music`, which plays at a lower priority. We will restart the `weirder-things` music and then try to stop only the `space-music` (which _is not_ playing at the time). In the older version of Mudlet, we'll hear that the `weirder-things` music stops too when pulling level P the second time, which is not desired. A bug in reusing media players caused more music (all music in this case) to stop, when it is only intended to stop the space music.

The issue appears in 4.16.0, where all music stops on step 8 below:

1. Open Mudlet, login to StickMUD at stickmud.com 7670 secure
2. Go e;2u
3. pull lever N with gmcp
4. pull lever O with gmcp
5. pull lever P with gmcp
6. pull lever Q with gmcp
7. pull lever O with gmcp
8. pull lever P with gmcp
9. close Mudlet

Pulling level P should have only stopped `space-music`, but it stops the `weirder-things` music also.

The issue shows fixed with the PR version where the weirder things music keeps playing on step 7 below: 

1. Open Mudlet, relogin to StickMUD at stickmud.com 7760 secure
2. pull lever N with gmcp
3. pull lever O with gmcp
4. pull lever P with gmcp
5. pull lever Q with gmcp
6. pull lever O with gmcp
7. pull lever P with gmcp
8. pull lever Q with gmcp
9. close Mudlet

Success is when pulling lever P the second time does nothing.  This is the intended functionality.  Use lever Q to stop all the music.