### PR TITLE
Fix: return room list to be within mapper

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -82,6 +82,7 @@ const QString& key_icon_dialog_cancel = qsl(":/icons/dialog-cancel.png");
 T2DMap::T2DMap(QWidget* parent)
 : QWidget(parent)
 {
+    mMultiSelectionListWidget.setParent(this);
     mMultiSelectionListWidget.setColumnCount(2);
     mMultiSelectionListWidget.hideColumn(1);
     QStringList headerLabels;


### PR DESCRIPTION
This will close issue #6369 which was brought about by my PR #5937 - but how isn't obvious to me. Somehow before that PR the `(QTreeWidget) T2DMap::mMulitSelectionListWidget` was automagically getting the idea of what its parent widget was - but afterwards it wasn't - so it no longer had a widget to position itself relative to when `QWidget::move(int, int)` was called on it and instead moved relative to (on my GNU/Linux box) the top left corner of the desktop. Given the behaviour that @Kebap noticed in the original issue it seems that the Windows PC he noted it on used a different reference position. Nevertheless I feel confident that now that this PR explicitly tells the widget who its "daddy" (well parent) is, it will properly position itself back to where it should be!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>