### PR TITLE
Add: isActiveID(...) and existsID(...) functions

### DIFF
--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -483,7 +483,9 @@ public:
     static int disableScript(lua_State*);
     static int permAlias(lua_State*);
     static int exists(lua_State*);
+    static int existsID(lua_State*);
     static int isActive(lua_State*);
+    static int isActiveID(lua_State*);
     static int tempAlias(lua_State*);
     static int enableAlias(lua_State*);
     static int disableAlias(lua_State*);


### PR DESCRIPTION
This PR is an alternative/replacement for #6401 that provides the functionality with a *new* function rather than overloading the existing `isActive(name as string, type as string)`. This is at the request of @Kebap who expressed a strong desire for this alternative approach to establishing the status of a Mudlet item by ID number rather than by name. As temporary items do not *have* names but they do possess a unique ID this will also work for them whereas the unmodified `isActive(...)` function can not. Unlike the `isActive(...)` function there can only be a single item that matches the ID so the return value is a boolean value rather than an integer count (of matching items that are active).

Whilst developing the `isActiveID(...)` function I spotted that there was potentially a need for the related `existsID(...)` in the same way that there is an `exists(name, type)` alongside the `active(name, type)` function. Like the `isActiveID(...)`function compared to the `isActive(...)` the `existsID(...)` too only relates to a single item so also returns a boolean result.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>