### PR TITLE
Fix: ensure area selector widget is updated after map is loaded

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3850,6 +3850,10 @@ void Host::createMapper(const bool loadDefaultMap)
 
     } else {
         if (pMap->mpMapper) {
+            // Needed to set the area selector widget to right area when map is
+            // loaded by clicking on Map main toolbar button:
+            pMap->mpMapper->updateAreaComboBox();
+            pMap->mpMapper->resetAreaComboBoxToPlayerRoomArea();
             pMap->mpMapper->show();
         }
     }


### PR DESCRIPTION
I was looking into #3576 and discovered what I initially thought was the cause (but I no longer think so) in that if the mapper is created by pressing the "Map" button on the main toolbar the area selector widget in the mapper does not get adjusted so that it is on the area that the player room is in after the map gets loaded. Due to the different flow of execution this is NOT an issue when the mapper is created in the main (or a user-window) via the `createMapper(...)` Lua function.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>