### PR TITLE
Infrastructure: correct an error associated with `QColor` in "Room properties" and "Room symbol" classes

### DIFF
--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -420,7 +420,7 @@ QFont dlgRoomProperties::getFontForPreview(QString symbolString)
 
 void dlgRoomProperties::slot_openSymbolColorSelector()
 {
-    auto* dialog = new QColorDialog(selectedSymbolColor.isValid() ? selectedSymbolColor: defaultSymbolColor(), this);
+    auto* dialog = new QColorDialog(selectedSymbolColor.isValid() ? selectedSymbolColor : defaultSymbolColor(), this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(tr("Set symbol color"));
     dialog->open(this, SLOT(slot_symbolColorSelected(const QColor&)));

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -378,7 +378,7 @@ int dlgRoomProperties::getNewWeight()
 
 void dlgRoomProperties::slot_updatePreview()
 {
-    auto realSymbolColor = selectedSymbolColor != nullptr ? selectedSymbolColor : defaultSymbolColor();
+    auto realSymbolColor = selectedSymbolColor.isValid() ? selectedSymbolColor : defaultSymbolColor();
     QString newSymbol = getNewSymbol();
     if (newSymbol == multipleValuesPlaceholder) {
         newSymbol = QString();
@@ -420,7 +420,7 @@ QFont dlgRoomProperties::getFontForPreview(QString symbolString)
 
 void dlgRoomProperties::slot_openSymbolColorSelector()
 {
-    auto* dialog = (selectedSymbolColor != nullptr) ? new QColorDialog(selectedSymbolColor, this) : new QColorDialog(defaultSymbolColor(), this);
+    auto* dialog = new QColorDialog(selectedSymbolColor.isValid() ? selectedSymbolColor: defaultSymbolColor(), this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(tr("Set symbol color"));
     dialog->open(this, SLOT(slot_symbolColorSelected(const QColor&)));

--- a/src/dlgRoomSymbol.cpp
+++ b/src/dlgRoomSymbol.cpp
@@ -198,7 +198,7 @@ QFont dlgRoomSymbol::getFontForPreview(QString text) {
 
 void dlgRoomSymbol::slot_openColorSelector()
 {
-    auto* dialog = new QColorDialog(selectedColor.isValid() ? selectedColor: defaultColor(), this);
+    auto* dialog = new QColorDialog(selectedColor.isValid() ? selectedColor : defaultColor(), this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(tr("Pick color"));
     dialog->open(this, SLOT(slot_colorSelected(const QColor&)));

--- a/src/dlgRoomSymbol.cpp
+++ b/src/dlgRoomSymbol.cpp
@@ -166,7 +166,7 @@ QString dlgRoomSymbol::getNewSymbol()
 
 void dlgRoomSymbol::slot_updatePreview()
 {
-    auto realColor = selectedColor != nullptr ? selectedColor : defaultColor();
+    auto realColor = selectedColor.isValid() ? selectedColor : defaultColor();
     auto newSymbol = getNewSymbol();
     label_preview->setFont(getFontForPreview(newSymbol));
     label_preview->setText(newSymbol);
@@ -198,7 +198,7 @@ QFont dlgRoomSymbol::getFontForPreview(QString text) {
 
 void dlgRoomSymbol::slot_openColorSelector()
 {
-    auto* dialog = selectedColor != nullptr ? new QColorDialog(selectedColor, this) : new QColorDialog(defaultColor(), this);
+    auto* dialog = new QColorDialog(selectedColor.isValid() ? selectedColor: defaultColor(), this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(tr("Pick color"));
     dialog->open(this, SLOT(slot_colorSelected(const QColor&)));


### PR DESCRIPTION
In a couple of places a `QColor` in the `dlgRoomSymbol` class - which was duplicated in the new `dlgRoomProperties` one - was being compared to a `nullptr` to determine if it has been set to anything. This is incorrect because the item will have a memory address whether it has been assigned a meaningful colour value or not. Instead the `QColor::isValid()` method is the correct way to do this. (An invalid or uninitiated QColor has red, green, blue and alpha values all being 0 out of 255 - i.e. it would be transparent!)

As to whether the code now works correctly I have not been able to exhaustively check. This ought to be confirmed before it is merged.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>