### PR TITLE
Infrastructure: resolve merge conflict

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3903,7 +3903,7 @@ void T2DMap::slot_setRoomProperties(
     }
     repaint();
     update();
-    mpMap->mUnsavedMap = true;
+    mpMap->setUnsaved(__func__);
 }
 
 void T2DMap::slot_setImage()

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -475,7 +475,7 @@ void dlgRoomProperties::slot_defineNewColor()
         slot_openRoomColorSelector();
     }
     repaint();
-    mpHost->mpMap->mUnsavedMap = true;
+    mpHost->mpMap->setUnsaved(__func__);
 }
 
 
@@ -502,7 +502,7 @@ void dlgRoomProperties::slot_openRoomColorSelector()
 
             mpHost->mpMap->mCustomEnvColors.remove(color.toInt());
             repaint();
-            mpHost->mpMap->mUnsavedMap = true;
+            mpHost->mpMap->setUnsaved(__func__);
         });
 
         menu.exec(QCursor::pos());


### PR DESCRIPTION
This came about because of a change I made in #6285 which clashed with @Kebap 's #6354. I made `(bool) TMap::mUnsavedMap` private to force setting it to `true` to be done via `(void) TMap::setUnsaved(const char*)` - which tracks (for debugging purposes) where the call was made from. However that change was not in Kebap's code and was not detected when my code was merged in after theirs.

This is a **high** priority bug-fix because without it the **`development` branch will fail to build - making it unusable for new PRs.**

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>