### PR TITLE
Fix: fix getMainWindowSize values if console tab is not in focus (hidden)

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -628,12 +628,12 @@ void TConsole::resizeEvent(QResizeEvent* event)
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());
     }
 
+    QWidget::resizeEvent(event);
+
     if (mType & MainConsole) {
         // don't call event in lua if size didn't change
         bool preventLuaEvent = (getMainWindowSize() == mOldSize);
-        QWidget::resizeEvent(event);
         mOldSize = getMainWindowSize();
-
         if (preventLuaEvent) {
             return;
         }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -1927,7 +1927,7 @@ void TConsole::slot_searchBufferDown()
 
 QSize TConsole::getMainWindowSize() const
 {
-    if (isHidden()){
+    if (isHidden()) {
         return mOldSize;
     }
     QSize consoleSize = size();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -629,9 +629,9 @@ void TConsole::resizeEvent(QResizeEvent* event)
     }
 
     // don't call event in lua if size didn't change
-    bool preventLuaEvent = (mpMainDisplay->size() == mOldSize);
+    bool preventLuaEvent = (getMainWindowSize() == mOldSize);
     QWidget::resizeEvent(event);
-    mOldSize = mpMainDisplay->size();
+    mOldSize = getMainWindowSize();
 
     if (preventLuaEvent) {
         return;
@@ -1928,6 +1928,9 @@ void TConsole::slot_searchBufferDown()
 
 QSize TConsole::getMainWindowSize() const
 {
+    if (isHidden()){
+        return mOldSize;
+    }
     QSize consoleSize = size();
     int toolbarWidth = mpLeftToolBar->width() + mpRightToolBar->width();
     int toolbarHeight = mpTopToolBar->height();

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -628,16 +628,15 @@ void TConsole::resizeEvent(QResizeEvent* event)
         layerCommandLine->move(0, mpBaseVFrame->height() - layerCommandLine->height());
     }
 
-    // don't call event in lua if size didn't change
-    bool preventLuaEvent = (getMainWindowSize() == mOldSize);
-    QWidget::resizeEvent(event);
-    mOldSize = getMainWindowSize();
-
-    if (preventLuaEvent) {
-        return;
-    }
-
     if (mType & MainConsole) {
+        // don't call event in lua if size didn't change
+        bool preventLuaEvent = (getMainWindowSize() == mOldSize);
+        QWidget::resizeEvent(event);
+        mOldSize = getMainWindowSize();
+
+        if (preventLuaEvent) {
+            return;
+        }
         TLuaInterpreter* pLua = mpHost->getLuaInterpreter();
         QString func = "handleWindowResizeEvent";
         QString n = "WindowResizeEvent";


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Trying to fix wrong getMainWindowSize values if console is hidden,
for example when another console tab is in focus
#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
should fix #5960 