### PR TITLE
Infrastructure: Add `pcre` as an explicit dependency to macOS builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -308,7 +308,7 @@ jobs:
         run-luarocks install --local luautf8
         run-luarocks install --local lua-zip
         run-luarocks install SQLITE_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" --local LuaSQL-SQLite3
-        run-luarocks install --local lrexlib-pcre
+        run-luarocks install PCRE_INCDIR="${{env.VCPKG_ROOT}}/installed/${{matrix.triplet}}/include" --local lrexlib-pcre
 
         # CI changelog generation dependencies
         run-luarocks install --local argparse

--- a/3rdparty/our-vcpkg-dependencies/vcpkg-x64-linux-dependencies
+++ b/3rdparty/our-vcpkg-dependencies/vcpkg-x64-linux-dependencies
@@ -6,3 +6,5 @@ pugixml
 --overlay-ports=../our-vcpkg-dependencies/lua
 lua[core]
 sqlite3
+pcre
+

--- a/3rdparty/our-vcpkg-dependencies/vcpkg-x64-osx-dependencies
+++ b/3rdparty/our-vcpkg-dependencies/vcpkg-x64-osx-dependencies
@@ -6,3 +6,4 @@ pugixml
 --overlay-ports=../our-vcpkg-dependencies/lua
 lua[core]
 sqlite3
+pcre


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add `pcre` as an explicit dependency to macOS builds
#### Motivation for adding to Mudlet
Couldn't find it being requested anywhere but it is needed. Maybe this will fix the failing builds on the 20221121.1 macOS GHA images
#### Other info (issues closed, discussion etc)
