### PR TITLE
Fix: restoring deleted default profile to work right in dev builds

### DIFF
--- a/src/dlgConnectionProfiles.cpp
+++ b/src/dlgConnectionProfiles.cpp
@@ -531,8 +531,7 @@ void dlgConnectionProfiles::slot_saveName()
         fillout_form();
         // and re-select the profile since focus is lost
         auto pRestoredItems = findData(*profiles_tree_widget, newProfileName, csmNameRole);
-        Q_ASSERT_X(pRestoredItems.count() < 1, "dlgConnectionProfiles::slot_saveName", "no previously deleted Mud found with matching name when trying to restore one");
-        Q_ASSERT_X(pRestoredItems.count() > 1, "dlgConnectionProfiles::slot_saveName", "multiple deleted Muds found with matching name when trying to restore one");
+        Q_ASSERT_X(pRestoredItems.count() == 1, "dlgConnectionProfiles::slot_saveName", "Couldn't find exactly 1 restored profile to select");
 
         // As we are using QAbstractItemView::SingleSelection this will
         // automatically unselect the previous item:


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed restoring deleted default profile to work right. Official versions were not affected, only dev ones.
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/6410