### PR TITLE
Fix: Display correct background color of wrapped text indent

### DIFF
--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -60,10 +60,10 @@ TChar::TChar(const QColor& fg, const QColor& bg, const TChar::AttributeFlags fla
 {
 }
 
-TChar::TChar(Host* pH)
-: mFlags(None)
-, mFgColor(pH ? pH->mFgColor : QColorConstants::White)
-, mBgColor(pH ? pH->mBgColor : QColorConstants::Black)
+TChar::TChar(TConsole* pC)
+: mFgColor(pC ? pC->mFormatCurrent.foreground() : QColorConstants::White)
+, mBgColor(pC ? pC->mFormatCurrent.background() : QColorConstants::Black)
+, mFlags(pC ? pC->mFormatCurrent.allDisplayAttributes() : AttributeFlag::None)
 {
 }
 
@@ -2300,7 +2300,7 @@ bool TBuffer::insertInLine(QPoint& P, const QString& text, const TChar& format)
             return false;
         }
         if (x >= static_cast<int>(buffer.at(y).size())) {
-            TChar c;
+            TChar c(mpConsole);
             expandLine(y, x - buffer.at(y).size(), c);
         }
         for (int i = 0, total = text.size(); i < total; ++i) {
@@ -2353,7 +2353,7 @@ TBuffer TBuffer::copy(QPoint& P1, QPoint& P2)
 TBuffer TBuffer::cut(QPoint& P1, QPoint& P2)
 {
     TBuffer slice = copy(P1, P2);
-    TChar format;
+    TChar format(mpConsole);
     replaceInLine(P1, P2, QString(), format);
     return slice;
 }
@@ -2395,7 +2395,7 @@ void TBuffer::paste(QPoint& P, const TBuffer& chunk)
     }
 
     if (hasAppended && y != -1) {
-        TChar format;
+        TChar format(mpConsole);
         wrapLine(y, mWrapAt, mWrapIndent, format);
     }
 }
@@ -2472,6 +2472,7 @@ inline int TBuffer::wrap(int startLine)
     QStringList timeList;
     QList<bool> promptList;
     int lineCount = 0;
+    TChar pSpace(mpConsole);
     for (int i = startLine, total = static_cast<int>(buffer.size()); i < total; ++i) {
         bool isPrompt = promptBuffer[i];
         std::deque<TChar> newLine;
@@ -2480,7 +2481,6 @@ inline int TBuffer::wrap(int startLine)
         int indent = 0;
         if (static_cast<int>(buffer[i].size()) >= mWrapAt) {
             for (int i3 = 0; i3 < mWrapIndent; ++i3) {
-                TChar pSpace;
                 newLine.push_back(pSpace);
                 lineText.append(" ");
             }
@@ -2734,7 +2734,7 @@ bool TBuffer::moveCursor(QPoint& where)
     }
 
     if (static_cast<int>(buffer[y].size()) - 1 > x) {
-        TChar c;
+        TChar c(mpConsole);
         // CHECKME: should "buffer[cookedY].size() - 1" be bracketed - which would change the -1 to +1 in the following:
         expandLine(y, x - buffer[y].size() - 1, c);
     }

--- a/src/TBuffer.h
+++ b/src/TBuffer.h
@@ -83,11 +83,11 @@ public:
     };
     Q_DECLARE_FLAGS(AttributeFlags, AttributeFlag)
 
-    // Default constructor - the default argument means it can be used with no
-    // supplied arguments, but it must NOT be marked 'explicit' so as to allow
+    // Not a default constructor - the defaulted argument means it could have
+    // been used if supplied with no arguments, but the 'explicit' prevents
     // this:
-    explicit TChar(Host* pH = nullptr);
-    // A non-default constructor:
+    explicit TChar(TConsole* pC = nullptr);
+    // Another non-default constructor:
     TChar(const QColor& fg, const QColor& bg, const TChar::AttributeFlags flags = TChar::None, const int linkIndex = 0);
     // User defined copy-constructor:
     TChar(const TChar&);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -129,8 +129,6 @@ TConsole::TConsole(Host* pH, ConsoleType type, QWidget* parent)
         }
     }
     setContentsMargins(0, 0, 0, 0);
-    mFormatSystemMessage.setBackground(mBgColor);
-    mFormatSystemMessage.setForeground(Qt::red);
     setAttribute(Qt::WA_DeleteOnClose);
     setAttribute(Qt::WA_OpaquePaintEvent); //was disabled
 
@@ -1403,7 +1401,7 @@ void TConsole::luaWrapLine(int line)
     if (!mpHost) {
         return;
     }
-    TChar ch(mpHost);
+    TChar ch(this);
     buffer.wrapLine(line, mWrapAt, mIndentCount, ch);
 }
 

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -241,8 +241,6 @@ public:
     int mDisplayFontSize = 14;
     QFont mDisplayFont = QFont(mDisplayFontName, mDisplayFontSize, QFont::Normal);
     int mEngineCursor = -1;
-    TChar mFormatBasic;
-    TChar mFormatSystemMessage;
 
     int mIndentCount = 0;
     int mMainFrameBottomHeight = 0;


### PR DESCRIPTION
We were using default constructed `TChar` instances in both `(int) TBuffer::wrap(int)` and other places but these would be constructed with an invalid (hence transparent and thus effectively black) background and that is not correct if the background has been set to any other colour. By changing the constructor that previously took a `Host*` to one that takes the `TConsole` that owns the `TBuffer` where the `TChar` is being used it is possible to detect and use the current background and foreground colour (and text rendering settings) instead.

There are other places where such default constructed `TChar`s were being used - it is not immediately obvious whether they actually have any effect but it seemed sensible to "fix" them as well and see whether it makes any other changes...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>