### PR TITLE
Fix: update GCC version used in CI builds

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -21,6 +21,7 @@ jobs:
             buildname: 'ubuntu / gcc / lua tests'
             triplet: x64-linux
             compiler: gcc_64
+            gcc_compiler_version: 8
             qt: '5.14.2'
             deploy: 'deploy'
             run_tests: 'true'
@@ -28,6 +29,8 @@ jobs:
             buildname: 'ubuntu / clang'
             triplet: x64-linux
             compiler: clang_64
+            # We still need a gcc for some sub-stages - and it ain't always the same one:
+            gcc_compiler_version: 9
             qt: '5.14.2'
           - os: macos-11
             buildname: 'macos / c++ tests'
@@ -178,14 +181,18 @@ jobs:
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
         # imagemagick is for the desktop screenshot
-        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-8 \
+        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{gcc_compiler_version}} \
           libxkbcommon-x11-0 imagemagick -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
-        sudo update-alternatives --set gcc /usr/bin/gcc-8
-        sudo update-alternatives --set g++ /usr/bin/g++-8
+        # Ubuntu-18.06.4 and Ubuntu-22.04.1 do have a gcc-8 - it is the default
+        # now for the former but not the latter and for the "Ubuntu / clang"
+        # job it seems a bit suspect to have to force a gcc version given that
+        # we should not be intending to use it! Slysven 2022/12
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-$${{gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-$${{gcc_compiler_version}}
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -185,10 +185,6 @@ jobs:
           libxkbcommon-x11-0 imagemagick -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
-        # Ubuntu-18.06.4 and Ubuntu-22.04.1 do have a gcc-8 - it is the default
-        # now for the former but not the latter and for the "Ubuntu / clang"
-        # job it seems a bit suspect to have to force a gcc version given that
-        # we should not be intending to use it! Slysven 2022/12
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
         sudo update-alternatives --set gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}}

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -178,14 +178,14 @@ jobs:
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
         # imagemagick is for the desktop screenshot
-        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-7 \
+        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-8 \
           libxkbcommon-x11-0 imagemagick -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
-        sudo update-alternatives --set gcc /usr/bin/gcc-7
-        sudo update-alternatives --set g++ /usr/bin/g++-7
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
+        sudo update-alternatives --set gcc /usr/bin/gcc-8
+        sudo update-alternatives --set g++ /usr/bin/g++-8
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -181,7 +181,7 @@ jobs:
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
         # imagemagick is for the desktop screenshot
-        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{matrix.gcc_compiler_version}} \
+        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} \
           libxkbcommon-x11-0 imagemagick -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
@@ -189,10 +189,10 @@ jobs:
         # now for the former but not the latter and for the "Ubuntu / clang"
         # job it seems a bit suspect to have to force a gcc version given that
         # we should not be intending to use it! Slysven 2022/12
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
-        sudo update-alternatives --set gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}}
-        sudo update-alternatives --set g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-${{matrix.gcc_compiler_version}}
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -181,7 +181,7 @@ jobs:
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
         # imagemagick is for the desktop screenshot
-        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{gcc_compiler_version}} \
+        sudo apt-get install ccache pkg-config pcregrep expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{matrix.gcc_compiler_version}} \
           libxkbcommon-x11-0 imagemagick -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
@@ -189,10 +189,10 @@ jobs:
         # now for the former but not the latter and for the "Ubuntu / clang"
         # job it seems a bit suspect to have to force a gcc version given that
         # we should not be intending to use it! Slysven 2022/12
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
-        sudo update-alternatives --set gcc /usr/bin/gcc-$${{gcc_compiler_version}}
-        sudo update-alternatives --set g++ /usr/bin/g++-$${{gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}}
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -121,17 +121,17 @@ jobs:
       run: |
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
-        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{matrix.gcc_compiler_version}} -y
+        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
         # Ubuntu-18.06.4 and Ubuntu-22.04.1 do have a gcc-8 - it is the default
         # now for the former but not the latter and for the "Ubuntu / clang"
         # job it seems a bit suspect to have to force a gcc version given that
         # we should not be intending to use it! Slysven 2022/12
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
-        sudo update-alternatives --set gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}}
-        sudo update-alternatives --set g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-${{matrix.gcc_compiler_version}}
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -119,13 +119,13 @@ jobs:
       run: |
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
-        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-7 -y
+        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-8 -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
-        sudo update-alternatives --set gcc /usr/bin/gcc-7
-        sudo update-alternatives --set g++ /usr/bin/g++-7
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
+        sudo update-alternatives --set gcc /usr/bin/gcc-8
+        sudo update-alternatives --set g++ /usr/bin/g++-8
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -121,17 +121,17 @@ jobs:
       run: |
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
-        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{gcc_compiler_version}} -y
+        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{matrix.gcc_compiler_version}} -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
         # Ubuntu-18.06.4 and Ubuntu-22.04.1 do have a gcc-8 - it is the default
         # now for the former but not the latter and for the "Ubuntu / clang"
         # job it seems a bit suspect to have to force a gcc version given that
         # we should not be intending to use it! Slysven 2022/12
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
-        sudo update-alternatives --set gcc /usr/bin/gcc-$${{gcc_compiler_version}}
-        sudo update-alternatives --set g++ /usr/bin/g++-$${{gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}} $${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-$${{matrix.gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-$${{matrix.gcc_compiler_version}}
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -124,10 +124,6 @@ jobs:
         sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-${{matrix.gcc_compiler_version}} -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
-        # Ubuntu-18.06.4 and Ubuntu-22.04.1 do have a gcc-8 - it is the default
-        # now for the former but not the latter and for the "Ubuntu / clang"
-        # job it seems a bit suspect to have to force a gcc version given that
-        # we should not be intending to use it! Slysven 2022/12
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{matrix.gcc_compiler_version}} ${{matrix.gcc_compiler_version}}
         sudo update-alternatives --set gcc /usr/bin/gcc-${{matrix.gcc_compiler_version}}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,8 @@ jobs:
             qt: '5.14.1'
             triplet: x64-linux
             compiler: gcc_64
+            # We need a gcc and it ain't always the same one:
+            gcc_compiler_version: 9
             os: ubuntu-latest
 
     env:
@@ -119,13 +121,17 @@ jobs:
       run: |
         # Install from vcpkg everything we can for cross-platform consistency
         # If not available, use other methods
-        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-8 -y
+        sudo apt-get install ccache pkg-config pcregrep luarocks expect libzip-dev libglu1-mesa-dev libpulse-dev g++-$${{gcc_compiler_version}} -y
 
         # switch to GCC that supports C++17 while retaining support for older OS's
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
-        sudo update-alternatives --set gcc /usr/bin/gcc-8
-        sudo update-alternatives --set g++ /usr/bin/g++-8
+        # Ubuntu-18.06.4 and Ubuntu-22.04.1 do have a gcc-8 - it is the default
+        # now for the former but not the latter and for the "Ubuntu / clang"
+        # job it seems a bit suspect to have to force a gcc version given that
+        # we should not be intending to use it! Slysven 2022/12
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$${{gcc_compiler_version}} $${{gcc_compiler_version}}
+        sudo update-alternatives --set gcc /usr/bin/gcc-$${{gcc_compiler_version}}
+        sudo update-alternatives --set g++ /usr/bin/g++-$${{gcc_compiler_version}}
 
         echo "CCACHE_DIR=${{runner.workspace}}/ccache" >> $GITHUB_ENV
 

--- a/CI/travis.linux.install.sh
+++ b/CI/travis.linux.install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 mkdir -p "${HOME}/latest-gcc-symlinks"
-ln -s /usr/bin/g++-7 "${HOME}/latest-gcc-symlinks/g++"
-ln -s /usr/bin/gcc-7 "${HOME}/latest-gcc-symlinks/gcc"
+ln -s /usr/bin/g++-8 "${HOME}/latest-gcc-symlinks/g++"
+ln -s /usr/bin/gcc-8 "${HOME}/latest-gcc-symlinks/gcc"
 
 # lua-utf8 is not in the repositories...
 luarocks install --local luautf8


### PR DESCRIPTION
From 7.x to 8.x.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>