### PR TITLE
Fix: mark the right thing as being experimental

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -124,6 +124,8 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     listScripts();
     listActions();
     listTimers();
+
+    setWindowTitle(tr("Package Exporter (experimental) - %1").arg(mpHost->getName()));
 }
 
 dlgPackageExporter::~dlgPackageExporter()

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -48,7 +48,7 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     connect(mPackageTable, &QTableWidget::currentItemChanged, this, &dlgPackageManager::slot_itemClicked);
     connect(mPackageTable, &QTableWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggleRemoveButton);
 
-    setWindowTitle(tr("Package Manager (experimental) - %1").arg(mpHost->getName()));
+    setWindowTitle(tr("Package Manager - %1").arg(mpHost->getName()));
     mDetailsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     mDetailsTable->setFocusPolicy(Qt::NoFocus);
     mDetailsTable->setSelectionMode(QAbstractItemView::NoSelection);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -472,23 +472,23 @@ mudlet::mudlet()
     mpMainToolBar->widgetForAction(mpActionNotes)->setObjectName(mpActionNotes->objectName());
 
     mpButtonPackageManagers = new QToolButton(this);
-    mpButtonPackageManagers->setText(tr("Packages (exp.)"));
+    mpButtonPackageManagers->setText(tr("Packages"));
     mpButtonPackageManagers->setObjectName(qsl("package_manager"));
     mpButtonPackageManagers->setContextMenuPolicy(Qt::ActionsContextMenu);
     mpButtonPackageManagers->setPopupMode(QToolButton::MenuButtonPopup);
     mpButtonPackageManagers->setAutoRaise(true);
     mpMainToolBar->addWidget(mpButtonPackageManagers);
 
-    mpActionPackageManager = new QAction(tr("Package Manager (experimental)"), this);
+    mpActionPackageManager = new QAction(tr("Package Manager"), this);
     mpActionPackageManager->setIcon(QIcon(qsl(":/icons/package-manager.png")));
-    mpActionPackageManager->setIconText(tr("Packages (exp.)", "exp. stands for experimental; shortened so it doesn't make buttons huge in the main interface"));
+    mpActionPackageManager->setIconText(tr("Packages"));
     mpActionPackageManager->setObjectName(qsl("package_manager"));
 
     mpActionModuleManager = new QAction(tr("Module Manager"), this);
     mpActionModuleManager->setIcon(QIcon(qsl(":/icons/module-manager.png")));
     mpActionModuleManager->setObjectName(qsl("module_manager"));
 
-    mpActionPackageExporter = new QAction(tr("Package Exporter"), this);
+    mpActionPackageExporter = new QAction(tr("Package Exporter (experimental)"), this);
     mpActionPackageExporter->setIcon(QIcon(qsl(":/icons/package-exporter.png")));
     mpActionPackageExporter->setObjectName(qsl("package_exporter"));
 

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Package Exporter</string>
+   <string>Package Exporter (experimental)</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -291,7 +291,10 @@
   </action>
   <action name="dactionPackageExporter">
    <property name="text">
-    <string>Package exporter</string>
+    <string>Package exporter (exp.)</string>
+   </property>
+   <property name="iconText">
+    <string comment="&quot;exp. stands for experimental; shortened so it doesn't make menu entries/buttons huge in the main interface&quot;">Package exporter (exp.)</string>
    </property>
    <property name="toolTip">
     <string>&lt;p&gt;Gather and bundle up collections of Mudlet Lua items and other reasources into a module.&lt;/p&gt;</string>


### PR DESCRIPTION
It was the package *exporter* that had previously been marked as "**experimental**" the manager wasn't - but #5226 seems to have messed that up.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>