### PR TITLE
Infrastructure: move away from constructor initialisation lists (part 3)

### DIFF
--- a/src/AnnouncerUnix.cpp
+++ b/src/AnnouncerUnix.cpp
@@ -20,15 +20,19 @@
 
 #include "Announcer.h"
 
+#include "pre_guard.h"
 #include <QDebug>
 #include <QAccessible>
+#include "post_guard.h"
 
 InvisibleNotification::InvisibleNotification(QWidget *parent)
 : QWidget(parent)
 {
-    setObjectName("InvisibleNotification");
-    setAccessibleName("InvisibleNotification");
-    setAccessibleDescription("An invisible widget used as a workaround to announce text to the screen reader");
+    setObjectName(qsl("InvisibleNotification"));
+    // This class should not be "visible" to anyone, but it should be localised
+    // in case it does show up:
+    setAccessibleName(tr("InvisibleNotification"));
+    setAccessibleDescription(tr("An invisible widget used as a workaround to announce text to the screen reader"));
 }
 
 void InvisibleNotification::setText(const QString &text)
@@ -57,9 +61,11 @@ QString InvisibleAccessibleNotification::text(QAccessible::Text t) const
 InvisibleStatusbar::InvisibleStatusbar(QWidget *parent)
 : QWidget(parent)
 {
-    setObjectName("InvisibleStatusbar");
-    setAccessibleName("InvisibleStatusbar");
-    setAccessibleDescription("An invisible widget used as part as a workaround to announce text to the screen reader");
+    setObjectName(qsl("InvisibleStatusbar"));
+    // This class should not be "visible" to anyone, but it should be localised
+    // in case it does show up:
+    setAccessibleName(tr("InvisibleStatusbar"));
+    setAccessibleDescription(tr("An invisible widget used as part as a workaround to announce text to the screen reader"));
 }
 
 Announcer::Announcer(QWidget *parent)
@@ -71,7 +77,7 @@ Announcer::Announcer(QWidget *parent)
 
 void Announcer::announce(const QString& text, const QString& processing)
 {
-    Q_UNUSED(processing);
+    Q_UNUSED(processing)
     notification->setText(text);
 
     QAccessibleEvent event(notification, QAccessible::ObjectShow);

--- a/src/AnnouncerWindows.cpp
+++ b/src/AnnouncerWindows.cpp
@@ -20,11 +20,12 @@
  ***************************************************************************/
 
 #include "Announcer.h"
-#include "uiawrapper.h"
-#include "utils.h"
 
+#include "pre_guard.h"
+#include "uiawrapper.h"
 #include <QAccessible>
 #include <QLibrary>
+#include "post_guard.h"
 
 #include <memory>
 #include <ole2.h>
@@ -42,135 +43,132 @@
 
 // this class is largely inspired by OSARA's UiaProvider:
 // https://github.com/jcsteh/osara/blob/master/src/uia.cpp
-class Announcer::UiaProvider : public IRawElementProviderSimple {
+class Announcer::UiaProvider : public IRawElementProviderSimple
+{
 public:
     UiaProvider(_In_ HWND hwnd)
-    : refCount(0)
-    , controlHWnd(hwnd)
+    : controlHWnd(hwnd)
     {}
 
-  ULONG STDMETHODCALLTYPE AddRef() { return InterlockedIncrement(&refCount); }
+    ULONG STDMETHODCALLTYPE AddRef() { return InterlockedIncrement(&refCount); }
 
-  ULONG STDMETHODCALLTYPE Release() {
-    long val = InterlockedDecrement(&refCount);
-    if (val == 0) {
-      delete this;
-    }
-    return val;
-  }
-
-  HRESULT STDMETHODCALLTYPE QueryInterface(_In_ REFIID riid,
-                                           _Outptr_ void **ppInterface) {
-    if (ppInterface) {
-      return E_INVALIDARG;
-    }
-    if (riid == __uuidof(IUnknown)) {
-      *ppInterface = static_cast<IRawElementProviderSimple *>(this);
-    } else if (riid == __uuidof(IRawElementProviderSimple)) {
-      *ppInterface = static_cast<IRawElementProviderSimple *>(this);
-    } else {
-      *ppInterface = nullptr;
-      return E_NOINTERFACE;
-    }
-    (static_cast<IUnknown *>(*ppInterface))->AddRef();
-    return S_OK;
-  }
-
-  HRESULT STDMETHODCALLTYPE
-  get_ProviderOptions(_Out_ ProviderOptions *pRetVal) {
-    if (!pRetVal) {
-      return E_INVALIDARG;
+    ULONG STDMETHODCALLTYPE Release()
+    {
+        long val = InterlockedDecrement(&refCount);
+        if (val == 0) {
+            delete this;
+        }
+        return val;
     }
 
-    *pRetVal = static_cast<ProviderOptions>(ProviderOptions_ServerSideProvider |
-                                            ProviderOptions_UseComThreading);
-    return S_OK;
-  }
-
-  HRESULT STDMETHODCALLTYPE GetPatternProvider(
-      PATTERNID patternId, _Outptr_result_maybenull_ IUnknown **pRetVal) {
-    *pRetVal = NULL;
-    return S_OK;
-  }
-
-  HRESULT STDMETHODCALLTYPE GetPropertyValue(PROPERTYID propertyId,
-                                             _Out_ VARIANT *pRetVal) {
-    switch (propertyId) {
-    case UIA_ControlTypePropertyId:
-      // Stop Narrator from ever speaking this as a window
-      pRetVal->vt = VT_I4;
-      pRetVal->lVal = UIA_CustomControlTypeId;
-      break;
-    case UIA_IsControlElementPropertyId:
-    case UIA_IsContentElementPropertyId:
-    case UIA_IsKeyboardFocusablePropertyId:
-      pRetVal->vt = VT_BOOL;
-      pRetVal->boolVal = VARIANT_FALSE;
-      break;
-    case UIA_ProviderDescriptionPropertyId:
-      pRetVal->vt = VT_BSTR;
-      pRetVal->bstrVal = SysAllocString(L"Mudlet");
-      break;
-    default:
-      pRetVal->vt = VT_EMPTY;
+    HRESULT STDMETHODCALLTYPE QueryInterface(_In_ REFIID riid, _Outptr_ void** ppInterface)
+    {
+        if (ppInterface) {
+            return E_INVALIDARG;
+        }
+        if (riid == __uuidof(IUnknown)) {
+            *ppInterface = static_cast<IRawElementProviderSimple*>(this);
+        } else if (riid == __uuidof(IRawElementProviderSimple)) {
+            *ppInterface = static_cast<IRawElementProviderSimple*>(this);
+        } else {
+            *ppInterface = nullptr;
+            return E_NOINTERFACE;
+        }
+        (static_cast<IUnknown*>(*ppInterface))->AddRef();
+        return S_OK;
     }
-    return S_OK;
-  }
 
-  HRESULT STDMETHODCALLTYPE
-  get_HostRawElementProvider(IRawElementProviderSimple **pRetVal) {
-    return UiaWrapper::self()->hostProviderFromHwnd(controlHWnd, pRetVal);
-  }
+    HRESULT STDMETHODCALLTYPE get_ProviderOptions(_Out_ ProviderOptions* pRetVal)
+    {
+        if (!pRetVal) {
+            return E_INVALIDARG;
+        }
+
+        *pRetVal = static_cast<ProviderOptions>(ProviderOptions_ServerSideProvider | ProviderOptions_UseComThreading);
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetPatternProvider(PATTERNID patternId, _Outptr_result_maybenull_ IUnknown** pRetVal)
+    {
+        *pRetVal = NULL;
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetPropertyValue(PROPERTYID propertyId, _Out_ VARIANT* pRetVal)
+    {
+        switch (propertyId) {
+        case UIA_ControlTypePropertyId:
+            // Stop Narrator from ever speaking this as a window
+            pRetVal->vt = VT_I4;
+            pRetVal->lVal = UIA_CustomControlTypeId;
+            break;
+        case UIA_IsControlElementPropertyId:
+        case UIA_IsContentElementPropertyId:
+        case UIA_IsKeyboardFocusablePropertyId:
+            pRetVal->vt = VT_BOOL;
+            pRetVal->boolVal = VARIANT_FALSE;
+            break;
+        case UIA_ProviderDescriptionPropertyId:
+            pRetVal->vt = VT_BSTR;
+            pRetVal->bstrVal = SysAllocString(L"Mudlet");
+            break;
+        default:
+            pRetVal->vt = VT_EMPTY;
+        }
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE get_HostRawElementProvider(IRawElementProviderSimple** pRetVal) { return UiaWrapper::self()->hostProviderFromHwnd(controlHWnd, pRetVal); }
 
 private:
-  virtual ~UiaProvider() {}
+    virtual ~UiaProvider() {}
 
-  ULONG refCount;
-  HWND controlHWnd;
+    ULONG refCount = 0;
+    HWND controlHWnd = nullptr;
 };
 
-bool Announcer::initializeUia() {
-  // Constructor initializes refcount to 0, assignment to a CComPtr
-  // takes it to 1.
-  uiaProvider = new UiaProvider((HWND)this->winId());
-  // as we are not using CComPtr, ensure refcount is incremented to prevent the provider from being deleted early
-  uiaProvider->AddRef();
-  return true;
+bool Announcer::initializeUia()
+{
+    // Constructor initializes refcount to 0, assignment to a CComPtr
+    // takes it to 1.
+    uiaProvider = new UiaProvider((HWND)this->winId());
+    // as we are not using CComPtr, ensure refcount is incremented to prevent the provider from being deleted early
+    uiaProvider->AddRef();
+    return true;
 }
 
-Announcer::Announcer(QWidget *parent)
-: QWidget{parent}
+Announcer::Announcer(QWidget* parent) : QWidget{parent}
 {
     initializeUia();
 }
 
-BSTR bStrFromQString(const QString &value) {
-  return SysAllocString(reinterpret_cast<const wchar_t *>(value.utf16()));
+BSTR bStrFromQString(const QString& value)
+{
+    return SysAllocString(reinterpret_cast<const wchar_t*>(value.utf16()));
 }
 
-void Announcer::announce(const QString& text, const QString& processing) {
-  BSTR displayString = bStrFromQString(text);
-  BSTR activityId = bStrFromQString(qsl("Mudlet"));
+void Announcer::announce(const QString& text, const QString& processing)
+{
+    BSTR displayString = bStrFromQString(text);
+    BSTR activityId = bStrFromQString(qsl("Mudlet"));
 
-  auto processingvalue = NotificationProcessing_All;
-  if (Q_LIKELY(processing.isEmpty() || processing == qsl("all"))) {
-    processingvalue = NotificationProcessing_All;
-  } else if (processing == qsl("importantall")) {
-    processingvalue = NotificationProcessing_ImportantAll;
-  } else if (processing == qsl("importantmostrecent")) {
-    processingvalue = NotificationProcessing_ImportantMostRecent;
-  } else if (processing == qsl("mostrecent")) {
-    processingvalue = NotificationProcessing_MostRecent;
-  } else if (processing == qsl("currentthenmostrecent")) {
-    processingvalue = NotificationProcessing_CurrentThenMostRecent;
-  } else {
-    Q_ASSERT_X(false, "Announcer::announce(...)", "invalid processing value given");
-  }
+    auto processingvalue = NotificationProcessing_All;
+    if (Q_LIKELY(processing.isEmpty() || processing == qsl("all"))) {
+        processingvalue = NotificationProcessing_All;
+    } else if (processing == qsl("importantall")) {
+        processingvalue = NotificationProcessing_ImportantAll;
+    } else if (processing == qsl("importantmostrecent")) {
+        processingvalue = NotificationProcessing_ImportantMostRecent;
+    } else if (processing == qsl("mostrecent")) {
+        processingvalue = NotificationProcessing_MostRecent;
+    } else if (processing == qsl("currentthenmostrecent")) {
+        processingvalue = NotificationProcessing_CurrentThenMostRecent;
+    } else {
+        Q_ASSERT_X(false, "Announcer::announce(...)", "invalid processing value given");
+    }
 
-  UiaWrapper::self()->raiseNotificationEvent(
-      uiaProvider, NotificationKind_ItemAdded, processingvalue,
-      displayString, activityId);
+    UiaWrapper::self()->raiseNotificationEvent(uiaProvider, NotificationKind_ItemAdded, processingvalue, displayString, activityId);
 
-  ::SysFreeString(displayString);
-  ::SysFreeString(activityId);
+    SysFreeString(displayString);
+    SysFreeString(activityId);
 }

--- a/src/EAction.cpp
+++ b/src/EAction.cpp
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2017, 2019, 2022 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,13 +22,15 @@
 
 
 #include "EAction.h"
+
+#include "mudlet.h" // this includes the needed Host class header
 #include "TAction.h"
-#include "mudlet.h"
 
 
-EAction::EAction(QIcon& icon, QString& name)
+EAction::EAction(Host* pHost, const QIcon& icon, const QString& name, const int id)
 : QAction(icon, name, mudlet::self())
-, mID()
+, mID(id)
+, mpHost(pHost)
 {
     setText(name);
     setObjectName(name);

--- a/src/EAction.h
+++ b/src/EAction.h
@@ -4,7 +4,8 @@
 /***************************************************************************
  *   Copyright (C) 2008-2009 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2017, 2019 by Stephen Lyons - slysven@virginmedia.com   *
+ *   Copyright (C) 2017, 2019, 2022 by Stephen Lyons                       *
+ *                                               - slysven@virginmedia.com *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -29,8 +30,6 @@
 #include "post_guard.h"
 
 class Host;
-class mudlet;
-
 
 class EAction : public QAction
 {
@@ -38,13 +37,13 @@ class EAction : public QAction
 
 public:
     Q_DISABLE_COPY(EAction)
-    EAction(QIcon&, QString&);
+    explicit EAction(Host*, const QIcon&, const QString&, const int);
 
 public slots:
     void slot_execute(bool checked);
 
-public: // TODO: private:
-    int mID;
+private:
+    int mID = 0;
     QPointer<Host> mpHost;
 };
 

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -242,11 +242,8 @@ void TAction::expandToolbar(TToolBar* pT)
 void TAction::insertActions(TToolBar* pT, QMenu* menu)
 {
     mpToolBar = pT;
-    QIcon icon(mIcon);
-    auto action = new EAction(icon, mName);
+    auto action = new EAction(mpHost, QIcon(mIcon), mName, mID);
     action->setCheckable(mIsPushDownButton);
-    action->mID = mID;
-    action->mpHost = mpHost;
     action->setStatusTip(mName);
     if (mpEButton) {
         mpEButton->deleteLater();
@@ -341,10 +338,7 @@ void TAction::fillMenu(TEasyButtonBar* pT, QMenu* menu)
             continue;
         }
         mpEasyButtonBar = pT;
-        QIcon icon(mIcon);
-        auto newAction = new EAction(icon, action->mName);
-        newAction->mID = action->mID;
-        newAction->mpHost = mpHost;
+        auto newAction = new EAction(mpHost, QIcon(mIcon), action->mName, mID);
         newAction->setStatusTip(action->mName);
         newAction->setCheckable(action->mIsPushDownButton);
         if (action->mIsPushDownButton) {
@@ -388,11 +382,8 @@ void TAction::fillMenu(TEasyButtonBar* pT, QMenu* menu)
 void TAction::insertActions(TEasyButtonBar* pT, QMenu* menu)
 {
     mpEasyButtonBar = pT;
-    QIcon icon(mIcon);
-    auto action = new EAction(icon, mName);
+    auto action = new EAction(mpHost, QIcon(mIcon), mName, mID);
     action->setCheckable(mIsPushDownButton);
-    action->mID = mID;
-    action->mpHost = mpHost;
     action->setStatusTip(mName);
     if (mpEButton) {
         mpEButton->deleteLater();

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -11982,7 +11982,7 @@ int TLuaInterpreter::installModule(lua_State* L)
         return warnArgumentValue(L, __func__, message);
     }
     auto moduleManager = host.mpModuleManager;
-    if (moduleManager && moduleManager->mModuleTable->isVisible()) {
+    if (moduleManager && moduleManager->moduleTable->isVisible()) {
         moduleManager->layoutModules();
     }
     lua_pushboolean(L, true);
@@ -11999,7 +11999,7 @@ int TLuaInterpreter::uninstallModule(lua_State* L)
         return 1;
     }
     auto moduleManager = host.mpModuleManager;
-    if (moduleManager && moduleManager->mModuleTable->isVisible()) {
+    if (moduleManager && moduleManager->moduleTable->isVisible()) {
         moduleManager->layoutModules();
     }
     lua_pushboolean(L, true);
@@ -12025,9 +12025,9 @@ int TLuaInterpreter::enableModuleSync(lua_State* L)
     }
 
     auto moduleManager = host.mpModuleManager;
-    if (moduleManager && !moduleManager->mModuleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
-        int row = moduleManager->mModuleTable->findItems(module, Qt::MatchExactly)[0]->row();
-        auto checkItem = moduleManager->mModuleTable->item(row, 2);
+    if (moduleManager && !moduleManager->moduleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
+        int row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
+        auto checkItem = moduleManager->moduleTable->item(row, 2);
         checkItem->setCheckState(Qt::Checked);
     }
 
@@ -12045,9 +12045,9 @@ int TLuaInterpreter::disableModuleSync(lua_State* L)
     }
 
     auto moduleManager = host.mpModuleManager;
-    if (moduleManager && !moduleManager->mModuleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
-        int row = moduleManager->mModuleTable->findItems(module, Qt::MatchExactly)[0]->row();
-        auto checkItem = moduleManager->mModuleTable->item(row, 2);
+    if (moduleManager && !moduleManager->moduleTable->findItems(module, Qt::MatchExactly).isEmpty()) {
+        int row = moduleManager->moduleTable->findItems(module, Qt::MatchExactly)[0]->row();
+        auto checkItem = moduleManager->moduleTable->item(row, 2);
         checkItem->setCheckState(Qt::Unchecked);
     }
 

--- a/src/dlgMapLabel.cpp
+++ b/src/dlgMapLabel.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2022 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -16,19 +17,15 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
+
 #include "dlgMapLabel.h"
 
-#include "pre_guard.h"
-#include <QColorDialog>
-#include <QFontDialog>
-#include "post_guard.h"
+#include "utils.h"
 
-static QString BUTTON_STYLESHEET = QStringLiteral("QPushButton { background-color: rgba(%1, %2, %3, %4); }");
+static QString BUTTON_STYLESHEET = qsl("QPushButton { background-color: rgba(%1, %2, %3, %4); }");
 
 dlgMapLabel::dlgMapLabel(QWidget* pParentWidget)
 : QDialog(pParentWidget)
-, fgColor(QColor(255, 255, 50, 255))
-, bgColor(QColor(50, 50, 150, 100))
 {
     setupUi(this);
 
@@ -58,8 +55,6 @@ dlgMapLabel::dlgMapLabel(QWidget* pParentWidget)
     slot_updateControls();
     slot_updateControlsVisibility();
 }
-
-dlgMapLabel::~dlgMapLabel() {}
 
 bool dlgMapLabel::isTextLabel()
 {

--- a/src/dlgMapLabel.h
+++ b/src/dlgMapLabel.h
@@ -3,6 +3,7 @@
 
 /***************************************************************************
  *   Copyright (C) 2022 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -36,7 +37,6 @@ class dlgMapLabel : public QDialog, public Ui::map_label
 public:
     Q_DISABLE_COPY(dlgMapLabel)
     explicit dlgMapLabel(QWidget*);
-    ~dlgMapLabel();
 
     bool isTextLabel();
     QString getImagePath();
@@ -57,8 +57,8 @@ private:
     QColorDialog* fgColorDialog = nullptr;
     QString imagePath;
     QString text;
-    QColor fgColor;
-    QColor bgColor;
+    QColor fgColor = QColor(255, 255, 50, 255);
+    QColor bgColor = QColor(50, 50, 150, 100);
     QFont font;
 
 private slots:

--- a/src/dlgModuleManager.cpp
+++ b/src/dlgModuleManager.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2011 by Chris Mitchell                                  *
  *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
- *   Copyright (C) 2021-2022 by Stephen Lyons - slysven@virginmedia..com   *
+ *   Copyright (C) 2021-2022 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/dlgModuleManager.h
+++ b/src/dlgModuleManager.h
@@ -2,8 +2,8 @@
 #define MUDLET_DLGMODULEMANAGER_H
 
 /***************************************************************************
- *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
  *   Copyright (C) 2011 by Chris Mitchell                                  *
+ *   Copyright (C) 2021 by Manuel Wegmann - wegmann.manuel@yahoo.com       *
  *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -26,25 +26,20 @@
 #include "Host.h"
 
 #include "pre_guard.h"
-#include "QTableWidget"
+#include "ui_module_manager.h"
 #include <QDialog>
 #include "post_guard.h"
 
-class Host;
-namespace Ui {
-class module_manager;
-}
-
-class dlgModuleManager : public QDialog
+class dlgModuleManager : public QDialog, public Ui::module_manager
 {
     Q_OBJECT
 
 public:
     Q_DISABLE_COPY(dlgModuleManager)
     explicit dlgModuleManager(QWidget* parent, Host*);
-    ~dlgModuleManager();
-     void layoutModules();
-     QTableWidget* mModuleTable;
+    ~dlgModuleManager() override;
+
+    void layoutModules();
 
 private slots:
     void slot_installModule();
@@ -54,11 +49,7 @@ private slots:
     void slot_moduleChanged(QTableWidgetItem*);
 
 private:
-    Ui::module_manager* ui = nullptr;
     Host* mpHost = nullptr;
-    QPushButton* mModuleUninstallButton = nullptr;
-    QPushButton* mModuleInstallButton = nullptr;
-    QPushButton* mModuleHelpButton = nullptr;
 };
 
 #endif

--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -21,50 +21,45 @@
 
 
 #include "dlgPackageManager.h"
-#include "ui_package_manager.h"
+
 #include "mudlet.h"
 
+#include "pre_guard.h"
 #include <QFileDialog>
 #include <QScrollBar>
 #include <QMessageBox>
+#include "post_guard.h"
 
 
 dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
 : QDialog(parent)
-, ui(new Ui::package_manager)
 , mpHost(pHost)
 {
-    ui->setupUi(this);
-    mPackageTable = ui->packageTable;
-    mInstallButton = ui->installButton;
-    mRemoveButton = ui->removeButton;
-    mDetailsTable = ui->additionalDetails;
-    mDescription = ui->packageDescription;
+    setupUi(this);
     resetPackageTable();
-    connect(mPackageTable, &QTableWidget::itemClicked, this, &dlgPackageManager::slot_itemClicked);
-    connect(mInstallButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_installPackage);
-    connect(mRemoveButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_removePackages);
+    connect(packageTable, &QTableWidget::itemClicked, this, &dlgPackageManager::slot_itemClicked);
+    connect(installButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_installPackage);
+    connect(removeButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_removePackages);
     connect(mpHost->mpConsole, &QWidget::destroyed, this, &dlgPackageManager::close);
-    connect(mPackageTable, &QTableWidget::currentItemChanged, this, &dlgPackageManager::slot_itemClicked);
-    connect(mPackageTable, &QTableWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggleRemoveButton);
+    connect(packageTable, &QTableWidget::currentItemChanged, this, &dlgPackageManager::slot_itemClicked);
+    connect(packageTable, &QTableWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggleRemoveButton);
 
-    setWindowTitle(tr("Package Manager (experimental) - %1").arg(mpHost->getName()));
-    mDetailsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    mDetailsTable->setFocusPolicy(Qt::NoFocus);
-    mDetailsTable->setSelectionMode(QAbstractItemView::NoSelection);
-    mPackageTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    mPackageTable->setSelectionBehavior(QAbstractItemView::SelectRows);
-    mPackageTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
-    mDetailsTable->hide();
-    ui->detailsLabel->hide();
-    mDescription->hide();
+    setWindowTitle(tr("Package Manager - %1").arg(mpHost->getName()));
+    additionalDetails->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    additionalDetails->setFocusPolicy(Qt::NoFocus);
+    additionalDetails->setSelectionMode(QAbstractItemView::NoSelection);
+    packageTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    packageTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    packageTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    additionalDetails->hide();
+    detailsLabel->hide();
+    packageDescription->hide();
     setAttribute(Qt::WA_DeleteOnClose);
 }
 
 dlgPackageManager::~dlgPackageManager()
 {
     mpHost->mpPackageManager = nullptr;
-    delete ui;
 }
 
 void dlgPackageManager::resetPackageTable()
@@ -72,13 +67,13 @@ void dlgPackageManager::resetPackageTable()
     if (!mpHost) {
         return;
     }
-    for (int i =  mPackageTable->rowCount() - 1; i >= 0; --i) {
-        mPackageTable->removeRow(i);
+    for (int i =  packageTable->rowCount() - 1; i >= 0; --i) {
+        packageTable->removeRow(i);
     }
 
-    mPackageTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    packageTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
     for (int i = 0; i < mpHost->mInstalledPackages.size(); i++) {
-        mPackageTable->insertRow(i);
+        packageTable->insertRow(i);
         auto packageName = new QTableWidgetItem();
         auto shortDescription = new QTableWidgetItem();
         packageName->setTextAlignment(Qt::AlignCenter);
@@ -94,10 +89,10 @@ void dlgPackageManager::resetPackageTable()
         packageName->setIcon(QIcon(iconDir));
         auto title = packageInfo.value(qsl("title"));
         shortDescription->setText(title);
-        mPackageTable->setItem(i, 0, packageName);
-        mPackageTable->setItem(i, 1, shortDescription);
+        packageTable->setItem(i, 0, packageName);
+        packageTable->setItem(i, 1, shortDescription);
     }
-    mPackageTable->resizeColumnsToContents();
+    packageTable->resizeColumnsToContents();
 }
 
 void dlgPackageManager::slot_installPackage()
@@ -118,11 +113,11 @@ void dlgPackageManager::slot_installPackage()
 
 void dlgPackageManager::slot_removePackages()
 {
-    QModelIndexList selection = mPackageTable->selectionModel()->selectedRows();
+    QModelIndexList selection = packageTable->selectionModel()->selectedRows();
     QStringList removePackages;
     for (int i = 0; i < selection.count(); i++) {
         QModelIndex index = selection.at(i);
-        auto package = mPackageTable->item(index.row(), 0);
+        auto package = packageTable->item(index.row(), 0);
         removePackages << package->text();
     }
 
@@ -130,9 +125,9 @@ void dlgPackageManager::slot_removePackages()
         mpHost->uninstallPackage(removePackages.at(i), 0);
     }
 
-    mDetailsTable->hide();
-    ui->detailsLabel->hide();
-    mDescription->hide();
+    additionalDetails->hide();
+    detailsLabel->hide();
+    packageDescription->hide();
 }
 
 void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
@@ -142,16 +137,16 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
     }
 
     //clear details Table
-    for (int i = mDetailsTable->rowCount() - 1; i >= 0; --i) {
-        mDetailsTable->removeRow(i);
+    for (int i = additionalDetails->rowCount() - 1; i >= 0; --i) {
+        additionalDetails->removeRow(i);
     }
-    QString packageName = mPackageTable->item(pItem->row(), 0)->text();
+    QString packageName = packageTable->item(pItem->row(), 0)->text();
     auto packageInfo{mpHost->mPackageInfo.value(packageName)};
     if (packageInfo.isEmpty()) {
-        mDescription->clear();
-        mDetailsTable->hide();
-        ui->detailsLabel->hide();
-        mDescription->hide();
+        packageDescription->clear();
+        additionalDetails->hide();
+        detailsLabel->hide();
+        packageDescription->hide();
         return;
     }
     packageInfo.remove(qsl("mpackage"));
@@ -160,12 +155,12 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
 
     QString description = packageInfo.take(qsl("description"));
     if (description.isEmpty()) {
-        mDescription->hide();
+        packageDescription->hide();
     } else {
-        mDescription->show();
+        packageDescription->show();
         QString packageDir = mudlet::self()->getMudletPath(mudlet::profileDataItemPath, mpHost->getName(), packageName);
         description.replace(QLatin1String("$packagePath"), packageDir);
-        mDescription->setMarkdown(description);
+        packageDescription->setMarkdown(description);
     }
 
     QStringList labelText, details;
@@ -180,9 +175,9 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
         QLabel* info = new QLabel();
         QLabel* value = new QLabel();
         info->setEnabled(false);
-        mDetailsTable->insertRow(counter);
-        mDetailsTable->setCellWidget(counter, 0, info);
-        mDetailsTable->setCellWidget(counter++, 1, value);
+        additionalDetails->insertRow(counter);
+        additionalDetails->setCellWidget(counter, 0, info);
+        additionalDetails->setCellWidget(counter++, 1, value);
         info->setText(labelText.at(i));
         info->setAlignment(Qt::AlignLeft);
         value->setText(valueText);
@@ -193,34 +188,34 @@ void dlgPackageManager::slot_itemClicked(QTableWidgetItem* pItem)
     if (!packageInfo.isEmpty()) {
         fillAdditionalDetails(packageInfo);
     }
-    mDetailsTable->resizeColumnsToContents();
-    mDetailsTable->resizeRowsToContents();
-    mDetailsTable->horizontalHeader()->resizeSection(0, mDetailsTable->horizontalHeader()->sectionSize(0) + 10);
-    if (mDetailsTable->rowCount() == 0) {
-        mDetailsTable->hide();
-        ui->detailsLabel->hide();
+    additionalDetails->resizeColumnsToContents();
+    additionalDetails->resizeRowsToContents();
+    additionalDetails->horizontalHeader()->resizeSection(0, additionalDetails->horizontalHeader()->sectionSize(0) + 10);
+    if (additionalDetails->rowCount() == 0) {
+        additionalDetails->hide();
+        detailsLabel->hide();
     } else {
-        mDetailsTable->show();
-        ui->detailsLabel->show();
+        additionalDetails->show();
+        detailsLabel->show();
     }
-    int maxHeight = mDetailsTable->rowCount() * mDetailsTable->rowHeight(0);
-    mDetailsTable->setMaximumHeight(maxHeight);
-    mDetailsTable->verticalScrollBar()->hide();
-    mPackageTable->scrollToItem(pItem);
-    mPackageTable->selectRow(pItem->row());
+    int maxHeight = additionalDetails->rowCount() * additionalDetails->rowHeight(0);
+    additionalDetails->setMaximumHeight(maxHeight);
+    additionalDetails->verticalScrollBar()->hide();
+    packageTable->scrollToItem(pItem);
+    packageTable->selectRow(pItem->row());
 }
 
 void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& packageInfo)
 {
     QMap<QString, QString>::const_iterator iter = packageInfo.constBegin();
-    int counter = mDetailsTable->rowCount();
+    int counter = additionalDetails->rowCount();
     while (iter != packageInfo.constEnd()) {
         QLabel* info = new QLabel();
         QLabel* value = new QLabel();
         info->setEnabled(false);
-        mDetailsTable->insertRow(counter);
-        mDetailsTable->setCellWidget(counter, 0, info);
-        mDetailsTable->setCellWidget(counter++, 1, value);
+        additionalDetails->insertRow(counter);
+        additionalDetails->setCellWidget(counter, 0, info);
+        additionalDetails->setCellWidget(counter++, 1, value);
         info->setText(iter.key());
         info->setAlignment(Qt::AlignLeft);
         value->setText(iter.value());
@@ -233,16 +228,16 @@ void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& pack
 
 void dlgPackageManager::slot_toggleRemoveButton()
 {
-    QModelIndexList selection = mPackageTable->selectionModel()->selectedRows();
+    QModelIndexList selection = packageTable->selectionModel()->selectedRows();
     int selectionCount = selection.count();
-    mRemoveButton->setEnabled(selectionCount);
+    removeButton->setEnabled(selectionCount);
     if (selectionCount) {
-        mRemoveButton->setText(tr("Remove %n package(s)",
+        removeButton->setText(tr("Remove %n package(s)",
                                   // Intentional comment to separate arguments
                                   "Message on button in package manager to remove one or more (%n is the count of) selected package(s).",
                                   selectionCount));
     } else {
-        mRemoveButton->setText(tr("Remove package",
+        removeButton->setText(tr("Remove package",
                                   // Intentional comment to separate arguments
                                   "Message on button in package manager initially and when there is no packages to remove."));
     }

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -26,24 +26,23 @@
 #include "Host.h"
 
 #include "pre_guard.h"
+#include "ui_package_manager.h"
 #include <QDialog>
 #include <QTableWidget>
 #include <QTextBrowser>
 #include "post_guard.h"
 
 class Host;
-namespace Ui {
-class package_manager;
-}
 
-class dlgPackageManager : public QDialog
+
+class dlgPackageManager : public QDialog, public Ui::package_manager
 {
     Q_OBJECT
 
 public:
     Q_DISABLE_COPY(dlgPackageManager)
     explicit dlgPackageManager(QWidget* parent, Host*);
-    ~dlgPackageManager();
+    ~dlgPackageManager() override;
     void resetPackageTable();
 
 private slots:
@@ -55,13 +54,7 @@ private slots:
 private:
     void fillAdditionalDetails(const QMap<QString, QString>&);
 
-    Ui::package_manager* ui = nullptr;
     Host* mpHost = nullptr;
-    QTableWidget* mPackageTable = nullptr;
-    QTableWidget* mDetailsTable = nullptr;
-    QTextBrowser* mDescription = nullptr;
-    QPushButton* mInstallButton = nullptr;
-    QPushButton* mRemoveButton = nullptr;
 };
 
 #endif


### PR DESCRIPTION
Start to process the outstanding items in #4578:
* Some clean up of the AnnoucerXxxx files - insert missing `pre_guard` and `post_guard` header files.
* `EAction` - improve the constructor to take two more arguments that the class needs. By doing so it is possible to make the two class members that retain those values `private` - eliminating a `TODO` comment!
* `dlgMapLabel` - move a couple of (non-standard) colour initialisations to the header file. Also remove a dummy destructor. Convert a `QStringLiteral(...)` wrapper to our `qsl(...)` one.
* `dlgModuleManager` - switch from the "Direct" to the "Multiple Inheritance" approach. This means we can remove a number of pointers and refer to members from the form/ dialogue directly in the class by their direct identifier. Insert missing `pre_guard`/`post_guard` Mudlet headers to `.cpp` file. Add missing `override` to the destructor.
* `dlgPackageManager` - same changes as per `dlgModuleManger`.

For the differences between the "Direct" and "Multiple Inheritance" approaches mentioned above see:
https://doc.qt.io/qt-5/designer-using-a-ui-file.html

Unfortunately, the `dlgPackageExporter` class is NOT amenable to this simplification as it uses a custom widget (derived from `QTextEdit`) whose class is also defined in the same file.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>