### PR TITLE
Infrastructure: Remove "experimental" name from package exporter menu, etc.

### DIFF
--- a/src/dlgPackageExporter.cpp
+++ b/src/dlgPackageExporter.cpp
@@ -125,7 +125,9 @@ dlgPackageExporter::dlgPackageExporter(QWidget *parent, Host* pHost)
     listActions();
     listTimers();
 
-    setWindowTitle(tr("Package Exporter (experimental) - %1").arg(mpHost->getName()));
+    setWindowTitle(tr("Package Exporter - %1",
+        "Title of the window. The %1 will be replaced by the current profile's name.")
+        .arg(mpHost->getName()));
 }
 
 dlgPackageExporter::~dlgPackageExporter()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -488,7 +488,7 @@ mudlet::mudlet()
     mpActionModuleManager->setIcon(QIcon(qsl(":/icons/module-manager.png")));
     mpActionModuleManager->setObjectName(qsl("module_manager"));
 
-    mpActionPackageExporter = new QAction(tr("Package Exporter (experimental)"), this);
+    mpActionPackageExporter = new QAction(tr("Package Exporter"), this);
     mpActionPackageExporter->setIcon(QIcon(qsl(":/icons/package-exporter.png")));
     mpActionPackageExporter->setObjectName(qsl("package_exporter"));
 
@@ -2864,7 +2864,7 @@ void mudlet::doAutoLogin(const QString& profile_name)
 
     pHost->setLogin(readProfileData(profile_name, qsl("login")));
     pHost->setPass(readProfileData(profile_name, qsl("password")));
-    
+
     QString val = readProfileData(profile_name, qsl("autoreconnect"));
     if (!val.isEmpty() && val.toInt() == Qt::Checked) {
         pHost->setAutoReconnect(true);

--- a/src/ui/dlgPackageExporter.ui
+++ b/src/ui/dlgPackageExporter.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Package Exporter (experimental)</string>
+   <string>Package Exporter</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/ui/main_window.ui
+++ b/src/ui/main_window.ui
@@ -291,10 +291,7 @@
   </action>
   <action name="dactionPackageExporter">
    <property name="text">
-    <string>Package exporter (exp.)</string>
-   </property>
-   <property name="iconText">
-    <string comment="&quot;exp. stands for experimental; shortened so it doesn't make menu entries/buttons huge in the main interface&quot;">Package exporter (exp.)</string>
+    <string>Package exporter</string>
    </property>
    <property name="toolTip">
     <string>&lt;p&gt;Gather and bundle up collections of Mudlet Lua items and other reasources into a module.&lt;/p&gt;</string>


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove any mentions of "experimental" around package UI

#### Motivation for adding to Mudlet
Vadi wrote in #5226 on May 13, 2021:

> I imagine after 3-4 months if everything is going well, we can finally take the labels off 👍

That was 1.5 years ago now. We didn't hear from any folks having trouble with the package exporter either.

#### Other info (issues closed, discussion etc)
Follow-up to #6454 - see discussion there and in #5226 itself already.