### PR TITLE
Improve: move away from constructor initialisation lists (part 4)

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -440,7 +440,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
         thankForUsingPTB();
     }
 
-    if (mudlet::self()->firstLaunch) {
+    if (mudlet::self()->smFirstLaunch) {
         QTimer::singleShot(0, this, [this]() {
             mpConsole->mpCommandLine->setPlaceholderText(tr("Text to send to the game"));
         });
@@ -453,10 +453,10 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
     // enable by default in case of offline connection; if the profile connects - timer will be disabled
     purgeTimer.start(1min);
 
-    auto i = mudlet::self()->mShortcutsManager->iterator();
+    auto i = mudlet::self()->mpShortcutsManager->iterator();
     while (i.hasNext()) {
         auto entry = i.next();
-        profileShortcuts.insert(entry, new QKeySequence(*mudlet::self()->mShortcutsManager->getSequence(entry)));
+        profileShortcuts.insert(entry, new QKeySequence(*mudlet::self()->mpShortcutsManager->getSequence(entry)));
     }
 
     startMapAutosave();
@@ -628,7 +628,7 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
     int xmlIndex = zip_name_locate(zipFile, qsl("%1.xml").arg(moduleName).toUtf8().constData(), ZIP_FL_ENC_GUESS);
     zip_delete(zipFile, xmlIndex);
     struct zip_source* s = zip_source_file(zipFile, filename_xml.toUtf8().constData(), 0, -1);
-    if (mudlet::debugMode && s == nullptr) {
+    if (mudlet::smDebugMode && s == nullptr) {
         TDebug(QColor(Qt::white), QColor(Qt::red)) << tr("Failed to open xml file \"%1\" inside module %2 to update it. Error message was: \"%3\".",
                                                          // Intentional comment to separate arguments
                                                          "This error message will appear when the xml file inside the module zip cannot be updated for some reason.")
@@ -640,7 +640,7 @@ void Host::updateModuleZips(const QString& zipName, const QString& moduleName)
         err = zip_close(zipFile);
     }
 
-    if (mudlet::debugMode && err == -1) {
+    if (mudlet::smDebugMode && err == -1) {
         TDebug(QColor(Qt::white), QColor(Qt::red)) << tr("Failed to save \"%1\" to module \"%2\". Error message was: \"%3\".",
                                                          // Intentional comment to separate arguments
                                                          "This error message will appear when a module is saved as package but cannot be done for some reason.")
@@ -921,9 +921,9 @@ void Host::updateConsolesFont()
         mpEditorDialog->mpErrorConsole->setFont(mDisplayFont.family());
         mpEditorDialog->mpErrorConsole->setFontSize(mDisplayFont.pointSize());
     }
-    if (mudlet::self()->mpDebugArea) {
-        mudlet::self()->mpDebugConsole->setFont(mDisplayFont.family());
-        mudlet::self()->mpDebugConsole->setFontSize(mDisplayFont.pointSize());
+    if (mudlet::self()->smpDebugArea) {
+        mudlet::self()->smpDebugConsole->setFont(mDisplayFont.family());
+        mudlet::self()->smpDebugConsole->setFontSize(mDisplayFont.pointSize());
     }
 }
 
@@ -2118,7 +2118,7 @@ QString Host::getPackageConfig(const QString& luaConfig, bool isModule)
         break;
     }
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(QColor(Qt::white), QColor(Qt::red)) << "LUA: " << reason.c_str() << " in " << luaConfig << " ERROR:" << e.c_str() << "\n" >> 0;
     }
 

--- a/src/TAction.cpp
+++ b/src/TAction.cpp
@@ -82,7 +82,7 @@ void TAction::compileAll()
 {
     mNeedsToBeCompiled = true;
     if (!compileScript()) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of action:" << mName << "\n" >> mpHost;
         }
         mOK_code = false;
@@ -96,7 +96,7 @@ void TAction::compile()
 {
     if (mNeedsToBeCompiled) {
         if (!compileScript()) {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of action:" << mName << "\n" >> mpHost;
             }
             mOK_code = false;

--- a/src/TAlias.cpp
+++ b/src/TAlias.cpp
@@ -128,7 +128,7 @@ bool TAlias::match(const QString& toMatch)
         }
         qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
     } else {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::cyan, Qt::black) << "Alias name=" << mName << "(" << mRegexCode << ") matched.\n" >> mpHost;
         }
     }
@@ -148,7 +148,7 @@ bool TAlias::match(const QString& toMatch)
         match.append(substring_start, substring_length);
         captureList.push_back(match);
         posList.push_back(ovector[2 * i]);
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::darkCyan, Qt::black) << "Alias: capture group #" << (i + 1) << " = " >> mpHost;
             TDebug(Qt::darkMagenta, Qt::black) << TDebug::csmContinue << "<" << match.c_str() << ">\n" >> mpHost;
         }
@@ -212,7 +212,7 @@ bool TAlias::match(const QString& toMatch)
             match.append(substring_start, substring_length);
             captureList.push_back(match);
             posList.push_back(ovector[2 * i]);
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::darkCyan, Qt::black) << "capture group #" << (i + 1) << " = " >> mpHost;
                 TDebug(Qt::darkMagenta, Qt::black) << TDebug::csmContinue << "<" << match.c_str() << ">\n" >> mpHost;
             }
@@ -260,7 +260,7 @@ void TAlias::compileRegex()
 
     if (re == nullptr) {
         mOK_init = false;
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "REGEX ERROR: failed to compile, reason:\n" << error << "\n" >> mpHost;
             TDebug(Qt::red, Qt::gray) << TDebug::csmContinue << R"(in: ")" << mRegexCode << "\"\n" >> mpHost;
         }
@@ -285,7 +285,7 @@ void TAlias::compileAll()
 {
     mNeedsToBeCompiled = true;
     if (!compileScript()) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of alias:" << mName << "\n" >> mpHost;
         }
         mOK_code = false;
@@ -300,7 +300,7 @@ void TAlias::compile()
 {
     if (mNeedsToBeCompiled) {
         if (!compileScript()) {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of alias:" << mName << "\n" >> mpHost;
             }
             mOK_code = false;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -732,8 +732,8 @@ void TConsole::closeEvent(QCloseEvent* event)
             return;
         } else {
             hide();
-            mudlet::mpDebugArea->setVisible(false);
-            mudlet::debugMode = false;
+            mudlet::smpDebugArea->setVisible(false);
+            mudlet::smDebugMode = false;
             mudlet::self()->refreshTabBar();
             event->ignore();
             return;
@@ -1531,7 +1531,7 @@ int TConsole::select(const QString& text, int numOfMatch)
         return -1;
     }
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::darkMagenta, Qt::black) << "line under current user cursor: " >> mpHost;
         TDebug(Qt::red, Qt::black) << TDebug::csmContinue << mUserCursor.y() << "#:" >> mpHost;
         TDebug(Qt::gray, Qt::black) << TDebug::csmContinue << buffer.line(mUserCursor.y()) << "\n" >>  mpHost;
@@ -1560,7 +1560,7 @@ int TConsole::select(const QString& text, int numOfMatch)
     P_end.setX(end);
     P_end.setY(mUserCursor.y());
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::darkRed, Qt::black) << "P_begin(" << P_begin.x() << "/" << P_begin.y() << "), P_end(" << P_end.x() << "/" << P_end.y()
                                                        << ") selectedText = " << buffer.line(mUserCursor.y()).mid(P_begin.x(), P_end.x() - P_begin.x()) << "\n"
                 >> mpHost;
@@ -1570,7 +1570,7 @@ int TConsole::select(const QString& text, int numOfMatch)
 
 bool TConsole::selectSection(int from, int to)
 {
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::darkMagenta, Qt::black) << "selectSection(" << from << "," << to << "): line under current user cursor: " << buffer.line(mUserCursor.y()) << "\n" >> mpHost;
     }
     if (from < 0) {
@@ -1588,7 +1588,7 @@ bool TConsole::selectSection(int from, int to)
     P_end.setX(from + to);
     P_end.setY(mUserCursor.y());
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::darkMagenta, Qt::black) << "P_begin(" << P_begin.x() << "/" << P_begin.y() << "), P_end(" << P_end.x() << "/" << P_end.y() << ") selectedText:\n\""
                                            << buffer.line(mUserCursor.y()).mid(P_begin.x(), P_end.x() - P_begin.x()) << "\"\n"
                 >> mpHost;
@@ -1753,7 +1753,7 @@ void TConsole::print(const QString& msg)
     mUpperPane->showNewLines();
     mLowerPane->showNewLines();
 
-    if (Q_UNLIKELY(mudlet::self()->mMirrorToStdOut)) {
+    if (Q_UNLIKELY(mudlet::self()->smMirrorToStdOut)) {
         qDebug().nospace().noquote() << qsl("%1| %2").arg(mConsoleName, msg);
     }
 }
@@ -1766,7 +1766,7 @@ void TConsole::print(const QString& msg, const QColor fgColor, const QColor bgCo
     mUpperPane->showNewLines();
     mLowerPane->showNewLines();
 
-    if (Q_UNLIKELY(mudlet::self()->mMirrorToStdOut)) {
+    if (Q_UNLIKELY(mudlet::self()->smMirrorToStdOut)) {
         qDebug().nospace().noquote() << qsl("%1| %2").arg(mConsoleName, msg);
     }
 }

--- a/src/TDebug.cpp
+++ b/src/TDebug.cpp
@@ -40,7 +40,7 @@ TDebug::TDebug(const QColor& c, const QColor& d)
 // came, which is deduced from the supplied Host pointer.
 TDebug& TDebug::operator>>(Host* pHost)
 {
-    if (Q_UNLIKELY(!mudlet::mpDebugConsole)) {
+    if (Q_UNLIKELY(!mudlet::smpDebugConsole)) {
         if (Q_LIKELY(!msg.isEmpty())) {
             // Don't enqueue empty messages
             auto tag = deduceProfileTag(msg, pHost);
@@ -50,14 +50,14 @@ TDebug& TDebug::operator>>(Host* pHost)
 
     } else {
         if (Q_UNLIKELY(!smMessageQueue.isEmpty())) {
-            // The mpDebugConsole must have just come on-line - so unload all
+            // The smpDebugConsole must have just come on-line - so unload all
             // the stacked up messages:
             while (!smMessageQueue.isEmpty()) {
                 const auto& message = smMessageQueue.dequeue();
                 if (message.mTag.isNull()) {
-                    mudlet::mpDebugConsole->print(message.mMessage, message.mForeground, message.mBackground);
+                    mudlet::smpDebugConsole->print(message.mMessage, message.mForeground, message.mBackground);
                 } else {
-                    mudlet::mpDebugConsole->print(message.mTag % message.mMessage, message.mForeground, message.mBackground);
+                    mudlet::smpDebugConsole->print(message.mTag % message.mMessage, message.mForeground, message.mBackground);
                 }
             }
         }
@@ -69,14 +69,14 @@ TDebug& TDebug::operator>>(Host* pHost)
             // case we will already done everything needed in previous chunk
             // of code. Otherwise just print the message without a tag marking:
             if (!msg.isEmpty()) {
-                mudlet::mpDebugConsole->print(msg, fgColor, bgColor);
+                mudlet::smpDebugConsole->print(msg, fgColor, bgColor);
             }
         } else if (tag == csmTagSystemMessage || Q_UNLIKELY(tag == csmTagFault) || TDebug::smIdentifierMap.count() > 1) {
             // This is a system message or something went wrong in identifying the profile or more than one profile is active
-            mudlet::mpDebugConsole->print(tag % msg, fgColor, bgColor);
+            mudlet::smpDebugConsole->print(tag % msg, fgColor, bgColor);
         } else {
             // Only one profile active - so don't print the tag:
-            mudlet::mpDebugConsole->print(msg, fgColor, bgColor);
+            mudlet::smpDebugConsole->print(msg, fgColor, bgColor);
         }
     }
     return *this;
@@ -198,7 +198,7 @@ void TDebug::changeHostName(const Host* pHost, const QString& newName)
     localMessage << qsl("Profile '%1' started.\n").arg(hostName) >> nullptr;
     TDebug tableMessage(Qt::white, Qt::black);
     tableMessage << TDebug::displayNewTable() >> nullptr;
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         // Can't use TTabBar::applyPrefixToDisplayedText(hostName, newIdentifier.second)
         // here as the profile's tab has not been added to the tabbar yet.
         // Instead arrange for all the tabs to be refreshed when we are next

--- a/src/TKey.cpp
+++ b/src/TKey.cpp
@@ -130,7 +130,7 @@ void TKey::compileAll()
 {
     mNeedsToBeCompiled = true;
     if (!compileScript()) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of key binding:" << mName << "\n" >> mpHost;
         }
         mOK_code = false;
@@ -144,7 +144,7 @@ void TKey::compile()
 {
     if (mNeedsToBeCompiled) {
         if (!compileScript()) {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of key binding:" << mName << "\n" >> mpHost;
             }
             mOK_code = false;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -335,7 +335,7 @@ int TLuaInterpreter::warnArgumentValue(lua_State* L, const char* functionName, c
         lua_pushboolean(L, false);
     }
     lua_pushstring(L, message.toUtf8().constData());
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         auto& host = getHostFromLua(L);
         TDebug(Qt::white, QColorConstants::Svg::orange) << "Lua: " << functionName << ": " << message << "\n" >> &host;
     }
@@ -350,7 +350,7 @@ int TLuaInterpreter::warnArgumentValue(lua_State* L, const char* functionName, c
         lua_pushboolean(L, false);
     }
     lua_pushstring(L, message);
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         auto& host = getHostFromLua(L);
         TDebug(Qt::white, QColorConstants::Svg::orange) << "Lua: " << functionName << ": " << message << "\n" >> &host;
     }
@@ -1362,7 +1362,7 @@ int TLuaInterpreter::selectCaptureGroup(lua_State *L)
             }
 
             length = QString::fromStdString(s).size();
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "selectCaptureGroup(" << begin << ", " << length << ")\n" >> &host;
             }
         }
@@ -10354,14 +10354,14 @@ int TLuaInterpreter::downloadFile(lua_State* L)
     host.mLuaInterpreter.downloadMap.insert(reply, localFile);
     connect(reply, &QNetworkReply::downloadProgress, [=](qint64 bytesDownloaded, qint64 totalBytes) {
         raiseDownloadProgressEvent(L, urlString, bytesDownloaded, totalBytes);
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& lHost = getHostFromLua(L);
             TDebug(Qt::white, Qt::blue) << "downloadFile: " << bytesDownloaded << "/" << totalBytes
                                         << " bytes ready for " << reply->url().toString() << "\n" >> &lHost;
         }
     });
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::white, Qt::blue) << "downloadFile: start download from " << reply->url().toString() << "\n" >> &host;
     }
 
@@ -12555,7 +12555,7 @@ int TLuaInterpreter::ttsSpeak(lua_State* L)
     for (const QString& dropThis : dontSpeak) {
         if (textToSay.contains(dropThis)) {
             textToSay.replace(dropThis, QString());
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 auto& host = getHostFromLua(L);
                 TDebug(Qt::white, Qt::darkGreen) << "LUA: removed angle-shaped brackets (<>) from text to speak (TTS)\n" >> &host;
             }
@@ -12829,7 +12829,7 @@ int TLuaInterpreter::ttsQueue(lua_State* L)
     for (const QString& dropThis : dontSpeak) {
         if (inputText.contains(dropThis)) {
             inputText.replace(dropThis, QString());
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 auto& host = getHostFromLua(L);
                 TDebug(Qt::white, Qt::darkGreen) << "LUA: removed angle-shaped brackets (<>) from text to speak (TTS)\n" >> &host;
             }
@@ -13145,7 +13145,7 @@ bool TLuaInterpreter::compileAndExecuteScript(const QString& code)
             e = "Lua error:";
             e += lua_tostring(L, 1);
         }
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             qDebug() << "LUA ERROR: code did not compile: ERROR:" << e.c_str();
         }
         QString _n = "error in Lua code";
@@ -13193,7 +13193,7 @@ QString TLuaInterpreter::formatLuaCode(const QString &code)
             e = "Lua error:";
             e += lua_tostring(L, 1);
         }
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             qDebug() << "LUA ERROR: code did not compile: ERROR:" << e.c_str();
         }
         QString objectName = "error in Lua code";
@@ -13225,12 +13225,12 @@ bool TLuaInterpreter::compile(const QString& code, QString& errorMsg, const QStr
         errorMsg = "<b><font color='blue'>";
         errorMsg.append(e.c_str());
         errorMsg.append("</font></b>");
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::red) << "\n " << e.c_str() << "\n" >> &host;
         }
     } else {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA: code compiled without errors. OK\n" >> &host;
         }
@@ -13443,7 +13443,7 @@ TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString
     event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
 
     Host &host = getHostFromLua(L);
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg("mxp", token);
         host.mpConsole->printSystemMessage(msg);
     }
@@ -13602,7 +13602,7 @@ void TLuaInterpreter::parseJSON(QString& key, const QString& string_data, const 
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
         event.mArgumentList.append(key);
         event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
             host.mpConsole->printSystemMessage(msg);
         }
@@ -13717,7 +13717,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
             event.mArgumentList.append(token);
             event.mArgumentTypeList.append(ARGUMENT_TYPE_STRING);
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 QString msg = qsl("\n%1 event <%2> display(%1) to see the full content\n").arg(protocol, token);
                 host.mpConsole->printSystemMessage(msg);
             }
@@ -13921,14 +13921,14 @@ bool TLuaInterpreter::call_luafunction(void* pT)
                     QString _n = "error in anonymous Lua function";
                     QString _n2 = "no debug data available";
                     logError(e, _n, _n2);
-                    if (mudlet::debugMode) {
+                    if (mudlet::smDebugMode) {
                         auto& host = getHostFromLua(L);
                         TDebug(Qt::white, Qt::red) << "LUA: ERROR running anonymous Lua function ERROR:" << e.c_str() >> &host;
                     }
                 }
             }
         } else {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 auto& host = getHostFromLua(L);
                 TDebug(Qt::white, Qt::darkGreen) << "LUA OK anonymous Lua function ran without errors\n" >> &host;
             }
@@ -13964,7 +13964,7 @@ void TLuaInterpreter::delete_luafunction(const QString& name)
         lua_pushnil(L);
         lua_setglobal(L, name.toUtf8().constData());
         lua_pop(L, lua_gettop(L));
-    } else if (mudlet::debugMode) {
+    } else if (mudlet::smDebugMode) {
         qWarning() << "LUA: ERROR deleting " << name << ", it is not a function as expected";
     }
 }
@@ -13993,7 +13993,7 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
                     QString _n = "error in anonymous Lua function";
                     QString _n2 = "no debug data available";
                     logError(e, _n, _n2);
-                    if (mudlet::debugMode) {
+                    if (mudlet::smDebugMode) {
                         auto& host = getHostFromLua(L);
                         TDebug(Qt::white, Qt::red) << "LUA: ERROR running anonymous Lua function ERROR:" << e.c_str() >> &host;
                     }
@@ -14005,7 +14005,7 @@ std::pair<bool, bool> TLuaInterpreter::callLuaFunctionReturnBool(void* pT)
                 returnValue = lua_toboolean(L, index);
             }
 
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 auto& host = getHostFromLua(L);
                 TDebug(Qt::white, Qt::darkGreen) << "LUA OK anonymous Lua function ran without errors\n" >> &host;
             }
@@ -14039,14 +14039,14 @@ bool TLuaInterpreter::call(const QString& function, const QString& mName, const 
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
                 logError(e, mName, function);
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
                     TDebug(Qt::white, Qt::red) << "LUA ERROR: when running script " << mName << " (" << function << "),\nreason: " << e.c_str() << "\n" >> &host;
                 }
             }
         }
     } else {
-        if (mudlet::debugMode && !muteDebugOutput) {
+        if (mudlet::smDebugMode && !muteDebugOutput) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA OK: script " << mName << " (" << function << ") ran without errors\n" >> &host;
         }
@@ -14073,7 +14073,7 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
                 logError(e, mName, function);
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
                     TDebug(Qt::white, Qt::red) << "LUA: ERROR running script " << mName << " (" << function << ") ERROR:" << e.c_str() << "\n" >> &host;
                 }
@@ -14085,7 +14085,7 @@ std::pair<bool, bool> TLuaInterpreter::callReturnBool(const QString& function, c
             returnValue = lua_toboolean(L, index);
         }
 
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors\n" >> &host;
         }
@@ -14154,14 +14154,14 @@ bool TLuaInterpreter::callConditionFunction(std::string& function, const QString
                 e += lua_tostring(L, i);
                 QString _f = function.c_str();
                 logError(e, mName, _f);
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
                     TDebug(Qt::white, Qt::red) << "LUA: ERROR running script " << mName << " (" << function.c_str() << ") ERROR:" << e.c_str() << "\n" >> &host;
                 }
             }
         }
     } else {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function.c_str() << ") ran without errors\n" >> &host;
         }
@@ -14215,14 +14215,14 @@ bool TLuaInterpreter::callMulti(const QString& function, const QString& mName)
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
                 logError(e, mName, function);
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
                     TDebug(Qt::white, Qt::red) << "LUA: ERROR running script " << mName << " (" << function << ") ERROR:" << e.c_str() << "\n" >> &host;
                 }
             }
         }
     } else {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors\n" >> &host;
         }
@@ -14265,7 +14265,7 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
             if (lua_isstring(L, i)) {
                 e += lua_tostring(L, i);
                 logError(e, mName, function);
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
                     TDebug(Qt::white, Qt::red) << "LUA: ERROR running script " << mName << " (" << function << ") ERROR:" << e.c_str() << "\n" >> &host;
                 }
@@ -14277,7 +14277,7 @@ std::pair<bool, bool> TLuaInterpreter::callMultiReturnBool(const QString& functi
             returnValue = lua_toboolean(L, index);
         }
 
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA OK script " << mName << " (" << function << ") ran without errors\n" >> &host;
         }
@@ -14297,7 +14297,7 @@ bool TLuaInterpreter::callReference(lua_State* L, QString name, int parameters)
             err += lua_tostring(L, -1);
         }
         logError(err, name, qsl("anonymous Lua function"));
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::red) << "LUA: ERROR running anonymous Lua function (" << name << ")\nError: " << err.c_str() << "\n" >> &host;
         }
@@ -14518,7 +14518,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
 
     error = lua_pcall(L, maxArguments, LUA_MULTRET, 0);
 
-    if (mudlet::debugMode && pE.mArgumentList.size() > LUA_FUNCTION_MAX_ARGS) {
+    if (mudlet::smDebugMode && pE.mArgumentList.size() > LUA_FUNCTION_MAX_ARGS) {
         auto& host = getHostFromLua(L);
         TDebug(Qt::white, Qt::red) << "LUA: ERROR running script " << function << " (" << function << ")\nError: more than " << LUA_FUNCTION_MAX_ARGS
                                    << " arguments passed to Lua function, exceeding Lua's limit. Trimmed arguments to " << LUA_FUNCTION_MAX_ARGS << " only.\n"
@@ -14532,7 +14532,7 @@ bool TLuaInterpreter::callEventHandler(const QString& function, const TEvent& pE
         }
         QString name = "event handler function";
         logError(err, name, function);
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::red) << "LUA: ERROR running script " << function << " (" << function << ")\nError: " << err.c_str() << "\n" >> &host;
         }
@@ -14560,14 +14560,14 @@ double TLuaInterpreter::condenseMapLoad()
                 e += lua_tostring(L, i);
                 QString _f = luaFunction.toUtf8().constData();
                 logError(e, luaFunction, _f);
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     auto& host = getHostFromLua(L);
                     TDebug(Qt::white, Qt::red) << "LUA: ERROR running " << luaFunction << " ERROR:" << e.c_str() << "\n" >> &host;
                 }
             }
         }
     } else {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             auto& host = getHostFromLua(L);
             TDebug(Qt::white, Qt::darkGreen) << "LUA OK " << luaFunction << " ran without errors\n" >> &host;
         }
@@ -14690,7 +14690,7 @@ int TLuaInterpreter::performHttpRequest(lua_State *L, const char* functionName, 
             reply = host.mLuaInterpreter.mpFileDownloader->sendCustomRequest(request, verb.toUtf8(), fileToUpload.isEmpty() ?dataToPost.toUtf8() : fileToUpload);
     };
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::white, Qt::blue) << functionName << ": script is uploading data to " << reply->url().toString() << "\n" >> &host;
     }
 
@@ -14737,7 +14737,7 @@ int TLuaInterpreter::getHTTP(lua_State* L)
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->get(request);
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::white, Qt::blue) << qsl("getHTTP: script is getting data from %1\n").arg(reply->url().toString()) >> &host;
     }
 
@@ -14791,7 +14791,7 @@ int TLuaInterpreter::deleteHTTP(lua_State *L)
     host.updateProxySettings(host.mLuaInterpreter.mpFileDownloader);
     QNetworkReply* reply = host.mLuaInterpreter.mpFileDownloader->deleteResource(request);
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::white, Qt::blue) << qsl("deleteHTTP: script is sending delete request for %1\n").arg(reply->url().toString()) >> &host;
     }
 
@@ -17239,7 +17239,7 @@ int TLuaInterpreter::registerMapInfo(lua_State* L)
         int error = lua_pcall(L, 4, 6, 0);
         if (error) {
             int errorCount = lua_gettop(L);
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 for (int i = 1; i <= errorCount; i++) {
                     if (lua_isstring(L, i)) {
                         auto errorMessage = lua_tostring(L, i);
@@ -17421,7 +17421,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
 
     auto success = [&]()
     {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::blue) << qsl("setConfig: a script has changed %1\n").arg(key) >> &host;
         }
         lua_pushboolean(L, true);

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1195,7 +1195,7 @@ void TMainConsole::runTriggers(int line)
     mpHost->getLuaInterpreter()->set_lua_string(cmLuaLineVariable, mCurrentLine);
     mCurrentLine.append('\n');
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::darkGreen, Qt::black) << "new line arrived:" >> mpHost;
         TDebug(Qt::lightGray, Qt::black) << TDebug::csmContinue << mCurrentLine << "\n" >> mpHost;
     }

--- a/src/TScript.cpp
+++ b/src/TScript.cpp
@@ -107,7 +107,7 @@ void TScript::compile()
 {
     if (mNeedsToBeCompiled) {
         if (!compileScript()) {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of script:" << mName << "\n" >> mpHost;
             }
             mOK_code = false;

--- a/src/TTimer.cpp
+++ b/src/TTimer.cpp
@@ -152,7 +152,7 @@ void TTimer::compile()
 {
     if (mNeedsToBeCompiled) {
         if (!compileScript()) {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of timer:" << mName << "\n" >> mpHost;
             }
             mOK_code = false;
@@ -167,7 +167,7 @@ void TTimer::compileAll()
 {
     mNeedsToBeCompiled = true;
     if (!compileScript()) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of timer:" << mName << "\n" >> mpHost;
         }
         mOK_code = false;

--- a/src/TTrigger.cpp
+++ b/src/TTrigger.cpp
@@ -218,7 +218,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
             QSharedPointer<pcre> re(pcre_compile(regexp.constData(), PCRE_UTF8 | PCRE_UCP, &error, &erroffset, nullptr), pcre_deleter);
 
             if (!re) {
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     TDebug(Qt::white, Qt::red) << "REGEX ERROR: failed to compile, reason:\n" << error << "\n" >> mpHost;
                     TDebug(Qt::red, Qt::gray) << TDebug::csmContinue << R"(in: ")" << regexp.constData() << "\"\n" >> mpHost;
                 }
@@ -227,7 +227,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
                          .arg(QString::number(i + 1), regexp.constData(), error)));
                 state = false;
             } else {
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     TDebug(Qt::white, Qt::darkGreen) << "[OK]: REGEX_COMPILE OK\n" >> mpHost;
                 }
             }
@@ -247,7 +247,7 @@ bool TTrigger::setRegexCodeList(QStringList patterns, QList<int> patternKinds)
                          .arg(tr(R"(Error: in item %1, lua function "%2" failed to compile, reason: "%3".)")
                          .arg(QString::number(i + 1), patterns.at(i), error)));
                 state = false;
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     TDebug(Qt::white, Qt::red) << "LUA ERROR: failed to compile, reason:\n" << error << "\n" >> mpHost;
                     TDebug(Qt::red, Qt::gray) << TDebug::csmContinue << R"(in lua condition function: ")" << patterns.at(i) << "\"\n" >> mpHost;
                 }
@@ -293,7 +293,7 @@ bool TTrigger::match_perl(char* haystackC, const QString& haystack, int patternN
     QSharedPointer<pcre> re = mRegexMap[patternNumber];
 
     if (!re) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "ERROR:" >> mpHost;
             TDebug(Qt::darkRed, Qt::darkGray) << TDebug::csmContinue << " the regex of trigger " << mName
                                               << " does not compile. Please correct the expression. This trigger will never match until it is fixed.\n"
@@ -330,7 +330,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         qWarning() << "CRITICAL ERROR: SHOULD NOT HAPPEN pcre_info() got wrong number of capture groups ovector only has room for" << MAX_CAPTURE_GROUPS << "captured substrings";
     }
 
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::blue, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
 
@@ -354,7 +354,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
         match.append(substring_start, substring_length);
         captureList.push_back(match);
         posList.push_back(utf16_pos + posOffset);
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::darkCyan, Qt::black) << "capture group #" << (i + 1) << " = " >> mpHost;
             TDebug(Qt::darkMagenta, Qt::black) << TDebug::csmContinue << "<" << match.c_str() << ">\n" >> mpHost;
         }
@@ -428,7 +428,7 @@ void TTrigger::processRegexMatch(const char* haystackC, const QString& haystack,
             match.append(substring_start, substring_length);
             captureList.push_back(match);
             posList.push_back(utf16_pos + posOffset);
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::darkCyan, Qt::black) << "<regex mode: match all> capture group #" << (i + 1) << " = " >> mpHost;
                 TDebug(Qt::darkMagenta, Qt::black) << "<" << match.c_str() << ">\n" >> mpHost;
             }
@@ -526,7 +526,7 @@ void TTrigger::processBeginOfLine(const QString& needle, int patternNumber, int 
     std::list<int> posList;
     captureList.emplace_back(needle.toUtf8().constData());
     posList.push_back(0 + posOffset);
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::darkCyan, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
@@ -586,7 +586,7 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         } else {
             pCondition->nameCaptures.push_back(QVector<QPair<QString, QString>>());
         }
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::darkYellow, Qt::black) << "match state " << mConditionMap.size() << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber
                                               << "/" << mPatterns.size() << ") regex=" << mPatterns[regexNumber] << "\n"
                     >> mpHost;
@@ -596,7 +596,7 @@ inline void TTrigger::updateMultistates(int regexNumber, std::list<std::string>&
         for (auto& matchStatePair : mConditionMap) {
             k++;
             if (matchStatePair.second->nextCondition() == regexNumber) {
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     TDebug(Qt::darkYellow, Qt::black) << "match state " << k << "/" << mConditionMap.size() << " condition #" << regexNumber << "=true (" << regexNumber << "/"
                                                       << mPatterns.size() << ") regex=" << mPatterns[regexNumber] << "\n"
                             >> mpHost;
@@ -663,7 +663,7 @@ void TTrigger::processSubstringMatch(const QString& haystack, const QString& nee
             posList.push_back(where + posOffset);
         }
     }
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::cyan, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(regexNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
@@ -843,7 +843,7 @@ bool TTrigger::match_line_spacer(int patternNumber)
             k++;
             if (matchStatePair.second->nextCondition() == patternNumber) {
                 if (matchStatePair.second->lineSpacerMatch(mPatterns.value(patternNumber).toInt())) {
-                    if (mudlet::debugMode) {
+                    if (mudlet::smDebugMode) {
                         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") condition #" << patternNumber << "=true " >> mpHost;
                         TDebug(Qt::darkYellow, Qt::black) << TDebug::csmContinue << "match state " << k << "/" << mConditionMap.size() << " condition #" << patternNumber << "=true (" << patternNumber + 1 << "/"
                                                           << mPatterns.size() << ") line spacer=" << mPatterns.value(patternNumber) << "lines\n"
@@ -869,7 +869,7 @@ bool TTrigger::match_lua_code(int patternNumber)
     }
 
     if (mpLua->callConditionFunction(mLuaConditionMap[patternNumber], mName)) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
         }
         if (mIsMultiline) {
@@ -895,7 +895,7 @@ bool TTrigger::match_prompt(int patternNumber)
 
 void TTrigger::processPromptMatch(int patternNumber)
 {
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsMultiline) {
@@ -927,7 +927,7 @@ void TTrigger::processExactMatch(const QString& line, int patternNumber, int pos
     std::list<int> posList;
     captureList.emplace_back(line.toUtf8().constData());
     posList.push_back(0 + posOffset);
-    if (mudlet::debugMode) {
+    if (mudlet::smDebugMode) {
         TDebug(Qt::yellow, Qt::black) << "Trigger name=" << mName << "(" << mPatterns.value(patternNumber) << ") matched.\n" >> mpHost;
     }
     if (mIsColorizerTrigger) {
@@ -1074,7 +1074,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
                 k++;
                 if (matchStatePair.second->isComplete()) {
                     mKeepFiring = mStayOpen;
-                    if (mudlet::debugMode) {
+                    if (mudlet::smDebugMode) {
                         TDebug(Qt::yellow, Qt::darkMagenta) << "multiline trigger name=" << mName << " *FIRES* all conditions are fulfilled. Executing script.\n" >> mpHost;
                     }
                     removeList.push_back(matchStatePair.first);
@@ -1113,7 +1113,7 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
             for (auto& matchState : removeList) {
                 if (mConditionMap.find(matchState) != mConditionMap.end()) {
                     delete mConditionMap[matchState];
-                    if (mudlet::debugMode) {
+                    if (mudlet::smDebugMode) {
                         TDebug(Qt::darkBlue, Qt::black) << "removing condition from condition table.\n" >> mpHost;
                     }
                     mConditionMap.erase(matchState);
@@ -1159,12 +1159,12 @@ bool TTrigger::match(char* haystackC, const QString& haystack, int line, int pos
             if (mExpiryCount == 0) {
                 mpHost->getTriggerUnit()->markCleanup(this);
 
-                if (mudlet::debugMode) {
+                if (mudlet::smDebugMode) {
                     // FIXME: This message is translated - but most other TDebug ones are not!
                     TDebug(Qt::yellow, Qt::darkMagenta) << qsl("%1\n").arg(tr("Trigger name=%1 expired.").arg(mName)) >> mpHost;
                 }
 
-            } else if (mudlet::debugMode) {
+            } else if (mudlet::smDebugMode) {
                 // FIXME: This message is translated - but most other TDebug ones are not!
                 TDebug(Qt::yellow, Qt::darkMagenta) << qsl("%1\n").arg(tr("Trigger name=%1 will fire %n more time(s).", "", mExpiryCount).arg(mName)) >> mpHost;
             }
@@ -1281,7 +1281,7 @@ void TTrigger::compileAll()
 {
     mNeedsToBeCompiled = true;
     if (!compileScript()) {
-        if (mudlet::debugMode) {
+        if (mudlet::smDebugMode) {
             TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of Trigger:" << mName << "\n" >> mpHost;
         }
         mOK_code = false;
@@ -1297,7 +1297,7 @@ void TTrigger::compile()
 {
     if (mNeedsToBeCompiled) {
         if (!compileScript()) {
-            if (mudlet::debugMode) {
+            if (mudlet::smDebugMode) {
                 TDebug(Qt::white, Qt::red) << "ERROR: Lua compile error. compiling script of Trigger:" << mName << "\n" >> mpHost;
             }
             mOK_code = false;

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -594,7 +594,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
         }
     }
     {
-        auto iterator = mudlet::self()->mShortcutsManager->iterator();
+        auto iterator = mudlet::self()->mpShortcutsManager->iterator();
         while (iterator.hasNext()) {
             auto key = iterator.next();
             auto shortcut = host.append_child("profileShortcut");

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -529,7 +529,7 @@ void cTelnet::slot_socketDisconnected()
     }
 
     if (sslerr) {
-        mudlet::self()->show_options_dialog(qsl("tab_connection"));
+        mudlet::self()->showOptionsDialog(qsl("tab_connection"));
     }
 #endif
 

--- a/src/dlgAboutDialog.cpp
+++ b/src/dlgAboutDialog.cpp
@@ -1097,11 +1097,19 @@ void dlgAboutDialog::setSupportersTab(const QString& htmlHead)
     textBrowser_supporters->setOpenExternalLinks(true);
 }
 
-QString dlgAboutDialog::createBuildInfo() const {
-    return qsl("<table border=\"0\" style=\"margin-bottom:18px; margin-left:36px; margin-right:36px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">\n")
-        .append(qsl("<tr><td colspan=\"2\" style=\"font-weight: 800\">%1</td></tr>").arg(tr("Technical information:")))
-        .append(qsl("<tr><td style=\"padding-right: 10px;\">%1<td>%2</td></tr>").arg(tr("Version"), mudlet::self()->version))
-        .append(qsl("<tr><td style=\"padding-right: 10px;\">%1</td><td>%2</td></tr>").arg(tr("OS"), QSysInfo::prettyProductName()))
-        .append(qsl("<tr><td style=\"padding-right: 10px;\">%1</td><td>%2</td></tr>").arg(tr("CPU"), QSysInfo::currentCpuArchitecture()))
-        .append(qsl("</table>"));
+QString dlgAboutDialog::createBuildInfo() const
+{
+    return qsl("<table border=\"0\" style=\"margin-bottom:18px; margin-left:36px; margin-right:36px;\" width=\"100%\" cellspacing=\"2\" cellpadding=\"0\">\n"
+               "<tr><td colspan=\"2\" style=\"font-weight: 800\">%1</td></tr>\n"
+               "<tr><td style=\"padding-right: 10px;\">%2<td>%3</td></tr>\n"
+               "<tr><td style=\"padding-right: 10px;\">%4</td><td>%5</td></tr>\n"
+               "<tr><td style=\"padding-right: 10px;\">%6</td><td>%7</td></tr>\n"
+               "</table>")
+            .arg(tr("Technical information:"), // %1
+                 tr("Version"), // %2
+                 mudlet::self()->scmVersion, // %3
+                 tr("OS"), // %4
+                 QSysInfo::prettyProductName(), // %5
+                 tr("CPU"), // %6
+                 QSysInfo::currentCpuArchitecture()); // %7
 }

--- a/src/dlgAliasMainArea.cpp
+++ b/src/dlgAliasMainArea.cpp
@@ -30,7 +30,7 @@ dlgAliasMainArea::dlgAliasMainArea(QWidget* pParentWidget)
 
     connect(lineEdit_alias_name, &QLineEdit::editingFinished, this, &dlgAliasMainArea::slot_editingNameFinished);
 
-    if (mudlet::self()->firstLaunch) {
+    if (mudlet::self()->smFirstLaunch) {
         lineEdit_alias_pattern->setPlaceholderText(tr("for example, ^myalias$ to match 'myalias'", "This text is shown as placeholder in the pattern box when no real pattern was entered, yet."));
     }
 }

--- a/src/dlgIRC.cpp
+++ b/src/dlgIRC.cpp
@@ -38,7 +38,7 @@
 
 dlgIRC::dlgIRC(Host* pHost)
 : mpHost(pHost)
-, mRealName(mudlet::self()->version)
+, mRealName(mudlet::self()->scmVersion)
 {
     setupUi(this);
     setWindowIcon(QIcon(qsl(":/icons/mudlet_irc.png")));

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -167,10 +167,10 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         checkbox_noAutomaticUpdates->setDisabled(true);
         checkbox_noAutomaticUpdates->setToolTip(utils::richText(tr("Automatic updates are disabled in development builds to prevent an update from overwriting your Mudlet.")));
     } else {
-        checkbox_noAutomaticUpdates->setChecked(!pMudlet->updater->updateAutomatically());
+        checkbox_noAutomaticUpdates->setChecked(!pMudlet->pUpdater->updateAutomatically());
         // This is the extra connect(...) relating to settings' changes saved by
         // a different profile mentioned further down in this constructor:
-        connect(pMudlet->updater, &Updater::signal_automaticUpdatesChanged, this, &dlgProfilePreferences::slot_changeAutomaticUpdates);
+        connect(pMudlet->pUpdater, &Updater::signal_automaticUpdatesChanged, this, &dlgProfilePreferences::slot_changeAutomaticUpdates);
     }
 #else
     groupBox_updates->hide();
@@ -286,7 +286,7 @@ dlgProfilePreferences::dlgProfilePreferences(QWidget* pParentWidget, Host* pHost
         auto& nativeName = translation.getNativeName();
         if (translation.fromResourceFile()) {
             auto& translatedPc = translation.getTranslatedPercentage();
-            if (translatedPc >= pMudlet->mTranslationGoldStar) {
+            if (translatedPc >= pMudlet->scmTranslationGoldStar) {
                 comboBox_guiLanguage->addItem(QIcon(":/icons/rating.png"),
                                               nativeName,
                                               code);
@@ -1201,7 +1201,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
 
     //Shortcuts tab
-    auto shortcutKeys = mudlet::self()->mShortcutsManager->iterator();
+    auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
     int shortcutsRow = 0;
     while (shortcutKeys.hasNext()) {
         auto key = shortcutKeys.next();
@@ -1209,7 +1209,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         currentShortcuts.insert(key, sequence);
         auto sequenceEdit = new QKeySequenceEdit(*sequence);
 
-        gridLayout_groupBox_shortcuts->addWidget(new QLabel(mudlet::self()->mShortcutsManager->getLabel(key)), floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 1);
+        gridLayout_groupBox_shortcuts->addWidget(new QLabel(mudlet::self()->mpShortcutsManager->getLabel(key)), floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 1);
         gridLayout_groupBox_shortcuts->addWidget(sequenceEdit, floor(shortcutsRow / 2), (shortcutsRow % 2) * 2 + 2);
         shortcutsRow++;
         connect(sequenceEdit, &QKeySequenceEdit::editingFinished, this, [=]() {
@@ -1226,8 +1226,8 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
             delete newSequence;
         });
         connect(this, &dlgProfilePreferences::signal_resetMainWindowShortcutsToDefaults, sequenceEdit, [=]() {
-            sequenceEdit->setKeySequence(*mudlet::self()->mShortcutsManager->getDefault(key));
-            QKeySequence* newSequence = new QKeySequence(*mudlet::self()->mShortcutsManager->getDefault(key));
+            sequenceEdit->setKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));
+            QKeySequence* newSequence = new QKeySequence(*mudlet::self()->mpShortcutsManager->getDefault(key));
             sequence->swap(*newSequence);
             delete newSequence;
         });
@@ -2882,7 +2882,7 @@ void dlgProfilePreferences::slot_saveAndClose()
                                              pHost->mpMap->mPlayerRoomInnerColor);
         }
 
-        auto iterator = mudlet::self()->mShortcutsManager->iterator();
+        auto iterator = mudlet::self()->mpShortcutsManager->iterator();
         while (iterator.hasNext()) {
             auto key = iterator.next();
             QKeySequence sequence = QKeySequence(*currentShortcuts.value(key));
@@ -2892,7 +2892,7 @@ void dlgProfilePreferences::slot_saveAndClose()
 
 #if defined(INCLUDE_UPDATER)
     if (mudlet::scmIsReleaseVersion || mudlet::scmIsPublicTestVersion) {
-        pMudlet->updater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
+        pMudlet->pUpdater->setAutomaticUpdates(!checkbox_noAutomaticUpdates->isChecked());
     }
 #endif
 

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -254,8 +254,8 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     //QScopedPointer<edbee::StringTextAutoCompleteProvider> provider(new edbee::StringTextAutoCompleteProvider);
 
     // Add lua functions and reserved lua terms to an AutoComplete provider
-    for (QString key : mudlet::mLuaFunctionNames.keys()) {
-        provider->add(key, 3, mudlet::mLuaFunctionNames.value(key).toString());
+    for (QString key : mudlet::smLuaFunctionNames.keys()) {
+        provider->add(key, 3, mudlet::smLuaFunctionNames.value(key).toString());
     }
 
     provider->add(qsl("and"), 14);
@@ -7312,10 +7312,10 @@ void dlgTriggerEditor::slot_toggleCentralDebugConsole()
 {
     mudlet::self()->attachDebugArea(mpHost->getName());
 
-    mudlet::mpDebugArea->setVisible(!mudlet::debugMode);
-    mudlet::debugMode = !mudlet::debugMode;
-    mudlet::mpDebugArea->setWindowTitle("Central Debug Console");
-    if (mudlet::debugMode) {
+    mudlet::smpDebugArea->setVisible(!mudlet::smDebugMode);
+    mudlet::smDebugMode = !mudlet::smDebugMode;
+    mudlet::smpDebugArea->setWindowTitle(tr("Central Debug Console"));
+    if (mudlet::smDebugMode) {
         // If this is the first time the window is shown we want any previously
         // enqueued messages to be painted onto the central debug console:
         TDebug::flushMessageQueue();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -465,8 +465,6 @@ int main(int argc, char* argv[])
 #endif // defined(Q_OS_LINUX)
 #endif // defined(INCLUDE_FONTS)
 
-    mudlet::debugMode = false;
-
     QString homeLink = qsl("%1/mudlet-data").arg(QDir::homePath());
 #if defined(Q_OS_WIN32)
     /*
@@ -522,7 +520,7 @@ int main(int argc, char* argv[])
         splash.finish(mudlet::self());
     }
 
-    mudlet::self()->mMirrorToStdOut = parser.isSet(mirrorToStdout);
+    mudlet::self()->smMirrorToStdOut = parser.isSet(mirrorToStdout);
     mudlet::self()->show();
 
     mudlet::self()->startAutoLogin(cliProfile);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -104,7 +104,7 @@ using namespace std::chrono_literals;
 bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
 {
     if (event->type() == QEvent::Close) {
-        mudlet::debugMode = false;
+        mudlet::smDebugMode = false;
         mudlet::self()->refreshTabBar();
         return QObject::eventFilter(obj, event);
     } else {
@@ -112,152 +112,20 @@ bool TConsoleMonitor::eventFilter(QObject* obj, QEvent* event)
     }
 }
 
-// "mMudletXmlDefaultFormat" number represents a major (integer part) and minor
-// (1000ths, range 0 to 999) that is used as a "version" attribute number when
-// writing the <MudletPackage ...> element of all (but maps if I ever get around
-// to doing a Map Xml file exporter/writer) Xml files used to export/save Mudlet
-// button/menu/toolbars; aliases. keys, scripts, timers, triggers and variables
-// and collections of these as modules/packages and entire profiles as "game
-// saves".  Mudlet versions up to 3.0.1 never bothered checking the version
-// detail and it had been hard coded as "1.0" back as far as history can
-// determine.  From that version a check was coded to test that the version
-// was less than 2.000f with the intention to loudly and clearly fail if a
-// higher version was encountered. Values above 1.000f have not yet been
-// codified but should be accepted so it should be possible to raise the number
-// a little and to use that to extend the Xml data format in a manner that older
-// versions ignore (possibly with some noise) but which they can still get the
-// details they can handle yet allow a later upgraded version to get extra
-// information they want.
-//
-// Taking this number to 2.000f or more WILL prevent old versions from reading
-// Xml files and should be considered a step associated with a major version
-// number change in the Mudlet application itself and SHOULD NOT BE DONE WITHOUT
-// agreement and consideration from the Project management, even a minor part
-// increment should not be done without justification...!
-// XML version Change history (what and why):
-// 1.001    Added method to allow XML format to permit ASCII control codes
-//          0x01-0x08, 0x0b, 0x0c, 0x0e-0x1f, 0x7f to be stored as part of the
-//          "script" element for a Mudlet "item" (0x09, 0x0a, 0x0d are the only
-//          ones that ARE permitted) - this is wanted so that, for instance
-//          ANSI ESC codes can be included in a Lua script without breaking
-//          the XML format used to store it - prior to this embedding such
-//          codes would break or destroy the script that used it.
-const QString mudlet::scmMudletXmlDefaultVersion = QString::number(1.001f, 'f', 3);
-
-// The Qt runtime version is needed in various places but as it is a constant
-// during the application run it is easiest to define it as one once:
-const QVersionNumber mudlet::scmRunTimeQtVersion = QVersionNumber::fromString(QString(qVersion()));
-
-// This is equivalent to QDataStream::Qt_5_12 but it is needed when we are
-// compiling with versions older than that which do not have that enum value:
-const int mudlet::scmQDataStreamFormat_5_12 = 18;
-
-QPointer<TConsole> mudlet::mpDebugConsole = nullptr;
-QPointer<QMainWindow> mudlet::mpDebugArea = nullptr;
-bool mudlet::debugMode = false;
-
-const bool mudlet::scmIsReleaseVersion = QByteArray(APP_BUILD).isEmpty();
-const bool mudlet::scmIsPublicTestVersion = QByteArray(APP_BUILD).startsWith("-ptb");
-const bool mudlet::scmIsDevelopmentVersion = !mudlet::scmIsReleaseVersion && !mudlet::scmIsPublicTestVersion;
-
-QVariantHash mudlet::mLuaFunctionNames;
-
-QPointer<mudlet> mudlet::_self = nullptr;
-
-void mudlet::start()
+/*static*/ void mudlet::start()
 {
-    _self = new mudlet;
+    smpSelf = new mudlet;
 }
 
-mudlet* mudlet::self()
+/*static*/ mudlet* mudlet::self()
 {
-    return _self;
+    return smpSelf;
 }
 
 mudlet::mudlet()
 : QMainWindow()
-, mFontManager()
-, mDiscord()
-, mToolbarIconSize(0)
-, mEditorTreeWidgetIconSize(0)
-, mWindowMinimized(false)
-, mReplaySpeed(1)
-, mpMainToolBar(nullptr)
-, version(qsl("Mudlet " APP_VERSION APP_BUILD))
-, mpCurrentActiveHost(nullptr)
-, mpTabBar(nullptr)
-, mIsLoadingLayout(false)
-, mHasSavedLayout(false)
-, mpAboutDlg(nullptr)
-, mConnectionDialog(nullptr)
-, mShowIconsOnDialogs(true)
-, mShowIconsOnMenuCheckedState(Qt::PartiallyChecked)
-, mEditorTextOptions()
-#if defined(INCLUDE_UPDATER)
-, updater(nullptr)
-#endif
-, mEnableFullScreenMode(false)
-, mCopyAsImageTimeout{3}
-, mUsingMudletDictionaries(false)
-, mpDlgProfilePreferences(nullptr)
-, mpWidget_profileContainer(nullptr)
-, mIsGoingDown(false)
-, mMenuBarVisibility(visibleAlways)
-, mToolbarVisibility(visibleAlways)
-, mpActionReplaySpeedDown(nullptr)
-, mpActionReplaySpeedUp(nullptr)
-, mpActionSpeedDisplay(nullptr)
-, mpActionReplayTime(nullptr)
-, mpLabelReplaySpeedDisplay(nullptr)
-, mpLabelReplayTime(nullptr)
-, mpTimerReplay(nullptr)
-, mpToolBarReplay(nullptr)
-, triggersShortcut(nullptr)
-, showMapShortcut(nullptr)
-, inputLineShortcut(nullptr)
-, optionsShortcut(nullptr)
-, notepadShortcut(nullptr)
-, packagesShortcut(nullptr)
-, modulesShortcut(nullptr)
-, multiViewShortcut(nullptr)
-, connectShortcut(nullptr)
-, disconnectShortcut(nullptr)
-, reconnectShortcut(nullptr)
-, mpActionReplay(nullptr)
-, mpActionAbout(nullptr)
-, mpButtonAbout(nullptr)
-, mpActionAliases(nullptr)
-, mpActionButtons(nullptr)
-, mpButtonConnect(nullptr)
-, mpActionConnect(nullptr)
-, mpActionDisconnect(nullptr)
-, mpActionFullScreenView(nullptr)
-, mpActionHelp(nullptr)
-, mpActionIRC(nullptr)
-, mpButtonDiscord(nullptr)
-, mpActionKeys(nullptr)
-, mpActionMapper(nullptr)
-, mpActionMultiView(nullptr)
-, mpActionReportIssue(nullptr)
-, mpActionNotes(nullptr)
-, mpActionOptions(nullptr)
-, mpButtonPackageManagers(nullptr)
-, mpActionPackageManager(nullptr)
-, mpActionModuleManager(nullptr)
-, mpActionPackageExporter(nullptr)
-, mpActionReconnect(nullptr)
-, mpActionCloseProfile(nullptr)
-, mpActionScripts(nullptr)
-, mpActionTimers(nullptr)
-, mpActionTriggers(nullptr)
-, mpActionVariables(nullptr)
-, mshowMapAuditErrors(false)
-, mTimeFormat(tr("hh:mm:ss",
-                 "Formatting string for elapsed time display in replay playback - see QDateTime::toString(const QString&) for the gory details...!"))
-, mHunspell_sharedDictionary(nullptr)
-, mMultiView(false)
 {
-    firstLaunch = !QFile::exists(mudlet::getMudletPath(mudlet::profilesPath));
+    smFirstLaunch = !QFile::exists(mudlet::getMudletPath(mudlet::profilesPath));
 
     mShowIconsOnMenuOriginally = !qApp->testAttribute(Qt::AA_DontShowIconsInMenus);
     mpSettings = getQSettings();
@@ -278,7 +146,13 @@ mudlet::mudlet()
     scanForQtTranslations(getMudletPath(qtTranslationsPath));
     loadTranslators(mInterfaceLanguage);
 
-    if (QStringList{"windowsvista", "macintosh"}.contains(mDefaultStyle, Qt::CaseInsensitive)) {
+    // Cannot assign a value in the constructor list as it requires the
+    // translations to be loaded first:
+    mTimeFormat = tr("hh:mm:ss",
+                     // Intentional comment to separate arguments
+                     "Formatting string for elapsed time display in replay playback - see QDateTime::toString(const QString&) for the gory details...!");
+
+    if (QStringList{qsl("windowsvista"), qsl("macintosh")}.contains(mDefaultStyle, Qt::CaseInsensitive)) {
         qDebug().nospace().noquote() << "mudlet::mudlet() INFO - '" << mDefaultStyle << "' has been detected as the style factory in use - QPushButton styling fix applied!";
         mBG_ONLY_STYLESHEET = qsl("QPushButton {background-color: %1; border: 1px solid #8f8f91;}");
         mTEXT_ON_BG_STYLESHEET = qsl("QPushButton {color: %1; background-color: %2; border: 1px solid #8f8f91;}");
@@ -299,7 +173,7 @@ mudlet::mudlet()
 
     setAttribute(Qt::WA_DeleteOnClose);
     QSizePolicy sizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    setWindowTitle(version);
+    setWindowTitle(scmVersion);
     if (scmIsReleaseVersion) {
         setWindowIcon(QIcon(qsl(":/icons/mudlet.png")));
     } else if (scmIsPublicTestVersion) {
@@ -642,31 +516,31 @@ mudlet::mudlet()
 
     // we historically use Alt on Windows and Linux, but that is uncomfortable on macOS
 #if defined(Q_OS_MACOS)
-    triggersKeySequence = QKeySequence(Qt::CTRL | Qt::Key_E);
-    showMapKeySequence = QKeySequence(Qt::CTRL | Qt::Key_M);
-    inputLineKeySequence = QKeySequence(Qt::CTRL | Qt::Key_L);
-    optionsKeySequence = QKeySequence(Qt::CTRL | Qt::Key_P);
-    notepadKeySequence = QKeySequence(Qt::CTRL | Qt::Key_N);
-    packagesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_O);
-    modulesKeySequence = QKeySequence(Qt::CTRL | Qt::Key_I);
-    multiViewKeySequence = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_V);
-    connectKeySequence = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_C);
-    disconnectKeySequence = QKeySequence(Qt::CTRL | Qt::Key_D);
-    reconnectKeySequence = QKeySequence(Qt::CTRL | Qt::Key_R);
-    closeProfileKeySequence = QKeySequence(Qt::CTRL | Qt::Key_W);
+    mKeySequenceTriggers = QKeySequence(Qt::CTRL | Qt::Key_E);
+    mKeySequenceShowMap = QKeySequence(Qt::CTRL | Qt::Key_M);
+    mKeySequenceInputLine = QKeySequence(Qt::CTRL | Qt::Key_L);
+    mKeySequenceOptions = QKeySequence(Qt::CTRL | Qt::Key_P);
+    mKeySequenceNotepad = QKeySequence(Qt::CTRL | Qt::Key_N);
+    mKeySequencePackages = QKeySequence(Qt::CTRL | Qt::Key_O);
+    mKeySequenceModules = QKeySequence(Qt::CTRL | Qt::Key_I);
+    mKeySequenceMultiView = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_V);
+    mKeySequenceConnect = QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_C);
+    mKeySequenceDisconnect = QKeySequence(Qt::CTRL | Qt::Key_D);
+    mKeySequenceReconnect = QKeySequence(Qt::CTRL | Qt::Key_R);
+    mKeySequenceCloseProfile = QKeySequence(Qt::CTRL | Qt::Key_W);
 #else
-    triggersKeySequence = QKeySequence(Qt::ALT | Qt::Key_E);
-    showMapKeySequence = QKeySequence(Qt::ALT | Qt::Key_M);
-    inputLineKeySequence = QKeySequence(Qt::ALT | Qt::Key_L);
-    optionsKeySequence = QKeySequence(Qt::ALT | Qt::Key_P);
-    notepadKeySequence = QKeySequence(Qt::ALT | Qt::Key_N);
-    packagesKeySequence = QKeySequence(Qt::ALT | Qt::Key_O);
-    modulesKeySequence = QKeySequence(Qt::ALT | Qt::Key_I);
-    multiViewKeySequence = QKeySequence(Qt::ALT | Qt::Key_V);
-    connectKeySequence = QKeySequence(Qt::ALT | Qt::Key_C);
-    disconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_D);
-    reconnectKeySequence = QKeySequence(Qt::ALT | Qt::Key_R);
-    closeProfileKeySequence = QKeySequence(Qt::ALT | Qt::Key_W);
+    mKeySequenceTriggers = QKeySequence(Qt::ALT | Qt::Key_E);
+    mKeySequenceShowMap = QKeySequence(Qt::ALT | Qt::Key_M);
+    mKeySequenceInputLine = QKeySequence(Qt::ALT | Qt::Key_L);
+    mKeySequenceOptions = QKeySequence(Qt::ALT | Qt::Key_P);
+    mKeySequenceNotepad = QKeySequence(Qt::ALT | Qt::Key_N);
+    mKeySequencePackages = QKeySequence(Qt::ALT | Qt::Key_O);
+    mKeySequenceModules = QKeySequence(Qt::ALT | Qt::Key_I);
+    mKeySequenceMultiView = QKeySequence(Qt::ALT | Qt::Key_V);
+    mKeySequenceConnect = QKeySequence(Qt::ALT | Qt::Key_C);
+    mKeySequenceDisconnect = QKeySequence(Qt::ALT | Qt::Key_D);
+    mKeySequenceReconnect = QKeySequence(Qt::ALT | Qt::Key_R);
+    mKeySequenceCloseProfile = QKeySequence(Qt::ALT | Qt::Key_W);
 #endif
     connect(this, &mudlet::signal_menuBarVisibilityChanged, this, &mudlet::slot_updateShortcuts);
     connect(this, &mudlet::signal_hostCreated, this, &mudlet::slot_assignShortcutsFromProfile);
@@ -675,19 +549,19 @@ mudlet::mudlet()
         slot_assignShortcutsFromProfile(getActiveHost());
     });
 
-    mShortcutsManager = new ShortcutsManager();
-    mShortcutsManager->registerShortcut(qsl("Script editor"), tr("Script editor"), &triggersKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Show Map"), tr("Show Map"), &showMapKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Compact input line"), tr("Compact input line"), &inputLineKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Preferences"), tr("Preferences"), &optionsKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Notepad"), tr("Notepad"), &notepadKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Package manager"), tr("Package manager"), &packagesKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Module manager"), tr("Module manager"), &modulesKeySequence);
-    mShortcutsManager->registerShortcut(qsl("MultiView"), tr("MultiView"), &multiViewKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Play"), tr("Play"), &connectKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Disconnect"), tr("Disconnect"), &disconnectKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Reconnect"), tr("Reconnect"), &reconnectKeySequence);
-    mShortcutsManager->registerShortcut(qsl("Close profile"), tr("Close profile"), &closeProfileKeySequence);
+    mpShortcutsManager = new ShortcutsManager();
+    mpShortcutsManager->registerShortcut(qsl("Script editor"), tr("Script editor"), &mKeySequenceTriggers);
+    mpShortcutsManager->registerShortcut(qsl("Show Map"), tr("Show Map"), &mKeySequenceShowMap);
+    mpShortcutsManager->registerShortcut(qsl("Compact input line"), tr("Compact input line"), &mKeySequenceInputLine);
+    mpShortcutsManager->registerShortcut(qsl("Preferences"), tr("Preferences"), &mKeySequenceOptions);
+    mpShortcutsManager->registerShortcut(qsl("Notepad"), tr("Notepad"), &mKeySequenceNotepad);
+    mpShortcutsManager->registerShortcut(qsl("Package manager"), tr("Package manager"), &mKeySequencePackages);
+    mpShortcutsManager->registerShortcut(qsl("Module manager"), tr("Module manager"), &mKeySequenceModules);
+    mpShortcutsManager->registerShortcut(qsl("MultiView"), tr("MultiView"), &mKeySequenceMultiView);
+    mpShortcutsManager->registerShortcut(qsl("Play"), tr("Play"), &mKeySequenceConnect);
+    mpShortcutsManager->registerShortcut(qsl("Disconnect"), tr("Disconnect"), &mKeySequenceDisconnect);
+    mpShortcutsManager->registerShortcut(qsl("Reconnect"), tr("Reconnect"), &mKeySequenceReconnect);
+    mpShortcutsManager->registerShortcut(qsl("Close profile"), tr("Close profile"), &mKeySequenceCloseProfile);
 
     mpSettings = getQSettings();
     readLateSettings(*mpSettings);
@@ -695,14 +569,14 @@ mudlet::mudlet()
     connect(mpMainToolBar, &QToolBar::visibilityChanged, this, &mudlet::slot_handleToolbarVisibilityChanged);
 
 #if defined(INCLUDE_UPDATER)
-    updater = new Updater(this, mpSettings);
-    connect(updater, &Updater::signal_updateAvailable, this, &mudlet::slot_updateAvailable);
+    pUpdater = new Updater(this, mpSettings);
+    connect(pUpdater, &Updater::signal_updateAvailable, this, &mudlet::slot_updateAvailable);
     connect(dactionUpdate, &QAction::triggered, this, &mudlet::slot_manualUpdateCheck);
 #if defined(Q_OS_MACOS)
     // ensure that 'Check for updates' is under the Applications menu per convention
     dactionUpdate->setMenuRole(QAction::ApplicationSpecificRole);
 #else
-    connect(updater, &Updater::signal_updateInstalled, this, &mudlet::slot_updateInstalled);
+    connect(pUpdater, &Updater::signal_updateInstalled, this, &mudlet::slot_updateInstalled);
 #endif // !Q_OS_MACOS
 #endif // INCLUDE_UPDATER
 
@@ -731,7 +605,7 @@ mudlet::mudlet()
 
     // initialize Announcer after the window is loaded, as UIA on Windows requires it
     QTimer::singleShot(0, this, [this]() {
-        announcer = new Announcer(this);
+        mpAnnouncer = new Announcer(this);
     });
 }
 
@@ -1100,17 +974,17 @@ void mudlet::loadMaps()
 // migrates the Central Debug Console to the next available host, if any
 void mudlet::migrateDebugConsole(Host* currentHost)
 {
-    if (!mpDebugArea) {
+    if (!smpDebugArea) {
         return;
     }
 
-    const auto debugConsoleHost = mpDebugConsole->getHost();
+    const auto debugConsoleHost = smpDebugConsole->getHost();
     if (debugConsoleHost != currentHost) {
         return;
     }
 
-    mpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
-    mpDebugArea->close();
+    smpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
+    smpDebugArea->close();
 }
 
 // As we are currently only using files from a resource file we only need to
@@ -1120,7 +994,7 @@ void mudlet::migrateDebugConsole(Host* currentHost)
 // language/locale:
 void mudlet::scanForMudletTranslations(const QString& path)
 {
-    mMudletTranslationsPathName = path;
+    mPathNameMudletTranslations = path;
     // qDebug().nospace().noquote() << "mudlet::scanForMudletTranslations(\"" << path << "\") INFO - Seeking Mudlet translation files:";
     mTranslationsMap.clear();
 
@@ -1218,7 +1092,7 @@ void mudlet::scanForMudletTranslations(const QString& path)
 // QMap.
 void mudlet::scanForQtTranslations(const QString& path)
 {
-    mQtTranslationsPathName = path;
+    mPathNameQtTranslations = path;
     // qDebug().nospace().noquote() << "mudlet::scanForQtTranslations(\"" << path << "\") INFO - Seeking Qt translation files:";
     QMutableMapIterator<QString, translation> itTranslation(mTranslationsMap);
     while (itTranslation.hasNext()) {
@@ -1272,9 +1146,9 @@ void mudlet::loadTranslators(const QString& languageCode)
         // mangles the former to find the actual best one to use, but we
         // shouldn't include the path in the first element as it seems to mess
         // up the process of locating the file:
-        pQtTranslator->load(qtTranslatorFileName, mQtTranslationsPathName);
+        pQtTranslator->load(qtTranslatorFileName, mPathNameQtTranslations);
         if (!pQtTranslator->isEmpty()) {
-            // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mQtTranslationsPathName << "/"<< qtTranslatorFileName << "\"...";
+            // qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Qt libraries' translation from a path and file name specified as: \"" << mPathNameQtTranslations << "/"<< qtTranslatorFileName << "\"...";
             qApp->installTranslator(pQtTranslator);
             mTranslatorsLoadedList.append(pQtTranslator);
         }
@@ -1283,9 +1157,9 @@ void mudlet::loadTranslators(const QString& languageCode)
     QPointer<QTranslator> pMudletTranslator = new QTranslator;
     QString mudletTranslatorFileName = currentTranslation.getMudletTranslationFileName();
     if (!mudletTranslatorFileName.isEmpty()) {
-        pMudletTranslator->load(mudletTranslatorFileName, mMudletTranslationsPathName);
+        pMudletTranslator->load(mudletTranslatorFileName, mPathNameMudletTranslations);
         if (!pMudletTranslator->isEmpty()) {
-//            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mMudletTranslationsPathName << "/"
+//            qDebug().nospace().noquote() << "mudlet::loadTranslators(\"" << languageCode << "\") INFO - installing Mudlet translation from: \"" << mPathNameMudletTranslations << "/"
 //                                         << mudletTranslatorFileName << "\"...";
             qApp->installTranslator(pMudletTranslator);
             mTranslatorsLoadedList.append(pMudletTranslator);
@@ -1533,8 +1407,16 @@ void mudlet::slot_tabChanged(int tabID)
     mpTabBar->setStyleSheet(mpCurrentActiveHost->mProfileStyleSheet);
     menuBar()->setStyleSheet(mpCurrentActiveHost->mProfileStyleSheet);
 
+    // Will conflict with PR #6267 - when merging with that select this
+    // version (which has scmVersion for the second argument) - and
+    // remove this comment!
+
     // update the window title for the currently selected profile
-    setWindowTitle(mpCurrentActiveHost->getName() + " - " + version);
+    setWindowTitle(tr("%1 - %2",
+                      // Intentional comment to separate arguments
+                      "Title for the main window when a profile is loaded or active, %1 is the name "
+                      "of the profile and %2 is the Mudlet version string.")
+                           .arg(mpCurrentActiveHost->getName(), scmVersion));
 
     dactionInputLine->setChecked(mpCurrentActiveHost->getCompactInputLine());
 
@@ -1578,8 +1460,16 @@ void mudlet::addConsoleForNewHost(Host* pH)
      */
     mpTabBar->setTabData(newTabID, tabName);
 
-    //update the main window title when we spawn a new tab
-    setWindowTitle(pH->getName() + " - " + version);
+    // Will conflict with PR #6267 - when merging with that change the
+    // "version" to "scmVersion" for the second argument when this chunk of code
+    // gets moved to mudlet::activateProfile() - and remove this comment!
+    // update the window title for the currently selected profile
+    setWindowTitle(tr("%1 - %2",
+                      // Intentional comment to separate arguments
+                      "Title for the main window when a profile is loaded or active, %1 is the name "
+                      "of the profile and %2 is the Mudlet version string.")
+                           .arg(pH->getName(), scmVersion));
+
 
     mpSplitter_profileContainer->addWidget(pConsole);
     if (mpCurrentActiveHost && !mMultiView) {
@@ -1871,9 +1761,9 @@ void mudlet::closeEvent(QCloseEvent* event)
     writeSettings();
 
     goingDown();
-    if (mpDebugArea) {
-        mpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
-        mpDebugArea->close();
+    if (smpDebugArea) {
+        smpDebugArea->setAttribute(Qt::WA_DeleteOnClose);
+        smpDebugArea->close();
     }
 
     for (auto pHost : mHostManager) {
@@ -1968,7 +1858,7 @@ void mudlet::readEarlySettings(const QSettings& settings)
 
     auto appearance = settings.value(qsl("appearance"), QVariant(0)).toInt();
     if (appearance == 0) {
-        mAppearance = settings.contains(qsl("darkTheme")) ? (oldDarkTheme ? Appearance::dark : Appearance::light) : Appearance::system;
+        mAppearance = settings.contains(qsl("darkTheme")) ? (oldDarkTheme ? Appearance::dark : Appearance::light) : Appearance::systemSetting;
     } else {
         mAppearance = static_cast<Appearance>(appearance);
     }
@@ -2002,7 +1892,7 @@ void mudlet::readLateSettings(const QSettings& settings)
     setToolBarVisibility(static_cast<controlsVisibilityFlag>(settings.value("toolBarVisibility", static_cast<int>(visibleAlways)).toInt()));
     mEditorTextOptions = static_cast<QTextOption::Flags>(settings.value("editorTextOptions", QVariant(0)).toInt());
 
-    mshowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();
+    mShowMapAuditErrors = settings.value("reportMapIssuesToConsole", QVariant(false)).toBool();
     mStorePasswordsSecurely = settings.value("storePasswordsSecurely", QVariant(true)).toBool();
 
 
@@ -2138,7 +2028,7 @@ void mudlet::writeSettings()
     settings.setValue("toolBarVisibility", static_cast<int>(mToolbarVisibility));
     settings.setValue("maximized", isMaximized());
     settings.setValue("editorTextOptions", static_cast<int>(mEditorTextOptions));
-    settings.setValue("reportMapIssuesToConsole", mshowMapAuditErrors);
+    settings.setValue("reportMapIssuesToConsole", mShowMapAuditErrors);
     settings.setValue("storePasswordsSecurely", mStorePasswordsSecurely);
     settings.setValue("showIconsInMenus", mShowIconsOnMenuCheckedState);
     settings.setValue("enableFullScreenMode", mEnableFullScreenMode);
@@ -2151,16 +2041,16 @@ void mudlet::writeSettings()
 
 void mudlet::slot_showConnectionDialog()
 {
-    if (mConnectionDialog) {
+    if (mpConnectionDialog) {
         return;
     }
-    mConnectionDialog = new dlgConnectionProfiles(this);
-    connect(mConnectionDialog, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connectionDialogueFinished);
-    mConnectionDialog->fillout_form();
+    mpConnectionDialog = new dlgConnectionProfiles(this);
+    connect(mpConnectionDialog, &dlgConnectionProfiles::signal_load_profile, this, &mudlet::slot_connectionDialogueFinished);
+    mpConnectionDialog->fillout_form();
 
-    connect(mConnectionDialog, &QDialog::accepted, this, [=]() { enableToolbarButtons(); });
-    mConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);
-    mConnectionDialog->show();
+    connect(mpConnectionDialog, &QDialog::accepted, this, [=]() { enableToolbarButtons(); });
+    mpConnectionDialog->setAttribute(Qt::WA_DeleteOnClose);
+    mpConnectionDialog->show();
 }
 
 void mudlet::slot_showEditorDialog()
@@ -2292,7 +2182,7 @@ void mudlet::slot_showActionDialog()
 }
 
 // tab must be the "objectName" of the tab in the preferences NOT the "titleText"
-void mudlet::show_options_dialog(const QString& tab)
+void mudlet::showOptionsDialog(const QString& tab)
 {
     Host* pHost = getActiveHost();
 
@@ -2327,10 +2217,10 @@ void mudlet::show_options_dialog(const QString& tab)
 void mudlet::slot_assignShortcutsFromProfile(Host* pHost)
 {
     if (pHost) {
-        auto iterator = mShortcutsManager->iterator();
+        auto iterator = mpShortcutsManager->iterator();
         while (iterator.hasNext()) {
             auto key = iterator.next();
-            mShortcutsManager->setShortcut(key, pHost->profileShortcuts.value(key));
+            mpShortcutsManager->setShortcut(key, pHost->profileShortcuts.value(key));
         }
     }
     assignKeySequences();
@@ -2384,64 +2274,64 @@ void mudlet::assignKeySequences()
         // call to "disconnect(...)" as that happens on deletion and since it
         // is okay to delete a nullptr there is no need to include a non-null
         // test first:
-        delete triggersShortcut.data();
-        triggersShortcut = new QShortcut(triggersKeySequence, this);
-        connect(triggersShortcut.data(), &QShortcut::activated, this, &mudlet::slot_showEditorDialog);
+        delete mpShortcutTriggers.data();
+        mpShortcutTriggers = new QShortcut(mKeySequenceTriggers, this);
+        connect(mpShortcutTriggers.data(), &QShortcut::activated, this, &mudlet::slot_showEditorDialog);
         dactionScriptEditor->setShortcut(QKeySequence());
 
-        delete showMapShortcut.data();
-        showMapShortcut = new QShortcut(showMapKeySequence, this);
-        connect(showMapShortcut.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
+        delete mpShortcutShowMap.data();
+        mpShortcutShowMap = new QShortcut(mKeySequenceShowMap, this);
+        connect(mpShortcutShowMap.data(), &QShortcut::activated, this, &mudlet::slot_mapper);
         dactionShowMap->setShortcut(QKeySequence());
 
-        delete inputLineShortcut.data();
-        inputLineShortcut = new QShortcut(inputLineKeySequence, this);
-        connect(inputLineShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggleCompactInputLine);
+        delete mpShortcutInputLine.data();
+        mpShortcutInputLine = new QShortcut(mKeySequenceInputLine, this);
+        connect(mpShortcutInputLine.data(), &QShortcut::activated, this, &mudlet::slot_toggleCompactInputLine);
         dactionInputLine->setShortcut(QKeySequence());
 
-        delete optionsShortcut.data();
-        optionsShortcut = new QShortcut(optionsKeySequence, this);
-        connect(optionsShortcut.data(), &QShortcut::activated, this, &mudlet::slot_showPreferencesDialog);
+        delete mpShortcutOptions.data();
+        mpShortcutOptions = new QShortcut(mKeySequenceOptions, this);
+        connect(mpShortcutOptions.data(), &QShortcut::activated, this, &mudlet::slot_showPreferencesDialog);
         dactionOptions->setShortcut(QKeySequence());
 
-        delete notepadShortcut.data();
-        notepadShortcut = new QShortcut(notepadKeySequence, this);
-        connect(notepadShortcut.data(), &QShortcut::activated, this, &mudlet::slot_notes);
+        delete mpShortcutNotepad.data();
+        mpShortcutNotepad = new QShortcut(mKeySequenceNotepad, this);
+        connect(mpShortcutNotepad.data(), &QShortcut::activated, this, &mudlet::slot_notes);
         dactionNotepad->setShortcut(QKeySequence());
 
-        delete packagesShortcut.data();
-        packagesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(packagesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_packageManager);
+        delete mpShortcutPackages.data();
+        mpShortcutPackages = new QShortcut(mKeySequencePackages, this);
+        connect(mpShortcutPackages.data(), &QShortcut::activated, this, &mudlet::slot_packageManager);
         dactionPackageManager->setShortcut(QKeySequence());
 
-        delete modulesShortcut.data();
-        modulesShortcut = new QShortcut(packagesKeySequence, this);
-        connect(modulesShortcut.data(), &QShortcut::activated, this, &mudlet::slot_moduleManager);
+        delete mpShortcutModules.data();
+        mpShortcutModules = new QShortcut(mKeySequencePackages, this);
+        connect(mpShortcutModules.data(), &QShortcut::activated, this, &mudlet::slot_moduleManager);
         dactionModuleManager->setShortcut(QKeySequence());
 
-        delete multiViewShortcut.data();
-        multiViewShortcut = new QShortcut(multiViewKeySequence, this);
-        connect(multiViewShortcut.data(), &QShortcut::activated, this, &mudlet::slot_toggleMultiView);
+        delete mpShortcutMultiView.data();
+        mpShortcutMultiView = new QShortcut(mKeySequenceMultiView, this);
+        connect(mpShortcutMultiView.data(), &QShortcut::activated, this, &mudlet::slot_toggleMultiView);
         dactionMultiView->setShortcut(QKeySequence());
 
-        delete connectShortcut.data();
-        connectShortcut = new QShortcut(connectKeySequence, this);
-        connect(connectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_showConnectionDialog);
+        delete mpShortcutConnect.data();
+        mpShortcutConnect = new QShortcut(mKeySequenceConnect, this);
+        connect(mpShortcutConnect.data(), &QShortcut::activated, this, &mudlet::slot_showConnectionDialog);
         dactionConnect->setShortcut(QKeySequence());
 
-        delete disconnectShortcut.data();
-        disconnectShortcut = new QShortcut(disconnectKeySequence, this);
-        connect(disconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
+        delete mpShortcutDisconnect.data();
+        mpShortcutDisconnect = new QShortcut(mKeySequenceDisconnect, this);
+        connect(mpShortcutDisconnect.data(), &QShortcut::activated, this, &mudlet::slot_disconnect);
         dactionDisconnect->setShortcut(QKeySequence());
 
-        delete reconnectShortcut.data();
-        reconnectShortcut = new QShortcut(reconnectKeySequence, this);
-        connect(reconnectShortcut.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
+        delete mpShortcutReconnect.data();
+        mpShortcutReconnect = new QShortcut(mKeySequenceReconnect, this);
+        connect(mpShortcutReconnect.data(), &QShortcut::activated, this, &mudlet::slot_reconnect);
         dactionReconnect->setShortcut(QKeySequence());
 
-        delete closeProfileShortcut.data();
-        closeProfileShortcut = new QShortcut(closeProfileKeySequence, this);
-        connect(closeProfileShortcut.data(), &QShortcut::activated, this, &mudlet::slot_closeCurrentProfile);
+        delete mpShortcutCloseProfile.data();
+        mpShortcutCloseProfile = new QShortcut(mKeySequenceCloseProfile, this);
+        connect(mpShortcutCloseProfile.data(), &QShortcut::activated, this, &mudlet::slot_closeCurrentProfile);
         dactionCloseProfile->setShortcut(QKeySequence());
     } else {
         // The menu is shown so tie the QKeySequences to the menu items and it
@@ -2449,47 +2339,47 @@ void mudlet::assignKeySequences()
 
         // Because we are deleting the object that it points at
         // this will also clear() the shortcut pointer:
-        delete triggersShortcut.data();
-        dactionScriptEditor->setShortcut(triggersKeySequence);
+        delete mpShortcutTriggers.data();
+        dactionScriptEditor->setShortcut(mKeySequenceTriggers);
 
-        delete showMapShortcut.data();
-        dactionShowMap->setShortcut(showMapKeySequence);
+        delete mpShortcutShowMap.data();
+        dactionShowMap->setShortcut(mKeySequenceShowMap);
 
-        delete inputLineShortcut.data();
-        dactionInputLine->setShortcut(inputLineKeySequence);
+        delete mpShortcutInputLine.data();
+        dactionInputLine->setShortcut(mKeySequenceInputLine);
 
-        delete optionsShortcut.data();
-        dactionOptions->setShortcut(optionsKeySequence);
+        delete mpShortcutOptions.data();
+        dactionOptions->setShortcut(mKeySequenceOptions);
 
-        delete notepadShortcut.data();
-        dactionNotepad->setShortcut(notepadKeySequence);
+        delete mpShortcutNotepad.data();
+        dactionNotepad->setShortcut(mKeySequenceNotepad);
 
-        delete packagesShortcut.data();
-        dactionPackageManager->setShortcut(packagesKeySequence);
+        delete mpShortcutPackages.data();
+        dactionPackageManager->setShortcut(mKeySequencePackages);
 
-        delete modulesShortcut.data();
-        dactionModuleManager->setShortcut(modulesKeySequence);
+        delete mpShortcutModules.data();
+        dactionModuleManager->setShortcut(mKeySequenceModules);
 
-        delete multiViewShortcut.data();
-        dactionMultiView->setShortcut(multiViewKeySequence);
+        delete mpShortcutMultiView.data();
+        dactionMultiView->setShortcut(mKeySequenceMultiView);
 
-        delete connectShortcut.data();
-        dactionConnect->setShortcut(connectKeySequence);
+        delete mpShortcutConnect.data();
+        dactionConnect->setShortcut(mKeySequenceConnect);
 
-        delete disconnectShortcut.data();
-        dactionDisconnect->setShortcut(disconnectKeySequence);
+        delete mpShortcutDisconnect.data();
+        dactionDisconnect->setShortcut(mKeySequenceDisconnect);
 
-        delete reconnectShortcut.data();
-        dactionReconnect->setShortcut(reconnectKeySequence);
+        delete mpShortcutReconnect.data();
+        dactionReconnect->setShortcut(mKeySequenceReconnect);
 
-        delete closeProfileShortcut.data();
-        dactionCloseProfile->setShortcut(closeProfileKeySequence);
+        delete mpShortcutCloseProfile.data();
+        dactionCloseProfile->setShortcut(mKeySequenceCloseProfile);
     }
 }
 
 void mudlet::slot_showPreferencesDialog()
 {
-    show_options_dialog(qsl("tab_general"));
+    showOptionsDialog(qsl("tab_general"));
 }
 
 void mudlet::slot_showHelpDialog()
@@ -2786,26 +2676,26 @@ int64_t mudlet::getPhysicalMemoryTotal()
 // Ensure the debug area is attached to at least one Host
 void mudlet::attachDebugArea(const QString& hostname)
 {
-    if (mpDebugArea) {
+    if (smpDebugArea) {
         return;
     }
 
-    mpDebugArea = new QMainWindow(nullptr);
+    smpDebugArea = new QMainWindow(nullptr);
     const auto pHost = mHostManager.getHost(hostname);
-    mpDebugConsole = new TConsole(pHost, TConsole::CentralDebugConsole);
-    mpDebugConsole->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    mpDebugConsole->setWrapAt(100);
-    mpDebugArea->setCentralWidget(mpDebugConsole);
-    mpDebugArea->setWindowTitle(tr("Central Debug Console"));
-    mpDebugArea->setWindowIcon(QIcon(qsl(":/icons/mudlet_debug.png")));
+    smpDebugConsole = new TConsole(pHost, TConsole::CentralDebugConsole);
+    smpDebugConsole->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    smpDebugConsole->setWrapAt(100);
+    smpDebugArea->setCentralWidget(smpDebugConsole);
+    smpDebugArea->setWindowTitle(tr("Central Debug Console"));
+    smpDebugArea->setWindowIcon(QIcon(qsl(":/icons/mudlet_debug.png")));
 
-    auto consoleCloser = new TConsoleMonitor(mpDebugArea);
-    mpDebugArea->installEventFilter(consoleCloser);
+    auto consoleCloser = new TConsoleMonitor(smpDebugArea);
+    smpDebugArea->installEventFilter(consoleCloser);
 
     QSize generalRule(qApp->desktop()->size());
     generalRule -= QSize(30, 30);
-    mpDebugArea->resize(QSize(800, 600).boundedTo(generalRule));
-    mpDebugArea->hide();
+    smpDebugArea->resize(QSize(800, 600).boundedTo(generalRule));
+    smpDebugArea->hide();
 }
 
 void mudlet::doAutoLogin(const QString& profile_name)
@@ -2941,11 +2831,11 @@ void mudlet::slot_connectionDialogueFinished(const QString& profile, bool connec
     }
 
     // install default packages
-    for (int i = 0; i < packagesToInstallList.size(); i++) {
-        pHost->installPackage(packagesToInstallList[i], 0);
+    for (int i = 0; i < mPackagesToInstallList.size(); i++) {
+        pHost->installPackage(mPackagesToInstallList[i], 0);
     }
 
-    packagesToInstallList.clear();
+    mPackagesToInstallList.clear();
 
     pHost->mIsProfileLoadingSequence = false;
 
@@ -3041,7 +2931,7 @@ void mudlet::slot_compactInputLine(const bool state)
     if (mpCurrentActiveHost) {
         mpCurrentActiveHost->setCompactInputLine(state);
         // Make sure players don't get confused when accidentally hiding buttons.
-        if (QKeySequence* shortcut = mShortcutsManager->getSequence(qsl("Compact input line")); state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
+        if (QKeySequence* shortcut = mpShortcutsManager->getSequence(qsl("Compact input line")); state && !mpCurrentActiveHost->mTutorialForCompactLineAlreadyShown && shortcut && !shortcut->isEmpty()) {
             QString infoMsg = tr("[ INFO ]  - Compact input line set. Press %1 to show bottom-right buttons again.",
                                  "Here %1 will be replaced with the keyboard shortcut, default is ALT+L.").arg(shortcut->toString());
             mpCurrentActiveHost->postMessage(infoMsg);
@@ -3058,9 +2948,9 @@ mudlet::~mudlet()
     delete (mpTimerReplay);
     mpTimerReplay = nullptr;
 
-    if (mHunspell_sharedDictionary) {
+    if (mpHunspell_sharedDictionary) {
         saveDictionary(getMudletPath(mainDataItemPath, qsl("mudlet")), mWordSet_shared);
-        mHunspell_sharedDictionary = nullptr;
+        mpHunspell_sharedDictionary = nullptr;
     }
     if (!mTranslatorsLoadedList.isEmpty()) {
         qDebug().nospace().noquote() << "mudlet::~mudlet() INFO - uninstalling translation...";
@@ -3075,7 +2965,7 @@ mudlet::~mudlet()
             }
         }
     }
-    mudlet::_self = nullptr;
+    mudlet::smpSelf = nullptr;
 }
 
 void mudlet::slot_toggleFullScreenView()
@@ -3368,7 +3258,7 @@ bool mudlet::loadLuaFunctionList()
         return false;
     }
 
-    mudlet::mLuaFunctionNames = json_obj.toVariantHash();
+    mudlet::smLuaFunctionNames = json_obj.toVariantHash();
 
     return true;
 }
@@ -3686,13 +3576,13 @@ void mudlet::checkUpdatesOnStart()
     if (scmIsReleaseVersion || scmIsPublicTestVersion) {
         // Only try and create an updater (which checks for updates online) if
         // this is a release/public test version:
-        updater->checkUpdatesOnStart();
+        pUpdater->checkUpdatesOnStart();
     }
 }
 
 void mudlet::slot_manualUpdateCheck()
 {
-    updater->manuallyCheckUpdates();
+    pUpdater->manuallyCheckUpdates();
 }
 
 void mudlet::slot_reportIssue()
@@ -3782,11 +3672,11 @@ void mudlet::slot_updateInstalled()
 
 void mudlet::showChangelogIfUpdated()
 {
-    if (!updater->shouldShowChangelog()) {
+    if (!pUpdater->shouldShowChangelog()) {
         return;
     }
 
-    updater->showChangelog();
+    pUpdater->showChangelog();
 }
 #endif // INCLUDE_UPDATER
 
@@ -4011,8 +3901,8 @@ void mudlet::slot_passwordMigratedToPortableStorage(QKeychain::Job* job)
 
 void mudlet::setShowMapAuditErrors(const bool state)
 {
-    if (mshowMapAuditErrors != state) {
-        mshowMapAuditErrors = state;
+    if (mShowMapAuditErrors != state) {
+        mShowMapAuditErrors = state;
 
         emit signal_showMapAuditErrorsChanged(state);
     }
@@ -4045,7 +3935,7 @@ void mudlet::setAppearance(const Appearance state, const bool& loading)
     }
 
     mDarkMode = false;
-    if (state == Appearance::dark || (state == Appearance::system && desktopInDarkMode())) {
+    if (state == Appearance::dark || (state == Appearance::systemSetting && desktopInDarkMode())) {
         mDarkMode = true;
     }
 
@@ -4095,7 +3985,7 @@ QString mudlet::autodetectPreferredLanguage()
         auto& translation = mTranslationsMap.value(code);
         if (translation.fromResourceFile()) {
             auto& translatedPc = translation.getTranslatedPercentage();
-            if (translatedPc >= mTranslationGoldStar) {
+            if (translatedPc >= scmTranslationGoldStar) {
                 availableQualityTranslations.append(code);
             }
         }
@@ -4314,7 +4204,7 @@ int mudlet::scanWordList(QStringList& wl, QHash<QString, unsigned int>& gc)
 // This will load up the spelling dictionary for the profile - and handles the
 // absence of files for the first run in a new profile or from an older
 // Mudlet version - it processes any changes made by the user in the ".dic" file
-// and regenerates (deduplicates and sorts) it and (rebuilds the "TRY" line) in
+// and regenerates (deduplicates and sorts) it and rebuilds (the "TRY" line in)
 // the ".aff" file:
 Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QString>& wordSet)
 {
@@ -4377,8 +4267,8 @@ Hunhandle* mudlet::prepareProfileDictionary(const QString& hostName, QSet<QStrin
 // the ".aff" file:
 Hunhandle* mudlet::prepareSharedDictionary()
 {
-    if (mHunspell_sharedDictionary) {
-        return mHunspell_sharedDictionary;
+    if (mpHunspell_sharedDictionary) {
+        return mpHunspell_sharedDictionary;
     }
 
     // Need to check that the files exist first:
@@ -4418,8 +4308,8 @@ Hunhandle* mudlet::prepareSharedDictionary()
     mudlet::self()->sanitizeUtf8Path(affixPathFileName, qsl("profile.dic"));
     mudlet::self()->sanitizeUtf8Path(dictionaryPathFileName, qsl("profile.aff"));
 #endif
-    mHunspell_sharedDictionary = Hunspell_create(affixPathFileName.toUtf8().constData(), dictionaryPathFileName.toUtf8().constData());
-    return mHunspell_sharedDictionary;
+    mpHunspell_sharedDictionary = Hunspell_create(affixPathFileName.toUtf8().constData(), dictionaryPathFileName.toUtf8().constData());
+    return mpHunspell_sharedDictionary;
 }
 
 // This commits any changes noted in the wordSet into the ".dic" file and
@@ -4467,7 +4357,7 @@ bool mudlet::saveDictionary(const QString& pathFileBaseName, QSet<QString>& word
 QPair<bool, bool> mudlet::addWordToSet(const QString& word)
 {
     bool isAdded = false;
-    Hunspell_add(mHunspell_sharedDictionary, word.toUtf8().constData());
+    Hunspell_add(mpHunspell_sharedDictionary, word.toUtf8().constData());
     if (!mWordSet_shared.contains(word)) {
         mWordSet_shared.insert(word);
         qDebug().noquote().nospace() << "mudlet::addWordToSet(\"" << word << "\") INFO - word added to shared mWordSet.";
@@ -4479,7 +4369,7 @@ QPair<bool, bool> mudlet::addWordToSet(const QString& word)
 QPair<bool, bool> mudlet::removeWordFromSet(const QString& word)
 {
     bool isRemoved = false;
-    Hunspell_remove(mHunspell_sharedDictionary, word.toUtf8().constData());
+    Hunspell_remove(mpHunspell_sharedDictionary, word.toUtf8().constData());
     if (mWordSet_shared.remove(word)) {
         qDebug().noquote().nospace() << "mudlet::removeWordFromSet(\"" << word << "\") INFO - word removed from shared mWordSet.";
         isRemoved = true;
@@ -4668,7 +4558,7 @@ void mudlet::refreshTabBar()
 {
     for (const auto& pHost : mHostManager) {
         QString hostName = pHost->getName();
-        if (debugMode) {
+        if (smDebugMode) {
             mpTabBar->applyPrefixToDisplayedText(hostName, TDebug::getTag(pHost.data()));
         } else {
             mpTabBar->applyPrefixToDisplayedText(hostName);
@@ -4703,12 +4593,12 @@ void mudlet::setupPreInstallPackages(const QString& gameUrl)
     while (i.hasNext()) {
         i.next();
         if (i.value().first() == QLatin1String("*") || i.value().contains(gameUrl)) {
-            mudlet::self()->packagesToInstallList.append(i.key());
+            mudlet::self()->mPackagesToInstallList.append(i.key());
         }
     }
 
-    if (!mudlet::self()->packagesToInstallList.contains(qsl(":/mudlet-mapper.xml"))) {
-        mudlet::self()->packagesToInstallList.append(qsl(":/mudlet-lua/lua/generic-mapper/generic_mapper.xml"));
+    if (!mudlet::self()->mPackagesToInstallList.contains(qsl(":/mudlet-mapper.xml"))) {
+        mudlet::self()->mPackagesToInstallList.append(qsl(":/mudlet-lua/lua/generic-mapper/generic_mapper.xml"));
     }
 }
 
@@ -4743,5 +4633,5 @@ bool mudlet::desktopInDarkMode()
 
 void mudlet::announce(const QString& text, const QString& processing)
 {
-    announcer->announce(text, processing);
+    mpAnnouncer->announce(text, processing);
 }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -27,20 +27,19 @@
  ***************************************************************************/
 
 #include "Announcer.h"
-#include "utils.h"
-#include "HostManager.h"
+#include "discord.h"
 #include "FontManager.h"
+#include "HostManager.h"
+#include "ShortcutsManager.h"
+#include "utils.h"
 
-#include "edbee/views/texttheme.h"
-#include "ui_main_window.h"
 #if defined(INCLUDE_UPDATER)
 #include "updater.h"
 #endif
 
-#include "discord.h"
-#include "ShortcutsManager.h"
-
 #include "pre_guard.h"
+#include "ui_main_window.h"
+#include "edbee/views/texttheme.h"
 #include <QAction>
 #include <QDir>
 #include <QFlags>
@@ -62,10 +61,7 @@
 #else
 #include <qt5keychain/keychain.h>
 #endif
-
 #include <optional>
-#include "post_guard.h"
-
 #include <hunspell/hunspell.hxx>
 #include <hunspell/hunspell.h>
 
@@ -95,8 +91,8 @@
 #else
 // Any other OS?
 #endif
+#include "post_guard.h"
 
-class QAction;
 class QCloseEvent;
 class QMediaPlayer;
 class QMenu;
@@ -111,22 +107,21 @@ class QTextEdit;
 class QToolButton;
 class QTimer;
 
+class dlgAboutDialog;
+class dlgConnectionProfiles;
+class dlgIRC;
+class dlgProfilePreferences;
 class Host;
+class ShortcutManager;
 class TConsole;
 class TDockWidget;
 class TEvent;
 class TLabel;
+class translation;
 class TScrollBox;
 class TTabBar;
 class TTimer;
 class TToolBar;
-class dlgIRC;
-class dlgAboutDialog;
-class dlgConnectionProfiles;
-class dlgProfilePreferences;
-class ShortcutManager;
-
-class translation;
 
 class mudlet : public QMainWindow, public Ui::main_window
 {
@@ -135,7 +130,21 @@ class mudlet : public QMainWindow, public Ui::main_window
 public:
     Q_DISABLE_COPY(mudlet)
     mudlet();
-    ~mudlet();
+    ~mudlet() override;
+
+    enum Appearance {
+        systemSetting = 0,
+        light = 1,
+        dark = 2
+    };
+
+    enum controlsVisibilityFlag {
+        visibleNever = 0,
+        visibleOnlyWithoutLoadedProfile = 0x1,
+        visibleMaskNormally = 0x2,
+        visibleAlways = 0x3
+    };
+    Q_DECLARE_FLAGS(controlsVisibility, controlsVisibilityFlag)
 
     enum mudletPathType {
         // The root of all mudlet data for the user - does not end in a '/'
@@ -220,170 +229,222 @@ public:
         hunspellDictionaryPath
     };
 
+
+    static QString getMudletPath(mudletPathType, const QString& extra1 = QString(), const QString& extra2 = QString());
+    // From https://stackoverflow.com/a/14678964/4805858 an answer to:
+    // "How to find and replace string?" by "Czarek Tomczak":
+    static bool loadEdbeeTheme(const QString& themeName, const QString& themeFile);
+    static bool loadLuaFunctionList();
+    static std::string replaceString(std::string subject, const std::string& search, const std::string& replace);
     static mudlet* self();
+    static void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
     // This method allows better debugging when mudlet::self() is called inappropriately.
     static void start();
-    HostManager& getHostManager() { return mHostManager; }
-    void attachDebugArea(const QString& hostname);
-    void addConsoleForNewHost(Host* pH);
-    void disableToolbarButtons();
-    void enableToolbarButtons();
-    Host* getActiveHost();
-    void forceClose();
-    bool saveWindowLayout();
-    bool loadWindowLayout();
-    void commitLayoutUpdates(bool flush = false);
+    static bool unzip(const QString& archivePath, const QString& destination, const QDir& tmpDir);
 
-    std::optional<QSize> getImageSize(const QString& imageLocation);
-    QString readProfileData(const QString& profile, const QString& item);
-    QPair<bool, QString> writeProfileData(const QString& profile, const QString& item, const QString& what);
+
+    // final, official release
+    inline static const bool scmIsReleaseVersion = QByteArray(APP_BUILD).isEmpty();
+    // unofficial "nightly" build - still a type of a release
+    inline static const bool scmIsPublicTestVersion = QByteArray(APP_BUILD).startsWith("-ptb");
+    // used by developers in everyday coding:
+    inline static const bool scmIsDevelopmentVersion = !mudlet::scmIsReleaseVersion && !mudlet::scmIsPublicTestVersion;
+    // "scmMudletXmlDefaultVersion" number represents a major (integer part) and minor
+    // (1000ths, range 0 to 999) that is used as a "version" attribute number when
+    // writing the <MudletPackage ...> element of all (but maps if I ever get around
+    // to doing a Map Xml file exporter/writer) Xml files used to export/save Mudlet
+    // button/menu/toolbars; aliases. keys, scripts, timers, triggers and variables
+    // and collections of these as modules/packages and entire profiles as "game
+    // saves".  Mudlet versions up to 3.0.1 never bothered checking the version
+    // detail and it had been hard coded as "1.0" back as far as history can
+    // determine.  From that version a check was coded to test that the version
+    // was less than 2.000f with the intention to loudly and clearly fail if a
+    // higher version was encountered. Values above 1.001f have not yet been
+    // codified but should be accepted so it should be possible to raise the number
+    // a little and to use that to extend the Xml data format in a manner that older
+    // versions ignore (possibly with some noise) but which they can still get the
+    // details they can handle yet allow a later upgraded version to get extra
+    // information they want.
+    //
+    // Taking this number to 2.000f or more WILL prevent old versions from reading
+    // Xml files and should be considered a step associated with a major version
+    // number change in the Mudlet application itself and SHOULD NOT BE DONE WITHOUT
+    // agreement and consideration from the Project management, even a minor part
+    // increment should not be done without justification...!
+    // XML version Change history (what and why):
+    // 1.001    Added method to allow XML format to permit ASCII control codes
+    //          0x01-0x08, 0x0b, 0x0c, 0x0e-0x1f, 0x7f to be stored as part of the
+    //          "script" element for a Mudlet "item" (0x09, 0x0a, 0x0d are the only
+    //          ones that ARE permitted) - this is wanted so that, for instance
+    //          ANSI ESC codes can be included in a Lua script without breaking
+    //          the XML format used to store it - prior to this embedding such
+    //          codes would break or destroy the script that used it.
+    inline static const QString scmMudletXmlDefaultVersion = QString::number(1.001f, 'f', 3);
+    // A constant equivalent to QDataStream::Qt_5_12 needed in several places
+    // which can't be pulled from Qt as it is not going to be defined for older
+    // versions:
+    static const int scmQDataStreamFormat_5_12 = 18;
+    // The Qt runtime version is needed in various places but as it is a constant
+    // during the application run it is easiest to define it as one once:
+    inline static const QVersionNumber scmRunTimeQtVersion = QVersionNumber::fromString(QLatin1String(qVersion()));
+    // translations done high enough will get a gold star to hide the last few percent
+    // as well as encourage translators to maintain it;
+    static const int scmTranslationGoldStar = 95;
+    inline static const QString scmVersion = qsl("Mudlet " APP_VERSION APP_BUILD);
+    // These have to be "inline" to satisfy the ODR (One Definition Rule):
+    inline static bool smDebugMode = false;
+    inline static bool smFirstLaunch = false;
+    inline static QVariantHash smLuaFunctionNames;
+    inline static QPointer<TConsole> smpDebugConsole;
+    inline static QPointer<QMainWindow> smpDebugArea;
+    // mirror everything shown in any console to stdout. Helpful for CI environments
+    inline static bool smMirrorToStdOut = false;
+
+
+    void showEvent(QShowEvent*) override;
+    void hideEvent(QHideEvent*) override;
+
+
+    void activateProfile(Host*);
+    void addConsoleForNewHost(Host*);
+    QPair<bool, bool> addWordToSet(const QString&);
+    void adjustMenuBarVisibility();
+    void adjustToolBarVisibility();
+    void announce(const QString& text, const QString& processing = QString());
+    void attachDebugArea(const QString&);
+    void checkUpdatesOnStart();
+    void commitLayoutUpdates(bool flush = false);
     void deleteProfileData(const QString &profile, const QString &item);
+    void disableToolbarButtons();
+    void doAutoLogin(const QString&);
+    void enableToolbarButtons();
+    void forceClose();
+    Host* getActiveHost();
+    QStringList getAvailableFonts();
+    QList<QString> getAvailableTranslationCodes() const { return mTranslationsMap.keys(); }
+    const QMap<QByteArray, QString>& getEncodingNamesMap() const { return mEncodingNameMap; }
+    HostManager& getHostManager() { return mHostManager; }
+    std::optional<QSize> getImageSize(const QString&);
+    const QString& getInterfaceLanguage() const { return mInterfaceLanguage; }
+    int64_t getPhysicalMemoryTotal();
+    QSettings* getQSettings();
+    const QLocale& getUserLocale() const { return mUserLocale; }
+    QSet<QString> getWordSet();
+    bool inDarkMode() const { return mDarkMode; }
+    // Used to enable "emergency" control recovery action - if Mudlet is
+    // operating without either menubar or main toolbar showing.
+    bool isControlsVisible() const;
+    bool isGoingDown() { return mIsGoingDown; }
+    bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
+    bool loadWindowLayout();
+    controlsVisibility menuBarVisibility() const { return mMenuBarVisibility; }
+    bool migratePasswordsToProfileStorage();
+    bool migratePasswordsToSecureStorage();
+    bool openWebPage(const QString&);
+    // Both of these revises the contents of the .aff file and handle a .dic
+    // file that has been updated externally/manually (to add or remove words)
+    // - the first also puts the contents of the .dic file into the
+    // supplied second argument before returning the handle to the dictionary
+    // loaded:
+    Hunhandle* prepareProfileDictionary(const QString&, QSet<QString>&);
+    Hunhandle* prepareSharedDictionary();
+    void processEventLoopHack();
     void readEarlySettings(const QSettings&);
     void readLateSettings(const QSettings&);
-    void writeSettings();
-    bool openWebPage(const QString& path);
-    void checkUpdatesOnStart();
-    void processEventLoopHack();
-    bool isGoingDown() { return mIsGoingDown; }
-    void setToolBarIconSize(int);
-    void setEditorTreeWidgetIconSize(int);
-    enum controlsVisibilityFlag {
-        visibleNever = 0,
-        visibleOnlyWithoutLoadedProfile = 0x1,
-        visibleMaskNormally = 0x2,
-        visibleAlways = 0x3
-    };
-    Q_DECLARE_FLAGS(controlsVisibility, controlsVisibilityFlag)
-    void setToolBarVisibility(controlsVisibility);
-    void setMenuBarVisibility(controlsVisibility);
-    void adjustToolBarVisibility();
-    void adjustMenuBarVisibility();
-    controlsVisibility menuBarVisibility() const { return mMenuBarVisibility; }
-    controlsVisibility toolBarVisibility() const { return mToolbarVisibility; }
-    bool replayStart();
-    bool setClickthrough(Host* pHost, const QString& name, bool clickthrough);
-    void replayOver();
-    void showEvent(QShowEvent* event) override;
-    void hideEvent(QHideEvent* event) override;
-    void doAutoLogin(const QString&);
-    QStringList getAvailableFonts();
-    std::pair<bool, QString> setProfileIcon(const QString& profile, const QString& newIconPath);
-    std::pair<bool, QString> resetProfileIcon(const QString& profile);
-#if defined(Q_OS_WIN32)
-    void sanitizeUtf8Path(QString& originalLocation, const QString& fileName) const;
-#endif
-    void activateProfile(Host*);
-    void setEditorTextoptions(bool isTabsAndSpacesToBeShown, bool isLinesAndParagraphsToBeShown);
-    static bool loadLuaFunctionList();
-    static bool loadEdbeeTheme(const QString& themeName, const QString& themeFile);
-    void announce(const QString& text, const QString& processing = QString());
-
+    QPair<bool, bool> removeWordFromSet(const QString&);
+    QString readProfileData(const QString& profile, const QString& item);
+    void refreshTabBar();
     // Used by a profile to tell the mudlet class
     // to tell other profiles to reload the updated
     // maps (via signal_profileMapReloadRequested(...))
     void requestProfilesToReloadMaps(QList<QString>);
-    void showChangelogIfUpdated();
-
-    bool showMapAuditErrors() const { return mshowMapAuditErrors; }
-    void setShowMapAuditErrors(const bool);
-    void setShowIconsOnMenu(const Qt::CheckState);
-    void setGlobalStyleSheet(const QString& styleSheet);
-    void setupPreInstallPackages(const QString& gameUrl);
-    static bool unzip(const QString& archivePath, const QString& destination, const QDir& tmpDir);
-
-    // From https://stackoverflow.com/a/14678964/4805858 an answer to:
-    // "How to find and replace string?" by "Czarek Tomczak":
-    static std::string replaceString(std::string subject, const std::string& search, const std::string& replace);
-
-    static QString getMudletPath(mudletPathType, const QString& extra1 = QString(), const QString& extra2 = QString());
-    // Used to enable "emergency" control recovery action - if Mudlet is
-    // operating without either menubar or main toolbar showing.
-    bool isControlsVisible() const;
-    bool loadReplay(Host*, const QString&, QString* pErrMsg = nullptr);
-    void show_options_dialog(const QString& tab);
-    void setInterfaceLanguage(const QString &languageCode);
-    const QString& getInterfaceLanguage() const { return mInterfaceLanguage; }
-    const QLocale& getUserLocale() const { return mUserLocale; }
-    QList<QString> getAvailableTranslationCodes() const { return mTranslationsMap.keys(); }
-    void setEnableFullScreenMode(const bool);
-    bool migratePasswordsToProfileStorage();
-    bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
-    bool migratePasswordsToSecureStorage();
-    static void setNetworkRequestDefaults(const QUrl& url, QNetworkRequest& request);
-
-    // Both of these revises the contents of the .aff file: the first will
-    // handle a .dic file that has been updated externally/manually (to add
-    // or remove words) - it also puts the contents of the .dic file into the
-    // supplied second argument; the second will replace the .dic file with just
-    // the words in the supplied second argument and is to be used at the end of
-    // a session to store away the user's changes:
-    Hunhandle* prepareProfileDictionary(const QString&, QSet<QString>&);
-    Hunhandle* prepareSharedDictionary();
+    void replayOver();
+    bool replayStart();
+    std::pair<bool, QString> resetProfileIcon(const QString&);
+#if defined(Q_OS_WIN32)
+    void sanitizeUtf8Path(QString& originalLocation, const QString& fileName) const;
+#endif
+    // This will save and replace the .dic file with just the words in the
+    // supplied second argument and update the .aff file as appropriate. It is
+    // to be used at the end of a session to store away the user's changes:
     bool saveDictionary(const QString&, QSet<QString>&);
-    QPair<bool, bool> addWordToSet(const QString&);
-    QPair<bool, bool> removeWordFromSet(const QString&);
-    QSet<QString> getWordSet();
+    bool saveWindowLayout();
     void scanForMudletTranslations(const QString&);
     void scanForQtTranslations(const QString&);
+    void setAppearance(Appearance, const bool& loading = false);
+    bool setClickthrough(Host*, const QString&, bool);
+    void setEditorTextoptions(bool isTabsAndSpacesToBeShown, bool isLinesAndParagraphsToBeShown);
+    void setEditorTreeWidgetIconSize(int);
+    void setEnableFullScreenMode(const bool);
+    void setGlobalStyleSheet(const QString&);
+    void setInterfaceLanguage(const QString&);
+    void setMenuBarVisibility(controlsVisibility);
+    std::pair<bool, QString> setProfileIcon(const QString& profile, const QString& newIconPath);
+    void setShowIconsOnMenu(const Qt::CheckState);
+    void setShowMapAuditErrors(const bool);
+    void setupPreInstallPackages(const QString&);
+    void setToolBarIconSize(int);
+    void setToolBarVisibility(controlsVisibility);
+    void showChangelogIfUpdated();
+    bool showMapAuditErrors() const { return mShowMapAuditErrors; }
+    // Brings up the preferences dialog and selects the tab whos objectName is
+    // supplied:
+    void showOptionsDialog(const QString&);
     void startAutoLogin(const QString&);
-    int64_t getPhysicalMemoryTotal();
-    const QMap<QByteArray, QString>& getEncodingNamesMap() const { return mEncodingNameMap; }
-    void refreshTabBar();
+    bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
+    controlsVisibility toolBarVisibility() const { return mToolbarVisibility; }
     void updateDiscordNamedIcon();
     void updateMultiViewControls();
-    QSettings* getQSettings();
+    QPair<bool, QString> writeProfileData(const QString& profile, const QString& item, const QString& what);
+    void writeSettings();
 
-    bool firstLaunch = false;
-    // Needed to work around a (likely only Windows) issue:
+
+    Appearance mAppearance = Appearance::systemSetting;
+    // 1 (of 2) needed to work around a (Windows/MacOs specific QStyleFactory)
+    // issue:
     QString mBG_ONLY_STYLESHEET;
-    QString mTEXT_ON_BG_STYLESHEET;
-
-    FontManager mFontManager;
+    // approximate max duration that 'Copy as image' is allowed to take
+    // (seconds):
+    int mCopyAsImageTimeout = 3;
+    // A list of potential dictionary languages - probably will cover a much
+    // wider range of languages compared to the translations - and is intended
+    // for Dictionary identification - there is a request for users to submit
+    // entries in their system if they do not appear in this and thus get
+    // reported in the dictionary selection as the hunspell dictionary/affix
+    // filename (e.g. a "xx" or "xx_YY" form rather than "words"):
+    QHash<QString, QString>mDictionaryLanguageCodeMap;
     Discord mDiscord;
-    QPointer<QSettings> mpSettings;
-    static const QString scmMudletXmlDefaultVersion;
-    static QPointer<TConsole> mpDebugConsole;
-    static QPointer<QMainWindow> mpDebugArea;
-    static bool debugMode;
-    int mToolbarIconSize;
-    int mEditorTreeWidgetIconSize;
-    bool mWindowMinimized;
-
-    QPointer<ShortcutsManager> mShortcutsManager;
-
-    // used by developers in everyday coding
-    static const bool scmIsDevelopmentVersion;
-    // unofficial "nightly" build - still a type of a release
-    static const bool scmIsPublicTestVersion;
-    // final, official release
-    static const bool scmIsReleaseVersion;
-
-    static const QVersionNumber scmRunTimeQtVersion;
-    // A constant equivalent to QDataStream::Qt_5_12 needed in several places
-    // which can't be pulled from Qt as it is not going to be defined for older
-    // versions:
-    static const int scmQDataStreamFormat_5_12;
-
-    QTime mReplayTime;
-    int mReplaySpeed;
-    QToolBar* mpMainToolBar;
-    QString version;
-    QPointer<Host> mpCurrentActiveHost;
-    TTabBar* mpTabBar;
-    QStringList packagesToInstallList;
-    bool mIsLoadingLayout;
-    static QVariantHash mLuaFunctionNames;
-    bool mHasSavedLayout;
+    // Used for editor area, but
+    // only ::ShowTabsAndSpaces
+    // and ::ShowLineAndParagraphSeparators
+    // are considered/used/stored
+    QTextOption::Flags mEditorTextOptions = QTextOption::Flags();
+    int mEditorTreeWidgetIconSize = 0;
+    // Currently tracks the "mudlet_option_use_smallscreen" file's existence but
+    // may eventually migrate solely to the "EnableFullScreenMode" in the main
+    // QSetting file - it is only stored as a file now to maintain backwards
+    // compatibility...
+    bool mEnableFullScreenMode = false;
+    FontManager mFontManager;
+    bool mHasSavedLayout = false;
+    bool mIsLoadingLayout = false;
     QPointer<dlgAboutDialog> mpAboutDlg;
-    QPointer<dlgConnectionProfiles> mConnectionDialog;
+    QStringList mPackagesToInstallList;
+    QPointer<dlgConnectionProfiles> mpConnectionDialog;
+    QPointer<Host> mpCurrentActiveHost;
+    // Options dialog when there's no active host
+    QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
+    QToolBar* mpMainToolBar = nullptr;
+    QPointer<QSettings> mpSettings;
+    QPointer<ShortcutsManager> mpShortcutsManager;
+    TTabBar* mpTabBar = nullptr;
+    int mReplaySpeed = 1;
     // More modern Desktop styles no longer include icons on the buttons in
     // QDialogButtonBox buttons - but some users are using Desktops (KDE4?) that
     // does use them - use this flag to determine whether we should apply our
     // icons to override some of them:
-    bool mShowIconsOnDialogs;
-    // Value of QCoreApplication::testAttribute(Qt::AA_DontShowIconsInMenus) on
-    // startup which the user may leave as is or force on or off:
-    bool mShowIconsOnMenuOriginally;
+    QTime mReplayTime;
+    bool mShowIconsOnDialogs = true;
     // This is the state for the tri-state control on the preferences and
     // means:
     // Qt::PartiallyChecked = use the previous state set on application start
@@ -392,311 +453,262 @@ public:
     //    to false ourselves)
     // Qt::Checked = icons are used on menus (set AA_DontShowIconsInMenus to
     //    true ourselves)
-    Qt::CheckState mShowIconsOnMenuCheckedState;
-
-    // Used for editor area, but
-    // only ::ShowTabsAndSpaces
-    // and ::ShowLineAndParagraphSeparators
-    // are considered/used/stored
-    QTextOption::Flags mEditorTextOptions;
-
-    QSystemTrayIcon mTrayIcon;
-
-#if defined(INCLUDE_UPDATER)
-    Updater* updater;
-#endif
-
-
-    // Currently tracks the "mudlet_option_use_smallscreen" file's existence but
-    // may eventually migrate solely to the "EnableFullScreenMode" in the main
-    // QSetting file - it is only stored as a file now to maintain backwards
-    // compatibility...
-    bool mEnableFullScreenMode;
-
-    // approximate max duration that 'Copy as image' is allowed to take (seconds)
-    int mCopyAsImageTimeout;
-
+    Qt::CheckState mShowIconsOnMenuCheckedState = Qt::PartiallyChecked;
+    // Value of QCoreApplication::testAttribute(Qt::AA_DontShowIconsInMenus) on
+    // startup which the user may leave as is or force on or off:
+    bool mShowIconsOnMenuOriginally = true;
+    // 2 (of 2) needed to work around a (Windows/MacOs specific QStyleFactory)
+    // issue:
+    QString mTEXT_ON_BG_STYLESHEET;
+    int mToolbarIconSize = 0;
     QMap<QString, translation> mTranslationsMap;
-
-    // translations done high enough will get a gold star to hide the last few percent
-    // as well as encourage translators to maintain it;
-    const int mTranslationGoldStar = 95;
-
-    // A list of potential dictionary languages - probably will cover a much
-    // wider range of languages compared to the translations - and is intended
-    // for Dictionary identification - there is a request for users to submit
-    // entries in their system if they do not appear in this and thus get
-    // reported in the dictionary selection as the hunspell dictionary/affix
-    // filename (e.g. a "xx" or "xx_YY" form rather than "words"):
-    QHash<QString, QString>mDictionaryLanguageCodeMap;
-
     // This is used to keep track of where the main dictionary files are located
     // will be true if they are ones bundled with Mudlet, false if provided by
     // the system
-    bool mUsingMudletDictionaries;
+    QSystemTrayIcon mTrayIcon;
+    bool mUsingMudletDictionaries = false;
+    bool mWindowMinimized = false;
 
-    // Options dialog when there's no active host
-    QPointer<dlgProfilePreferences> mpDlgProfilePreferences;
-
-    enum Appearance {
-        system = 0,
-        light = 1,
-        dark = 2
-    };
-    Appearance mAppearance = Appearance::system;
-    void setAppearance(Appearance, const bool& loading = false);
-    bool inDarkMode() const { return mDarkMode; }
-
-    // mirror everything shown in any console to stdout. Helpful for CI environments
-    inline static bool mMirrorToStdOut;
+#if defined(INCLUDE_UPDATER)
+    Updater* pUpdater = nullptr;
+#endif
 
 
 public slots:
-    void slot_processEventLoopHackTimerRun();
-    void slot_mapper();
-    void slot_replayTimeChanged();
-    void slot_replaySpeedUp();
-    void slot_replaySpeedDown();
-    void slot_toggleFullScreenView();
-    void slot_showAboutDialog();
-    void slot_showHelpDialogVideo();
-    void slot_showHelpDialogForum();
-// Not used:    void slot_showHelpDialogIrc();
-    void slot_openMappingScriptsPage();
-    void slot_multiView(const bool);
-    void slot_toggleMultiView();
-    void slot_connectionDialogueFinished(const QString& profile, bool connectOnLoad);
-    void slot_timerFires();
-    void slot_replay();
-    void slot_disconnect();
-    void slot_notes();
-    void slot_reconnect();
     void slot_closeCurrentProfile();
     void slot_closeProfileRequested(int);
+    void slot_connectionDialogueFinished(const QString&, bool);
+    void slot_disconnect();
+    void slot_handleToolbarVisibilityChanged(bool);
     void slot_irc();
-    void slot_profileDiscord();
-    void slot_mudletDiscord();
-    void slot_packageManager();
-    void slot_packageExporter();
-    void slot_moduleManager();
 #if defined(INCLUDE_UPDATER)
     void slot_manualUpdateCheck();
 #endif
+    void slot_mapper();
+    void slot_moduleManager();
+    void slot_mudletDiscord();
+    void slot_multiView(const bool);
+    void slot_newDataOnHost(const QString&, bool isLowerPriorityChange = false);
+    void slot_notes();
+    void slot_openMappingScriptsPage();
+    void slot_packageExporter();
+    void slot_packageManager();
+    void slot_processEventLoopHackTimerRun();
+    void slot_profileDiscord();
+    void slot_reconnect();
+    void slot_replay();
+    void slot_replaySpeedUp();
+    void slot_replaySpeedDown();
+    void slot_replayTimeChanged();
     void slot_restoreMainMenu() { setMenuBarVisibility(visibleAlways); }
     void slot_restoreMainToolBar() { setToolBarVisibility(visibleAlways); }
-    void slot_handleToolbarVisibilityChanged(bool);
-    void slot_newDataOnHost(const QString&, bool isLowerPriorityChange = false);
+    void slot_showAboutDialog();
+    void slot_showHelpDialogForum();
+// Not used:    void slot_showHelpDialogIrc();
+    void slot_showHelpDialogVideo();
+    void slot_timerFires();
+    void slot_toggleFullScreenView();
+    void slot_toggleMultiView();
 
 
 protected:
-    void closeEvent(QCloseEvent* event) override;
+    void closeEvent(QCloseEvent*) override;
+
 
 signals:
+    void signal_appearanceChanged(mudlet::Appearance);
     void signal_editorTextOptionsChanged(QTextOption::Flags);
-    void signal_profileMapReloadRequested(QList<QString>);
-    void signal_tabChanged(const QString& hostName);
-    void signal_setToolBarIconSize(int);
-    void signal_setTreeIconSize(int);
+    void signal_enableFulScreenModeChanged(bool);
+    void signal_guiLanguageChanged(const QString&);
     void signal_hostCreated(Host*, quint8);
     void signal_hostDestroyed(Host*, quint8);
-    void signal_profileActivated(Host *, quint8);
-    void signal_appearanceChanged(Appearance);
-    void signal_enableFulScreenModeChanged(bool);
-    void signal_showMapAuditErrorsChanged(bool);
-    void signal_menuBarVisibilityChanged(const controlsVisibility);
-    void signal_toolBarVisibilityChanged(const controlsVisibility);
-    void signal_showIconsOnMenusChanged(const Qt::CheckState);
-    void signal_guiLanguageChanged(const QString&);
-    void signal_passwordsMigratedToSecure();
+    void signal_menuBarVisibilityChanged(const mudlet::controlsVisibility);
     void signal_passwordMigratedToSecure(const QString&);
     void signal_passwordsMigratedToProfiles();
+    void signal_passwordsMigratedToSecure();
+    void signal_profileActivated(Host *, quint8);
+    void signal_profileMapReloadRequested(QList<QString>);
+    void signal_setToolBarIconSize(int);
+    void signal_setTreeIconSize(int);
     void signal_shortcutsChanged();
+    void signal_showIconsOnMenusChanged(const Qt::CheckState);
+    void signal_showMapAuditErrorsChanged(bool);
+    void signal_tabChanged(const QString&);
+    void signal_toolBarVisibilityChanged(const mudlet::controlsVisibility);
 
 
 private slots:
-    void slot_tabChanged(int);
-    void slot_showHelpDialog();
-    void slot_showConnectionDialog();
-    void slot_showEditorDialog();
-    void slot_showTriggerDialog();
-    void slot_showAliasDialog();
-    void slot_showScriptDialog();
-    void slot_showTimerDialog();
-    void slot_showActionDialog();
-    void slot_showKeyDialog();
-    void slot_showVariableDialog();
-    void slot_updateShortcuts();
-    void slot_showPreferencesDialog();
     void slot_assignShortcutsFromProfile(Host* pHost = nullptr);
+    void slot_compactInputLine(const bool);
 #ifdef QT_GAMEPAD_LIB
-    void slot_gamepadButtonPress(int deviceId, QGamepadManager::GamepadButton button, double value);
-    void slot_gamepadButtonRelease(int deviceId, QGamepadManager::GamepadButton button);
-    void slot_gamepadConnected(int deviceId);
-    void slot_gamepadDisconnected(int deviceId);
-    void slot_gamepadAxisEvent(int deviceId, QGamepadManager::GamepadAxis axis, double value);
+    void slot_gamepadButtonPress(int, QGamepadManager::GamepadButton, double);
+    void slot_gamepadButtonRelease(int, QGamepadManager::GamepadButton);
+    void slot_gamepadConnected(int);
+    void slot_gamepadDisconnected(int);
+    void slot_gamepadAxisEvent(int, QGamepadManager::GamepadAxis, double);
 #endif
+    void slot_passwordMigratedToPortableStorage(QKeychain::Job*);
+    void slot_passwordMigratedToSecureStorage(QKeychain::Job*);
 #if defined(INCLUDE_UPDATER)
-    void slot_updateInstalled();
-    void slot_updateAvailable(const int);
     void slot_reportIssue();
 #endif
-    void slot_toggleCompactInputLine();
-    void slot_compactInputLine(const bool);
-    void slot_passwordMigratedToSecureStorage(QKeychain::Job *job);
-    void slot_passwordMigratedToPortableStorage(QKeychain::Job *job);
+    void slot_showActionDialog();
+    void slot_showAliasDialog();
+    void slot_showConnectionDialog();
+    void slot_showEditorDialog();
+    void slot_showHelpDialog();
+    void slot_showKeyDialog();
+    void slot_showPreferencesDialog();
+    void slot_showScriptDialog();
+    void slot_showTimerDialog();
+    void slot_showTriggerDialog();
+    void slot_showVariableDialog();
+    void slot_tabChanged(int);
     void slot_tabMoved(const int oldPos, const int newPos);
+    void slot_toggleCompactInputLine();
+#if defined(INCLUDE_UPDATER)
+    void slot_updateAvailable(const int);
+    void slot_updateInstalled();
+#endif
+    void slot_updateShortcuts();
 
 
 private:
-    void initEdbee();
+    static bool desktopInDarkMode();
+
+
+    void assignKeySequences();
+    QString autodetectPreferredLanguage();
+    void closeHost(const QString&);
+    int getDictionaryWordCount(QFile&);
     void goingDown() { mIsGoingDown = true; }
+    void initEdbee();
+    void installModulesList(Host*, QStringList);
+    void loadMaps();
+    void loadTranslators(const QString&);
+    void migrateDebugConsole(Host*);
+    bool overwriteAffixFile(QFile&, QHash<QString, unsigned int>&);
+    bool overwriteDictionaryFile(QFile&, const QStringList&);
     bool scanDictionaryFile(QFile&, int&, QHash<QString, unsigned int>&, QStringList&);
     int scanWordList(QStringList&, QHash<QString, unsigned int>&);
-    bool overwriteDictionaryFile(QFile&, const QStringList&);
-    bool overwriteAffixFile(QFile&, QHash<QString, unsigned int>&);
-    int getDictionaryWordCount(QFile&);
-    void loadTranslators(const QString &languageCode);
-    void loadMaps();
-    void migrateDebugConsole(Host* currentHost);
-    QString autodetectPreferredLanguage();
-    void installModulesList(Host*, QStringList);
     void setupTrayIcon();
-    static bool desktopInDarkMode();
-    void assignKeySequences();
-    void closeHost(const QString& name);
     void reshowRequiredMainConsoles();
 
-    QWidget* mpWidget_profileContainer;
-    QHBoxLayout* mpHBoxLayout_profileContainer;
-    QSplitter* mpSplitter_profileContainer;
 
-    static QPointer<mudlet> _self;
-    QMap<Host*, QToolBar*> mUserToolbarMap;
-    QMenu* restoreBar;
-    bool mIsGoingDown;
-    controlsVisibility mMenuBarVisibility;
-    controlsVisibility mToolbarVisibility;
+    inline static QPointer<mudlet> smpSelf = nullptr;
 
-    QPointer<QAction> mpActionReplaySpeedDown;
-    QPointer<QAction> mpActionReplaySpeedUp;
-    QPointer<QAction> mpActionSpeedDisplay;
-    QPointer<QAction> mpActionReplayTime;
-    QPointer<QLabel> mpLabelReplaySpeedDisplay;
-    QPointer<QLabel> mpLabelReplayTime;
-    QPointer<QTimer> mpTimerReplay;
-    QPointer<QToolBar> mpToolBarReplay;
 
-    QPointer<QShortcut> triggersShortcut;
-    QPointer<QShortcut> showMapShortcut;
-    QPointer<QShortcut> inputLineShortcut;
-    QPointer<QShortcut> optionsShortcut;
-    QPointer<QShortcut> notepadShortcut;
-    QPointer<QShortcut> packagesShortcut;
-    QPointer<QShortcut> modulesShortcut;
-    QPointer<QShortcut> multiViewShortcut;
-    QPointer<QShortcut> connectShortcut;
-    QPointer<QShortcut> disconnectShortcut;
-    QPointer<QShortcut> reconnectShortcut;
-    QPointer<QShortcut> closeProfileShortcut;
-    QKeySequence triggersKeySequence;
-    QKeySequence showMapKeySequence;
-    QKeySequence inputLineKeySequence;
-    QKeySequence optionsKeySequence;
-    QKeySequence notepadKeySequence;
-    QKeySequence packagesKeySequence;
-    QKeySequence modulesKeySequence;
-    QKeySequence multiViewKeySequence;
-    QKeySequence connectKeySequence;
-    QKeySequence disconnectKeySequence;
-    QKeySequence reconnectKeySequence;
-    QKeySequence closeProfileKeySequence;
-
-    QPointer<QAction> mpActionReplay;
-
-    QPointer<QAction> mpActionAbout;
-    QPointer<QAction> mpActionAboutWithUpdates;
-    QPointer<QToolButton> mpButtonAbout;
-    QPointer<QAction> mpActionAliases;
-    QPointer<QAction> mpActionButtons;
-    QPointer<QToolButton> mpButtonConnect;
-    QPointer<QAction> mpActionConnect;
-    QPointer<QAction> mpActionDisconnect;
-    QPointer<QAction> mpActionFullScreenView;
-    QPointer<QAction> mpActionHelp;
-    QPointer<QAction> mpActionDiscord;
-    QPointer<QAction> mpActionMudletDiscord;
-    QPointer<QAction> mpActionIRC;
-    QPointer<QToolButton> mpButtonDiscord;
-    QPointer<QAction> mpActionKeys;
-    QPointer<QAction> mpActionMapper;
-    QPointer<QAction> mpActionMultiView;
-    QPointer<QAction> mpActionReportIssue;
-    QPointer<QAction> mpActionNotes;
-    QPointer<QAction> mpActionOptions;
-    QPointer<QToolButton> mpButtonPackageManagers;
-    QPointer<QAction> mpActionPackageManager;
-    QPointer<QAction> mpActionModuleManager;
-    QPointer<QAction> mpActionPackageExporter;
-    QPointer<QAction> mpActionReconnect;
-    QPointer<QAction> mpActionCloseProfile;
-    QPointer<QAction> mpActionScripts;
-    QPointer<QAction> mpActionTimers;
-    QPointer<QAction> mpActionTriggers;
-    QPointer<QAction> mpActionVariables;
-
-    HostManager mHostManager;
-    Announcer* announcer;
-
-    bool mshowMapAuditErrors;
-
-    // Argument to QDateTime::toString(...) to format the elapsed time display
-    // on the mpToolBarReplay:
-    QString mTimeFormat;
-
+    bool mDarkMode = false;
     QString mDefaultStyle;
-
-    // Has default form of "en_US" but can be just an ISO language code e.g. "fr" for french,
-    // without a country designation. Replaces xx in "mudlet_xx.qm" to provide the translation
-    // file for GUI translation
-    QString mInterfaceLanguage {};
-    // An encapsulation of the above in a form that Qt uses to hold all the
-    // details:
-    QLocale mUserLocale {};
-
-    // The next pair retains the path argument supplied to the corresponding
-    // scanForXxxTranslations(...) method so it is available to the subsequent
-    // loadTranslators(...) call
-    QString mQtTranslationsPathName;
-    QString mMudletTranslationsPathName;
-    QList<QPointer<QTranslator>> mTranslatorsLoadedList;
-
-    // Points to the common mudlet dictionary handle once a profile has
-    // requested it, then gets closed at termination of the application.
-    Hunhandle* mHunspell_sharedDictionary;
-    // The collection of words in the above:
-    QSet<QString> mWordSet_shared;
-
-    QString mMudletDiscordInvite = qsl("https://www.mudlet.org/chat");
-
-    // a list of profiles currently being migrated to secure or profile storage
-    QStringList mProfilePasswordsToMigrate {};
-
-    bool mStorePasswordsSecurely {true};
     // Stores the translated names for the Encodings for the static and thus
     // const TBuffer::csmEncodingTable:
     QMap<QByteArray, QString> mEncodingNameMap;
-
+    HostManager mHostManager;
+    // Points to the common mudlet dictionary handle once a profile has
+    // requested it, then gets closed at termination of the application.
+    Hunhandle* mpHunspell_sharedDictionary = nullptr;
+    // Has default form of "en_US" but can be just an ISO language code e.g. "fr" for french,
+    // without a country designation. Replaces xx in "mudlet_xx.qm" to provide the translation
+    // file for GUI translation
+    QString mInterfaceLanguage;
+    QKeySequence mKeySequenceCloseProfile;
+    QKeySequence mKeySequenceConnect;
+    QKeySequence mKeySequenceDisconnect;
+    QKeySequence mKeySequenceInputLine;
+    QKeySequence mKeySequenceModules;
+    QKeySequence mKeySequenceMultiView;
+    QKeySequence mKeySequenceNotepad;
+    QKeySequence mKeySequenceOptions;
+    QKeySequence mKeySequencePackages;
+    QKeySequence mKeySequenceReconnect;
+    QKeySequence mKeySequenceShowMap;
+    QKeySequence mKeySequenceTriggers;
+    bool mIsGoingDown = false;
     // Whether multi-view is in effect:
-    bool mMultiView;
-
-    // read-only value to see if the interface is light or dark. To set the value,
-    // use setAppearance instead
-    bool mDarkMode = false;
-
+    controlsVisibility mMenuBarVisibility = visibleAlways;
     // Used to ensure that mudlet::slot_updateShortcuts() only runs once each
     // time the main if () logic changes state - will be true if the menu is
     // supposed to be visible, false if not and not have a value initially:
     std::optional<bool> mMenuVisibleState;
+    QString mMudletDiscordInvite = qsl("https://www.mudlet.org/chat");
+    bool mMultiView = false;
+    QPointer<QAction> mpActionAbout;
+    QPointer<QAction> mpActionAboutWithUpdates;
+    QPointer<QAction> mpActionAliases;
+    QPointer<QAction> mpActionButtons;
+    QPointer<QAction> mpActionCloseProfile;
+    QPointer<QAction> mpActionConnect;
+    QPointer<QAction> mpActionDisconnect;
+    QPointer<QAction> mpActionDiscord;
+    QPointer<QAction> mpActionFullScreenView;
+    QPointer<QAction> mpActionHelp;
+    QPointer<QAction> mpActionIRC;
+    QPointer<QAction> mpActionKeys;
+    QPointer<QAction> mpActionMapper;
+    QPointer<QAction> mpActionModuleManager;
+    QPointer<QAction> mpActionMudletDiscord;
+    QPointer<QAction> mpActionMultiView;
+    QPointer<QAction> mpActionNotes;
+    QPointer<QAction> mpActionOptions;
+    QPointer<QAction> mpActionPackageExporter;
+    QPointer<QAction> mpActionPackageManager;
+    QPointer<QAction> mpActionReconnect;
+    QPointer<QAction> mpActionReplay;
+    QPointer<QAction> mpActionReplaySpeedDown;
+    QPointer<QAction> mpActionReplaySpeedUp;
+    QPointer<QAction> mpActionReplayTime;
+    QPointer<QAction> mpActionReportIssue;
+    QPointer<QAction> mpActionScripts;
+    QPointer<QAction> mpActionSpeedDisplay;
+    QPointer<QAction> mpActionTimers;
+    QPointer<QAction> mpActionTriggers;
+    QPointer<QAction> mpActionVariables;
+    Announcer* mpAnnouncer = nullptr;
+    // This pair retains the path argument supplied to the corresponding
+    // scanForXxxTranslations(...) method so it is available to the subsequent
+    // loadTranslators(...) call
+    QString mPathNameMudletTranslations;
+    QString mPathNameQtTranslations;
+    QPointer<QToolButton> mpButtonAbout;
+    QPointer<QToolButton> mpButtonConnect;
+    QPointer<QToolButton> mpButtonDiscord;
+    QPointer<QToolButton> mpButtonPackageManagers;
+    QHBoxLayout* mpHBoxLayout_profileContainer = nullptr;
+    QPointer<QLabel> mpLabelReplaySpeedDisplay;
+    QPointer<QLabel> mpLabelReplayTime;
+    // a list of profiles currently being migrated to secure or profile storage
+    QStringList mProfilePasswordsToMigrate;
+    QPointer<QShortcut> mpShortcutCloseProfile;
+    QPointer<QShortcut> mpShortcutConnect;
+    QPointer<QShortcut> mpShortcutDisconnect;
+    QPointer<QShortcut> mpShortcutInputLine;
+    QPointer<QShortcut> mpShortcutModules;
+    QPointer<QShortcut> mpShortcutMultiView;
+    QPointer<QShortcut> mpShortcutNotepad;
+    QPointer<QShortcut> mpShortcutOptions;
+    QPointer<QShortcut> mpShortcutPackages;
+    QPointer<QShortcut> mpShortcutReconnect;
+    QPointer<QShortcut> mpShortcutShowMap;
+    QPointer<QShortcut> mpShortcutTriggers;
+    QPointer<QTimer> mpTimerReplay;
+    QPointer<QToolBar> mpToolBarReplay;
+    QWidget* mpWidget_profileContainer = nullptr;
+    // read-only value to see if the interface is light or dark. To set the value,
+    // use setAppearance instead
+    bool mShowMapAuditErrors = false;
+    QSplitter* mpSplitter_profileContainer = nullptr;
+    bool mStorePasswordsSecurely = true;
+    // Argument to QDateTime::toString(...) to format the elapsed time display
+    // on the mpToolBarReplay:
+    QString mTimeFormat;
+    controlsVisibility mToolbarVisibility = visibleAlways;
+    QList<QPointer<QTranslator>> mTranslatorsLoadedList;
+    // An encapsulation of the mInterfaceLanguage in a form that Qt uses to
+    // hold all the details:
+    QLocale mUserLocale;
+    QMap<Host*, QToolBar*> mUserToolbarMap;
+    // The collection of words in what mpHunspell_sharedDictionary points to:
+    QSet<QString> mWordSet_shared;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(mudlet::controlsVisibility)
@@ -707,9 +719,12 @@ class TConsoleMonitor : public QObject
 
 public:
     Q_DISABLE_COPY(TConsoleMonitor)
-    explicit TConsoleMonitor(QObject* parent) : QObject(parent) {}
+    explicit TConsoleMonitor(QObject* parent)
+    : QObject(parent)
+    {}
+
 protected:
-    bool eventFilter(QObject* obj, QEvent* event) override;
+    bool eventFilter(QObject*, QEvent*) override;
 };
 
 
@@ -723,7 +738,9 @@ class translation
     friend void mudlet::scanForQtTranslations(const QString&);
 
 public:
-    explicit translation(const int translationPercent = -1) : mTranslatedPercentage(translationPercent) {}
+    explicit translation(const int translationPercent = -1)
+    : mTranslatedPercentage(translationPercent)
+    {}
 
     const QString& getNativeName() const { return mNativeName; }
     const QString& getMudletTranslationFileName() const { return mMudletTranslationFileName; }
@@ -732,18 +749,19 @@ public:
     bool fromResourceFile() const { return mTranslatedPercentage >= 0; }
 
 private:
-    // Used for display in the profile preferences and is never translated:
-    QString mNativeName;
     // ONLY if the translation is loaded from an embedded resource file,
     // this is the percentage complete of the translation
-    int mTranslatedPercentage;
+    int mTranslatedPercentage = -1;
+    // Used for display in the profile preferences and is never translated:
+    QString mNativeName;
     // filename translation is loaded from
     QString mMudletTranslationFileName;
-    // Qt translation file was found to be, note that in most
-    // cases the loaded file will be a "xx" language only file even though it
-    // is an "xx_YY" one here:
+    // Qt translation file was found to be, note that in most cases the loaded
+    // file will be a "xx" language only file even though it is an "xx_YY" one
+    // here:
     QString mQtTranslationFileName;
-    // Similar filename locations will require adding for any 3rd party translations we load
+    // Similar filename locations will require adding for any 3rd party translations
+    // we load!
 };
 
 #endif // MUDLET_MUDLET_H


### PR DESCRIPTION
This PR is also concerned with cleaning up the `mudlet` class. As well as moving the elements in the constructor initialisation to the header file it also renames and groups by member/method visibility and then largely by name within each grouping (possibly adding "type prefixes" to some members or swapping word orders) and moves some global values from the `.cpp` file to the `.h` file - making them explicitly `static` if not `const`. Sorted by "old name" here the changes are (if a type is not specified after the `==>` then it is unchanged):
* `(“global” QPointer<mudlet>) mudlet::_self` ==> `(inline static QPointer<mudlet>) mudlet::smpSelf`
* `mudlet::~mudlet()` ==> `mudlet::~mudlet override`
* `(Announcer*) mudlet::announcer` ==> `mudlet::mpAnnouncer`
* `(QKeySequence) mudlet::closeProfileKeySequence` ==> `mudlet::mKeySequenceCloseProfile`
* `(QPointer<QShortcut>) mudlet::closeProfileShortcut` ==> `mudlet::mpShortcutCloseProfile`
* `(QKeySequence) mudlet::connectKeySequence` ==> `mudlet::mKeySequenceConnect`
* `(QPointer<QShortcut>) mudlet::connectShortcut` ==> `mudlet::mpShortcutConnect`
* `(“global” bool) mudlet::debugMode` ==> `(static bool) mudlet::smDebugMode`
* `(QKeySequence) mudlet::disconnectKeySequence` ==> `mudlet::mKeySequenceDisconnect`
* `(QPointer<QShortcut>) mudlet::disconnectShortcut` ==> `mudlet::mpShortcutDisconnect`
* `(bool) mudlet::firstLaunch` ==> `(static bool) mudlet::smFirstLaunch`
* `(QKeySequence) mudlet::inputLineKeySequence` ==> `mudlet::mKeySequenceInputLine`
* `(QPointer<QShortcut>) mudlet::inputLineShortcut` ==> `mudlet::mpShortcutInputLine`
* `(Hunhandle*) mudlet::mHunspell_sharedDictionary` ==> `mudlet::mpHunspell_sharedDictionary`
* `(QPointer<dlgConnectionProfiles>) mudlet::mConnectionDialog` ==> `mudlet::mpConnectionDialog`
* `(“global” QVariantHash) mudlet::mLuaFunctionNames` ==> `(static QVariantHash) mudlet::smLuaFunctionNames`
* `(Inline static bool) mudlet::mMirrorToStdOut` ==> `mudlet::smMirrorToStdOut`
* `(QString) mudlet::mMudletTranslationsPathName` ==> `mudlet::mPathNameMudletTranslations`
* `(QKeySequence) mudlet::modulesKeySequence` ==> `mudlet::mKeySequenceModules`
* `(QPointer<QShortcut>) mudlet::modulesShortcut` ==> `mudlet::mpShortcutModules`
* `(“global” QPointer<QMainWindow>) mudlet::mpDebugArea` ==> `(static QPointer<QMainWindow>) mudlet::smpDebugArea`
* `(“global” QPointer<TConsole>) mudlet::mpDebugConsole` ==> `(static QPointer<TConsole>) mudlet::smpDebugConsole`
* `(QString) mudlet::mQtTranslationsPathName` ==> `mudlet::mPathNameQtTranslations`
* `(QPointer<ShortcutsManager>) mudlet::mShortcutsManager` ==> `mudlet::mpShortcutsManager`
* `(bool) mudlet::mshowMapAuditErrors` ==> `mudlet::mShowMapAuditErrors`
* `(const int) mudlet::mTranslationGoldStar` ==> `(static const int) mudlet::scmTranslationGoldStar`
* `(QKeySequence) mudlet::multiViewKeySequence` ==> `mudlet::mKeySequenceMultiView`
* `(QPointer<QShortcut>) mudlet::multiViewShortcut` ==> `mudlet::mpShortcutMultiView`
* `(QKeySequence) mudlet::notepadKeySequence` ==> `mudlet::mKeySequenceNotepad`
* `(QPointer<QShortcut>) mudlet::notepadShortcut` ==> `mudlet::mpShortcutNotepad`
* `(QKeySequence) mudlet::optionsKeySequence` ==> `mudlet::mKeySequenceOptions`
* `(QPointer<QShortcut>) mudlet::optionsShortcut` ==> `mudlet::mpShortcutOptions`
* `(QKeySequence) mudlet::packagesKeySequence` ==> `mudlet::mKeySequencePackages`
* `(QPointer<QShortcut>) mudlet::packagesShortcut` ==> `mudlet::mpShortcutPackages`
* `(QStringList) mudlet::packagesToInstallList` ==> `mudlet::mPackagesToInstallList`
* `(QKeySequence) mudlet::reconnectKeySequence` ==> `mudlet::mKeySequenceReconnect`
* `(QPointer<QShortcut>) mudlet::reconnectShortcut` ==> `mudlet::mpShortcutReconnect`
* `(“global” const bool) mudlet::scmIsDevelopmentVersion` ==> `(inline static const bool) mudlet::scmIsDevelopmentVersion`
* `(“global” const bool) mudlet::scmIsPublicTestVersion` ==> `(inline static const bool) mudlet::scmIsPublicTestVersion`
* `(“global” const bool) mudlet::scmIsReleaseVersion` ==> `(inline static const bool) mudlet::scmIsReleaseVersion`
* `(“global” const QString) mudlet::scmMudletXmlDefaultVersion` ==> `(inline static const QString) mudlet::scmMudletXmlDefaultVersion`
* `(“global” const int) mudlet::scmQDataStreamFormat_5_12` ==> `(static const int) mudlet::scmQDataStreamFormat_5_12`
* `(“global” const QVersionNumber) mudlet::scmRunTimeQtVersion` ==> `(inline static const QVersionNumber) mudlet::scmRunTimeQtVersion`
* `(bool) mudlet::show_options_dialog(const QString&)` ==> `mudlet::showOptionsDialog(const QString&)`
* `(void) mudlet::show_options_dialog(const QString&)` ==> `mudlet::showOptionsDialog(const QString&)`
* `(QKeySequence) mudlet::showMapKeySequence` ==> `mudlet::mKeySequenceShowMap`
* `(QPointer<QShortcut>) mudlet::showMapShortcut` ==> `mudlet::mpShortcutShowMap`
* `(enum) mudlet::Appearance::system` ==> `mudlet::Appearance::systemSetting` This is desirable as `system` shadows a completely different `enum` value from Qt itself.
* `(QKeySequence) mudlet::triggersKeySequence` ==> `mudlet::mKeySequenceTriggers`
* `(QPointer<QShortcut>) mudlet::triggersShortcut` ==> `mudlet::mpShortcutTriggers`
* `(Updater*) mudlet::updater` ==> `mudlet::pUpdater`
* `(QString) mudlet::version` ==> `(inline static const QString) mudlet::scmVersion`

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>