### PR TITLE
Improve: give add item/add group/delete item buttons individual names

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -439,27 +439,23 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(treeWidget_keys, &QTreeWidget::itemDoubleClicked, this, &dlgTriggerEditor::slot_toggleItemOrGroupActiveFlag);
 
 
-    mAddItem = new QAction(QIcon(qsl(":/icons/document-new.png")), tr("Add Item"), this);
-    mAddItem->setStatusTip(tr("Add new Trigger, Script, Alias or Filter"));
+    mAddItem = new QAction(QIcon(qsl(":/icons/document-new.png")), QString(), this);
     connect(mAddItem, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewItem);
 
-    mDeleteItem = new QAction(QIcon::fromTheme(qsl(":/icons/edit-delete"), QIcon(qsl(":/icons/edit-delete.png"))), tr("Delete Item"), this);
-    mDeleteItem->setStatusTip(tr("Delete Trigger, Script, Alias or Filter"));
+    mDeleteItem = new QAction(QIcon::fromTheme(qsl(":/icons/edit-delete"), QIcon(qsl(":/icons/edit-delete.png"))), QString(), this);
     mDeleteItem->setToolTip(qsl("<p>%1 (%2)</p>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
     mDeleteItem->setShortcutContext(Qt::WidgetWithChildrenShortcut);
     mDeleteItem->setShortcut(QKeySequence(QKeySequence::Delete));
     frame_left->addAction(mDeleteItem);
     connect(mDeleteItem, &QAction::triggered, this, &dlgTriggerEditor::slot_deleteItemOrGroup);
 
-    mAddGroup = new QAction(QIcon(qsl(":/icons/folder-new.png")), tr("Add Group"), this);
-    mAddGroup->setStatusTip(tr("Add new Group"));
+    mAddGroup = new QAction(QIcon(qsl(":/icons/folder-new.png")), QString(), this);
     connect(mAddGroup, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
 
-    mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), tr("Save Item"), this);
+    mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), QString(), this);
     mSaveItem->setToolTip(tr("<p>Saves the selected item. (Ctrl+S)</p>"
                               "<p>Saving causes any changes to the item to take effect. It will not save to disk, "
                               "so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)</p>"));
-    mSaveItem->setStatusTip(tr("Saves the selected trigger, script, alias, etc, causing new changes to take effect - does not save to disk though..."));
     connect(mSaveItem, &QAction::triggered, this, &dlgTriggerEditor::slot_saveEdits);
 
     QAction* copyAction = new QAction(tr("Copy"), this);
@@ -6770,9 +6766,13 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
         mAddItem->setText(tr("Add Trigger"));
+        mAddItem->setStatusTip(tr("Add new trigger"));
         mAddGroup->setText(tr("Add Trigger Group"));
+        mAddGroup->setStatusTip(tr("Add new group of triggers"));
         mDeleteItem->setText(tr("Delete Trigger"));
+        mDeleteItem->setStatusTip(tr("Delete the selected trigger"));
         mSaveItem->setText(tr("Save Trigger"));
+        mSaveItem->setStatusTip(tr("Saves the selected trigger, causing new changes to take effect - does not save to disk though..."));
         break;
     case EditorViewType::cmTimerView:
         mAddItem->setText(tr("Add Timer"));
@@ -6806,7 +6806,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
         break;
     case EditorViewType::cmVarsView:
         mAddItem->setText(tr("Add Variable"));
-        mAddGroup->setText(tr("Add Variable Group"));
+        mAddGroup->setText(tr("Add Lua table"));
         mDeleteItem->setText(tr("Delete Variable"));
         mSaveItem->setText(tr("Save Variable"));
         break;
@@ -6814,7 +6814,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
         qDebug() << "ERROR: dlgTriggerEditor::changeView() undefined view";
     }
 
-    
+
 }
 
 void dlgTriggerEditor::slot_showTimers()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -439,28 +439,28 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(treeWidget_keys, &QTreeWidget::itemDoubleClicked, this, &dlgTriggerEditor::slot_toggleItemOrGroupActiveFlag);
 
 
-    mAddItemAction = new QAction(QIcon(qsl(":/icons/document-new.png")), tr("Add Item"), this);
-    mAddItemAction->setStatusTip(tr("Add new Trigger, Script, Alias or Filter"));
-    connect(mAddItemAction, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewItem);
+    mAddItem = new QAction(QIcon(qsl(":/icons/document-new.png")), tr("Add Item"), this);
+    mAddItem->setStatusTip(tr("Add new Trigger, Script, Alias or Filter"));
+    connect(mAddItem, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewItem);
 
-    mDeleteItemAction = new QAction(QIcon::fromTheme(qsl(":/icons/edit-delete"), QIcon(qsl(":/icons/edit-delete.png"))), tr("Delete Item"), this);
-    mDeleteItemAction->setStatusTip(tr("Delete Trigger, Script, Alias or Filter"));
-    mDeleteItemAction->setToolTip(qsl("<p>%1 (%2)</p>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
-    mDeleteItemAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    mDeleteItemAction->setShortcut(QKeySequence(QKeySequence::Delete));
-    frame_left->addAction(mDeleteItemAction);
-    connect(mDeleteItemAction, &QAction::triggered, this, &dlgTriggerEditor::slot_deleteItemOrGroup);
+    mDeleteItem = new QAction(QIcon::fromTheme(qsl(":/icons/edit-delete"), QIcon(qsl(":/icons/edit-delete.png"))), tr("Delete Item"), this);
+    mDeleteItem->setStatusTip(tr("Delete Trigger, Script, Alias or Filter"));
+    mDeleteItem->setToolTip(qsl("<p>%1 (%2)</p>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
+    mDeleteItem->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mDeleteItem->setShortcut(QKeySequence(QKeySequence::Delete));
+    frame_left->addAction(mDeleteItem);
+    connect(mDeleteItem, &QAction::triggered, this, &dlgTriggerEditor::slot_deleteItemOrGroup);
 
-    mAddGroupAction = new QAction(QIcon(qsl(":/icons/folder-new.png")), tr("Add Group"), this);
-    mAddGroupAction->setStatusTip(tr("Add new Group"));
-    connect(mAddGroupAction, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
+    mAddGroup = new QAction(QIcon(qsl(":/icons/folder-new.png")), tr("Add Group"), this);
+    mAddGroup->setStatusTip(tr("Add new Group"));
+    connect(mAddGroup, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
 
-    QAction* saveAction = new QAction(QIcon(qsl(":/icons/document-save-as.png")), tr("Save Item"), this);
-    saveAction->setToolTip(tr("<p>Saves the selected item. (Ctrl+S)</p>"
+    mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), tr("Save Item"), this);
+    mSaveItem->setToolTip(tr("<p>Saves the selected item. (Ctrl+S)</p>"
                               "<p>Saving causes any changes to the item to take effect. It will not save to disk, "
                               "so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)</p>"));
-    saveAction->setStatusTip(tr("Saves the selected trigger, script, alias, etc, causing new changes to take effect - does not save to disk though..."));
-    connect(saveAction, &QAction::triggered, this, &dlgTriggerEditor::slot_saveEdits);
+    mSaveItem->setStatusTip(tr("Saves the selected trigger, script, alias, etc, causing new changes to take effect - does not save to disk though..."));
+    connect(mSaveItem, &QAction::triggered, this, &dlgTriggerEditor::slot_saveEdits);
 
     QAction* copyAction = new QAction(tr("Copy"), this);
     copyAction->setShortcut(QKeySequence(QKeySequence::Copy));
@@ -541,7 +541,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     toolBar->setMovable(true);
     toolBar->addAction(toggleActiveAction);
-    toolBar->addAction(saveAction);
+    toolBar->addAction(mSaveItem);
     toolBar->setWindowTitle(tr("Editor Toolbar - %1 - Actions",
                                // Intentional comment to separate arguments
                                "This is the toolbar that is initially placed at the top of the editor.")
@@ -549,11 +549,11 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     toolBar->addSeparator();
 
-    toolBar->addAction(mAddItemAction);
-    toolBar->addAction(mAddGroupAction);
+    toolBar->addAction(mAddItem);
+    toolBar->addAction(mAddGroup);
 
     toolBar->addSeparator();
-    toolBar->addAction(mDeleteItemAction);
+    toolBar->addAction(mDeleteItem);
     toolBar->addAction(importAction);
     toolBar->addAction(mpExportAction);
     toolBar->addAction(mProfileSaveAsAction);
@@ -6769,39 +6769,46 @@ void dlgTriggerEditor::changeView(EditorViewType view)
 
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
-        mAddItemAction->setIconText(tr("Add Trigger"));
-        mAddGroupAction->setIconText(tr("Add Trigger Group"));
-        mDeleteItemAction->setIconText(tr("Delete Trigger"));
+        mAddItem->setIconText(tr("Add Trigger"));
+        mAddGroup->setIconText(tr("Add Trigger Group"));
+        mDeleteItem->setIconText(tr("Delete Trigger"));
+        mSaveItem->setIconText(tr("Save Trigger"));
         break;
     case EditorViewType::cmTimerView:
-        mAddItemAction->setIconText(tr("Add Timer"));
-        mAddGroupAction->setIconText(tr("Add Timer Group"));
-        mDeleteItemAction->setIconText(tr("Delete Timer"));
+        mAddItem->setIconText(tr("Add Timer"));
+        mAddGroup->setIconText(tr("Add Timer Group"));
+        mDeleteItem->setIconText(tr("Delete Timer"));
+        mSaveItem->setIconText(tr("Save Timer"));
         break;
     case EditorViewType::cmAliasView:
-        mAddItemAction->setIconText(tr("Add Alias"));
-        mAddGroupAction->setIconText(tr("Add Alias Group"));
-        mDeleteItemAction->setIconText(tr("Delete Alias"));
+        mAddItem->setIconText(tr("Add Alias"));
+        mAddGroup->setIconText(tr("Add Alias Group"));
+        mDeleteItem->setIconText(tr("Delete Alias"));
+        mSaveItem->setIconText(tr("Save Alias"));
         break;
     case EditorViewType::cmScriptView:
-        mAddItemAction->setIconText(tr("Add Script"));
-        mAddGroupAction->setIconText(tr("Add Script Group"));
-        mDeleteItemAction->setIconText(tr("Delete Script"));
+        mAddItem->setIconText(tr("Add Script"));
+        mAddGroup->setIconText(tr("Add Script Group"));
+        mDeleteItem->setIconText(tr("Delete Script"));
+        mSaveItem->setIconText(tr("Save Script"));
         break;
     case EditorViewType::cmActionView:
-        mAddItemAction->setIconText(tr("Add Button"));
-        mAddGroupAction->setIconText(tr("Add Button Group"));
-        mDeleteItemAction->setIconText(tr("Delete Button"));
+        mAddItem->setIconText(tr("Add Button"));
+        mAddGroup->setIconText(tr("Add Button Group"));
+        mDeleteItem->setIconText(tr("Delete Button"));
+        mSaveItem->setIconText(tr("Save Button"));
         break;
     case EditorViewType::cmKeysView:
-        mAddItemAction->setIconText(tr("Add Key"));
-        mAddGroupAction->setIconText(tr("Add Key Group"));
-        mDeleteItemAction->setIconText(tr("Delete Key"));
+        mAddItem->setIconText(tr("Add Key"));
+        mAddGroup->setIconText(tr("Add Key Group"));
+        mDeleteItem->setIconText(tr("Delete Key"));
+        mSaveItem->setIconText(tr("Save Key"));
         break;
     case EditorViewType::cmVarsView:
-        mAddItemAction->setIconText(tr("Add Variable"));
-        mAddGroupAction->setIconText(tr("Add Variable Group"));
-        mDeleteItemAction->setIconText(tr("Delete Variable"));
+        mAddItem->setIconText(tr("Add Variable"));
+        mAddGroup->setIconText(tr("Add Variable Group"));
+        mDeleteItem->setIconText(tr("Delete Variable"));
+        mSaveItem->setIconText(tr("Save Variable"));
         break;
     default:
         qDebug() << "ERROR: dlgTriggerEditor::changeView() undefined view";

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -439,21 +439,21 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(treeWidget_keys, &QTreeWidget::itemDoubleClicked, this, &dlgTriggerEditor::slot_toggleItemOrGroupActiveFlag);
 
 
-    QAction* addTriggerAction = new QAction(QIcon(qsl(":/icons/document-new.png")), tr("Add Item"), this);
-    addTriggerAction->setStatusTip(tr("Add new Trigger, Script, Alias or Filter"));
-    connect(addTriggerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewItem);
+    mAddItemAction = new QAction(QIcon(qsl(":/icons/document-new.png")), tr("Add Item"), this);
+    mAddItemAction->setStatusTip(tr("Add new Trigger, Script, Alias or Filter"));
+    connect(mAddItemAction, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewItem);
 
-    QAction* deleteTriggerAction = new QAction(QIcon::fromTheme(qsl(":/icons/edit-delete"), QIcon(qsl(":/icons/edit-delete.png"))), tr("Delete Item"), this);
-    deleteTriggerAction->setStatusTip(tr("Delete Trigger, Script, Alias or Filter"));
-    deleteTriggerAction->setToolTip(qsl("<p>%1 (%2)</p>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
-    deleteTriggerAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    deleteTriggerAction->setShortcut(QKeySequence(QKeySequence::Delete));
-    frame_left->addAction(deleteTriggerAction);
-    connect(deleteTriggerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_deleteItemOrGroup);
+    mDeleteItemAction = new QAction(QIcon::fromTheme(qsl(":/icons/edit-delete"), QIcon(qsl(":/icons/edit-delete.png"))), tr("Delete Item"), this);
+    mDeleteItemAction->setStatusTip(tr("Delete Trigger, Script, Alias or Filter"));
+    mDeleteItemAction->setToolTip(qsl("<p>%1 (%2)</p>").arg(tr("Delete Item"), QKeySequence(QKeySequence::Delete).toString()));
+    mDeleteItemAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    mDeleteItemAction->setShortcut(QKeySequence(QKeySequence::Delete));
+    frame_left->addAction(mDeleteItemAction);
+    connect(mDeleteItemAction, &QAction::triggered, this, &dlgTriggerEditor::slot_deleteItemOrGroup);
 
-    QAction* addFolderAction = new QAction(QIcon(qsl(":/icons/folder-new.png")), tr("Add Group"), this);
-    addFolderAction->setStatusTip(tr("Add new Group"));
-    connect(addFolderAction, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
+    mAddGroupAction = new QAction(QIcon(qsl(":/icons/folder-new.png")), tr("Add Group"), this);
+    mAddGroupAction->setStatusTip(tr("Add new Group"));
+    connect(mAddGroupAction, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
 
     QAction* saveAction = new QAction(QIcon(qsl(":/icons/document-save-as.png")), tr("Save Item"), this);
     saveAction->setToolTip(tr("<p>Saves the selected item. (Ctrl+S)</p>"
@@ -549,11 +549,11 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
 
     toolBar->addSeparator();
 
-    toolBar->addAction(addTriggerAction);
-    toolBar->addAction(addFolderAction);
+    toolBar->addAction(mAddItemAction);
+    toolBar->addAction(mAddGroupAction);
 
     toolBar->addSeparator();
-    toolBar->addAction(deleteTriggerAction);
+    toolBar->addAction(mDeleteItemAction);
     toolBar->addAction(importAction);
     toolBar->addAction(mpExportAction);
     toolBar->addAction(mProfileSaveAsAction);
@@ -6766,6 +6766,48 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     checkBox_displayAllVariables->setVisible(view == EditorViewType::cmVarsView);
 
     mpExportAction->setEnabled(view != EditorViewType::cmVarsView);
+
+    switch (mCurrentView) {
+    case EditorViewType::cmTriggerView:
+        mAddItemAction->setIconText(tr("Add Trigger"));
+        mAddGroupAction->setIconText(tr("Add Trigger Group"));
+        mDeleteItemAction->setIconText(tr("Delete Trigger"));
+        break;
+    case EditorViewType::cmTimerView:
+        mAddItemAction->setIconText(tr("Add Timer"));
+        mAddGroupAction->setIconText(tr("Add Timer Group"));
+        mDeleteItemAction->setIconText(tr("Delete Timer"));
+        break;
+    case EditorViewType::cmAliasView:
+        mAddItemAction->setIconText(tr("Add Alias"));
+        mAddGroupAction->setIconText(tr("Add Alias Group"));
+        mDeleteItemAction->setIconText(tr("Delete Alias"));
+        break;
+    case EditorViewType::cmScriptView:
+        mAddItemAction->setIconText(tr("Add Script"));
+        mAddGroupAction->setIconText(tr("Add Script Group"));
+        mDeleteItemAction->setIconText(tr("Delete Script"));
+        break;
+    case EditorViewType::cmActionView:
+        mAddItemAction->setIconText(tr("Add Button"));
+        mAddGroupAction->setIconText(tr("Add Button Group"));
+        mDeleteItemAction->setIconText(tr("Delete Button"));
+        break;
+    case EditorViewType::cmKeysView:
+        mAddItemAction->setIconText(tr("Add Key"));
+        mAddGroupAction->setIconText(tr("Add Key Group"));
+        mDeleteItemAction->setIconText(tr("Delete Key"));
+        break;
+    case EditorViewType::cmVarsView:
+        mAddItemAction->setIconText(tr("Add Variable"));
+        mAddGroupAction->setIconText(tr("Add Variable Group"));
+        mDeleteItemAction->setIconText(tr("Delete Variable"));
+        break;
+    default:
+        qDebug() << "ERROR: dlgTriggerEditor::changeView() undefined view";
+    }
+
+    
 }
 
 void dlgTriggerEditor::slot_showTimers()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6763,6 +6763,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
 
     mpExportAction->setEnabled(view != EditorViewType::cmVarsView);
 
+    // texts are duplicated here so that translators can work with the full string
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
         mAddItem->setText(tr("Add Trigger"));
@@ -6776,39 +6777,63 @@ void dlgTriggerEditor::changeView(EditorViewType view)
         break;
     case EditorViewType::cmTimerView:
         mAddItem->setText(tr("Add Timer"));
+        mAddItem->setStatusTip(tr("Add new timer"));
         mAddGroup->setText(tr("Add Timer Group"));
+        mAddGroup->setStatusTip(tr("Add new group of timers"));
         mDeleteItem->setText(tr("Delete Timer"));
+        mDeleteItem->setStatusTip(tr("Delete the selected timer"));
         mSaveItem->setText(tr("Save Timer"));
+        mSaveItem->setStatusTip(tr("Saves the selected timer, causing new changes to take effect - does not save to disk though..."));
         break;
     case EditorViewType::cmAliasView:
         mAddItem->setText(tr("Add Alias"));
+        mAddItem->setStatusTip(tr("Add new alias"));
         mAddGroup->setText(tr("Add Alias Group"));
+        mAddGroup->setStatusTip(tr("Add new group of aliases"));
         mDeleteItem->setText(tr("Delete Alias"));
+        mDeleteItem->setStatusTip(tr("Delete the selected alias"));
         mSaveItem->setText(tr("Save Alias"));
+        mSaveItem->setStatusTip(tr("Saves the selected alias, causing new changes to take effect - does not save to disk though..."));
         break;
     case EditorViewType::cmScriptView:
         mAddItem->setText(tr("Add Script"));
+        mAddItem->setStatusTip(tr("Add new script"));
         mAddGroup->setText(tr("Add Script Group"));
+        mAddGroup->setStatusTip(tr("Add new group of scripts"));
         mDeleteItem->setText(tr("Delete Script"));
+        mDeleteItem->setStatusTip(tr("Delete the selected script"));
         mSaveItem->setText(tr("Save Script"));
+        mSaveItem->setStatusTip(tr("Saves the selected script, causing new changes to take effect - does not save to disk though..."));
         break;
     case EditorViewType::cmActionView:
         mAddItem->setText(tr("Add Button"));
+        mAddItem->setStatusTip(tr("Add new button"));
         mAddGroup->setText(tr("Add Button Group"));
+        mAddGroup->setStatusTip(tr("Add new group of buttons"));
         mDeleteItem->setText(tr("Delete Button"));
+        mDeleteItem->setStatusTip(tr("Delete the selected button"));
         mSaveItem->setText(tr("Save Button"));
+        mSaveItem->setStatusTip(tr("Saves the selected button, causing new changes to take effect - does not save to disk though..."));
         break;
     case EditorViewType::cmKeysView:
         mAddItem->setText(tr("Add Key"));
+        mAddItem->setStatusTip(tr("Add new key"));
         mAddGroup->setText(tr("Add Key Group"));
+        mAddGroup->setStatusTip(tr("Add new group of keys"));
         mDeleteItem->setText(tr("Delete Key"));
+        mDeleteItem->setStatusTip(tr("Delete the selected key"));
         mSaveItem->setText(tr("Save Key"));
+        mSaveItem->setStatusTip(tr("Saves the selected key, causing new changes to take effect - does not save to disk though..."));
         break;
     case EditorViewType::cmVarsView:
         mAddItem->setText(tr("Add Variable"));
+        mAddItem->setStatusTip(tr("Add new variable"));
         mAddGroup->setText(tr("Add Lua table"));
+        mAddGroup->setStatusTip(tr("Add new Lua table"));
         mDeleteItem->setText(tr("Delete Variable"));
+        mDeleteItem->setStatusTip(tr("Delete the selected variable"));
         mSaveItem->setText(tr("Save Variable"));
+        mSaveItem->setStatusTip(tr("Saves the selected variable, causing new changes to take effect - does not save to disk though..."));
         break;
     default:
         qDebug() << "ERROR: dlgTriggerEditor::changeView() undefined view";

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6769,46 +6769,46 @@ void dlgTriggerEditor::changeView(EditorViewType view)
 
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
-        mAddItem->setIconText(tr("Add Trigger"));
-        mAddGroup->setIconText(tr("Add Trigger Group"));
-        mDeleteItem->setIconText(tr("Delete Trigger"));
-        mSaveItem->setIconText(tr("Save Trigger"));
+        mAddItem->setText(tr("Add Trigger"));
+        mAddGroup->setText(tr("Add Trigger Group"));
+        mDeleteItem->setText(tr("Delete Trigger"));
+        mSaveItem->setText(tr("Save Trigger"));
         break;
     case EditorViewType::cmTimerView:
-        mAddItem->setIconText(tr("Add Timer"));
-        mAddGroup->setIconText(tr("Add Timer Group"));
-        mDeleteItem->setIconText(tr("Delete Timer"));
-        mSaveItem->setIconText(tr("Save Timer"));
+        mAddItem->setText(tr("Add Timer"));
+        mAddGroup->setText(tr("Add Timer Group"));
+        mDeleteItem->setText(tr("Delete Timer"));
+        mSaveItem->setText(tr("Save Timer"));
         break;
     case EditorViewType::cmAliasView:
-        mAddItem->setIconText(tr("Add Alias"));
-        mAddGroup->setIconText(tr("Add Alias Group"));
-        mDeleteItem->setIconText(tr("Delete Alias"));
-        mSaveItem->setIconText(tr("Save Alias"));
+        mAddItem->setText(tr("Add Alias"));
+        mAddGroup->setText(tr("Add Alias Group"));
+        mDeleteItem->setText(tr("Delete Alias"));
+        mSaveItem->setText(tr("Save Alias"));
         break;
     case EditorViewType::cmScriptView:
-        mAddItem->setIconText(tr("Add Script"));
-        mAddGroup->setIconText(tr("Add Script Group"));
-        mDeleteItem->setIconText(tr("Delete Script"));
-        mSaveItem->setIconText(tr("Save Script"));
+        mAddItem->setText(tr("Add Script"));
+        mAddGroup->setText(tr("Add Script Group"));
+        mDeleteItem->setText(tr("Delete Script"));
+        mSaveItem->setText(tr("Save Script"));
         break;
     case EditorViewType::cmActionView:
-        mAddItem->setIconText(tr("Add Button"));
-        mAddGroup->setIconText(tr("Add Button Group"));
-        mDeleteItem->setIconText(tr("Delete Button"));
-        mSaveItem->setIconText(tr("Save Button"));
+        mAddItem->setText(tr("Add Button"));
+        mAddGroup->setText(tr("Add Button Group"));
+        mDeleteItem->setText(tr("Delete Button"));
+        mSaveItem->setText(tr("Save Button"));
         break;
     case EditorViewType::cmKeysView:
-        mAddItem->setIconText(tr("Add Key"));
-        mAddGroup->setIconText(tr("Add Key Group"));
-        mDeleteItem->setIconText(tr("Delete Key"));
-        mSaveItem->setIconText(tr("Save Key"));
+        mAddItem->setText(tr("Add Key"));
+        mAddGroup->setText(tr("Add Key Group"));
+        mDeleteItem->setText(tr("Delete Key"));
+        mSaveItem->setText(tr("Save Key"));
         break;
     case EditorViewType::cmVarsView:
-        mAddItem->setIconText(tr("Add Variable"));
-        mAddGroup->setIconText(tr("Add Variable Group"));
-        mDeleteItem->setIconText(tr("Delete Variable"));
-        mSaveItem->setIconText(tr("Save Variable"));
+        mAddItem->setText(tr("Add Variable"));
+        mAddGroup->setText(tr("Add Variable Group"));
+        mDeleteItem->setText(tr("Delete Variable"));
+        mSaveItem->setText(tr("Save Variable"));
         break;
     default:
         qDebug() << "ERROR: dlgTriggerEditor::changeView() undefined view";

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -490,6 +490,10 @@ private:
 
     QRegularExpression* simplifyEdbeeStatusBarRegex = nullptr;
 
+    QAction* mAddItemAction = nullptr;
+    QAction* mDeleteItemAction = nullptr;
+    QAction* mAddGroupAction = nullptr;
+
     SearchOptions mSearchOptions = SearchOptionNone;
 
     // This has a menu which the following QActions are inserted into:

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -490,9 +490,10 @@ private:
 
     QRegularExpression* simplifyEdbeeStatusBarRegex = nullptr;
 
-    QAction* mAddItemAction = nullptr;
-    QAction* mDeleteItemAction = nullptr;
-    QAction* mAddGroupAction = nullptr;
+    QAction* mAddItem = nullptr;
+    QAction* mDeleteItem = nullptr;
+    QAction* mAddGroup = nullptr;
+    QAction* mSaveItem = nullptr;
 
     SearchOptions mSearchOptions = SearchOptionNone;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Give add item/add group/delete item buttons individual names
#### Motivation for adding to Mudlet
So visually impaired folk can tell right away what the button will actually add
#### Other info (issues closed, discussion etc)
