### PR TITLE
Infrastructure: try to fix action for updating crowdin text

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -16,6 +16,7 @@ jobs:
         ref: development
         submodules: true
         fetch-depth: 0
+        persist-credentials: false
 
     - name: update text for translation
       uses: Mudlet/lupdate-action@master


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet
So crowdin text updates can resume as usual
#### Other info (issues closed, discussion etc)
Action has been failing for a few months now, and I notice that https://github.com/gr2m/create-or-update-pull-request-action mentions some new arguments need to be used at checkout 