### PR TITLE
Fix: limit maximum replay speed up multiplier

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -3012,9 +3012,8 @@ void mudlet::replayOver()
 void mudlet::slot_replaySpeedUp()
 {
     if (mpLabelReplaySpeedDisplay) {
-        mReplaySpeed = mReplaySpeed * 2;
+        mReplaySpeed = qMin(1024, mReplaySpeed * 2);
         mpLabelReplaySpeedDisplay->setText(qsl("<font size=25><b>%1</b></font>").arg(tr("Speed: X%1").arg(mReplaySpeed)));
-
         mpLabelReplaySpeedDisplay->show();
     }
 }
@@ -3022,10 +3021,7 @@ void mudlet::slot_replaySpeedUp()
 void mudlet::slot_replaySpeedDown()
 {
     if (mpLabelReplaySpeedDisplay) {
-        mReplaySpeed = mReplaySpeed / 2;
-        if (mReplaySpeed < 1) {
-            mReplaySpeed = 1;
-        }
+        mReplaySpeed = qMax(1, mReplaySpeed / 2);
         mpLabelReplaySpeedDisplay->setText(qsl("<font size=25><b>%1</b></font>").arg(tr("Speed: X%1").arg(mReplaySpeed)));
         mpLabelReplaySpeedDisplay->show();
     }


### PR DESCRIPTION
By repeatedly clicking the speed up button it is possible to overflow the `(int) mudlet::mReplaySpeed` variable such that it takes on a value that is impossible to work with and then it crashes Mudlet. This PR limits the maximum (and minimum) multiplier so that it is clamped between 1 and 1,024.

This should close #6466.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>