### PR TITLE
add support for multiple profiles from command line

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,7 +303,7 @@ int main(int argc, char* argv[])
     /*******************************************************************
      * If we get to HERE then we are going to run a GUI application... *
      *******************************************************************/
-    QString cliProfile = parser.value(profileToOpen);
+    QStringList cliProfiles = parser.values(profileToOpen);
 
 
     bool show_splash = !(parser.isSet(beQuiet)); // Not --quiet.
@@ -523,7 +523,7 @@ int main(int argc, char* argv[])
     mudlet::self()->smMirrorToStdOut = parser.isSet(mirrorToStdout);
     mudlet::self()->show();
 
-    mudlet::self()->startAutoLogin(cliProfile);
+    mudlet::self()->startAutoLogin(cliProfiles);
 
 #if defined(INCLUDE_UPDATER)
     mudlet::self()->checkUpdatesOnStart();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char* argv[])
     }
 
     QCommandLineParser parser;
-    QCommandLineOption profileToOpen(qsl("profile"), QCoreApplication::translate("main", "Profile to open automatically"), QCoreApplication::translate("main", "profile"));
+    QCommandLineOption profileToOpen(QStringList() << qsl("p") << qsl("profile"), QCoreApplication::translate("main", "Profile to open automatically"), QCoreApplication::translate("main", "profile"));
     parser.addOption(profileToOpen);
 
     QCommandLineOption showHelp(QStringList() << "h" <<"help", QCoreApplication::translate("main", "Display help and exit"));
@@ -218,18 +218,21 @@ int main(int argc, char* argv[])
     QCommandLineOption mirrorToStdout(QStringList() << "m" << "mirror", QCoreApplication::translate("main", "Mirror output of all consoles to STDOUT"));
     parser.addOption(mirrorToStdout);
 
-    parser.parse(app->arguments());
+    bool parsedCommandLineOk = parser.parse(app->arguments());
 
     // Non-GUI actions --help and --version as suggested by GNU coding standards,
     // section 4.7: http://www.gnu.org/prep/standards/standards.html#Command_002dLine-Interfaces
     QStringList texts;
-    if (parser.isSet(showHelp)) {
+    if (!parsedCommandLineOk || parser.isSet(showHelp)) {
+        if (!parsedCommandLineOk) {
+            texts << qsl("%1\n\n").arg(QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()));
+        }
         // Do "help" action
         texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Usage: %1 [OPTION...]\n"
                                "       -h, --help           displays this message.\n"
                                "       -v, --version        displays version information.\n"
                                "       -q, --quiet          no splash screen on startup.\n"
-                               "       --profile=<profile>  additional profile to open\n\n"
+                               "       -p, --profile=<profile>  additional profile to open, may be repeated\n\n"
                                "There are other inherited options that arise from the Qt Libraries which are\n"
                                "less likely to be useful for normal use of this application:")
                  .arg(QLatin1String(APP_TARGET)));
@@ -276,7 +279,7 @@ int main(int argc, char* argv[])
         texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues"));
         texts << qsl("%1\n").arg(QCoreApplication::translate("main", "Project home page: http://www.mudlet.org/"));
         std::cout << texts.join(QString()).toStdString();
-        return 0;
+        return parsedCommandLineOk ? 0 :-1;
     }
 
     if (parser.isSet(showVersion)) {

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2507,9 +2507,17 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     hostList.removeDuplicates();
     bool openedProfile = false;
 
+    for (auto& pHost : cliProfiles){
+        if (hostList.contains(pHost)) {
+            doAutoLogin(pHost);
+            openedProfile = true;
+            hostList.removeOne(pHost);
+        }
+    }
+
     for (auto& pHost : hostList) {
         QString val = readProfileData(pHost, qsl("autologin"));
-        if (val.toInt() == Qt::Checked || cliProfiles.contains(pHost)) {
+        if (val.toInt() == Qt::Checked) {
             doAutoLogin(pHost);
             openedProfile = true;
         }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2507,18 +2507,18 @@ void mudlet::startAutoLogin(const QStringList& cliProfiles)
     hostList.removeDuplicates();
     bool openedProfile = false;
 
-    for (auto& pHost : cliProfiles){
-        if (hostList.contains(pHost)) {
-            doAutoLogin(pHost);
+    for (auto& hostName : cliProfiles){
+        if (hostList.contains(hostName)) {
+            doAutoLogin(hostName);
             openedProfile = true;
-            hostList.removeOne(pHost);
+            hostList.removeOne(hostName);
         }
     }
 
-    for (auto& pHost : hostList) {
-        QString val = readProfileData(pHost, qsl("autologin"));
+    for (auto& hostName : hostList) {
+        QString val = readProfileData(hostName, qsl("autologin"));
         if (val.toInt() == Qt::Checked) {
-            doAutoLogin(pHost);
+            doAutoLogin(hostName);
             openedProfile = true;
         }
     }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2499,7 +2499,7 @@ void mudlet::deleteProfileData(const QString& profile, const QString& item)
 }
 
 // this slot is called via a timer in the constructor of mudlet::mudlet()
-void mudlet::startAutoLogin(const QString& cliProfile)
+void mudlet::startAutoLogin(const QStringList& cliProfiles)
 {
     QStringList hostList = QDir(getMudletPath(profilesPath)).entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
     hostList += TGameDetails::keys();
@@ -2509,7 +2509,7 @@ void mudlet::startAutoLogin(const QString& cliProfile)
 
     for (auto& pHost : hostList) {
         QString val = readProfileData(pHost, qsl("autologin"));
-        if (val.toInt() == Qt::Checked || pHost == cliProfile) {
+        if (val.toInt() == Qt::Checked || cliProfiles.contains(pHost)) {
             doAutoLogin(pHost);
             openedProfile = true;
         }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -390,7 +390,7 @@ public:
     // Brings up the preferences dialog and selects the tab whos objectName is
     // supplied:
     void showOptionsDialog(const QString&);
-    void startAutoLogin(const QString&);
+    void startAutoLogin(const QStringList&);
     bool storingPasswordsSecurely() const { return mStorePasswordsSecurely; }
     controlsVisibility toolBarVisibility() const { return mToolbarVisibility; }
     void updateDiscordNamedIcon();


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This makes it so that `--profile="one" --profile="two"` will connect to both profiles instead of just the last one.
Also added is `-p "one"` style, and an error message if bad args given.
#### Motivation for adding to Mudlet
Normally I have Mudlet open with five profiles open on one copy for games that I monitor, and then a second copy of test builds open for connecting to things I'm testing.  If I put a checkmark on "Open profile on Mudlet start" for each the five profiles, then my test builds will open up with those same profiles.  So, I made a shortcut to open the release version with the command line arguments listing my 5 profiles.  Only one actually opened.  I looked up the process, and it doesn't ask parser for list of arguments and run through them, but rather asks about each type of argument.  I looked up what the parser[.value(x)](https://doc.qt.io/qt-5/qcommandlineparser.html#value) did, and scrolled down and found [.values(x)](https://doc.qt.io/qt-5/qcommandlineparser.html#values-1) just below it which is a similar thing using list.  It was quicker to program this change than it was to look that up.

#### Other info (issues closed, discussion etc)
The existing process was to go through the profile folder in alphabetical order and check if each profile has the box checked or was named in the `--profile="X"`.  ~~I haven't changed that, I only changed the "equal to X" to "contained in X".  So `--profile="one" --profile="two"` is not going to open `one` and then `two` because of them being listed in that order, it's going to go through the directory listing in alphabetical order just like the checkmark way has worked.  I didn't make it run through the list of args in order or anything like that.~~  Now it will first look at the ones from the command line in the order given and open them if they are in the folder list and skip it if they are not (to avoid typos making a new profile), and then for the remaining folders, it will alphabetically look for the ones with the autologin set as before.

I'm not aware of any issues from other people who expected the command line argument to work multiple times.  The help prior to my edit already calls it "additional profile to open", which makes me think that it was intended to be for opening multiple.