### PR TITLE
Fix: clean up after some right-click (context) menus

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2778,6 +2778,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
     if (event->buttons() & Qt::RightButton) {
         auto popup = new QMenu(this);
         popup->setToolTipsVisible(true);
+        popup->setAttribute(Qt::WA_DeleteOnClose);
 
         if (mCustomLinesRoomFrom > 0) {
             if (mDialogLock) {
@@ -3098,6 +3099,7 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
             QStringList menuInfo = it.value();
             QString displayName = menuInfo[1];
             auto userMenu = new QMenu(displayName, this);
+            userMenu->setAttribute(Qt::WA_DeleteOnClose);
             userMenus.insert(it.key(), userMenu);
         }
         it.toFront();

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -1835,6 +1835,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
                     QVector<int> luaReference = mpBuffer->mLinkStore.getReference(mpBuffer->buffer.at(y).at(x).linkIndex());
                     if (command.size() > 1) {
                         auto popup = new QMenu(this);
+                        popup->setAttribute(Qt::WA_DeleteOnClose);
                         for (int i = 0, total = command.size(); i < total; ++i) {
                             QAction* pA;
                             if (i < hint.size()) {
@@ -1889,6 +1890,7 @@ void TTextEdit::mouseReleaseEvent(QMouseEvent* event)
         }
 
         auto popup = new QMenu(this);
+        popup->setAttribute(Qt::WA_DeleteOnClose);
         popup->setToolTipsVisible(true); // Not the default...
         popup->addAction(action);
         popup->addAction(action2);


### PR DESCRIPTION
Each time they were used (on the 2D map or any `TTextEdit`) a new one was created but it did not disappear (although it was hidden) once an action was selected or the menu was closed by moving the mouse away from it.

This was discovered using GammaRay which showed each `QMenu` item being left behind after a right click action on those two things.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>