### PR TITLE
Fix: Linux PTBs and release builds getting compressed

### DIFF
--- a/CI/travis.linux.after_success.sh
+++ b/CI/travis.linux.after_success.sh
@@ -97,9 +97,9 @@ if { [ "${DEPLOY}" = "deploy" ]; } ||
     fi
 
     if [ "${public_test_build}" == "true" ]; then
-      tar -czvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" "Mudlet PTB.AppImage"
+      tar -cvf "Mudlet-${VERSION}${MUDLET_VERSION_BUILD}-linux-x64.AppImage.tar" "Mudlet PTB.AppImage"
     else
-      tar -czvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
+      tar -cvf "Mudlet-${VERSION}-linux-x64.AppImage.tar" "Mudlet.AppImage"
     fi
 
     # if [ "${public_test_build}" == "true" ]; then


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fixed our Appimage.tar's really being gzipped tarballs, when they were not intended to be
#### Motivation for adding to Mudlet
Compression does not add much here, we're only using a tarball for the executable bit
#### Other info (issues closed, discussion etc)
Ark on KDE apparently errors extracting https://www.mudlet.org/download/Mudlet-4.16.0-linux-x64.AppImage.tar