### PR TITLE
Fix: make whole menubar clickable again

### DIFF
--- a/src/AnnouncerMac.mm
+++ b/src/AnnouncerMac.mm
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2022 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *   Copyright (C) 2023 by Stephen Lyons - slysven@virginmedia.com         *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,9 +24,12 @@
 #include <QDebug>
 
 Announcer::Announcer(QWidget *parent)
-    : QWidget{parent}
+: QWidget{parent}
 {
-
+    // Needed to prevent this (invisible) widget from being seen by itself in
+    // the top left corner of the main application window where it masks part of
+    // the main menu bar:
+    setVisible(false);
 }
 
 void Announcer::announce(const QString& text, const QString& processing)

--- a/src/AnnouncerUnix.cpp
+++ b/src/AnnouncerUnix.cpp
@@ -66,6 +66,10 @@ InvisibleStatusbar::InvisibleStatusbar(QWidget *parent)
     // in case it does show up:
     setAccessibleName(tr("InvisibleStatusbar"));
     setAccessibleDescription(tr("An invisible widget used as part as a workaround to announce text to the screen reader"));
+    // Needed to prevent this (invisible) widget from being seen by itself in
+    // the top left corner of the main application window where it masks part of
+    // the main menu bar:
+    setVisible(false);
 }
 
 Announcer::Announcer(QWidget *parent)

--- a/src/AnnouncerUnix.cpp
+++ b/src/AnnouncerUnix.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
 *   Copyright (C) 2022 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
-*   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+*   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
 *                                                                         *
 *   This program is free software; you can redistribute it and/or modify  *
 *   it under the terms of the GNU General Public License as published by  *
@@ -61,15 +61,6 @@ QString InvisibleAccessibleNotification::text(QAccessible::Text t) const
 InvisibleStatusbar::InvisibleStatusbar(QWidget *parent)
 : QWidget(parent)
 {
-    setObjectName(qsl("InvisibleStatusbar"));
-    // This class should not be "visible" to anyone, but it should be localised
-    // in case it does show up:
-    setAccessibleName(tr("InvisibleStatusbar"));
-    setAccessibleDescription(tr("An invisible widget used as part as a workaround to announce text to the screen reader"));
-    // Needed to prevent this (invisible) widget from being seen by itself in
-    // the top left corner of the main application window where it masks part of
-    // the main menu bar:
-    setVisible(false);
 }
 
 Announcer::Announcer(QWidget *parent)
@@ -77,6 +68,10 @@ Announcer::Announcer(QWidget *parent)
 , statusbar(new InvisibleStatusbar(this))
 {
     notification = new InvisibleNotification(statusbar);
+    // Needed to prevent this (invisible) widget from being seen by itself in
+    // the top left corner of the main application window where it masks part of
+    // the main menu bar:
+    setVisible(false);
 }
 
 void Announcer::announce(const QString& text, const QString& processing)

--- a/src/AnnouncerWindows.cpp
+++ b/src/AnnouncerWindows.cpp
@@ -39,7 +39,7 @@
 #include <uiautomationcoreapi.h>
 
 // mingw 7.30's uiautomationclient.h is outdated, lacks this define
-#if ! defined(UIA_CustomControlTypeId)
+#if !defined(UIA_CustomControlTypeId)
 #define UIA_CustomControlTypeId (50025)
 #endif
 

--- a/src/AnnouncerWindows.cpp
+++ b/src/AnnouncerWindows.cpp
@@ -2,6 +2,7 @@
  *   Copyright 2019-2022 Leonard de Ruijter, James Teh - OSARA             *
  *   Copyright 2017 The Qt Company Ltd.                                    *
  *   Copyright (C) 2022 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
+ *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/AnnouncerWindows.cpp
+++ b/src/AnnouncerWindows.cpp
@@ -39,7 +39,9 @@
 #include <uiautomationcoreapi.h>
 
 // mingw 7.30's uiautomationclient.h is outdated, lacks this define
+#if ! defined(UIA_CustomControlTypeId)
 #define UIA_CustomControlTypeId (50025)
+#endif
 
 // this class is largely inspired by OSARA's UiaProvider:
 // https://github.com/jcsteh/osara/blob/master/src/uia.cpp
@@ -137,9 +139,14 @@ bool Announcer::initializeUia()
     return true;
 }
 
-Announcer::Announcer(QWidget* parent) : QWidget{parent}
+Announcer::Announcer(QWidget* parent)
+: QWidget{parent}
 {
     initializeUia();
+    // Needed to prevent this (invisible) widget from being seen by itself in
+    // the top left corner of the main application window where it masks part of
+    // the main menu bar:
+    setVisible(false);
 }
 
 BSTR bStrFromQString(const QString& value)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -778,7 +778,7 @@ HEADERS += \
     ../3rdparty/discord/rpc/include/discord_rpc.h
 
 macx {
-    OBJECTIVE_SOURCES += AnnouncerMac.mm
+    SOURCES += AnnouncerMac.mm
 }
 
 win32 {


### PR DESCRIPTION
This had been noticed by users/developers even when they were not used a screen-reader and it was unclear why the "Game" menu item was not reachable and the "Options" item was hard to get to. The solution is to "hide" the widget which seems to fix the problem but not otherwise interfere with the operation of the screen-reading.

This issue was definitely present in the current Windows development code and I presume it is also an issue for other OSes but I haven't confirmed it but I have duplicated it in the Unix version.

Also,  there is a `#define` in place in the `./src/AnnouncerWindows.cpp` file that was being included unconditionally - but it is not needed in ALL Windows build environments...! (My MSYS2/Mingw-w64 has it correctly defined already) so I've made it a conditional inclusion.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>