### PR TITLE
Fix: not able to import packages/modules on first profile load

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -788,9 +788,6 @@ void Host::resetProfile_phase2()
 // returns true+filepath if successful or false+error message otherwise
 std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, const QString& saveName, bool syncModules)
 {
-    emit profileSaveStarted();
-    qApp->processEvents();
-
     QString directory_xml;
     if (saveFolder.isEmpty()) {
         directory_xml = mudlet::getMudletPath(mudlet::profileXmlFilesPath, getName());
@@ -819,6 +816,9 @@ std::tuple<bool, QString, QString> Host::saveProfile(const QString& saveFolder, 
     if (currentlySavingProfile()) {
         return std::make_tuple(false, QString(), qsl("a save is already in progress"));
     }
+
+    emit profileSaveStarted();
+    qApp->processEvents();
 
     auto writer = new XMLexport(this);
     writers.insert(qsl("profile"), writer);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix: not able to import packages/modules on first profile load.
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/6488.

Code had a logic bug that emitted the profile save event even though the profile saving would not actually be going through.