### PR TITLE
Fix: OS dependent DEFINEDs for Screen-readers

### DIFF
--- a/src/Announcer.h
+++ b/src/Announcer.h
@@ -4,7 +4,7 @@
  *   Copyright 2019-2022 Leonard de Ruijter, James Teh - OSARA             *
  *   Copyright 2017 The Qt Company Ltd.                                    *
  *   Copyright (C) 2022 by Vadim Peretokin - vadim.peretokin@mudlet.org    *
- *   Copyright (C) 2022 by Stephen Lyons - slysven@virginmedia.com         *
+ *   Copyright (C) 2022-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,7 +35,8 @@
 #endif
 #include "post_guard.h"
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN32)
+// i.e. all other OSes
 // implemented per recommendation from Orca dev: https://mail.gnome.org/archives/orca-list/2022-June/msg00027.html
 class InvisibleNotification : public QWidget
 {
@@ -92,7 +93,8 @@ public:
     explicit Announcer(QWidget* parent = nullptr);
     void announce(const QString& text, const QString& processing = QString());
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN32)
+    // i.e. all other OSes
     static QAccessibleInterface* accessibleFactory(const QString& classname, QObject* object)
     {
 #undef interface // mingw compilation breaks without this
@@ -109,7 +111,8 @@ public:
 #endif
 
 private:
-#if defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD)
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN32)
+    // i.e. all other OSes
     InvisibleNotification* notification;
     InvisibleStatusbar* statusbar;
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2014-2017 by Ahmed Charles - acharles@outlook.com       #
-#    Copyright (C) 2015-2018, 2020 by Stephen Lyons                        #
+#    Copyright (C) 2015-2018, 2020, 2023 by Stephen Lyons                  #
 #                                                - slysven@virginmedia.com #
 #    Copyright (C) 2018 by Huadong Qi - novload@outlook.com                #
 #    Copyright (C) 2022 by Thiago Jung Bauermann - bauermann@kolabnow.com  #
@@ -159,11 +159,11 @@ set(mudlet_SRCS
 
 if(APPLE)
   list(APPEND mudlet_SRCS AnnouncerMac.mm)
-elseif(UNIX AND NOT APPLE)
-  list(APPEND mudlet_SRCS AnnouncerUnix.cpp)
 elseif(WIN32)
   list(APPEND mudlet_SRCS AnnouncerWindows.cpp)
   list(APPEND mudlet_SRCS uiawrapper.cpp)
+else()
+  list(APPEND mudlet_SRCS AnnouncerUnix.cpp)
 endif()
 
 # This is for compiled UI files, not those used at runtime

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1,5 +1,5 @@
 ############################################################################
-#    Copyright (C) 2013-2015, 2017-2018, 2020-2022 by Stephen Lyons        #
+#    Copyright (C) 2013-2015, 2017-2018, 2020-2023 by Stephen Lyons        #
 #                                                - slysven@virginmedia.com #
 #    Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            #
 #    Copyright (C) 2017 by Ian Adkins - ieadkins@gmail.com                 #
@@ -777,18 +777,19 @@ HEADERS += \
     ../3rdparty/discord/rpc/include/discord_register.h \
     ../3rdparty/discord/rpc/include/discord_rpc.h
 
-macx {
-    OBJECTIVE_SOURCES += AnnouncerMac.mm
-}
+macx|win32 {
+    macx {
+        OBJECTIVE_SOURCES += AnnouncerMac.mm
+    }
 
-win32 {
-    SOURCES += AnnouncerWindows.cpp \
-        uiawrapper.cpp
+    win32 {
+        SOURCES += AnnouncerWindows.cpp \
+            uiawrapper.cpp
 
-    HEADERS += uiawrapper.h
-}
-
-openbsd|linux {
+        HEADERS += uiawrapper.h
+    }
+} else {
+    # Everything else
     SOURCES += \
         AnnouncerUnix.cpp
 }


### PR DESCRIPTION
For OSes other than MacOs, Windows, Linux and OpenBSD the source code would fail to compile because some OS dependent portions did not accommodate them.

This proved to be a problem when I want back to boot into FreeBSD!

It is now set so that the `/src/AnnouncerUnix.cpp` file is included for all OSes other than MacOs or Windows.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>