### PR TITLE
Infrastructure: don't limit Mudlet binary installation to only Debug and Release CMake builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -601,7 +601,5 @@ if(UNIX AND NOT APPLE)
         GROUP_READ
         GROUP_EXECUTE
         WORLD_READ
-        WORLD_EXECUTE
-      CONFIGURATIONS Debug Release
-      COMPONENT All)
+        WORLD_EXECUTE)
 endif()


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Don't limit Mudlet binary installation to only Debug and Release CMake builds
#### Motivation for adding to Mudlet
Other configuration types such as `RelWithDebInfo` were excluded and that's not useful
#### Other info (issues closed, discussion etc)
Installation of the Mudlet binary should work for "all" configurations, and leaving the `CONFIGURATIONS` keyword out automatically makes it apply to "all". Removed "COMPONENT" for consistency