### PR TITLE
Fix: crash when reorganising scripts in editor tree view

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -232,7 +232,13 @@ void TTreeWidget::rowsInserted(const QModelIndex& parent, int start, int end)
     // determine position in parent list
 
     if (mIsDropAction) {
-        QModelIndex child = parent.model()->index(start, 0, parent);
+        // If parent.isValid() is false for the item being considered then that
+        // item is a top-level item. The obsolete parent.child(start, 0) that we
+        // used to use would return a null "QModelIndex" directly but now,
+        // since we must get the (const QAbstractModel*) from parent.model()
+        // and use that, we have to handle the case where that returns a
+        // nullptr - see: https://github.com/Mudlet/Mudlet/issues/6313
+        QModelIndex child = parent.isValid() ? parent.model()->index(start, 0, parent) : QModelIndex();
         int parentPosition = parent.row();
         int childPosition = child.row();
         if (!mChildID) {


### PR DESCRIPTION
This will close #6313 which was introduced by #4461. Note that although it now prevents the crashes - which came about from trying to use the `nullptr` returned from `QModelIndex::model()` when the `QModelIndex` instance that it is called on is *invalid*; the behaviour is now the same as from the previously used (but now declared obsolete) `QModelInded::child(int, int, QModelIndex&)` in that when a (script in this case) is dragged to the extreme left of the `QTreeWidget` it stays there in a horizontal position that would normally only be used by the root node in the tree which we take steps to hide completely in our `TTreeWidget`s.

On saving and loading such cases however the item does get shifted over to the right to a "normal" position - which is how our code used to behave. This is still something that should be addressed - so that we intercept such cases and fix them as they arrive, however my understanding of how Qt's Model/Views system works is just not good enough for me to be able to solve that issue currently.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>

<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

#### Motivation for adding to Mudlet

#### Other info (issues closed, discussion etc)
