### PR TITLE
Fix: stop user (floating/dockable) windows from being moved by `setWindow()`

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2022 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2015-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
  *                                                                         *
@@ -3294,6 +3294,20 @@ std::pair<bool, QString> Host::setWindow(const QString& windowname, const QStrin
     if (!mpConsole) {
         return {false, QString()};
     }
+    //checks - for reasons why the indicated thing might not be moved to the indicated destination
+    auto pDCheck = mpConsole->mDockWidgetMap.value(name);
+    if (pDCheck) {
+        return {false, qsl("element '%1' is the base of a floating/dockable user window and may not be moved").arg(name)};
+    }
+    if (mpDockableMapWidget) {
+        if (!name.compare(QLatin1String("mapper"), Qt::CaseInsensitive)) {
+            return {false, qsl("element '%1' is the map in a floating/dockable window and may not be moved").arg(name)};
+        }
+        if (!windowname.compare(QLatin1String("mapper"), Qt::CaseInsensitive)) {
+            return {false, qsl("window '%1' is the map in a floating/dockable window and may not receive other elements").arg(windowname)};
+        }
+    }
+
     //children
     auto pL = mpConsole->mLabelMap.value(name);
     auto pC = mpConsole->mSubConsoleMap.value(name);
@@ -3305,7 +3319,9 @@ std::pair<bool, QString> Host::setWindow(const QString& windowname, const QStrin
     auto pD = mpConsole->mDockWidgetMap.value(windowname);
     auto pSW = mpConsole->mScrollBoxMap.value(windowname);
 
-    if (!pSW && !pD && windowname.toLower() != QLatin1String("main")) {
+    if (!pSW && !pD && windowname.compare(QLatin1String("main"), Qt::CaseInsensitive)) {
+        // Third argument is non-zero (i.e. true) if the window name is NOT
+        // the given string:
         return {false, qsl("window '%1' not found").arg(windowname)};
     }
 
@@ -3347,7 +3363,7 @@ std::pair<bool, QString> Host::setWindow(const QString& windowname, const QStrin
             pN->show();
         }
         return {true, QString()};
-    } else if (pM && name.toLower() == QLatin1String("mapper")) {
+    } else if (pM && !name.compare(QLatin1String("mapper"), Qt::CaseInsensitive)) {
         pM->setParent(pW);
         pM->move(x1, y1);
         if (show) {


### PR DESCRIPTION
Otherwise it splits the `TConsole` from it's parent `TDockWidget` and it cannot be put back; they also share the same name internally which makes things confusing if they get divorced from each other.

The same could also apply if the map is being displayed in it's own floating/dockable widget, so detect, abort and report if that is the case, or if the window that that is in is given as the destination for any element (otherwise the message that the "element 'mapper' not found" is confusingly misleading)!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>