### PR TITLE
Fix: broken 'Ctrl+S' shortcut in PTBs

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -453,7 +453,7 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mAddGroup, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
 
     // 'Save Item' does not see to be translated as it is only ever used programmatically and not visible to the player
-    // 1/3 save button texts need to be kept in sync
+    // PLACEMARKER 1/3 save button texts need to be kept in sync
     mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), qsl("Save Item"), this);
     mSaveItem->setToolTip(tr("<p>Saves the selected item. (Ctrl+S)</p>"
                               "<p>Saving causes any changes to the item to take effect. It will not save to disk, "
@@ -6768,7 +6768,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     // texts are duplicated here so that translators can work with the full string
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
-        // 2/3 save button texts need to be kept in sync
+        // PLACEMARKER 2/3 save button texts need to be kept in sync
         mAddItem->setText(tr("Add Trigger"));
         mAddItem->setStatusTip(tr("Add new trigger"));
         mAddGroup->setText(tr("Add Trigger Group"));
@@ -8431,7 +8431,7 @@ void dlgTriggerEditor::setShortcuts(const bool active)
 {
     QList<QAction*> actionList = toolBar->actions();
     QString actionText;
-    // 3/3 save button texts need to be kept in sync
+    // PLACEMARKER 3/3 save button texts need to be kept in sync
     const QStringList saveButtonNames = {qsl("Save Item"), tr("Save Trigger"), tr("Save Timer"), tr("Save Alias"), tr("Save Script"), tr("Save Button"), tr("Save Key"), tr("Save Variable")};
     for (auto& action : actionList) {
         actionText = action->text();

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -452,7 +452,9 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     mAddGroup = new QAction(QIcon(qsl(":/icons/folder-new.png")), QString(), this);
     connect(mAddGroup, &QAction::triggered, this, &dlgTriggerEditor::slot_addNewGroup);
 
-    mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), QString(), this);
+    // 'Save Item' does not see to be translated as it is only ever used programmatically and not visible to the player
+    // 1/3 save button texts need to be kept in sync
+    mSaveItem = new QAction(QIcon(qsl(":/icons/document-save-as.png")), qsl("Save Item"), this);
     mSaveItem->setToolTip(tr("<p>Saves the selected item. (Ctrl+S)</p>"
                               "<p>Saving causes any changes to the item to take effect. It will not save to disk, "
                               "so changes will be lost in case of a computer/program crash (but Save Profile to the right will be secure.)</p>"));
@@ -6766,6 +6768,7 @@ void dlgTriggerEditor::changeView(EditorViewType view)
     // texts are duplicated here so that translators can work with the full string
     switch (mCurrentView) {
     case EditorViewType::cmTriggerView:
+        // 2/3 save button texts need to be kept in sync
         mAddItem->setText(tr("Add Trigger"));
         mAddItem->setStatusTip(tr("Add new trigger"));
         mAddGroup->setText(tr("Add Trigger Group"));
@@ -8428,9 +8431,11 @@ void dlgTriggerEditor::setShortcuts(const bool active)
 {
     QList<QAction*> actionList = toolBar->actions();
     QString actionText;
+    // 3/3 save button texts need to be kept in sync
+    const QStringList saveButtonNames = {qsl("Save Item"), tr("Save Trigger"), tr("Save Timer"), tr("Save Alias"), tr("Save Script"), tr("Save Button"), tr("Save Key"), tr("Save Variable")};
     for (auto& action : actionList) {
         actionText = action->text();
-        if (actionText ==  tr("Save Item")) {
+        if (saveButtonNames.contains(actionText)) {
             action->setShortcut((active) ? tr("Ctrl+S") : QString());
         } else if (actionText == tr("Save Profile")) {
             action->setShortcut((active) ? tr("Ctrl+Shift+S") : QString());
@@ -8439,7 +8444,6 @@ void dlgTriggerEditor::setShortcuts(const bool active)
     actionList = toolBar2->actions();
     for (auto& action : actionList) {
         actionText = action->text();
-        // TODO: Refactor into nice list to iterate
         if (actionText == tr("Triggers")) {
             action->setShortcut((active) ? tr("Ctrl+1") : QString());
         } else if (actionText == tr("Aliases")) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Restore 'Ctr+S' to work again
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/6514
#### Other info (issues closed, discussion etc)
The code to enable a shortcut depended on the buttons name to be `Save Item`, which got removed and was instead a blank string ("") at the time the code was running due to https://github.com/Mudlet/Mudlet/pull/6462.