### PR TITLE
Infrastucture: add clion and flatpak folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ CMakeLists.txt.user
 #CLion
 .idea
 cmake-build-debug
+cmake-build-minsizerel
+cmake-build-release
+cmake-build-relwithdebinfo
 
 #VS Code
 .vscode/*.code-workspace
@@ -38,3 +41,7 @@ compile_commands.json
 .vs
 out
 CMakeSettings.json
+
+# flatpak builder
+CI/.flatpak-builder
+CI/build-dir


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Add clion and flatpak folders to gitignore
#### Motivation for adding to Mudlet
Less cruft in the working HEAD for developers
#### Other info (issues closed, discussion etc)
