### PR TITLE
Infrastructure: disable Windows builds in github

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -38,11 +38,11 @@ jobs:
             compiler: clang_64
             qt: '5.14.2'
             deploy: 'deploy'
-          - os: windows-2019
-            buildname: 'windows'
-            triplet: x64-mingw-dynamic
-            # compiler: flag not used in windows pipeline
-            qt: '5.14.2'
+#           - os: windows-2019
+#             buildname: 'windows'
+#             triplet: x64-mingw-dynamic
+#             # compiler: flag not used in windows pipeline
+#             qt: '5.14.2'
 
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Disable Windows builds in github - we use Appveyor for the actual Windows builds anyhow.
#### Motivation for adding to Mudlet
So we get green ticks again.
#### Other info (issues closed, discussion etc)
A library we use via vcpkg is no longer available for download on its source website - but at the same time, updating vcpkg to latest [didn't work](https://github.com/Mudlet/Mudlet/actions/runs/4026284770) and requires more time & energy to investigate.