### PR TITLE
Infrastructure: fix automated Crowdin texts update failing

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   update-and-commit-text:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # for gr2m/create-or-update-pull-request-action to push local changes
+      pull-requests: write  # for gr2m/create-or-update-pull-request-action to create a PR
     if: ${{ github.repository_owner == 'Mudlet' }}
     steps:
     - uses: actions/checkout@v3
@@ -32,7 +35,7 @@ jobs:
         echo ::set-output name=lines_changed::$lines_changed
 
     - name: send in a pull request
-      uses: gr2m/create-or-update-pull-request-action@v1.x
+      uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
       if: steps.getdiff.outputs.lines_changed > 0
       env:
         GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_3RDPARTY }}


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix automated Crowdin texts update failing
#### Motivation for adding to Mudlet
So texts to translate in Crowdin are up to date again.
#### Other info (issues closed, discussion etc)
I'm not sure if this really will fix it, but nodejs [does it this way](https://github.com/nodejs/node/blob/main/.github/workflows/license-builder.yml) so let's see.

Other actions (such as 3rd party sources update) will follow if this one works.