### PR TITLE
Infrastructure: Automatically build only in Mudlet repository

### DIFF
--- a/.github/workflows/build-mudlet.yml
+++ b/.github/workflows/build-mudlet.yml
@@ -12,6 +12,7 @@ jobs:
   compile-mudlet:
     name: ${{matrix.buildname}}
     runs-on: ${{matrix.os}}
+    if: ${{ github.repository_owner == 'Mudlet' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
#### Brief overview of PR changes/additions
[build-mudlet.yml](https://github.com/Mudlet/Mudlet/blob/development/.github/workflows/build-mudlet.yml) workflow will not run in forks automatically anymore.

#### Motivation for adding to Mudlet
Fix #6517

#### Other info (issues closed, discussion etc)
