### PR TITLE
Fix: off-by-one-million error in third argument to Lua `showNotification()`

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -17153,16 +17153,14 @@ int TLuaInterpreter::showNotification(lua_State* L)
     if (n >= 2) {
         text = getVerifiedString(L, __func__, 2, "message");
     }
-    int notificationExpirationTime = 1000;
-    bool timeoutGiven = false;
+    std::optional<int> notificationExpirationTime;
     if (n >= 3) {
         notificationExpirationTime = qMax(qRound(getVerifiedDouble(L, __func__, 3, "expiration time in seconds") * 1000), 1000);
-        timeoutGiven = true;
     }
 
     mudlet::self()->mTrayIcon.show();
-    if (timeoutGiven) {
-        mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon(), notificationExpirationTime);
+    if (notificationExpirationTime.has_value()) {
+        mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon(), notificationExpirationTime.value());
     } else {
         mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon());
     }

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -17153,14 +17153,21 @@ int TLuaInterpreter::showNotification(lua_State* L)
     if (n >= 2) {
         text = getVerifiedString(L, __func__, 2, "message");
     }
-    int notificationExpirationTime = 1;
+    int notificationExpirationTime = 1000;
+    bool timeoutGiven = false;
     if (n >= 3) {
-        notificationExpirationTime = qMax(qRound(getVerifiedDouble(L, __func__, 3, "expiration time in seconds") / 1000), 1);
+        notificationExpirationTime = qMax(qRound(getVerifiedDouble(L, __func__, 3, "expiration time in seconds") * 1000), 1000);
+        timeoutGiven = true;
     }
 
     mudlet::self()->mTrayIcon.show();
-    mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon(), notificationExpirationTime);
-    return 0;
+    if (timeoutGiven) {
+        mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon(), notificationExpirationTime);
+    } else {
+        mudlet::self()->mTrayIcon.showMessage(title, text, mudlet::self()->mTrayIcon.icon());
+    }
+    lua_pushboolean(L, true);
+    return 1;
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#saveJsonMap


### PR DESCRIPTION
This defect was present in the original PR #4468.

It is due to the `QSystemTrayIcon::showMessage(...)` methods taking an optional `int` timeout argument which represents a period in **miliiseconds** and not *seconds* that the Lua function uses. The default value is 10000 milliseconds or 10 seconds.

As such the parameter that the user supplies needs to be multiplied by 1000 instead of being divided by that amount! This means that the prior code would probably only briefly flash the message text - however since the Windows OS case tends to ignore the timeout if the application is the one in focus it might not have been quite as obvious for some users.

Note that, at least the KDE DE on Linux case, the tray icon may be separate from the pop-up display of the messages - in that the latter may not appear adjacent to the icon. This was confusing me at first when I discovered the issue as the icon with two options ("Hide" and "Quit Mudlet") was being shown the first time the `showNotification(...)` function was used, but it didn't provide any other functionality besides hiding itself and quitting Mudlet and it does not hide itself after the message has gone away. Also, hiding the icon does not dismiss the message either!

This PR also revises the function to return a `true` argument on successful invocation - which could be used with a minimum `1` second value as the third argument for a profile that wants to use such user notifications to check whether it has the prior version, that will return nothing (i.e. a `nil`) and on anything other than Windows only show something briefly, (e.g. a suggested "Profile Xxxx started") before immediately hiding it compared to after this PR has been incorporated which would give a `true` and display the same message for a second. On Windows, assuming Mudlet is in the foreground the UX will likely be the same for both cases.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>