### PR TITLE
Infrastructure: Delete popup window on close

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4536,6 +4536,7 @@ void T2DMap::slot_setCustomLine()
     if (!dialog) {
         return;
     }
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowIcon(QIcon(qsl(":/icons/mudlet_custom_exit.png")));
     mCustomLinesRoomFrom = mMultiSelectionHighlightRoomId;
     mCustomLinesRoomTo = 0;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4059,6 +4059,7 @@ void T2DMap::slot_setArea()
     if (!set_room_area_dialog) {
         return;
     }
+    set_room_area_dialog->setAttribute(Qt::WA_DeleteOnClose);
     arealist_combobox = set_room_area_dialog->findChild<QComboBox*>("arealist_combobox");
     if (!arealist_combobox) {
         return;

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3983,6 +3983,7 @@ void T2DMap::slot_setExits()
         auto pD = new dlgRoomExits(mpHost, mMultiSelectionHighlightRoomId, this);
         pD->show();
         pD->raise();
+        pD->setAttribute(Qt::WA_DeleteOnClose);
     }
 }
 

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3597,6 +3597,7 @@ void T2DMap::slot_movePosition()
 
     auto dialog = new QDialog(this);
     auto gridLayout = new QGridLayout;
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setLayout(gridLayout);
     dialog->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     dialog->setContentsMargins(0, 0, 0, 0);

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -3262,6 +3262,7 @@ void T2DMap::slot_customLineProperties()
                 qWarning("T2DMap::slot_customLineProperties() ERROR: failed to create the dialog!");
                 return;
             }
+            dialog->setAttribute(Qt::WA_DeleteOnClose);
             dialog->setWindowIcon(QIcon(qsl(":/icons/mudlet_custom_exit_properties.png")));
             auto* le_toId = dialog->findChild<QLineEdit*>(qsl("toId"));
             auto* le_fromId = dialog->findChild<QLineEdit*>(qsl("fromId"));

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4,7 +4,7 @@
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2021-2022 by Piotr Wilczynski - delwing@gmail.com       *
- *   Copyright (C) 2022 by Lecker Kebap - Leris@mudlet.org                 *
+ *   Copyright (C) 2022-2023 by Lecker Kebap - Leris@mudlet.org            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -8,6 +8,7 @@
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2017 by Michael Hupp - darksix@northfire.org            *
  *   Copyright (C) 2017 by Colton Rasbury - rasbury.colton@gmail.com       *
+ *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -1674,6 +1675,7 @@ void cTelnet::processTelnetCommand(const std::string& command)
                 mpProgressDialog = new QProgressDialog(tr("downloading game GUI from server"), tr("Cancel", "Cancel download of GUI package from Server"), 0, 4000000, mpHost->mpConsole);
                 connect(mpPackageDownloadReply, &QNetworkReply::downloadProgress, this, &cTelnet::slot_setDownloadProgress);
                 connect(mpProgressDialog, &QProgressDialog::canceled, mpPackageDownloadReply, &QNetworkReply::abort);
+                mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose);
                 mpProgressDialog->show();
             }
             return;
@@ -2036,6 +2038,7 @@ void cTelnet::setGMCPVariables(const QByteArray& msg)
         mpProgressDialog = new QProgressDialog(tr("downloading game GUI from server"), tr("Cancel", "Cancel download of GUI package from Server"), 0, 4000000, mpHost->mpConsole);
         connect(mpPackageDownloadReply, &QNetworkReply::downloadProgress, this, &cTelnet::slot_setDownloadProgress);
         connect(mpProgressDialog, &QProgressDialog::canceled, mpPackageDownloadReply, &QNetworkReply::abort);
+        mpProgressDialog->setAttribute(Qt::WA_DeleteOnClose);
         mpProgressDialog->show();
         return;
     } else if (transcodedMsg.startsWith(QLatin1String("Client.Map"), Qt::CaseInsensitive)) {

--- a/src/dlgRoomProperties.cpp
+++ b/src/dlgRoomProperties.cpp
@@ -482,6 +482,7 @@ void dlgRoomProperties::slot_defineNewColor()
 void dlgRoomProperties::slot_openRoomColorSelector()
 {
     auto dialog = new QDialog(this);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->setWindowTitle(tr("Set room color"));
     auto vboxLayout = new QVBoxLayout;
     dialog->setLayout(vboxLayout);

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -7,6 +7,7 @@
  *   Copyright (C) 2017 by Tom Scheper - scheper@gmail.com                 *
  *   Copyright (C) 2011-2021 by Vadim Peretokin - vperetokin@gmail.com     *
  *   Copyright (C) 2022 by Thiago Jung Bauermann - bauermann@kolabnow.com  *
+ *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1215,8 +1215,9 @@ void mudlet::slot_packageExporter()
     if (!pH) {
         return;
     }
-    auto d = new dlgPackageExporter(this, pH);
-    d->show();
+    auto dialog = new dlgPackageExporter(this, pH);
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->show();
 }
 
 void mudlet::slot_closeCurrentProfile()

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -1216,9 +1216,8 @@ void mudlet::slot_packageExporter()
     if (!pH) {
         return;
     }
-    auto dialog = new dlgPackageExporter(this, pH);
-    dialog->setAttribute(Qt::WA_DeleteOnClose);
-    dialog->show();
+    auto d = new dlgPackageExporter(this, pH);
+    d->show();
 }
 
 void mudlet::slot_closeCurrentProfile()


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Make sure to actually delete the popup windows after the player closes them, so they do not linger on.

#### Motivation for adding to Mudlet
Fix #6490 for some but not all popups:

- [x] Move to position (in `T2DMap::slot_movePosition()`)
- [x] Set exits (in `T2DMap::slot_setExits()`)
- [x] Move to area (in `T2DMap::slot_setArea()`)
- [x] Create exit line (in `T2DMap::slot_setCustomLine()`)
- [x] Custom line properties (in `T2DMap::slot_customLineProperties()`)
- [x] Select room color (in `dlgRoomProperties::slot_openRoomColorSelector()`)
- [ ] "Package exporter" (in `mudlet::slot_packageExporter()`) - postponed after failed attempt below to #6545 
- [x] "downloading game GUI from server"  (ATCP) (in `void cTelnet::processTelnetCommand(const std::string& command)`)
- [x] "downloading game GUI from server"  (GMCP) (in `void cTelnet::setGMCPVariables(const QByteArray& msg)`)

#### Other info (issues closed, discussion etc)
Thanks to atari2600tim and SlySven!