### PR TITLE
Infrastructure: Only assign milestones to PRs without one

### DIFF
--- a/.github/workflows/tag-pull-requests.yml
+++ b/.github/workflows/tag-pull-requests.yml
@@ -33,8 +33,17 @@ jobs:
       env:
         TOKEN: ${{ secrets.GH_PAT_UPDATE_PULL_REQUESTS }}
       run: |
-        curl -s --request PATCH \
+        # Fetch pull request details
+        PR_DETAILS=$(curl -s --request GET \
           -H "Accept: application/vnd.github.v3+json"      \
           --url ${{ github.event.pull_request.issue_url }} \
-          --header "authorization: token $TOKEN"           \
-          --data '{"milestone": '"$MILESTONE_NUMBER"'}'
+          --header "authorization: token $TOKEN")
+
+        # Check if the pull request has a milestone already
+        if [ $(echo "$PR_DETAILS" | jq '.milestone == null') == "true" ]; then
+            curl -s --request PATCH \
+              -H "Accept: application/vnd.github.v3+json"      \
+              --url ${{ github.event.pull_request.issue_url }} \
+              --header "authorization: token $TOKEN"           \
+              --data '{"milestone": '"$MILESTONE_NUMBER"'}'
+        fi


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Only assign milestones to PRs without one
#### Motivation for adding to Mudlet
This is so if a PR is not meant to go into the next release - but perhaps next-next release - the 
#### Other info (issues closed, discussion etc)
Code written by ChatGPT and tested by me locally

![image](https://user-images.githubusercontent.com/110988/216419207-0e8cd4d6-8aed-4470-bd13-dca091dc292d.png)
