### PR TITLE
Infrastructure: remove 'code-scanning' configuration from CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -95,7 +95,7 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        queries: code-scanning, security-extended, security-and-quality
+        queries: security-extended, security-and-quality
 
     # workaround a poor interaction between github actions/cmake/vcpkg, see https://github.com/lukka/run-vcpkg/issues/88#issuecomment-885758902
     - name: Use CMake 3.20.1


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Remove 'code-scanning' configuration from CodeQL
#### Motivation for adding to Mudlet
It is not actually a valid configuration, despite github [mentioning it](https://github.com/github/roadmap/issues/633)
