### PR TITLE
Infrastructure: improve TLabel creation

### DIFF
--- a/src/TLabel.cpp
+++ b/src/TLabel.cpp
@@ -32,11 +32,13 @@
 #include "post_guard.h"
 
 
-TLabel::TLabel(Host* pH, QWidget* pW)
+TLabel::TLabel(Host* pH, const QString& name, QWidget* pW)
 : QLabel(pW)
 , mpHost(pH)
+, mName(name)
 {
     setMouseTracking(true);
+    setObjectName(qsl("label_%1_%2").arg(pH->getName(), mName));
 }
 
 TLabel::~TLabel()

--- a/src/TLabel.h
+++ b/src/TLabel.h
@@ -43,7 +43,7 @@ class TLabel : public QLabel
 
 public:
     Q_DISABLE_COPY(TLabel)
-    explicit TLabel(Host* pH, QWidget* pW = nullptr);
+    explicit TLabel(Host*, const QString&, QWidget* pW = nullptr);
     ~TLabel();
 
     void setClick(const int func);
@@ -64,6 +64,7 @@ public:
     void setClickThrough(bool clickthrough);
 
     QPointer<Host> mpHost;
+    QString mName;
     int mClickFunction = 0;
     int mDoubleClickFunction = 0;
     int mReleaseFunction = 0;

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -554,14 +554,13 @@ TLabel* TMainConsole::createLabel(const QString& windowname, const QString& name
     auto pS = mScrollBoxMap.value(windowname);
     if (!pL) {
         if (pW) {
-            pL = new TLabel(mpHost, pW->widget());
+            pL = new TLabel(mpHost, name, pW->widget());
         } else if (pS) {
-            pL = new TLabel(mpHost, pS->widget());
+            pL = new TLabel(mpHost, name, pS->widget());
         } else {
-            pL = new TLabel(mpHost, mpMainFrame);
+            pL = new TLabel(mpHost, name, mpMainFrame);
         }
         mLabelMap[name] = pL;
-        pL->setObjectName(name);
         pL->setAutoFillBackground(fillBackground);
         pL->setClickThrough(clickThrough);
         pL->resize(width, height);
@@ -570,9 +569,9 @@ TLabel* TMainConsole::createLabel(const QString& windowname, const QString& name
         pL->show();
         mpHost->setBackgroundColor(name, 32, 32, 32, 255);
         return pL;
-    } else {
-        return nullptr;
     }
+
+    return nullptr;
 }
 
 std::pair<bool, QString> TMainConsole::deleteLabel(const QString& name)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
This improves the `TLabel` creation by taking the name as an argument to the constructor so that it can be stored within (not immediately useful except perhaps in temporary debugging code) and also used to create a more meaningful `(QString) objectName` which now is of the form `label_<HostName>_<LabelName>`.

#### Motivation for adding to Mudlet
I was debugging some code and realised that I could not identify some particular labels because they had the same name but were from different profiles and that their `objectName` was being manually added after creation - I realised that I could reasonably move the name assignment to the constructor and add a more meaningful name therein.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>