### PR TITLE
Fix: blankLinesBehaviour and caretShortcut's setConfig option

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -13727,7 +13727,7 @@ void TLuaInterpreter::parseMSSP(const QString& string_data)
                 host.mMSSPHostName = msspVAL;
             } else if (msspVAR == "TLS" || msspVAR == "SSL") {
                 // In certain MSSP fields "-1" and "1" denote not supported/supported indicators,
-                // however the port is the standard value here. Ignore those values here. 
+                // however the port is the standard value here. Ignore those values here.
                 host.mMSSPTlsPort = (msspVAL != "-1" && msspVAL != "1") ? msspVAL.toInt() : 0;
             }
         }
@@ -17556,6 +17556,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
         } else if (behaviour == qsl("replacewithspace")) {
             host.mBlankLineBehaviour = Host::BlankLineBehaviour::ReplaceWithSpace;
         }
+        return success();
     }
     if (key == qsl("caretShortcut")) {
         static const QStringList keys{"none", "tab", "ctrltab", "f6"};
@@ -17576,6 +17577,7 @@ int TLuaInterpreter::setConfig(lua_State * L)
         } else if (key == qsl("f6")) {
             host.mCaretShortcut = Host::CaretShortcut::F6;
         }
+        return success();
     }
 
     return warnArgumentValue(L, __func__, qsl("'%1' isn't a valid configuration option").arg(key));


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix blankLinesBehaviour and caretShortcut's setConfig option not to erronously return "isn't a valid configuration option" after it did successfully set the option
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
Thanks to SlySven for finding it