### PR TITLE
Fix: temporarily stop using QtGamePad on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,7 +364,11 @@ find_package(
              UiTools
              Widgets
              Concurrent)
-find_package(Qt5 COMPONENTS Gamepad QUIET)
+if(NOT WIN32)
+  # there is a suspicion that the Gamepad module is breaking things on Windows
+  # See: https://github.com/Mudlet/Mudlet/issues/6500
+  find_package(Qt5 COMPONENTS Gamepad QUIET)
+endif()
 find_package(Qt5 COMPONENTS TextToSpeech QUIET)
 
 if(Qt5Core_VERSION VERSION_LESS 5.14)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -85,7 +85,9 @@ win32 {
 }
 
 QT += network uitools multimedia gui concurrent
-qtHaveModule(gamepad) {
+# there is a suspicion that the Gamepad module is breaking things on Windows
+# See: https://github.com/Mudlet/Mudlet/issues/6500
+!win32 : qtHaveModule(gamepad) {
     QT += gamepad
     !build_pass : message("Using Gamepad module")
 }


### PR DESCRIPTION
This is intended to be merged into `development` for a couple of days to see if it is the cause of upgrade failures on that platform, this is to be measured by investigating TWO cases:
1. whether the upgrade works on that platform when the PTB build for the **upgrade** version does not have the gamepad module.
2. whether the upgrade works on that platform when the **existing** version does not have the gamepad module.

If this is successful in resolving the problem in Issue #6500 then it means that we will have to withdraw supporting that feature on that OS. It should be noted that Qt is withdrawing that module from Qt 6.x so it will be going away eventually for us as well.

The reason for this PR is that I have noticed that my local (64-bit) builds in my Windows MSYS2/Mingw-w64 environment are Seg. Faulting (i.e. fatally crashing) during the termination of the Mudlet application inside that Qt Module's code. As such I suspect it may be impacting the update mechanism on that platform that normally does "things" relating to the update process when the Mudlet application terminates and if it isn't doing so properly that could be the cause of the current breakage in that process on THAT OS.

#### Other info (issues closed, discussion etc)
If this makes no changes to the situation after BOTH the PTB version being upgraded from and the later version being upgraded to do NOT have the Qt Gamepad module in them then this **PR should be reverted** and we'll have to investigate other causes...