### PR TITLE
Fix: Mudlet crashing on start when you create a buffer

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2164,7 +2164,7 @@ void TConsole::slot_adjustAccessibleNames()
         return;
     case Buffer:
         // This is not a visible thing so is not accessible to screen readers
-        break;
+        return;
     case UnknownType:
         // Should never be used -  and since we have now handled ALL enum values
         // we do not need a "default:" entry

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -2164,7 +2164,7 @@ void TConsole::slot_adjustAccessibleNames()
         return;
     case Buffer:
         // This is not a visible thing so is not accessible to screen readers
-        [[fallthrough]];
+        break;
     case UnknownType:
         // Should never be used -  and since we have now handled ALL enum values
         // we do not need a "default:" entry


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Mudlet was crashing on start when you created a buffer as of a few commits ago
#### Motivation for adding to Mudlet
Bugfix
#### Other info (issues closed, discussion etc)
This also means we don't have any Busted tests for creating buffers!