### PR TITLE
Infrastructure: revert "Fix: temporarily stop using QtGamePad on Windows (#6548)"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -364,11 +364,7 @@ find_package(
              UiTools
              Widgets
              Concurrent)
-if(NOT WIN32)
-  # there is a suspicion that the Gamepad module is breaking things on Windows
-  # See: https://github.com/Mudlet/Mudlet/issues/6500
-  find_package(Qt5 COMPONENTS Gamepad QUIET)
-endif()
+find_package(Qt5 COMPONENTS Gamepad QUIET)
 find_package(Qt5 COMPONENTS TextToSpeech QUIET)
 
 if(Qt5Core_VERSION VERSION_LESS 5.14)

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -85,9 +85,7 @@ win32 {
 }
 
 QT += network uitools multimedia gui concurrent
-# there is a suspicion that the Gamepad module is breaking things on Windows
-# See: https://github.com/Mudlet/Mudlet/issues/6500
-!win32 : qtHaveModule(gamepad) {
+qtHaveModule(gamepad) {
     QT += gamepad
     !build_pass : message("Using Gamepad module")
 }


### PR DESCRIPTION
This reverts commit aa4aa5acdde79e09f833e980377a740cc028324e.

It seems the QGamepad module is NOT the cause of #6500.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>