### PR TITLE
Fix: uninstalling many synced modules at once crashes Mudlet

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2024,14 +2024,13 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     QString dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
     removeDir(dest, dest);
 
-    static std::optional<bool> saveTimer;
     // ensure only one timer is running in case multiple modules are uninstalled at once
-    if (!saveTimer.has_value() || !saveTimer.value()) {
-        saveTimer = true;
+    if (!mSaveTimer.has_value() || !mSaveTimer.value()) {
+        mSaveTimer = true;
         // save the profile on the next Qt main loop cycle in order for the asyncronous save mechanism
         // not to try to write to disk a package/module that just got uninstalled and removed from memory
         QTimer::singleShot(0, this, [this]() {
-            saveTimer = false;
+            mSaveTimer = false;
             saveProfile();
         });
     }

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -1921,6 +1921,12 @@ bool Host::uninstallPackage(const QString& packageName, int module)
     //     0=package, 1=uninstall from dialog, 2=uninstall due to module syncing,
     //     3=uninstall from a script
 
+    // block packages/modules from being uninstalled while a profile save is in progress
+    // just so the save mechanism doesn't get surprised with something getting removed from memory under its feet
+    if (currentlySavingProfile()) {
+        return false;
+    }
+
     if (module) {
         if (!mInstalledModules.contains(packageName)) {
             return false;
@@ -2017,7 +2023,19 @@ bool Host::uninstallPackage(const QString& packageName, int module)
 
     QString dest = mudlet::getMudletPath(mudlet::profilePackagePath, getName(), packageName);
     removeDir(dest, dest);
-    saveProfile();
+
+    static std::optional<bool> saveTimer;
+    // ensure only one timer is running in case multiple modules are uninstalled at once
+    if (!saveTimer.has_value() || !saveTimer.value()) {
+        saveTimer = true;
+        // save the profile on the next Qt main loop cycle in order for the asyncronous save mechanism
+        // not to try to write to disk a package/module that just got uninstalled and removed from memory
+        QTimer::singleShot(0, this, [this]() {
+            saveTimer = false;
+            saveProfile();
+        });
+    }
+
     //NOW we reset if we're uninstalling a module
     if (mpEditorDialog && module == 3) {
         mpEditorDialog->doCleanReset();

--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -2031,7 +2031,9 @@ bool Host::uninstallPackage(const QString& packageName, int module)
         // not to try to write to disk a package/module that just got uninstalled and removed from memory
         QTimer::singleShot(0, this, [this]() {
             mSaveTimer = false;
-            saveProfile();
+            if (auto [ok, filename, error] = saveProfile(); !ok) {
+                qDebug() << qsl("Host::uninstallPackage: Couldn't save '%1' to '%2' because: %3").arg(getName(), filename, error);
+            }
         });
     }
 

--- a/src/Host.h
+++ b/src/Host.h
@@ -724,6 +724,8 @@ private:
     AliasUnit mAliasUnit;
     ActionUnit mActionUnit;
     KeyUnit mKeyUnit;
+    // ensures that only one saveProfile call is active when multiple modules are being uninstalled in one go
+    std::optional<bool> mSaveTimer;
 
     QFile mErrorLogFile;
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix uninstalling many synced modules at once crashing Mudlet.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/6414
#### Other info (issues closed, discussion etc)
Because profile saving is and runs on a different thread (to freeze Mudlet the least amount of time), if you're uninstalling many modules at once, the previous code would start saving _while_ uninstallations were still happening. That's a problem, because it would try to write to disk something that didn't exist anymore.

Code now will only kick off one save for multiple modules and at the same time, block uninstallation should a save be in progress.