### PR TITLE
Fix: application crash after move room to area

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -4060,7 +4060,6 @@ void T2DMap::slot_setArea()
     if (!set_room_area_dialog) {
         return;
     }
-    set_room_area_dialog->setAttribute(Qt::WA_DeleteOnClose);
     arealist_combobox = set_room_area_dialog->findChild<QComboBox*>("arealist_combobox");
     if (!arealist_combobox) {
         return;
@@ -4116,6 +4115,7 @@ void T2DMap::slot_setArea()
             }
         }
     }
+    set_room_area_dialog->deleteLater();
     repaint();
 }
 


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions

Parent dialog was deleted while selectbox object was still accessed.

#### Motivation for adding to Mudlet

No crashese :)

#### Other info (issues closed, discussion etc)

fixes #6558 
