### PR TITLE
Add: Find and Replace feature in script editor #3694 

### DIFF
--- a/src/dlgSourceEditorFindArea.cpp
+++ b/src/dlgSourceEditorFindArea.cpp
@@ -31,6 +31,7 @@ dlgSourceEditorFindArea::dlgSourceEditorFindArea(QWidget* pParentWidget)
     // init generated dialog
     setupUi(this);
     lineEdit_findText->installEventFilter(this);
+    lineEdit_replaceText->installEventFilter(this);
 }
 
 bool dlgSourceEditorFindArea::eventFilter(QObject* obj, QEvent* event)
@@ -39,6 +40,19 @@ bool dlgSourceEditorFindArea::eventFilter(QObject* obj, QEvent* event)
         if (event->type() == QEvent::KeyPress) {
             QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
             if (keyEvent->key() == Qt::Key_Enter or keyEvent->key() == Qt::Key_Return) {
+                if (keyEvent->modifiers().testFlag(Qt::ShiftModifier)) {
+                    emit signal_sourceEditorFindPrevious();
+                } else {
+                    emit signal_sourceEditorFindNext();
+                }
+                return true;
+            }
+        }
+    } else if (obj == lineEdit_replaceText) {
+        if (event->type() == QEvent::KeyPress) {
+            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+            if (keyEvent->key() == Qt::Key_Enter or keyEvent->key() == Qt::Key_Return) {
+                emit signal_sourceEditorReplace();
                 if (keyEvent->modifiers().testFlag(Qt::ShiftModifier)) {
                     emit signal_sourceEditorFindPrevious();
                 } else {

--- a/src/dlgSourceEditorFindArea.h
+++ b/src/dlgSourceEditorFindArea.h
@@ -45,6 +45,7 @@ signals:
     void signal_sourceEditorFindPrevious();
     void signal_sourceEditorFindNext();
     void signal_sourceEditorMovementNecessary();
+    void signal_sourceEditorReplace();
 };
 
 #endif // MUDLET_DLGSOURCEEDITORFINDAREA_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -223,8 +223,10 @@ dlgTriggerEditor::dlgTriggerEditor(Host* pH)
     connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorMovementNecessary, this, &dlgTriggerEditor::slot_sourceFindMove);
     connect(mpSourceEditorFindArea->pushButton_findPrevious, &QPushButton::clicked, this, &dlgTriggerEditor::slot_sourceFindPrevious);
     connect(mpSourceEditorFindArea->pushButton_findNext, &QPushButton::clicked, this, &dlgTriggerEditor::slot_sourceFindNext);
+    connect(mpSourceEditorFindArea->pushButton_replace, &QPushButton::clicked, this, &dlgTriggerEditor::slot_sourceReplace);
     connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorFindPrevious, this, &dlgTriggerEditor::slot_sourceFindPrevious);
     connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorFindNext, this, &dlgTriggerEditor::slot_sourceFindNext);
+    connect(mpSourceEditorFindArea, &dlgSourceEditorFindArea::signal_sourceEditorReplace, this, &dlgTriggerEditor::slot_sourceReplace);
     connect(mpSourceEditorFindArea->pushButton_close, &QPushButton::clicked, this, &dlgTriggerEditor::slot_closeSourceFind);
 
     auto openSourceFindAction = new QAction(this);
@@ -7231,6 +7233,21 @@ void dlgTriggerEditor::slot_closeSourceFind()
     controller->update();
     mpSourceEditorFindArea->hide();
     mpSourceEditorEdbee->setFocus();
+}
+
+void dlgTriggerEditor::slot_sourceReplace()
+{
+    auto controller = mpSourceEditorEdbee->controller();
+    auto replaceText = mpSourceEditorFindArea->lineEdit_replaceText->text();
+    for(int i = 0; i < controller->textSelection()->rangeCount(); i++) {
+        auto &range = controller->textSelection()->range(i);
+        if(mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
+            slot_sourceFindNext();
+            continue;
+        }
+        mpSourceEditorEdbee->textDocument()->replace(range.anchor(), range.length(), replaceText);
+        range.setLength(mpSourceEditorFindArea->lineEdit_replaceText->text().length());
+    }
 }
 
 void dlgTriggerEditor::slot_sourceFindPrevious()

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7244,6 +7244,9 @@ void dlgTriggerEditor::slot_sourceReplace()
         if(mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
             slot_sourceFindNext();
             continue;
+        } else if (range.length() == 0) {
+            slot_sourceFindPrevious();
+            continue;
         }
         mpSourceEditorEdbee->textDocument()->replace(range.anchor(), range.length(), replaceText);
         range.setLength(mpSourceEditorFindArea->lineEdit_replaceText->text().length());

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7244,7 +7244,8 @@ void dlgTriggerEditor::slot_sourceReplace()
         if (mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
             slot_sourceFindNext();
             continue;
-        } else if (range.length() == 0) {
+        }
+        if (!range.hasSelection()) {
             slot_sourceFindPrevious();
             continue;
         }

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -7239,9 +7239,9 @@ void dlgTriggerEditor::slot_sourceReplace()
 {
     auto controller = mpSourceEditorEdbee->controller();
     auto replaceText = mpSourceEditorFindArea->lineEdit_replaceText->text();
-    for(int i = 0; i < controller->textSelection()->rangeCount(); i++) {
+    for (int i = 0; i < controller->textSelection()->rangeCount(); i++) {
         auto &range = controller->textSelection()->range(i);
-        if(mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
+        if (mpSourceEditorEdbee->textDocument()->text().mid(range.anchor(), range.length()) == replaceText) {
             slot_sourceFindNext();
             continue;
         } else if (range.length() == 0) {

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -266,6 +266,7 @@ public slots:
     void slot_sourceFindPrevious();
     void slot_sourceFindNext();
     void slot_sourceFindTextChanges();
+    void slot_sourceReplace();
     void slot_saveEdits();
     void slot_copyXml();
     void slot_pasteXml();

--- a/src/ui/source_editor_find_area.ui
+++ b/src/ui/source_editor_find_area.ui
@@ -37,6 +37,9 @@
    </property>
    <item>
     <widget class="QLineEdit" name="lineEdit_findText">
+     <property name="placeholderText">
+      <string>Find</string>
+     </property>
      <property name="clearButtonEnabled">
       <bool>true</bool>
      </property>
@@ -77,7 +80,11 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEdit_replaceText"/>
+    <widget class="QLineEdit" name="lineEdit_replaceText">
+     <property name="placeholderText">
+      <string>Replace</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QPushButton" name="pushButton_replace">

--- a/src/ui/source_editor_find_area.ui
+++ b/src/ui/source_editor_find_area.ui
@@ -19,7 +19,7 @@
   <property name="focusPolicy">
    <enum>Qt::StrongFocus</enum>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="6,0,1,0,0,0">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="5,0,0,5,0,0">
    <property name="sizeConstraint">
     <enum>QLayout::SetDefaultConstraint</enum>
    </property>
@@ -98,7 +98,8 @@
       <string/>
      </property>
      <property name="icon">
-      <iconset theme="edit-paste"/>
+      <iconset theme="edit-paste">
+       <normaloff>.</normaloff>.</iconset>
      </property>
      <property name="flat">
       <bool>true</bool>

--- a/src/ui/source_editor_find_area.ui
+++ b/src/ui/source_editor_find_area.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>340</width>
-    <height>30</height>
+    <width>542</width>
+    <height>36</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="focusPolicy">
    <enum>Qt::StrongFocus</enum>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="6,1,1,0">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="6,0,1,0,0,0">
    <property name="sizeConstraint">
     <enum>QLayout::SetDefaultConstraint</enum>
    </property>
@@ -70,6 +70,28 @@
      <property name="icon">
       <iconset resource="../mudlet.qrc">
        <normaloff>:/icons/import.png</normaloff>:/icons/import.png</iconset>
+     </property>
+     <property name="flat">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="lineEdit_replaceText"/>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_replace">
+     <property name="maximumSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset theme="edit-paste"/>
      </property>
      <property name="flat">
       <bool>true</bool>


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
This PR adds a Replace feature to the dlgSourceEditorFindArea class. It can be triggered from the clipboard-like icon (wasn't able to make the find-replace icon fit in 16x16 correctly, probably a nice improvement to perform later) or by pressing enter on the second textbar.

#### Motivation for adding to Mudlet
I found out about the project from the bounty, and was interested because I used to play a lot of MUDs when I first got into programming :) And it was also requested by bounty issue #3694 

#### Other info (issues closed, discussion etc)
Probably should look into the icon, since the current clipboard isn't very intuitive.