### PR TITLE
Fix: global numeric index causing a crash when viewed in Variables editor

### DIFF
--- a/src/LuaInterface.cpp
+++ b/src/LuaInterface.cpp
@@ -108,29 +108,21 @@ bool LuaInterface::loadKey(lua_State* L, TVar* var)
 {
     if (setjmp(buf) == 0) {
         int keyType = var->getKeyType();
-        qDebug() << "keyType" << keyType << "loading" << var;
-        qDebug() << "var name is" << var->getName().toInt();
         if (var->isReference()) {
             lua_rawgeti(L, LUA_REGISTRYINDEX, var->getName().toInt());
-            qDebug() << "loading reference";
         } else {
             if (keyType == LUA_TNUMBER) {
-                qDebug() << "loading number";
                 lua_pushnumber(L, var->getName().toInt());
             } else if (keyType == LUA_TTABLE) {
-                qDebug() << "loading table";
             } else if (keyType == LUA_TBOOLEAN) {
-                qDebug() << "loading boolean";
                 lua_pushboolean(L, var->getName().toLower() == "true" ? 1 : 0);
             } else {
-                qDebug() << "loading string";
                 lua_pushstring(L, var->getName().toUtf8().constData());
             }
         }
         return lua_type(L, -1) == keyType;
     }
 
-    qDebug() << "setjmp failed";
     return false;
 }
 
@@ -684,19 +676,26 @@ void LuaInterface::renameVar(TVar* var)
 
 QString LuaInterface::getValue(TVar* var)
 {
-    qDebug() << "LuaInterface::getValue for " << var;
     if (setjmp(buf) == 0) {
-
         QList<TVar*> vars = varOrder(var);
         if (vars.empty()) {
-            return QString();
+            return {};
         }
         int pCount = vars.size(); //how many things we need to pop at the end
         //load from _G first
-        lua_getglobal(mL, (vars[0]->getName()).toUtf8().constData());
+        auto firstVariable = vars.constFirst();
+        if (firstVariable->getKeyType() == LUA_TSTRING) {
+            lua_getglobal(mL, (firstVariable->getName()).toUtf8().constData());
+        } else if (firstVariable->getKeyType() == LUA_TNUMBER) {
+            lua_rawgeti(mL, LUA_GLOBALSINDEX, firstVariable->getName().toInt());
+        }
+        if (lua_isnoneornil(mL, lua_gettop(mL))) {
+            qDebug() << "Failed to read root value" << firstVariable->getName() << "in order to get" << var->getName() << "onto the stack, perhaps the key type isn't supported?";
+            return {};
+        }
         for (int i = 1; i < vars.size(); i++) {
-            if (!loadValue(mL, vars[i], -2)) {
-                return QString();
+            if (!loadValue(mL, vars.at(i), -2)) {
+                return {};
             }
         }
         int vType = lua_type(mL, -1);
@@ -709,7 +708,7 @@ QString LuaInterface::getValue(TVar* var)
         lua_pop(mL, pCount);
         return value;
     }
-    return QString();
+    return {};
 }
 
 void LuaInterface::iterateTable(lua_State* L, int index, TVar* tVar, bool hide)

--- a/src/TVar.cpp
+++ b/src/TVar.cpp
@@ -45,10 +45,10 @@ TVar::TVar()
 , reference(false)
 , parent(nullptr)
 , name(QString())
-, kType(LUA_TNONE)
+, keyType(LUA_TNONE)
 , value(QString())
-, vType(LUA_TNONE)
-, nkType(LUA_TNONE)
+, valueType(LUA_TNONE)
+, newKeyType(LUA_TNONE)
 , nName(QString())
 {
 }
@@ -61,10 +61,10 @@ TVar::TVar(TVar* p)
 , reference(false)
 , parent(p)
 , name(QString())
-, kType(LUA_TNONE)
+, keyType(LUA_TNONE)
 , value(QString())
-, vType(LUA_TNONE)
-, nkType(LUA_TNONE)
+, valueType(LUA_TNONE)
+, newKeyType(LUA_TNONE)
 , nName(QString())
 {
 }
@@ -77,10 +77,10 @@ TVar::TVar(TVar* p, const QString& kName, const int kt, const QString& val, cons
 , reference(false)
 , parent(p)
 , name(kName)
-, kType(kt)
+, keyType(kt)
 , value(val)
-, vType(vt)
-, nkType(LUA_TNONE)
+, valueType(vt)
+, newKeyType(LUA_TNONE)
 , nName(QString())
 {
 }
@@ -143,7 +143,7 @@ void TVar::removeChild(TVar* t)
 
 int TVar::getKeyType()
 {
-    return kType;
+    return keyType;
 }
 
 QString TVar::getValue()
@@ -153,18 +153,18 @@ QString TVar::getValue()
 
 int TVar::getValueType()
 {
-    return vType;
+    return valueType;
 }
 
 void TVar::setNewName(const QString& n, const int t)
 {
     nName = n;
-    nkType = t;
+    newKeyType = t;
 }
 
 int TVar::getNewKeyType()
 {
-    return nkType;
+    return newKeyType;
 }
 
 QString TVar::getNewName()
@@ -175,9 +175,9 @@ QString TVar::getNewName()
 void TVar::clearNewName()
 {
     name = nName;
-    kType = nkType;
+    keyType = newKeyType;
     nName = QString();
-    nkType = LUA_TNIL; // CHECK: Was 0 but perhaps it should have been -1 (LUA_TNONE ?)
+    newKeyType = LUA_TNIL; // CHECK: Was 0 but perhaps it should have been -1 (LUA_TNONE ?)
 }
 
 bool TVar::setValue(const QString& val)
@@ -189,20 +189,20 @@ bool TVar::setValue(const QString& val)
 bool TVar::setValue(const QString& val, const int t)
 {
     value = val;
-    vType = t;
+    valueType = t;
     return true;
 }
 
 bool TVar::setValueType(const int t)
 {
-    vType = t;
+    valueType = t;
     return true;
 }
 
 bool TVar::setName(const QString& n, const int kt)
 {
     name = n;
-    kType = kt;
+    keyType = kt;
     return true;
 }
 

--- a/src/TVar.h
+++ b/src/TVar.h
@@ -67,10 +67,10 @@ private:
     QList<TVar*> children;
     TVar* parent;
     QString name;
-    int kType;
+    int keyType;
     QString value;
-    int vType;
-    int nkType;
+    int valueType;
+    int newKeyType;
     QString nName;
 };
 

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -26,6 +26,7 @@
 
 #include "pre_guard.h"
 #include <QTreeWidgetItem>
+#include <QDebug>
 #include "post_guard.h"
 
 
@@ -146,6 +147,7 @@ TVar* VarUnit::getTVar(QTreeWidgetItem* p)
 TVar* VarUnit::getWVar(QTreeWidgetItem* p)
 {
     if (wVars.contains(p)) {
+        qDebug() << "for tree widget"<<p<<"returning variable"<<wVars[p];
         return wVars[p];
     }
     return nullptr;

--- a/src/VarUnit.cpp
+++ b/src/VarUnit.cpp
@@ -147,7 +147,6 @@ TVar* VarUnit::getTVar(QTreeWidgetItem* p)
 TVar* VarUnit::getWVar(QTreeWidgetItem* p)
 {
     if (wVars.contains(p)) {
-        qDebug() << "for tree widget"<<p<<"returning variable"<<wVars[p];
         return wVars[p];
     }
     return nullptr;

--- a/src/VarUnit.h
+++ b/src/VarUnit.h
@@ -77,7 +77,9 @@ public:
 private:
     TVar* base;
     QSet<QString> varList;
+    // ?? variables
     QMap<QTreeWidgetItem*, TVar*> wVars;
+    // temporary variables
     QMap<QTreeWidgetItem*, TVar*> tVars;
     QSet<const void*> pointers;
 };

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5387,7 +5387,6 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     TVar* var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
-    qDebug() << "working with" << var;
     QList<QTreeWidgetItem*> list;
     if (state == Qt::Checked || state == Qt::PartiallyChecked) {
         if (var) {
@@ -5547,7 +5546,6 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
 
     mpVarsMainArea->checkBox_variable_hidden->setChecked(vu->isHidden(var));
     mpVarsMainArea->lineEdit_var_name->setText(var->getName());
-    qDebug() << "about to get value of " << var;
     clearDocument(mpSourceEditorEdbee, lI->getValue(var));
     pItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsAutoTristate | Qt::ItemIsUserCheckable);
     pItem->setToolTip(0, utils::richText(tr("Checked variables will be saved and loaded with your profile.")));

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5431,9 +5431,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     mpSourceEditorArea->show();
 
     mpCurrentVarItem = pItem; //remember what has been clicked to save it
-    // There was repeated test for pItem being null here but we have NOT altered
-    // it since the start of the function where it was already tested for not
-    // being zero so we don't need to retest it! - Slysven
+
     if (column) {
         mChangingVar = false;
         return;

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -5387,6 +5387,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
     LuaInterface* lI = mpHost->getLuaInterface();
     VarUnit* vu = lI->getVarUnit();
     TVar* var = vu->getWVar(pItem); // This does NOT modify pItem or what it points at
+    qDebug() << "working with" << var;
     QList<QTreeWidgetItem*> list;
     if (state == Qt::Checked || state == Qt::PartiallyChecked) {
         if (var) {
@@ -5546,6 +5547,7 @@ void dlgTriggerEditor::slot_variableSelected(QTreeWidgetItem* pItem)
 
     mpVarsMainArea->checkBox_variable_hidden->setChecked(vu->isHidden(var));
     mpVarsMainArea->lineEdit_var_name->setText(var->getName());
+    qDebug() << "about to get value of " << var;
     clearDocument(mpSourceEditorEdbee, lI->getValue(var));
     pItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled | Qt::ItemIsDragEnabled | Qt::ItemIsAutoTristate | Qt::ItemIsUserCheckable);
     pItem->setToolTip(0, utils::richText(tr("Checked variables will be saved and loaded with your profile.")));
@@ -5688,7 +5690,7 @@ void dlgTriggerEditor::slot_treeSelectionChanged()
     auto * sender = qobject_cast<TTreeWidget*>(QObject::sender());
     if (sender) {
         QList<QTreeWidgetItem*> items = sender->selectedItems();
-        if (items.length()) {
+        if (!items.empty()) {
             QTreeWidgetItem* item = items.first();
             if (sender == treeWidget_scripts) {
                 slot_scriptsSelected(item);


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
If you created a table right at _G with a key that was a number, the variables view would crash.
#### Motivation for adding to Mudlet
Fix https://github.com/Mudlet/Mudlet/issues/6119
#### Other info (issues closed, discussion etc)
Fixed by adding a case alongside existing support for string keys to support number keys as well. Function, table, userdata, etc keys are not supported but they won't crash either.