### PR TITLE
Infrastructure: fix compiler warning around ambigious QPointer declaration

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2215,7 +2215,7 @@ void cTelnet::promptTlsConnectionAvailable()
         && (mpHost->mMSSPHostName.isEmpty() || QString::compare(hostName, mpHost->mMSSPHostName, Qt::CaseInsensitive) == 0)) {
         postMessage(tr("[ INFO ]  - A more secure connection on port %1 is available.").arg(QString::number(mpHost->mMSSPTlsPort)));
 
-        QPointer msgBox = new QMessageBox();
+        auto msgBox = new QMessageBox();
 
         msgBox->setIcon(QMessageBox::Question);
         msgBox->setText(tr("For data transfer protection and privacy, this connection advertises a secure port."));


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Fix compiler warning around ambigious QPointer declaration
#### Motivation for adding to Mudlet
Cleaner code
#### Other info (issues closed, discussion etc)
