### PR TITLE
Fix: ensure 3D push-button is updated if mode is changed by `setConfig(...)`

### DIFF
--- a/src/dlgMapper.cpp
+++ b/src/dlgMapper.cpp
@@ -234,10 +234,10 @@ void dlgMapper::slot_setMapperPanelVisible(bool panelVisible)
 void dlgMapper::slot_toggle3DView(const bool is3DMode)
 {
 #if defined(INCLUDE_3DMAPPER)
-    if (mpHost->mpMap->mpM && mpHost->mpMap->mpMapper) {
-        mpHost->mpMap->mpM->update();
-    }
-    if (!glWidget) {
+    pushButton_3D->setDown(is3DMode);
+    if (glWidget) {
+        glWidget->update();
+    } else {
         glWidget = new GLWidget(mpMap, mpHost, this);
         glWidget->setObjectName("glWidget");
 
@@ -247,7 +247,7 @@ void dlgMapper::slot_toggle3DView(const bool is3DMode)
         sizePolicy.setHeightForWidth(glWidget->sizePolicy().hasHeightForWidth());
         glWidget->setSizePolicy(sizePolicy);
         verticalLayout_mapper->insertWidget(0, glWidget);
-        mpMap->mpM = mpMap->mpMapper->glWidget;
+        mpMap->mpM = glWidget;
         connect(pushButton_ortho, &QAbstractButton::clicked, glWidget, &GLWidget::slot_showAllLevels);
         connect(pushButton_singleLevel, &QAbstractButton::clicked, glWidget, &GLWidget::slot_singleLevelView);
         connect(pushButton_increaseTop, &QAbstractButton::clicked, glWidget, &GLWidget::slot_showMoreUpperLevels);

--- a/src/dlgMapper.h
+++ b/src/dlgMapper.h
@@ -52,6 +52,8 @@ public:
     void setDefaultAreaShown(bool);
     bool getDefaultAreaShown() { return mShowDefaultArea; }
     void resetAreaComboBoxToPlayerRoomArea();
+    // The button is the goto source for this bit of information:
+    bool isIn3DMode() const { return pushButton_3D->isDown(); }
     bool isFloatAndDockable() const;
 
 public slots:


### PR DESCRIPTION
Before this PR changing the setting did not update the button with the result that if it was changed by the Lua API once the next click of the button would not produce any change as it changed to match the actual state.

Also adds a getter `(bool) isIn3DMode()` to the `dlgMapper` class so that other parts of the application can find out the current setting without poking around too deeply in that class.

This will close an issue for this particular item that I raised in our Discord **mudlet-devlopment** channel:
https://canary.discord.com/channels/283581582550237184/283582439002210305/1078169157155160075

Signed-off by: Stephen Lyons <slysven@virginmedia.com>