### PR TITLE
fix: launch Mudlet anyway when given unknown command line options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,10 +231,13 @@ int main(int argc, char* argv[])
     // Non-GUI actions --help and --version as suggested by GNU coding standards,
     // section 4.7: http://www.gnu.org/prep/standards/standards.html#Command_002dLine-Interfaces
     QStringList texts;
-    if (!parsedCommandLineOk || parser.isSet(showHelp)) {
-        if (!parsedCommandLineOk) {
-            texts << append2LF.arg(QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()));
-        }
+
+    if (!parsedCommandLineOk) {
+        // Warn of unknown options but tolerate them, in case user is not typing in command line.
+        texts << append2LF.arg(QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()));
+    }
+
+    if (parser.isSet(showHelp)) {
         // Do "help" action
         texts << appendLF.arg(QCoreApplication::translate("main", "Usage: %1 [OPTION...]",
                                                           // Comment to separate arguments
@@ -292,7 +295,7 @@ int main(int argc, char* argv[])
         texts << appendLF.arg(QCoreApplication::translate("main", "Report bugs to: https://github.com/Mudlet/Mudlet/issues"));
         texts << appendLF.arg(QCoreApplication::translate("main", "Project home page: http://www.mudlet.org/"));
         std::cout << texts.join(QString()).toStdString();
-        return parsedCommandLineOk ? 0 :-1;
+        return 0;
     }
 
     if (parser.isSet(showVersion)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,8 +233,12 @@ int main(int argc, char* argv[])
     QStringList texts;
 
     if (!parsedCommandLineOk) {
-        // Warn of unknown options but tolerate them, in case user is not typing in command line.
-        std::cout << QCoreApplication::translate("main", "Error: %1\n").arg(parser.errorText()).toStdString();
+        // Warn of unknown options but tolerate them.
+        // We want the message to be visible for someone launching from command prompt
+        // and will have standard output left on their screen, but still allow program
+        // to start when launched by installer.
+        // --squirrel-firstrun for example is given for launch at end of install process.
+        std::cout << QCoreApplication::translate("main", "Warning: %1\n").arg(parser.errorText()).toStdString();
     }
 
     if (parser.isSet(showHelp)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
 
     if (!parsedCommandLineOk) {
         // Warn of unknown options but tolerate them, in case user is not typing in command line.
-        std::cout << QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()).toStdString();
+        std::cout << QCoreApplication::translate("main", "Error: %1\n").arg(parser.errorText()).toStdString();
     }
 
     if (parser.isSet(showHelp)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
 
     if (!parsedCommandLineOk) {
         // Warn of unknown options but tolerate them, in case user is not typing in command line.
-        texts << append2LF.arg(QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()));
+        std::cout << QCoreApplication::translate("main", "Error: %1").arg(parser.errorText());
     }
 
     if (parser.isSet(showHelp)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
 
     if (!parsedCommandLineOk) {
         // Warn of unknown options but tolerate them, in case user is not typing in command line.
-        std::cout << QCoreApplication::translate("main", "Error: %1").arg(parser.errorText());
+        std::cout << QCoreApplication::translate("main", "Error: %1").arg(parser.errorText()).toStdString();
     }
 
     if (parser.isSet(showHelp)) {


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Refrain from shutting down when an unrecognized command line option was given.  Display a warning, but do not shut down as if user had started the program from command line and requested help via command line.
#### Motivation for adding to Mudlet
In #6470 the scope got expanded from just handling `--profile` better to also making unknown command line options act as as `--help`.  It turns out that the installer launches the program with `--squirrrel-firstrun` at end of install to facilitate "Welcome" and "What's new" type of stuff.  So this meant that the final step of installation would mess up.  We thought it was not launching either due to update code or installer code, but it was in fact launching and then immediately shutting down.  Because it wasn't launched from command line, we were not seeing the message sent to standard output.  This change simply undoes that part.  Having a handler for that specific option would be good.
#### Other info (issues closed, discussion etc)
FIxes #6500.