### PR TITLE
Fix: get translations working on command line actions

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -993,6 +993,9 @@ void mudlet::migrateDebugConsole(Host* currentHost)
 // selectable location, or even from a read-only part of their computer's
 // file-system we would have to do this each time they looked to change
 // language/locale:
+// If we ever change the usage of this to take a path other than the
+// resource file's one then the code in the main.cpp file's
+// (void) loadTranslationsForCommandLine() will have to be revised as well:
 void mudlet::scanForMudletTranslations(const QString& path)
 {
     mPathNameMudletTranslations = path;
@@ -3917,7 +3920,11 @@ QString mudlet::autodetectPreferredLanguage()
         }
     }
 
-    for (auto language : QLocale::system().uiLanguages()) {
+    QStringList systemUiLanguages = QLocale::system().uiLanguages();
+    // The code in the loop may modify the value anyway so explicity detach
+    // from the original:
+    systemUiLanguages.detach();
+    for (auto& language : systemUiLanguages) {
         if (availableQualityTranslations.contains(language.replace(qsl("-"), qsl("_")))) {
             return language;
         }


### PR DESCRIPTION
We need to load the appropriate Mudlet translation file to get the texts for the appropriate locale when we produce the `-v`/`--version` and `-h`/`--help` output to the command line. We also need to unload them should we go on to start the full GUI application.

I have generated the (white-space) laid out help text translations for Russian and German and put them up on Crowdin. In order to get that correct it was easiest to actually work on them locally with Qt Linguist texts sourced from Google translate and then copy/paste them into CrowdIn as I do not speak either language. **However it does mean that a native language speaker should check them, preserving the hanging paragraph format.**

I have also implemented the changes made in the top most part of `main.cpp` that were suggested in #6600 as those texts are not used and do not need to be translated. As such this replaces that PR.

Signed-off by: Stephen Lyons <slysven@virginmedia.com>