### PR TITLE
Infrastructure: try to fix failure to update dblsql feed with PTB builds

### DIFF
--- a/.github/workflows/link-ptbs-to-dblsqd.yml
+++ b/.github/workflows/link-ptbs-to-dblsqd.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   link-ptbs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Mudlet' }}
 
     steps:

--- a/.github/workflows/tag-pull-requests.yml
+++ b/.github/workflows/tag-pull-requests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   add-milestone:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -1567,7 +1567,9 @@ OTHER_FILES += \
     ../.github/workflows/codespell-analysis.yml \
     ../.github/workflows/dangerjs.yml \
     ../.github/workflows/generate-changelog.yml \
+    ../.github/workflows/generate-coder-attribution.yml \
     ../.github/workflows/link-ptbs-to-dblsqd.yml \
+    ../.github/workflows/performance-analysis.yml \
     ../.github/workflows/tag-pull-requests.yml \
     ../.github/workflows/update-3rdparty.yml \
     ../.github/workflows/update-autocompletion.yml \


### PR DESCRIPTION
This (the `link-ptbs-todblsqqd` GHA job) has been failing since 2023/01/02 and it seems that the version of Luarocks expects a later `libc` than is present in the Ubuntu version "Focal LTS" 20.04 that we are using. This updates the Linux OS used for that GH Action to the Ubuntu *latest* which is now 22.x. Hopefully this will restore operation.

Also update the `tag-pull-request` as it also was using the same older Ubuntu version.

Furthermore this PR also adds two other recently added GHA job files to the files shown in Qt Creator - which makes it easier to get to them in that environment.