### PR TITLE
Fix: Do not prompt to use TLS if Qt was built withoutt SSL support

### DIFF
--- a/src/ctelnet.cpp
+++ b/src/ctelnet.cpp
@@ -2082,7 +2082,9 @@ void cTelnet::setMSSPVariables(const QByteArray& msg)
 
     mpHost->mLuaInterpreter.setMSSPTable(transcodedMsg);
 
+#if !defined(QT_NO_SSL)
     promptTlsConnectionAvailable();
+#endif
 }
 
 // Documentation: https://wiki.mudlet.org/w/Manual:Supported_Protocols#MSP
@@ -2209,6 +2211,7 @@ bool cTelnet::isIPAddress(QString& arg)
     return isIPAddress;
 }
 
+#if !defined(QT_NO_SSL)
 void cTelnet::promptTlsConnectionAvailable()
 {
     // If an SSL port is detected by MSSP and we're not using it, prompt to use on future connections
@@ -2248,6 +2251,7 @@ void cTelnet::promptTlsConnectionAvailable()
         }
     }
 }
+#endif
 
 bool cTelnet::purgeMediaCache()
 {

--- a/src/ctelnet.h
+++ b/src/ctelnet.h
@@ -252,7 +252,9 @@ private:
     void raiseProtocolEvent(const QString& name, const QString& protocol);
     void setKeepAlive(int socketHandle);
     void processChunks();
+#if !defined(QT_NO_SSL)
     void promptTlsConnectionAvailable();
+#endif
     void sendNAWS(int x, int y);
     static std::pair<bool, bool> testReadReplayFile();
 


### PR DESCRIPTION

#### Brief overview of PR changes/additions

Do not build `promptTlsConnectionAvailable` in ctelnet if `QT_NO_SSL` is set.

#### Motivation for adding to Mudlet

Tried to build using Qt built without SSL support and noticed the changes from #6409 do not check if `QT_NO_SSL` is defined.

#### Other info (issues closed, discussion etc)
