### PR TITLE
Infrastructure: lower translation threshhold to 85% for a month

### DIFF
--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -288,8 +288,9 @@ public:
     // during the application run it is easiest to define it as one once:
     inline static const QVersionNumber scmRunTimeQtVersion = QVersionNumber::fromString(QLatin1String(qVersion()));
     // translations done high enough will get a gold star to hide the last few percent
-    // as well as encourage translators to maintain it;
-    static const int scmTranslationGoldStar = 95;
+    // as well as encourage translators to maintain it
+    // temporary until 2023-04-01: lower from 95 to 85 because translation updates weren't coming for 3 months
+    static const int scmTranslationGoldStar = 85;
     inline static const QString scmVersion = qsl("Mudlet " APP_VERSION APP_BUILD);
     // These have to be "inline" to satisfy the ODR (One Definition Rule):
     inline static bool smDebugMode = false;


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Lower translation threshhold to 85% until 2023-04-01 so languages above that threshhold get auto-selected for first-time installs.
#### Motivation for adding to Mudlet
No translations were being put into Crowdin for 3 months since mid-November and translators didn't have the chance to stay up to date with new strings are they were coming in.
#### Other info (issues closed, discussion etc)
Will not change the crowdin comment bot gold star in order to encourage translators to reach the 'real' level.