### PR TITLE
Infrastructure: fix libreadline error in changelog workflow

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -29,6 +29,9 @@ jobs:
       uses: leafo/gh-actions-lua@v10
       with:
         luaVersion: "5.1.5"
+        
+    - name: Install libreadline-dev
+      run: sudo apt-get install libreadline-dev -y
 
     - name: Install Luarocks
       uses: leafo/gh-actions-luarocks@v4


### PR DESCRIPTION
<!-- Keep the title short & concise so anyone non-technical can understand it,
     the title appears in PTB changelogs -->
#### Brief overview of PR changes/additions
Install libreadline for changelog workflow
#### Motivation for adding to Mudlet
Fix changelog generation action to work again. It seems Luarocks started failing to install due to: https://github.com/Mudlet/Mudlet/actions/runs/4329087139/jobs/7559370774#step:4:40
#### Other info (issues closed, discussion etc)
The fix might be applicable to other workflows (see https://github.com/Mudlet/Mudlet/pull/6605), will port it if it works.