### PR TITLE
Fix: correct search for Lua interpreter for qmake builds

### DIFF
--- a/translations/translated/CMakeLists.txt
+++ b/translations/translated/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #    Copyright (C) 2018 by Vadim Peretokin - vperetokin@gmail.com          #
-#    Copyright (C) 2020 by Stephen Lyons - slysven@virginmedia.com         #
+#    Copyright (C) 2020, 2023 by Stephen Lyons - slysven@virginmedia.com   #
 #                                                                          #
 #    This program is free software; you can redistribute it and/or modify  #
 #    it under the terms of the GNU General Public License as published by  #
@@ -51,9 +51,15 @@ if(NOT WIN32)
 #  message(STATUS "The environmental variable LANG should now be reset to: ${OLDLANG} and it is now: $ENV{LANG}")
 endif()
 
-find_program(LUA_LOCATION lua5.1)
+find_program(LUA_LOCATION lua-5.1)
 if(NOT LUA_LOCATION)
-  find_program(LUA_LOCATION lua)
+  find_program(LUA_LOCATION lua5.1)
+  if(NOT LUA_LOCATION)
+    find_program(LUA_LOCATION lua51)
+    if(NOT LUA_LOCATION)
+      find_program(LUA_LOCATION lua)
+    endif()
+  endif()
 endif()
 
 execute_process(

--- a/translations/translated/updateqm.pri
+++ b/translations/translated/updateqm.pri
@@ -46,34 +46,59 @@ STATS_GENERATOR = $$system_path("$${PWD}/generate-translation-stats.lua")
 
 win32 {
     CMD = "where"
-    message("You can safely ignore one or two \"INFO: Could not find files for the given pattern(s).\" messages that may appear!")
+    message("You can safely ignore one to three \"INFO: Could not find files for the given pattern(s).\" messages that may appear!")
 } else {
     # OpenBSD reports the failure to find lua5.1 loudly enough to be seen;
     # so explictly bin the stderr output:
     CMD = "which 2>/dev/null"
 }
 
-LUA_SEARCH_OUT = $$system("$$CMD lua5.1")
-isEmpty(LUA_SEARCH_OUT) {
-    LUA_SEARCH_OUT = $$system("$$CMD lua51")
-    isEmpty(LUA_SEARCH_OUT) {
-        LUA_SEARCH_OUT = $$system("$$CMD lua")
-        isEmpty(LUA_SEARCH_OUT) {
-            error("no lua found in PATH")
-        } else {
-            LUA_COMMAND = "lua"
-        }
-    } else {
-        LUA_COMMAND = "lua51"
-    }
+win32 {
+    # The '.1' in the file name confuses the QMake system() utility or the
+    # shell used in the Windows case as it is considered to be an extension
+    # unless we put in the actual 'exe' extension as well:
+    LUA_SEARCH_OUT = $$system("$$CMD lua-5.1.exe")
 } else {
+    LUA_SEARCH_OUT = $$system("$$CMD lua-5.1")
+}
+isEmpty(LUA_SEARCH_OUT) {
     win32 {
-        # The '.1' in the file name confuses the QMake system() utility or the
-        # shell used in the Windows case as it is considered to be an extension
-        # unless we put in the actual 'exe' extension as well:
-        LUA_COMMAND = "lua5.1.exe"
+        LUA_SEARCH_OUT = $$system("$$CMD lua5.1.exe")
     } else {
-        LUA_COMMAND = "lua5.1"
+        LUA_SEARCH_OUT = $$system("$$CMD lua5.1")
+    }
+    isEmpty(LUA_SEARCH_OUT) {
+        # This can be used for all OS since there is no '.'
+        LUA_SEARCH_OUT = $$system("$$CMD lua51")
+        isEmpty(LUA_SEARCH_OUT) {
+            LUA_SEARCH_OUT = $$system("$$CMD lua")
+            isEmpty(LUA_SEARCH_OUT) {
+                error("no lua found in PATH")
+            } else {
+               # "lua" worked
+               LUA_COMMAND = "lua"
+            }
+
+        } else {
+            # "lua51" worked
+            LUA_COMMAND = "lua51"
+        }
+
+    } else {
+        # "lua5.1" worked
+        win32 {
+            LUA_COMMAND = "lua5.1.exe"
+        } else {
+            LUA_COMMAND = "lua5.1"
+        }
+    }
+
+} else {
+    # "lua-5.1" worked
+    win32 {
+        LUA_COMMAND = "lua-5.1.exe"
+    } else {
+        LUA_COMMAND = "lua-5.1"
     }
 }
 


### PR DESCRIPTION
Discord user **#Caith#8202** discovered that building Mudlet on aarch64 i.e. the Arm64 platform on Fedora fails (see the Mudlet **#help** channel on Discord starting 2023/03/06 03:55 UTC with the text):
> lua-yajl is the bane of my existence.  edited the hell out of the cmake
scripts and mudlet.pro to finally get it to start using lua 5.1 instead of 5.4, then had to rig up some hunspell junk, but no matter what i do, qmake won't cooperate with the lua-yajl install.
>
> compiles fine on ubuntu and arch, so i'm bewildered.

One detail that came to light is that on that system the 5.1 version of the Lua interpreter is called `lua-5.1` but that is not one of the names that `./translations/translated/updateqm.pri` tries so it fails to generate/update the binary translations for inclusion in the project.

This PR should extend the tries to a fourth one that will handle that form, it also restructures the code slightly as it looked to me as the Windows OS handling was off.

The corresponding CMake build file has also been updated to handle the same four variants - prior to that it only tried two which might not have worked in all cases.

Signed-off by: Stephen Lyons <slysven@virginmedia.com>