### PR TITLE
Fix: Move right-click menu to release event rather than press event.

### DIFF
--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2485,7 +2485,7 @@ void T2DMap::updateMapLabel(QRectF labelRectangle, int labelId, TArea* pArea)
     }
 }
 
-void T2DMap::mouseReleaseEvent(QMouseEvent* e)
+void T2DMap::mouseReleaseEvent(QMouseEvent* event)
 {
     if (!mpMap) {
         return;
@@ -2502,7 +2502,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* e)
         unsetCursor();
     }
 
-    if (e->button() & Qt::LeftButton) {
+    if (event->button() & Qt::LeftButton) {
         mMultiSelection = false; // End drag-to-select rectangle resizing
         mHelpMsg.clear();
         if (mSizeLabel) {
@@ -2513,269 +2513,8 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* e)
         mMultiRect = QRect(0, 0, 0, 0);
         update();
     }
-}
 
-bool T2DMap::event(QEvent* event)
-{
-    // NOTE: key events aren't being forwarded to T2DMap because the widget
-    // currently never has focus because it's more comfortable for the user
-    // to always have focus on the command line. If this were to be changed some
-    // day the setFocusPolicy() calls in the constructor need to be uncommented
-
-    if (event->type() == QEvent::KeyPress) {
-//        auto* ke = static_cast<QKeyEvent*>(event);
-//        if (ke->key() == Qt::Key_Delete ) {
-//            if (mCustomLineSelectedRoom != 0  ) {
-//                if (mpMap->rooms.contains(mCustomLineSelectedRoom)) {
-//                    TRoom * pR = mpMap->rooms[mCustomLineSelectedRoom];
-//                    if (pR->customLines.contains( mCustomLineSelectedExit)) {
-//                        pR->customLines.remove(mCustomLineSelectedExit);
-//                        repaint();
-//                        mCustomLineSelectedRoom = 0;
-//                        mCustomLineSelectedExit = "";
-//                        mCustomLineSelectedPoint = -1;
-//                        return QWidget::event(event);
-//                    }
-//                }
-//            }
-//        }
-    } else if (event->type() == QEvent::Resize) { // Tweak the room selection widget to fit
-        resizeMultiSelectionWidget();
-    }
-    return QWidget::event(event);
-}
-
-void T2DMap::mousePressEvent(QMouseEvent* event)
-{
-    if (!mpMap) {
-        return;
-    }
-    mudlet::self()->activateProfile(mpHost);
-    mNewMoveAction = true;
-    if (event->buttons() & Qt::LeftButton) {
-        // move map with left mouse button + ALT, or just a left mouse button in viewOnly mode
-        if (event->modifiers().testFlag(Qt::AltModifier) || mMapViewOnly) {
-            setCursor(Qt::ClosedHandCursor);
-            mpMap->mLeftDown = true;
-        }
-
-        // drawing new custom exit line
-        if (mCustomLinesRoomFrom > 0) {
-            if (mDialogLock) {
-                return; // Prevent any line drawing until ready
-            }
-
-            TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
-            if (room) {
-                float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
-                // might be useful to have a snap to grid type option
-                room->customLines[mCustomLinesRoomExit].push_back(QPointF(mx, my));
-                room->calcRoomDimensions();
-                repaint();
-                return;
-            }
-        }
-
-        // check click on custom exit lines (not in viewOnly mode)
-        if (mMultiSelectionSet.isEmpty() && !mMapViewOnly) {
-            // But NOT if got one or more rooms already selected!
-            TArea* pA = mpMap->mpRoomDB->getArea(mAreaID);
-            if (pA) {
-                float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
-                float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
-                QPointF pc = QPointF(mx, my);
-                QSetIterator<int> itRoom = pA->rooms;
-                while (itRoom.hasNext()) {
-                    int currentRoomId = itRoom.next();
-                    TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
-                    if (!room) {
-                        continue;
-                    }
-                    QMapIterator<QString, QList<QPointF>> it(room->customLines);
-                    while (it.hasNext()) {
-                        it.next();
-                        const QList<QPointF>& _pL = it.value();
-                        if (!_pL.empty()) {
-                            // The way this code is structured means that EARLIER
-                            // points are selected in preference to later ones!
-                            // This might not be intuitive to the users...
-                            float olx, oly, lx, ly;
-                            for (int j = 0; j < _pL.size(); j++) {
-                                if (j == 0) {
-                                    // First segment of a custom line
-                                    // start it at the centre of the room
-                                    olx = room->x;
-                                    oly = room->y;
-                                    //FIXME: use exit direction to calculate start of line
-                                    lx = _pL[0].x();
-                                    ly = _pL[0].y();
-                                } else {
-                                    // Not the first segment of a custom line
-                                    // so start it at the end of the previous one
-                                    olx = lx;
-                                    oly = ly;
-                                    lx = _pL[j].x();
-                                    ly = _pL[j].y();
-                                }
-                                // End of each custom line segment is given
-
-                                // click auf einen edit - punkt
-                                if (mCustomLineSelectedRoom != 0) {
-                                    // We have already chosen a line to edit
-                                    if (fabs(mx - lx) <= 0.25 && fabs(my - ly) <= 0.25) {
-                                        // And this looks close enough to a point that we should edit it
-                                        mCustomLineSelectedPoint = j;
-                                        return;
-                                    }
-                                }
-
-                                // We have not previously chosen a line to edit
-                                QLineF line = QLineF(olx, oly, lx, ly);
-                                QLineF normal = line.normalVector();
-                                QLineF tl;
-                                tl.setP1(pc);
-                                tl.setAngle(normal.angle());
-                                tl.setLength(0.1);
-                                QLineF tl2;
-                                tl2.setP1(pc);
-                                tl2.setAngle(normal.angle());
-                                tl2.setLength(-0.1);
-                                QPointF pi;
-                                if ((line.intersects(tl, &pi) == QLineF::BoundedIntersection) || (line.intersects(tl2, &pi) == QLineF::BoundedIntersection)) {
-                                    // Choose THIS line to edit as we have
-                                    // clicked close enough to it...
-                                    mCustomLineSelectedRoom = room->getId();
-                                    mCustomLineSelectedExit = it.key();
-                                    repaint();
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            mCustomLineSelectedRoom = 0;
-            mCustomLineSelectedExit = "";
-        }
-
-        if (mRoomBeingMoved) {
-            // Moving rooms so end that
-            mPick = true;
-
-            setMouseTracking(false);
-            mRoomBeingMoved = false;
-        } else if (!mPopupMenu) {
-            // Not in a context menu, so start selection mode - including drag to select if not in viewOnly mode
-            mMultiSelection = !mMapViewOnly;
-            mMultiRect = QRect(event->pos(), event->pos());
-            if (!mpMap->mpRoomDB->getRoom(mRoomID)) {
-                return;
-            }
-            TArea* pArea = mpMap->mpRoomDB->getArea(mAreaID);
-            if (!pArea) {
-                return;
-            }
-            float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
-            float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
-
-            if (!event->modifiers().testFlag(Qt::ControlModifier)) {
-                if (!mMapViewOnly) {
-                    // If control key NOT down then clear selection, and put up helpful text
-                    mHelpMsg = tr("Drag to select multiple rooms or labels, release to finish...", "2D Mapper big, bottom of screen help message");
-                }
-                mMultiSelectionSet.clear();
-            }
-
-            QSetIterator<int> itRoom(pArea->getAreaRooms());
-            while (itRoom.hasNext()) { // Scan to find rooms in selection
-                int currentAreaRoom = itRoom.next();
-                TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
-                if (!room) {
-                    continue;
-                }
-                int rx = room->x * mRoomWidth + fx;
-                int ry = room->y * -1 * mRoomHeight + fy;
-                int rz = room->z;
-
-                int mx = event->pos().x();
-                int my = event->pos().y();
-                int mz = mOz;
-                if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
-                    if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
-                        mMultiSelectionSet.remove(currentAreaRoom);
-                    } else {
-                        mMultiSelectionSet.insert(currentAreaRoom);
-                    }
-
-                    if (!mMultiSelectionSet.empty()) {
-                        mMultiSelection = false;
-                    }
-                }
-            }
-            switch (mMultiSelectionSet.size()) {
-            case 0:
-                mMultiSelectionHighlightRoomId = 0;
-                break;
-            case 1:
-                mMultiSelection = false; // OK, found one room so stop
-                mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
-                mHelpMsg.clear();
-                break;
-            default:
-                mMultiSelection = false; // OK, found more than one room so stop
-                mHelpMsg.clear();
-                getCenterSelection();
-            }
-
-            // select labels (not in viewOnly mode)
-            if (!pArea->mMapLabels.isEmpty() && !mMapViewOnly) {
-                QMutableMapIterator<int, TMapLabel> itMapLabel(pArea->mMapLabels);
-                while (itMapLabel.hasNext()) {
-                    itMapLabel.next();
-                    auto mapLabel = itMapLabel.value();
-                    if (mapLabel.pos.z() != mOz) {
-                        continue;
-                    }
-
-                    QPointF labelPosition;
-                    float labelX = mapLabel.pos.x() * mRoomWidth + mRX;
-                    float labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
-
-                    labelPosition.setX(labelX);
-                    labelPosition.setY(labelY);
-                    int mx = event->pos().x();
-                    int my = event->pos().y();
-                    QPoint click = QPoint(mx, my);
-                    QRectF br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
-                    if (br.contains(click)) {
-                        mapLabel.highlight = !mapLabel.highlight;
-                        mLabelHighlighted = mapLabel.highlight;
-                        pArea->mMapLabels[itMapLabel.key()] = mapLabel;
-                        update();
-                        return;
-                    }
-                }
-            }
-
-            mLabelHighlighted = false;
-            update();
-
-            if (mMultiSelection && !mMultiSelectionSet.empty() && (event->modifiers().testFlag(Qt::ControlModifier))) {
-                // We were dragging multi-selection rectangle, we had selected at
-                // least one room and the user has <CTRL>-clicked with the mouse
-                // so switch off the dragging
-                mMultiSelection = false;
-                mHelpMsg.clear();
-            }
-
-        } else { // In popup menu, so end that
-            mPopupMenu = false;
-        }
-
-    }
-
-    if (event->buttons() & Qt::RightButton) {
+    if (event->button() & Qt::RightButton) {
         auto popup = new QMenu(this);
         popup->setToolTipsVisible(true);
         popup->setAttribute(Qt::WA_DeleteOnClose);
@@ -3141,6 +2880,267 @@ void T2DMap::mousePressEvent(QMouseEvent* event)
         // After all has been added, finally have Qt display the context menu as a whole
         mPopupMenu = true;
         popup->popup(mapToGlobal(event->pos()));
+    }
+}
+
+bool T2DMap::event(QEvent* event)
+{
+    // NOTE: key events aren't being forwarded to T2DMap because the widget
+    // currently never has focus because it's more comfortable for the user
+    // to always have focus on the command line. If this were to be changed some
+    // day the setFocusPolicy() calls in the constructor need to be uncommented
+
+    if (event->type() == QEvent::KeyPress) {
+//        auto* ke = static_cast<QKeyEvent*>(event);
+//        if (ke->key() == Qt::Key_Delete ) {
+//            if (mCustomLineSelectedRoom != 0  ) {
+//                if (mpMap->rooms.contains(mCustomLineSelectedRoom)) {
+//                    TRoom * pR = mpMap->rooms[mCustomLineSelectedRoom];
+//                    if (pR->customLines.contains( mCustomLineSelectedExit)) {
+//                        pR->customLines.remove(mCustomLineSelectedExit);
+//                        repaint();
+//                        mCustomLineSelectedRoom = 0;
+//                        mCustomLineSelectedExit = "";
+//                        mCustomLineSelectedPoint = -1;
+//                        return QWidget::event(event);
+//                    }
+//                }
+//            }
+//        }
+    } else if (event->type() == QEvent::Resize) { // Tweak the room selection widget to fit
+        resizeMultiSelectionWidget();
+    }
+    return QWidget::event(event);
+}
+
+void T2DMap::mousePressEvent(QMouseEvent* event)
+{
+    if (!mpMap) {
+        return;
+    }
+    mudlet::self()->activateProfile(mpHost);
+    mNewMoveAction = true;
+    if (event->buttons() & Qt::LeftButton) {
+        // move map with left mouse button + ALT, or just a left mouse button in viewOnly mode
+        if (event->modifiers().testFlag(Qt::AltModifier) || mMapViewOnly) {
+            setCursor(Qt::ClosedHandCursor);
+            mpMap->mLeftDown = true;
+        }
+
+        // drawing new custom exit line
+        if (mCustomLinesRoomFrom > 0) {
+            if (mDialogLock) {
+                return; // Prevent any line drawing until ready
+            }
+
+            TRoom* room = mpMap->mpRoomDB->getRoom(mCustomLinesRoomFrom);
+            if (room) {
+                float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
+                float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                // might be useful to have a snap to grid type option
+                room->customLines[mCustomLinesRoomExit].push_back(QPointF(mx, my));
+                room->calcRoomDimensions();
+                repaint();
+                return;
+            }
+        }
+
+        // check click on custom exit lines (not in viewOnly mode)
+        if (mMultiSelectionSet.isEmpty() && !mMapViewOnly) {
+            // But NOT if got one or more rooms already selected!
+            TArea* pA = mpMap->mpRoomDB->getArea(mAreaID);
+            if (pA) {
+                float mx = (event->pos().x() / mRoomWidth) + mOx - (xspan / 2.0);
+                float my = (yspan / 2.0) - (event->pos().y() / mRoomHeight) - mOy;
+                QPointF pc = QPointF(mx, my);
+                QSetIterator<int> itRoom = pA->rooms;
+                while (itRoom.hasNext()) {
+                    int currentRoomId = itRoom.next();
+                    TRoom* room = mpMap->mpRoomDB->getRoom(currentRoomId);
+                    if (!room) {
+                        continue;
+                    }
+                    QMapIterator<QString, QList<QPointF>> it(room->customLines);
+                    while (it.hasNext()) {
+                        it.next();
+                        const QList<QPointF>& _pL = it.value();
+                        if (!_pL.empty()) {
+                            // The way this code is structured means that EARLIER
+                            // points are selected in preference to later ones!
+                            // This might not be intuitive to the users...
+                            float olx, oly, lx, ly;
+                            for (int j = 0; j < _pL.size(); j++) {
+                                if (j == 0) {
+                                    // First segment of a custom line
+                                    // start it at the centre of the room
+                                    olx = room->x;
+                                    oly = room->y;
+                                    //FIXME: use exit direction to calculate start of line
+                                    lx = _pL[0].x();
+                                    ly = _pL[0].y();
+                                } else {
+                                    // Not the first segment of a custom line
+                                    // so start it at the end of the previous one
+                                    olx = lx;
+                                    oly = ly;
+                                    lx = _pL[j].x();
+                                    ly = _pL[j].y();
+                                }
+                                // End of each custom line segment is given
+
+                                // click auf einen edit - punkt
+                                if (mCustomLineSelectedRoom != 0) {
+                                    // We have already chosen a line to edit
+                                    if (fabs(mx - lx) <= 0.25 && fabs(my - ly) <= 0.25) {
+                                        // And this looks close enough to a point that we should edit it
+                                        mCustomLineSelectedPoint = j;
+                                        return;
+                                    }
+                                }
+
+                                // We have not previously chosen a line to edit
+                                QLineF line = QLineF(olx, oly, lx, ly);
+                                QLineF normal = line.normalVector();
+                                QLineF tl;
+                                tl.setP1(pc);
+                                tl.setAngle(normal.angle());
+                                tl.setLength(0.1);
+                                QLineF tl2;
+                                tl2.setP1(pc);
+                                tl2.setAngle(normal.angle());
+                                tl2.setLength(-0.1);
+                                QPointF pi;
+                                if ((line.intersects(tl, &pi) == QLineF::BoundedIntersection) || (line.intersects(tl2, &pi) == QLineF::BoundedIntersection)) {
+                                    // Choose THIS line to edit as we have
+                                    // clicked close enough to it...
+                                    mCustomLineSelectedRoom = room->getId();
+                                    mCustomLineSelectedExit = it.key();
+                                    repaint();
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            mCustomLineSelectedRoom = 0;
+            mCustomLineSelectedExit = "";
+        }
+
+        if (mRoomBeingMoved) {
+            // Moving rooms so end that
+            mPick = true;
+
+            setMouseTracking(false);
+            mRoomBeingMoved = false;
+        } else if (!mPopupMenu) {
+            // Not in a context menu, so start selection mode - including drag to select if not in viewOnly mode
+            mMultiSelection = !mMapViewOnly;
+            mMultiRect = QRect(event->pos(), event->pos());
+            if (!mpMap->mpRoomDB->getRoom(mRoomID)) {
+                return;
+            }
+            TArea* pArea = mpMap->mpRoomDB->getArea(mAreaID);
+            if (!pArea) {
+                return;
+            }
+            float fx = ((xspan / 2.0) - mOx) * mRoomWidth;
+            float fy = ((yspan / 2.0) - mOy) * mRoomHeight;
+
+            if (!event->modifiers().testFlag(Qt::ControlModifier)) {
+                if (!mMapViewOnly) {
+                    // If control key NOT down then clear selection, and put up helpful text
+                    mHelpMsg = tr("Drag to select multiple rooms or labels, release to finish...", "2D Mapper big, bottom of screen help message");
+                }
+                mMultiSelectionSet.clear();
+            }
+
+            QSetIterator<int> itRoom(pArea->getAreaRooms());
+            while (itRoom.hasNext()) { // Scan to find rooms in selection
+                int currentAreaRoom = itRoom.next();
+                TRoom* room = mpMap->mpRoomDB->getRoom(currentAreaRoom);
+                if (!room) {
+                    continue;
+                }
+                int rx = room->x * mRoomWidth + fx;
+                int ry = room->y * -1 * mRoomHeight + fy;
+                int rz = room->z;
+
+                int mx = event->pos().x();
+                int my = event->pos().y();
+                int mz = mOz;
+                if ((abs(mx - rx) < qRound(mRoomWidth * rSize / 2.0)) && (abs(my - ry) < qRound(mRoomHeight * rSize / 2.0)) && (mz == rz)) {
+                    if (mMultiSelectionSet.contains(currentAreaRoom) && event->modifiers().testFlag(Qt::ControlModifier)) {
+                        mMultiSelectionSet.remove(currentAreaRoom);
+                    } else {
+                        mMultiSelectionSet.insert(currentAreaRoom);
+                    }
+
+                    if (!mMultiSelectionSet.empty()) {
+                        mMultiSelection = false;
+                    }
+                }
+            }
+            switch (mMultiSelectionSet.size()) {
+            case 0:
+                mMultiSelectionHighlightRoomId = 0;
+                break;
+            case 1:
+                mMultiSelection = false; // OK, found one room so stop
+                mMultiSelectionHighlightRoomId = *(mMultiSelectionSet.begin());
+                mHelpMsg.clear();
+                break;
+            default:
+                mMultiSelection = false; // OK, found more than one room so stop
+                mHelpMsg.clear();
+                getCenterSelection();
+            }
+
+            // select labels (not in viewOnly mode)
+            if (!pArea->mMapLabels.isEmpty() && !mMapViewOnly) {
+                QMutableMapIterator<int, TMapLabel> itMapLabel(pArea->mMapLabels);
+                while (itMapLabel.hasNext()) {
+                    itMapLabel.next();
+                    auto mapLabel = itMapLabel.value();
+                    if (mapLabel.pos.z() != mOz) {
+                        continue;
+                    }
+
+                    QPointF labelPosition;
+                    float labelX = mapLabel.pos.x() * mRoomWidth + mRX;
+                    float labelY = mapLabel.pos.y() * mRoomHeight * -1 + mRY;
+
+                    labelPosition.setX(labelX);
+                    labelPosition.setY(labelY);
+                    int mx = event->pos().x();
+                    int my = event->pos().y();
+                    QPoint click = QPoint(mx, my);
+                    QRectF br = QRect(labelX, labelY, mapLabel.clickSize.width(), mapLabel.clickSize.height());
+                    if (br.contains(click)) {
+                        mapLabel.highlight = !mapLabel.highlight;
+                        mLabelHighlighted = mapLabel.highlight;
+                        pArea->mMapLabels[itMapLabel.key()] = mapLabel;
+                        update();
+                        return;
+                    }
+                }
+            }
+
+            mLabelHighlighted = false;
+            update();
+
+            if (mMultiSelection && !mMultiSelectionSet.empty() && (event->modifiers().testFlag(Qt::ControlModifier))) {
+                // We were dragging multi-selection rectangle, we had selected at
+                // least one room and the user has <CTRL>-clicked with the mouse
+                // so switch off the dragging
+                mMultiSelection = false;
+                mHelpMsg.clear();
+            }
+
+        } else { // In popup menu, so end that
+            mPopupMenu = false;
+        }
+
     }
 
     updateSelectionWidget();

--- a/src/T2DMap.cpp
+++ b/src/T2DMap.cpp
@@ -2512,6 +2512,7 @@ void T2DMap::mouseReleaseEvent(QMouseEvent* event)
         }
         mMultiRect = QRect(0, 0, 0, 0);
         update();
+        return;
     }
 
     if (event->button() & Qt::RightButton) {


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Moves the right-click menu from the mouse press event to the mouse release event. This is more normal behavior for the right click menu. It also prevents accidentally selecting items out of the menu during the release event when all you wanted to do was open the menu.

#### Motivation for adding to Mudlet
Resolve the issue where people kept accidentally creating rooms when trying to bring up the right-click menu.
#### Other info (issues closed, discussion etc)
Fix https://github.com/Mudlet/Mudlet/issues/5743

*edit: Kebap: Mentioned the fix, so the issue will close upon merge*